### PR TITLE
chore(app-deps-dev): bump electron from 34.3.0 to 41.3.0

### DIFF
--- a/packages/app/package-lock.json
+++ b/packages/app/package-lock.json
@@ -18,7 +18,7 @@
         "@types/react-dom": "^19.1.0",
         "@vitejs/plugin-react": "^4.4.1",
         "autoprefixer": "^10.5.0",
-        "electron": "^34.3.0",
+        "electron": "^41.3.0",
         "electron-builder": "^26.0.12",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -2975,12 +2975,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/offscreencanvas": {
@@ -4583,14 +4583,14 @@
       }
     },
     "node_modules/electron": {
-      "version": "34.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-34.3.0.tgz",
-      "integrity": "sha512-I238qRnYTAsuwJ/rS7HGaFNY4NNKAcjX8nlj7mnNmj1TK3z4HvNoD1r7Zud81DYDFx8AITuLd76EPrEnnfF9Bg==",
+      "version": "41.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.3.0.tgz",
+      "integrity": "sha512-2Q5aeocmFdeheZGDUTrAvSR3t+n0c3d104AJWWEnt7syJU0tE4VdibMYaPtQ47QuXSoUf0/xSsfUUvu/uSXIfg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^20.9.0",
+        "@types/node": "^24.9.0",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -7853,9 +7853,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unique-filename": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -31,7 +31,7 @@
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.4.1",
     "autoprefixer": "^10.5.0",
-    "electron": "^34.3.0",
+    "electron": "^41.3.0",
     "electron-builder": "^26.0.12",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",


### PR DESCRIPTION
## Summary

Replaces dependabot PR #90 with the same bump but a clean local build verified. Electron 34 → 41 (7 majors).

## Test plan

- [x] \`cd packages/app && npm run typecheck\` — clean
- [x] \`npm run build:main\` (TypeScript main process) — clean
- [x] \`npm run build:renderer\` (Vite) — clean
- [ ] Manual: \`npm run dev:electron\` — verify tray app launches and shows graph
- [ ] Manual: \`npm run pack\` — verify packaging still works

## Notes

Our Electron API surface is small (menubar package, BrowserWindow basics) — no breakings encountered between v34 and v41 in our code.

Closes #90.