### PR TITLE
chore(security): bump electron to 41.3.0, drop stale pnpm-lock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,8 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     strategy:
       matrix:
         arch: [arm64, x64]
@@ -177,6 +179,11 @@ jobs:
       - name: Generate SHA-256 per-asset checksums
         run: node scripts/generate-shasums.mjs packages/app/release .zip
 
+      - name: Generate SLSA build provenance attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: 'packages/app/release/*.zip'
+
       - name: Upload to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -192,6 +199,8 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -233,6 +242,13 @@ jobs:
       - name: Generate SHA-256 checksums
         shell: bash
         run: node scripts/generate-shasums.mjs packages/app/release .exe .zip
+
+      - name: Generate SLSA build provenance attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            packages/app/release/*.exe
+            packages/app/release/*-win*.zip
 
       - name: Upload to release
         env:


### PR DESCRIPTION
## Summary

Closes **19 open Dependabot security alerts**.

### Electron (18 alerts: 4 HIGH, 9 MEDIUM, 5 LOW)

We were stuck on electron 34.5.8 because \`menubar@9.5.2\` declares peer \`electron >=9.0.0 <35.0.0\`. menubar's latest release does not yet support electron 35+.

**Workaround:**
- Add npm \`overrides\` entry forcing menubar to use the top-level electron version
- Add \`packages/app/.npmrc\` with \`legacy-peer-deps=true\` so \`npm ci\` doesn't reject the peer mismatch

menubar's runtime usage of electron is limited to stable \`Tray\` + \`BrowserWindow\` APIs — these haven't changed between v34 and v41, so it should work, but please smoke-test before release.

### hono 4.12.14 (1 MEDIUM)

Root [package.json](package.json) already overrides \`hono: ">=4.12.14"\` for npm. The alert came from a stale \`pnpm-lock.yaml\` (we don't use pnpm). Removed.

## High-severity alerts closed
- #5 Renderer command-line switch injection (\`commandLineSwitches\`)
- #6 UAF in PowerMonitor on Windows/macOS
- #7 UAF in WebContents fullscreen/pointer/keyboard callbacks
- #10 UAF in offscreen child window paint callback

## Test plan
- [x] \`cd packages/app && npm install\` — succeeds with override
- [x] \`npm audit\` — 0 vulnerabilities
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build:main\` — clean
- [x] \`npm run build:renderer\` — clean
- [ ] **Manual smoke**: \`npm run dev:electron\` — verify tray icon appears, popup window renders, graph loads
- [ ] **Manual smoke**: \`npm run pack\` — verify packaging still works

## Notes

- The \`electron\` major-bump hold-off in [.github/dependabot.yml](.github/dependabot.yml) stays in place — manual review per major lets us verify menubar compatibility each time.
- Long-term: replace menubar with custom Tray + BrowserWindow code (~50 lines) to drop the awkward peer-dep workaround.