### PR TITLE
fix(indexer): stop following directory symlinks during file discovery

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,9 +18,9 @@ All user-supplied paths are validated before any file is read.
 
 Symlinks can be used to escape the project root and read arbitrary files.
 
-* **Symlinks are always skipped** — `fs.lstatSync()` detects symlinks without following them.
-* When a symlink is encountered during indexing, it is logged as a warning and excluded.
-* There is no option to follow symlinks — this is a hard security boundary.
+* **Symlinked files are always skipped at extraction time** — `fs.lstatSync()` detects symlinks without following them, regardless of any config setting. When a symlink is encountered during indexing, it is logged as a warning and excluded. This is a hard security boundary with no opt-out.
+* **Directory symlinks are not followed during file discovery by default** (`follow_symlinks: false`). This prevents a directory symlink that cycles back to an ancestor — e.g. Ansible Molecule's `roles/<role>/molecule/<scenario>/roles/<role> -> ../../../` layout — from making the glob walker recurse until the OS raises `ENAMETOOLONG` (#218).
+* Setting `follow_symlinks: true` only widens *discovery* (which directories the glob walker descends into) — it does not disable the always-on file-level symlink rejection above. Enable it only for trees known to be free of symlink cycles; on a tree with a cycle it can silently truncate traversal once fast-glob's internal error suppression kicks in.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,7 @@ You can add more via `.traceignore` or the `ignore.directories` config key.
 | `root` | `string` | `"."` | Project root directory |
 | `include` | `string[]` | Auto-detected | Glob patterns for files to index |
 | `exclude` | `string[]` | Common exclusions | Glob patterns to skip |
+| `follow_symlinks` | `boolean` | `false` | Follow directory symlinks during file discovery. Leave off unless you know the tree is free of symlink cycles — enabling it on a tree with a cycle (e.g. Ansible Molecule's `roles/<role>/molecule/<scenario>/roles/<role> -> ../../../` layout) can silently truncate traversal. Symlinked *files* are always skipped regardless of this setting. |
 | `ignore.directories` | `string[]` | `[]` | Extra directory names to skip (added to built-in list) |
 | `ignore.patterns` | `string[]` | `[]` | Extra gitignore-style patterns to exclude from indexing |
 | `plugins` | `string[]` | `[]` | Paths to custom plugins |

--- a/src/__tests__/config-jsonc-merge.test.ts
+++ b/src/__tests__/config-jsonc-merge.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression coverage for #218 — `saveProjectConfigJsonc` used to call
+ * `modifyGlobalConfigJsonc(['projects', projectRoot], config)`, and
+ * jsonc-parser's `modify()` REPLACES the whole object at that path. Since
+ * `setupProject` always passes a fresh `{root, include, exclude}`, a
+ * re-register (`init --force` / `add --force`) silently dropped any
+ * caller-omitted, user-added keys in the per-project section — e.g. a
+ * hand-edited `ignore` block. The fix merges onto the existing section before
+ * writing so caller-supplied keys win but unrelated keys survive.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { parse } from 'jsonc-parser';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let tmpHome: string;
+let configJsonc: typeof import('../config-jsonc.js');
+let GLOBAL_CONFIG_PATH: string;
+
+beforeEach(async () => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-config-jsonc-'));
+  vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+  vi.resetModules();
+  configJsonc = await import('../config-jsonc.js');
+  ({ GLOBAL_CONFIG_PATH } = await import('../global.js'));
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe('saveProjectConfigJsonc — merge-before-write (#218)', () => {
+  it('preserves a user-added ignore block across a re-register that omits it', () => {
+    fs.mkdirSync(path.dirname(GLOBAL_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(
+      GLOBAL_CONFIG_PATH,
+      JSON.stringify({
+        projects: {
+          '/fake/proj': {
+            root: '.',
+            include: ['old/**/*.ts'],
+            exclude: ['old-dist/**'],
+            ignore: { directories: ['custom'] },
+          },
+        },
+      }),
+      'utf-8',
+    );
+
+    configJsonc.saveProjectConfigJsonc('/fake/proj', {
+      root: '.',
+      include: ['src/**/*.ts'],
+      exclude: ['dist/**'],
+    });
+
+    const written = parse(fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8'));
+    const section = written.projects['/fake/proj'];
+
+    expect(section.root).toBe('.');
+    expect(section.include).toEqual(['src/**/*.ts']);
+    expect(section.exclude).toEqual(['dist/**']);
+    expect(section.ignore.directories).toContain('custom');
+  });
+
+  it('does not fail when the projects section or file is missing yet', () => {
+    expect(() =>
+      configJsonc.saveProjectConfigJsonc('/fresh/proj', {
+        root: '.',
+        include: ['src/**/*.ts'],
+        exclude: [],
+      }),
+    ).not.toThrow();
+
+    const written = parse(fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8'));
+    expect(written.projects['/fresh/proj'].include).toEqual(['src/**/*.ts']);
+  });
+});

--- a/src/config-jsonc.ts
+++ b/src/config-jsonc.ts
@@ -46,10 +46,22 @@ export function modifyGlobalConfigJsonc(jsonPath: (string | number)[], value: un
 // High-level: save / remove project config (comment-safe replacements)
 // ---------------------------------------------------------------------------
 
-/** Save per-project config section in the global config file (JSONC-safe). */
+/**
+ * Save per-project config section in the global config file (JSONC-safe).
+ *
+ * `modifyGlobalConfigJsonc` replaces the whole object at the path, so a bare
+ * re-register (init --force / add --force) would silently drop caller-omitted
+ * keys — e.g. a user-added `ignore` block — since callers here only ever pass
+ * `{root, include, exclude}`. Merge onto the existing section first so
+ * caller-supplied keys win but unrelated keys survive (#218).
+ */
 export function saveProjectConfigJsonc(projectRoot: string, config: Record<string, unknown>): void {
   ensureGlobalDirs();
-  modifyGlobalConfigJsonc(['projects', projectRoot], config);
+  const existing = parse(readGlobalConfigText()) as
+    | { projects?: Record<string, Record<string, unknown>> }
+    | undefined;
+  const existingSection = existing?.projects?.[projectRoot] ?? {};
+  modifyGlobalConfigJsonc(['projects', projectRoot], { ...existingSection, ...config });
 }
 
 /** Remove a per-project config section from the global config file (JSONC-safe). */

--- a/src/config.ts
+++ b/src/config.ts
@@ -854,6 +854,11 @@ export const TraceMcpConfigSchema = z.object({
     '**/.eggs/**',
     '**/*.egg-info/**',
   ]),
+  // Directory symlinks are not followed during indexing by default — a symlink
+  // cycling back to an ancestor (e.g. Ansible Molecule's `roles/<role> -> ../../../`
+  // layout) would otherwise make fast-glob recurse until the OS raises
+  // ENAMETOOLONG (#218). Opt in only for trees known to be cycle-free.
+  follow_symlinks: z.boolean().default(false),
   ignore: IgnoreConfigSchema,
   frameworks: FrameworkConfigSchema,
   ai: AiConfigSchema,

--- a/src/indexer/__tests__/env-indexer-symlinks.test.ts
+++ b/src/indexer/__tests__/env-indexer-symlinks.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression coverage for #218 — EnvIndexer's fast-glob call was the ONLY one
+ * in src/ with neither `suppressErrors` nor a surrounding try/catch, so an
+ * Ansible Molecule-style directory symlink cycle (`roles/<role>/molecule/
+ * <scenario>/roles/<role> -> ../../../`) crashed the whole indexing run with
+ * an uncaught ENAMETOOLONG rejection. A .env discovery failure must never
+ * abort the whole index.
+ */
+import Database from 'better-sqlite3';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TraceMcpConfigSchema } from '../../config.js';
+import { initializeDatabase } from '../../db/schema.js';
+import { Store } from '../../db/store.js';
+import { EnvIndexer } from '../env-indexer.js';
+
+let workDir: string;
+let db: Database.Database;
+let store: Store;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'env-indexer-symlinks-'));
+  db = initializeDatabase(join(workDir, 'index.db'));
+  store = new Store(db);
+});
+
+afterEach(() => {
+  try {
+    db.close();
+  } catch {
+    /* best-effort */
+  }
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('EnvIndexer.indexEnvFiles — symlink containment (#218)', () => {
+  it('resolves without throwing and still indexes a real .env on a molecule-style cycle', async () => {
+    const repoDir = join(workDir, 'repo');
+    const roleDir = join(repoDir, 'roles', 'docker');
+    const scenarioRolesDir = join(roleDir, 'molecule', 'default', 'roles');
+    mkdirSync(scenarioRolesDir, { recursive: true });
+    writeFileSync(join(repoDir, '.env'), 'DATABASE_URL=postgres://localhost/db\n');
+
+    let symlinkOk = true;
+    try {
+      symlinkSync('../../../', join(scenarioRolesDir, 'docker'), 'dir');
+    } catch {
+      symlinkOk = false;
+    }
+    if (!symlinkOk) {
+      return;
+    }
+
+    const config = TraceMcpConfigSchema.parse({});
+    const indexer = new EnvIndexer(store, config, repoDir);
+
+    await expect(indexer.indexEnvFiles(false)).resolves.toBeUndefined();
+
+    const envFile = store.getFile('.env');
+    expect(envFile).toBeDefined();
+    expect(store.getEnvVarsByFile(envFile?.id ?? -1).map((v) => v.key)).toContain('DATABASE_URL');
+  });
+});

--- a/src/indexer/__tests__/file-collector-symlinks.test.ts
+++ b/src/indexer/__tests__/file-collector-symlinks.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression coverage for #218 — an Ansible Molecule-style directory symlink
+ * cycling back to an ancestor (`roles/<role>/molecule/<scenario>/roles/<role> ->
+ * ../../../`) made fast-glob's default `followSymbolicLinks: true` recurse
+ * until the OS raised ENAMETOOLONG. `collectFiles` uses `suppressErrors: true`
+ * so it never crashed, but it DID follow the cycle first, collecting the same
+ * real files under ever-longer duplicated paths before the error was swallowed
+ * — a silent data-quality bug, not just a crash risk.
+ *
+ * These tests pin:
+ *   - default (`follow_symlinks: false`): the cycle is not descended into, and
+ *     no duplicated/cyclic path is returned.
+ *   - opt-in (`follow_symlinks: true`) on a NON-cyclic symlinked directory:
+ *     the escape hatch actually includes files behind the symlink.
+ */
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TraceMcpConfigSchema } from '../../config.js';
+import { collectFiles } from '../file-collector.js';
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'file-collector-symlinks-'));
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('collectFiles — symlink containment (#218)', () => {
+  it('resolves on a molecule-style symlink cycle and returns only the real files', async () => {
+    // Ansible Molecule layout: roles/<role>/molecule/<scenario>/roles/<role> -> ../../../
+    const roleDir = join(workDir, 'roles', 'docker');
+    const scenarioRolesDir = join(roleDir, 'molecule', 'default', 'roles');
+    mkdirSync(scenarioRolesDir, { recursive: true });
+    mkdirSync(join(workDir, 'src'), { recursive: true });
+    writeFileSync(join(workDir, 'src', 'real.ts'), 'export const real = 1;\n');
+    writeFileSync(join(roleDir, 'task.ts'), 'export const task = 1;\n');
+
+    let symlinkOk = true;
+    try {
+      symlinkSync('../../../', join(scenarioRolesDir, 'docker'), 'dir');
+    } catch {
+      symlinkOk = false;
+    }
+    if (!symlinkOk) {
+      // Windows CI without symlink privilege — skip rather than fail.
+      return;
+    }
+
+    const config = TraceMcpConfigSchema.parse({ include: ['**/*.ts'], exclude: [] });
+
+    const entries = await collectFiles({
+      config,
+      rootPath: workDir,
+      workspaces: [],
+      traceignore: undefined,
+      maxFiles: 10_000,
+    });
+
+    expect(entries).toEqual(expect.arrayContaining(['src/real.ts', 'roles/docker/task.ts']));
+    // No path may traverse into (or through) the symlinked directory — that
+    // would mean the cycle was followed, duplicating `roles/docker` under itself.
+    for (const entry of entries) {
+      expect(entry).not.toContain('molecule/default/roles/docker');
+    }
+    expect(entries.length).toBe(2);
+  });
+
+  it('opt-in follow_symlinks:true includes files behind a non-cyclic symlinked dir', async () => {
+    const outsideDir = join(workDir, 'outside');
+    mkdirSync(outsideDir, { recursive: true });
+    writeFileSync(join(outsideDir, 'shared.ts'), 'export const shared = 1;\n');
+
+    const projectDir = join(workDir, 'project');
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(join(projectDir, 'real.ts'), 'export const real = 1;\n');
+
+    let symlinkOk = true;
+    try {
+      symlinkSync(outsideDir, join(projectDir, 'linked'), 'dir');
+    } catch {
+      symlinkOk = false;
+    }
+    if (!symlinkOk) {
+      return;
+    }
+
+    const defaultConfig = TraceMcpConfigSchema.parse({ include: ['**/*.ts'], exclude: [] });
+    const defaultEntries = await collectFiles({
+      config: defaultConfig,
+      rootPath: projectDir,
+      workspaces: [],
+      traceignore: undefined,
+      maxFiles: 10_000,
+    });
+    expect(defaultEntries).toEqual(['real.ts']);
+
+    const followConfig = TraceMcpConfigSchema.parse({
+      include: ['**/*.ts'],
+      exclude: [],
+      follow_symlinks: true,
+    });
+    const followEntries = await collectFiles({
+      config: followConfig,
+      rootPath: projectDir,
+      workspaces: [],
+      traceignore: undefined,
+      maxFiles: 10_000,
+    });
+    expect(followEntries).toEqual(expect.arrayContaining(['real.ts', 'linked/shared.ts']));
+  });
+});

--- a/src/indexer/env-indexer.ts
+++ b/src/indexer/env-indexer.ts
@@ -35,18 +35,34 @@ export class EnvIndexer {
   }
 
   async indexEnvFiles(force: boolean): Promise<void> {
+    try {
+      await this.indexEnvFilesUnsafe(force);
+    } catch (err) {
+      logger.warn({ err }, 'Env indexing failed — skipping');
+    }
+  }
+
+  private async indexEnvFilesUnsafe(force: boolean): Promise<void> {
     await initContentHasher();
     // Default config.exclude contains `**/.env` / `**/.env.*` to keep env files out of
     // the code index. EnvIndexer only records keys + inferred types/formats (no values),
     // so those patterns would wrongly hide our input — filter them before globbing.
     const ignore = this.config.exclude.filter((p) => !isEnvFilePattern(p));
 
+    // followSymbolicLinks defaults to false (config.follow_symlinks) — a directory
+    // symlink cycling back to an ancestor (e.g. Ansible Molecule's
+    // `roles/<role> -> ../../../` layout) would otherwise make fast-glob recurse
+    // until ENAMETOOLONG (#218). suppressErrors: true is a second layer of defense
+    // on top of the outer try/catch — traversal errors should skip .env discovery,
+    // not abort indexing.
     const envPaths = await fg(ENV_GLOB, {
       cwd: this.rootPath,
       ignore,
       dot: true,
       absolute: false,
       onlyFiles: true,
+      followSymbolicLinks: this.config.follow_symlinks,
+      suppressErrors: true,
     });
 
     if (envPaths.length === 0) return;

--- a/src/indexer/file-collector.ts
+++ b/src/indexer/file-collector.ts
@@ -38,6 +38,10 @@ export async function collectFiles(params: FileCollectorParams): Promise<string[
   // `test/**` include) made fast-glob throw ENOTDIR and abort the whole
   // initial index, bricking the project in 'error' state. Traversal errors
   // (ENOTDIR/EACCES/ELOOP) must skip the entry, not kill indexing.
+  // followSymbolicLinks: directory symlinks are not followed by default
+  // (config.follow_symlinks) — cycle safety (issue #218, Ansible Molecule's
+  // self-referential `roles/<role> -> ../../../` layout), consistent with
+  // FileExtractor already skipping symlinked files.
   let entries = await fg(config.include, {
     cwd: rootPath,
     ignore,
@@ -45,6 +49,7 @@ export async function collectFiles(params: FileCollectorParams): Promise<string[
     absolute: false,
     onlyFiles: true,
     suppressErrors: true,
+    followSymbolicLinks: config.follow_symlinks,
   });
 
   // Monorepo / folder-of-projects: the directory-rooted include globs
@@ -66,6 +71,7 @@ export async function collectFiles(params: FileCollectorParams): Promise<string[
         absolute: false,
         onlyFiles: true,
         suppressErrors: true,
+        followSymbolicLinks: config.follow_symlinks,
       });
       if (wsEntries.length > 0) {
         const merged = new Set(entries);
@@ -88,6 +94,7 @@ export async function collectFiles(params: FileCollectorParams): Promise<string[
         absolute: false,
         onlyFiles: true,
         suppressErrors: true,
+        followSymbolicLinks: config.follow_symlinks,
       });
       if (entries.length > 0) {
         logger.info(

--- a/src/tools/navigation/__tests__/zero-index-symlinks.test.ts
+++ b/src/tools/navigation/__tests__/zero-index-symlinks.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression coverage for #218 on the zero-index fallback walker
+ * (`fallbackSearch` -> `manualSearch` -> `walk`, used when ripgrep is
+ * unavailable). The old implementation used `readdirSync` + `statSync`
+ * (follows symlinks) with no symlink gate, no visited set, and no depth cap,
+ * so a directory symlink cycling back to an ancestor (Ansible Molecule's
+ * `roles/<role> -> ../../../` layout) would spin unboundedly. Each call is
+ * wrapped in try/catch so it never crashed, but it never terminated either.
+ *
+ * The fix switches to `readdirSync(dir, { withFileTypes: true })` with an
+ * `entry.isDirectory()` gate (lstat semantics — does not follow directory
+ * symlinks) plus a depth cap as a second layer of defense.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fallbackSearch } from '../zero-index.js';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execFileSync: vi.fn(),
+  };
+});
+
+const mockedExecFileSync = vi.mocked(execFileSync);
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'zero-index-symlinks-'));
+  // Force the ripgrep path to fail with ENOENT so fallbackSearch falls
+  // through to the manual walk-based search (the code path under test).
+  mockedExecFileSync.mockImplementation(() => {
+    const err = new Error('rg not found') as NodeJS.ErrnoException;
+    err.code = 'ENOENT';
+    throw err;
+  });
+});
+
+afterEach(() => {
+  vi.mocked(execFileSync).mockReset();
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('fallbackSearch manual walker — symlink containment (#218)', () => {
+  it('terminates on a molecule-style symlink cycle and still finds real matches', () => {
+    const roleDir = join(workDir, 'roles', 'docker');
+    const scenarioRolesDir = join(roleDir, 'molecule', 'default', 'roles');
+    mkdirSync(scenarioRolesDir, { recursive: true });
+    writeFileSync(join(roleDir, 'task.ts'), 'const NEEDLE = 1;\n');
+
+    let symlinkOk = true;
+    try {
+      symlinkSync('../../../', join(scenarioRolesDir, 'docker'), 'dir');
+    } catch {
+      symlinkOk = false;
+    }
+    if (!symlinkOk) {
+      return;
+    }
+
+    const result = fallbackSearch(workDir, 'NEEDLE', {});
+
+    expect(result.fallback).toBe(true);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]?.file).toBe(join('roles', 'docker', 'task.ts'));
+  });
+});

--- a/src/tools/navigation/zero-index.ts
+++ b/src/tools/navigation/zero-index.ts
@@ -9,7 +9,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { readdirSync, readFileSync, type Stats, statSync } from 'node:fs';
+import { type Dirent, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import type { Store } from '../../db/store.js';
 import { TraceignoreMatcher } from '../../utils/traceignore.js';
@@ -156,30 +156,40 @@ function manualSearch(
   const regex = new RegExp(escapeRegex(query), 'gi');
   const traceignore = new TraceignoreMatcher(projectRoot);
 
-  function walk(dir: string): void {
+  // Depth cap guards against directory cycles the Dirent gate can't see (e.g.
+  // bind mounts). Symlink cycles themselves (Ansible Molecule's self-referential
+  // `roles/<role> -> ../../../` layout, #218) are already excluded: Dirent uses
+  // lstat semantics, so a symlinked directory reports false for both
+  // isDirectory() and isFile() and the entry is skipped entirely.
+  const MAX_WALK_DEPTH = 20;
+
+  function walk(dir: string, depth = 0): void {
     if (matches.length >= limit) return;
-    let entries: string[];
+    if (depth > MAX_WALK_DEPTH) return;
+    let entries: Dirent[];
     try {
-      entries = readdirSync(dir);
+      entries = readdirSync(dir, { withFileTypes: true });
     } catch {
       return;
     }
 
     for (const entry of entries) {
       if (matches.length >= limit) return;
-      if (traceignore.isSkippedDir(entry)) continue;
+      if (traceignore.isSkippedDir(entry.name)) continue;
 
-      const full = path.join(dir, entry);
-      let stat: Stats;
-      try {
-        stat = statSync(full);
-      } catch {
-        continue;
-      }
+      const full = path.join(dir, entry.name);
 
-      if (stat.isDirectory()) {
-        walk(full);
-      } else if (stat.isFile() && stat.size < 512 * 1024) {
+      if (entry.isDirectory()) {
+        walk(full, depth + 1);
+      } else if (entry.isFile()) {
+        let size: number;
+        try {
+          size = statSync(full).size;
+        } catch {
+          continue;
+        }
+        if (size >= 512 * 1024) continue;
+
         const rel = path.relative(projectRoot, full);
         if (traceignore.isIgnored(rel)) continue;
         try {


### PR DESCRIPTION
Fixes #218

## Root cause

`trace-mcp index` crashed with an uncaught `ENAMETOOLONG` on any tree containing a directory symlink that resolves to its own ancestor (the Ansible Molecule layout `roles/<role>/molecule/<scenario>/roles/<role> -> ../../../`). fast-glob's `followSymbolicLinks` defaults to `true` and its walker has no cycle detection, so the deep glob recursed through the cycle until the OS refused the path. The env-indexer's `fg()` call was the only one in the codebase with neither `suppressErrors` nor a try/catch anywhere up its call chain — the rejection escaped as an uncaught exception at the very last pipeline pass (matching the reported "crash near the end of the run, after edges are resolved"). The three file-collector `fg()` calls did not crash (`suppressErrors: true`) but silently followed the cycle first, collecting duplicated paths.

## Fix

- **Directory symlinks are no longer followed during file discovery** (file collector + env indexer), consistent with symlinked *files* already being skipped at extraction time. New `follow_symlinks` config option (default `false`) opts back in for trees known to be cycle-free — documented in `docs/configuration.md` and `SECURITY.md`.
- **Env indexing can no longer abort the run**: `suppressErrors: true` plus an outer try/catch that degrades to a warning.
- **zero-index fallback walker** (ripgrep-less text search) switched from `statSync` (follows symlinks, unbounded) to Dirent-gated recursion with a depth cap.
- **Config durability** (also reported in #218): `saveProjectConfigJsonc` now merges onto the existing per-project section instead of replacing it, so a re-register (`init --force` / `add --force`) no longer silently drops hand-added keys like `ignore`.

## Verification

- 6 new regression tests (symlink cycles created at runtime in temp dirs, skipped on platforms without symlink support); each verified to fail against pre-fix code.
- Full suite: 8299 passed, 2 pre-existing failures unrelated to this change (verified via stash round-trip).
- Canonical repro from #218 (100% reproducible before the fix): now exits 0 on both initial index and re-index; the produced DB contains exactly the real source files with no duplicated cycle paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)