### PR TITLE
fix(app): coalesce remaining res.statusCode → number ?? 0

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -448,7 +448,12 @@ function fetchLatestRelease(): Promise<{
           data += chunk;
         });
         res.on('end', () =>
-          resolve({ status: res.statusCode, body: data, etag: res.headers.etag, resetAt }),
+          resolve({
+            status: res.statusCode ?? 0,
+            body: data,
+            etag: res.headers.etag as string | undefined,
+            resetAt,
+          }),
         );
       },
     );


### PR DESCRIPTION
Missed third call site at line 451 in `fetchLatestRelease`. Same TS2322 root cause as #115.