### PR TITLE
fix(daemon): retry transient transport errors in ProxyBackend.send

### DIFF
--- a/src/daemon/router/proxy-backend.ts
+++ b/src/daemon/router/proxy-backend.ts
@@ -3,6 +3,7 @@ import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import { logger } from '../../logger.js';
 import { resolveWorktreeAware, worktreeHint } from '../../registry-worktree.js';
 import { resolveDeepestKnownRoot } from '../../subproject/resolve.js';
+import { isTransientError, withRetry } from '../../utils/retry.js';
 import type { Backend } from './types.js';
 
 /**
@@ -164,7 +165,17 @@ export class ProxyBackend implements Backend {
     // Cache the handshake so we can replay it if the daemon session dies.
     if (isInitializeRequest(msg)) this.initializeFrame = msg;
     try {
-      await this.httpTransport.send(msg);
+      // Transient network blips (daemon mid-restart, dropped connection) are
+      // common during a daemon respawn; retry a couple of times with short
+      // backoff before falling through to the heavier session-lost recovery
+      // or surfacing an error to the client (#TRA-6).
+      await withRetry(() => this.httpTransport!.send(msg), {
+        maxAttempts: 3,
+        initialDelayMs: 200,
+        maxDelayMs: 800,
+        label: 'ProxyBackend.send',
+        isRetryable: isTransientError,
+      });
       return;
     } catch (err) {
       // Only recover from a lost daemon session, and never for the initialize

--- a/tests/daemon/proxy-backend.test.ts
+++ b/tests/daemon/proxy-backend.test.ts
@@ -215,17 +215,41 @@ describe('ProxyBackend daemon-restart recovery', () => {
     expect((transports[1]!.sent[2] as { id: number }).id).toBe(5);
   });
 
-  it('propagates non-session errors without re-initializing', async () => {
+  it('propagates non-session errors without re-initializing once retries are exhausted', async () => {
     const backend = makeBackend();
     await backend.start();
     await backend.send(initFrame(1));
 
     const first = transports[0]!;
+    let calls = 0;
     first.send = async () => {
+      calls++;
       throw new Error('ECONNRESET socket hang up');
     };
 
     await expect(backend.send(toolCall(2))).rejects.toThrow(/ECONNRESET/);
-    expect(transports).toHaveLength(1);
+    expect(transports).toHaveLength(1); // retried on the same transport, no reinit
+    expect(calls).toBe(3); // exhausted the transient-retry budget
+  });
+
+  it('retries a transient transport error and succeeds without hard-failing the request', async () => {
+    const backend = makeBackend();
+    await backend.start();
+    await backend.send(initFrame(1));
+
+    const first = transports[0]!;
+    const realSend = first.send.bind(first);
+    let attempts = 0;
+    first.send = async (msg) => {
+      attempts++;
+      if (attempts < 3) throw new TypeError('fetch failed');
+      return realSend(msg);
+    };
+
+    await backend.send(toolCall(2));
+
+    expect(attempts).toBe(3);
+    expect(transports).toHaveLength(1); // no reinit needed — same transport recovered
+    expect(first.sent.map(methodOf)).toEqual(['initialize', 'tools/call']);
   });
 });


### PR DESCRIPTION
## Summary
- `ProxyBackend.send()` now retries transient transport failures (ECONNRESET, `fetch failed`, connection refused, 5xx/429) with short bounded backoff (3 attempts, 200ms initial delay) before falling through to the existing session-lost reinit recovery or surfacing an error to the client.
- Previously these transient errors propagated immediately, hit `MessageRouter`'s catch blocks, and were surfaced to the MCP client as `MCP error -32603: Backend send failed: ...` — the majority of the ~80 transport-level failures across 1813 analyzed sessions (52 on `get_outline`, 17 on `get_index_health`, 5 on `get_feature_context`).
- Reuses the existing `withRetry`/`isTransientError` utility in `src/utils/retry.ts` (already used by AI provider clients) rather than adding new retry machinery.

## Test plan
- [x] `pnpm run test --run tests/daemon/proxy-backend.test.ts` — added two tests: retries exhausted still propagates the error (no reinit), and a transient error that clears within budget succeeds transparently.
- [x] `pnpm run test --run tests/daemon` — 218/218 passed.
- [x] `pnpm run test --run` (full suite) — 8432 passed, 9 skipped, 0 failed.
- [x] `pnpm run lint` (tsc --noEmit) — clean.
- [x] `pnpm run build` — succeeds.

Fixes TRA-6.