### PR TITLE
chore(ci)(deps): bump github/codeql-action to v4.37.1 in lockstep

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,13 +37,13 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -50,6 +50,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -43,7 +43,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF to code-scanning
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         if: always()
         with:
           sarif_file: semgrep.sarif


### PR DESCRIPTION
Bumps every `github/codeql-action` reference (`init`, `analyze`, `upload-sarif`) from **v4.36.3 → v4.37.1** in a single commit.

### Why one PR instead of Dependabot's three
Dependabot split this into #247 (init), #245 (analyze) and #244 (upload-sarif). But `codeql.yml` pins `init` and `analyze` to the **same** version, and CodeQL requires them to match. Bumping only one leaves a mixed `init@4.37.1` / `analyze@4.36.3` pair, which fails hard:

```
##[error]Loaded a configuration file for version '4.37.1', but running version '4.36.3'
CodeQL job status was configuration error.
```

That's exactly why #245 and #247 show red Analyze checks — neither can go green alone. Moving all refs together is the only consistent fix.

### Verification
Pinned SHA `7188fc363630916deb702c7fdcf4e481b751f97a` confirmed to be the commit the annotated `v4.37.1` tag dereferences to.

Supersedes and closes #244, #245, #247.
