### PR TITLE
fix(updater): locate installed .app by bundle id instead of guessing ~/Applications

### DIFF
--- a/packages/app/electron-builder.yml
+++ b/packages/app/electron-builder.yml
@@ -11,6 +11,10 @@ files:
 extraResources:
   - from: ../../scripts/apply-pending-update.mjs
     to: scripts/apply-pending-update.mjs
+  # locate-app.mjs is imported by apply-pending-update.mjs at runtime, so it
+  # must ship alongside it inside the bundle's Resources/scripts/.
+  - from: ../../scripts/locate-app.mjs
+    to: scripts/locate-app.mjs
 mac:
   category: public.app-category.developer-tools
   icon: build/icon.png

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -840,6 +840,69 @@ function appendUpdateLog(entry: Record<string, unknown>): void {
   }
 }
 
+// --- Bundle self-location ---------------------------------------------------
+//
+// The updater scripts (postinstall-app.mjs, apply-pending-update.mjs) used to
+// hard-code `~/Applications` and silently no-op for users whose .app lived in
+// `/Applications` — the more common drag-install target. We now have a shared
+// `scripts/locate-app.mjs` helper with a marker-file → mdfind → known-dirs
+// chain, but it cannot be imported here directly (this file is compiled by
+// tsc with `rootDir: src/main`, and scripts/ lives outside that root). So we
+// reimplement the writer inline. Constants below intentionally mirror the
+// helper's so a single grep across the repo finds all producers + consumers.
+
+const APP_BUNDLE_ID = 'com.trace-mcp.app';
+const APP_LOCATION_MARKER = path.join(
+  os.homedir(),
+  '.trace-mcp',
+  'app-location.json',
+);
+
+/**
+ * Walk up from `process.execPath` to the enclosing `.app` directory. Returns
+ * null in development (electron's own Electron.app is not our bundle) and on
+ * non-darwin. Caller is expected to fall back to the legacy `~/Applications`
+ * convention only when this returns null AND we're forced into the packaged
+ * code path — otherwise the legacy guess is the bug we're fixing.
+ */
+function deriveBundlePath(): string | null {
+  if (process.platform !== 'darwin') return null;
+  if (!app.isPackaged) return null;
+  let dir = path.dirname(process.execPath);
+  for (let i = 0; i < 10 && dir && dir !== '/'; i++) {
+    if (dir.endsWith('.app')) return dir;
+    dir = path.dirname(dir);
+  }
+  return null;
+}
+
+/**
+ * Persist the running bundle's path so the next npm-side postinstall picks
+ * the right `INSTALL_DIR`. Written every startup (cheap, ~150 bytes) so a
+ * user who moves the .app between launches self-heals on first run. Atomic
+ * via rename — concurrent readers never see a half-written file.
+ */
+function writeAppLocationMarker(bundlePath: string): void {
+  try {
+    fs.mkdirSync(path.dirname(APP_LOCATION_MARKER), { recursive: true });
+    const payload = {
+      appPath: bundlePath,
+      bundleId: APP_BUNDLE_ID,
+      version: app.getVersion().replace(/^v/, ''),
+      writtenAt: Date.now(),
+    };
+    const tmp = `${APP_LOCATION_MARKER}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(payload, null, 2));
+    fs.renameSync(tmp, APP_LOCATION_MARKER);
+    appendUpdateLog({ event: 'app-location:written', appPath: bundlePath });
+  } catch (err) {
+    appendUpdateLog({
+      event: 'app-location:write-failed',
+      error: (err as Error)?.message ?? String(err),
+    });
+  }
+}
+
 function readInstalledVersion(npmRoot: string | null): string | undefined {
   if (!npmRoot) return undefined;
   try {
@@ -988,9 +1051,17 @@ ipcMain.handle('apply-update', async () => {
   return { ok: true, pending, outcome, version: pending ? installedVersion : undefined };
 });
 
-// Pending update plumbing — postinstall stages a verified zip into ~/Applications/
-// when it detects this app is running, so the swap can be deferred until exit.
-const INSTALL_DIR = path.join(os.homedir(), 'Applications');
+// Pending update plumbing — postinstall stages a verified zip next to the
+// installed .app so the swap can be deferred until exit. The install dir is
+// derived from the running bundle (`process.execPath`-walked-to-.app) instead
+// of the previously-hardcoded `~/Applications`, which silently missed users
+// with the .app dragged into `/Applications`. Dev-mode falls back to
+// `~/Applications` — the pending flow is unreachable there anyway because
+// extraResources are only present in packaged builds.
+const BUNDLE_PATH = deriveBundlePath();
+const INSTALL_DIR = BUNDLE_PATH
+  ? path.dirname(BUNDLE_PATH)
+  : path.join(os.homedir(), 'Applications');
 const PENDING_ZIP = path.join(INSTALL_DIR, '.trace-mcp-pending.zip');
 const PENDING_VERSION = path.join(INSTALL_DIR, '.trace-mcp-pending-version');
 // Bundled via electron-builder `extraResources` in production; falls back to the
@@ -1067,6 +1138,11 @@ ipcMain.handle('restart-app', () => {
 });
 
 app.whenReady().then(() => {
+  // Refresh the bundle-location marker so the npm-side postinstall + the
+  // detached apply-pending-update helper read the actual install location
+  // instead of guessing `~/Applications`. Cheap (~150 byte JSON write) and
+  // best-effort — failures are logged to update.log but never surface.
+  if (BUNDLE_PATH) writeAppLocationMarker(BUNDLE_PATH);
   // macOS: set custom dock icon so it's ready when the window shows.
   if (process.platform === 'darwin' && fs.existsSync(dockIconPath)) {
     app.dock?.setIcon(nativeImage.createFromPath(dockIconPath));

--- a/scripts/apply-pending-update.mjs
+++ b/scripts/apply-pending-update.mjs
@@ -26,13 +26,18 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-const APP_NAME = 'trace-mcp.app';
-const INSTALL_DIR = path.join(os.homedir(), 'Applications');
-const APP_PATH = path.join(INSTALL_DIR, APP_NAME);
-const PENDING_ZIP = path.join(INSTALL_DIR, '.trace-mcp-pending.zip');
-const PENDING_VERSION = path.join(INSTALL_DIR, '.trace-mcp-pending-version');
-const PENDING_CHECKSUM = path.join(INSTALL_DIR, '.trace-mcp-pending.sha256');
-const VERSION_MARKER = path.join(INSTALL_DIR, '.trace-mcp-version');
+import { APP_NAME, locateInstalledApp } from './locate-app.mjs';
+
+// Resolved by main() via locateInstalledApp(). Pending-zip and version markers
+// must live next to the actual `.app` (atomic `fs.renameSync` requires the
+// same filesystem), so all paths are derived from APP_PATH rather than a
+// hard-coded `~/Applications` install root.
+let APP_PATH = '';
+let INSTALL_DIR = '';
+let PENDING_ZIP = '';
+let PENDING_VERSION = '';
+let PENDING_CHECKSUM = '';
+let VERSION_MARKER = '';
 const LAUNCHER_ENV = path.join(os.homedir(), '.trace-mcp', 'launcher.env');
 const DAEMON_PLIST = path.join(
   os.homedir(),
@@ -236,6 +241,19 @@ async function main() {
     log('abort: not darwin');
     return;
   }
+  const located = locateInstalledApp();
+  if (!located) {
+    log('abort: locateInstalledApp returned null (no bundle resolved)');
+    return;
+  }
+  APP_PATH = located.appPath;
+  INSTALL_DIR = path.dirname(APP_PATH);
+  PENDING_ZIP = path.join(INSTALL_DIR, '.trace-mcp-pending.zip');
+  PENDING_VERSION = path.join(INSTALL_DIR, '.trace-mcp-pending-version');
+  PENDING_CHECKSUM = path.join(INSTALL_DIR, '.trace-mcp-pending.sha256');
+  VERSION_MARKER = path.join(INSTALL_DIR, '.trace-mcp-version');
+  log(`locate: source=${located.source} appPath=${APP_PATH}`);
+
   if (!fs.existsSync(PENDING_ZIP) || !fs.existsSync(PENDING_VERSION)) {
     log('abort: no pending zip/version');
     return;

--- a/scripts/locate-app.mjs
+++ b/scripts/locate-app.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+
+/**
+ * Single source of truth for "where is the installed trace-mcp.app".
+ *
+ * Three callers historically computed this independently and all hard-coded
+ * `~/Applications`:
+ *   - scripts/postinstall-app.mjs       (zip-stage on npm install)
+ *   - scripts/apply-pending-update.mjs  (bundle swap on restart)
+ *   - packages/app/src/main/index.ts    (Electron-side update IPC)
+ *
+ * When the user drag-installed the .app into `/Applications` (system-wide)
+ * — the more common location on macOS — every path missed it, the postinstall
+ * exited silently without staging, the in-app updater shipped a npm-only
+ * update, and the "Restart to install" banner cycled forever.
+ *
+ * Resolution chain (highest-confidence first):
+ *
+ *   1. **Marker file** `~/.trace-mcp/app-location.json`, written by Electron
+ *      main on every startup from `process.execPath`. This is exact: the path
+ *      came from the running bundle itself, not from a guess about install
+ *      conventions. The marker is the steady-state mechanism after the first
+ *      successful upgrade past this change.
+ *
+ *   2. **`mdfind` by `CFBundleIdentifier`**. Spotlight's Launch Services index
+ *      knows every installed .app regardless of install location, so this
+ *      finds the bundle on a *first* run before the marker exists. Used to
+ *      bootstrap users currently stuck on a pre-marker version of the .app.
+ *
+ *   3. **Conventional fallback directories** `~/Applications` then
+ *      `/Applications`. Last-resort for environments where Spotlight is
+ *      disabled (rare, corporate MDM territory). Logged as `fallback` so
+ *      diagnostic queries can spot the degraded mode.
+ *
+ * Validation: every candidate path is checked for `Contents/Info.plist` with
+ * a matching `CFBundleIdentifier`, so a stale Spotlight entry or a
+ * leftover-marker pointing at a moved bundle is rejected and the chain
+ * continues. A path that fails validation is never returned.
+ *
+ * Returns `null` on non-darwin platforms or when nothing is found — callers
+ * are expected to no-op in that case (matches prior `process.exit(0)`
+ * behavior of postinstall-app.mjs when the .app was absent).
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export const APP_NAME = 'trace-mcp.app';
+export const BUNDLE_ID = 'com.trace-mcp.app';
+export const LOCATION_MARKER_FILENAME = 'app-location.json';
+
+/**
+ * @typedef {Object} LocateResult
+ * @property {string} appPath - Absolute path to the validated `.app` bundle.
+ * @property {'marker'|'mdfind'|'fallback'} source - Which step of the chain resolved it.
+ */
+
+/**
+ * @typedef {Object} LocateOptions
+ * @property {string} [homeDir]      Override `os.homedir()` (tests).
+ * @property {string} [appName]      Bundle filename, default `trace-mcp.app`.
+ * @property {string} [bundleId]     Expected `CFBundleIdentifier`.
+ * @property {string} [mdfindBin]    Path to `mdfind`, default `/usr/bin/mdfind`.
+ * @property {string} [plistBuddyBin] Path to `PlistBuddy`, default Apple's location.
+ * @property {string[]} [fallbackDirs] Conventional directories to probe last.
+ * @property {string}  [platform]    Override `process.platform` (tests).
+ */
+
+/**
+ * @param {LocateOptions} [options]
+ * @returns {LocateResult | null}
+ */
+export function locateInstalledApp(options = {}) {
+  const platform = options.platform ?? process.platform;
+  if (platform !== 'darwin') return null;
+
+  const home = options.homeDir ?? os.homedir();
+  const appName = options.appName ?? APP_NAME;
+  const bundleId = options.bundleId ?? BUNDLE_ID;
+  const mdfindBin = options.mdfindBin ?? '/usr/bin/mdfind';
+  const plistBuddyBin = options.plistBuddyBin ?? '/usr/libexec/PlistBuddy';
+  const fallbackDirs = options.fallbackDirs ?? [path.join(home, 'Applications'), '/Applications'];
+  const markerPath = path.join(home, '.trace-mcp', LOCATION_MARKER_FILENAME);
+
+  const fromMarker = resolveFromMarker(markerPath, bundleId, plistBuddyBin);
+  if (fromMarker) return { appPath: fromMarker, source: 'marker' };
+
+  const fromMdfind = resolveFromMdfind(mdfindBin, bundleId, plistBuddyBin);
+  if (fromMdfind) return { appPath: fromMdfind, source: 'mdfind' };
+
+  for (const dir of fallbackDirs) {
+    const candidate = path.join(dir, appName);
+    if (isValidAppBundle(candidate, bundleId, plistBuddyBin)) {
+      return { appPath: candidate, source: 'fallback' };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Write the location marker. Called by Electron main on every startup with
+ * `process.execPath`-derived path. Best-effort: failures are swallowed
+ * because losing the marker degrades gracefully to mdfind fallback.
+ *
+ * @param {string} appPath  Absolute path to the running `.app` bundle.
+ * @param {{ version?: string, homeDir?: string, bundleId?: string }} [meta]
+ */
+export function writeAppLocationMarker(appPath, meta = {}) {
+  try {
+    const home = meta.homeDir ?? os.homedir();
+    const markerDir = path.join(home, '.trace-mcp');
+    fs.mkdirSync(markerDir, { recursive: true });
+    const payload = {
+      appPath,
+      bundleId: meta.bundleId ?? BUNDLE_ID,
+      version: meta.version,
+      writtenAt: Date.now(),
+    };
+    const markerPath = path.join(markerDir, LOCATION_MARKER_FILENAME);
+    // Atomic via rename so a concurrent reader never sees a half-written file.
+    const tmp = `${markerPath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(payload, null, 2));
+    fs.renameSync(tmp, markerPath);
+  } catch {
+    /* marker is best-effort; mdfind covers the bootstrap path */
+  }
+}
+
+function resolveFromMarker(markerPath, bundleId, plistBuddyBin) {
+  let raw;
+  try {
+    raw = fs.readFileSync(markerPath, 'utf-8');
+  } catch {
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const candidate = typeof parsed?.appPath === 'string' ? parsed.appPath : null;
+  if (!candidate) return null;
+  if (!isValidAppBundle(candidate, bundleId, plistBuddyBin)) return null;
+  return candidate;
+}
+
+function resolveFromMdfind(mdfindBin, bundleId, plistBuddyBin) {
+  let stdout;
+  try {
+    stdout = execFileSync(mdfindBin, [`kMDItemCFBundleIdentifier == '${bundleId}'`], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf-8',
+      timeout: 5_000,
+    });
+  } catch {
+    return null;
+  }
+  const candidates = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  for (const candidate of candidates) {
+    if (isValidAppBundle(candidate, bundleId, plistBuddyBin)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * A path is a valid bundle when it contains `Contents/Info.plist` whose
+ * `CFBundleIdentifier` matches `bundleId`. PlistBuddy handles both XML and
+ * binary plists; if it is unavailable we fall back to a regex over the raw
+ * file (works for the XML plists electron-builder produces).
+ */
+function isValidAppBundle(candidatePath, bundleId, plistBuddyBin) {
+  if (!candidatePath) return false;
+  const infoPlist = path.join(candidatePath, 'Contents', 'Info.plist');
+  if (!fs.existsSync(infoPlist)) return false;
+  try {
+    const out = execFileSync(plistBuddyBin, ['-c', 'Print :CFBundleIdentifier', infoPlist], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf-8',
+    });
+    return out.trim() === bundleId;
+  } catch {
+    // PlistBuddy missing or binary plist on a non-Apple host — try a regex
+    // over the raw bytes. Good enough for electron-builder XML plists.
+    try {
+      const raw = fs.readFileSync(infoPlist, 'utf-8');
+      const m = raw.match(/<key>CFBundleIdentifier<\/key>\s*<string>([^<]+)<\/string>/);
+      return m?.[1]?.trim() === bundleId;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/scripts/postinstall-app.mjs
+++ b/scripts/postinstall-app.mjs
@@ -29,12 +29,19 @@ import https from 'node:https';
 import os from 'node:os';
 import path from 'node:path';
 
-const APP_NAME = 'trace-mcp.app';
-const INSTALL_DIR = path.join(os.homedir(), 'Applications');
-const APP_PATH = path.join(INSTALL_DIR, APP_NAME);
-const PENDING_ZIP = path.join(INSTALL_DIR, '.trace-mcp-pending.zip');
-const PENDING_VERSION = path.join(INSTALL_DIR, '.trace-mcp-pending-version');
-const PENDING_CHECKSUM = path.join(INSTALL_DIR, '.trace-mcp-pending.sha256');
+import { APP_NAME, locateInstalledApp } from './locate-app.mjs';
+
+// Resolved at top-level after the platform/no-update gates run. `null` means
+// no install was found — the script then exits 0 like the old hardcoded
+// `!fs.existsSync(APP_PATH)` short-circuit. All path constants below are
+// derived from the resolved bundle so pending-zip files are written next to
+// the actual `.app` (same filesystem → atomic rename works).
+let APP_PATH = '';
+let INSTALL_DIR = '';
+let PENDING_ZIP = '';
+let PENDING_VERSION = '';
+let PENDING_CHECKSUM = '';
+
 const GITHUB_REPO = 'nikolai-vysotskyi/trace-mcp';
 
 if (process.env.TRACE_MCP_NO_AUTO_UPDATE === '1') process.exit(0);
@@ -77,7 +84,16 @@ function stopRunningDaemon() {
 
 stopRunningDaemon();
 
-if (process.platform !== 'darwin' || !fs.existsSync(APP_PATH)) process.exit(0);
+if (process.platform !== 'darwin') process.exit(0);
+
+const located = locateInstalledApp();
+if (!located) process.exit(0);
+
+APP_PATH = located.appPath;
+INSTALL_DIR = path.dirname(APP_PATH);
+PENDING_ZIP = path.join(INSTALL_DIR, '.trace-mcp-pending.zip');
+PENDING_VERSION = path.join(INSTALL_DIR, '.trace-mcp-pending-version');
+PENDING_CHECKSUM = path.join(INSTALL_DIR, '.trace-mcp-pending.sha256');
 
 /** Returns true if the installed trace-mcp.app is currently running. */
 function appIsRunning() {

--- a/tests/scripts/locate-app.test.ts
+++ b/tests/scripts/locate-app.test.ts
@@ -1,0 +1,273 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const MODULE_PATH = path.join(REPO_ROOT, 'scripts', 'locate-app.mjs');
+
+const BUNDLE_ID = 'com.trace-mcp.app';
+
+/**
+ * Build a minimal .app bundle with a matching CFBundleIdentifier. We write a
+ * real XML Info.plist so the PlistBuddy path and the regex fallback both
+ * resolve in CI environments — vitest runs the same suite on macOS and Linux.
+ */
+function createFakeBundle(parentDir: string, bundleId: string = BUNDLE_ID): string {
+  const appPath = path.join(parentDir, 'trace-mcp.app');
+  const contents = path.join(appPath, 'Contents');
+  fs.mkdirSync(contents, { recursive: true });
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>${bundleId}</string>
+  <key>CFBundleShortVersionString</key>
+  <string>9.9.9</string>
+</dict>
+</plist>
+`;
+  fs.writeFileSync(path.join(contents, 'Info.plist'), plist);
+  return appPath;
+}
+
+/**
+ * A `mdfind` stub: a tiny shell script that echoes whatever lines we ask it
+ * to. Lets us cover both the "bundle exists" and "Spotlight returns a stale
+ * entry" cases without touching the real Launch Services index.
+ */
+function createMdfindStub(home: string, lines: string[]): string {
+  const stub = path.join(home, 'mdfind-stub.sh');
+  // We ignore arguments — the helper only cares about stdout content.
+  const script = `#!/usr/bin/env bash\ncat <<'EOF'\n${lines.join('\n')}\nEOF\n`;
+  fs.writeFileSync(stub, script, { mode: 0o755 });
+  return stub;
+}
+
+/**
+ * Drive locateInstalledApp via a child node process so each test owns a
+ * clean process.env / module-resolution context. We pass options as JSON
+ * through argv to keep the harness self-contained.
+ */
+function runLocate(opts: {
+  homeDir: string;
+  fallbackDirs: string[];
+  mdfindBin?: string;
+  platform?: NodeJS.Platform;
+}): { result: { appPath: string; source: string } | null; stderr: string } {
+  const harness = `
+import { locateInstalledApp } from ${JSON.stringify(MODULE_PATH)};
+const opts = JSON.parse(process.argv[2]);
+const r = locateInstalledApp(opts);
+process.stdout.write(JSON.stringify(r));
+`;
+  const harnessPath = path.join(opts.homeDir, 'locate-harness.mjs');
+  fs.writeFileSync(harnessPath, harness);
+  let stdout = '';
+  let stderr = '';
+  try {
+    stdout = execFileSync(process.execPath, [harnessPath, JSON.stringify(opts)], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+      timeout: 15_000,
+    });
+  } catch (err) {
+    const e = err as { stdout?: Buffer | string; stderr?: Buffer | string };
+    stdout = e.stdout?.toString() ?? '';
+    stderr = e.stderr?.toString() ?? '';
+  }
+  let result: { appPath: string; source: string } | null = null;
+  if (stdout) {
+    try {
+      result = JSON.parse(stdout);
+    } catch {
+      result = null;
+    }
+  }
+  return { result, stderr };
+}
+
+function runWriteMarker(home: string, appPath: string, version: string): void {
+  const harness = `
+import { writeAppLocationMarker } from ${JSON.stringify(MODULE_PATH)};
+writeAppLocationMarker(${JSON.stringify(appPath)}, { homeDir: ${JSON.stringify(home)}, version: ${JSON.stringify(version)} });
+`;
+  const harnessPath = path.join(home, 'write-harness.mjs');
+  fs.writeFileSync(harnessPath, harness);
+  execFileSync(process.execPath, [harnessPath], { stdio: 'ignore', timeout: 10_000 });
+}
+
+describe('locateInstalledApp', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-locate-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('returns null on non-darwin platforms', () => {
+    const { result } = runLocate({
+      homeDir: home,
+      fallbackDirs: [home],
+      platform: 'linux',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('prefers the marker file when it points at a valid bundle', () => {
+    // Two real bundles: marker target and a fallback. Helper must pick the marker.
+    const markerTarget = createFakeBundle(path.join(home, 'marker-dest'));
+    const fallbackRoot = path.join(home, 'fallback-apps');
+    fs.mkdirSync(fallbackRoot, { recursive: true });
+    createFakeBundle(fallbackRoot);
+
+    runWriteMarker(home, markerTarget, '1.2.3');
+
+    const { result } = runLocate({
+      homeDir: home,
+      fallbackDirs: [fallbackRoot],
+      // mdfind stub that would return a totally different bundle — must be ignored.
+      mdfindBin: createMdfindStub(home, ['/nowhere/should-not-be-used.app']),
+      platform: 'darwin',
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.source).toBe('marker');
+    expect(result?.appPath).toBe(markerTarget);
+  });
+
+  it('rejects a marker whose bundle no longer exists, falls through to mdfind', () => {
+    // Marker points at a path that was deleted between launches.
+    fs.mkdirSync(path.join(home, '.trace-mcp'), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, '.trace-mcp', 'app-location.json'),
+      JSON.stringify({
+        appPath: path.join(home, 'gone', 'trace-mcp.app'),
+        bundleId: BUNDLE_ID,
+        version: '1.0.0',
+        writtenAt: Date.now(),
+      }),
+    );
+
+    const mdfindTarget = createFakeBundle(path.join(home, 'mdfind-dest'));
+    const mdfindBin = createMdfindStub(home, [mdfindTarget]);
+
+    const { result } = runLocate({
+      homeDir: home,
+      fallbackDirs: [],
+      mdfindBin,
+      platform: 'darwin',
+    });
+
+    expect(result?.source).toBe('mdfind');
+    expect(result?.appPath).toBe(mdfindTarget);
+  });
+
+  it('rejects a marker whose Info.plist has the wrong bundle id', () => {
+    const wrong = createFakeBundle(path.join(home, 'wrong'), 'com.someoneelse.app');
+    runWriteMarker(home, wrong, '1.0.0');
+
+    const mdfindTarget = createFakeBundle(path.join(home, 'real'));
+    const mdfindBin = createMdfindStub(home, [mdfindTarget]);
+
+    const { result } = runLocate({
+      homeDir: home,
+      fallbackDirs: [],
+      mdfindBin,
+      platform: 'darwin',
+    });
+
+    expect(result?.source).toBe('mdfind');
+    expect(result?.appPath).toBe(mdfindTarget);
+  });
+
+  it('uses mdfind when no marker exists', () => {
+    const mdfindTarget = createFakeBundle(path.join(home, 'launch-services-dest'));
+    const mdfindBin = createMdfindStub(home, [mdfindTarget]);
+
+    const { result } = runLocate({
+      homeDir: home,
+      fallbackDirs: [],
+      mdfindBin,
+      platform: 'darwin',
+    });
+
+    expect(result?.source).toBe('mdfind');
+    expect(result?.appPath).toBe(mdfindTarget);
+  });
+
+  it('skips stale mdfind hits whose bundle was deleted', () => {
+    // First mdfind result is a path that does not exist; second is valid.
+    const realTarget = createFakeBundle(path.join(home, 'real'));
+    const mdfindBin = createMdfindStub(home, [
+      path.join(home, 'deleted', 'trace-mcp.app'),
+      realTarget,
+    ]);
+
+    const { result } = runLocate({
+      homeDir: home,
+      fallbackDirs: [],
+      mdfindBin,
+      platform: 'darwin',
+    });
+
+    expect(result?.source).toBe('mdfind');
+    expect(result?.appPath).toBe(realTarget);
+  });
+
+  it('falls back to conventional dirs when marker and mdfind both miss', () => {
+    const conventionalDir = path.join(home, 'system-applications');
+    fs.mkdirSync(conventionalDir, { recursive: true });
+    const target = createFakeBundle(conventionalDir);
+
+    const { result } = runLocate({
+      homeDir: home,
+      fallbackDirs: [conventionalDir],
+      // mdfind stub returns nothing.
+      mdfindBin: createMdfindStub(home, []),
+      platform: 'darwin',
+    });
+
+    expect(result?.source).toBe('fallback');
+    expect(result?.appPath).toBe(target);
+  });
+
+  it('returns null when nothing resolves', () => {
+    const { result } = runLocate({
+      homeDir: home,
+      fallbackDirs: [path.join(home, 'nowhere')],
+      mdfindBin: createMdfindStub(home, []),
+      platform: 'darwin',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('writeAppLocationMarker round-trips through the marker reader', () => {
+    const target = createFakeBundle(path.join(home, 'bundle-here'));
+    runWriteMarker(home, target, '1.39.5');
+
+    const markerRaw = fs.readFileSync(path.join(home, '.trace-mcp', 'app-location.json'), 'utf-8');
+    const parsed = JSON.parse(markerRaw);
+    expect(parsed.appPath).toBe(target);
+    expect(parsed.bundleId).toBe(BUNDLE_ID);
+    expect(parsed.version).toBe('1.39.5');
+    expect(typeof parsed.writtenAt).toBe('number');
+
+    const { result } = runLocate({
+      homeDir: home,
+      fallbackDirs: [],
+      mdfindBin: createMdfindStub(home, []),
+      platform: 'darwin',
+    });
+    expect(result?.source).toBe('marker');
+    expect(result?.appPath).toBe(target);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/locate-app.mjs` as the single source of truth for *"where is the installed `trace-mcp.app`"* (marker file → `mdfind` by CFBundleIdentifier → conventional dirs), with full CFBundleIdentifier validation of every candidate.
- Electron main writes `~/.trace-mcp/app-location.json` on every `whenReady` from `process.execPath`, so the npm-side postinstall + detached apply-pending-update read the actual install location instead of guessing.
- `postinstall-app.mjs`, `apply-pending-update.mjs`, and `packages/app/src/main/index.ts` all derive `INSTALL_DIR`/`PENDING_*` from the located bundle — pending-zip stays on the same filesystem as the `.app`, atomic `renameSync` works as before.

## Root cause

Three independent call sites each hard-coded `~/Applications` as the install root. Users who drag-installed the `.app` into `/Applications` (the more common target) hit a silent breakage:

1. `scripts/postinstall-app.mjs` short-circuited on `!fs.existsSync('~/Applications/trace-mcp.app')` — no zip ever staged.
2. The in-app updater fell through to the npm-only outcome with the running Electron bundle frozen at the prior version.
3. \"Restart to install\" relaunched into the same un-swapped bundle; the next \`check-for-update\` saw the mismatch and re-armed the banner. Verified locally on a stuck install (bundle 1.39.2, npm 1.39.4) with recurring `runningVersion !== installedVersion` entries in `~/.trace-mcp/update.log`.

## Architecture

Same pattern as [packages/app/src/main/update-state.ts](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/packages/app/src/main/update-state.ts) — Electron persists a small JSON file under `~/.trace-mcp/` so out-of-process callers don't have to guess about state only the running bundle knows. The marker is the steady-state mechanism; `mdfind` bootstraps users whose currently-running bundle pre-dates this change; conventional dirs are the diagnostic last-resort.

Every candidate is validated by reading `Contents/Info.plist` and checking `CFBundleIdentifier == com.trace-mcp.app`, so stale Spotlight entries, leftover markers pointing at deleted bundles, and unrelated apps with similar names cannot be returned.

## Bootstrap caveat

Users on pre-1.39.5 bundles will see the new postinstall stage the zip in the correct location, but their *old* Electron still looks for \`PENDING_ZIP\` under \`~/Applications\` and will not pick it up. A single manual reinstall of the new \`.app\` (drag from the release zip into wherever they keep it) fixes them; from there the marker file takes over. Worth a CHANGELOG note when this lands.

## Test plan

- [x] `pnpm test` — 7489 passed, 0 failed, 9 skipped (full suite green).
- [x] `tests/scripts/locate-app.test.ts` (9 new cases): marker / mdfind / fallback happy paths, stale-marker rejection, wrong-bundle-id rejection, stale-mdfind-hit skip, marker write→read round-trip, non-darwin null.
- [x] `pnpm typecheck` in `packages/app` clean. (Root \`pnpm typecheck\` has 7 pre-existing errors in `src/tools/register/navigation.ts` unrelated to this PR — confirmed by stashing the diff and re-running.)
- [x] `pnpm exec biome check` clean on every changed file.
- [ ] Reviewer: smoke-test manually that the marker file appears under `~/.trace-mcp/app-location.json` after first launch of a packaged build, and that `mdfind \"kMDItemCFBundleIdentifier == 'com.trace-mcp.app'\"` returns the expected path before the marker is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)