### PR TITLE
fix(init): doctor false-positives on CLAUDE.md files that reject a competing tool

### DIFF
--- a/src/init/conflict-detector.ts
+++ b/src/init/conflict-detector.ts
@@ -536,6 +536,11 @@ function scanClaudeMdFiles(projectRoot?: string): Conflict[] {
 
     for (const { pattern, competitor, marker } of COMPETING_CLAUDE_MD_PATTERNS) {
       if (pattern.test(content)) {
+        // Block markers are unambiguous injected control blocks — always flag.
+        // Bare name/API mentions can also appear in files that *reject* the
+        // competitor (e.g. "never call jcodemunch tools"); skip those.
+        if (!marker && isNegatedMention(content, pattern)) continue;
+
         const id = `claude_md:${competitor}:${filePath}`;
         // Avoid duplicate entries for same file+competitor
         if (conflicts.some((c) => c.id === id)) continue;
@@ -562,6 +567,25 @@ function scanClaudeMdFiles(projectRoot?: string): Conflict[] {
   }
 
   return conflicts;
+}
+
+/** Words/phrases indicating a mention rejects/deprecates the competitor rather than directing its use. */
+const NEGATION_PATTERN =
+  /\b(never|don't|do not|deprecated|stop using|instead of|avoid|reject|must not|no longer|banned|forbidden|disallow(?:ed)?)\b/i;
+
+/**
+ * True if every line matching `pattern` also carries negation language
+ * (e.g. "never call jcodemunch") — i.e. the file rejects the competitor
+ * rather than directing the AI to prefer it.
+ */
+function isNegatedMention(content: string, pattern: RegExp): boolean {
+  let sawMatch = false;
+  for (const line of content.split(/\r?\n/)) {
+    if (!pattern.test(line)) continue;
+    sawMatch = true;
+    if (!NEGATION_PATTERN.test(line)) return false;
+  }
+  return sawMatch;
 }
 
 /** Check if content has a markdown heading containing the competitor name. */

--- a/tests/init/conflict-detector.test.ts
+++ b/tests/init/conflict-detector.test.ts
@@ -177,6 +177,34 @@ describe('detectConflicts', () => {
     expect(claudeConflicts.length).toBeGreaterThanOrEqual(1);
   });
 
+  it('does not flag CLAUDE.md that rejects the competing tool', () => {
+    const root = fixture({
+      'CLAUDE.md':
+        '# Project\n\njCodeMunch is deprecated for this user. Never call jcodemunch tools; ' +
+        'use trace-mcp equivalents instead.',
+    });
+
+    const report = detectConflicts(root);
+    const claudeConflicts = report.conflicts.filter(
+      (c) => c.category === 'claude_md' && c.target.startsWith(root),
+    );
+    expect(claudeConflicts).toHaveLength(0);
+  });
+
+  it('still flags a marker block even when surrounding text uses negation words', () => {
+    const root = fixture({
+      'CLAUDE.md':
+        '# Project\n\n<!-- jcodemunch:start -->\nNever skip jcodemunch tools\n<!-- jcodemunch:end -->',
+    });
+
+    const report = detectConflicts(root);
+    const jcm = report.conflicts.find(
+      (c) => c.category === 'claude_md' && c.target.startsWith(root) && c.competitor === 'jcodemunch-mcp',
+    );
+    expect(jcm).toBeDefined();
+    expect(jcm!.severity).toBe('critical');
+  });
+
   it('does not flag clean CLAUDE.md', () => {
     const root = fixture({
       'CLAUDE.md': '# Project\n\nUse trace-mcp tools for code navigation.\n',

--- a/tests/init/conflict-detector.test.ts
+++ b/tests/init/conflict-detector.test.ts
@@ -199,7 +199,10 @@ describe('detectConflicts', () => {
 
     const report = detectConflicts(root);
     const jcm = report.conflicts.find(
-      (c) => c.category === 'claude_md' && c.target.startsWith(root) && c.competitor === 'jcodemunch-mcp',
+      (c) =>
+        c.category === 'claude_md' &&
+        c.target.startsWith(root) &&
+        c.competitor === 'jcodemunch-mcp',
     );
     expect(jcm).toBeDefined();
     expect(jcm!.severity).toBe('critical');


### PR DESCRIPTION
## Summary
- `scanClaudeMdFiles`'s bare name/API patterns in `COMPETING_CLAUDE_MD_PATTERNS` matched any mention of a competitor's name, so memory files whose entire content is "never use jcodemunch" tripped the same `doctor` warning as files that direct the AI to prefer it.
- Added `isNegatedMention`: for non-marker pattern matches, skip the warning when every matching line also carries negation language (never, deprecated, instead of, avoid, ...). Marker-based block detections (`<!-- jcodemunch:start -->` etc.) are unambiguous injected control blocks and always still fire regardless of surrounding wording.

Fixes TRA-19.

## Test plan
- [x] `pnpm run test --run tests/init/conflict-detector.test.ts` — added regression tests for the false-positive case and confirmed marker blocks still fire even with negation words nearby
- [x] `pnpm run test --run tests/init/` — full init suite passes
- [x] `pnpm run build`
- [x] `pnpm run lint` (`tsc --noEmit`)