### PR TITLE
chore(deps): bump zod from 3.24 to 4.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "tree-sitter-wasms": "^0.1.13",
         "web-tree-sitter": "^0.24.7",
         "yaml": "^2.8.3",
-        "zod": "^3.24.0"
+        "zod": "^4.3.6"
       },
       "bin": {
         "trace-mcp": "dist/cli.js"
@@ -6540,9 +6540,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "tree-sitter-wasms": "^0.1.13",
     "web-tree-sitter": "^0.24.7",
     "yaml": "^2.8.3",
-    "zod": "^3.24.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,7 @@ const AiConfigSchema = z.object({
     embedding: z.boolean().default(true),
     inference: z.boolean().default(true),
     fast_inference: z.boolean().default(true),
-  }).default({}),
+  }).prefault({}),
   base_url: z.string().optional(),
   api_key: z.string().optional(),
   inference_model: z.string().optional(),
@@ -67,21 +67,21 @@ const PredictiveConfigSchema = z.object({
       coupling: z.number().default(0.15),
       pagerank: z.number().default(0.10),
       authors: z.number().default(0.15),
-    }).default({}),
+    }).prefault({}),
     tech_debt: z.object({
       complexity: z.number().default(0.30),
       coupling: z.number().default(0.25),
       test_gap: z.number().default(0.25),
       churn: z.number().default(0.20),
-    }).default({}),
+    }).prefault({}),
     change_risk: z.object({
       blast_radius: z.number().default(0.25),
       complexity: z.number().default(0.20),
       churn: z.number().default(0.20),
       test_gap: z.number().default(0.20),
       coupling: z.number().default(0.15),
-    }).default({}),
-  }).default({}),
+    }).prefault({}),
+  }).prefault({}),
   cache_ttl_minutes: z.number().default(60),
   git_since_days: z.number().default(180),
   module_depth: z.number().default(2),
@@ -106,16 +106,16 @@ const RuntimeConfigSchema = z.object({
     port: z.number().int().min(0).max(65535).default(4318),
     host: z.string().default('127.0.0.1'),
     max_body_bytes: z.number().positive().default(4 * 1024 * 1024),
-  }).default({}),
+  }).prefault({}),
   retention: z.object({
     max_span_age_days: z.number().positive().default(7),
     max_aggregate_age_days: z.number().positive().default(90),
     prune_interval: z.number().int().min(0).default(100),
-  }).default({}),
+  }).prefault({}),
   mapping: z.object({
     fqn_attributes: z.array(z.string()).default(['code.function', 'code.namespace', 'code.filepath']),
     route_patterns: z.array(z.string()).default(['^(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\\s+(.+)$']),
-  }).default({}),
+  }).prefault({}),
 }).optional();
 
 const ToolDescriptionOverrideSchema = z.union([
@@ -162,7 +162,7 @@ const QualityGatesConfigSchema = z.object({
     max_security_critical_findings: QualityGatesRuleSchema.optional(),
     max_antipattern_count: QualityGatesRuleSchema.optional(),
     max_code_smell_count: QualityGatesRuleSchema.optional(),
-  }).default({}),
+  }).prefault({}),
 }).optional();
 
 const IgnoreConfigSchema = z.object({
@@ -170,7 +170,7 @@ const IgnoreConfigSchema = z.object({
   directories: z.array(z.string()).default([]),
   /** Extra gitignore-style patterns to exclude from indexing. */
   patterns: z.array(z.string()).default([]),
-}).default({});
+}).prefault({});
 
 const LspServerConfigSchema = z.object({
   command: z.string(),
@@ -182,7 +182,7 @@ const LspServerConfigSchema = z.object({
 
 const LspConfigSchema = z.object({
   enabled: z.boolean().default(false),
-  servers: z.record(z.string(), LspServerConfigSchema).default({}),
+  servers: z.record(z.string(), LspServerConfigSchema).prefault({}),
   auto_detect: z.boolean().default(true),
   max_concurrent_servers: z.number().int().min(1).max(4).default(2),
   enrichment_timeout_ms: z.number().int().min(5000).max(600000).default(120000),
@@ -201,7 +201,7 @@ export const TraceMcpConfigSchema = z.object({
   root: z.string().default('.'),
   db: z.object({
     path: z.string().default('.trace-mcp/index.db'),
-  }).default({}),
+  }).prefault({}),
   include: z.array(z.string()).default([
     'src/**/*.{ts,tsx,js,jsx,py,go,rs,java,kt,rb,php,vue,svelte}',
     'lib/**/*.{ts,tsx,js,jsx,py,go,rs,java,kt,rb,php}',
@@ -246,16 +246,16 @@ export const TraceMcpConfigSchema = z.object({
   watch: z.object({
     enabled: z.boolean().default(true),
     debounceMs: z.number().int().min(500).max(30000).default(2000),
-  }).default({}),
+  }).prefault({}),
   logging: z.object({
     file: z.boolean().default(false),
     path: z.string().default('~/.trace-mcp/run.log'),
     level: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).default('info'),
     max_size_mb: z.number().positive().max(500).default(10),
-  }).default({}),
+  }).prefault({}),
   git: z.object({
     defaultBaseBranch: z.string().max(256).optional().describe('Default base branch for diff tools (e.g. "develop"). Auto-detects main/master if omitted.'),
-  }).default({}),
+  }).prefault({}),
   /**
    * Minutes of stdin silence before the stdio process releases full-mode
    * resources (DB, indexer, watcher). The process itself stays alive and
@@ -307,7 +307,7 @@ export const TraceMcpConfigSchema = z.object({
     enabled: z.union([z.literal('auto'), z.boolean()]).default('auto'),
     home_override: z.string().optional(),
     profile: z.string().optional(),
-  }).default({}),
+  }).prefault({}),
   children: z.array(z.string()).optional(),
 });
 

--- a/src/tools/quality/quality-gates.ts
+++ b/src/tools/quality/quality-gates.ts
@@ -52,7 +52,7 @@ export const QualityGatesConfigSchema = z.object({
     max_security_critical_findings: QualityGateRuleSchema.optional(),
     max_antipattern_count: QualityGateRuleSchema.optional(),
     max_code_smell_count: QualityGateRuleSchema.optional(),
-  }).default({}),
+  }).prefault({}),
 });
 
 export type QualityGatesConfig = z.infer<typeof QualityGatesConfigSchema>;


### PR DESCRIPTION
## Summary

Replaces dependabot PR #98 — zod 3 → 4 major migration.

## Migration

zod 4 changed how \`.default()\` works on objects: it now validates the default value against the schema's *output* type (after nested defaults fire), so \`.default({})\` no longer works for objects whose fields have their own \`.default()\`.

The replacement is **\`.prefault({})\`** — an input-side default that lets inner defaults fire normally. Affects 17 schemas across:

- [src/config.ts](src/config.ts) — 16 occurrences
- [src/tools/quality/quality-gates.ts](src/tools/quality/quality-gates.ts) — 1 occurrence

Semantics preserved: when the user omits a config section entirely, \`prefault({})\` triggers the schema with an empty input, and inner field-level defaults fire to produce the same final value as before.

## Test plan

- [x] \`npm run build\` — clean (tsup ESM + DTS)
- [x] \`npm test\` — 4542 passing, 4 skipped (no failures)
- [ ] Manual: load existing config files (\`.trace-mcp.json\`) and verify they still parse

Closes #98.