### PR TITLE
fix(quality): get_changed_symbols base-branch auto-detection for non-main/master repos

### DIFF
--- a/src/tools/quality/changed-symbols.ts
+++ b/src/tools/quality/changed-symbols.ts
@@ -52,14 +52,20 @@ interface DiffHunk {
  */
 function detectOriginHeadBranch(rootPath: string): string | undefined {
   try {
-    // codeql[js/path-injection]: rootPath is ctx.projectRoot, the server's
-    // own trusted indexing root set at startup — never a per-request value —
-    // same pattern already used unflagged as `cwd` throughout this file
-    // (see compareBranches below).
+    // rootPath is ctx.projectRoot, the server's own trusted indexing root
+    // set at startup — never a per-request value — same pattern already
+    // used unflagged as `cwd` throughout this file (see compareBranches).
+    const gitOpts = {
+      cwd: rootPath, // codeql[js/path-injection]: see trust note above
+      encoding: 'utf-8' as const,
+      timeout: 5_000,
+      env: safeGitEnv(),
+      stdio: 'pipe' as const,
+    };
     const ref = execFileSync(
       'git',
       ['symbolic-ref', '--quiet', '--short', 'refs/remotes/origin/HEAD'],
-      { cwd: rootPath, encoding: 'utf-8', timeout: 5_000, env: safeGitEnv(), stdio: 'pipe' },
+      gitOpts,
     ).trim();
     return ref || undefined;
   } catch {
@@ -73,14 +79,20 @@ function detectOriginHeadBranch(rootPath: string): string | undefined {
  */
 function detectUpstreamBranch(rootPath: string): string | undefined {
   try {
-    // codeql[js/path-injection]: rootPath is ctx.projectRoot, the server's
-    // own trusted indexing root set at startup — never a per-request value —
-    // same pattern already used unflagged as `cwd` throughout this file
-    // (see compareBranches below).
+    // rootPath is ctx.projectRoot, the server's own trusted indexing root
+    // set at startup — never a per-request value — same pattern already
+    // used unflagged as `cwd` throughout this file (see compareBranches).
+    const gitOpts = {
+      cwd: rootPath, // codeql[js/path-injection]: see trust note above
+      encoding: 'utf-8' as const,
+      timeout: 5_000,
+      env: safeGitEnv(),
+      stdio: 'pipe' as const,
+    };
     const ref = execFileSync(
       'git',
       ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
-      { cwd: rootPath, encoding: 'utf-8', timeout: 5_000, env: safeGitEnv(), stdio: 'pipe' },
+      gitOpts,
     ).trim();
     return ref || undefined;
   } catch {

--- a/src/tools/quality/changed-symbols.ts
+++ b/src/tools/quality/changed-symbols.ts
@@ -52,6 +52,10 @@ interface DiffHunk {
  */
 function detectOriginHeadBranch(rootPath: string): string | undefined {
   try {
+    // codeql[js/path-injection]: rootPath is ctx.projectRoot, the server's
+    // own trusted indexing root set at startup — never a per-request value —
+    // same pattern already used unflagged as `cwd` throughout this file
+    // (see compareBranches below).
     const ref = execFileSync(
       'git',
       ['symbolic-ref', '--quiet', '--short', 'refs/remotes/origin/HEAD'],
@@ -69,6 +73,10 @@ function detectOriginHeadBranch(rootPath: string): string | undefined {
  */
 function detectUpstreamBranch(rootPath: string): string | undefined {
   try {
+    // codeql[js/path-injection]: rootPath is ctx.projectRoot, the server's
+    // own trusted indexing root set at startup — never a per-request value —
+    // same pattern already used unflagged as `cwd` throughout this file
+    // (see compareBranches below).
     const ref = execFileSync(
       'git',
       ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],

--- a/src/tools/quality/changed-symbols.ts
+++ b/src/tools/quality/changed-symbols.ts
@@ -46,14 +46,52 @@ interface DiffHunk {
 }
 
 /**
+ * Read the remote's default branch via the local `refs/remotes/origin/HEAD`
+ * symref (set by `git clone` / `git remote set-head origin -a`). Returns
+ * e.g. "origin/main". Undefined if unset or no `origin` remote.
+ */
+function detectOriginHeadBranch(rootPath: string): string | undefined {
+  try {
+    const ref = execFileSync(
+      'git',
+      ['symbolic-ref', '--quiet', '--short', 'refs/remotes/origin/HEAD'],
+      { cwd: rootPath, encoding: 'utf-8', timeout: 5_000, env: safeGitEnv(), stdio: 'pipe' },
+    ).trim();
+    return ref || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Read the current branch's configured upstream (e.g. "origin/develop").
+ * Undefined if HEAD is detached or has no upstream configured.
+ */
+function detectUpstreamBranch(rootPath: string): string | undefined {
+  try {
+    const ref = execFileSync(
+      'git',
+      ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
+      { cwd: rootPath, encoding: 'utf-8', timeout: 5_000, env: safeGitEnv(), stdio: 'pipe' },
+    ).trim();
+    return ref || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Auto-detect the base branch and return merge-base with the target ref.
- * Priority: configured defaultBaseBranch → main → master → err.
+ * Priority: configured defaultBaseBranch (exclusive, no further fallback)
+ * → origin/HEAD symref → current branch's upstream → "main" → "master" → err.
+ * The origin/HEAD and upstream probes cover repos whose default branch is
+ * neither "main" nor "master" (e.g. "develop", "trunk").
  */
 function detectBaseBranch(
   rootPath: string,
   until: string,
   defaultBaseBranch?: string,
-): TraceMcpResult<string> {
+): TraceMcpResult<{ base: string; mergeBase: string }> {
   // `until` is already validated by the caller; defend against accidental
   // misuse if a future caller wires it up wrong.
   if (!isSafeGitRef(until)) {
@@ -63,10 +101,21 @@ function detectBaseBranch(
     });
   }
 
-  const candidates = defaultBaseBranch ? [defaultBaseBranch] : ['main', 'master'];
+  const candidates: string[] = [];
+  if (defaultBaseBranch) {
+    candidates.push(defaultBaseBranch);
+  } else {
+    const originHead = detectOriginHeadBranch(rootPath);
+    if (originHead) candidates.push(originHead);
+    const upstream = detectUpstreamBranch(rootPath);
+    if (upstream) candidates.push(upstream);
+    candidates.push('main', 'master');
+  }
 
+  const tried: string[] = [];
   for (const candidate of candidates) {
-    if (!isSafeGitRef(candidate)) continue;
+    if (!isSafeGitRef(candidate) || tried.includes(candidate)) continue;
+    tried.push(candidate);
     try {
       const mergeBase = execFileSync('git', ['merge-base', candidate, until], {
         cwd: rootPath,
@@ -75,16 +124,16 @@ function detectBaseBranch(
         env: safeGitEnv(),
         stdio: 'pipe',
       }).trim();
-      return ok(mergeBase);
+      return ok({ base: candidate, mergeBase });
     } catch {
       // try next candidate
     }
   }
 
-  const tried = candidates.map((c) => `"${c}"`).join(', ');
+  const triedStr = tried.map((c) => `"${c}"`).join(', ') || 'none';
   return err({
     code: 'VALIDATION_ERROR',
-    message: `Cannot auto-detect base branch (tried ${tried}). Please provide an explicit "since" ref or set git.defaultBaseBranch in config.`,
+    message: `Cannot auto-detect base branch (tried ${triedStr}). Please provide an explicit "since" ref or set git.defaultBaseBranch in config.`,
   });
 }
 
@@ -122,7 +171,7 @@ export function getChangedSymbols(
   } else {
     const detected = detectBaseBranch(rootPath, until, opts.defaultBaseBranch);
     if (detected.isErr()) return detected as never;
-    since = detected.value;
+    since = detected.value.mergeBase;
   }
 
   const range = `${since}..${until}`;
@@ -377,8 +426,8 @@ export function compareBranches(
   } else {
     const detected = detectBaseBranch(rootPath, branch, opts.defaultBaseBranch);
     if (detected.isErr()) return detected as never;
-    mergeBase = detected.value;
-    base = opts.defaultBaseBranch ?? 'main';
+    mergeBase = detected.value.mergeBase;
+    base = detected.value.base;
   }
 
   // Count commits in range

--- a/tests/tools/behavioural/get-changed-symbols.behavioural.test.ts
+++ b/tests/tools/behavioural/get-changed-symbols.behavioural.test.ts
@@ -29,12 +29,31 @@ interface GitMock {
   nameStatus?: string;
   /** Output for `git diff --unified=0 …`. */
   unified?: string;
+  /** Output for `git symbolic-ref --short refs/remotes/origin/HEAD`, or throws if unset. */
+  originHead?: string;
+  /** Output for `git rev-parse --abbrev-ref --symbolic-full-name @{upstream}`, or throws if unset. */
+  upstream?: string;
+  /** Base-branch names that fail merge-base (simulates "branch doesn't exist"). */
+  mergeBaseFailsFor?: string[];
 }
 
 function mockGit(g: GitMock): void {
   mockExec.mockImplementation(((_cmd: string, args: readonly string[] | undefined) => {
     const a = (args ?? []) as string[];
-    if (a[0] === 'merge-base') return g.mergeBase ?? 'abc1234';
+    if (a[0] === 'symbolic-ref') {
+      if (g.originHead === undefined) throw new Error('no origin HEAD');
+      return g.originHead;
+    }
+    if (a[0] === 'rev-parse' && a.includes('@{upstream}')) {
+      if (g.upstream === undefined) throw new Error('no upstream');
+      return g.upstream;
+    }
+    if (a[0] === 'merge-base') {
+      const candidate = a[1];
+      if (g.mergeBaseFailsFor?.includes(candidate))
+        throw new Error(`unknown revision: ${candidate}`);
+      return g.mergeBase ?? 'abc1234';
+    }
     if (a[0] === 'diff' && a.includes('--name-status')) return g.nameStatus ?? '';
     if (a[0] === 'diff' && a.includes('--unified=0')) return g.unified ?? '';
     return '';
@@ -206,5 +225,73 @@ describe('getChangedSymbols() — behavioural contract', () => {
     });
     expect(mergeBaseCall).toBeDefined();
     expect(result.value.since).toBe('merge-base-sha');
+  });
+
+  it('falls back to origin/HEAD when default branch is neither main nor master', () => {
+    mockGit({
+      originHead: 'origin/trunk',
+      mergeBase: 'trunk-merge-base',
+      nameStatus: 'M\tsrc/auth/login.ts',
+      unified: '+++ b/src/auth/login.ts\n@@ -5,3 +5,5 @@\n',
+    });
+
+    const result = getChangedSymbols(store, '/proj', { until: 'HEAD' });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) return;
+
+    expect(result.value.since).toBe('trunk-merge-base');
+    const mergeBaseCall = mockExec.mock.calls.find((c) => (c[1] as string[])[0] === 'merge-base');
+    expect((mergeBaseCall?.[1] as string[])[1]).toBe('origin/trunk');
+  });
+
+  it('falls back to the upstream branch when origin/HEAD is unset', () => {
+    mockGit({
+      // no originHead → symbolic-ref throws
+      upstream: 'origin/develop',
+      mergeBase: 'develop-merge-base',
+      nameStatus: 'M\tsrc/auth/login.ts',
+      unified: '+++ b/src/auth/login.ts\n@@ -5,3 +5,5 @@\n',
+    });
+
+    const result = getChangedSymbols(store, '/proj', { until: 'HEAD' });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) return;
+
+    expect(result.value.since).toBe('develop-merge-base');
+    const mergeBaseCall = mockExec.mock.calls.find((c) => (c[1] as string[])[0] === 'merge-base');
+    expect((mergeBaseCall?.[1] as string[])[1]).toBe('origin/develop');
+  });
+
+  it('still falls back to main/master when origin/HEAD and upstream are both unset', () => {
+    mockGit({
+      // no originHead, no upstream → both probes throw
+      mergeBaseFailsFor: ['main'],
+      mergeBase: 'master-merge-base',
+      nameStatus: 'M\tsrc/auth/login.ts',
+      unified: '+++ b/src/auth/login.ts\n@@ -5,3 +5,5 @@\n',
+    });
+
+    const result = getChangedSymbols(store, '/proj', { until: 'HEAD' });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) return;
+
+    expect(result.value.since).toBe('master-merge-base');
+  });
+
+  it('an explicit defaultBaseBranch config is tried exclusively (no main/master fallback)', () => {
+    mockGit({
+      mergeBaseFailsFor: ['release'],
+      nameStatus: '',
+      unified: '',
+    });
+
+    const result = getChangedSymbols(store, '/proj', {
+      until: 'HEAD',
+      defaultBaseBranch: 'release',
+    });
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error.message).toContain('"release"');
+    expect(result.error.message).not.toContain('"main"');
   });
 });


### PR DESCRIPTION
## Summary
- `TRA-7` (part a): `get_changed_symbols`/`compare_branches` base-branch auto-detection previously only tried `main` and `master`, and failed outright on repos whose default branch is something else (`develop`, `trunk`, ...) — a 36% error rate across 22 calls per the TRA-3 session analysis.
- `detectBaseBranch` now also probes `refs/remotes/origin/HEAD` (the symref set by `git clone`/`git remote set-head`) and the current branch's configured upstream (`@{upstream}`) before falling back to `main`/`master`. An explicit `defaultBaseBranch` config value is still tried exclusively, with no fallback.
- `compareBranches`' `base` field in the result now reflects the branch actually resolved, instead of hardcoding `'main'` when auto-detected.
- Part (b) of TRA-7 (`get_env_vars` credential-guard false positive) was already fixed in #172 — verified the current implementation never exposes values (keys/types/formats only, redacted-mode is line-level with no values) and needed no further change.

## Test plan
- [x] Added 4 new behavioural tests: origin/HEAD fallback, upstream fallback, main/master fallback when neither is set, and exclusive-use of an explicit `defaultBaseBranch`.
- [x] `pnpm run build` — passes
- [x] `pnpm run lint` (`tsc --noEmit`) — passes
- [x] `pnpm run test --run` — full suite: 759 files / 8435 tests passing