### PR TITLE
docs: align CONTRIBUTING setup with pnpm packageManager

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,11 @@ The full CLA text is available in [CLA.md](CLA.md). Key points:
 ## Development
 
 ```bash
-npm install
-npm run build
-npm test
+corepack enable
+corepack prepare pnpm@10.33.0 --activate
+pnpm install
+pnpm run build
+pnpm test
 ```
 
 ## License


### PR DESCRIPTION
This PR aligns contributor setup instructions with the package manager declared in `package.json` (`pnpm@10.33.0`). No code changes.