### PR TITLE
fix(merge): drop duplicate imports + restore missing path import

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -35,31 +35,12 @@ import {
 } from '../config-jsonc.js';
 import { parse as parseJsonc } from 'jsonc-parser';
 import { loadConfig, removeProjectConfig, saveProjectConfig } from '../config.js';
-import {
-  migrateGlobalConfig,
-  modifyGlobalConfigJsonc,
-  readGlobalConfigText,
-} from '../config-jsonc.js';
 import { initializeDatabase } from '../db/schema.js';
 import { Store } from '../db/store.js';
-import { ensureGlobalDirs, GLOBAL_CONFIG_PATH, getDbPath } from '../global.js';
 import { IndexingPipeline } from '../indexer/pipeline.js';
 import { generateConfig } from '../init/config-generator.js';
 import { detectConflicts } from '../init/conflict-detector.js';
 import { fixAllConflicts } from '../init/conflict-resolver.js';
-import { findProjectRoot, discoverChildProjects, hasRootMarkers } from '../project-root.js';
-import { generateConfig } from '../init/config-generator.js';
-import {
-  registerProject,
-  getProject,
-  listProjects,
-  updateLastIndexed,
-  unregisterProject,
-} from '../registry.js';
-import { saveProjectConfig, removeProjectConfig, loadConfig } from '../config.js';
-import { initializeDatabase } from '../db/schema.js';
-import { setupProject } from '../project-setup.js';
-import { Store } from '../db/store.js';
 import { PluginRegistry } from '../plugin-api/registry.js';
 import { discoverChildProjects, findProjectRoot, hasRootMarkers } from '../project-root.js';
 import { setupProject } from '../project-setup.js';

--- a/src/init/detector.ts
+++ b/src/init/detector.ts
@@ -5,6 +5,7 @@
 
 import fs from 'node:fs';
 import os from 'node:os';
+import path from 'node:path';
 import { parse as parseJsonc } from 'jsonc-parser';
 import { buildProjectContext } from '../indexer/project-context.js';
 import { PluginRegistry } from '../plugin-api/registry.js';

--- a/src/init/mcp-client.ts
+++ b/src/init/mcp-client.ts
@@ -9,8 +9,6 @@ import os from 'node:os';
 import path from 'node:path';
 import { applyEdits, type FormattingOptions, modify, parse as parseJsonc } from 'jsonc-parser';
 import YAML from 'yaml';
-import { applyEdits, modify, parse as parseJsonc, type FormattingOptions } from 'jsonc-parser';
-import type { DetectedMcpClient, InitStepResult } from './types.js';
 import { getLauncherPath } from './launcher.js';
 import type { DetectedMcpClient, InitStepResult } from './types.js';
 


### PR DESCRIPTION
## Summary
Fallout from PR #112 squash-merge where \`git merge -X theirs\` left two import blocks per file (one from each side). oxc parser rejected redeclared identifiers, breaking \`npm test\` on master.

- \`src/cli/init.ts\`: collapse duplicate imports
- \`src/init/mcp-client.ts\`: drop duplicate jsonc-parser + types imports
- \`src/init/detector.ts\`: re-add missing \`import path from 'node:path'\`

## Test plan
- [x] \`npm run build\` green
- [x] \`npm test\` green (4597 passed)