### PR TITLE
fix(tools): default preset to standard (~50 tools), not full (~170)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -383,7 +383,7 @@ The `tools.*` section controls what the MCP server injects into every session �
 ```jsonc
 {
   "tools": {
-    "preset": "full",                    // "full" | "minimal" | custom preset
+    "preset": "standard",                // "full" | "standard" | "minimal" | "review" | "architecture"
     "description_verbosity": "full",     // "full" | "minimal" | "none"
     "instructions_verbosity": "full",    // "full" | "minimal" | "none" — controls the tool-routing block
     "agent_behavior": "off",             // "strict" | "minimal" | "off" — see below
@@ -395,7 +395,7 @@ The `tools.*` section controls what the MCP server injects into every session �
 
 | Option | Default | Description |
 |---|---|---|
-| `tools.preset` | `"full"` | Tool preset (`full`, `minimal`, or custom name from `~/.trace-mcp/presets/`) |
+| `tools.preset` | `"standard"` | Tool preset: `standard` (~50 tools, default — covers >99% of real-world tool calls per session-log mining), `minimal` (~16 tools), `review`, `architecture`, or `full` (all ~170 tools, opt-in) |
 | `tools.include` | — | Whitelist specific tools by name |
 | `tools.exclude` | — | Blacklist specific tools by name |
 | `tools.description_verbosity` | `"full"` | Per-tool description length. `minimal` = first sentence. `none` = empty |

--- a/src/config.ts
+++ b/src/config.ts
@@ -214,7 +214,12 @@ const ToolDescriptionOverrideSchema = z.union([
 
 const ToolsConfigSchema = z
   .object({
-    preset: z.string().default('full'),
+    // Default trimmed to 'standard' (~50 tools) per TRA-5: session mining of
+    // 1813 local sessions showed only 64/~170 tools ever get called, and the
+    // top dozen cover the vast majority of calls. 'full' remains available
+    // as an explicit opt-in (config `tools.preset: "full"` or
+    // `TRACE_MCP_PRESET=full`) for anyone who wants the entire surface.
+    preset: z.string().default('standard'),
     include: z.array(z.string()).optional(),
     exclude: z.array(z.string()).optional(),
     descriptions: z.record(z.string(), ToolDescriptionOverrideSchema).optional(),

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -483,7 +483,7 @@ export function createServer(
   }
 
   // Install tool gate (preset filtering, description overrides, savings/journal wrapping)
-  const presetName = process.env.TRACE_MCP_PRESET ?? config.tools?.preset ?? 'full';
+  const presetName = process.env.TRACE_MCP_PRESET ?? config.tools?.preset ?? 'standard';
   const presetResult = resolvePreset(presetName);
   const activePreset = presetResult ?? 'all';
 

--- a/src/tools/project/presets.ts
+++ b/src/tools/project/presets.ts
@@ -17,6 +17,11 @@ export const TOOL_PRESETS: Record<string, string[] | 'all'> = {
     'get_feature_context',
     'suggest_queries',
     'get_index_health',
+    // register_edit/batch are core infra (every edit-and-reindex loop and
+    // every multi-query round-trip needs them) — every non-full preset
+    // must carry them, not just 'full'.
+    'register_edit',
+    'batch',
     // Live decision-memory quartet on the minimal preset:
     //   remember = remember_decision (live agent write into the decision graph)
     //   recall   = query_decisions   (FTS search across captured decisions)
@@ -44,6 +49,8 @@ export const TOOL_PRESETS: Record<string, string[] | 'all'> = {
     'get_feature_context',
     'suggest_queries',
     'get_index_health',
+    'register_edit',
+    'batch',
     // navigation+
     'get_related_symbols',
     'get_context_bundle',
@@ -53,13 +60,23 @@ export const TOOL_PRESETS: Record<string, string[] | 'all'> = {
     'get_implementations',
     'reindex',
     'get_env_vars',
+    'get_changed_symbols',
     // analysis
     'get_dead_code',
+    'remove_dead_code',
+    'get_dead_exports',
     'get_circular_imports',
     'get_complexity_report',
     'check_rename',
     'get_coupling',
     'detect_antipatterns',
+    'check_duplication',
+    'get_control_flow',
+    // quality & security (top real-world usage per TRA-3 session mining)
+    'check_quality_gates',
+    'scan_security',
+    'self_audit',
+    'apply_codemod',
     // framework (gated further by has())
     'get_request_flow',
     'get_component_tree',
@@ -104,6 +121,8 @@ export const TOOL_PRESETS: Record<string, string[] | 'all'> = {
     'get_dead_code',
     'get_complexity_report',
     'detect_antipatterns',
+    'register_edit',
+    'batch',
   ],
 
   architecture: [
@@ -111,6 +130,8 @@ export const TOOL_PRESETS: Record<string, string[] | 'all'> = {
     'get_index_health',
     'search',
     'get_outline',
+    'register_edit',
+    'batch',
     'get_circular_imports',
     'get_coupling',
     'get_pagerank',

--- a/tests/tools/tool-config.test.ts
+++ b/tests/tools/tool-config.test.ts
@@ -3,6 +3,27 @@ import { TraceMcpConfigSchema } from '../../src/config.js';
 import { resolvePreset, TOOL_PRESETS } from '../../src/tools/project/presets.js';
 
 describe('Tool config schema', () => {
+  it('defaults tools.preset to "standard", not "full" (TRA-5: trim default surface)', () => {
+    const result = TraceMcpConfigSchema.safeParse({ tools: {} });
+    expect(result.success).toBe(true);
+    expect(result.data?.tools?.preset).toBe('standard');
+  });
+
+  it('the default preset registers well under half of the full tool surface', () => {
+    // Guards against the "170 tools loaded by default" regression this issue fixed.
+    const standard = resolvePreset('standard');
+    expect(standard).toBeInstanceOf(Set);
+    expect((standard as Set<string>).size).toBeLessThan(80);
+  });
+
+  it('every non-full preset carries register_edit and batch', () => {
+    for (const [name, tools] of Object.entries(TOOL_PRESETS)) {
+      if (tools === 'all') continue;
+      expect(tools, `preset "${name}" is missing register_edit`).toContain('register_edit');
+      expect(tools, `preset "${name}" is missing batch`).toContain('batch');
+    }
+  });
+
   it('accepts descriptions override in tools config', () => {
     const result = TraceMcpConfigSchema.safeParse({
       tools: {


### PR DESCRIPTION
## Summary

Closes TRA-5. TRA-3's session-log mining (1813 local Claude Code sessions) found only 64 of ~170 exposed trace-mcp tools were ever called, with the top ~12 covering the vast majority of calls — but every session paid the schema-token cost for all ~170 by default (`tools.preset` defaulted to `"full"`).

The preset/tool-gate infrastructure to fix this already existed (`src/tools/project/presets.ts`, `installToolGate`); this PR just:

- Changes the default `tools.preset` from `"full"` to `"standard"` (~50 tools). `full` remains available as an explicit opt-in (`tools.preset: "full"` in config, or `TRACE_MCP_PRESET=full`).
- Fixes a real gap found while cross-checking the presets against actual usage data: `register_edit` and `batch` — the **#4 and #6 most-called tools** — were missing from every preset except `full`. Anyone who had already opted into `minimal`/`standard`/`review`/`architecture` couldn't edit or batch. Added to all four.
- Adds the other top real-usage tools missing from `standard` (`remove_dead_code`, `get_dead_exports`, `get_changed_symbols`, `check_quality_gates`, `scan_security`, `self_audit`, `apply_codemod`, `check_duplication`, `get_control_flow`) so the new default doesn't regress any workflow the repo's own CLAUDE.md checklists rely on (e.g. "before PR/commit" and "deleting code").
- Updates `docs/configuration.md` to reflect the new default and preset list.

No tool signatures changed; this is pure preset/default-wiring — the long tail (~120 tools) stays fully reachable via `full`.

## Evidence

Re-ran the tool-usage mining locally across `~/.claude/projects/**/*.jsonl` (1813 sessions) to size the new default precisely — top 30 tools by call count cover 99.0% of all `mcp__trace-mcp__*` calls; `standard` (52 tools after this change) is a superset of that list plus the framework/predictive/architecture tools already curated there.

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 758 files / 8433 tests passed, 0 failed
- [x] `pnpm run biome:ci` — clean
- [x] New tests added: default preset resolves to `standard`, default preset registers well under half the full surface, every non-full preset carries `register_edit`/`batch`