### PR TITLE
doctor --fix cleans up stale registry entries and overlaps

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3152,14 +3152,23 @@ program
       console.log('No projects registered. Run `trace-mcp add` in a project directory.');
     } else {
       console.log('Registered projects:\n');
+      let staleCount = 0;
       for (const p of projects) {
         const lastIdx = p.lastIndexed ? new Date(p.lastIndexed).toLocaleString() : 'never';
+        const rootExists = fs.existsSync(p.root);
         const dbExists = fs.existsSync(p.dbPath) ? 'ok' : 'missing';
-        console.log(`  ${p.name}`);
+        console.log(`  ${p.name}${rootExists ? '' : '  [STALE — folder deleted]'}`);
         console.log(`    Root: ${p.root}`);
         console.log(`    DB: ${dbExists}`);
         console.log(`    Last indexed: ${lastIdx}`);
         console.log();
+        if (!rootExists) staleCount++;
+      }
+      if (staleCount > 0) {
+        console.log(
+          `${staleCount} stale entr${staleCount === 1 ? 'y' : 'ies'} (folder deleted). ` +
+            'Clean up with `trace-mcp doctor --fix` or `trace-mcp prune --apply`.',
+        );
       }
     }
   });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -21,7 +21,12 @@ import {
 } from '../init/launcher.js';
 import { LAUNCHER_VERSION } from '../init/types.js';
 import { findProjectRoot } from '../project-root.js';
-import { findOverlappingProjects, inspectRegistry } from '../registry.js';
+import {
+  findOverlappingProjects,
+  inspectRegistry,
+  pruneStaleProjects,
+  unregisterProject,
+} from '../registry.js';
 
 const _SEVERITY_ICON: Record<ConflictSeverity, string> = {
   critical: 'X',
@@ -59,6 +64,15 @@ export const doctorCommand = new Command('doctor')
       // stale registrations (deleted folders, missing/corrupt DBs) that would
       // otherwise only manifest as runtime "Project not found" errors.
       const registry = diagnoseRegistry();
+      const hasRegistryIssues = registry.staleCount > 0 || registry.overlaps.length > 0;
+
+      // --fix / --dry-run also clean up the registry itself (TRA-18): missing-root
+      // entries and overlap containers have one unambiguous remediation each, so
+      // (unlike project conflicts) they don't need an interactive per-item prompt.
+      const registryFix: RegistryFixResult | null =
+        hasRegistryIssues && (opts.fix || opts.dryRun)
+          ? fixRegistryIssues(registry, { dryRun: opts.dryRun })
+          : null;
 
       // Detect project root (optional — doctor works without it)
       let projectRoot: string | undefined;
@@ -75,7 +89,9 @@ export const doctorCommand = new Command('doctor')
       if (opts.json) {
         if (opts.fix || opts.dryRun) {
           const results = fixAllConflicts(conflicts, { dryRun: opts.dryRun });
-          console.log(JSON.stringify({ registry, conflicts, fixes: results }, null, 2));
+          console.log(
+            JSON.stringify({ registry, registryFix, conflicts, fixes: results }, null, 2),
+          );
         } else {
           console.log(JSON.stringify({ registry, ...report }, null, 2));
         }
@@ -83,6 +99,7 @@ export const doctorCommand = new Command('doctor')
       }
 
       printRegistryReport(registry);
+      if (registryFix) printRegistryFixResult(registryFix, { dryRun: !!opts.dryRun });
 
       // --- No conflicts ---
       if (conflicts.length === 0) {
@@ -229,7 +246,7 @@ interface RegistryOverlapReport {
   descendantRoot: string;
 }
 
-interface RegistryHealthReport {
+export interface RegistryHealthReport {
   registryPath: string;
   registryExists: boolean;
   registryCorrupt: boolean;
@@ -254,7 +271,7 @@ function checkDbReadable(dbPath: string): boolean {
   }
 }
 
-function diagnoseRegistry(): RegistryHealthReport {
+export function diagnoseRegistry(): RegistryHealthReport {
   const inspection = inspectRegistry();
   const entries: RegistryEntryHealth[] = inspection.entries.map((e) => {
     let status: RegistryEntryStatus;
@@ -280,6 +297,56 @@ function diagnoseRegistry(): RegistryHealthReport {
       descendantRoot: o.descendant.root,
     })),
   };
+}
+
+export interface RegistryFixResult {
+  /** Roots removed (or, in dry-run, that would be removed) because the folder is gone. */
+  removedMissingRoots: string[];
+  /** Ancestor roots removed (or previewed) because a descendant is also registered. */
+  removedOverlapContainers: string[];
+}
+
+/**
+ * Apply (or preview, when dryRun) the two registry remediations `doctor` already
+ * knows how to describe: drop entries whose folder is gone (same as `prune --apply`'s
+ * registry sweep), and drop the *ancestor* of an overlapping pair — the descendant is
+ * always the more specific, intentional registration, so removing the container is the
+ * unambiguous fix `printRegistryReport` already tells the user to run by hand.
+ */
+export function fixRegistryIssues(
+  r: RegistryHealthReport,
+  opts: { dryRun?: boolean },
+): RegistryFixResult {
+  const missingRoots = r.entries.filter((e) => e.status === 'missing_root').map((e) => e.root);
+  const overlapContainers = [...new Set(r.overlaps.map((o) => o.ancestorRoot))];
+
+  if (opts.dryRun) {
+    return { removedMissingRoots: missingRoots, removedOverlapContainers: overlapContainers };
+  }
+
+  const removedMissingRoots = pruneStaleProjects();
+  for (const root of overlapContainers) unregisterProject(root);
+  return { removedMissingRoots, removedOverlapContainers: overlapContainers };
+}
+
+function printRegistryFixResult(fix: RegistryFixResult, opts: { dryRun: boolean }): void {
+  const lines: string[] = [];
+  const verb = opts.dryRun ? 'Would remove' : 'Removed';
+  if (fix.removedMissingRoots.length > 0) {
+    lines.push(
+      `${verb} ${fix.removedMissingRoots.length} stale entr${fix.removedMissingRoots.length === 1 ? 'y' : 'ies'} (folder deleted):`,
+    );
+    for (const r of fix.removedMissingRoots) lines.push(`  ${shortPath(r)}`);
+  }
+  if (fix.removedOverlapContainers.length > 0) {
+    lines.push(
+      `${verb} ${fix.removedOverlapContainers.length} overlap container${fix.removedOverlapContainers.length === 1 ? '' : 's'}:`,
+    );
+    for (const r of fix.removedOverlapContainers) lines.push(`  ${shortPath(r)}`);
+  }
+  if (lines.length === 0) return;
+  console.log(lines.join('\n'));
+  console.log('');
 }
 
 const REGISTRY_STATUS_LABEL: Record<RegistryEntryStatus, string> = {

--- a/tests/cli/doctor-registry.test.ts
+++ b/tests/cli/doctor-registry.test.ts
@@ -1,0 +1,94 @@
+/**
+ * TRA-18: `doctor --fix`/`--dry-run` should be able to clean up the registry
+ * itself (missing-root entries, overlap containers), not just report on it.
+ * Isolated via TRACE_MCP_DATA_DIR, same pattern as registry-health.test.ts.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('doctor registry fix (TRA-18)', () => {
+  let tmpHome: string;
+  let registry: typeof import('../../src/registry.js');
+  let doctor: typeof import('../../src/cli/doctor.js');
+
+  beforeEach(async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-doctor-'));
+    vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+    vi.resetModules();
+    registry = await import('../../src/registry.js');
+    doctor = await import('../../src/cli/doctor.js');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function makeProjectDir(name: string): string {
+    const dir = path.join(tmpHome, name);
+    fs.mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  it('dry-run previews removal without touching the registry', () => {
+    const alive = makeProjectDir('alive');
+    const gone = makeProjectDir('gone');
+    registry.registerProject(alive);
+    registry.registerProject(gone);
+    fs.rmSync(gone, { recursive: true, force: true });
+
+    const report = doctor.diagnoseRegistry();
+    const fix = doctor.fixRegistryIssues(report, { dryRun: true });
+
+    expect(fix.removedMissingRoots).toEqual([gone]);
+    expect(
+      registry
+        .listProjects()
+        .map((e) => e.root)
+        .sort(),
+    ).toEqual([alive, gone].sort());
+  });
+
+  it('--fix removes entries whose folder is gone', () => {
+    const alive = makeProjectDir('alive');
+    const gone = makeProjectDir('gone');
+    registry.registerProject(alive);
+    registry.registerProject(gone);
+    fs.rmSync(gone, { recursive: true, force: true });
+
+    const report = doctor.diagnoseRegistry();
+    const fix = doctor.fixRegistryIssues(report, { dryRun: false });
+
+    expect(fix.removedMissingRoots).toEqual([gone]);
+    expect(registry.listProjects().map((e) => e.root)).toEqual([alive]);
+  });
+
+  it('--fix removes the ancestor of an overlapping pair, keeps the descendant', () => {
+    const umbrella = makeProjectDir('ws');
+    const child = makeProjectDir('ws/app');
+    registry.registerProject(umbrella);
+    registry.registerProject(child);
+
+    const report = doctor.diagnoseRegistry();
+    expect(report.overlaps).toHaveLength(1);
+
+    const fix = doctor.fixRegistryIssues(report, { dryRun: false });
+    expect(fix.removedOverlapContainers).toEqual([umbrella]);
+    expect(registry.listProjects().map((e) => e.root)).toEqual([child]);
+  });
+
+  it('is a no-op when the registry is healthy', () => {
+    const alive = makeProjectDir('alive');
+    registry.registerProject(alive);
+
+    const report = doctor.diagnoseRegistry();
+    const fix = doctor.fixRegistryIssues(report, { dryRun: false });
+
+    expect(fix.removedMissingRoots).toEqual([]);
+    expect(fix.removedOverlapContainers).toEqual([]);
+    expect(registry.listProjects()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- `trace-mcp list` now flags registry entries whose project folder no longer exists (`[STALE — folder deleted]`), instead of silently showing "Last indexed: never" with no explanation.
- `trace-mcp doctor --fix` (and `--dry-run` to preview) now also cleans up the registry itself: removes entries whose root is gone (same remediation `prune --apply` already does), and removes the *ancestor* of an overlapping-root pair — the exact fix `doctor`'s own report text already told users to run by hand (`trace-mcp remove <container-path>`).
- Previously this cleanup only happened via `prune --apply`, and only for missing roots — overlaps had no automated fix at all despite the tool prescribing one in its own output.

Addresses TRA-18 (part of the trace-mcp usage audit in TRA-16): registry bloat from dead/ephemeral project entries (deleted workdirs, overlapping roots) was accumulating with no cleanup path other than manually running `prune`.

Deliberately out of scope: auto-skipping registration of ephemeral scratch/tmp directories at register-time. That's a "consider" item in the issue and risks false positives for legitimately-named projects in a general-purpose OSS tool — the doctor/prune cleanup path here already makes the accumulation self-healing (`doctor --fix` retires dead rows any time it's run), which covers the reported impact without adding registration-time heuristics.

## Test plan
- [x] New `tests/cli/doctor-registry.test.ts`: dry-run preview, `--fix` removes missing-root entries, `--fix` removes overlap ancestor and keeps descendant, no-op when registry is healthy (isolated via `TRACE_MCP_DATA_DIR`, same pattern as `src/__tests__/registry-health.test.ts`).
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `pnpm run test` — 8445 passed, 9 skipped, 761 files