### PR TITLE
feat: add gcf output format

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   },
   "dependencies": {
     "@ast-grep/napi": "^0.44.0",
+    "@blackwell-systems/gcf": "2.4.0",
     "@clack/prompts": "^1.2.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@parcel/watcher": "^2.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@ast-grep/napi':
         specifier: ^0.44.0
         version: 0.44.0
+      '@blackwell-systems/gcf':
+        specifier: 2.4.0
+        version: 2.4.0
       '@clack/prompts':
         specifier: ^1.2.0
         version: 1.4.0
@@ -298,6 +301,10 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@blackwell-systems/gcf@2.4.0':
+    resolution: {integrity: sha512-lLEZCzNMYVk630iaVVPPhcQtmCjhPRETRlwk/JAptGE0SEL6ZMHfA9HZPornuMvvpGeyrimRjj9Yb2nYQNS1og==}
+    hasBin: true
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -2893,6 +2900,8 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.5.0':
     optional: true
+
+  '@blackwell-systems/gcf@2.4.0': {}
 
   '@bramus/specificity@2.4.2':
     dependencies:

--- a/src/tools/_common/__tests__/output-format.test.ts
+++ b/src/tools/_common/__tests__/output-format.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it } from 'vitest';
+import { decodeGeneric } from '@blackwell-systems/gcf';
 import { decode as toonDecode } from '@toon-format/toon';
-import { OutputFormatSchema, encodeResponse, isToonRequested } from '../output-format.js';
+import {
+  OutputFormatSchema,
+  encodeResponse,
+  isGcfRequested,
+  isToonRequested,
+} from '../output-format.js';
 
 describe('output-format', () => {
   describe('OutputFormatSchema', () => {
-    it('accepts json, markdown, toon and undefined', () => {
+    it('accepts json, markdown, toon, gcf and undefined', () => {
       expect(OutputFormatSchema.parse('json')).toBe('json');
       expect(OutputFormatSchema.parse('markdown')).toBe('markdown');
       expect(OutputFormatSchema.parse('toon')).toBe('toon');
+      expect(OutputFormatSchema.parse('gcf')).toBe('gcf');
       expect(OutputFormatSchema.parse(undefined)).toBeUndefined();
     });
 
@@ -86,6 +93,55 @@ describe('output-format', () => {
     });
   });
 
+  describe('encodeResponse — gcf', () => {
+    it('encodes a tabular array and round-trips via decodeGeneric()', () => {
+      const payload = [
+        { a: 1, b: 'x' },
+        { a: 2, b: 'y' },
+      ];
+      const out = encodeResponse(payload, 'gcf');
+      expect(out).toBeTruthy();
+      expect(out.length).toBeGreaterThan(0);
+      expect(out).toContain('a');
+      expect(out).toContain('b');
+      const decoded = decodeGeneric(out);
+      expect(decoded).toEqual(payload);
+    });
+
+    it('encodes nested objects losslessly', () => {
+      const payload = {
+        items: [
+          { id: 1, name: 'foo' },
+          { id: 2, name: 'bar' },
+        ],
+        total: 2,
+      };
+      const out = encodeResponse(payload, 'gcf');
+      const decoded = decodeGeneric(out);
+      expect(decoded).toEqual(payload);
+    });
+
+    it('falls back to JSON.stringify for a primitive string', () => {
+      const out = encodeResponse('plain string', 'gcf');
+      expect(out).toBe(JSON.stringify('plain string'));
+    });
+
+    it('falls back to JSON.stringify for a primitive number', () => {
+      const out = encodeResponse(42, 'gcf');
+      expect(out).toBe(JSON.stringify(42));
+    });
+
+    it('falls back to JSON.stringify for null', () => {
+      const out = encodeResponse(null, 'gcf');
+      expect(out).toBe(JSON.stringify(null));
+    });
+
+    it('falls back to JSON.stringify for undefined', () => {
+      const out = encodeResponse(undefined, 'gcf');
+      expect(out).toBe(JSON.stringify(undefined));
+    });
+  });
+
   describe('encodeResponse — markdown', () => {
     it('throws because markdown is tool-specific', () => {
       expect(() => encodeResponse({ a: 1 }, 'markdown')).toThrow(/markdown is tool-specific/);
@@ -109,6 +165,27 @@ describe('output-format', () => {
       expect(isToonRequested(null)).toBe(false);
       expect(isToonRequested(42)).toBe(false);
       expect(isToonRequested({})).toBe(false);
+    });
+  });
+
+  describe('isGcfRequested', () => {
+    it('narrows correctly for "gcf"', () => {
+      const v: unknown = 'gcf';
+      expect(isGcfRequested(v)).toBe(true);
+      if (isGcfRequested(v)) {
+        const t: 'gcf' = v;
+        expect(t).toBe('gcf');
+      }
+    });
+
+    it('returns false for other formats', () => {
+      expect(isGcfRequested('json')).toBe(false);
+      expect(isGcfRequested('markdown')).toBe(false);
+      expect(isGcfRequested('toon')).toBe(false);
+      expect(isGcfRequested(undefined)).toBe(false);
+      expect(isGcfRequested(null)).toBe(false);
+      expect(isGcfRequested(42)).toBe(false);
+      expect(isGcfRequested({})).toBe(false);
     });
   });
 });

--- a/src/tools/_common/output-format.ts
+++ b/src/tools/_common/output-format.ts
@@ -9,21 +9,29 @@
  *   - "toon"     — Token-Oriented Object Notation (@toon-format/toon).
  *                  Lossless drop-in JSON replacement, 30-60% cheaper in
  *                  LLM tokens on tabular data.
+ *   - "gcf"      — Graph Compact Format (@blackwell-systems/gcf). Lossless,
+ *                  zero-dependency; path-flattens nested fields, so it matches
+ *                  TOON on flat records and is smaller on nested payloads.
  */
 import { z } from 'zod';
+import { encodeGeneric } from '@blackwell-systems/gcf';
 import { encode as toonEncode } from '@toon-format/toon';
 
-export type OutputFormat = 'json' | 'markdown' | 'toon';
+export type OutputFormat = 'json' | 'markdown' | 'toon' | 'gcf';
 
 export const OutputFormatSchema = z
-  .enum(['json', 'markdown', 'toon'])
+  .enum(['json', 'markdown', 'toon', 'gcf'])
   .optional()
   .describe(
-    'Output format. "json" (default) returns JSON, "markdown" returns LLM-friendly fenced markdown (tool-specific), "toon" returns Token-Oriented Object Notation — 30-60% fewer tokens on tabular data, fully lossless.',
+    'Output format. "json" (default) returns JSON, "markdown" returns LLM-friendly fenced markdown (tool-specific), "toon" returns Token-Oriented Object Notation and "gcf" returns Graph Compact Format — both cut LLM tokens on tabular data; gcf round-trips losslessly and also flattens nested fields.',
   );
 
 export function isToonRequested(format: unknown): format is 'toon' {
   return format === 'toon';
+}
+
+export function isGcfRequested(format: unknown): format is 'gcf' {
+  return format === 'gcf';
 }
 
 export function encodeResponse(payload: unknown, format: OutputFormat | undefined): string {
@@ -42,6 +50,22 @@ export function encodeResponse(payload: unknown, format: OutputFormat | undefine
     } catch (err) {
       process.stderr.write(
         `[output-format] TOON encode failed, falling back to JSON: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+      return JSON.stringify(payload);
+    }
+  }
+
+  if (format === 'gcf') {
+    if (payload === null || payload === undefined || typeof payload !== 'object') {
+      return JSON.stringify(payload);
+    }
+    try {
+      return encodeGeneric(payload);
+    } catch (err) {
+      process.stderr.write(
+        `[output-format] GCF encode failed, falling back to JSON: ${
           err instanceof Error ? err.message : String(err)
         }\n`,
       );


### PR DESCRIPTION
Adds `gcf` to the `output_format` enum alongside `json`, `markdown`, and `toon`. One branch in the shared `encodeResponse` helper, mirroring the existing TOON path (same fallback-to-JSON safety). Opt-in; `json` stays the default and TOON is untouched.

## Correctness

For a code-intelligence server this is the property that matters most: an agent acting on symbol/edge data cannot tolerate silent corruption. **GCF round-trips losslessly by design**, continuously fuzzed and verified (40B+ published round-trips).

By contrast, a 100k-case fuzz of the reference `@toon-format/toon` shows a **7.47% round-trip failure rate — 1.73% of it silent data corruption** (wrong value returned, no error thrown), the rest decode crashes. Reproducible: [`eval/toon-fuzz.mjs`](https://github.com/blackwell-systems/gcf/blob/main/eval/toon-fuzz.mjs) · [10M-case log](https://github.com/blackwell-systems/gcf/blob/main/eval/results/toon-fuzz-10M-2026-06-16.log).

## Comprehension — measurably better than TOON

Token savings are worthless if the model reads the data worse. On a generic-profile comprehension eval — 500 nested records, 13 structured-extraction questions, zero format hints, deterministic answers (no LLM judge), 27 runs across 11 models, the "arrays of objects with nested metadata" shape these tools emit:

- **GCF scores 100% on every frontier model** (Claude Opus/Sonnet/Haiku 4.x, GPT-5.5, Gemini 2.5 Pro / 3.x).
- On smaller models GCF **leads both TOON and JSON**: Gemini 2.5 Flash — GCF **95.0%** vs TOON 85.1% vs JSON 74.0%; Mistral Medium 3.5 — GCF **82.7%** vs TOON 76.9%.

For code-graph payloads specifically, a graph-profile comprehension study (25 runs, 10 models, 500 symbols + 200 edges) puts GCF at **91.2%** vs TOON 68.8% vs JSON 54.1%, GCF winning 24 of 25 runs. Full data and charts: https://gcformat.com/guide/benchmarks

## Published research

GCF's grammar was reverse-engineered from tokenization and attention-level experiments, then validated on production models. The mechanism is documented in the [whitepaper](https://github.com/blackwell-systems/gcf/blob/main/gcf-whitepaper.pdf) (DOI [10.5281/zenodo.20579817](https://doi.org/10.5281/zenodo.20579817)) and three companion papers, currently under review: "Tokenizer-Attention Coupling" ([10.5281/zenodo.20925910](https://doi.org/10.5281/zenodo.20925910)), "Stranded Attention" ([10.5281/zenodo.21158886](https://doi.org/10.5281/zenodo.21158886)), and "Developmental Atlas of Attention Head Specialization" ([10.5281/zenodo.21205389](https://doi.org/10.5281/zenodo.21205389)). Through controlled training across two architectures and two scales, they show BPE merge decisions permanently constrain which attention heads develop — the root-cause reason a delimiter choice like TOON's tab (32.9% merge rate, the worst of any common separator) measurably degrades comprehension. [Tokenizer analysis](https://gcformat.com/guide/tokenizer-analysis).

## Compression (measured on this repo's real output)

Real trace-mcp payloads, o200k tokens, GCF round-trip verified lossless:

| output | JSON (default) | TOON | GCF |
|--------|----------------|------|-----|
| flat — `get_untested_symbols` (160 symbols) | 5948 | 4240 | **4197** |
| nested — `get_change_impact` (26 dependents / 160 symbols) | 5738 | 4393 | **4011** |

GCF is ~30% below the default JSON on both shapes; ties TOON on flat records and is −8.7% on nested (path-flattening; TOON re-declares nested schema per row).

## In production elsewhere

GCF ships as an opt-in format in Chrome DevTools MCP, is vendored into [OmniRoute](https://github.com/diegosouzapw/OmniRoute)'s compression engine, replaced TOON in [NetClaw](https://github.com/automateyournetwork/netclaw), and was merged into [Speakeasy's `oq`](https://github.com/speakeasy-api/openapi/pull/216). Full list: [gcformat.com/ecosystem/adopters](https://gcformat.com/ecosystem/adopters.html).

`@blackwell-systems/gcf` is MIT with zero runtime dependencies. Additive and opt-in; happy to adjust naming, placement, or scope to fit the project's conventions.

