### PR TITLE
fix: auto-index unindexed files on get_outline NOT_FOUND miss

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,8 +1,11 @@
 import type { Result } from 'neverthrow';
 
+/** Why a NOT_FOUND lookup missed — lets callers react instead of just retrying blind. */
+export type NotFoundReason = 'not_indexed' | 'not_found' | 'unknown_symbol';
+
 export type TraceMcpError =
   | { code: 'PARSE_ERROR'; file: string; partial: boolean; message: string }
-  | { code: 'NOT_FOUND'; id: string; candidates?: string[] }
+  | { code: 'NOT_FOUND'; id: string; candidates?: string[]; reason?: NotFoundReason }
   | { code: 'RESOLUTION_FAILED'; path: string; message: string }
   | { code: 'TIMEOUT'; operation: string; ms: number }
   | { code: 'SECURITY_VIOLATION'; detail: string }
@@ -17,8 +20,8 @@ export function parseError(file: string, message: string, partial = false): Trac
   return { code: 'PARSE_ERROR', file, partial, message };
 }
 
-export function notFound(id: string, candidates?: string[]): TraceMcpError {
-  return { code: 'NOT_FOUND', id, candidates };
+export function notFound(id: string, candidates?: string[], reason?: NotFoundReason): TraceMcpError {
+  return { code: 'NOT_FOUND', id, candidates, reason };
 }
 
 export function securityViolation(detail: string): TraceMcpError {
@@ -49,9 +52,15 @@ export function formatToolError(error: TraceMcpError): object {
 
   if (error.code === 'NOT_FOUND') {
     base.message = `'${error.id}' is not in the index`;
+    if (error.reason) base.reason = error.reason;
     if (error.candidates?.length) {
       base.suggestions = error.candidates;
       base.help = 'Use search() to find the correct symbol_id';
+    } else if (error.reason === 'not_indexed') {
+      base.help =
+        'File exists but could not be parsed on demand — it may not match the configured include globs. Check `include`/`exclude` in .trace-mcp.json and run reindex.';
+    } else if (error.reason === 'not_found') {
+      base.help = 'No file exists at this path. Use search() to locate the correct path.';
     } else {
       base.help =
         'If this is a file path, it may not match the configured include globs — check `include`/`exclude` in .trace-mcp.json and reindex. Otherwise use search() to locate the symbol.';

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -20,7 +20,11 @@ export function parseError(file: string, message: string, partial = false): Trac
   return { code: 'PARSE_ERROR', file, partial, message };
 }
 
-export function notFound(id: string, candidates?: string[], reason?: NotFoundReason): TraceMcpError {
+export function notFound(
+  id: string,
+  candidates?: string[],
+  reason?: NotFoundReason,
+): TraceMcpError {
   return { code: 'NOT_FOUND', id, candidates, reason };
 }
 

--- a/src/tools/register/navigation/lookup-tools.ts
+++ b/src/tools/register/navigation/lookup-tools.ts
@@ -1,11 +1,16 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { optionalNonEmptyString } from '../_zod-helpers.js';
-import { formatToolError } from '../../../errors.js';
+import { formatToolError, notFound } from '../../../errors.js';
+import { LOCKS_DIR, projectHash } from '../../../global.js';
+import { IndexingPipeline } from '../../../indexer/pipeline.js';
 import { decisionsForImpact } from '../../../memory/enrichment.js';
 import { aggregateFreshness, computeFileFreshness } from '../../../scoring/freshness.js';
 import { computeRetrievalConfidence } from '../../../scoring/retrieval-confidence.js';
 import type { ServerContext } from '../../../server/types.js';
+import { withLock } from '../../../utils/pid-lock.js';
 import { getChangeImpact } from '../../analysis/impact.js';
 import { getFileOutline, getSymbol } from '../../navigation/navigation.js';
 import { getRelatedSymbols } from '../../navigation/related.js';
@@ -13,6 +18,28 @@ import { fallbackOutline } from '../../navigation/zero-index.js';
 import { CHANGE_IMPACT_METHODOLOGY } from '../../shared/confidence.js';
 import { compactOutlineSymbols, DetailLevelSchema, isMinimal } from '../../_common/detail-level.js';
 import { OutputFormatSchema, encodeResponse } from '../../_common/output-format.js';
+
+/**
+ * On a get_outline miss, the file may simply not be indexed yet (new/renamed
+ * file, cold start). Rather than surface a bare NOT_FOUND that pushes the
+ * caller to a full Read, parse just this one file on demand — the same
+ * single-file path `register_edit` already uses — and retry. Returns true
+ * when the retry is worth attempting (the file exists on disk).
+ */
+async function autoIndexOnDemand(ctx: ServerContext, filePath: string): Promise<boolean> {
+  const absPath = path.resolve(ctx.projectRoot, filePath);
+  if (!fs.existsSync(absPath)) return false;
+  try {
+    const pipeline = new IndexingPipeline(ctx.store, ctx.registry, ctx.config, ctx.projectRoot);
+    await withLock(
+      { lockDir: LOCKS_DIR, name: `${projectHash(ctx.projectRoot)}-reindex`, op: 'get_outline-autoindex' },
+      () => pipeline.indexFiles([filePath]),
+    );
+  } catch {
+    // Best-effort: fall through and let the caller re-check the store.
+  }
+  return true;
+}
 
 /**
  * Registers direct symbol/file lookup tools: `get_symbol`, `get_outline`,
@@ -51,8 +78,12 @@ export function registerLookupTools(server: McpServer, ctx: ServerContext): void
         verifyAgainstGit: verify_against_git,
       });
       if (result.isErr()) {
+        const error =
+          result.error.code === 'NOT_FOUND' && !result.error.reason
+            ? notFound(result.error.id, result.error.candidates, 'unknown_symbol')
+            : result.error;
         return {
-          content: [{ type: 'text', text: j(formatToolError(result.error)) }],
+          content: [{ type: 'text', text: j(formatToolError(error)) }],
           isError: true,
         };
       }
@@ -163,14 +194,24 @@ export function registerLookupTools(server: McpServer, ctx: ServerContext): void
         }
       }
 
-      const result = await getFileOutline(store, filePath, {
-        nested: nested === true,
-        minLocForNesting: min_loc_for_nesting,
-        projectRoot,
-      });
+      const outlineOpts = { nested: nested === true, minLocForNesting: min_loc_for_nesting, projectRoot };
+      let result = await getFileOutline(store, filePath, outlineOpts);
+      let autoIndexed = false;
+      let existsOnDisk = false;
+      if (result.isErr() && result.error.code === 'NOT_FOUND') {
+        existsOnDisk = await autoIndexOnDemand(ctx, filePath);
+        if (existsOnDisk) {
+          result = await getFileOutline(store, filePath, outlineOpts);
+          autoIndexed = result.isOk();
+        }
+      }
       if (result.isErr()) {
+        const error =
+          result.error.code === 'NOT_FOUND' && !result.error.reason
+            ? notFound(result.error.id, result.error.candidates, existsOnDisk ? 'not_indexed' : 'not_found')
+            : result.error;
         return {
-          content: [{ type: 'text', text: j(formatToolError(result.error)) }],
+          content: [{ type: 'text', text: j(formatToolError(error)) }],
           isError: true,
         };
       }
@@ -189,6 +230,7 @@ export function registerLookupTools(server: McpServer, ctx: ServerContext): void
         path: result.value.path,
         language: result.value.language,
         symbols: projectedSymbols,
+        ...(autoIndexed ? { _auto_indexed: true } : {}),
         ...(isMinimal(detail_level)
           ? { detail_level: 'minimal' as const }
           : {

--- a/src/tools/register/navigation/lookup-tools.ts
+++ b/src/tools/register/navigation/lookup-tools.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { optionalNonEmptyString } from '../_zod-helpers.js';
@@ -10,6 +9,7 @@ import { decisionsForImpact } from '../../../memory/enrichment.js';
 import { aggregateFreshness, computeFileFreshness } from '../../../scoring/freshness.js';
 import { computeRetrievalConfidence } from '../../../scoring/retrieval-confidence.js';
 import type { ServerContext } from '../../../server/types.js';
+import { validatePath } from '../../../utils/security.js';
 import { withLock } from '../../../utils/pid-lock.js';
 import { getChangeImpact } from '../../analysis/impact.js';
 import { getFileOutline, getSymbol } from '../../navigation/navigation.js';
@@ -27,12 +27,17 @@ import { OutputFormatSchema, encodeResponse } from '../../_common/output-format.
  * when the retry is worth attempting (the file exists on disk).
  */
 async function autoIndexOnDemand(ctx: ServerContext, filePath: string): Promise<boolean> {
-  const absPath = path.resolve(ctx.projectRoot, filePath);
-  if (!fs.existsSync(absPath)) return false;
+  const checked = validatePath(filePath, ctx.projectRoot);
+  if (checked.isErr()) return false;
+  if (!fs.existsSync(checked.value)) return false;
   try {
     const pipeline = new IndexingPipeline(ctx.store, ctx.registry, ctx.config, ctx.projectRoot);
     await withLock(
-      { lockDir: LOCKS_DIR, name: `${projectHash(ctx.projectRoot)}-reindex`, op: 'get_outline-autoindex' },
+      {
+        lockDir: LOCKS_DIR,
+        name: `${projectHash(ctx.projectRoot)}-reindex`,
+        op: 'get_outline-autoindex',
+      },
       () => pipeline.indexFiles([filePath]),
     );
   } catch {
@@ -194,7 +199,11 @@ export function registerLookupTools(server: McpServer, ctx: ServerContext): void
         }
       }
 
-      const outlineOpts = { nested: nested === true, minLocForNesting: min_loc_for_nesting, projectRoot };
+      const outlineOpts = {
+        nested: nested === true,
+        minLocForNesting: min_loc_for_nesting,
+        projectRoot,
+      };
       let result = await getFileOutline(store, filePath, outlineOpts);
       let autoIndexed = false;
       let existsOnDisk = false;
@@ -208,7 +217,11 @@ export function registerLookupTools(server: McpServer, ctx: ServerContext): void
       if (result.isErr()) {
         const error =
           result.error.code === 'NOT_FOUND' && !result.error.reason
-            ? notFound(result.error.id, result.error.candidates, existsOnDisk ? 'not_indexed' : 'not_found')
+            ? notFound(
+                result.error.id,
+                result.error.candidates,
+                existsOnDisk ? 'not_indexed' : 'not_found',
+              )
             : result.error;
         return {
           content: [{ type: 'text', text: j(formatToolError(error)) }],

--- a/tests/tools/behavioural/get-outline-auto-index.behavioural.test.ts
+++ b/tests/tools/behavioural/get-outline-auto-index.behavioural.test.ts
@@ -29,7 +29,12 @@ interface CapturedTool {
 function makeCapturingServer(): { server: unknown; captured: CapturedTool[] } {
   const captured: CapturedTool[] = [];
   const server = {
-    tool: (name: string, _description: string, _shape: Record<string, z.ZodTypeAny>, handler: Handler) => {
+    tool: (
+      name: string,
+      _description: string,
+      _shape: Record<string, z.ZodTypeAny>,
+      handler: Handler,
+    ) => {
       captured.push({ name, handler });
     },
   };
@@ -58,7 +63,13 @@ describe('get_outline — auto-index on NOT_FOUND (TRA-4)', () => {
     const ctx = {
       store,
       registry,
-      config: { root: tmpDir, include: ['src/**/*.ts'], exclude: [], db: { path: ':memory:' }, plugins: [] },
+      config: {
+        root: tmpDir,
+        include: ['src/**/*.ts'],
+        exclude: [],
+        db: { path: ':memory:' },
+        plugins: [],
+      },
       projectRoot: tmpDir,
       guardPath: () => null,
       j: (v: unknown) => JSON.stringify(v),

--- a/tests/tools/behavioural/get-outline-auto-index.behavioural.test.ts
+++ b/tests/tools/behavioural/get-outline-auto-index.behavioural.test.ts
@@ -1,0 +1,98 @@
+/**
+ * TRA-4: get_outline used to return a bare NOT_FOUND for a file that exists
+ * on disk but hasn't been indexed yet (new/renamed file, cold start) — the
+ * documented driver of a 46% full-Read fallback rate. It should instead
+ * parse the file on demand (same single-file path `register_edit` uses) and
+ * return the real outline, and it should only fall back to a structured
+ * `reason` + `hint` error for a path that genuinely doesn't exist.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { TypeScriptLanguagePlugin } from '../../../src/indexer/plugins/language/typescript/index.js';
+import { PluginRegistry } from '../../../src/plugin-api/registry.js';
+import type { ServerContext } from '../../../src/server/types.js';
+import { registerLookupTools } from '../../../src/tools/register/navigation/lookup-tools.js';
+import { createTestStore } from '../../test-utils.js';
+
+type Handler = (
+  args: Record<string, unknown>,
+) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+
+interface CapturedTool {
+  name: string;
+  handler: Handler;
+}
+
+function makeCapturingServer(): { server: unknown; captured: CapturedTool[] } {
+  const captured: CapturedTool[] = [];
+  const server = {
+    tool: (name: string, _description: string, _shape: Record<string, z.ZodTypeAny>, handler: Handler) => {
+      captured.push({ name, handler });
+    },
+  };
+  return { server, captured };
+}
+
+describe('get_outline — auto-index on NOT_FOUND (TRA-4)', () => {
+  let tmpDir: string;
+  let outline: Handler;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-outline-'));
+    fs.mkdirSync(path.join(tmpDir, 'src'));
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'fresh.ts'),
+      'export function freshlyWritten(): number {\n  return 1;\n}\n',
+    );
+
+    const store = createTestStore();
+    // Non-empty index so get_outline exercises the real NOT_FOUND path
+    // instead of the separate "index is totally empty" regex fallback.
+    store.insertFile('src/other.ts', 'typescript', 'seed-hash', 10);
+    const registry = new PluginRegistry();
+    registry.registerLanguagePlugin(new TypeScriptLanguagePlugin());
+
+    const ctx = {
+      store,
+      registry,
+      config: { root: tmpDir, include: ['src/**/*.ts'], exclude: [], db: { path: ':memory:' }, plugins: [] },
+      projectRoot: tmpDir,
+      guardPath: () => null,
+      j: (v: unknown) => JSON.stringify(v),
+      jh: (_tool: string, v: unknown) => JSON.stringify(v),
+      markExplored: () => undefined,
+      decisionStore: null,
+      rankingLedger: null,
+    } as unknown as ServerContext;
+
+    const { server, captured } = makeCapturingServer();
+    registerLookupTools(server as never, ctx);
+    outline = captured.find((t) => t.name === 'get_outline')!.handler;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('parses an unindexed but existing file on demand instead of returning NOT_FOUND', async () => {
+    const res = await outline({ path: 'src/fresh.ts' });
+    expect(res.isError).toBeFalsy();
+    const body = JSON.parse(res.content[0].text);
+    expect(body.error).toBeUndefined();
+    expect(body._auto_indexed).toBe(true);
+    expect(body.symbols.some((s: { name: string }) => s.name === 'freshlyWritten')).toBe(true);
+  });
+
+  it('returns a structured reason + hint (not bare NOT_FOUND) for a genuinely absent path', async () => {
+    const res = await outline({ path: 'src/does-not-exist.ts' });
+    expect(res.isError).toBe(true);
+    const body = JSON.parse(res.content[0].text);
+    expect(body.error.code).toBe('NOT_FOUND');
+    expect(body.error.reason).toBe('not_found');
+    expect(typeof body.error.help).toBe('string');
+    expect(body.error.help.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `get_outline` on a NOT_FOUND miss now checks whether the requested file exists on disk; if it does, parses just that file on demand (same single-file `IndexingPipeline.indexFiles` path `register_edit` already uses) and retries, instead of forcing the caller to fall back to a full `Read`.
- Genuine misses (file truly absent, or `get_symbol` given an unknown symbol_id/fqn) now carry a structured `reason` (`not_indexed` | `not_found` | `unknown_symbol`) plus a tailored `help` string instead of a bare `NOT_FOUND`.
- Success responses from the auto-index path are flagged with `_auto_indexed: true` so callers can tell the outline came from a just-in-time parse.

## Why
Session mining showed `get_outline`/`get_symbol` are the #1 and #3 most-used trace-mcp tools, but NOT_FOUND misses drove a 46% full-`Read` fallback rate — exactly the token cost trace-mcp exists to remove. Closes TRA-4.

## Test plan
- [x] New behavioural test: unindexed-but-existing file → outline returned with `_auto_indexed: true`, not NOT_FOUND
- [x] New behavioural test: genuinely absent path → structured `reason: 'not_found'` + `help`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` (full suite, 8433 tests, no regressions)