### PR TITLE
chore(deps): bump typescript to 6.0.3 (root + app)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "fast-check": "^4.6.0",
         "tsup": "^8.4.0",
         "tsx": "^4.19.0",
-        "typescript": "^5.7.0",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.4"
       },
       "engines": {
@@ -6251,9 +6251,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "fast-check": "^4.6.0",
     "tsup": "^8.4.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.4"
   },
   "optionalDependencies": {

--- a/packages/app/package-lock.json
+++ b/packages/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trace-mcp-app",
-  "version": "1.27.0",
+  "version": "1.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trace-mcp-app",
-      "version": "1.27.0",
+      "version": "1.31.0",
       "hasInstallScript": true,
       "dependencies": {
         "@cosmos.gl/graph": "3.0.0-beta.7",
@@ -24,7 +24,7 @@
         "react-dom": "^19.1.0",
         "sharp": "^0.34.5",
         "tailwindcss": "^4.1.4",
-        "typescript": "^5.8.3",
+        "typescript": "^6.0.3",
         "vite": "^6.3.2"
       }
     },
@@ -7828,9 +7828,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -37,7 +37,7 @@
     "react-dom": "^19.1.0",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.1.4",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vite": "^6.3.2"
   }
 }

--- a/packages/app/src/renderer/types.d.ts
+++ b/packages/app/src/renderer/types.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/packages/app/tsconfig.main.json
+++ b/packages/app/tsconfig.main.json
@@ -9,7 +9,8 @@
     "outDir": "dist/main",
     "rootDir": "src/main",
     "lib": ["ES2022"],
-    "types": ["node"]
+    "types": ["node"],
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/main/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "declarationMap": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
## Summary

Stack-merge of dependabot PRs #93 and #99 into a single branch. Bumps TypeScript to v6.0.3 in both root and \`packages/app\`.

- Root: 5.7 → 6.0.3
- App: 5.8.3 → 6.0.3

## Required adjustments

- **\`tsconfig.json\`**: added \`ignoreDeprecations: "6.0"\` — tsup 8.5.1 internally injects \`baseUrl\` during DTS generation, which is deprecated in TS 6 and will fail in TS 7. Silenced until tsup adapts.
- **\`packages/app/src/renderer/types.d.ts\`** (new): declares \`*.css\` modules — TS 6 enforces type declarations for side-effect imports of non-code resources.

## Test plan

- [x] \`npm run build\` — passes (tsup ESM + DTS, ~14 MB output)
- [x] \`npm test\` — 4542 passing, 4 skipped (no failures)
- [x] \`cd packages/app && npm run typecheck\` — clean

## Notes

\`npm run lint\` (root \`tsc --noEmit\`) reports 388 pre-existing errors on master; this PR does not change that count. Cleaning those up is a separate tech-debt task.

Closes #93, closes #99.