### PR TITLE
feat(daemon): idle project unload, per-connection SQLite memory caps, ancestor watcher restart

### DIFF
--- a/src/__tests__/config-index-memory-defaults.test.ts
+++ b/src/__tests__/config-index-memory-defaults.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Guards the per-project-connection SQLite pragma defaults and the
+ * idle-unload sweep default. A per-project daemon connection opens
+ * `PRAGMA cache_size` + `PRAGMA mmap_size` (src/db/schema.ts initializeDatabase),
+ * so their cost scales linearly with the number of registered projects
+ * loaded by the daemon — a 10-project daemon at the old 64 MB cache /
+ * 256 MB mmap defaults resident-mapped ~770 MB just for these two pragmas.
+ * Pins the lowered defaults and that `project_idle_unload_minutes` is on by
+ * default so idle projects get reclaimed without user opt-in.
+ */
+import { describe, expect, it } from 'vitest';
+import { TraceMcpConfigSchema } from '../config.js';
+
+describe('per-project memory config defaults', () => {
+  const cfg = TraceMcpConfigSchema.parse({});
+
+  it('index_cache_mb defaults to 16 (down from the old hardcoded 64 MB)', () => {
+    expect(cfg.index_cache_mb).toBe(16);
+  });
+
+  it('index_mmap_mb defaults to 64 (down from the old hardcoded 256 MB)', () => {
+    expect(cfg.index_mmap_mb).toBe(64);
+  });
+
+  it('index_mmap_mb accepts 0 to disable mmap entirely', () => {
+    const parsed = TraceMcpConfigSchema.parse({ index_mmap_mb: 0 });
+    expect(parsed.index_mmap_mb).toBe(0);
+  });
+
+  it('project_idle_unload_minutes defaults to 30 (enabled out of the box)', () => {
+    expect(cfg.project_idle_unload_minutes).toBe(30);
+  });
+
+  it('project_idle_unload_minutes accepts 0 to disable the sweep', () => {
+    const parsed = TraceMcpConfigSchema.parse({ project_idle_unload_minutes: 0 });
+    expect(parsed.project_idle_unload_minutes).toBe(0);
+  });
+
+  it('rejects negative values for the memory-sizing knobs', () => {
+    expect(() => TraceMcpConfigSchema.parse({ index_cache_mb: -1 })).toThrow();
+    expect(() => TraceMcpConfigSchema.parse({ index_mmap_mb: -1 })).toThrow();
+    expect(() => TraceMcpConfigSchema.parse({ project_idle_unload_minutes: -1 })).toThrow();
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -944,7 +944,14 @@ program
               // wins (full watched mode).
               const asSubproject =
                 !folderMissing && !getProject(projectRoot) && isKnownSubproject(projectRoot);
-              const canAutoAdd = !folderMissing && !dangerReason && (hasMarkers || asSubproject);
+              // A root present in the on-disk registry but absent from the
+              // manager was idle-unloaded by the sweep
+              // (project_idle_unload_minutes) — always eligible for lazy
+              // reload, even without generic root markers (the user already
+              // vetted it at registration time).
+              const isRegistered = !folderMissing && !!getProject(projectRoot);
+              const canAutoAdd =
+                !folderMissing && !dangerReason && (hasMarkers || asSubproject || isRegistered);
               if (canAutoAdd && !projectManager.getProject(projectRoot)) {
                 try {
                   await projectManager.addProject(
@@ -1059,10 +1066,22 @@ program
 
       // Health endpoint — includes project status
       if (req.method === 'GET' && url.pathname === '/health') {
-        const projects = projectManager.listProjects().map((p) => ({
-          root: p.root,
-          status: p.status,
-        }));
+        const loadedRoots = new Set<string>();
+        const projects: Array<{
+          root: string;
+          status: ManagedProject['status'] | 'unloaded';
+        }> = projectManager.listProjects().map((p) => {
+          loadedRoots.add(p.root);
+          return { root: p.root, status: p.status };
+        });
+        // Registered projects idle-unloaded by the sweep (project_idle_unload_minutes)
+        // are absent from listProjects() — surface them as 'unloaded' rather than
+        // silently dropping them, so /health still reflects every registered root.
+        for (const entry of listProjects()) {
+          if (!loadedRoots.has(entry.root)) {
+            projects.push({ root: entry.root, status: 'unloaded' });
+          }
+        }
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(
           JSON.stringify({
@@ -1995,6 +2014,42 @@ program
           res.end(JSON.stringify({ error: `invalid JSON body: ${(e as Error).message}` }));
           return;
         }
+        // The project may be registered but idle-unloaded (project_idle_unload_minutes) —
+        // getProject() alone would see it as gone and handleReindexFile would
+        // 404 (non-retryable). Mirror the /mcp auto-register path: kick off a
+        // lazy reload and answer 503 + Retry-After so the hook falls back and
+        // retries transparently, same UX as a still-warming cold-start project.
+        const idleUnloadedRoot =
+          parsed?.project &&
+          !projectManager.getProject(parsed.project) &&
+          getProject(parsed.project)
+            ? parsed.project
+            : undefined;
+        if (idleUnloadedRoot) {
+          void projectManager
+            .addProject(idleUnloadedRoot)
+            .then(() => {
+              // Mirror the /mcp auto-register path: re-arm the progress
+              // listener the idle-unload sweep tore down, so the reload's
+              // indexing progress reaches SSE subscribers again.
+              subscribeToProjectProgress(idleUnloadedRoot);
+              broadcastEvent({
+                type: 'project_status',
+                project: idleUnloadedRoot,
+                status: 'indexing',
+              });
+            })
+            .catch((err) => {
+              logger.warn(
+                { err: String(err), projectRoot: idleUnloadedRoot },
+                'Lazy reload of idle-unloaded project failed',
+              );
+            });
+          res.writeHead(503, { 'Content-Type': 'application/json', 'Retry-After': '5' });
+          res.end(JSON.stringify({ error: `project not ready: reloading` }));
+          return;
+        }
+        pokeActivity(parsed.project);
         const result = await handleReindexFile(parsed, {
           getProject: (root) => projectManager.getProject(root),
         });
@@ -2657,6 +2712,31 @@ program
         await shutdown('idle-exit');
       },
     });
+
+    // ── Per-project idle-unload sweep ───────────────────────────
+    // Distinct from the whole-daemon idle-exit monitor above: this unloads
+    // individual cold projects (in-memory DB/pipeline/watcher/server) while
+    // the daemon keeps serving everything else, reclaiming per-connection
+    // SQLite cache/mmap for projects nobody has touched recently. Stays
+    // registered — reloads lazily on the next request (see the /mcp
+    // auto-register path and /api/projects/reindex-file). 0 disables.
+    const configuredIdleUnloadMinutes =
+      typeof globalRaw.project_idle_unload_minutes === 'number'
+        ? globalRaw.project_idle_unload_minutes
+        : 30;
+    projectManager.startIdleUnloadSweep(configuredIdleUnloadMinutes * 60_000, {
+      onUnloaded: (roots) => {
+        for (const root of roots) {
+          // Same cleanup as the DELETE endpoint: without it the progress
+          // listener closure pins the unloaded project's ProgressState for
+          // the daemon's lifetime. Sessions are already gone (the sweep
+          // skips refCount > 0 projects) so this is mostly the listener +
+          // throttle-key teardown.
+          teardownProjectBookkeeping(root);
+          broadcastEvent({ type: 'project_status', project: root, status: 'unloaded' });
+        }
+      },
+    });
     // Track activity: wrap the client/session/SSE mutation points in-place via
     // a ticker that re-evaluates on every /health check (cheap, idempotent).
     // Plus explicit hook below on key mutations.
@@ -2698,6 +2778,10 @@ program
     const pokeActivity = (projectRoot?: string): void => {
       idleMonitor.onActivity();
       memoryScheduler.notifyActivity(projectRoot);
+      // Resets the per-project idle-unload clock (project_idle_unload_minutes).
+      // No-op for the coarse (no-projectRoot) callers and for projects not
+      // currently loaded.
+      if (projectRoot) projectManager.touchActivity(projectRoot);
     };
 
     // ── Self-staleness detection ─────────────────────────────────

--- a/src/config.ts
+++ b/src/config.ts
@@ -946,6 +946,33 @@ export const TraceMcpConfigSchema = z.object({
    */
   daemon_idle_exit_minutes: z.number().min(0).max(1440).default(15),
   /**
+   * Minutes a registered project can go without a request/watcher-relevant
+   * touch before the daemon's periodic sweep unloads its in-memory state
+   * (DB handle, pipeline, watcher, MCP server) while leaving it registered.
+   * The next request for that project re-adds it lazily (503 + Retry-After
+   * while it warms, same UX as a cold-start project — see cli.ts serve-http
+   * Phase 5.1). 0 disables the sweep. Never unloads a project that is still
+   * indexing or has connected clients/SSE subscribers.
+   */
+  project_idle_unload_minutes: z.number().min(0).max(1440).default(30),
+  /**
+   * Per-project-connection SQLite page cache size, in MB, applied via
+   * `PRAGMA cache_size` on every index DB connection (one per registered
+   * project in the daemon). Memory cost scales linearly with project count —
+   * lower this if the daemon holds many registered projects. See
+   * `index_mmap_mb` for the other major per-connection memory knob.
+   */
+  index_cache_mb: z.number().min(1).max(1024).default(16),
+  /**
+   * Per-project-connection SQLite mmap window size, in MB, applied via
+   * `PRAGMA mmap_size` on every index DB connection. Like `index_cache_mb`,
+   * this is resident-set cost multiplied by the number of registered
+   * projects the daemon loads — raise it back up for perf-sensitive setups
+   * with few, large projects; lower it (or rely on the default) when many
+   * projects are registered on one daemon. 0 disables mmap.
+   */
+  index_mmap_mb: z.number().min(0).max(4096).default(64),
+  /**
    * Hermes Agent (NousResearch) session provider.
    *
    * - `enabled: 'auto'` (default) registers the provider; discovery is a no-op

--- a/src/daemon/__tests__/project-manager-ancestor-watcher.test.ts
+++ b/src/daemon/__tests__/project-manager-ancestor-watcher.test.ts
@@ -1,0 +1,164 @@
+/**
+ * #209 follow-up: a registered ANCESTOR of other registered roots (e.g. an
+ * umbrella folder containing several already-registered repos) independently
+ * watched and indexed every descendant's subtree — every descendant file
+ * change fired two full watcher-driven reindex passes (ancestor + the
+ * descendant's own project).
+ *
+ * `descendantExcludeGlobs()` / `registeredDescendantRoots()` (registry.ts)
+ * already scope the ancestor's *indexing* passes (collectFiles + indexFiles —
+ * see registry-health.test.ts). This file pins the remaining piece: the
+ * ancestor's live FileWatcher subscription must also pick up a fresh exclude
+ * list whenever a project is registered or removed underneath it, instead of
+ * running forever with the ignore list it was started with.
+ *
+ * We mock IndexingPipeline + FileWatcher + createServer so ProjectManager's
+ * heavy machinery (real DB, real @parcel/watcher, real MCP server) never
+ * starts — only the ancestor-watcher-restart wiring is under test.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+interface FakeWatcherCall {
+  root: string;
+  descendantExcludeGlobs: string[];
+}
+
+const watcherStartCalls: FakeWatcherCall[] = [];
+const watcherRestartCalls: FakeWatcherCall[] = [];
+
+vi.mock('../../indexer/pipeline.js', () => {
+  class FakeIndexingPipeline {
+    async indexAll() {
+      return { totalFiles: 0, indexed: 0, skipped: 0, errors: 0, durationMs: 0 };
+    }
+    async indexFiles() {
+      return { totalFiles: 0, indexed: 0, skipped: 0, errors: 0, durationMs: 0 };
+    }
+    deleteFiles() {}
+    async dispose() {}
+  }
+  return { IndexingPipeline: FakeIndexingPipeline };
+});
+
+vi.mock('../../indexer/watcher.js', () => {
+  class FakeWatcher {
+    private root = '';
+    async start(rootPath: string, _config: unknown, ..._rest: unknown[]) {
+      this.root = rootPath;
+      const opts = _rest[_rest.length - 1] as { descendantExcludeGlobs?: string[] } | undefined;
+      watcherStartCalls.push({
+        root: rootPath,
+        descendantExcludeGlobs: opts?.descendantExcludeGlobs ?? [],
+      });
+    }
+    async restartWithExcludes(descendantExcludeGlobs: string[]) {
+      watcherRestartCalls.push({ root: this.root, descendantExcludeGlobs });
+    }
+    async stop() {}
+  }
+  return { FileWatcher: FakeWatcher };
+});
+
+vi.mock('../../server/server.js', async (orig) => {
+  const real = (await orig()) as Record<string, unknown>;
+  return {
+    ...real,
+    createServer: () => ({
+      server: { close: async () => undefined },
+      dispose: () => undefined,
+    }),
+  };
+});
+
+let tmpHome: string;
+let umbrella: string;
+let child: string;
+let pmRef: { shutdown(): Promise<void> } | undefined;
+
+function makeProjectDir(...segments: string[]): string {
+  const dir = join(tmpHome, ...segments);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+beforeEach(() => {
+  watcherStartCalls.length = 0;
+  watcherRestartCalls.length = 0;
+  tmpHome = mkdtempSync(join(tmpdir(), 'trace-mcp-ancestor-watcher-'));
+  vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+  vi.resetModules();
+  umbrella = makeProjectDir('ws');
+  child = makeProjectDir('ws', 'child-repo');
+  pmRef = undefined;
+});
+
+afterEach(async () => {
+  if (pmRef) {
+    try {
+      await pmRef.shutdown();
+    } catch {
+      /* half-initialized manager may throw on shutdown; only care resources release */
+    }
+    pmRef = undefined;
+  }
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  rmSync(tmpHome, { recursive: true, force: true });
+}, 30_000);
+
+describe('ProjectManager ancestor watcher restart (#209)', () => {
+  it('restarts an already-managed ancestor watcher when a descendant is registered under it', async () => {
+    const { ProjectManager } = await import('../project-manager.js');
+    const pm = new ProjectManager();
+    pmRef = pm;
+
+    await pm.addProject(umbrella);
+    // Ancestor started with no descendants registered yet.
+    expect(watcherStartCalls.at(-1)).toMatchObject({ root: umbrella, descendantExcludeGlobs: [] });
+
+    await pm.addProject(child);
+
+    // The umbrella's watcher must have been restarted with an exclude glob
+    // covering the newly-registered child, so its subtree is dropped from
+    // both the native ignore list and the per-event guard.
+    expect(watcherRestartCalls).toContainEqual({
+      root: umbrella,
+      descendantExcludeGlobs: ['child-repo/**'],
+    });
+  }, 30_000);
+
+  it('restarts the ancestor watcher again when the descendant is removed', async () => {
+    const { ProjectManager } = await import('../project-manager.js');
+    const pm = new ProjectManager();
+    pmRef = pm;
+
+    await pm.addProject(umbrella);
+    await pm.addProject(child);
+    watcherRestartCalls.length = 0;
+
+    await pm.removeProject(child, { keepDbFiles: true });
+
+    expect(watcherRestartCalls).toContainEqual({
+      root: umbrella,
+      descendantExcludeGlobs: [],
+    });
+  }, 30_000);
+
+  it('does not restart unrelated (sibling) project watchers', async () => {
+    const { ProjectManager } = await import('../project-manager.js');
+    const pm = new ProjectManager();
+    pmRef = pm;
+
+    const sibling = makeProjectDir('other-repo');
+    await pm.addProject(sibling);
+    await pm.addProject(umbrella);
+    watcherRestartCalls.length = 0;
+
+    await pm.addProject(child);
+
+    expect(watcherRestartCalls.some((c) => c.root === sibling)).toBe(false);
+  }, 30_000);
+});

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -32,6 +32,7 @@ import { detectGitWorktree } from '../project-root.js';
 import { isDangerousProjectRoot, setupProject } from '../project-setup.js';
 import {
   clearPendingReindex,
+  descendantExcludeGlobs,
   findOverlappingProjects,
   getProject,
   listProjects,
@@ -76,6 +77,12 @@ export interface ManagedProject {
    * `config.lsp?.enabled`).
    */
   lspEnricher?: BackgroundLspEnricher | null;
+  /**
+   * Epoch ms of the last request/watcher touch routed to this project.
+   * Updated via `ProjectManager.touchActivity()`. Drives the idle-unload
+   * sweep — see `project_idle_unload_minutes` config key.
+   */
+  lastAccessedAt: number;
 }
 
 async function runSubprojectAutoSync(projectRoot: string, config: TraceMcpConfig): Promise<void> {
@@ -149,6 +156,9 @@ export class ProjectManager {
    *  lifetime. Owned by cli.ts; injected here so tests can verify the wiring
    *  without dragging the HTTP layer in. */
   private resourcePool: ProjectResourcePool | null = null;
+  /** Idle-unload sweep timer — see startIdleUnloadSweep(). Null when not running
+   *  (never started, or stopped via stopIdleUnloadSweep()/shutdown()). */
+  private idleUnloadTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(opts?: { resourcePool?: ProjectResourcePool }) {
     this.resourcePool = opts?.resourcePool ?? null;
@@ -214,7 +224,10 @@ export class ProjectManager {
     const dbPath = getDbPath(indexRoot);
     ensureGlobalDirs();
 
-    const db = initializeDatabase(dbPath);
+    const db = initializeDatabase(dbPath, {
+      cacheMb: config.index_cache_mb,
+      mmapMb: config.index_mmap_mb,
+    });
     writeServerPid(db);
     const store = new Store(db);
     const registry = PluginRegistry.createWithDefaults();
@@ -376,6 +389,7 @@ export class ProjectManager {
       status: 'starting',
       aiAbortController,
       lspEnricher,
+      lastAccessedAt: Date.now(),
       cancelDebouncedAI: () => {
         debouncedSummarize.cancel();
         debouncedEmbed.cancel();
@@ -515,6 +529,10 @@ export class ProjectManager {
         projectRoot,
         config,
         async (paths) => {
+          // A filesystem change is real activity too — keep the idle-unload
+          // sweep from evicting a project that's being actively edited, even
+          // if no MCP session is connected (e.g. IDE-only editing).
+          managed.lastAccessedAt = Date.now();
           const watchStart = performance.now();
           const stats = getReindexStats();
           // Dedup against the recent-reindex cache: if the same Edit fired
@@ -635,11 +653,56 @@ export class ProjectManager {
         async (deleted) => {
           pipeline.deleteFiles(deleted);
         },
+        { descendantExcludeGlobs: descendantExcludeGlobs(projectRoot) },
       );
+    }
+
+    // A registered ancestor of this new project already has a live watcher
+    // whose ignore list was snapshotted before this project existed — it is
+    // now stale and would double-watch/double-index everything under
+    // `projectRoot` until restarted. Recompute and restart in place (only
+    // for ancestors this daemon actually manages in-memory; an ancestor that
+    // was never addProject()'d has nothing to restart). Gated on `persist`
+    // alone: that's what controls registry membership (setupProject() above)
+    // and thus what descendantExcludeGlobs() reports for `projectRoot` — a
+    // project can be registered (persist: true) without this call starting a
+    // live watcher for it (watch: false), and the ancestor still needs to
+    // exclude that subtree either way.
+    if (persist) {
+      await this.restartManagedAncestorWatchers(projectRoot);
     }
 
     logger.info({ projectRoot, watch, persist }, 'Project added to daemon');
     return managed;
+  }
+
+  /**
+   * Restart the watcher of every currently-managed project whose root is a
+   * strict ancestor of `changedRoot`, recomputing descendantExcludeGlobs()
+   * so the ancestor's ignore list picks up `changedRoot` having just been
+   * registered (addProject) or unregistered (removeProject). Cheap and rare:
+   * this only runs on registration changes, never on the watcher's hot path.
+   */
+  private async restartManagedAncestorWatchers(changedRoot: string): Promise<void> {
+    for (const managed of this.projects.values()) {
+      if (managed.root === changedRoot) continue;
+      const rel = path.relative(managed.root, changedRoot);
+      const isStrictAncestor = rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+      if (!isStrictAncestor) continue;
+      try {
+        await managed.watcher.restartWithExcludes(descendantExcludeGlobs(managed.root));
+        logger.info(
+          { ancestor: managed.root, changedRoot },
+          'Restarted ancestor watcher with recomputed descendant excludes',
+        );
+      } catch (err) {
+        logger.warn(
+          { error: err, ancestor: managed.root, changedRoot },
+          'Failed to restart ancestor watcher after registration change (non-fatal — ' +
+            'excludes will still be recomputed on next daemon restart via loadAllRegistered)',
+        );
+      }
+    }
   }
 
   /**
@@ -819,6 +882,11 @@ export class ProjectManager {
       };
     }
     unregisterProject(root);
+    // Mirror addProject(): a managed ancestor's watcher ignore list may have
+    // been scoped around this now-unregistered root and would otherwise stay
+    // stale (harmlessly over-excluding) until the next daemon restart.
+    // Recompute so the ancestor resumes owning these now-orphaned files.
+    await this.restartManagedAncestorWatchers(root);
     logger.info(
       {
         projectRoot: root,
@@ -841,11 +909,98 @@ export class ProjectManager {
   }
 
   /**
+   * Record a request/watcher touch for `root`, resetting its idle-unload
+   * clock. Call this at every point that routes work to a specific project
+   * (session connect/close, REST reindex-file, watcher-driven reindex, etc —
+   * mirrors the call sites of cli.ts's `pokeActivity`). No-op if the project
+   * isn't currently loaded.
+   */
+  touchActivity(root: string): void {
+    const managed = this.projects.get(root);
+    if (managed) managed.lastAccessedAt = Date.now();
+  }
+
+  /**
+   * Unload every currently-loaded project idle longer than `idleMs`, except:
+   *  - a project still `starting`/`indexing` (unloading mid-index would abort
+   *    real work, not reclaim idle memory);
+   *  - a project with connected clients/SSE subscribers, per
+   *    `resourcePool.getRefCount(root) > 0` — the same client-tracking
+   *    `daemon_idle_exit_minutes` relies on, scoped per-project.
+   *
+   * Unloading calls the same in-memory teardown as `removeProject()`
+   * (`stopProject`) WITHOUT touching the on-disk registry, so the project
+   * stays listed and is re-added lazily the next time a request for its root
+   * arrives (existing `addProject()` cold-start path — 503 + Retry-After
+   * while it warms, see cli.ts serve-http Phase 5.1).
+   *
+   * Returns the roots that were unloaded (mainly for tests/telemetry).
+   */
+  async unloadIdleProjects(idleMs: number): Promise<string[]> {
+    if (idleMs <= 0) return [];
+    const now = Date.now();
+    const candidates: string[] = [];
+    for (const managed of this.projects.values()) {
+      if (managed.status === 'starting' || managed.status === 'indexing') continue;
+      if (now - managed.lastAccessedAt < idleMs) continue;
+      if ((this.resourcePool?.getRefCount(managed.root) ?? 0) > 0) continue;
+      candidates.push(managed.root);
+    }
+    for (const root of candidates) {
+      logger.info({ projectRoot: root, idleMs }, 'Unloading idle project (stays registered)');
+      await this.stopProject(root);
+    }
+    return candidates;
+  }
+
+  /**
+   * Start the periodic idle-unload sweep. `intervalMs` defaults to 5 minutes
+   * per the design; `idleMs` is `project_idle_unload_minutes * 60_000` (0
+   * disables — no timer is armed). Idempotent: calling twice replaces the
+   * previous timer. The interval is unref'd so it never keeps the daemon
+   * process alive on its own.
+   *
+   * `onUnloaded` fires after each sweep tick that unloaded at least one
+   * project — cli.ts uses it to tear down its per-project bookkeeping
+   * (progress listener etc.), which would otherwise pin the unloaded
+   * project's ProgressState for the daemon's lifetime.
+   */
+  startIdleUnloadSweep(
+    idleMs: number,
+    opts?: { intervalMs?: number; onUnloaded?: (roots: string[]) => void },
+  ): void {
+    this.stopIdleUnloadSweep();
+    if (idleMs <= 0) return;
+    this.idleUnloadTimer = setInterval(
+      () => {
+        this.unloadIdleProjects(idleMs)
+          .then((roots) => {
+            if (roots.length > 0) opts?.onUnloaded?.(roots);
+          })
+          .catch((err) => {
+            logger.warn({ err: serializeError(err) }, 'Idle-unload sweep failed (non-fatal)');
+          });
+      },
+      opts?.intervalMs ?? 5 * 60_000,
+    );
+    this.idleUnloadTimer.unref?.();
+  }
+
+  /** Stop the periodic idle-unload sweep, if running. Safe to call when not running. */
+  stopIdleUnloadSweep(): void {
+    if (this.idleUnloadTimer) {
+      clearInterval(this.idleUnloadTimer);
+      this.idleUnloadTimer = null;
+    }
+  }
+
+  /**
    * Shut down all projects in-memory. Does NOT unregister from the on-disk
    * registry — the daemon may be restarting (e.g. version-mismatch respawn,
    * supervisor relaunch) and must not lose the user's project list.
    */
   async shutdown(): Promise<void> {
+    this.stopIdleUnloadSweep();
     const roots = Array.from(this.projects.keys());
     await Promise.all(roots.map((root) => this.stopProject(root)));
     if (this.sharedPool) {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1788,7 +1788,29 @@ function runMigrations(db: Database.Database, fromVersion: number): void {
   }
 }
 
-export function initializeDatabase(dbPath: string): Database.Database {
+export interface InitializeDatabaseOptions {
+  /**
+   * Page cache size in MB (`PRAGMA cache_size`). Mirrors config key
+   * `index_cache_mb`. Defaults match that config's default (16 MB) so
+   * one-shot CLI callers that never load config get the same low-memory
+   * behavior as the daemon.
+   */
+  cacheMb?: number;
+  /**
+   * mmap window size in MB (`PRAGMA mmap_size`). Mirrors config key
+   * `index_mmap_mb`. 0 disables mmap. Defaults match that config's default
+   * (64 MB).
+   */
+  mmapMb?: number;
+}
+
+const DEFAULT_INDEX_CACHE_MB = 16;
+const DEFAULT_INDEX_MMAP_MB = 64;
+
+export function initializeDatabase(
+  dbPath: string,
+  options?: InitializeDatabaseOptions,
+): Database.Database {
   const db = new Database(dbPath);
   restrictDbPerms(dbPath);
 
@@ -1801,10 +1823,16 @@ export function initializeDatabase(dbPath: string): Database.Database {
   // NORMAL is safe in WAL mode (data survives process crash, not OS crash) and
   // avoids an fsync per transaction — major win for batched indexing.
   db.pragma('synchronous = NORMAL');
-  // 64 MB page cache (default is ~2 MB) — keeps hot pages in memory during indexing
-  db.pragma('cache_size = -65536');
-  // 256 MB mmap — lets SQLite access pages via mmap instead of read() syscalls
-  db.pragma('mmap_size = 268435456');
+  // Page cache (default is ~2 MB) — keeps hot pages in memory during indexing.
+  // Configurable because this is a PER-CONNECTION cost: a daemon with many
+  // registered projects opens one connection each, so this multiplies by
+  // project count. See config keys `index_cache_mb` / `index_mmap_mb`.
+  const cacheMb = options?.cacheMb ?? DEFAULT_INDEX_CACHE_MB;
+  db.pragma(`cache_size = ${-Math.max(1, Math.round(cacheMb * 1024))}`);
+  // mmap — lets SQLite access pages via mmap instead of read() syscalls.
+  // Same per-connection multiplication concern as cache_size above.
+  const mmapMb = options?.mmapMb ?? DEFAULT_INDEX_MMAP_MB;
+  db.pragma(`mmap_size = ${Math.max(0, Math.round(mmapMb * 1024 * 1024))}`);
   // Keep temp tables / temp indices (ORDER BY, GROUP BY, DISTINCT) in RAM
   // instead of spilling to disk. Cheap win for read-heavy aggregations.
   db.pragma('temp_store = MEMORY');

--- a/src/indexer/watcher.ts
+++ b/src/indexer/watcher.ts
@@ -69,10 +69,45 @@ async function loadParcelWatcher(): Promise<ParcelWatcherModule> {
   throw lastErr;
 }
 
+interface StartOpts {
+  /**
+   * POSIX globs (relative to rootPath) for every registered project root
+   * that is a strict descendant of this watcher's rootPath — see
+   * `descendantExcludeGlobs()` in registry.ts. An umbrella root's watcher
+   * must not fire (or reindex) for files a more-specific registered
+   * project already owns; without this an ancestor + descendant pair
+   * double-watches and double-indexes every file under the descendant
+   * (#209). Empty/undefined when this project has no registered
+   * descendants.
+   */
+  descendantExcludeGlobs?: string[];
+}
+
 export class FileWatcher {
   private subscription: parcelWatcher.AsyncSubscription | null = null;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private pendingPaths: Set<string> = new Set();
+  /** Args from the most recent start() call, kept so restartWithExcludes()
+   *  can re-subscribe without the caller re-threading every closure. */
+  private lastStartArgs: {
+    rootPath: string;
+    config: TraceMcpConfig;
+    onChanges: (paths: string[]) => Promise<void>;
+    debounceMs: number;
+    onDeletes?: (paths: string[]) => Promise<void>;
+  } | null = null;
+  /**
+   * Serializes start()/stop()/restartWithExcludes() on this instance. Without
+   * this, two overlapping calls (e.g. ProjectManager.restartManagedAncestorWatchers
+   * firing for two sibling descendants registered under the same ancestor at
+   * nearly the same time) both read `this.subscription` before either has
+   * assigned its own, so the second `watcher.subscribe()` silently overwrites
+   * the first's subscription without ever unsubscribing it — a leaked live
+   * fs-event handle whose stale closure keeps double-indexing forever.
+   * Every call chains off this promise so it always observes the fully
+   * settled state left by the previous call.
+   */
+  private opQueue: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly _setTimeout: typeof setTimeout = setTimeout,
@@ -85,13 +120,34 @@ export class FileWatcher {
     onChanges: (paths: string[]) => Promise<void>,
     debounceMs = DEFAULT_DEBOUNCE_MS,
     onDeletes?: (paths: string[]) => Promise<void>,
+    opts?: StartOpts,
   ): Promise<void> {
+    const run = this.opQueue.then(() =>
+      this.startLocked(rootPath, config, onChanges, debounceMs, onDeletes, opts),
+    );
+    // Swallow rejections in the chain itself so one failed call doesn't wedge
+    // every subsequent queued call — the actual error still propagates below.
+    this.opQueue = run.catch(() => {});
+    return run;
+  }
+
+  private async startLocked(
+    rootPath: string,
+    config: TraceMcpConfig,
+    onChanges: (paths: string[]) => Promise<void>,
+    debounceMs: number,
+    onDeletes: ((paths: string[]) => Promise<void>) | undefined,
+    opts: StartOpts | undefined,
+  ): Promise<void> {
+    this.lastStartArgs = { rootPath, config, onChanges, debounceMs, onDeletes };
     // Re-entry guard: if start() is invoked again while a prior subscription is
     // live, the old AsyncSubscription (native fs-event handle + the registered
     // callback closure capturing onChanges/pipeline/traceignore) would leak.
-    // Tear it down first so the new subscription is the sole owner.
+    // Tear it down first so the new subscription is the sole owner. Safe to
+    // call stopLocked() directly (bypassing the queue) since startLocked()
+    // itself only ever runs serialized on the queue.
     if (this.subscription || this.debounceTimer) {
-      await this.stop();
+      await this.stopLocked();
     }
 
     const watcher = await loadParcelWatcher();
@@ -102,6 +158,15 @@ export class FileWatcher {
     // dirs excluded from full indexing (Laravel storage/framework/sessions,
     // caches) still triggered per-event reindexes. Apply the same globs here.
     const isExcluded = picomatch(config.exclude ?? [], { dot: true });
+    const descendantGlobs = opts?.descendantExcludeGlobs ?? [];
+    // Cheap per-event guard mirroring the native-level ignore below: covers
+    // the race where a project is registered under this ancestor AFTER this
+    // subscription was created (or removed just before) and the native
+    // ignore list, snapshotted at subscribe-time, has gone stale until the
+    // caller restarts us. See ProjectManager.addProject/removeProject.
+    const isOwnedByDescendant = descendantGlobs.length
+      ? picomatch(descendantGlobs, { dot: true })
+      : undefined;
 
     this.subscription = await watcher.subscribe(
       rootPath,
@@ -115,6 +180,7 @@ export class FileWatcher {
           if (ignoreDirs.some((d) => p.startsWith(d))) return false;
           const rel = path.relative(rootPath, p);
           if (isExcluded(rel.split(path.sep).join('/'))) return false;
+          if (isOwnedByDescendant?.(rel.split(path.sep).join('/'))) return false;
           return !traceignore.isIgnored(rel);
         };
 
@@ -158,10 +224,14 @@ export class FileWatcher {
         // process. Parcel matches globs relative to the watched root, so
         // `**/node_modules/**` and the config.exclude globs (storage/, caches)
         // drop those events before they ever cross the native→JS boundary.
+        // descendantGlobs (e.g. `the/**`) do the same for registered
+        // descendant project roots — a change under a descendant's subtree
+        // never reaches this process's fs-event callback at all (#209).
         ignore: [
           ...ignoreDirs,
           ...[...traceignore.getSkipDirs()].map((d) => `**/${d}/**`),
           ...(config.exclude ?? []),
+          ...descendantGlobs,
         ],
       },
     );
@@ -169,7 +239,33 @@ export class FileWatcher {
     logger.info({ rootPath }, 'File watcher started');
   }
 
+  /**
+   * Re-subscribe with a fresh `descendantExcludeGlobs` list, reusing every
+   * other argument from the most recent `start()` call. Used by
+   * ProjectManager when a project is registered/removed under an already-
+   * running ancestor's watcher — the ancestor's ignore list was snapshotted
+   * at subscribe-time and is now stale (#209). No-op if `start()` was never
+   * called (e.g. a read-mostly project with `watch: false` — nothing to
+   * restart) or already stopped.
+   */
+  async restartWithExcludes(descendantExcludeGlobs: string[]): Promise<void> {
+    if (!this.lastStartArgs) {
+      logger.debug('restartWithExcludes called before start() — ignoring');
+      return;
+    }
+    const { rootPath, config, onChanges, debounceMs, onDeletes } = this.lastStartArgs;
+    await this.start(rootPath, config, onChanges, debounceMs, onDeletes, {
+      descendantExcludeGlobs,
+    });
+  }
+
   async stop(): Promise<void> {
+    const run = this.opQueue.then(() => this.stopLocked());
+    this.opQueue = run.catch(() => {});
+    return run;
+  }
+
+  private async stopLocked(): Promise<void> {
     // Order matters: unsubscribe FIRST so parcel stops invoking our callback,
     // THEN drop the debounce timer. The opposite order leaves a window where
     // an in-flight parcel callback can schedule a new timer after we cleared

--- a/tests/daemon/project-manager-idle-unload.test.ts
+++ b/tests/daemon/project-manager-idle-unload.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Per-project idle-unload sweep (project_idle_unload_minutes). Mirrors the
+ * fake-ManagedProject injection pattern used by
+ * tests/daemon/project-manager-shutdown.test.ts / project-manager-abort.test.ts
+ * rather than spinning up a real DB/watcher/server stack.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/registry.js', () => ({
+  listProjects: vi.fn(() => []),
+  unregisterProject: vi.fn(),
+}));
+
+vi.mock('../../src/progress.js', () => ({
+  ProgressState: vi.fn(),
+  clearServerPid: vi.fn(),
+  writeServerPid: vi.fn(),
+}));
+
+vi.mock('../../src/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+import { ProjectManager, type ManagedProject } from '../../src/daemon/project-manager.js';
+
+interface FakeManaged {
+  root: string;
+  config: unknown;
+  db: { close: ReturnType<typeof vi.fn> };
+  store: unknown;
+  registry: unknown;
+  progress: unknown;
+  pipeline: { dispose: ReturnType<typeof vi.fn> };
+  watcher: { stop: ReturnType<typeof vi.fn> };
+  server: { close: ReturnType<typeof vi.fn> };
+  serverHandle: { dispose: ReturnType<typeof vi.fn> };
+  status: 'starting' | 'indexing' | 'ready' | 'error';
+  lastAccessedAt: number;
+}
+
+function makeFakeManaged(root: string, opts?: Partial<FakeManaged>): FakeManaged {
+  return {
+    root,
+    config: {},
+    db: { close: vi.fn() },
+    store: {},
+    registry: {},
+    progress: {},
+    pipeline: { dispose: vi.fn(async () => undefined) },
+    watcher: { stop: vi.fn(async () => undefined) },
+    server: { close: vi.fn(async () => undefined) },
+    serverHandle: { dispose: vi.fn() },
+    status: 'ready',
+    lastAccessedAt: Date.now(),
+    ...opts,
+  };
+}
+
+function injectProject(pm: ProjectManager, root: string, opts?: Partial<FakeManaged>): FakeManaged {
+  const fake = makeFakeManaged(root, opts);
+  // biome-ignore lint/suspicious/noExplicitAny: bypassing private state for behavioural test
+  (pm as any).projects.set(root, fake);
+  return fake;
+}
+
+describe('ProjectManager.touchActivity', () => {
+  it('updates lastAccessedAt for a loaded project', () => {
+    const pm = new ProjectManager();
+    const a = injectProject(pm, '/tmp/proj-a', { lastAccessedAt: 0 });
+
+    pm.touchActivity('/tmp/proj-a');
+
+    expect(a.lastAccessedAt).toBeGreaterThan(0);
+  });
+
+  it('is a no-op for a project that is not loaded', () => {
+    const pm = new ProjectManager();
+    // Must not throw even though nothing is registered.
+    expect(() => pm.touchActivity('/tmp/never-loaded')).not.toThrow();
+  });
+});
+
+describe('ProjectManager.unloadIdleProjects', () => {
+  it('unloads (stopProject) a project idle past the threshold', async () => {
+    const pm = new ProjectManager();
+    const a = injectProject(pm, '/tmp/proj-a', { lastAccessedAt: Date.now() - 60_000 });
+
+    const unloaded = await pm.unloadIdleProjects(30_000);
+
+    expect(unloaded).toEqual(['/tmp/proj-a']);
+    expect(a.watcher.stop).toHaveBeenCalledTimes(1);
+    expect(a.db.close).toHaveBeenCalledTimes(1);
+    // biome-ignore lint/suspicious/noExplicitAny: test introspection
+    expect((pm as any).projects.has('/tmp/proj-a')).toBe(false);
+  });
+
+  it('does NOT unload a project accessed within the idle window', async () => {
+    const pm = new ProjectManager();
+    const a = injectProject(pm, '/tmp/proj-a', { lastAccessedAt: Date.now() });
+
+    const unloaded = await pm.unloadIdleProjects(30_000);
+
+    expect(unloaded).toEqual([]);
+    expect(a.watcher.stop).not.toHaveBeenCalled();
+    // biome-ignore lint/suspicious/noExplicitAny: test introspection
+    expect((pm as any).projects.has('/tmp/proj-a')).toBe(true);
+  });
+
+  it('never unloads a project that is still indexing, even if idle', async () => {
+    const pm = new ProjectManager();
+    const a = injectProject(pm, '/tmp/proj-indexing', {
+      status: 'indexing',
+      lastAccessedAt: Date.now() - 3_600_000,
+    });
+
+    const unloaded = await pm.unloadIdleProjects(30_000);
+
+    expect(unloaded).toEqual([]);
+    expect(a.watcher.stop).not.toHaveBeenCalled();
+  });
+
+  it('never unloads a project that is still starting, even if idle', async () => {
+    const pm = new ProjectManager();
+    const a = injectProject(pm, '/tmp/proj-starting', {
+      status: 'starting',
+      lastAccessedAt: Date.now() - 3_600_000,
+    });
+
+    const unloaded = await pm.unloadIdleProjects(30_000);
+
+    expect(unloaded).toEqual([]);
+    expect(a.watcher.stop).not.toHaveBeenCalled();
+  });
+
+  it('never unloads a project with connected clients (resourcePool refCount > 0)', async () => {
+    const resourcePool = {
+      disposeProject: vi.fn(),
+      acquire: vi.fn(),
+      release: vi.fn(),
+      disposeAll: vi.fn(),
+      getRefCount: vi.fn((root: string) => (root === '/tmp/proj-busy' ? 1 : 0)),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: constructor accepts a partial test double
+    const pm = new ProjectManager({ resourcePool: resourcePool as any });
+    const busy = injectProject(pm, '/tmp/proj-busy', { lastAccessedAt: Date.now() - 3_600_000 });
+    const idle = injectProject(pm, '/tmp/proj-idle', { lastAccessedAt: Date.now() - 3_600_000 });
+
+    const unloaded = await pm.unloadIdleProjects(30_000);
+
+    expect(unloaded).toEqual(['/tmp/proj-idle']);
+    expect(busy.watcher.stop).not.toHaveBeenCalled();
+    expect(idle.watcher.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('idleMs <= 0 disables the sweep entirely (no-op, does not touch any project)', async () => {
+    const pm = new ProjectManager();
+    const a = injectProject(pm, '/tmp/proj-a', { lastAccessedAt: 0 });
+
+    const unloaded = await pm.unloadIdleProjects(0);
+
+    expect(unloaded).toEqual([]);
+    expect(a.watcher.stop).not.toHaveBeenCalled();
+  });
+
+  it('leaves sibling projects untouched when only one is idle', async () => {
+    const pm = new ProjectManager();
+    const idle = injectProject(pm, '/tmp/proj-idle', { lastAccessedAt: Date.now() - 3_600_000 });
+    const fresh = injectProject(pm, '/tmp/proj-fresh', { lastAccessedAt: Date.now() });
+
+    const unloaded = await pm.unloadIdleProjects(30_000);
+
+    expect(unloaded).toEqual(['/tmp/proj-idle']);
+    expect(idle.watcher.stop).toHaveBeenCalledTimes(1);
+    expect(fresh.watcher.stop).not.toHaveBeenCalled();
+    // biome-ignore lint/suspicious/noExplicitAny: test introspection
+    expect((pm as any).projects.has('/tmp/proj-fresh')).toBe(true);
+  });
+});
+
+describe('ProjectManager.startIdleUnloadSweep / stopIdleUnloadSweep', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('unloads an idle project on the periodic sweep tick', async () => {
+    const pm = new ProjectManager();
+    const a = injectProject(pm, '/tmp/proj-a', { lastAccessedAt: Date.now() - 3_600_000 });
+
+    pm.startIdleUnloadSweep(30_000, { intervalMs: 5 * 60_000 });
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+    expect(a.watcher.stop).toHaveBeenCalledTimes(1);
+    // biome-ignore lint/suspicious/noExplicitAny: test introspection
+    expect((pm as any).projects.has('/tmp/proj-a')).toBe(false);
+
+    pm.stopIdleUnloadSweep();
+  });
+
+  it('fires onUnloaded with the unloaded roots (and only when something was unloaded)', async () => {
+    const pm = new ProjectManager();
+    // idleMs (30 min) far exceeds the sweep interval (5 min) so the fake-Date
+    // advance of two ticks cannot age proj-fresh past the threshold.
+    injectProject(pm, '/tmp/proj-idle', { lastAccessedAt: Date.now() - 3_600_000 });
+    injectProject(pm, '/tmp/proj-fresh', { lastAccessedAt: Date.now() });
+    const onUnloaded = vi.fn();
+
+    pm.startIdleUnloadSweep(30 * 60_000, { intervalMs: 5 * 60_000, onUnloaded });
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+    expect(onUnloaded).toHaveBeenCalledTimes(1);
+    expect(onUnloaded).toHaveBeenCalledWith(['/tmp/proj-idle']);
+
+    // Next tick: nothing left to unload (proj-fresh is only 10 min idle) —
+    // the callback must NOT fire with an empty array.
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(onUnloaded).toHaveBeenCalledTimes(1);
+
+    pm.stopIdleUnloadSweep();
+  });
+
+  it('does not arm a timer when idleMs is 0 (disabled)', async () => {
+    const pm = new ProjectManager();
+    const a = injectProject(pm, '/tmp/proj-a', { lastAccessedAt: Date.now() - 3_600_000 });
+
+    pm.startIdleUnloadSweep(0, { intervalMs: 5 * 60_000 });
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+
+    expect(a.watcher.stop).not.toHaveBeenCalled();
+  });
+
+  it('a touchActivity() call between ticks saves the project from the next sweep', async () => {
+    const pm = new ProjectManager();
+    // idleMs (20 min) is longer than the sweep interval (5 min) so the first
+    // couple of ticks see the project as fresh; only silence past 20 min
+    // should trigger an unload.
+    const idleMs = 20 * 60_000;
+    const sweepIntervalMs = 5 * 60_000;
+    const a = injectProject(pm, '/tmp/proj-a', { lastAccessedAt: Date.now() });
+
+    pm.startIdleUnloadSweep(idleMs, { intervalMs: sweepIntervalMs });
+    // First tick (+5 min): well within the 20 min idle window.
+    await vi.advanceTimersByTimeAsync(sweepIntervalMs);
+    expect(a.watcher.stop).not.toHaveBeenCalled();
+
+    // Touch resets the clock just before the next tick would push elapsed
+    // time (10 min since last touch) close to the threshold.
+    await vi.advanceTimersByTimeAsync(sweepIntervalMs);
+    pm.touchActivity('/tmp/proj-a');
+
+    // Two more ticks (+10 min since the touch) — still well under 20 min
+    // from the touch, so the project must survive.
+    await vi.advanceTimersByTimeAsync(sweepIntervalMs * 2);
+    expect(a.watcher.stop).not.toHaveBeenCalled();
+
+    pm.stopIdleUnloadSweep();
+  });
+
+  it('stopIdleUnloadSweep prevents further ticks from running', async () => {
+    const pm = new ProjectManager();
+    const a = injectProject(pm, '/tmp/proj-a', { lastAccessedAt: Date.now() - 3_600_000 });
+
+    pm.startIdleUnloadSweep(30_000, { intervalMs: 5 * 60_000 });
+    pm.stopIdleUnloadSweep();
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+
+    expect(a.watcher.stop).not.toHaveBeenCalled();
+  });
+
+  it('shutdown() stops the sweep so no post-shutdown tick can fire', async () => {
+    const pm = new ProjectManager();
+    injectProject(pm, '/tmp/proj-a', { lastAccessedAt: Date.now() - 3_600_000 });
+
+    pm.startIdleUnloadSweep(30_000, { intervalMs: 5 * 60_000 });
+    await pm.shutdown();
+
+    // biome-ignore lint/suspicious/noExplicitAny: test introspection
+    expect((pm as any).idleUnloadTimer).toBeNull();
+  });
+});
+
+// Type-only sanity check: ManagedProject must expose lastAccessedAt so
+// touchActivity()/unloadIdleProjects() compile against the real shape.
+// (No runtime assertion — this is a compile-time guard.)
+function _typeGuard(m: ManagedProject): number {
+  return m.lastAccessedAt;
+}
+void _typeGuard;

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -108,4 +108,47 @@ describe('schema', () => {
     const fk = db.pragma('foreign_keys', { simple: true }) as number;
     expect(fk).toBe(1);
   });
+
+  describe('cache_size / mmap_size configurability', () => {
+    it('applies the low-memory defaults (16 MB cache, 64 MB mmap) when no options are passed', () => {
+      const tmpDir = createTmpDir('trace-mcp-pragma-defaults-');
+      const tmpDb = initializeDatabase(path.join(tmpDir, 'test.db'));
+      try {
+        const cacheSize = tmpDb.pragma('cache_size', { simple: true }) as number;
+        const mmapSize = tmpDb.pragma('mmap_size', { simple: true }) as number;
+        // Negative cache_size is in KB: -16384 KB == 16 MB.
+        expect(cacheSize).toBe(-16384);
+        expect(mmapSize).toBe(64 * 1024 * 1024);
+      } finally {
+        tmpDb.close();
+        removeTmpDir(tmpDir);
+      }
+    });
+
+    it('honors explicit cacheMb / mmapMb overrides', () => {
+      const tmpDir = createTmpDir('trace-mcp-pragma-override-');
+      const tmpDb = initializeDatabase(path.join(tmpDir, 'test.db'), { cacheMb: 4, mmapMb: 256 });
+      try {
+        const cacheSize = tmpDb.pragma('cache_size', { simple: true }) as number;
+        const mmapSize = tmpDb.pragma('mmap_size', { simple: true }) as number;
+        expect(cacheSize).toBe(-4096);
+        expect(mmapSize).toBe(256 * 1024 * 1024);
+      } finally {
+        tmpDb.close();
+        removeTmpDir(tmpDir);
+      }
+    });
+
+    it('mmapMb: 0 disables mmap', () => {
+      const tmpDir = createTmpDir('trace-mcp-pragma-nommap-');
+      const tmpDb = initializeDatabase(path.join(tmpDir, 'test.db'), { mmapMb: 0 });
+      try {
+        const mmapSize = tmpDb.pragma('mmap_size', { simple: true }) as number;
+        expect(mmapSize).toBe(0);
+      } finally {
+        tmpDb.close();
+        removeTmpDir(tmpDir);
+      }
+    });
+  });
 });


### PR DESCRIPTION
Integration PR for two locally-completed commits:

1. **feat(daemon)** — daemon memory footprint scaled linearly with registered project count: every project held its DB handle, pipeline, watcher, and MCP server forever, with default SQLite page cache and mmap per connection.
   - Periodic sweep unloads a project's in-memory state after `project_idle_unload_minutes` (default 30) idle; project stays registered, next request re-adds it lazily (503 + Retry-After while warming). Never unloads projects that are indexing or have connected clients.
   - New `index_cache_mb` (default 16) / `index_mmap_mb` (default 64) apply `PRAGMA cache_size` / `mmap_size` on every index DB connection.
   - Already-managed ancestor watcher restarts when a descendant project is registered under it.
2. **chore(quality-gates)** — threshold calibration from today's cleanup + scanner review.

Verified locally: `tsc --noEmit` clean, 35 tests across the four touched/new test files green, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)