### PR TITLE
chore(ci): group github-actions dependabot updates (keep codeql-action in lockstep)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,3 +87,22 @@ updates:
     commit-message:
       prefix: chore(ci)
       include: scope
+    groups:
+      # codeql-action's init / analyze / upload-sarif steps MUST move in
+      # lockstep: a mixed version pair fails CodeQL with
+      # "Loaded a configuration file for version X, but running version Y".
+      # Keep every github/codeql-action ref in a single PR across all update
+      # types so it can never be split into individually-failing PRs.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
+        update-types:
+          - major
+          - minor
+          - patch
+      # Batch remaining routine minor/patch action bumps into one PR.
+      # Major bumps of other actions are left as individual PRs for review.
+      github-actions-minor-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Adds a `groups:` config to the **github-actions** Dependabot ecosystem.

### Problem
The github-actions block had no grouping, so Dependabot opens one PR per action — and per `codeql-action` sub-path. A single `github/codeql-action` release therefore splits into three PRs (`init`, `analyze`, `upload-sarif`). But `codeql.yml` pins `init` and `analyze` to the **same** version and CodeQL requires them to match, so any PR that bumps only one fails:

```
Loaded a configuration file for version '4.37.1', but running version '4.36.3'
```

That's what happened with v4.37.1 — #245 and #247 could never go green (fixed manually in #248).

### Fix
- **`codeql-action` group** — every `github/codeql-action*` ref moves together in one PR across all update types, so it can never be split into individually-failing PRs.
- **`github-actions-minor-patch` group** — batches remaining routine minor/patch action bumps; major bumps of other actions stay as individual PRs for review.

Prevents the recurring red-CI churn on every future codeql-action release.
