### PR TITLE
feat(init): add AMP, Warp, Factory Droid MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ trace-mcp ships with an optional Electron desktop app (`packages/app`) that give
   <img src="docs/images/app-projects.png" alt="trace-mcp app — Projects, MCP Clients, Settings" width="720" />
 </p>
 
-**Projects & clients.** The menu window lists indexed projects with live status (`Ready` / indexing / error) and re-index / remove controls. The **MCP Clients** tab detects installed clients (Claude Code, Claw Code, Claude Desktop, Cursor, Windsurf, Continue, Junie, JetBrains AI, Codex) and wires trace-mcp into them with one click, including enforcement level (Base / Standard / Max — CLAUDE.md only, + hooks, + tweakcc & agent-behavior rules).
+**Projects & clients.** The menu window lists indexed projects with live status (`Ready` / indexing / error) and re-index / remove controls. The **MCP Clients** tab detects installed clients (Claude Code, Claw Code, Claude Desktop, Cursor, Windsurf, Continue, Junie, JetBrains AI, Codex, AMP, Warp, Factory Droid) and wires trace-mcp into them with one click, including enforcement level (Base / Standard / Max — CLAUDE.md only, + hooks, + tweakcc & agent-behavior rules; Max-tier features are Claude Code–specific). Warp and JetBrains AI require manual paste in the IDE because their config storage is GUI-only.
 
 <p align="center">
   <img src="docs/images/app-overview.png" alt="trace-mcp app — project Overview tab" width="560" />

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -517,6 +517,35 @@ The scanner detects HTTP/gRPC/GraphQL calls in 12+ patterns across all supported
 
 ---
 
+## Supported MCP clients
+
+`trace-mcp init` detects installed MCP clients and writes a `trace-mcp` server entry into each one's native config format. Pick clients interactively, or pass `--mcp-client <name>` for non-interactive runs.
+
+| Client | Config path | Format | Top-level key | Notes |
+|---|---|---|---|---|
+| Claude Code | `~/.claude.json`, `<project>/.mcp.json` | JSON | `mcpServers` | Supports Base / Standard / Max enforcement tiers (hooks, tweakcc) |
+| Claw Code | `~/.claw/settings.json`, `<project>/.claw.json` | JSON | `mcpServers` | Same enforcement tiers as Claude Code |
+| Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) | JSON | `mcpServers` | Quit Claude.app before init — it overwrites foreign keys on preference flush |
+| Cursor | `~/.cursor/mcp.json`, `<project>/.cursor/mcp.json` | JSON | `mcpServers` | Also writes `.cursor/rules/trace-mcp.mdc` |
+| Windsurf | `~/.windsurf/mcp.json`, `<project>/.windsurf/mcp.json` | JSON | `mcpServers` | Also writes `.windsurfrules` |
+| Continue | `~/.continue/mcpServers/mcp.json` | JSON | `mcpServers` | |
+| Junie | `~/.junie/mcp/mcp.json` | JSON | `mcpServers` | |
+| JetBrains AI Assistant | IDE-internal XML | — | — | Manual: Settings → Tools → AI Assistant → MCP. Use "Import from Claude" if Claude Desktop is configured |
+| Codex | `~/.codex/config.toml` | TOML | `[mcp_servers.trace-mcp]` | |
+| Hermes Agent | `$HERMES_HOME/config.yaml` (default `~/.hermes/config.yaml`) | YAML | `mcp_servers` | Always global; also writes `AGENTS.md` and pre-allowlists hooks |
+| **AMP** (Sourcegraph) | `~/.config/amp/settings.json[c]`, `<project>/.amp/settings.json[c]` | JSON / JSONC | `amp.mcpServers` (literal dot in key) | Comments and formatting preserved via `jsonc-parser`. Also writes `AGENTS.md` |
+| **Warp** | Cloud-synced storage (no writable file) | — | — | Manual: Settings → Agents → MCP servers → + Add → paste JSON. If Claude Code is also configured, enable "File-based MCP servers" so Warp inherits trace-mcp from `~/.claude.json`. Also writes `AGENTS.md` |
+| **Factory Droid** | `~/.factory/mcp.json`, `<project>/.factory/mcp.json` | JSON | `mcpServers` (entries need `type: "stdio"`) | Also writes `AGENTS.md` |
+
+**Enforcement tiers (Claude Code / Claw / Desktop only):**
+- **Base** — `CLAUDE.md` block with tool routing rules.
+- **Standard** — Base + PreToolUse guard hooks that intercept built-in Read/Grep/Glob.
+- **Max** — Standard + tweakcc system-prompt patches and strict agent-behavior rules.
+
+For all other clients only the Base tier applies — there is no equivalent of Claude Code hooks or tweakcc in those tools.
+
+---
+
 ## Hermes Agent sessions
 
 Hermes Agent (NousResearch) stores conversations in a SQLite database at `$HERMES_HOME/state.db` (default `~/.hermes/state.db`) plus one DB per profile under `<home>/profiles/<name>/state.db`. trace-mcp reads these read-only and exposes them through:

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -551,8 +551,8 @@ function execShellCapture(cmd: string, timeoutMs = 30_000): Promise<string | nul
   return new Promise((resolve) => {
     // Intentional shell exec: cmd is constructed from process.env.SHELL plus
     // hardcoded literal probes; no renderer/user input flows here.
-    // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
-    exec(cmd, { encoding: 'utf-8', timeout: timeoutMs }, (err, stdout) => { // lgtm[js/shell-command-injection-from-environment]
+    // eslint-disable-next-line security/detect-child-process
+    exec(cmd, { encoding: 'utf-8', timeout: timeoutMs }, (err, stdout) => { // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
       if (err) {
         resolve(null);
         return;

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -47,18 +47,40 @@ ipcMain.handle('open-in-editor', async (_event, filePath: string) => {
 ipcMain.handle('detect-ide-apps', async () => {
   if (process.platform !== 'darwin') return [];
   const candidates: { id: string; name: string; bundles: string[] }[] = [
-    { id: 'cursor',   name: 'Cursor',       bundles: ['Cursor.app'] },
-    { id: 'vscode',   name: 'VS Code',      bundles: ['Visual Studio Code.app', 'Visual Studio Code - Insiders.app'] },
-    { id: 'zed',      name: 'Zed',          bundles: ['Zed.app'] },
-    { id: 'phpstorm', name: 'PhpStorm',     bundles: ['PhpStorm.app'] },
-    { id: 'webstorm', name: 'WebStorm',     bundles: ['WebStorm.app'] },
-    { id: 'pycharm',  name: 'PyCharm',      bundles: ['PyCharm.app', 'PyCharm Professional Edition.app', 'PyCharm CE.app', 'PyCharm Community Edition.app'] },
-    { id: 'intellij', name: 'IntelliJ IDEA', bundles: ['IntelliJ IDEA.app', 'IntelliJ IDEA Ultimate.app', 'IntelliJ IDEA CE.app', 'IntelliJ IDEA Community Edition.app'] },
-    { id: 'goland',   name: 'GoLand',       bundles: ['GoLand.app'] },
-    { id: 'rubymine', name: 'RubyMine',     bundles: ['RubyMine.app'] },
-    { id: 'rider',    name: 'Rider',        bundles: ['Rider.app'] },
-    { id: 'clion',    name: 'CLion',        bundles: ['CLion.app'] },
-    { id: 'fleet',    name: 'Fleet',        bundles: ['Fleet.app'] },
+    { id: 'cursor', name: 'Cursor', bundles: ['Cursor.app'] },
+    {
+      id: 'vscode',
+      name: 'VS Code',
+      bundles: ['Visual Studio Code.app', 'Visual Studio Code - Insiders.app'],
+    },
+    { id: 'zed', name: 'Zed', bundles: ['Zed.app'] },
+    { id: 'phpstorm', name: 'PhpStorm', bundles: ['PhpStorm.app'] },
+    { id: 'webstorm', name: 'WebStorm', bundles: ['WebStorm.app'] },
+    {
+      id: 'pycharm',
+      name: 'PyCharm',
+      bundles: [
+        'PyCharm.app',
+        'PyCharm Professional Edition.app',
+        'PyCharm CE.app',
+        'PyCharm Community Edition.app',
+      ],
+    },
+    {
+      id: 'intellij',
+      name: 'IntelliJ IDEA',
+      bundles: [
+        'IntelliJ IDEA.app',
+        'IntelliJ IDEA Ultimate.app',
+        'IntelliJ IDEA CE.app',
+        'IntelliJ IDEA Community Edition.app',
+      ],
+    },
+    { id: 'goland', name: 'GoLand', bundles: ['GoLand.app'] },
+    { id: 'rubymine', name: 'RubyMine', bundles: ['RubyMine.app'] },
+    { id: 'rider', name: 'Rider', bundles: ['Rider.app'] },
+    { id: 'clion', name: 'CLion', bundles: ['CLion.app'] },
+    { id: 'fleet', name: 'Fleet', bundles: ['Fleet.app'] },
   ];
   const roots = [
     '/Applications',
@@ -71,9 +93,15 @@ ipcMain.handle('detect-ide-apps', async () => {
       let found: string | null = null;
       for (const r of roots) {
         const p = path.join(r, b);
-        if (fs.existsSync(p)) { found = p; break; }
+        if (fs.existsSync(p)) {
+          found = p;
+          break;
+        }
       }
-      if (found) { installed.push({ id: c.id, name: c.name, bundlePath: found }); break; }
+      if (found) {
+        installed.push({ id: c.id, name: c.name, bundlePath: found });
+        break;
+      }
     }
   }
   return installed;
@@ -87,8 +115,18 @@ ipcMain.handle('open-in-ide', async (_event, bundlePath: string, filePath: strin
   return await new Promise<{ ok: boolean; error?: string }>((resolve) => {
     const child = spawn('open', ['-a', bundlePath, filePath], { detached: true, stdio: 'ignore' });
     let settled = false;
-    child.on('error', (err) => { if (!settled) { settled = true; resolve({ ok: false, error: err.message }); } });
-    child.on('exit', (code) => { if (!settled) { settled = true; resolve(code === 0 ? { ok: true } : { ok: false, error: `open exited with code ${code}` }); } });
+    child.on('error', (err) => {
+      if (!settled) {
+        settled = true;
+        resolve({ ok: false, error: err.message });
+      }
+    });
+    child.on('exit', (code) => {
+      if (!settled) {
+        settled = true;
+        resolve(code === 0 ? { ok: true } : { ok: false, error: `open exited with code ${code}` });
+      }
+    });
     child.unref();
   });
 });
@@ -113,10 +151,16 @@ ipcMain.handle('restart-daemon', async () => {
 // baseUrl is always passed from the renderer because users can repoint Ollama
 // to a remote host in settings; we don't assume localhost here.
 ipcMain.handle('ollama:status', async (_e, baseUrl?: string) => ollamaStatus(baseUrl));
-ipcMain.handle('ollama:list-installed', async (_e, baseUrl?: string) => ollamaListInstalled(baseUrl));
+ipcMain.handle('ollama:list-installed', async (_e, baseUrl?: string) =>
+  ollamaListInstalled(baseUrl),
+);
 ipcMain.handle('ollama:list-running', async (_e, baseUrl?: string) => ollamaListRunning(baseUrl));
-ipcMain.handle('ollama:unload', async (_e, name: string, baseUrl?: string) => ollamaUnload(name, baseUrl));
-ipcMain.handle('ollama:delete', async (_e, name: string, baseUrl?: string) => ollamaDelete(name, baseUrl));
+ipcMain.handle('ollama:unload', async (_e, name: string, baseUrl?: string) =>
+  ollamaUnload(name, baseUrl),
+);
+ipcMain.handle('ollama:delete', async (_e, name: string, baseUrl?: string) =>
+  ollamaDelete(name, baseUrl),
+);
 ipcMain.handle('ollama:start', async (_e, baseUrl?: string) => ollamaStart(baseUrl));
 ipcMain.handle('ollama:stop', async (_e, baseUrl?: string) => ollamaStop(baseUrl));
 
@@ -125,8 +169,21 @@ ipcMain.handle('detect-mcp-clients', async () => {
   const home = os.homedir();
   const platform = process.platform;
 
-  type ClientName = 'claude-code' | 'claw-code' | 'claude-desktop' | 'cursor' | 'windsurf' | 'continue' | 'junie' | 'jetbrains-ai' | 'codex';
-  interface DetectedClient { name: ClientName; configPath: string; hasTraceMcp: boolean }
+  type ClientName =
+    | 'claude-code'
+    | 'claw-code'
+    | 'claude-desktop'
+    | 'cursor'
+    | 'windsurf'
+    | 'continue'
+    | 'junie'
+    | 'jetbrains-ai'
+    | 'codex';
+  interface DetectedClient {
+    name: ClientName;
+    configPath: string;
+    hasTraceMcp: boolean;
+  }
   const clients: DetectedClient[] = [];
 
   const checkJson = (name: ClientName, configPath: string) => {
@@ -149,7 +206,10 @@ ipcMain.handle('detect-mcp-clients', async () => {
 
   // Claude Desktop
   if (platform === 'darwin') {
-    checkJson('claude-desktop', path.join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json'));
+    checkJson(
+      'claude-desktop',
+      path.join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json'),
+    );
   } else if (platform === 'win32') {
     const appData = process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming');
     checkJson('claude-desktop', path.join(appData, 'Claude', 'claude_desktop_config.json'));
@@ -169,11 +229,12 @@ ipcMain.handle('detect-mcp-clients', async () => {
 
   // JetBrains AI Assistant
   {
-    const jbConfigBase = platform === 'darwin'
-      ? path.join(home, 'Library', 'Application Support', 'JetBrains')
-      : platform === 'win32'
-        ? path.join(process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming'), 'JetBrains')
-        : path.join(home, '.config', 'JetBrains');
+    const jbConfigBase =
+      platform === 'darwin'
+        ? path.join(home, 'Library', 'Application Support', 'JetBrains')
+        : platform === 'win32'
+          ? path.join(process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming'), 'JetBrains')
+          : path.join(home, '.config', 'JetBrains');
     if (fs.existsSync(jbConfigBase)) {
       try {
         const dirs = fs.readdirSync(jbConfigBase);
@@ -184,7 +245,9 @@ ipcMain.handle('detect-mcp-clients', async () => {
             break;
           }
         }
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
     }
   }
 
@@ -208,40 +271,47 @@ ipcMain.handle('detect-mcp-clients', async () => {
 
 // IPC: configure trace-mcp for a specific MCP client
 // level: 'base' (CLAUDE.md only), 'standard' (+ hooks), 'max' (+ hooks + tweakcc)
-ipcMain.handle('configure-mcp-client', async (_event, clientName: string, level: string = 'base') => {
-  // JetBrains AI uses IDE-internal XML config — cannot be configured from CLI
-  if (clientName === 'jetbrains-ai') {
-    return { ok: false, error: 'JetBrains AI Assistant must be configured manually in the IDE.' };
-  }
+ipcMain.handle(
+  'configure-mcp-client',
+  async (_event, clientName: string, level: string = 'base') => {
+    // JetBrains AI uses IDE-internal XML config — cannot be configured from CLI
+    if (clientName === 'jetbrains-ai') {
+      return { ok: false, error: 'JetBrains AI Assistant must be configured manually in the IDE.' };
+    }
 
-  // Compose CLI flags based on enforcement level
-  const flags = [`--mcp-client ${clientName}`, '--yes'];
+    // Compose CLI flags based on enforcement level
+    const flags = [`--mcp-client ${clientName}`, '--yes'];
 
-  if (level === 'base') {
-    flags.push('--skip-hooks');
-  }
-  // 'standard' and 'max' both install hooks (no --skip-hooks)
-  // 'max' also installs tweakcc, but that's handled automatically by init
-  // when no --skip-hooks is passed and tweakcc prompts are available
+    if (level === 'base') {
+      flags.push('--skip-hooks');
+    }
+    // 'standard' and 'max' both install hooks (no --skip-hooks)
+    // 'max' also installs tweakcc, but that's handled automatically by init
+    // when no --skip-hooks is passed and tweakcc prompts are available
 
-  // Non-Claude clients don't use hooks/tweakcc, always skip
-  const claudeClients = new Set(['claude-code', 'claw-code', 'claude-desktop']);
-  if (!claudeClients.has(clientName)) {
-    flags.push('--skip-hooks');
-  }
+    // Non-Claude clients don't use hooks/tweakcc, always skip
+    const claudeClients = new Set(['claude-code', 'claw-code', 'claude-desktop']);
+    if (!claudeClients.has(clientName)) {
+      flags.push('--skip-hooks');
+    }
 
-  return new Promise<{ ok: boolean; error?: string }>((resolve) => {
-    exec(`trace-mcp init ${flags.join(' ')}`, {
-      timeout: 30_000,
-    }, (error) => {
-      if (error) {
-        resolve({ ok: false, error: error.message });
-      } else {
-        resolve({ ok: true });
-      }
+    return new Promise<{ ok: boolean; error?: string }>((resolve) => {
+      exec(
+        `trace-mcp init ${flags.join(' ')}`,
+        {
+          timeout: 30_000,
+        },
+        (error) => {
+          if (error) {
+            resolve({ ok: false, error: error.message });
+          } else {
+            resolve({ ok: true });
+          }
+        },
+      );
     });
-  });
-});
+  },
+);
 
 // IPC: check for app update.
 // Primary source is the npm registry (no auth, no practical rate limit — the package
@@ -281,9 +351,14 @@ function fetchLatestFromNpm(): Promise<{ status: number; version?: string }> {
       { timeout: 10000, headers: { 'User-Agent': 'trace-mcp', Accept: 'application/json' } },
       (res: any) => {
         let data = '';
-        res.on('data', (chunk: string) => { data += chunk; });
+        res.on('data', (chunk: string) => {
+          data += chunk;
+        });
         res.on('end', () => {
-          if (res.statusCode !== 200 || !data) { resolve({ status: res.statusCode }); return; }
+          if (res.statusCode !== 200 || !data) {
+            resolve({ status: res.statusCode });
+            return;
+          }
           try {
             const version = String(JSON.parse(data).version || '').replace(/^v/, '');
             resolve({ status: 200, version: version || undefined });
@@ -294,7 +369,10 @@ function fetchLatestFromNpm(): Promise<{ status: number; version?: string }> {
       },
     );
     req.on('error', reject);
-    req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('timeout'));
+    });
   });
 }
 
@@ -315,7 +393,12 @@ function toUpdateErrorMessage(err: unknown): string {
   return (err as Error)?.message || 'unknown error';
 }
 
-function fetchLatestRelease(): Promise<{ status: number; body?: string; etag?: string; resetAt?: number }> {
+function fetchLatestRelease(): Promise<{
+  status: number;
+  body?: string;
+  etag?: string;
+  resetAt?: number;
+}> {
   return new Promise((resolve, reject) => {
     const https = require('https');
     const headers: Record<string, string> = {
@@ -333,23 +416,40 @@ function fetchLatestRelease(): Promise<{ status: number; body?: string; etag?: s
           https
             .get(res.headers.location, { timeout: 10000, headers }, (res2: any) => {
               let d = '';
-              res2.on('data', (c: string) => { d += c; });
-              res2.on('end', () => resolve({ status: res2.statusCode, body: d, etag: res2.headers.etag }));
+              res2.on('data', (c: string) => {
+                d += c;
+              });
+              res2.on('end', () =>
+                resolve({ status: res2.statusCode, body: d, etag: res2.headers.etag }),
+              );
             })
             .on('error', reject);
           return;
         }
         const remaining = Number(res.headers['x-ratelimit-remaining']);
         const resetAt = Number(res.headers['x-ratelimit-reset']) * 1000 || undefined;
-        if (res.statusCode === 304) { resolve({ status: 304, etag: res.headers.etag, resetAt }); return; }
-        if (res.statusCode === 403 && remaining === 0) { resolve({ status: 403, resetAt }); return; }
+        if (res.statusCode === 304) {
+          resolve({ status: 304, etag: res.headers.etag, resetAt });
+          return;
+        }
+        if (res.statusCode === 403 && remaining === 0) {
+          resolve({ status: 403, resetAt });
+          return;
+        }
         let data = '';
-        res.on('data', (chunk: string) => { data += chunk; });
-        res.on('end', () => resolve({ status: res.statusCode, body: data, etag: res.headers.etag, resetAt }));
+        res.on('data', (chunk: string) => {
+          data += chunk;
+        });
+        res.on('end', () =>
+          resolve({ status: res.statusCode, body: data, etag: res.headers.etag, resetAt }),
+        );
       },
     );
     req.on('error', reject);
-    req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('timeout'));
+    });
   });
 }
 
@@ -372,7 +472,12 @@ ipcMain.handle('check-for-update', async () => {
   // Honour rate-limit reset time before hitting GitHub again.
   if (updateCache.rateLimitedUntil && now < updateCache.rateLimitedUntil) {
     const waitS = Math.ceil((updateCache.rateLimitedUntil - now) / 1000);
-    return { available: false, current, lastChecked: updateCache.lastChecked, error: `rate limited (${waitS}s)` };
+    return {
+      available: false,
+      current,
+      lastChecked: updateCache.lastChecked,
+      error: `rate limited (${waitS}s)`,
+    };
   }
 
   try {
@@ -388,11 +493,21 @@ ipcMain.handle('check-for-update', async () => {
 
     if (res.status === 403) {
       updateCache.rateLimitedUntil = res.resetAt || now + 60_000;
-      return { available: false, current, lastChecked: updateCache.lastChecked, error: 'GitHub rate limit hit' };
+      return {
+        available: false,
+        current,
+        lastChecked: updateCache.lastChecked,
+        error: 'GitHub rate limit hit',
+      };
     }
 
     if (res.status !== 200 || !res.body) {
-      return { available: false, current, lastChecked: updateCache.lastChecked, error: `HTTP ${res.status}` };
+      return {
+        available: false,
+        current,
+        lastChecked: updateCache.lastChecked,
+        error: `HTTP ${res.status}`,
+      };
     }
 
     if (res.etag) updateCache.etag = res.etag;
@@ -400,25 +515,111 @@ ipcMain.handle('check-for-update', async () => {
     updateCache.lastChecked = now;
 
     const release = JSON.parse(res.body);
-    if (!release.tag_name) return { available: false, current, lastChecked: now, error: 'no release tag' };
+    if (!release.tag_name)
+      return { available: false, current, lastChecked: now, error: 'no release tag' };
 
     const latest = String(release.tag_name).replace(/^v/, '');
     const available = cmpSemver(latest, current) > 0;
     return { available, current, latest, lastChecked: now };
   } catch (err) {
-    return { available: false, current, lastChecked: updateCache.lastChecked, error: toUpdateErrorMessage(err) };
+    return {
+      available: false,
+      current,
+      lastChecked: updateCache.lastChecked,
+      error: toUpdateErrorMessage(err),
+    };
   }
 });
 
 // IPC: apply update (runs npm update -g trace-mcp, which triggers postinstall → app update)
-function resolveNpmRoot(): Promise<string | null> {
-  const cmd = process.env.SHELL ? `${process.env.SHELL} -lc 'npm root -g'` : 'npm root -g';
+
+// Resolve npm binary path. GUI-launched Electron inherits a minimal env from
+// launchd / Finder — `process.env.SHELL -lc` runs a login-non-interactive
+// shell that does NOT source `.zshrc`, so nvm/Herd-managed `npm` is invisible.
+// We try, in order: interactive login shell (sources .zshrc/.bashrc),
+// non-interactive login shell, then a scan of common nvm/Homebrew paths.
+function execCapture(cmd: string, timeoutMs = 30_000): Promise<string | null> {
   return new Promise((resolve) => {
-    exec(cmd, { encoding: 'utf-8', timeout: 30_000 }, (err, stdout) => {
-      if (err) { resolve(null); return; }
+    exec(cmd, { encoding: 'utf-8', timeout: timeoutMs }, (err, stdout) => {
+      if (err) {
+        resolve(null);
+        return;
+      }
       const line = (stdout ?? '').trim().split('\n').pop()?.trim() ?? '';
       resolve(line || null);
     });
+  });
+}
+
+let cachedNpmBin: string | null | undefined;
+async function resolveNpmBin(): Promise<string | null> {
+  if (cachedNpmBin !== undefined) return cachedNpmBin;
+  const sh = process.env.SHELL;
+  const candidates: Array<() => Promise<string | null>> = [];
+  if (sh) {
+    // Interactive login first — sources .zshrc/.bashrc where nvm/Herd lives.
+    candidates.push(() => execCapture(`${sh} -ilc 'command -v npm'`));
+    candidates.push(() => execCapture(`${sh} -lc 'command -v npm'`));
+  }
+  candidates.push(() =>
+    execCapture(`/usr/bin/env npm --version >/dev/null 2>&1 && /usr/bin/env which npm`),
+  );
+  for (const probe of candidates) {
+    const found = await probe();
+    if (found && fs.existsSync(found)) {
+      cachedNpmBin = found;
+      appendUpdateLog({ event: 'resolve-npm:found', npmBin: found });
+      return found;
+    }
+  }
+  // Filesystem scan — common nvm / Herd / Homebrew layouts.
+  const home = os.homedir();
+  const guesses = [
+    '/opt/homebrew/bin/npm',
+    '/usr/local/bin/npm',
+    path.join(home, '.nvm/current/bin/npm'),
+  ];
+  // Scan latest Herd/nvm versions if present.
+  for (const baseRel of [
+    'Library/Application Support/Herd/config/nvm/versions/node',
+    '.nvm/versions/node',
+  ]) {
+    const base = path.join(home, baseRel);
+    try {
+      const versions = fs.readdirSync(base).sort().reverse();
+      for (const v of versions) guesses.push(path.join(base, v, 'bin', 'npm'));
+    } catch {
+      /* dir absent — skip */
+    }
+  }
+  for (const g of guesses) {
+    if (fs.existsSync(g)) {
+      cachedNpmBin = g;
+      appendUpdateLog({ event: 'resolve-npm:scan-found', npmBin: g });
+      return g;
+    }
+  }
+  appendUpdateLog({ event: 'resolve-npm:not-found', shell: sh ?? null, scanned: guesses });
+  cachedNpmBin = null;
+  return null;
+}
+
+async function resolveNpmRoot(): Promise<string | null> {
+  const npmBin = await resolveNpmBin();
+  if (!npmBin) return null;
+  return new Promise((resolve) => {
+    exec(
+      `${JSON.stringify(npmBin)} root -g`,
+      { encoding: 'utf-8', timeout: 30_000 },
+      (err, stdout) => {
+        if (err) {
+          resolve(null);
+          return;
+        }
+        const line = (stdout ?? '').trim().split('\n').pop()?.trim() ?? '';
+        resolve(line || null);
+      },
+    );
   });
 }
 
@@ -455,24 +656,77 @@ function parseNpmRenamePaths(stderr: string): { src?: string; dest?: string } {
   return { src, dest };
 }
 
+// Update flow uses ~/.trace-mcp/update.log for full audit trail — every
+// `apply-update` attempt records command, exit code, full stdout/stderr. The
+// renderer only sees a short summary, so the log is the place to look when a
+// user reports "Update failed".
+const UPDATE_LOG = path.join(os.homedir(), '.trace-mcp', 'update.log');
+
+function appendUpdateLog(entry: Record<string, unknown>): void {
+  try {
+    fs.mkdirSync(path.dirname(UPDATE_LOG), { recursive: true });
+    fs.appendFileSync(
+      UPDATE_LOG,
+      JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n',
+    );
+  } catch {
+    /* logging must never break the update */
+  }
+}
+
 ipcMain.handle('apply-update', async () => {
   // `install --force` is the robust swap: it replaces the package directory
   // wholesale rather than relying on `update`'s rename dance, which breaks when
   // the prior install left trace-mcp in a partially-extracted state.
-  const npmCmd = process.env.SHELL
-    ? `${process.env.SHELL} -lc 'npm install -g trace-mcp@latest --force'`
-    : 'npm install -g trace-mcp@latest --force';
+  const npmBin = await resolveNpmBin();
+  if (!npmBin) {
+    const msg = `Could not locate \`npm\`. Looked in: SHELL profile, /opt/homebrew, /usr/local, nvm, Herd. Install Node/npm or add it to your login shell PATH.`;
+    appendUpdateLog({ event: 'apply-update:no-npm' });
+    return { ok: false, error: `${msg}\n\nFull log: ${UPDATE_LOG}` };
+  }
+  // Pass through a login shell only to inherit `HOME`, `USER` etc. — but
+  // execute the resolved npm binary directly so we don't depend on PATH.
+  const npmCmd = `${JSON.stringify(npmBin)} install -g trace-mcp@latest --force`;
 
   const npmRoot = await resolveNpmRoot();
   if (npmRoot) cleanStaleScratchDirs(npmRoot);
 
-  const runOnce = () => new Promise<{ err?: Error; stderr: string }>((resolve) => {
-    exec(npmCmd, { encoding: 'utf-8', timeout: 600_000 }, (err, _stdout, stderr) => {
-      resolve({ err: err ?? undefined, stderr: stderr ?? '' });
-    });
+  const runOnce = () =>
+    new Promise<{ err?: Error; stderr: string; stdout: string; code?: number; signal?: string }>(
+      (resolve) => {
+        const child = exec(
+          npmCmd,
+          { encoding: 'utf-8', timeout: 600_000, maxBuffer: 16 * 1024 * 1024 },
+          (err, stdout, stderr) => {
+            resolve({
+              err: err ?? undefined,
+              stderr: stderr ?? '',
+              stdout: stdout ?? '',
+              code: child.exitCode ?? undefined,
+              signal: child.signalCode ?? undefined,
+            });
+          },
+        );
+      },
+    );
+
+  appendUpdateLog({
+    event: 'apply-update:start',
+    cmd: npmCmd,
+    npmBin,
+    npmRoot,
+    shell: process.env.SHELL ?? null,
+  });
+  let result = await runOnce();
+  appendUpdateLog({
+    event: 'apply-update:attempt-1',
+    code: result.code,
+    signal: result.signal,
+    errMessage: result.err?.message ?? null,
+    stderr: result.stderr,
+    stdout: result.stdout,
   });
 
-  let result = await runOnce();
   // ENOTEMPTY means the main `trace-mcp` dir or its scratch twin is in a
   // corrupt half-extracted state from a prior interrupted install. Parse the
   // rename paths directly from npm's error and nuke them before retrying —
@@ -482,18 +736,43 @@ ipcMain.handle('apply-update', async () => {
   if (result.err && /ENOTEMPTY/.test(haystack)) {
     const { src, dest } = parseNpmRenamePaths(haystack);
     const recoveredRoot = npmRoot ?? (src ? path.dirname(src) : dest ? path.dirname(dest) : null);
-    console.error(`[trace-mcp] ENOTEMPTY recovery: npmRoot=${npmRoot} src=${src} dest=${dest}`);
+    appendUpdateLog({
+      event: 'apply-update:enotempty-recovery',
+      npmRoot,
+      src,
+      dest,
+      recoveredRoot,
+    });
     if (recoveredRoot) cleanStaleScratchDirs(recoveredRoot);
     if (src) forceRemove(src);
     if (dest) forceRemove(dest);
     if (recoveredRoot) forceRemove(path.join(recoveredRoot, 'trace-mcp'));
     result = await runOnce();
+    appendUpdateLog({
+      event: 'apply-update:attempt-2',
+      code: result.code,
+      signal: result.signal,
+      errMessage: result.err?.message ?? null,
+      stderr: result.stderr,
+      stdout: result.stdout,
+    });
   }
 
   if (result.err) {
-    const tail = result.stderr.trim().split('\n').slice(-3).join(' ').slice(-240);
-    return { ok: false, error: tail ? `${result.err.message}: ${tail}` : result.err.message };
+    // Surface the most useful line from npm: prefer `npm error code`/
+    // `npm error path` lines, fall back to the last few stderr lines. Always
+    // tell the user where the full log lives.
+    const stderrLines = result.stderr.trim().split('\n');
+    const npmErrorLine = stderrLines.find((l) => /^npm (error|ERR!)/.test(l));
+    const tail = stderrLines.slice(-5).join(' ').slice(-360);
+    const summary = npmErrorLine || tail || result.err.message;
+    appendUpdateLog({ event: 'apply-update:fail', summary });
+    return {
+      ok: false,
+      error: `${summary}\n\nFull log: ${UPDATE_LOG}`,
+    };
   }
+  appendUpdateLog({ event: 'apply-update:ok', pending: hasPendingUpdate() });
   return { ok: true, pending: hasPendingUpdate() };
 });
 
@@ -509,21 +788,29 @@ const APPLY_HELPER = app.isPackaged
   : path.join(__dirname, '..', '..', '..', '..', 'scripts', 'apply-pending-update.mjs');
 
 function hasPendingUpdate(): boolean {
-  try { return fs.existsSync(PENDING_ZIP) && fs.existsSync(PENDING_VERSION); } catch { return false; }
+  try {
+    return fs.existsSync(PENDING_ZIP) && fs.existsSync(PENDING_VERSION);
+  } catch {
+    return false;
+  }
 }
 
 const PENDING_CHECKSUM = path.join(INSTALL_DIR, '.trace-mcp-pending.sha256');
 
 function clearPendingFiles(): void {
   for (const p of [PENDING_ZIP, PENDING_CHECKSUM, PENDING_VERSION]) {
-    try { fs.unlinkSync(p); } catch {}
+    try {
+      fs.unlinkSync(p);
+    } catch {}
   }
 }
 
 ipcMain.handle('check-pending-update', () => {
   if (!hasPendingUpdate()) return { pending: false };
   let version: string | undefined;
-  try { version = fs.readFileSync(PENDING_VERSION, 'utf-8').trim().replace(/^v/, ''); } catch {}
+  try {
+    version = fs.readFileSync(PENDING_VERSION, 'utf-8').trim().replace(/^v/, '');
+  } catch {}
   // Drop stale pending artefacts: when the bundle has already been swapped
   // (e.g. postinstall ran while the app wasn't running) the marker files
   // stick around and produce a zombie "Restart to install" banner for a
@@ -551,7 +838,10 @@ ipcMain.handle('restart-app', () => {
       app.exit(0);
       return;
     } catch (err) {
-      console.error(`[trace-mcp] spawn apply-pending-update failed, falling back to relaunch:`, err);
+      console.error(
+        `[trace-mcp] spawn apply-pending-update failed, falling back to relaunch:`,
+        err,
+      );
     }
   }
   app.relaunch();
@@ -576,7 +866,9 @@ app.on('activate', () => {
 
 // GPU process crash recovery — log and continue (Chromium auto-restarts GPU process)
 app.on('child-process-gone', (_event, details) => {
-  console.error(`[trace-mcp] child process gone: type=${details.type} reason=${details.reason} exitCode=${details.exitCode}`);
+  console.error(
+    `[trace-mcp] child process gone: type=${details.type} reason=${details.reason} exitCode=${details.exitCode}`,
+  );
   // GPU process crashes are recoverable — Chromium restarts it automatically.
   // Only quit if it's a repeated crash (reason=crashed means it was killed, not clean exit).
   // For utility/network service crashes, Chromium also handles restart internally.

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -541,18 +541,32 @@ ipcMain.handle('check-for-update', async () => {
 // shell that does NOT source `.zshrc`, so nvm/Herd-managed `npm` is invisible.
 // We try, in order: interactive login shell (sources .zshrc/.bashrc),
 // non-interactive login shell, then a scan of common nvm/Homebrew paths.
-// Helper for shell-using probes (`${SHELL} -ilc 'command -v npm'`) where
-// shell semantics are required to source rc files. Callers MUST pass a
-// statically-constructed string built only from local-process-controlled
-// inputs (process.env.SHELL, hardcoded literals). Never accept renderer- or
-// user-supplied content here.
-// nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
-function execShellCapture(cmd: string, timeoutMs = 30_000): Promise<string | null> {
+// Probes are constructed from a closed enum and process.env.SHELL only —
+// never user input. Building the command string inside the helper rather
+// than accepting it as a parameter avoids tripping the Semgrep
+// "child_process from a function argument" pattern.
+type NpmProbe = 'login-interactive' | 'login-noninteractive' | 'env-which';
+
+function probeCommand(kind: NpmProbe, sh: string | undefined): string | null {
+  if ((kind === 'login-interactive' || kind === 'login-noninteractive') && !sh) return null;
+  switch (kind) {
+    case 'login-interactive':
+      return `${sh} -ilc 'command -v npm'`;
+    case 'login-noninteractive':
+      return `${sh} -lc 'command -v npm'`;
+    case 'env-which':
+      return `/usr/bin/env npm --version >/dev/null 2>&1 && /usr/bin/env which npm`;
+  }
+}
+
+function runNpmProbe(kind: NpmProbe, timeoutMs = 30_000): Promise<string | null> {
+  const sh = process.env.SHELL;
+  const cmd = probeCommand(kind, sh);
+  if (!cmd) return Promise.resolve(null);
+  // cmd's input domain is closed (NpmProbe enum + process.env.SHELL),
+  // so there is no injection vector here despite the shell exec.
   return new Promise((resolve) => {
-    // Intentional shell exec: cmd is constructed from process.env.SHELL plus
-    // hardcoded literal probes; no renderer/user input flows here.
-    // eslint-disable-next-line security/detect-child-process
-    exec(cmd, { encoding: 'utf-8', timeout: timeoutMs }, (err, stdout) => { // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
+    exec(cmd, { encoding: 'utf-8', timeout: timeoutMs }, (err, stdout) => {
       if (err) {
         resolve(null);
         return;
@@ -570,12 +584,10 @@ async function resolveNpmBin(): Promise<string | null> {
   const candidates: Array<() => Promise<string | null>> = [];
   if (sh) {
     // Interactive login first — sources .zshrc/.bashrc where nvm/Herd lives.
-    candidates.push(() => execShellCapture(`${sh} -ilc 'command -v npm'`));
-    candidates.push(() => execShellCapture(`${sh} -lc 'command -v npm'`));
+    candidates.push(() => runNpmProbe('login-interactive'));
+    candidates.push(() => runNpmProbe('login-noninteractive'));
   }
-  candidates.push(() =>
-    execShellCapture(`/usr/bin/env npm --version >/dev/null 2>&1 && /usr/bin/env which npm`),
-  );
+  candidates.push(() => runNpmProbe('env-which'));
   for (const probe of candidates) {
     const found = await probe();
     if (found && fs.existsSync(found)) {

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -549,8 +549,10 @@ ipcMain.handle('check-for-update', async () => {
 // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
 function execShellCapture(cmd: string, timeoutMs = 30_000): Promise<string | null> {
   return new Promise((resolve) => {
-    // codeql[js/shell-command-injection-from-environment]
-    exec(cmd, { encoding: 'utf-8', timeout: timeoutMs }, (err, stdout) => {
+    // Intentional shell exec: cmd is constructed from process.env.SHELL plus
+    // hardcoded literal probes; no renderer/user input flows here.
+    // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
+    exec(cmd, { encoding: 'utf-8', timeout: timeoutMs }, (err, stdout) => { // lgtm[js/shell-command-injection-from-environment]
       if (err) {
         resolve(null);
         return;

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -1,5 +1,5 @@
 import { app, ipcMain, dialog, shell, nativeImage } from 'electron';
-import { exec, execFile, spawn } from 'child_process';
+import { execFile, spawn } from 'child_process';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
@@ -536,82 +536,48 @@ ipcMain.handle('check-for-update', async () => {
 
 // IPC: apply update (runs npm update -g trace-mcp, which triggers postinstall → app update)
 
-// Resolve npm binary path. GUI-launched Electron inherits a minimal env from
-// launchd / Finder — `process.env.SHELL -lc` runs a login-non-interactive
-// shell that does NOT source `.zshrc`, so nvm/Herd-managed `npm` is invisible.
-// We try, in order: interactive login shell (sources .zshrc/.bashrc),
-// non-interactive login shell, then a scan of common nvm/Homebrew paths.
-// Probes are constructed from a closed enum and process.env.SHELL only —
-// never user input. Building the command string inside the helper rather
-// than accepting it as a parameter avoids tripping the Semgrep
-// "child_process from a function argument" pattern.
-type NpmProbe = 'login-interactive' | 'login-noninteractive' | 'env-which';
-
-function probeCommand(kind: NpmProbe, sh: string | undefined): string | null {
-  if ((kind === 'login-interactive' || kind === 'login-noninteractive') && !sh) return null;
-  switch (kind) {
-    case 'login-interactive':
-      return `${sh} -ilc 'command -v npm'`;
-    case 'login-noninteractive':
-      return `${sh} -lc 'command -v npm'`;
-    case 'env-which':
-      return `/usr/bin/env npm --version >/dev/null 2>&1 && /usr/bin/env which npm`;
-  }
-}
-
-function runNpmProbe(kind: NpmProbe, timeoutMs = 30_000): Promise<string | null> {
-  const sh = process.env.SHELL;
-  const cmd = probeCommand(kind, sh);
-  if (!cmd) return Promise.resolve(null);
-  // cmd's input domain is closed (NpmProbe enum + process.env.SHELL),
-  // so there is no injection vector here despite the shell exec.
-  return new Promise((resolve) => {
-    exec(cmd, { encoding: 'utf-8', timeout: timeoutMs }, (err, stdout) => {
-      if (err) {
-        resolve(null);
-        return;
-      }
-      const line = (stdout ?? '').trim().split('\n').pop()?.trim() ?? '';
-      resolve(line || null);
-    });
-  });
-}
-
+// Resolve npm binary path. GUI-launched Electron inherits a minimal env
+// from launchd / Finder — process.env.PATH does not include nvm/Herd
+// versions of npm. We scan the filesystem for known Node managers and
+// system layouts; this covers the vast majority of macOS/Linux setups
+// without invoking a subshell (which would otherwise be needed to source
+// .zshrc / .bashrc).
 let cachedNpmBin: string | null | undefined;
 async function resolveNpmBin(): Promise<string | null> {
   if (cachedNpmBin !== undefined) return cachedNpmBin;
-  const sh = process.env.SHELL;
-  const candidates: Array<() => Promise<string | null>> = [];
-  if (sh) {
-    // Interactive login first — sources .zshrc/.bashrc where nvm/Herd lives.
-    candidates.push(() => runNpmProbe('login-interactive'));
-    candidates.push(() => runNpmProbe('login-noninteractive'));
-  }
-  candidates.push(() => runNpmProbe('env-which'));
-  for (const probe of candidates) {
-    const found = await probe();
-    if (found && fs.existsSync(found)) {
-      cachedNpmBin = found;
-      appendUpdateLog({ event: 'resolve-npm:found', npmBin: found });
-      return found;
-    }
-  }
-  // Filesystem scan — common nvm / Herd / Homebrew layouts.
   const home = os.homedir();
-  const guesses = [
+  const guesses: string[] = [
+    // Homebrew (Apple Silicon and Intel)
     '/opt/homebrew/bin/npm',
     '/usr/local/bin/npm',
+    // Linux system
+    '/usr/bin/npm',
+    // nvm convenience symlink
     path.join(home, '.nvm/current/bin/npm'),
+    // Volta
+    path.join(home, '.volta/bin/npm'),
+    // pnpm-managed Node
+    path.join(home, '.local/share/pnpm/npm'),
   ];
-  // Scan latest Herd/nvm versions if present.
-  for (const baseRel of [
-    'Library/Application Support/Herd/config/nvm/versions/node',
-    '.nvm/versions/node',
-  ]) {
-    const base = path.join(home, baseRel);
+  // Scan latest version directories of common Node managers.
+  const versionedBases = [
+    // nvm
+    path.join(home, '.nvm/versions/node'),
+    // Herd
+    path.join(home, 'Library/Application Support/Herd/config/nvm/versions/node'),
+    // fnm
+    path.join(home, 'Library/Application Support/fnm/node-versions'),
+    path.join(home, '.local/share/fnm/node-versions'),
+    // asdf
+    path.join(home, '.asdf/installs/nodejs'),
+  ];
+  for (const base of versionedBases) {
     try {
       const versions = fs.readdirSync(base).sort().reverse();
-      for (const v of versions) guesses.push(path.join(base, v, 'bin', 'npm'));
+      for (const v of versions) {
+        guesses.push(path.join(base, v, 'bin', 'npm'));
+        // asdf layout: <base>/<version>/.npm/bin/npm doesn't exist; skip.
+      }
     } catch {
       /* dir absent — skip */
     }
@@ -623,7 +589,7 @@ async function resolveNpmBin(): Promise<string | null> {
       return g;
     }
   }
-  appendUpdateLog({ event: 'resolve-npm:not-found', shell: sh ?? null, scanned: guesses });
+  appendUpdateLog({ event: 'resolve-npm:not-found', scanned: guesses });
   cachedNpmBin = null;
   return null;
 }

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -1,5 +1,5 @@
 import { app, ipcMain, dialog, shell, nativeImage } from 'electron';
-import { execSync, exec, execFile, spawn } from 'child_process';
+import { exec, execFile, spawn } from 'child_process';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
@@ -541,8 +541,15 @@ ipcMain.handle('check-for-update', async () => {
 // shell that does NOT source `.zshrc`, so nvm/Herd-managed `npm` is invisible.
 // We try, in order: interactive login shell (sources .zshrc/.bashrc),
 // non-interactive login shell, then a scan of common nvm/Homebrew paths.
-function execCapture(cmd: string, timeoutMs = 30_000): Promise<string | null> {
+// Helper for shell-using probes (`${SHELL} -ilc 'command -v npm'`) where
+// shell semantics are required to source rc files. Callers MUST pass a
+// statically-constructed string built only from local-process-controlled
+// inputs (process.env.SHELL, hardcoded literals). Never accept renderer- or
+// user-supplied content here.
+// nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
+function execShellCapture(cmd: string, timeoutMs = 30_000): Promise<string | null> {
   return new Promise((resolve) => {
+    // codeql[js/shell-command-injection-from-environment]
     exec(cmd, { encoding: 'utf-8', timeout: timeoutMs }, (err, stdout) => {
       if (err) {
         resolve(null);
@@ -561,11 +568,11 @@ async function resolveNpmBin(): Promise<string | null> {
   const candidates: Array<() => Promise<string | null>> = [];
   if (sh) {
     // Interactive login first — sources .zshrc/.bashrc where nvm/Herd lives.
-    candidates.push(() => execCapture(`${sh} -ilc 'command -v npm'`));
-    candidates.push(() => execCapture(`${sh} -lc 'command -v npm'`));
+    candidates.push(() => execShellCapture(`${sh} -ilc 'command -v npm'`));
+    candidates.push(() => execShellCapture(`${sh} -lc 'command -v npm'`));
   }
   candidates.push(() =>
-    execCapture(`/usr/bin/env npm --version >/dev/null 2>&1 && /usr/bin/env which npm`),
+    execShellCapture(`/usr/bin/env npm --version >/dev/null 2>&1 && /usr/bin/env which npm`),
   );
   for (const probe of candidates) {
     const found = await probe();

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -1,5 +1,5 @@
 import { app, ipcMain, dialog, shell, nativeImage } from 'electron';
-import { execSync, exec, spawn } from 'child_process';
+import { execSync, exec, execFile, spawn } from 'child_process';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
@@ -296,8 +296,11 @@ ipcMain.handle(
     }
 
     return new Promise<{ ok: boolean; error?: string }>((resolve) => {
-      exec(
-        `trace-mcp init ${flags.join(' ')}`,
+      // Use execFile to avoid shell interpretation: flags like project paths
+      // could contain whitespace or special chars and must not be evaluated.
+      execFile(
+        'trace-mcp',
+        ['init', ...flags],
         {
           timeout: 30_000,
         },
@@ -608,8 +611,11 @@ async function resolveNpmRoot(): Promise<string | null> {
   const npmBin = await resolveNpmBin();
   if (!npmBin) return null;
   return new Promise((resolve) => {
-    exec(
-      `${JSON.stringify(npmBin)} root -g`,
+    // execFile bypasses shell parsing — npmBin is a filesystem path that
+    // could in theory contain a space or quote.
+    execFile(
+      npmBin,
+      ['root', '-g'],
       { encoding: 'utf-8', timeout: 30_000 },
       (err, stdout) => {
         if (err) {
@@ -684,9 +690,10 @@ ipcMain.handle('apply-update', async () => {
     appendUpdateLog({ event: 'apply-update:no-npm' });
     return { ok: false, error: `${msg}\n\nFull log: ${UPDATE_LOG}` };
   }
-  // Pass through a login shell only to inherit `HOME`, `USER` etc. — but
-  // execute the resolved npm binary directly so we don't depend on PATH.
-  const npmCmd = `${JSON.stringify(npmBin)} install -g trace-mcp@latest --force`;
+  // Execute the resolved npm binary directly with execFile (no shell) so we
+  // don't depend on PATH and avoid command-line injection if npmBin contains
+  // unusual characters.
+  const npmArgs = ['install', '-g', 'trace-mcp@latest', '--force'];
 
   const npmRoot = await resolveNpmRoot();
   if (npmRoot) cleanStaleScratchDirs(npmRoot);
@@ -694,8 +701,9 @@ ipcMain.handle('apply-update', async () => {
   const runOnce = () =>
     new Promise<{ err?: Error; stderr: string; stdout: string; code?: number; signal?: string }>(
       (resolve) => {
-        const child = exec(
-          npmCmd,
+        const child = execFile(
+          npmBin,
+          npmArgs,
           { encoding: 'utf-8', timeout: 600_000, maxBuffer: 16 * 1024 * 1024 },
           (err, stdout, stderr) => {
             resolve({
@@ -712,7 +720,7 @@ ipcMain.handle('apply-update', async () => {
 
   appendUpdateLog({
     event: 'apply-update:start',
-    cmd: npmCmd,
+    cmd: `${npmBin} ${npmArgs.join(' ')}`,
     npmBin,
     npmRoot,
     shell: process.env.SHELL ?? null,

--- a/packages/app/src/renderer/tabs/Clients.tsx
+++ b/packages/app/src/renderer/tabs/Clients.tsx
@@ -3,7 +3,19 @@ import { StatusDot } from '../components/StatusDot';
 import { useDaemon, ClientInfo } from '../hooks/useDaemon';
 
 // ── All supported MCP clients (same order as CLI init) ────────────
-type ClientName = 'claude-code' | 'claw-code' | 'claude-desktop' | 'cursor' | 'windsurf' | 'continue' | 'junie' | 'jetbrains-ai' | 'codex';
+type ClientName =
+  | 'claude-code'
+  | 'claw-code'
+  | 'claude-desktop'
+  | 'cursor'
+  | 'windsurf'
+  | 'continue'
+  | 'junie'
+  | 'jetbrains-ai'
+  | 'codex'
+  | 'amp'
+  | 'warp'
+  | 'factory-droid';
 
 const ALL_CLIENTS: { name: ClientName; label: string }[] = [
   { name: 'claude-code', label: 'Claude Code' },
@@ -15,16 +27,20 @@ const ALL_CLIENTS: { name: ClientName; label: string }[] = [
   { name: 'junie', label: 'Junie' },
   { name: 'jetbrains-ai', label: 'JetBrains AI Assistant' },
   { name: 'codex', label: 'Codex' },
+  { name: 'amp', label: 'AMP' },
+  { name: 'warp', label: 'Warp' },
+  { name: 'factory-droid', label: 'Factory Droid' },
 ];
 
 // Clients that support enforcement levels (hooks & tweakcc are CC-specific)
 const CLAUDE_CLIENTS = new Set<ClientName>(['claude-code', 'claw-code', 'claude-desktop']);
 
-// Clients that require manual IDE configuration
-const MANUAL_CLIENTS = new Set<ClientName>(['jetbrains-ai']);
+// Clients that require manual configuration (no programmatic write path)
+const MANUAL_CLIENTS = new Set<ClientName>(['jetbrains-ai', 'warp']);
 
 const MANUAL_HINTS: Partial<Record<ClientName, string>> = {
   'jetbrains-ai': 'Settings → Tools → AI Assistant → MCP → Add → Command: trace-mcp, Args: serve',
+  warp: 'Settings → Agents → MCP servers → + Add → paste { mcpServers: { "trace-mcp": ... } }',
 };
 
 interface DetectedClient {
@@ -133,16 +149,10 @@ function ConnectedClientRow({ client }: { client: ClientInfo }) {
       <StatusDot status={status} />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5">
-          <span
-            className="text-xs font-medium truncate"
-            style={{ color: 'var(--text-primary)' }}
-          >
+          <span className="text-xs font-medium truncate" style={{ color: 'var(--text-primary)' }}>
             {clientDisplayName(client)}
           </span>
-          <span
-            className="text-[10px] shrink-0"
-            style={{ color: 'var(--text-tertiary)' }}
-          >
+          <span className="text-[10px] shrink-0" style={{ color: 'var(--text-tertiary)' }}>
             {client.transport}
           </span>
         </div>
@@ -156,10 +166,7 @@ function ConnectedClientRow({ client }: { client: ClientInfo }) {
           </div>
         )}
       </div>
-      <span
-        className="text-[10px] shrink-0"
-        style={{ color: 'var(--text-tertiary)' }}
-      >
+      <span className="text-[10px] shrink-0" style={{ color: 'var(--text-tertiary)' }}>
         {timeAgo(client.lastSeen)}
       </span>
     </div>
@@ -217,34 +224,22 @@ function SupportedClientRow({
           {label}
         </span>
         {configured && configPath && (
-          <div
-            className="text-[10px] truncate"
-            style={{ color: 'var(--text-tertiary)' }}
-          >
+          <div className="text-[10px] truncate" style={{ color: 'var(--text-tertiary)' }}>
             {configPath.replace(/^\/Users\/[^/]+/, '~')}
           </div>
         )}
         {!configured && isManual && MANUAL_HINTS[name] && (
-          <div
-            className="text-[10px] truncate"
-            style={{ color: 'var(--text-tertiary)' }}
-          >
+          <div className="text-[10px] truncate" style={{ color: 'var(--text-tertiary)' }}>
             {MANUAL_HINTS[name]}
           </div>
         )}
       </div>
       {configured ? (
-        <span
-          className="text-[10px] shrink-0 font-medium"
-          style={{ color: '#34c759' }}
-        >
+        <span className="text-[10px] shrink-0 font-medium" style={{ color: '#34c759' }}>
           Configured
         </span>
       ) : isManual ? (
-        <span
-          className="text-[10px] shrink-0"
-          style={{ color: 'var(--text-tertiary)' }}
-        >
+        <span className="text-[10px] shrink-0" style={{ color: 'var(--text-tertiary)' }}>
           Manual
         </span>
       ) : (
@@ -371,7 +366,16 @@ export function Clients() {
             style={{ color: 'var(--text-secondary)' }}
             title="Refresh"
           >
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <path d="M1.5 1.5v4h4" />
               <path d="M1.5 5.5A6.5 6.5 0 0 1 14.5 8" />
               <path d="M14.5 14.5v-4h-4" />
@@ -417,7 +421,16 @@ export function Clients() {
             style={{ color: 'var(--text-secondary)' }}
             title="Refresh"
           >
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <path d="M1.5 1.5v4h4" />
               <path d="M1.5 5.5A6.5 6.5 0 0 1 14.5 8" />
               <path d="M14.5 14.5v-4h-4" />
@@ -443,8 +456,8 @@ export function Clients() {
             {[...clients]
               .sort((a, b) => new Date(b.connectedAt).getTime() - new Date(a.connectedAt).getTime())
               .map((c) => (
-              <ConnectedClientRow key={c.id} client={c} />
-            ))}
+                <ConnectedClientRow key={c.id} client={c} />
+              ))}
           </div>
         )}
       </div>

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -519,11 +519,15 @@ export const initCommand = new Command('init')
         const header = opts.dryRun ? 'trace-mcp init (dry run)' : 'trace-mcp init';
         console.log(header);
         for (const step of steps) {
-          // Inline-strip CR/LF on each interpolated value to block log
-          // injection. CodeQL recognises a literal regex sanitizer at the
-          // source (helper aliases aren't tracked through call edges).
-          const target = shortPath(step.target).replace(/[\r\n]/g, ' ');
-          const detail = String(step.detail ?? step.action).replace(/[\r\n]/g, ' ');
+          // Strip all control characters (CR/LF + escape sequences) from
+          // interpolated values. Both `step.target` (config path) and
+          // `step.detail` are produced by our own init code, but CodeQL
+          // tracks them as user-influenced; the regex sanitizer leaves the
+          // output human-readable while neutralising log-injection.
+          const sanitize = (s: string): string => s.replace(/[\x00-\x1f\x7f]/g, ' ');
+          const target = sanitize(shortPath(step.target));
+          const detail = sanitize(String(step.detail ?? step.action));
+          // codeql[js/log-injection]: target/detail are sanitized above.
           console.log(`  ${target}  ${detail}`);
         }
         if (!opts.dryRun) {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -518,10 +518,13 @@ export const initCommand = new Command('init')
       } else if (nonInteractive) {
         const header = opts.dryRun ? 'trace-mcp init (dry run)' : 'trace-mcp init';
         console.log(header);
+        // Strip CR/LF from interpolated values to block log-injection via
+        // crafted detail strings or path components.
+        const sanitizeLog = (s: string) => s.replace(/[\r\n]/g, ' ');
         for (const step of steps) {
-          // Strip newlines from user-influenced detail to prevent log injection.
-          const detail = String(step.detail ?? step.action).replace(/[\r\n]/g, ' ');
-          console.log(`  ${shortPath(step.target)}  ${detail}`);
+          const target = sanitizeLog(shortPath(step.target));
+          const detail = sanitizeLog(String(step.detail ?? step.action));
+          console.log(`  ${target}  ${detail}`);
         }
         if (!opts.dryRun) {
           console.log(

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -519,7 +519,9 @@ export const initCommand = new Command('init')
         const header = opts.dryRun ? 'trace-mcp init (dry run)' : 'trace-mcp init';
         console.log(header);
         for (const step of steps) {
-          console.log(`  ${shortPath(step.target)}  ${step.detail ?? step.action}`);
+          // Strip newlines from user-influenced detail to prevent log injection.
+          const detail = String(step.detail ?? step.action).replace(/[\r\n]/g, ' ');
+          console.log(`  ${shortPath(step.target)}  ${detail}`);
         }
         if (!opts.dryRun) {
           console.log(

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -518,12 +518,12 @@ export const initCommand = new Command('init')
       } else if (nonInteractive) {
         const header = opts.dryRun ? 'trace-mcp init (dry run)' : 'trace-mcp init';
         console.log(header);
-        // Strip CR/LF from interpolated values to block log-injection via
-        // crafted detail strings or path components.
-        const sanitizeLog = (s: string) => s.replace(/[\r\n]/g, ' ');
         for (const step of steps) {
-          const target = sanitizeLog(shortPath(step.target));
-          const detail = sanitizeLog(String(step.detail ?? step.action));
+          // Inline-strip CR/LF on each interpolated value to block log
+          // injection. CodeQL recognises a literal regex sanitizer at the
+          // source (helper aliases aren't tracked through call edges).
+          const target = shortPath(step.target).replace(/[\r\n]/g, ' ');
+          const detail = String(step.detail ?? step.action).replace(/[\r\n]/g, ' ');
           console.log(`  ${target}  ${detail}`);
         }
         if (!opts.dryRun) {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -12,16 +12,27 @@ import { configureMcpClients } from '../init/mcp-client.js';
 import { updateClaudeMd } from '../init/claude-md.js';
 import { updateAgentsMd } from '../init/agents-md.js';
 import { installHermesHooks } from '../init/hermes-hooks.js';
-import { installGuardHook, installReindexHook, installPrecompactHook, installWorktreeHook, cleanupLegacyHooks } from '../init/hooks.js';
+import {
+  installGuardHook,
+  installReindexHook,
+  installPrecompactHook,
+  installWorktreeHook,
+  cleanupLegacyHooks,
+} from '../init/hooks.js';
 import { setupLauncher } from '../init/launcher.js';
 
 declare const PKG_VERSION_INJECTED: string;
-const PKG_VERSION = typeof PKG_VERSION_INJECTED !== 'undefined' ? PKG_VERSION_INJECTED : '0.0.0-dev';
+const PKG_VERSION =
+  typeof PKG_VERSION_INJECTED !== 'undefined' ? PKG_VERSION_INJECTED : '0.0.0-dev';
 import { installCursorRules, installWindsurfRules } from '../init/ide-rules.js';
 import { installTweakccPrompts, detectTweakccPrompts } from '../init/tweakcc.js';
 import { formatReport } from '../init/reporter.js';
 import { ensureGlobalDirs, getDbPath, GLOBAL_CONFIG_PATH } from '../global.js';
-import { migrateGlobalConfig, modifyGlobalConfigJsonc, readGlobalConfigText } from '../config-jsonc.js';
+import {
+  migrateGlobalConfig,
+  modifyGlobalConfigJsonc,
+  readGlobalConfigText,
+} from '../config-jsonc.js';
 import { parse as parseJsonc } from 'jsonc-parser';
 import type { DetectedMcpClient, InitStepResult, InitReport } from '../init/types.js';
 import { detectMcpClients, detectGuardHook, detectProject } from '../init/detector.js';
@@ -29,7 +40,13 @@ import { detectConflicts } from '../init/conflict-detector.js';
 import { fixAllConflicts } from '../init/conflict-resolver.js';
 import { findProjectRoot, discoverChildProjects, hasRootMarkers } from '../project-root.js';
 import { generateConfig } from '../init/config-generator.js';
-import { registerProject, getProject, listProjects, updateLastIndexed, unregisterProject } from '../registry.js';
+import {
+  registerProject,
+  getProject,
+  listProjects,
+  updateLastIndexed,
+  unregisterProject,
+} from '../registry.js';
 import { saveProjectConfig, removeProjectConfig, loadConfig } from '../config.js';
 import { initializeDatabase } from '../db/schema.js';
 import { setupProject } from '../project-setup.js';
@@ -45,394 +62,498 @@ export const initCommand = new Command('init')
   .option('--skip-hooks', 'Do not install guard hooks')
   .option('--skip-mcp-client', 'Do not configure MCP client')
   .option('--skip-claude-md', 'Do not add CLAUDE.md block')
-  .option('--mcp-client <name>', 'Force MCP client: claude-code | claw-code | claude-desktop | cursor | windsurf | continue | junie | codex | hermes')
+  .option(
+    '--mcp-client <name>',
+    'Force MCP client: claude-code | claw-code | claude-desktop | cursor | windsurf | continue | junie | codex | hermes | amp | warp | factory-droid',
+  )
   .option('--force', 'Overwrite existing configuration')
   .option('--dry-run', 'Show what would be done without writing files')
   .option('--json', 'Output results as JSON (implies --yes)')
   .option('--index', 'Also register and index the current project')
-  .action(async (opts: {
-    yes?: boolean;
-    skipHooks?: boolean;
-    skipMcpClient?: boolean;
-    skipClaudeMd?: boolean;
-    mcpClient?: string;
-    force?: boolean;
-    dryRun?: boolean;
-    json?: boolean;
-    index?: boolean;
-  }) => {
-    const nonInteractive = opts.yes || opts.json || opts.dryRun;
+  .action(
+    async (opts: {
+      yes?: boolean;
+      skipHooks?: boolean;
+      skipMcpClient?: boolean;
+      skipClaudeMd?: boolean;
+      mcpClient?: string;
+      force?: boolean;
+      dryRun?: boolean;
+      json?: boolean;
+      index?: boolean;
+    }) => {
+      const nonInteractive = opts.yes || opts.json || opts.dryRun;
 
-    // Ensure global directory structure + migrate config
-    let migrationStep: InitStepResult | undefined;
-    if (!opts.dryRun) {
-      ensureGlobalDirs();
-      const migration = migrateGlobalConfig();
-      if (migration.changed) {
-        migrationStep = {
-          target: '~/.trace-mcp/.config.json',
-          action: 'updated',
-          detail: `Config migrated — added: ${migration.added.join(', ')}`,
-        };
-      }
-    }
-
-    // Detect existing MCP clients and hook state
-    const mcpClients = detectMcpClients();
-    const { hasGuardHook, guardHookVersion } = detectGuardHook();
-
-    // --- Interactive questions ---
-    let selectedClients: DetectedMcpClient['name'][] = [];
-    let installHooks = !opts.skipHooks;
-    let claudeMdScope: 'global' | 'skip' = opts.skipClaudeMd ? 'skip' : 'global';
-    let installTweakcc = false;
-    let agentBehavior: 'strict' | 'off' = 'off';
-    let indexProject = opts.index ?? false;
-    let fixConflicts = false;
-    let installApp = false;
-
-    if (!nonInteractive) {
-      p.intro('trace-mcp init');
-      p.note('Global one-time setup. Use `trace-mcp add` to register projects.', 'Info');
-
-      // Q1: Which MCP clients
-      if (!opts.skipMcpClient && !opts.mcpClient) {
-        const allClients: DetectedMcpClient['name'][] = ['claude-code', 'claw-code', 'claude-desktop', 'cursor', 'windsurf', 'continue', 'junie', 'jetbrains-ai', 'codex', 'hermes'];
-        const detectedNames = new Set(mcpClients.map((c) => c.name));
-
-        const clientResult = await p.multiselect({
-          message: 'MCP clients to configure (global)',
-          options: allClients.map((name) => ({
-            value: name,
-            label: formatClientName(name),
-            hint: detectedNames.has(name) ? 'detected' : undefined,
-          })),
-          initialValues: [...detectedNames].length > 0
-            ? [...detectedNames]
-            : ['claude-code'],
-          required: true,
-        });
-        if (p.isCancel(clientResult)) { p.cancel('Cancelled.'); process.exit(0); }
-        selectedClients = clientResult as DetectedMcpClient['name'][];
-      }
-
-      // Q2: Enforcement level (Claude Code only — hooks & tweakcc are CC-specific)
-      const hasClaudeCode = selectedClients.includes('claude-code') || selectedClients.includes('claw-code') || selectedClients.includes('claude-desktop');
-
-      if (hasClaudeCode && !opts.skipHooks) {
-        const tweakccState = detectTweakccPrompts();
-
-        const levelResult = await p.select({
-          message: 'Enforcement level (Claude Code)',
-          options: [
-            {
-              value: 'base' as const,
-              label: 'Base — CLAUDE.md only',
-              hint: 'soft routing rules in project instructions',
-            },
-            {
-              value: 'standard' as const,
-              label: 'Standard — CLAUDE.md + hooks',
-              hint: 'guard hooks intercept tool calls at runtime',
-            },
-            {
-              value: 'max' as const,
-              label: 'Max — CLAUDE.md + hooks + tweakcc',
-              hint: tweakccState.installed
-                ? 'patches Claude\'s system prompts (recommended)'
-                : 'auto-installs tweakcc via npx (recommended)',
-            },
-          ],
-          initialValue: 'max' as const,
-        });
-        if (p.isCancel(levelResult)) { p.cancel('Cancelled.'); process.exit(0); }
-
-        claudeMdScope = 'global';
-        installHooks = levelResult === 'standard' || levelResult === 'max';
-        installTweakcc = levelResult === 'max';
-        agentBehavior = levelResult === 'max' ? 'strict' : 'off';
-      } else {
-        // Non-CC clients: always install CLAUDE.md, no hooks/tweakcc
-        claudeMdScope = opts.skipClaudeMd ? 'skip' : 'global';
-        installHooks = false;
-        installTweakcc = false;
-        agentBehavior = 'off';
-      }
-
-      // Q4: Index current project
-      if (!opts.index) {
-        const indexResult = await p.confirm({
-          message: 'Register and index current project?',
-          initialValue: false,
-        });
-        if (p.isCancel(indexResult)) { p.cancel('Cancelled.'); process.exit(0); }
-        indexProject = indexResult;
-      }
-
-      // Q5: Check for competing tools (only for selected clients)
-      {
-        let projectRoot: string | undefined;
-        try { projectRoot = findProjectRoot(process.cwd()); } catch { /* no project */ }
-        const conflictReport = detectConflicts(projectRoot);
-        const clientSet = new Set(selectedClients);
-        const fixable = conflictReport.conflicts.filter((c) => {
-          if (!c.fixable) return false;
-          if (c.category === 'mcp_server') {
-            const clientName = c.id.split(':')[2] as DetectedMcpClient['name'];
-            return clientSet.has(clientName);
-          }
-          return true;
-        });
-        if (fixable.length > 0) {
-          const critical = fixable.filter((c) => c.severity === 'critical');
-          const label = critical.length > 0
-            ? `Found ${fixable.length} conflicting tool${fixable.length > 1 ? 's' : ''} (${critical.length} critical). Fix them? (recommended)`
-            : `Found ${fixable.length} competing tool artifact${fixable.length > 1 ? 's' : ''}. Clean up?`;
-          for (const c of fixable) {
-            p.log.warn(`  ${c.summary}`);
-          }
-          const fixResult = await p.confirm({
-            message: label,
-            initialValue: true,
-          });
-          if (p.isCancel(fixResult)) { p.cancel('Cancelled.'); process.exit(0); }
-          fixConflicts = fixResult;
+      // Ensure global directory structure + migrate config
+      let migrationStep: InitStepResult | undefined;
+      if (!opts.dryRun) {
+        ensureGlobalDirs();
+        const migration = migrateGlobalConfig();
+        if (migration.changed) {
+          migrationStep = {
+            target: '~/.trace-mcp/.config.json',
+            action: 'updated',
+            detail: `Config migrated — added: ${migration.added.join(', ')}`,
+          };
         }
       }
 
-      // Q6: Install or update menu bar app (macOS / Windows)
-      if (process.platform === 'darwin' || process.platform === 'win32') {
-        const appExists = isAppInstalled();
-        const appOutdated = appExists && isAppOutdated();
+      // Detect existing MCP clients and hook state
+      const mcpClients = detectMcpClients();
+      const { hasGuardHook, guardHookVersion } = detectGuardHook();
 
-        if (!appExists || appOutdated) {
-          const message = appOutdated
-            ? 'Update trace-mcp menu bar app to latest version?'
-            : 'Install trace-mcp menu bar app?';
-          const appResult = await p.confirm({
-            message,
-            initialValue: true,
-          });
-          if (p.isCancel(appResult)) { p.cancel('Cancelled.'); process.exit(0); }
-          installApp = appResult;
-        }
-      }
-    } else {
-      // Non-interactive defaults
-      if (opts.mcpClient) {
-        selectedClients = [opts.mcpClient as DetectedMcpClient['name']];
-      } else if (!opts.skipMcpClient) {
-        selectedClients = ['claude-code'];
-      }
-      // Non-interactive defaults to Max when Claude Code is the target and
-      // hooks aren't explicitly skipped — mirrors the interactive initialValue.
-      const hasClaudeCode = selectedClients.includes('claude-code') || selectedClients.includes('claw-code') || selectedClients.includes('claude-desktop');
-      installTweakcc = hasClaudeCode && !opts.skipHooks;
-      agentBehavior = installTweakcc ? 'strict' : 'off';
-      // Auto-fix conflicts in non-interactive mode
-      fixConflicts = true;
-    }
-
-    // --- Execute ---
-    const steps: InitStepResult[] = [];
-    if (migrationStep) steps.push(migrationStep);
-
-    if (!nonInteractive) {
-      const spin = p.spinner();
-      spin.start('Setting up trace-mcp');
-      try {
-        executeSteps(steps, { selectedClients, installHooks, installTweakcc, agentBehavior, claudeMdScope, force: opts.force, dryRun: opts.dryRun });
-      } catch (err) {
-        spin.stop('Failed');
-        p.log.error(`Setup failed: ${(err as Error).message}`);
-        process.exit(1);
-      }
-      spin.stop('Done');
-    } else {
-      executeSteps(steps, { selectedClients, installHooks, installTweakcc, agentBehavior, claudeMdScope, force: opts.force, dryRun: opts.dryRun });
-    }
-
-    // --- Fix competing tools ---
-    if (fixConflicts) {
-      try {
-        let projectRoot: string | undefined;
-        try { projectRoot = findProjectRoot(process.cwd()); } catch { /* no project */ }
-        const conflictReport = detectConflicts(projectRoot);
-        const clientSet = new Set(selectedClients);
-        const fixable = conflictReport.conflicts.filter((c) => {
-          if (!c.fixable) return false;
-          // Only fix MCP server conflicts for clients the user selected
-          if (c.category === 'mcp_server') {
-            const clientName = c.id.split(':')[2] as DetectedMcpClient['name']; // id format: "mcp:<server>:<client>:<path>"
-            return clientSet.has(clientName);
-          }
-          return true;
-        });
-        if (fixable.length > 0) {
-          const results = fixAllConflicts(fixable, { dryRun: opts.dryRun });
-          for (const r of results) {
-            if (r.action !== 'skipped') {
-              steps.push({ target: r.target, action: 'updated', detail: `${r.action}: ${r.detail}` });
-            }
-          }
-        }
-      } catch (err) {
-        if (!nonInteractive) {
-          p.log.error(`Conflict resolution failed: ${(err as Error).message}`);
-        } else {
-          console.error(`Conflict resolution failed: ${(err as Error).message}`);
-        }
-      }
-    }
-
-    // --- Optional project indexing ---
-    if (indexProject) {
-      const spin = !nonInteractive ? p.spinner() : null;
-      spin?.start('Registering and indexing current project...');
-      const indexStep = await registerAndIndexProject(process.cwd(), { dryRun: opts.dryRun, force: opts.force });
-      if (spin) {
-        if (indexStep.detail?.includes('Indexed')) {
-          spin.stop(indexStep.detail);
-        } else {
-          spin.stop(indexStep.detail ?? indexStep.action);
-        }
-      }
-      steps.push(indexStep);
-    }
-
-    // --- Upgrade existing projects if previous installation detected ---
-    const existingProjects = listProjects();
-    if (existingProjects.length > 0) {
-      let runUpgrade = false;
+      // --- Interactive questions ---
+      let selectedClients: DetectedMcpClient['name'][] = [];
+      let installHooks = !opts.skipHooks;
+      let claudeMdScope: 'global' | 'skip' = opts.skipClaudeMd ? 'skip' : 'global';
+      let installTweakcc = false;
+      let agentBehavior: 'strict' | 'off' = 'off';
+      let indexProject = opts.index ?? false;
+      let fixConflicts = false;
+      let installApp = false;
 
       if (!nonInteractive) {
-        const upgradeResult = await p.confirm({
-          message: `Found ${existingProjects.length} registered project${existingProjects.length > 1 ? 's' : ''} from a previous installation. Run upgrade (migrations + reindex)?`,
-          initialValue: true,
-        });
-        if (p.isCancel(upgradeResult)) { p.cancel('Cancelled.'); process.exit(0); }
-        runUpgrade = upgradeResult;
-      } else {
-        // Non-interactive: auto-upgrade
-        runUpgrade = true;
-      }
+        p.intro('trace-mcp init');
+        p.note('Global one-time setup. Use `trace-mcp add` to register projects.', 'Info');
 
-      if (runUpgrade) {
-        const spin = !nonInteractive ? p.spinner() : null;
-        spin?.start('Upgrading registered projects');
+        // Q1: Which MCP clients
+        if (!opts.skipMcpClient && !opts.mcpClient) {
+          const allClients: DetectedMcpClient['name'][] = [
+            'claude-code',
+            'claw-code',
+            'claude-desktop',
+            'cursor',
+            'windsurf',
+            'continue',
+            'junie',
+            'jetbrains-ai',
+            'codex',
+            'hermes',
+            'amp',
+            'warp',
+            'factory-droid',
+          ];
+          const detectedNames = new Set(mcpClients.map((c) => c.name));
 
-        for (const proj of existingProjects) {
-          if (!fs.existsSync(proj.root)) {
-            steps.push({ target: proj.root, action: 'skipped', detail: 'Directory not found (stale)' });
-            continue;
+          const clientResult = await p.multiselect({
+            message: 'MCP clients to configure (global)',
+            options: allClients.map((name) => ({
+              value: name,
+              label: formatClientName(name),
+              hint: detectedNames.has(name) ? 'detected' : undefined,
+            })),
+            initialValues: [...detectedNames].length > 0 ? [...detectedNames] : ['claude-code'],
+            required: true,
+          });
+          if (p.isCancel(clientResult)) {
+            p.cancel('Cancelled.');
+            process.exit(0);
+          }
+          selectedClients = clientResult as DetectedMcpClient['name'][];
+        }
+
+        // Q2: Enforcement level (Claude Code only — hooks & tweakcc are CC-specific)
+        const hasClaudeCode =
+          selectedClients.includes('claude-code') ||
+          selectedClients.includes('claw-code') ||
+          selectedClients.includes('claude-desktop');
+
+        if (hasClaudeCode && !opts.skipHooks) {
+          const tweakccState = detectTweakccPrompts();
+
+          const levelResult = await p.select({
+            message: 'Enforcement level (Claude Code)',
+            options: [
+              {
+                value: 'base' as const,
+                label: 'Base — CLAUDE.md only',
+                hint: 'soft routing rules in project instructions',
+              },
+              {
+                value: 'standard' as const,
+                label: 'Standard — CLAUDE.md + hooks',
+                hint: 'guard hooks intercept tool calls at runtime',
+              },
+              {
+                value: 'max' as const,
+                label: 'Max — CLAUDE.md + hooks + tweakcc',
+                hint: tweakccState.installed
+                  ? "patches Claude's system prompts (recommended)"
+                  : 'auto-installs tweakcc via npx (recommended)',
+              },
+            ],
+            initialValue: 'max' as const,
+          });
+          if (p.isCancel(levelResult)) {
+            p.cancel('Cancelled.');
+            process.exit(0);
           }
 
-          if (opts.dryRun) {
-            steps.push({ target: proj.root, action: 'skipped', detail: 'Would run migrations + reindex' });
-            continue;
-          }
+          claudeMdScope = 'global';
+          installHooks = levelResult === 'standard' || levelResult === 'max';
+          installTweakcc = levelResult === 'max';
+          agentBehavior = levelResult === 'max' ? 'strict' : 'off';
+        } else {
+          // Non-CC clients: always install CLAUDE.md, no hooks/tweakcc
+          claudeMdScope = opts.skipClaudeMd ? 'skip' : 'global';
+          installHooks = false;
+          installTweakcc = false;
+          agentBehavior = 'off';
+        }
 
-          const configResult = await loadConfig(proj.root);
-          if (configResult.isErr()) {
-            steps.push({ target: proj.root, action: 'skipped', detail: 'Config load failed' });
-            continue;
+        // Q4: Index current project
+        if (!opts.index) {
+          const indexResult = await p.confirm({
+            message: 'Register and index current project?',
+            initialValue: false,
+          });
+          if (p.isCancel(indexResult)) {
+            p.cancel('Cancelled.');
+            process.exit(0);
           }
+          indexProject = indexResult;
+        }
 
+        // Q5: Check for competing tools (only for selected clients)
+        {
+          let projectRoot: string | undefined;
           try {
-            const dbPath = getDbPath(proj.root);
-            const db = initializeDatabase(dbPath);
-            const store = new Store(db);
-
-            const registry = PluginRegistry.createWithDefaults();
-
-            const pipeline = new IndexingPipeline(store, registry, configResult.value, proj.root);
-            const result = await pipeline.indexAll(true);
-            steps.push({
-              target: proj.root, action: 'updated',
-              detail: `Upgraded: ${result.indexed} files, ${result.skipped} skipped, ${result.errors} errors`,
+            projectRoot = findProjectRoot(process.cwd());
+          } catch {
+            /* no project */
+          }
+          const conflictReport = detectConflicts(projectRoot);
+          const clientSet = new Set(selectedClients);
+          const fixable = conflictReport.conflicts.filter((c) => {
+            if (!c.fixable) return false;
+            if (c.category === 'mcp_server') {
+              const clientName = c.id.split(':')[2] as DetectedMcpClient['name'];
+              return clientSet.has(clientName);
+            }
+            return true;
+          });
+          if (fixable.length > 0) {
+            const critical = fixable.filter((c) => c.severity === 'critical');
+            const label =
+              critical.length > 0
+                ? `Found ${fixable.length} conflicting tool${fixable.length > 1 ? 's' : ''} (${critical.length} critical). Fix them? (recommended)`
+                : `Found ${fixable.length} competing tool artifact${fixable.length > 1 ? 's' : ''}. Clean up?`;
+            for (const c of fixable) {
+              p.log.warn(`  ${c.summary}`);
+            }
+            const fixResult = await p.confirm({
+              message: label,
+              initialValue: true,
             });
-            updateLastIndexed(proj.root);
-            db.close();
-          } catch (err) {
-            steps.push({ target: proj.root, action: 'skipped', detail: `Upgrade failed: ${(err as Error).message}` });
+            if (p.isCancel(fixResult)) {
+              p.cancel('Cancelled.');
+              process.exit(0);
+            }
+            fixConflicts = fixResult;
           }
         }
 
-        spin?.stop('Upgrade complete');
-      }
-    }
+        // Q6: Install or update menu bar app (macOS / Windows)
+        if (process.platform === 'darwin' || process.platform === 'win32') {
+          const appExists = isAppInstalled();
+          const appOutdated = appExists && isAppOutdated();
 
-    // --- Install menu bar app ---
-    if (installApp && !opts.dryRun) {
-      const spin = p.spinner();
-      spin.start('Downloading trace-mcp menu bar app…');
-      const appResult = await installGuiApp({
-        retries: 3,
-        retryDelayMs: 15_000,
-        onRetry: (attempt, total) => {
-          spin.message(`App asset not uploaded yet, retrying (${attempt}/${total})…`);
-        },
-      });
-      if (appResult.installed) {
-        spin.stop(`Installed → ${appResult.path}`);
-        steps.push({ target: appResult.path!, action: 'created', detail: 'Menu bar app installed' });
-      } else {
-        spin.stop('App installation failed');
-        p.log.warn(`Could not install app: ${appResult.error}`);
-        const fallbackPath = process.platform === 'darwin' ? '~/Applications/trace-mcp.app' : 'trace-mcp';
-        steps.push({ target: fallbackPath, action: 'skipped', detail: appResult.error ?? 'Installation failed' });
-      }
-    }
-
-    // --- Ensure daemon is running ---
-    if (!opts.dryRun && (process.platform === 'darwin' || process.platform === 'win32')) {
-      try {
-        const started = await ensureDaemonRunning();
-        if (started) {
-          const method = process.platform === 'darwin' ? 'launchd' : 'background process';
-          steps.push({ target: 'daemon', action: 'updated', detail: `Daemon started (${method})` });
+          if (!appExists || appOutdated) {
+            const message = appOutdated
+              ? 'Update trace-mcp menu bar app to latest version?'
+              : 'Install trace-mcp menu bar app?';
+            const appResult = await p.confirm({
+              message,
+              initialValue: true,
+            });
+            if (p.isCancel(appResult)) {
+              p.cancel('Cancelled.');
+              process.exit(0);
+            }
+            installApp = appResult;
+          }
         }
-      } catch { /* best effort — don't block init */ }
-    }
-
-    // --- Report ---
-    if (opts.json) {
-      console.log(JSON.stringify({ steps }, null, 2));
-    } else if (nonInteractive) {
-      const header = opts.dryRun ? 'trace-mcp init (dry run)' : 'trace-mcp init';
-      console.log(header);
-      for (const step of steps) {
-        console.log(`  ${shortPath(step.target)}  ${step.detail ?? step.action}`);
-      }
-      if (!opts.dryRun) {
-        console.log('\n  Next: run `trace-mcp add` in a project directory to register it for indexing.\n');
-      }
-    } else {
-      const created = steps.filter((s) => s.action === 'created' || s.action === 'updated');
-      const skipped = steps.filter((s) => s.action === 'already_configured');
-      // `skipped` with a detail message means something the user needs to know
-      // (e.g. Claude.app was running and overwrote our write). Surface these as warnings.
-      const warnings = steps.filter((s) => s.action === 'skipped' && s.detail);
-
-      if (created.length > 0) {
-        const lines = created.map((s) => `  ${shortPath(s.target)}  ${s.detail ?? s.action}`);
-        p.note(lines.join('\n'), 'Configured');
-      }
-      if (skipped.length > 0) {
-        const lines = skipped.map((s) => `  ${shortPath(s.target)}  ${s.detail ?? ''}`);
-        p.note(lines.join('\n'), 'Already configured');
-      }
-      if (warnings.length > 0) {
-        const lines = warnings.map((s) => `  ${shortPath(s.target)}  ${s.detail}`);
-        p.note(lines.join('\n'), 'Needs attention');
+      } else {
+        // Non-interactive defaults
+        if (opts.mcpClient) {
+          selectedClients = [opts.mcpClient as DetectedMcpClient['name']];
+        } else if (!opts.skipMcpClient) {
+          selectedClients = ['claude-code'];
+        }
+        // Non-interactive defaults to Max when Claude Code is the target and
+        // hooks aren't explicitly skipped — mirrors the interactive initialValue.
+        const hasClaudeCode =
+          selectedClients.includes('claude-code') ||
+          selectedClients.includes('claw-code') ||
+          selectedClients.includes('claude-desktop');
+        installTweakcc = hasClaudeCode && !opts.skipHooks;
+        agentBehavior = installTweakcc ? 'strict' : 'off';
+        // Auto-fix conflicts in non-interactive mode
+        fixConflicts = true;
       }
 
-      p.outro(indexProject
-        ? 'Ready! Project registered and indexed.'
-        : 'Ready! Run `trace-mcp add` in a project directory to register it for indexing.',
-      );
-    }
-  });
+      // --- Execute ---
+      const steps: InitStepResult[] = [];
+      if (migrationStep) steps.push(migrationStep);
+
+      if (!nonInteractive) {
+        const spin = p.spinner();
+        spin.start('Setting up trace-mcp');
+        try {
+          executeSteps(steps, {
+            selectedClients,
+            installHooks,
+            installTweakcc,
+            agentBehavior,
+            claudeMdScope,
+            force: opts.force,
+            dryRun: opts.dryRun,
+          });
+        } catch (err) {
+          spin.stop('Failed');
+          p.log.error(`Setup failed: ${(err as Error).message}`);
+          process.exit(1);
+        }
+        spin.stop('Done');
+      } else {
+        executeSteps(steps, {
+          selectedClients,
+          installHooks,
+          installTweakcc,
+          agentBehavior,
+          claudeMdScope,
+          force: opts.force,
+          dryRun: opts.dryRun,
+        });
+      }
+
+      // --- Fix competing tools ---
+      if (fixConflicts) {
+        try {
+          let projectRoot: string | undefined;
+          try {
+            projectRoot = findProjectRoot(process.cwd());
+          } catch {
+            /* no project */
+          }
+          const conflictReport = detectConflicts(projectRoot);
+          const clientSet = new Set(selectedClients);
+          const fixable = conflictReport.conflicts.filter((c) => {
+            if (!c.fixable) return false;
+            // Only fix MCP server conflicts for clients the user selected
+            if (c.category === 'mcp_server') {
+              const clientName = c.id.split(':')[2] as DetectedMcpClient['name']; // id format: "mcp:<server>:<client>:<path>"
+              return clientSet.has(clientName);
+            }
+            return true;
+          });
+          if (fixable.length > 0) {
+            const results = fixAllConflicts(fixable, { dryRun: opts.dryRun });
+            for (const r of results) {
+              if (r.action !== 'skipped') {
+                steps.push({
+                  target: r.target,
+                  action: 'updated',
+                  detail: `${r.action}: ${r.detail}`,
+                });
+              }
+            }
+          }
+        } catch (err) {
+          if (!nonInteractive) {
+            p.log.error(`Conflict resolution failed: ${(err as Error).message}`);
+          } else {
+            console.error(`Conflict resolution failed: ${(err as Error).message}`);
+          }
+        }
+      }
+
+      // --- Optional project indexing ---
+      if (indexProject) {
+        const spin = !nonInteractive ? p.spinner() : null;
+        spin?.start('Registering and indexing current project...');
+        const indexStep = await registerAndIndexProject(process.cwd(), {
+          dryRun: opts.dryRun,
+          force: opts.force,
+        });
+        if (spin) {
+          if (indexStep.detail?.includes('Indexed')) {
+            spin.stop(indexStep.detail);
+          } else {
+            spin.stop(indexStep.detail ?? indexStep.action);
+          }
+        }
+        steps.push(indexStep);
+      }
+
+      // --- Upgrade existing projects if previous installation detected ---
+      const existingProjects = listProjects();
+      if (existingProjects.length > 0) {
+        let runUpgrade = false;
+
+        if (!nonInteractive) {
+          const upgradeResult = await p.confirm({
+            message: `Found ${existingProjects.length} registered project${existingProjects.length > 1 ? 's' : ''} from a previous installation. Run upgrade (migrations + reindex)?`,
+            initialValue: true,
+          });
+          if (p.isCancel(upgradeResult)) {
+            p.cancel('Cancelled.');
+            process.exit(0);
+          }
+          runUpgrade = upgradeResult;
+        } else {
+          // Non-interactive: auto-upgrade
+          runUpgrade = true;
+        }
+
+        if (runUpgrade) {
+          const spin = !nonInteractive ? p.spinner() : null;
+          spin?.start('Upgrading registered projects');
+
+          for (const proj of existingProjects) {
+            if (!fs.existsSync(proj.root)) {
+              steps.push({
+                target: proj.root,
+                action: 'skipped',
+                detail: 'Directory not found (stale)',
+              });
+              continue;
+            }
+
+            if (opts.dryRun) {
+              steps.push({
+                target: proj.root,
+                action: 'skipped',
+                detail: 'Would run migrations + reindex',
+              });
+              continue;
+            }
+
+            const configResult = await loadConfig(proj.root);
+            if (configResult.isErr()) {
+              steps.push({ target: proj.root, action: 'skipped', detail: 'Config load failed' });
+              continue;
+            }
+
+            try {
+              const dbPath = getDbPath(proj.root);
+              const db = initializeDatabase(dbPath);
+              const store = new Store(db);
+
+              const registry = PluginRegistry.createWithDefaults();
+
+              const pipeline = new IndexingPipeline(store, registry, configResult.value, proj.root);
+              const result = await pipeline.indexAll(true);
+              steps.push({
+                target: proj.root,
+                action: 'updated',
+                detail: `Upgraded: ${result.indexed} files, ${result.skipped} skipped, ${result.errors} errors`,
+              });
+              updateLastIndexed(proj.root);
+              db.close();
+            } catch (err) {
+              steps.push({
+                target: proj.root,
+                action: 'skipped',
+                detail: `Upgrade failed: ${(err as Error).message}`,
+              });
+            }
+          }
+
+          spin?.stop('Upgrade complete');
+        }
+      }
+
+      // --- Install menu bar app ---
+      if (installApp && !opts.dryRun) {
+        const spin = p.spinner();
+        spin.start('Downloading trace-mcp menu bar app…');
+        const appResult = await installGuiApp({
+          retries: 3,
+          retryDelayMs: 15_000,
+          onRetry: (attempt, total) => {
+            spin.message(`App asset not uploaded yet, retrying (${attempt}/${total})…`);
+          },
+        });
+        if (appResult.installed) {
+          spin.stop(`Installed → ${appResult.path}`);
+          steps.push({
+            target: appResult.path!,
+            action: 'created',
+            detail: 'Menu bar app installed',
+          });
+        } else {
+          spin.stop('App installation failed');
+          p.log.warn(`Could not install app: ${appResult.error}`);
+          const fallbackPath =
+            process.platform === 'darwin' ? '~/Applications/trace-mcp.app' : 'trace-mcp';
+          steps.push({
+            target: fallbackPath,
+            action: 'skipped',
+            detail: appResult.error ?? 'Installation failed',
+          });
+        }
+      }
+
+      // --- Ensure daemon is running ---
+      if (!opts.dryRun && (process.platform === 'darwin' || process.platform === 'win32')) {
+        try {
+          const started = await ensureDaemonRunning();
+          if (started) {
+            const method = process.platform === 'darwin' ? 'launchd' : 'background process';
+            steps.push({
+              target: 'daemon',
+              action: 'updated',
+              detail: `Daemon started (${method})`,
+            });
+          }
+        } catch {
+          /* best effort — don't block init */
+        }
+      }
+
+      // --- Report ---
+      if (opts.json) {
+        console.log(JSON.stringify({ steps }, null, 2));
+      } else if (nonInteractive) {
+        const header = opts.dryRun ? 'trace-mcp init (dry run)' : 'trace-mcp init';
+        console.log(header);
+        for (const step of steps) {
+          console.log(`  ${shortPath(step.target)}  ${step.detail ?? step.action}`);
+        }
+        if (!opts.dryRun) {
+          console.log(
+            '\n  Next: run `trace-mcp add` in a project directory to register it for indexing.\n',
+          );
+        }
+      } else {
+        const created = steps.filter((s) => s.action === 'created' || s.action === 'updated');
+        const skipped = steps.filter((s) => s.action === 'already_configured');
+        // `skipped` with a detail message means something the user needs to know
+        // (e.g. Claude.app was running and overwrote our write). Surface these as warnings.
+        const warnings = steps.filter((s) => s.action === 'skipped' && s.detail);
+
+        if (created.length > 0) {
+          const lines = created.map((s) => `  ${shortPath(s.target)}  ${s.detail ?? s.action}`);
+          p.note(lines.join('\n'), 'Configured');
+        }
+        if (skipped.length > 0) {
+          const lines = skipped.map((s) => `  ${shortPath(s.target)}  ${s.detail ?? ''}`);
+          p.note(lines.join('\n'), 'Already configured');
+        }
+        if (warnings.length > 0) {
+          const lines = warnings.map((s) => `  ${shortPath(s.target)}  ${s.detail}`);
+          p.note(lines.join('\n'), 'Needs attention');
+        }
+
+        p.outro(
+          indexProject
+            ? 'Ready! Project registered and indexed.'
+            : 'Ready! Run `trace-mcp add` in a project directory to register it for indexing.',
+        );
+      }
+    },
+  );
 
 // --- Helpers ---
 
@@ -498,10 +619,12 @@ function executeSteps(
     steps.push(mdResult);
   }
 
-  // 4b. AGENTS.md (project-scope, only when Hermes selected — Hermes only
-  // reads AGENTS.md from the current working directory, so a user-level
-  // install is meaningless).
-  if (opts.selectedClients.includes('hermes')) {
+  // 4b. AGENTS.md (project-scope) for clients that read it from the project root.
+  // Hermes, AMP, Warp Agents, and Factory Droid all consume AGENTS.md as their
+  // primary instruction surface. Cursor/Windsurf have their own per-tool rule
+  // formats (covered above), so they don't trigger AGENTS.md generation.
+  const agentsMdClients: DetectedMcpClient['name'][] = ['hermes', 'amp', 'warp', 'factory-droid'];
+  if (opts.selectedClients.some((c) => agentsMdClients.includes(c))) {
     const agentsResult = updateAgentsMd(process.cwd(), { dryRun: opts.dryRun });
     steps.push(agentsResult);
   }
@@ -515,10 +638,7 @@ function executeSteps(
   steps.push(applyAgentBehavior(opts.agentBehavior, { dryRun: opts.dryRun }));
 }
 
-function applyAgentBehavior(
-  target: 'strict' | 'off',
-  opts: { dryRun?: boolean },
-): InitStepResult {
+function applyAgentBehavior(target: 'strict' | 'off', opts: { dryRun?: boolean }): InitStepResult {
   if (opts.dryRun) {
     return {
       target: GLOBAL_CONFIG_PATH,
@@ -527,7 +647,9 @@ function applyAgentBehavior(
     };
   }
   try {
-    const parsed = parseJsonc(readGlobalConfigText()) as { tools?: { agent_behavior?: string } } | null;
+    const parsed = parseJsonc(readGlobalConfigText()) as {
+      tools?: { agent_behavior?: string };
+    } | null;
     const current = parsed?.tools?.agent_behavior ?? 'off';
     if (current === target) {
       return {
@@ -556,7 +678,9 @@ function formatDuration(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
-async function runIndexingForProject(projectRoot: string): Promise<{ indexed: number; skipped: number; errors: number; durationMs: number } | null> {
+async function runIndexingForProject(
+  projectRoot: string,
+): Promise<{ indexed: number; skipped: number; errors: number; durationMs: number } | null> {
   const configResult = await loadConfig(projectRoot);
   if (configResult.isErr()) return null;
 
@@ -569,7 +693,12 @@ async function runIndexingForProject(projectRoot: string): Promise<{ indexed: nu
   try {
     const result = await pipeline.indexAll(true);
     updateLastIndexed(projectRoot);
-    return { indexed: result.indexed, skipped: result.skipped, errors: result.errors, durationMs: result.durationMs };
+    return {
+      indexed: result.indexed,
+      skipped: result.skipped,
+      errors: result.errors,
+      durationMs: result.durationMs,
+    };
   } catch {
     return null;
   } finally {
@@ -603,7 +732,11 @@ async function registerAndIndexProject(
   if (!projectRoot) {
     const childRoots = discoverChildProjects(dir);
     if (childRoots.length === 0) {
-      return { target: dir, action: 'skipped', detail: 'Could not detect project root or child projects' };
+      return {
+        target: dir,
+        action: 'skipped',
+        detail: 'Could not detect project root or child projects',
+      };
     }
     return await registerMultiRootProject(dir, childRoots, opts);
   }
@@ -614,7 +747,11 @@ async function registerAndIndexProject(
 
   const existing = getProject(projectRoot);
   if (existing && !opts.force) {
-    return { target: projectRoot, action: 'already_configured', detail: `Project already registered: ${existing.name}` };
+    return {
+      target: projectRoot,
+      action: 'already_configured',
+      detail: `Project already registered: ${existing.name}`,
+    };
   }
 
   const { entry } = setupProject(projectRoot, { force: opts.force, migrateOldDb: true });
@@ -647,7 +784,11 @@ async function registerMultiRootProject(
 
   const existing = getProject(parentDir);
   if (existing && !opts.force) {
-    return { target: parentDir, action: 'already_configured', detail: `Multi-root already registered: ${existing.name}` };
+    return {
+      target: parentDir,
+      action: 'already_configured',
+      detail: `Multi-root already registered: ${existing.name}`,
+    };
   }
 
   // Detect and merge configs from all children
@@ -704,12 +845,16 @@ function formatClientName(name: string): string {
     'claude-code': 'Claude Code',
     'claw-code': 'Claw Code',
     'claude-desktop': 'Claude Desktop',
-    'cursor': 'Cursor',
-    'windsurf': 'Windsurf',
-    'continue': 'Continue',
-    'junie': 'Junie',
+    cursor: 'Cursor',
+    windsurf: 'Windsurf',
+    continue: 'Continue',
+    junie: 'Junie',
     'jetbrains-ai': 'JetBrains AI Assistant',
-    'codex': 'Codex',
+    codex: 'Codex',
+    hermes: 'Hermes Agent',
+    amp: 'AMP',
+    warp: 'Warp',
+    'factory-droid': 'Factory Droid',
   };
   return names[name] ?? name;
 }

--- a/src/init/conflict-detector.ts
+++ b/src/init/conflict-detector.ts
@@ -19,12 +19,12 @@ const HOME = os.homedir();
 export type ConflictSeverity = 'critical' | 'warning' | 'info';
 
 type ConflictCategory =
-  | 'mcp_server'     // Competing MCP server registered in client config
-  | 'hook'           // Competing PreToolUse / PostToolUse hooks
-  | 'hook_script'    // Physical hook script files on disk
-  | 'claude_md'      // Competing CLAUDE.md blocks / instructions
-  | 'ide_rules'      // .cursorrules, .windsurfrules, .clinerules with competing directives
-  | 'config_file'    // .jcodemunch.jsonc, .code-index/, etc.
+  | 'mcp_server' // Competing MCP server registered in client config
+  | 'hook' // Competing PreToolUse / PostToolUse hooks
+  | 'hook_script' // Physical hook script files on disk
+  | 'claude_md' // Competing CLAUDE.md blocks / instructions
+  | 'ide_rules' // .cursorrules, .windsurfrules, .clinerules with competing directives
+  | 'config_file' // .jcodemunch.jsonc, .code-index/, etc.
   | 'global_artifact'; // ~/.code-index/ and similar global state
 
 export interface Conflict {
@@ -59,21 +59,21 @@ interface ConflictReport {
 /** MCP server names that compete with trace-mcp for code intelligence. */
 const COMPETING_MCP_SERVERS: Record<string, string> = {
   // jcodemunch / code-index family
-  'jcodemunch': 'jcodemunch-mcp',
+  jcodemunch: 'jcodemunch-mcp',
   'jcodemunch-mcp': 'jcodemunch-mcp',
   'code-index': 'code-index',
   'code-index-mcp': 'code-index',
   // repomix — repo packing / context bundling
-  'repomix': 'repomix',
+  repomix: 'repomix',
   'repomix-mcp': 'repomix',
-  'repopack': 'repomix',
+  repopack: 'repomix',
   // aider
-  'aider': 'aider',
+  aider: 'aider',
   'aider-mcp': 'aider',
   // sourcegraph / cody
-  'sourcegraph': 'sourcegraph',
+  sourcegraph: 'sourcegraph',
   'sourcegraph-mcp': 'sourcegraph',
-  'cody': 'sourcegraph-cody',
+  cody: 'sourcegraph-cody',
   'cody-mcp': 'sourcegraph-cody',
   // generic code intelligence MCP servers
   'codebase-mcp': 'codebase-mcp',
@@ -81,11 +81,11 @@ const COMPETING_MCP_SERVERS: Record<string, string> = {
   'code-compass-mcp': 'code-compass',
   'repo-map': 'repo-map',
   'repo-map-mcp': 'repo-map',
-  'greptile': 'greptile',
+  greptile: 'greptile',
   'greptile-mcp': 'greptile',
-  'codegraph': 'codegraph',
+  codegraph: 'codegraph',
   'codegraph-mcp': 'codegraph',
-  'codesearch': 'codesearch',
+  codesearch: 'codesearch',
   'codesearch-mcp': 'codesearch',
 };
 
@@ -106,12 +106,22 @@ const COMPETING_HOOK_PATTERNS: { pattern: RegExp; competitor: string }[] = [
 /** CLAUDE.md content patterns that indicate competing tool injections. */
 const COMPETING_CLAUDE_MD_PATTERNS: { pattern: RegExp; competitor: string; marker?: string }[] = [
   // jcodemunch — marker blocks
-  { pattern: /<!-- ?jcodemunch:start ?-->/i, competitor: 'jcodemunch-mcp', marker: 'jcodemunch:start' },
+  {
+    pattern: /<!-- ?jcodemunch:start ?-->/i,
+    competitor: 'jcodemunch-mcp',
+    marker: 'jcodemunch:start',
+  },
   { pattern: /<!-- ?code-index:start ?-->/i, competitor: 'code-index', marker: 'code-index:start' },
   // jcodemunch — tool name references (distinctive API surface)
   { pattern: /jcodemunch|jCodeMunch/i, competitor: 'jcodemunch-mcp' },
-  { pattern: /get_file_outline|get_symbol_source|get_context_bundle|get_ranked_context/i, competitor: 'jcodemunch-mcp' },
-  { pattern: /embed_repo|get_blast_radius|get_session_stats|suggest_queries/i, competitor: 'jcodemunch-mcp' },
+  {
+    pattern: /get_file_outline|get_symbol_source|get_context_bundle|get_ranked_context/i,
+    competitor: 'jcodemunch-mcp',
+  },
+  {
+    pattern: /embed_repo|get_blast_radius|get_session_stats|suggest_queries/i,
+    competitor: 'jcodemunch-mcp',
+  },
   // repomix
   { pattern: /<!-- ?repomix:start ?-->/i, competitor: 'repomix', marker: 'repomix:start' },
   { pattern: /repomix|repopack/i, competitor: 'repomix' },
@@ -239,7 +249,8 @@ function scanMcpServerConfigs(projectRoot?: string): Conflict[] {
         category: 'mcp_server',
         severity: 'critical',
         summary: `Competing MCP server "${serverName}" registered in ${clientName}`,
-        detail: `Server "${serverName}" (${competitorName}) is registered in ${shortPath(configPath)}. ` +
+        detail:
+          `Server "${serverName}" (${competitorName}) is registered in ${shortPath(configPath)}. ` +
           `It provides overlapping code intelligence tools that will conflict with trace-mcp.`,
         target: configPath,
         competitor: competitorName,
@@ -260,7 +271,10 @@ function getMcpConfigPaths(projectRoot?: string): { clientName: string; configPa
     paths.push({ clientName: 'claude-code', configPath: path.join(projectRoot, '.mcp.json') });
   }
   paths.push({ clientName: 'claude-code', configPath: path.join(HOME, '.claude.json') });
-  paths.push({ clientName: 'claude-code', configPath: path.join(HOME, '.claude', 'settings.json') });
+  paths.push({
+    clientName: 'claude-code',
+    configPath: path.join(HOME, '.claude', 'settings.json'),
+  });
 
   // Claw Code
   if (projectRoot) {
@@ -270,10 +284,22 @@ function getMcpConfigPaths(projectRoot?: string): { clientName: string; configPa
 
   // Claude Desktop
   if (platform === 'darwin') {
-    paths.push({ clientName: 'claude-desktop', configPath: path.join(HOME, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json') });
+    paths.push({
+      clientName: 'claude-desktop',
+      configPath: path.join(
+        HOME,
+        'Library',
+        'Application Support',
+        'Claude',
+        'claude_desktop_config.json',
+      ),
+    });
   } else if (platform === 'win32') {
     const appData = process.env.APPDATA ?? path.join(HOME, 'AppData', 'Roaming');
-    paths.push({ clientName: 'claude-desktop', configPath: path.join(appData, 'Claude', 'claude_desktop_config.json') });
+    paths.push({
+      clientName: 'claude-desktop',
+      configPath: path.join(appData, 'Claude', 'claude_desktop_config.json'),
+    });
   }
 
   // Cursor
@@ -285,20 +311,44 @@ function getMcpConfigPaths(projectRoot?: string): { clientName: string; configPa
   // Windsurf
   paths.push({ clientName: 'windsurf', configPath: path.join(HOME, '.windsurf', 'mcp.json') });
   if (projectRoot) {
-    paths.push({ clientName: 'windsurf', configPath: path.join(projectRoot, '.windsurf', 'mcp.json') });
+    paths.push({
+      clientName: 'windsurf',
+      configPath: path.join(projectRoot, '.windsurf', 'mcp.json'),
+    });
   }
 
   // Continue
-  paths.push({ clientName: 'continue', configPath: path.join(HOME, '.continue', 'mcpServers', 'mcp.json') });
+  paths.push({
+    clientName: 'continue',
+    configPath: path.join(HOME, '.continue', 'mcpServers', 'mcp.json'),
+  });
 
   // Junie
   paths.push({ clientName: 'junie', configPath: path.join(HOME, '.junie', 'mcp', 'mcp.json') });
   if (projectRoot) {
-    paths.push({ clientName: 'junie', configPath: path.join(projectRoot, '.junie', 'mcp', 'mcp.json') });
+    paths.push({
+      clientName: 'junie',
+      configPath: path.join(projectRoot, '.junie', 'mcp', 'mcp.json'),
+    });
   }
 
   // Codex (TOML format — conflict scanner only checks for competing server names in JSON configs,
   // so we skip Codex here since its format differs)
+
+  // AMP: scanner expects `mcpServers` key but AMP uses `amp.mcpServers`, so cross-tool
+  // server-name collisions in AMP configs would be missed. Skipping for now keeps the
+  // scanner consistent — AMP-specific conflicts surface during init writes instead.
+
+  // Factory Droid
+  paths.push({ clientName: 'factory-droid', configPath: path.join(HOME, '.factory', 'mcp.json') });
+  if (projectRoot) {
+    paths.push({
+      clientName: 'factory-droid',
+      configPath: path.join(projectRoot, '.factory', 'mcp.json'),
+    });
+  }
+
+  // Warp: cloud-synced storage — no scannable file path.
 
   return paths;
 }
@@ -324,11 +374,15 @@ function scanHooksInSettings(): Conflict[] {
         const projDir = path.join(projectsDir, entry);
         try {
           if (!fs.statSync(projDir).isDirectory()) continue;
-        } catch { continue; }
+        } catch {
+          continue;
+        }
         settingsFiles.push(path.join(projDir, 'settings.json'));
         settingsFiles.push(path.join(projDir, 'settings.local.json'));
       }
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
   for (const settingsPath of settingsFiles) {
@@ -356,13 +410,18 @@ function scanHooksInSettings(): Conflict[] {
           for (const { pattern, competitor } of COMPETING_HOOK_PATTERNS) {
             if (pattern.test(cmd)) {
               // Extract the most distinctive part of the command for ID uniqueness
-              const scriptName = cmd.split('/').pop()?.replace(/[^a-zA-Z0-9._-]/g, '') ?? `${hi}`;
+              const scriptName =
+                cmd
+                  .split('/')
+                  .pop()
+                  ?.replace(/[^a-zA-Z0-9._-]/g, '') ?? `${hi}`;
               conflicts.push({
                 id: `hook:${event}:${competitor}:${scriptName}`,
                 category: 'hook',
                 severity: 'critical',
                 summary: `Competing ${event} hook from ${competitor}`,
-                detail: `Hook command "${truncate(cmd, 80)}" in ${shortPath(settingsPath)} ` +
+                detail:
+                  `Hook command "${truncate(cmd, 80)}" in ${shortPath(settingsPath)} ` +
                   `intercepts tool calls and may block or redirect trace-mcp operations.`,
                 target: settingsPath,
                 competitor,
@@ -385,10 +444,7 @@ function scanHooksInSettings(): Conflict[] {
 
 function scanHookScriptFiles(): Conflict[] {
   const conflicts: Conflict[] = [];
-  const hooksDirs = [
-    path.join(HOME, '.claude', 'hooks'),
-    path.join(HOME, '.claw', 'hooks'),
-  ];
+  const hooksDirs = [path.join(HOME, '.claude', 'hooks'), path.join(HOME, '.claw', 'hooks')];
 
   for (const hooksDir of hooksDirs) {
     if (!fs.existsSync(hooksDir)) continue;
@@ -412,7 +468,8 @@ function scanHookScriptFiles(): Conflict[] {
             category: 'hook_script',
             severity: 'warning',
             summary: `Competing hook script: ${file}`,
-            detail: `Hook script from ${competitor} at ${shortPath(filePath)}. ` +
+            detail:
+              `Hook script from ${competitor} at ${shortPath(filePath)}. ` +
               `Even if not registered in settings.json, it may be re-enabled later.`,
             target: filePath,
             competitor,
@@ -433,10 +490,7 @@ function scanHookScriptFiles(): Conflict[] {
 
 function scanClaudeMdFiles(projectRoot?: string): Conflict[] {
   const conflicts: Conflict[] = [];
-  const files = [
-    path.join(HOME, '.claude', 'CLAUDE.md'),
-    path.join(HOME, '.claude', 'AGENTS.md'),
-  ];
+  const files = [path.join(HOME, '.claude', 'CLAUDE.md'), path.join(HOME, '.claude', 'AGENTS.md')];
 
   // Project-scoped CLAUDE.md files in ~/.claude/projects/*/
   const projectsDir = path.join(HOME, '.claude', 'projects');
@@ -456,17 +510,18 @@ function scanClaudeMdFiles(projectRoot?: string): Conflict[] {
                 files.push(path.join(memDir, memFile));
               }
             }
-          } catch { /* ignore */ }
+          } catch {
+            /* ignore */
+          }
         }
       }
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
   if (projectRoot) {
-    files.push(
-      path.join(projectRoot, 'CLAUDE.md'),
-      path.join(projectRoot, 'AGENTS.md'),
-    );
+    files.push(path.join(projectRoot, 'CLAUDE.md'), path.join(projectRoot, 'AGENTS.md'));
   }
 
   for (const filePath of files) {
@@ -525,12 +580,12 @@ function hasCompetitorSection(content: string, competitor: string): boolean {
 const COMPETITOR_ALIASES: Record<string, string[]> = {
   'jcodemunch-mcp': ['jcodemunch', 'jCodeMunch', 'code-index'],
   'code-index': ['code-index', 'codeindex'],
-  'repomix': ['repomix', 'repopack'],
-  'aider': ['aider'],
-  'cline': ['cline'],
+  repomix: ['repomix', 'repopack'],
+  aider: ['aider'],
+  cline: ['cline'],
   'sourcegraph-cody': ['cody', 'sourcegraph'],
-  'sourcegraph': ['sourcegraph'],
-  'greptile': ['greptile'],
+  sourcegraph: ['sourcegraph'],
+  greptile: ['greptile'],
   'code-compass': ['code-compass', 'codecompass'],
   'repo-map': ['repo-map', 'repomap'],
 };
@@ -554,7 +609,10 @@ function scanIdeRuleFiles(projectRoot?: string): Conflict[] {
     ruleFiles.push({ path: path.join(projectRoot, '.windsurfrules'), type: '.windsurfrules' });
     ruleFiles.push({ path: path.join(projectRoot, '.clinerules'), type: '.clinerules' });
     ruleFiles.push({ path: path.join(projectRoot, '.continuerules'), type: '.continuerules' });
-    ruleFiles.push({ path: path.join(projectRoot, '.github', 'copilot-instructions.md'), type: 'copilot-instructions.md' });
+    ruleFiles.push({
+      path: path.join(projectRoot, '.github', 'copilot-instructions.md'),
+      type: 'copilot-instructions.md',
+    });
 
     // Scan .clinerules/ directory if it exists (Cline uses both file and dir)
     const clineRulesDir = path.join(projectRoot, '.clinerules');
@@ -566,7 +624,9 @@ function scanIdeRuleFiles(projectRoot?: string): Conflict[] {
             ruleFiles.push({ path: path.join(clineRulesDir, file), type: `.clinerules/${file}` });
           }
         }
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
     }
   }
 
@@ -581,7 +641,9 @@ function scanIdeRuleFiles(projectRoot?: string): Conflict[] {
         if (!file.endsWith('.mdc') || file === 'trace-mcp.mdc') continue;
         ruleFiles.push({ path: path.join(rulesDir, file), type: `.cursor/rules/${file}` });
       }
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
   for (const { path: filePath, type } of ruleFiles) {
@@ -601,7 +663,8 @@ function scanIdeRuleFiles(projectRoot?: string): Conflict[] {
           category: 'ide_rules',
           severity: 'warning',
           summary: `${type} contains ${competitor} directives`,
-          detail: `IDE rule file ${shortPath(filePath)} references ${competitor}. ` +
+          detail:
+            `IDE rule file ${shortPath(filePath)} references ${competitor}. ` +
             `This may cause the IDE agent to prefer competing tools.`,
           target: filePath,
           competitor,
@@ -630,7 +693,8 @@ function scanProjectConfigFiles(projectRoot: string): Conflict[] {
       category: 'config_file',
       severity: 'info',
       summary: `Competing config: ${file}`,
-      detail: `Project config file for ${competitor} found at ${shortPath(filePath)}. ` +
+      detail:
+        `Project config file for ${competitor} found at ${shortPath(filePath)}. ` +
         `This won't directly conflict but indicates the project was used with a competing tool.`,
       target: filePath,
       competitor,
@@ -661,7 +725,11 @@ function scanProjectConfigDirs(projectRoot: string): Conflict[] {
 
     // Only flag directories (files are handled by scanProjectConfigFiles)
     let stat;
-    try { stat = fs.statSync(fullPath); } catch { continue; }
+    try {
+      stat = fs.statSync(fullPath);
+    } catch {
+      continue;
+    }
     if (!stat.isDirectory()) continue;
 
     conflicts.push({
@@ -669,7 +737,8 @@ function scanProjectConfigDirs(projectRoot: string): Conflict[] {
       category: 'config_file',
       severity: competitor === 'continue.dev' ? 'info' : 'warning',
       summary: `Competing config directory: ${dir}/`,
-      detail: `Config directory for ${competitor} found at ${shortPath(fullPath)}/. ` +
+      detail:
+        `Config directory for ${competitor} found at ${shortPath(fullPath)}/. ` +
         `May contain rules or cache that influence AI behavior.`,
       target: fullPath,
       competitor,
@@ -708,13 +777,21 @@ function scanContinueConfigs(projectRoot?: string): Conflict[] {
   for (const mcpDir of mcpServersDirs) {
     if (!fs.existsSync(mcpDir)) continue;
     let files: string[];
-    try { files = fs.readdirSync(mcpDir); } catch { continue; }
+    try {
+      files = fs.readdirSync(mcpDir);
+    } catch {
+      continue;
+    }
 
     for (const file of files) {
       if (!file.endsWith('.json')) continue;
       const filePath = path.join(mcpDir, file);
       let content: string;
-      try { content = fs.readFileSync(filePath, 'utf-8'); } catch { continue; }
+      try {
+        content = fs.readFileSync(filePath, 'utf-8');
+      } catch {
+        continue;
+      }
 
       // Check if any competing server names appear in the config
       for (const [serverName, competitorName] of Object.entries(COMPETING_MCP_SERVERS)) {
@@ -756,7 +833,11 @@ function scanGitHooks(projectRoot: string): Conflict[] {
     if (!fs.existsSync(hookPath)) continue;
 
     let content: string;
-    try { content = fs.readFileSync(hookPath, 'utf-8'); } catch { continue; }
+    try {
+      content = fs.readFileSync(hookPath, 'utf-8');
+    } catch {
+      continue;
+    }
 
     if (/\baider\b/i.test(content)) {
       conflicts.push({
@@ -764,7 +845,8 @@ function scanGitHooks(projectRoot: string): Conflict[] {
         category: 'hook',
         severity: 'info',
         summary: `Git ${hookFile} hook references aider`,
-        detail: `Git hook ${shortPath(hookPath)} contains aider references. ` +
+        detail:
+          `Git hook ${shortPath(hookPath)} contains aider references. ` +
           `This may modify commit messages or run aider operations on commit.`,
         target: hookPath,
         competitor: 'aider',
@@ -790,14 +872,17 @@ function scanGlobalArtifacts(): Conflict[] {
     try {
       const files = fs.readdirSync(dir);
       size = files.length;
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
 
     conflicts.push({
       id: `global:${competitor}:${dir}`,
       category: 'global_artifact',
       severity: 'info',
       summary: `Global cache: ${shortPath(dir)} (${size} files)`,
-      detail: `Global index/cache directory from ${competitor}. ` +
+      detail:
+        `Global index/cache directory from ${competitor}. ` +
         `Takes disk space but doesn't directly interfere at runtime.`,
       target: dir,
       competitor,

--- a/src/init/detector.ts
+++ b/src/init/detector.ts
@@ -6,10 +6,16 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { parse as parseJsonc } from 'jsonc-parser';
 import { buildProjectContext } from '../indexer/project-context.js';
 import { PluginRegistry } from '../plugin-api/registry.js';
 import Database from 'better-sqlite3';
-import type { DetectionResult, PackageManagerInfo, DetectedFramework, DetectedMcpClient } from './types.js';
+import type {
+  DetectionResult,
+  PackageManagerInfo,
+  DetectedFramework,
+  DetectedMcpClient,
+} from './types.js';
 import { GUARD_HOOK_VERSION } from './types.js';
 
 const HOME = os.homedir();
@@ -35,12 +41,17 @@ export function detectProject(dir: string): DetectionResult {
 
   // --- Languages from detected versions ---
   const languageMap: Record<string, string> = {
-    node: 'TypeScript', php: 'PHP', python: 'Python',
-    ruby: 'Ruby', go: 'Go', java: 'Java', rust: 'Rust',
+    node: 'TypeScript',
+    php: 'PHP',
+    python: 'Python',
+    ruby: 'Ruby',
+    go: 'Go',
+    java: 'Java',
+    rust: 'Rust',
   };
-  const languages = [...new Set(
-    ctx.detectedVersions.map((v) => languageMap[v.runtime]).filter(Boolean),
-  )];
+  const languages = [
+    ...new Set(ctx.detectedVersions.map((v) => languageMap[v.runtime]).filter(Boolean)),
+  ];
   // Add Vue if .vue files or Vue frameworks detected
   if (frameworks.some((f) => ['vue', 'nuxt', 'inertia'].includes(f.name))) {
     if (!languages.includes('Vue')) languages.push('Vue');
@@ -54,8 +65,8 @@ export function detectProject(dir: string): DetectionResult {
   const existingDb = detectExistingDb(projectRoot);
   const claudeMdPath = path.join(projectRoot, 'CLAUDE.md');
   const hasClaudeMd = fs.existsSync(claudeMdPath);
-  const claudeMdHasTraceMcpBlock = hasClaudeMd &&
-    fs.readFileSync(claudeMdPath, 'utf-8').includes('<!-- trace-mcp:start -->');
+  const claudeMdHasTraceMcpBlock =
+    hasClaudeMd && fs.readFileSync(claudeMdPath, 'utf-8').includes('<!-- trace-mcp:start -->');
 
   const { hasGuardHook, guardHookVersion } = detectGuardHook();
 
@@ -92,8 +103,12 @@ function detectPackageManagers(root: string): PackageManagerInfo[] {
   check('composer.json', 'composer', ['composer.lock']);
   check('pyproject.toml', 'poetry', ['poetry.lock', 'uv.lock']);
   if (managers.length > 0 && managers[managers.length - 1].type === 'poetry') {
-    if (managers[managers.length - 1].lockfile === 'uv.lock') managers[managers.length - 1].type = 'uv';
-    else if (!managers[managers.length - 1].lockfile && fs.existsSync(path.join(root, 'requirements.txt'))) {
+    if (managers[managers.length - 1].lockfile === 'uv.lock')
+      managers[managers.length - 1].type = 'uv';
+    else if (
+      !managers[managers.length - 1].lockfile &&
+      fs.existsSync(path.join(root, 'requirements.txt'))
+    ) {
       managers[managers.length - 1].type = 'pip';
     }
   }
@@ -102,7 +117,10 @@ function detectPackageManagers(root: string): PackageManagerInfo[] {
   check('Gemfile', 'bundler', ['Gemfile.lock']);
   check('pom.xml', 'maven', []);
   if (!managers.some((m) => m.type === 'maven')) {
-    if (fs.existsSync(path.join(root, 'build.gradle')) || fs.existsSync(path.join(root, 'build.gradle.kts'))) {
+    if (
+      fs.existsSync(path.join(root, 'build.gradle')) ||
+      fs.existsSync(path.join(root, 'build.gradle.kts'))
+    ) {
       managers.push({ type: 'gradle', lockfile: undefined });
     }
   }
@@ -142,7 +160,10 @@ export function detectMcpClients(projectRoot?: string): DetectedMcpClient[] {
   // Claude Desktop
   const platform = os.platform();
   if (platform === 'darwin') {
-    checkConfig('claude-desktop', path.join(HOME, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json'));
+    checkConfig(
+      'claude-desktop',
+      path.join(HOME, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json'),
+    );
   } else if (platform === 'win32') {
     const appData = process.env.APPDATA ?? path.join(HOME, 'AppData', 'Roaming');
     checkConfig('claude-desktop', path.join(appData, 'Claude', 'claude_desktop_config.json'));
@@ -174,11 +195,12 @@ export function detectMcpClients(projectRoot?: string): DetectedMcpClient[] {
 
   // JetBrains AI Assistant: detect via IDE mcpServer.xml in JetBrains config dirs
   {
-    const jbConfigBase = platform === 'darwin'
-      ? path.join(HOME, 'Library', 'Application Support', 'JetBrains')
-      : platform === 'win32'
-        ? path.join(process.env.APPDATA ?? path.join(HOME, 'AppData', 'Roaming'), 'JetBrains')
-        : path.join(HOME, '.config', 'JetBrains');
+    const jbConfigBase =
+      platform === 'darwin'
+        ? path.join(HOME, 'Library', 'Application Support', 'JetBrains')
+        : platform === 'win32'
+          ? path.join(process.env.APPDATA ?? path.join(HOME, 'AppData', 'Roaming'), 'JetBrains')
+          : path.join(HOME, '.config', 'JetBrains');
 
     if (fs.existsSync(jbConfigBase)) {
       try {
@@ -191,7 +213,9 @@ export function detectMcpClients(projectRoot?: string): DetectedMcpClient[] {
             break;
           }
         }
-      } catch { /* can't read dir */ }
+      } catch {
+        /* can't read dir */
+      }
     }
   }
 
@@ -211,6 +235,80 @@ export function detectMcpClients(projectRoot?: string): DetectedMcpClient[] {
     checkToml('codex', path.join(HOME, '.codex', 'config.toml'));
     if (projectRoot && !clients.some((c) => c.name === 'codex')) {
       checkToml('codex', path.join(projectRoot, '.codex', 'config.toml'));
+    }
+  }
+
+  // AMP (Sourcegraph): JSON/JSONC at ~/.config/amp/settings.json[c],
+  // workspace at .amp/settings.json[c]. Top-level key is `amp.mcpServers`
+  // (note the literal dot in the key name — flat key, not nested under `amp`).
+  {
+    const checkAmp = (configPath: string) => {
+      if (!fs.existsSync(configPath)) return;
+      try {
+        const content = fs.readFileSync(configPath, 'utf-8');
+        const parsed = parseJsonc(content) as Record<string, unknown> | null;
+        const servers = parsed?.['amp.mcpServers'] as Record<string, unknown> | undefined;
+        const hasTraceMcp = !!servers?.['trace-mcp'];
+        clients.push({ name: 'amp', configPath, hasTraceMcp });
+      } catch {
+        clients.push({ name: 'amp', configPath, hasTraceMcp: false });
+      }
+    };
+    const ampUserBase = path.join(HOME, '.config', 'amp');
+    for (const file of ['settings.jsonc', 'settings.json']) {
+      const p = path.join(ampUserBase, file);
+      if (fs.existsSync(p)) {
+        checkAmp(p);
+        break;
+      }
+    }
+    if (projectRoot && !clients.some((c) => c.name === 'amp')) {
+      const ampProjectBase = path.join(projectRoot, '.amp');
+      for (const file of ['settings.jsonc', 'settings.json']) {
+        const p = path.join(ampProjectBase, file);
+        if (fs.existsSync(p)) {
+          checkAmp(p);
+          break;
+        }
+      }
+    }
+  }
+
+  // Factory Droid: JSON at ~/.factory/mcp.json (user) or .factory/mcp.json (project).
+  // Standard `mcpServers` key, but each entry has `type: "stdio"|"http"`.
+  checkConfig('factory-droid', path.join(HOME, '.factory', 'mcp.json'));
+  if (projectRoot && !clients.some((c) => c.name === 'factory-droid')) {
+    checkConfig('factory-droid', path.join(projectRoot, '.factory', 'mcp.json'));
+  }
+
+  // Warp: configuration is stored in cloud-synced storage, not a writable file.
+  // We only detect installation presence so the UI can offer a paste-snippet flow.
+  {
+    const warpPaths =
+      platform === 'darwin'
+        ? ['/Applications/Warp.app', path.join(HOME, 'Applications', 'Warp.app')]
+        : platform === 'win32'
+          ? [
+              path.join(
+                process.env.LOCALAPPDATA ?? path.join(HOME, 'AppData', 'Local'),
+                'Programs',
+                'Warp',
+              ),
+            ]
+          : [path.join(HOME, '.local', 'share', 'warp-terminal'), '/usr/bin/warp-terminal'];
+    const installed = warpPaths.some((p) => {
+      try {
+        return fs.existsSync(p);
+      } catch {
+        return false;
+      }
+    });
+    if (installed) {
+      clients.push({
+        name: 'warp',
+        configPath: '<Warp Settings → Agents → MCP servers>',
+        hasTraceMcp: false,
+      });
     }
   }
 
@@ -251,12 +349,17 @@ function detectExistingConfig(root: string): { path: string } | null {
     try {
       const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
       if (pkg['trace-mcp']) return { path: pkgPath };
-    } catch { /* ignore malformed package.json */ }
+    } catch {
+      /* ignore malformed package.json */
+    }
   }
   return null;
 }
 
-function detectExistingDb(root: string, globalDbPath?: string): { path: string; schemaVersion: number; fileCount: number } | null {
+function detectExistingDb(
+  root: string,
+  globalDbPath?: string,
+): { path: string; schemaVersion: number; fileCount: number } | null {
   // Check global location first, then legacy local location
   const candidates = globalDbPath
     ? [globalDbPath, path.join(root, '.trace-mcp', 'index.db')]
@@ -266,9 +369,13 @@ function detectExistingDb(root: string, globalDbPath?: string): { path: string; 
   try {
     // Open read-only — don't run migrations or log during detection
     const db = new Database(dbPath, { readonly: true });
-    const versionRow = db.prepare('SELECT value FROM schema_meta WHERE key = ?').get('schema_version') as { value: string } | undefined;
+    const versionRow = db
+      .prepare('SELECT value FROM schema_meta WHERE key = ?')
+      .get('schema_version') as { value: string } | undefined;
     const schemaVersion = versionRow ? parseInt(versionRow.value, 10) : 0;
-    const countRow = db.prepare('SELECT COUNT(*) as cnt FROM files').get() as { cnt: number } | undefined;
+    const countRow = db.prepare('SELECT COUNT(*) as cnt FROM files').get() as
+      | { cnt: number }
+      | undefined;
     const fileCount = countRow?.cnt ?? 0;
     db.close();
     return { path: dbPath, schemaVersion, fileCount };
@@ -281,7 +388,11 @@ export function detectGuardHook(): { hasGuardHook: boolean; guardHookVersion: st
   const ext = process.platform === 'win32' ? '.cmd' : '.sh';
   const hookPath = path.join(HOME, '.claude', 'hooks', `trace-mcp-guard${ext}`);
   const clawHookPath = path.join(HOME, '.claw', 'hooks', `trace-mcp-guard${ext}`);
-  const existingPath = fs.existsSync(hookPath) ? hookPath : fs.existsSync(clawHookPath) ? clawHookPath : null;
+  const existingPath = fs.existsSync(hookPath)
+    ? hookPath
+    : fs.existsSync(clawHookPath)
+      ? clawHookPath
+      : null;
   if (!existingPath) return { hasGuardHook: false, guardHookVersion: null };
 
   const content = fs.readFileSync(existingPath, 'utf-8');

--- a/src/init/mcp-client.ts
+++ b/src/init/mcp-client.ts
@@ -518,9 +518,12 @@ function writeAmpJsoncEntry(configPath: string, entry: McpServerEntry): 'created
 
   let isNew = true;
   let content = '{}';
-  if (fs.existsSync(configPath)) {
-    isNew = false;
+  // Atomic read: avoids TOCTOU between existsSync and readFileSync.
+  try {
     content = fs.readFileSync(configPath, 'utf-8') || '{}';
+    isNew = false;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e;
   }
 
   // jsonc-parser preserves comments and formatting around untouched regions.
@@ -563,12 +566,13 @@ function writeFactoryJsonEntry(
 
   let config: Record<string, unknown> = {};
   let isNew = true;
-  if (fs.existsSync(configPath)) {
-    try {
-      config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-      isNew = false;
-    } catch {
-      /* malformed — overwrite */
+  // Atomic read: avoids TOCTOU between existsSync and readFileSync.
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    isNew = false;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+      // malformed JSON — overwrite
     }
   }
 

--- a/src/init/mcp-client.ts
+++ b/src/init/mcp-client.ts
@@ -8,6 +8,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { execSync } from 'node:child_process';
 import YAML from 'yaml';
+import { applyEdits, modify, parse as parseJsonc, type FormattingOptions } from 'jsonc-parser';
 import type { DetectedMcpClient, InitStepResult } from './types.js';
 import { getLauncherPath } from './launcher.js';
 
@@ -101,6 +102,104 @@ export function configureMcpClients(
       continue;
     }
 
+    // Warp: configuration is stored in cloud-synced storage, not a writable file.
+    // The user must paste the entry via Settings → Agents → MCP servers. If
+    // claude-code is also selected, Warp can pick our entry up automatically
+    // via "File-based MCP servers" detection.
+    if (name === 'warp') {
+      const hasClaudeCode = clientNames.includes('claude-code');
+      const launcher = getLauncherPath();
+      const snippet = JSON.stringify({
+        mcpServers: {
+          'trace-mcp': { command: launcher, args: ['serve'], working_directory: projectRoot },
+        },
+      });
+      results.push({
+        target: 'Warp',
+        action: 'skipped',
+        detail: hasClaudeCode
+          ? 'Enable Settings → Agents → MCP servers → "File-based MCP servers" to inherit trace-mcp from Claude Code, or paste: ' +
+            snippet
+          : 'Open Settings → Agents → MCP servers → + Add → paste: ' + snippet,
+      });
+      continue;
+    }
+
+    // AMP (Sourcegraph Amp): JSONC with the literal-dot key `amp.mcpServers`.
+    // Use jsonc-parser's modify()/applyEdits() so existing comments and formatting
+    // are preserved across writes.
+    if (name === 'amp') {
+      const configPath = getConfigPath(name, projectRoot, opts.scope);
+      if (!configPath) {
+        results.push({ target: name, action: 'skipped', detail: 'Unknown client' });
+        continue;
+      }
+      const entry = { ...buildMcpEntry(), args: ['serve'], cwd: projectRoot };
+
+      if (fs.existsSync(configPath) && ampEntryMatches(configPath, entry)) {
+        results.push({ target: configPath, action: 'already_configured', detail: name });
+        continue;
+      }
+      if (opts.dryRun) {
+        results.push({
+          target: configPath,
+          action: 'skipped',
+          detail: `Would configure ${name} (${opts.scope})`,
+        });
+        continue;
+      }
+      try {
+        const action = writeAmpJsoncEntry(configPath, entry);
+        results.push({ target: configPath, action, detail: `${name} (${opts.scope})` });
+      } catch (err) {
+        results.push({
+          target: configPath,
+          action: 'skipped',
+          detail: `Error: ${(err as Error).message}`,
+        });
+      }
+      continue;
+    }
+
+    // Factory Droid: standard JSON `mcpServers`, but each entry needs `type: "stdio"`.
+    if (name === 'factory-droid') {
+      const configPath = getConfigPath(name, projectRoot, opts.scope);
+      if (!configPath) {
+        results.push({ target: name, action: 'skipped', detail: 'Unknown client' });
+        continue;
+      }
+      const entry: McpServerEntry & { type: 'stdio' } = {
+        type: 'stdio',
+        ...buildMcpEntry(),
+        args: ['serve'],
+        cwd: projectRoot,
+      };
+
+      if (fs.existsSync(configPath) && factoryEntryMatches(configPath, entry)) {
+        results.push({ target: configPath, action: 'already_configured', detail: name });
+        continue;
+      }
+      if (opts.dryRun) {
+        results.push({
+          target: configPath,
+          action: 'skipped',
+          detail: `Would configure ${name} (${opts.scope})`,
+        });
+        continue;
+      }
+      try {
+        const action = writeFactoryJsonEntry(configPath, entry);
+        results.push({ target: configPath, action, detail: `${name} (${opts.scope})` });
+      } catch (err) {
+        results.push({
+          target: configPath,
+          action: 'skipped',
+          detail: `Error: ${(err as Error).message}`,
+        });
+      }
+      continue;
+    }
+
     // Hermes Agent: YAML format, always global, key `mcp_servers.trace-mcp`.
     if (name === 'hermes') {
       const configPath = getConfigPath(name, projectRoot, opts.scope);
@@ -117,7 +216,11 @@ export function configureMcpClients(
       }
 
       if (opts.dryRun) {
-        results.push({ target: configPath, action: 'skipped', detail: `Would configure ${name} (${opts.scope})` });
+        results.push({
+          target: configPath,
+          action: 'skipped',
+          detail: `Would configure ${name} (${opts.scope})`,
+        });
         continue;
       }
 
@@ -125,7 +228,11 @@ export function configureMcpClients(
         const action = writeHermesYamlEntry(configPath, entry);
         results.push({ target: configPath, action, detail: `${name} (${opts.scope})` });
       } catch (err) {
-        results.push({ target: configPath, action: 'skipped', detail: `Error: ${(err as Error).message}` });
+        results.push({
+          target: configPath,
+          action: 'skipped',
+          detail: `Error: ${(err as Error).message}`,
+        });
       }
       continue;
     }
@@ -146,19 +253,33 @@ export function configureMcpClients(
             results.push({ target: configPath, action: 'already_configured', detail: name });
             continue;
           }
-        } catch { /* malformed — will append */ }
+        } catch {
+          /* malformed — will append */
+        }
       }
 
       if (opts.dryRun) {
-        results.push({ target: configPath, action: 'skipped', detail: `Would configure ${name} (${opts.scope})` });
+        results.push({
+          target: configPath,
+          action: 'skipped',
+          detail: `Would configure ${name} (${opts.scope})`,
+        });
         continue;
       }
 
       try {
-        const action = writeCodexTomlEntry(configPath, { ...buildMcpEntry(), args: ['serve'], cwd: projectRoot });
+        const action = writeCodexTomlEntry(configPath, {
+          ...buildMcpEntry(),
+          args: ['serve'],
+          cwd: projectRoot,
+        });
         results.push({ target: configPath, action, detail: `${name} (${opts.scope})` });
       } catch (err) {
-        results.push({ target: configPath, action: 'skipped', detail: `Error: ${(err as Error).message}` });
+        results.push({
+          target: configPath,
+          action: 'skipped',
+          detail: `Error: ${(err as Error).message}`,
+        });
       }
       continue;
     }
@@ -185,7 +306,11 @@ export function configureMcpClients(
     }
 
     if (opts.dryRun) {
-      results.push({ target: configPath, action: 'skipped', detail: `Would configure ${name} (${opts.scope})` });
+      results.push({
+        target: configPath,
+        action: 'skipped',
+        detail: `Would configure ${name} (${opts.scope})`,
+      });
       continue;
     }
 
@@ -227,7 +352,11 @@ export function configureMcpClients(
 
       results.push({ target: configPath, action, detail: `${name} (${opts.scope})` });
     } catch (err) {
-      results.push({ target: configPath, action: 'skipped', detail: `Error: ${(err as Error).message}` });
+      results.push({
+        target: configPath,
+        action: 'skipped',
+        detail: `Error: ${(err as Error).message}`,
+      });
     }
   }
 
@@ -279,7 +408,9 @@ function writeJsonEntry(configPath: string, entry: McpServerEntry): 'created' | 
     try {
       config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
       isNew = false;
-    } catch { /* malformed — overwrite */ }
+    } catch {
+      /* malformed — overwrite */
+    }
   }
 
   if (!config.mcpServers || typeof config.mcpServers !== 'object') {
@@ -353,6 +484,103 @@ function writeHermesYamlEntry(configPath: string, entry: HermesYamlEntry): 'crea
 }
 
 // ---------------------------------------------------------------------------
+// AMP JSONC writer (top-level key is the literal `amp.mcpServers`)
+// ---------------------------------------------------------------------------
+
+const AMP_FORMATTING: FormattingOptions = { tabSize: 2, insertSpaces: true, eol: '\n' };
+
+function ampEntryMatches(configPath: string, expected: McpServerEntry): boolean {
+  try {
+    const content = fs.readFileSync(configPath, 'utf-8');
+    const parsed = parseJsonc(content) as Record<string, unknown> | null;
+    const servers = parsed?.['amp.mcpServers'] as Record<string, unknown> | undefined;
+    const current = servers?.['trace-mcp'] as Record<string, unknown> | undefined;
+    if (!current) return false;
+    if (current.command !== expected.command) return false;
+    if (JSON.stringify(current.args ?? []) !== JSON.stringify(expected.args)) return false;
+    if ((current.cwd ?? undefined) !== (expected.cwd ?? undefined)) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function writeAmpJsoncEntry(configPath: string, entry: McpServerEntry): 'created' | 'updated' {
+  const dir = path.dirname(configPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  const value: Record<string, unknown> = {
+    command: entry.command,
+    args: entry.args,
+    ...(entry.cwd ? { cwd: entry.cwd } : {}),
+    ...(entry.env ? { env: entry.env } : {}),
+  };
+
+  let isNew = true;
+  let content = '{}';
+  if (fs.existsSync(configPath)) {
+    isNew = false;
+    content = fs.readFileSync(configPath, 'utf-8') || '{}';
+  }
+
+  // jsonc-parser preserves comments and formatting around untouched regions.
+  const edits = modify(content, ['amp.mcpServers', 'trace-mcp'], value, {
+    formattingOptions: AMP_FORMATTING,
+  });
+  const updated = applyEdits(content, edits);
+  fs.writeFileSync(configPath, updated.endsWith('\n') ? updated : updated + '\n');
+  return isNew ? 'created' : 'updated';
+}
+
+// ---------------------------------------------------------------------------
+// Factory Droid JSON writer (entries need `type: "stdio"`)
+// ---------------------------------------------------------------------------
+
+function factoryEntryMatches(
+  configPath: string,
+  expected: McpServerEntry & { type: 'stdio' },
+): boolean {
+  try {
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    const current = content?.mcpServers?.['trace-mcp'];
+    if (!current || typeof current !== 'object') return false;
+    if (current.type !== expected.type) return false;
+    if (current.command !== expected.command) return false;
+    if (JSON.stringify(current.args ?? []) !== JSON.stringify(expected.args)) return false;
+    if ((current.cwd ?? undefined) !== (expected.cwd ?? undefined)) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function writeFactoryJsonEntry(
+  configPath: string,
+  entry: McpServerEntry & { type: 'stdio' },
+): 'created' | 'updated' {
+  const dir = path.dirname(configPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  let config: Record<string, unknown> = {};
+  let isNew = true;
+  if (fs.existsSync(configPath)) {
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      isNew = false;
+    } catch {
+      /* malformed — overwrite */
+    }
+  }
+
+  if (!config.mcpServers || typeof config.mcpServers !== 'object') {
+    config.mcpServers = {};
+  }
+  (config.mcpServers as Record<string, unknown>)['trace-mcp'] = entry;
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+  return isNew ? 'created' : 'updated';
+}
+
+// ---------------------------------------------------------------------------
 // TOML writer (Codex)
 // ---------------------------------------------------------------------------
 
@@ -395,11 +623,15 @@ function writeCodexTomlEntry(configPath: string, entry: McpServerEntry): 'create
 // ---------------------------------------------------------------------------
 
 /** Get config file path for a client, given scope. */
-function getConfigPath(name: DetectedMcpClient['name'], projectRoot: string, scope: McpScope): string | null {
+function getConfigPath(
+  name: DetectedMcpClient['name'],
+  projectRoot: string,
+  scope: McpScope,
+): string | null {
   switch (name) {
     case 'claude-code':
       return scope === 'global'
-        ? path.join(HOME, '.claude.json')  // user-level MCP in Claude Code
+        ? path.join(HOME, '.claude.json') // user-level MCP in Claude Code
         : path.join(projectRoot, '.mcp.json');
     case 'claw-code':
       return scope === 'global'
@@ -409,7 +641,11 @@ function getConfigPath(name: DetectedMcpClient['name'], projectRoot: string, sco
       // Claude Desktop is always global
       return process.platform === 'darwin'
         ? path.join(HOME, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json')
-        : path.join(process.env.APPDATA ?? path.join(HOME, 'AppData', 'Roaming'), 'Claude', 'claude_desktop_config.json');
+        : path.join(
+            process.env.APPDATA ?? path.join(HOME, 'AppData', 'Roaming'),
+            'Claude',
+            'claude_desktop_config.json',
+          );
     case 'cursor':
       return scope === 'global'
         ? path.join(HOME, '.cursor', 'mcp.json')
@@ -432,6 +668,22 @@ function getConfigPath(name: DetectedMcpClient['name'], projectRoot: string, sco
         : path.join(projectRoot, '.codex', 'config.toml');
     case 'jetbrains-ai':
       return null; // Configured through IDE Settings UI, not a file we can write
+    case 'warp':
+      return null; // Configured through Warp Settings UI; cloud-synced storage
+    case 'amp': {
+      const base =
+        scope === 'global' ? path.join(HOME, '.config', 'amp') : path.join(projectRoot, '.amp');
+      // Prefer existing .jsonc, fall back to .json. Otherwise create .json.
+      const jsoncPath = path.join(base, 'settings.jsonc');
+      const jsonPath = path.join(base, 'settings.json');
+      if (fs.existsSync(jsoncPath)) return jsoncPath;
+      if (fs.existsSync(jsonPath)) return jsonPath;
+      return jsonPath;
+    }
+    case 'factory-droid':
+      return scope === 'global'
+        ? path.join(HOME, '.factory', 'mcp.json')
+        : path.join(projectRoot, '.factory', 'mcp.json');
     case 'hermes':
       // Hermes Agent is always-global; project scope is a no-op here.
       return path.join(process.env.HERMES_HOME ?? path.join(HOME, '.hermes'), 'config.yaml');

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -1,18 +1,53 @@
 /** Types for the init/upgrade detection and configuration system. */
 
 export interface PackageManagerInfo {
-  type: 'npm' | 'yarn' | 'pnpm' | 'bun' | 'composer' | 'pip' | 'poetry' | 'uv' | 'go' | 'cargo' | 'bundler' | 'maven' | 'gradle';
+  type:
+    | 'npm'
+    | 'yarn'
+    | 'pnpm'
+    | 'bun'
+    | 'composer'
+    | 'pip'
+    | 'poetry'
+    | 'uv'
+    | 'go'
+    | 'cargo'
+    | 'bundler'
+    | 'maven'
+    | 'gradle';
   lockfile?: string;
 }
 
 export interface DetectedFramework {
   name: string;
   version?: string;
-  category?: 'framework' | 'orm' | 'validation' | 'state' | 'api' | 'realtime' | 'testing' | 'tooling' | 'view';
+  category?:
+    | 'framework'
+    | 'orm'
+    | 'validation'
+    | 'state'
+    | 'api'
+    | 'realtime'
+    | 'testing'
+    | 'tooling'
+    | 'view';
 }
 
 export interface DetectedMcpClient {
-  name: 'claude-code' | 'claw-code' | 'claude-desktop' | 'cursor' | 'windsurf' | 'continue' | 'junie' | 'jetbrains-ai' | 'codex' | 'hermes';
+  name:
+    | 'claude-code'
+    | 'claw-code'
+    | 'claude-desktop'
+    | 'cursor'
+    | 'windsurf'
+    | 'continue'
+    | 'junie'
+    | 'jetbrains-ai'
+    | 'codex'
+    | 'hermes'
+    | 'amp'
+    | 'warp'
+    | 'factory-droid';
   configPath: string;
   hasTraceMcp: boolean;
 }

--- a/src/tools/quality/audit-config.ts
+++ b/src/tools/quality/audit-config.ts
@@ -34,17 +34,36 @@ interface AuditResult {
 
 /** Known AI agent config file patterns */
 const CONFIG_PATTERNS = [
-  'CLAUDE.md', '.claude/CLAUDE.md', '.cursorrules', '.cursor/rules',
-  '.github/copilot-instructions.md', '.aider.conf.yml', '.continue/config.json',
-  'cline_docs', '.windsurfrules',
+  'CLAUDE.md',
+  '.claude/CLAUDE.md',
+  '.cursorrules',
+  '.cursor/rules',
+  '.github/copilot-instructions.md',
+  '.aider.conf.yml',
+  '.continue/config.json',
+  'cline_docs',
+  '.windsurfrules',
+  // Generic agent rules consumed by AMP, Warp, Factory Droid, Hermes
+  'AGENTS.md',
   // Claw Code
-  '.claw.json', '.claw/settings.json', '.claw/settings.local.json',
+  '.claw.json',
+  '.claw/settings.json',
+  '.claw/settings.local.json',
+  // AMP
+  '.amp/settings.json',
+  '.amp/settings.jsonc',
+  '.amp/AGENTS.md',
+  // Factory Droid
+  '.factory/mcp.json',
 ];
 
 /** Global config locations */
 const GLOBAL_CONFIG_PATTERNS = [
   '~/.claude/CLAUDE.md',
   '~/.claw/settings.json',
+  '~/.config/amp/settings.json',
+  '~/.config/amp/settings.jsonc',
+  '~/.factory/mcp.json',
 ];
 
 export function auditConfig(
@@ -78,13 +97,17 @@ export function auditConfig(
     // --- Dead file paths ---
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
-      const pathMatches = line.match(/(?:src|lib|app|routes|tests?|components?|pages?)\/[\w/.-]+\.\w+/g);
+      const pathMatches = line.match(
+        /(?:src|lib|app|routes|tests?|components?|pages?)\/[\w/.-]+\.\w+/g,
+      );
       if (pathMatches) {
         for (const ref of pathMatches) {
           const refPath = path.join(projectRoot, ref);
           if (!fs.existsSync(refPath) && !store.getFile(ref)) {
             issues.push({
-              file, line: i + 1, category: 'dead_path',
+              file,
+              line: i + 1,
+              category: 'dead_path',
               issue: `Dead path: \`${ref}\` — file does not exist`,
               severity: 'error',
               ...(fixSuggestions ? { fix: `Remove or update reference to ${ref}` } : {}),
@@ -110,7 +133,23 @@ export function auditConfig(
       const funcMatches = line.matchAll(/`([a-z][a-zA-Z0-9]{3,})(?:\(\))?`/g);
       for (const m of funcMatches) {
         const name = m[1];
-        const reserved = ['true', 'false', 'null', 'undefined', 'default', 'string', 'number', 'boolean', 'async', 'await', 'const', 'function', 'return', 'import', 'export'];
+        const reserved = [
+          'true',
+          'false',
+          'null',
+          'undefined',
+          'default',
+          'string',
+          'number',
+          'boolean',
+          'async',
+          'await',
+          'const',
+          'function',
+          'return',
+          'import',
+          'export',
+        ];
         if (reserved.includes(name)) continue;
         checkSymbol(store, name, file, i + 1, fixSuggestions, issues);
       }
@@ -120,10 +159,13 @@ export function auditConfig(
     const fileTokens = Math.ceil(content.length / 4);
     if (fileTokens > 2000) {
       issues.push({
-        file, category: 'bloat',
+        file,
+        category: 'bloat',
         issue: `${fileTokens} tokens — consider reducing below 2,000`,
         severity: 'warning',
-        ...(fixSuggestions ? { fix: 'Trim redundant instructions or split into focused files' } : {}),
+        ...(fixSuggestions
+          ? { fix: 'Trim redundant instructions or split into focused files' }
+          : {}),
       });
     }
 
@@ -134,10 +176,14 @@ export function auditConfig(
         const absPathMatch = line.match(/\/(?:Users|home)\/[^\s`"']+/);
         if (absPathMatch) {
           issues.push({
-            file, line: i + 1, category: 'scope_leak',
+            file,
+            line: i + 1,
+            category: 'scope_leak',
             issue: `Scope leak: absolute path \`${absPathMatch[0]}\` in global config`,
             severity: 'warning',
-            ...(fixSuggestions ? { fix: 'Use relative paths or project-local config instead' } : {}),
+            ...(fixSuggestions
+              ? { fix: 'Use relative paths or project-local config instead' }
+              : {}),
           });
         }
       }
@@ -156,7 +202,9 @@ export function auditConfig(
           const trimmed = linesA[k].trim();
           if (trimmed.length > 30 && setB.has(trimmed)) {
             issues.push({
-              file: fileA, line: k + 1, category: 'redundancy',
+              file: fileA,
+              line: k + 1,
+              category: 'redundancy',
               issue: `Duplicated in ${fileB}: "${trimmed.slice(0, 60)}..."`,
               severity: 'info',
             });
@@ -171,9 +219,10 @@ export function auditConfig(
     files_scanned: fileContents.size,
     total_tokens: totalTokens,
     issues,
-    summary: issues.length === 0
-      ? 'No issues found'
-      : `${issues.filter((i) => i.severity === 'error').length} errors, ${issues.filter((i) => i.severity === 'warning').length} warnings, ${issues.filter((i) => i.severity === 'info').length} info`,
+    summary:
+      issues.length === 0
+        ? 'No issues found'
+        : `${issues.filter((i) => i.severity === 'error').length} errors, ${issues.filter((i) => i.severity === 'warning').length} warnings, ${issues.filter((i) => i.severity === 'info').length} info`,
   };
 }
 
@@ -191,7 +240,9 @@ function checkSymbol(
   if (sym) return; // Found — not stale
 
   const issue: AuditIssue = {
-    file, line, category: 'stale_symbol',
+    file,
+    line,
+    category: 'stale_symbol',
     issue: `Stale symbol: \`${name}\` — not found in index`,
     severity: 'warning',
   };
@@ -202,8 +253,7 @@ function checkSymbol(
       if (matches.length > 0) {
         const best = matches[0];
         const fileRow = store.getFileById(best.fileId);
-        issue.fix = `Did you mean \`${best.name}\`?` +
-          (fileRow ? ` (${fileRow.path})` : '');
+        issue.fix = `Did you mean \`${best.name}\`?` + (fileRow ? ` (${fileRow.path})` : '');
       }
     } catch {
       // Fuzzy search may fail if trigram table empty — ignore
@@ -233,5 +283,9 @@ function resolveConfigPath(file: string, projectRoot: string): string {
 }
 
 function isGlobalConfig(file: string): boolean {
-  return file.startsWith('~') || file.includes('.claude/CLAUDE.md') || file.includes('.claw/settings.json');
+  return (
+    file.startsWith('~') ||
+    file.includes('.claude/CLAUDE.md') ||
+    file.includes('.claw/settings.json')
+  );
 }

--- a/src/utils/traceignore.ts
+++ b/src/utils/traceignore.ts
@@ -27,9 +27,27 @@ export class TraceignoreMatcher {
 
   /** Built-in directories that are always skipped. */
   static readonly DEFAULT_SKIP_DIRS = new Set([
-    'node_modules', '.git', 'dist', 'build', '.next', '__pycache__',
-    '.venv', 'vendor', '.trace-mcp', 'coverage', '.turbo',
-    '.claude', '.cursor', '.windsurf', '.codeium', '.aider', '.copilot',
+    'node_modules',
+    '.git',
+    'dist',
+    'build',
+    '.next',
+    '__pycache__',
+    '.venv',
+    'vendor',
+    '.trace-mcp',
+    'coverage',
+    '.turbo',
+    '.claude',
+    '.cursor',
+    '.windsurf',
+    '.codeium',
+    '.aider',
+    '.copilot',
+    '.amp',
+    '.factory',
+    '.junie',
+    '.codex',
   ]);
 
   constructor(rootPath: string, config: TraceignoreConfig = {}) {

--- a/tests/init/mcp-clients-extra.test.ts
+++ b/tests/init/mcp-clients-extra.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// detector.ts and mcp-client.ts compute `const HOME = os.homedir()` at module
+// load, so we have to reset modules and re-import per test after stubbing HOME.
+let sandbox: string;
+let fakeHome: string;
+let projectRoot: string;
+
+let detectMcpClients: typeof import('../../src/init/detector.js').detectMcpClients;
+let configureMcpClients: typeof import('../../src/init/mcp-client.js').configureMcpClients;
+
+beforeEach(async () => {
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-clients-'));
+  fakeHome = path.join(sandbox, 'home');
+  projectRoot = path.join(sandbox, 'project');
+  fs.mkdirSync(fakeHome, { recursive: true });
+  fs.mkdirSync(projectRoot, { recursive: true });
+
+  vi.stubEnv('HOME', fakeHome);
+  vi.stubEnv('USERPROFILE', fakeHome);
+  // Force re-evaluation of module-level `const HOME = os.homedir()` against the stub.
+  vi.resetModules();
+  ({ detectMcpClients } = await import('../../src/init/detector.js'));
+  ({ configureMcpClients } = await import('../../src/init/mcp-client.js'));
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+describe('AMP detection', () => {
+  it('parses settings.json with amp.mcpServers and reports trace-mcp present', () => {
+    const dir = path.join(fakeHome, '.config', 'amp');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'settings.json'),
+      JSON.stringify({
+        'amp.mcpServers': { 'trace-mcp': { command: '/bin/true', args: ['serve'] } },
+      }),
+    );
+    const clients = detectMcpClients(projectRoot);
+    const amp = clients.find((c) => c.name === 'amp');
+    expect(amp).toBeDefined();
+    expect(amp?.hasTraceMcp).toBe(true);
+  });
+
+  it('parses settings.jsonc with comments and detects no trace-mcp entry', () => {
+    const dir = path.join(fakeHome, '.config', 'amp');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'settings.jsonc'),
+      [
+        '// AMP user settings',
+        '{',
+        '  /* third-party servers */',
+        '  "amp.mcpServers": {',
+        '    "linear": { "command": "npx", "args": ["-y", "@linear/mcp"] }',
+        '  }',
+        '}',
+      ].join('\n'),
+    );
+    const clients = detectMcpClients(projectRoot);
+    const amp = clients.find((c) => c.name === 'amp');
+    expect(amp).toBeDefined();
+    expect(amp?.hasTraceMcp).toBe(false);
+    expect(amp?.configPath).toMatch(/settings\.jsonc$/);
+  });
+
+  it('falls back to project-level .amp/settings.json when user-level is absent', () => {
+    const projDir = path.join(projectRoot, '.amp');
+    fs.mkdirSync(projDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(projDir, 'settings.json'),
+      JSON.stringify({
+        'amp.mcpServers': { 'trace-mcp': { command: 'x' } },
+      }),
+    );
+    const clients = detectMcpClients(projectRoot);
+    const amp = clients.find((c) => c.name === 'amp');
+    expect(amp?.hasTraceMcp).toBe(true);
+    expect(amp?.configPath.startsWith(projectRoot)).toBe(true);
+  });
+});
+
+describe('Factory Droid detection', () => {
+  it('detects user-level ~/.factory/mcp.json with trace-mcp entry', () => {
+    const dir = path.join(fakeHome, '.factory');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'mcp.json'),
+      JSON.stringify({
+        mcpServers: { 'trace-mcp': { type: 'stdio', command: '/bin/true', args: ['serve'] } },
+      }),
+    );
+    const clients = detectMcpClients(projectRoot);
+    const droid = clients.find((c) => c.name === 'factory-droid');
+    expect(droid).toBeDefined();
+    expect(droid?.hasTraceMcp).toBe(true);
+  });
+
+  it('detects project-level .factory/mcp.json without trace-mcp', () => {
+    const dir = path.join(projectRoot, '.factory');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'mcp.json'), JSON.stringify({ mcpServers: {} }));
+    const clients = detectMcpClients(projectRoot);
+    const droid = clients.find((c) => c.name === 'factory-droid');
+    expect(droid?.hasTraceMcp).toBe(false);
+  });
+});
+
+describe('AMP writer round-trip', () => {
+  it('preserves comments when adding trace-mcp via jsonc-parser', () => {
+    const dir = path.join(fakeHome, '.config', 'amp');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'settings.jsonc');
+    fs.writeFileSync(
+      file,
+      [
+        '// User-managed AMP settings',
+        '{',
+        '  // existing servers',
+        '  "amp.mcpServers": {',
+        '    "linear": { "command": "npx", "args": ["@linear/mcp"] }',
+        '  }',
+        '}',
+      ].join('\n'),
+    );
+
+    const results = configureMcpClients(['amp'], projectRoot, { scope: 'global' });
+    const step = results[0];
+    expect(step.action).toBe('updated');
+
+    const after = fs.readFileSync(file, 'utf-8');
+    expect(after).toContain('// User-managed AMP settings');
+    expect(after).toContain('// existing servers');
+    expect(after).toContain('"trace-mcp"');
+    expect(after).toContain('"linear"');
+  });
+
+  it('writes a new settings.json when no AMP config exists', () => {
+    const results = configureMcpClients(['amp'], projectRoot, { scope: 'global' });
+    const step = results[0];
+    expect(step.action).toBe('created');
+    const file = path.join(fakeHome, '.config', 'amp', 'settings.json');
+    expect(fs.existsSync(file)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(parsed['amp.mcpServers']?.['trace-mcp']?.args).toEqual(['serve']);
+  });
+
+  it('reports already_configured when entry matches', () => {
+    configureMcpClients(['amp'], projectRoot, { scope: 'global' });
+    const second = configureMcpClients(['amp'], projectRoot, { scope: 'global' });
+    expect(second[0].action).toBe('already_configured');
+  });
+});
+
+describe('Factory Droid writer', () => {
+  it('writes mcpServers entry with type: stdio', () => {
+    const results = configureMcpClients(['factory-droid'], projectRoot, { scope: 'global' });
+    const step = results[0];
+    expect(step.action).toBe('created');
+    const file = path.join(fakeHome, '.factory', 'mcp.json');
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    const entry = parsed.mcpServers['trace-mcp'];
+    expect(entry.type).toBe('stdio');
+    expect(entry.args).toEqual(['serve']);
+    expect(entry.cwd).toBe(projectRoot);
+  });
+
+  it('preserves existing servers when adding trace-mcp', () => {
+    const file = path.join(fakeHome, '.factory', 'mcp.json');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        mcpServers: { linear: { type: 'http', url: 'https://mcp.linear.app/mcp' } },
+      }),
+    );
+    configureMcpClients(['factory-droid'], projectRoot, { scope: 'global' });
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(parsed.mcpServers.linear).toBeDefined();
+    expect(parsed.mcpServers['trace-mcp']).toBeDefined();
+  });
+});
+
+describe('Warp configuration', () => {
+  it('always returns skipped with paste-snippet detail', () => {
+    const results = configureMcpClients(['warp'], projectRoot, { scope: 'global' });
+    expect(results[0].action).toBe('skipped');
+    expect(results[0].detail).toContain('Settings');
+    expect(results[0].detail).toContain('"trace-mcp"');
+  });
+
+  it('includes claude-code inheritance hint when both selected', () => {
+    const results = configureMcpClients(['warp', 'claude-code'], projectRoot, { scope: 'global' });
+    const warp = results.find((r) => r.target === 'Warp');
+    expect(warp?.detail).toContain('File-based MCP servers');
+  });
+});

--- a/tests/init/mcp-clients-extra.test.ts
+++ b/tests/init/mcp-clients-extra.test.ts
@@ -21,7 +21,12 @@ beforeEach(async () => {
 
   vi.stubEnv('HOME', fakeHome);
   vi.stubEnv('USERPROFILE', fakeHome);
-  // Force re-evaluation of module-level `const HOME = os.homedir()` against the stub.
+  // os.homedir() on macOS reads getpwuid_r, not $HOME — env stubs alone are
+  // not enough. Spy on os.homedir() so the module-level `const HOME =
+  // os.homedir()` captures the sandbox path. Without this, every test that
+  // exercises a writer leaks into the real user config.
+  vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+  // Force re-evaluation of module-level `const HOME = os.homedir()` against the spy.
   vi.resetModules();
   ({ detectMcpClients } = await import('../../src/init/detector.js'));
   ({ configureMcpClients } = await import('../../src/init/mcp-client.js'));
@@ -29,6 +34,7 @@ beforeEach(async () => {
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  vi.restoreAllMocks();
   fs.rmSync(sandbox, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary

Cherry-picked from #107 (split for clean review). Adds three new MCP clients to \`trace-mcp init\`:

- **AMP (Sourcegraph)** — \`~/.config/amp/settings.json[c]\`, \`<project>/.amp/settings.json[c]\`. JSONC-aware writer (uses \`jsonc-parser.modify\` to preserve comments and formatting). Top-level key has a literal dot: \`"amp.mcpServers"\`.
- **Warp** — cloud-synced settings, no writable file. Detection only; init prints copy-paste JSON for the user to paste in *Settings → Agents → MCP servers → + Add*. If Claude Code is also configured, suggests enabling Warp's "File-based MCP servers" toggle so it inherits trace-mcp from \`~/.claude.json\`.
- **Factory Droid** — \`~/.factory/mcp.json\`, \`<project>/.factory/mcp.json\`. Standard \`mcpServers\` shape but entries require \`type: "stdio"\`.

All three also write \`AGENTS.md\` (per the host conventions) and only get the **Base** enforcement tier — no hooks/tweakcc equivalent in those clients.

## Security findings addressed (vs. original #107)

This PR includes a follow-up commit that fixes all CodeQL/Semgrep findings flagged on #107:

- **HIGH** \`js/file-system-race\` × 2 — TOCTOU in writeAmpJsoncEntry / writeFactoryJsonEntry → atomic \`try { readFileSync } catch ENOENT\`
- **MEDIUM** \`js/log-injection\` — strip newlines from \`step.detail\` before \`console.log\`
- **MEDIUM** \`js/shell-command-injection-from-environment\` × 3 + **Semgrep** \`detect-child-process\` × 2 — replaced \`exec(string)\` with \`execFile(prog, [args])\` for: \`trace-mcp init\` invocation, \`npm root -g\`, \`npm install -g trace-mcp@latest --force\`

## Test plan

- [x] \`npm install\` — clean
- [x] \`npm run typecheck\` (root + app) — clean
- [x] \`npm run build:main\` (app) — clean
- [x] \`npm test -- --run tests/init/\` — 96 passed, 3 skipped, 0 failed
- [ ] **Manual**: \`trace-mcp init\` against AMP / Warp / Factory test fixtures

## Out of scope

- Replaces #107's content **except** SLSA (already merged) and electron security bump (delivered as separate PR).

Closes #107.