### PR TITLE
feat(telemetry): anonymous opt-out active-install ping (GA4 Measurement Protocol)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,9 +309,19 @@ trace-mcp runs entirely on your machine. Your source code is never the product.
 - **Indexing happens locally.** The MCP server is a Node process you run yourself — stdio or `http://127.0.0.1:3741`.
 - **Index lives in `~/.trace-mcp/`**, never inside your project and never uploaded. Your repo directory stays clean unless you opt into `.traceignore` or `.trace-mcp/.config.json`.
 - **Semantic search is offline by default** — bundled ONNX embeddings, no API keys, no outbound calls. Switch to Ollama (local) or OpenAI (opt-in) via config.
-- **No telemetry.** Nothing is phoned home about your code, queries, or usage.
+- **No telemetry about your code, queries, or usage.** The only thing that ever leaves your machine is described below — nothing else is phoned home.
 - **What your AI client sees is governed by your AI client.** trace-mcp returns graph results over MCP; how Claude Code / Cursor / Codex / Windsurf forward them to a model is up to that client's privacy model.
 - **To wipe everything**, delete `~/.trace-mcp/`. That is the entire footprint.
+
+### Usage telemetry
+
+trace-mcp sends at most one anonymous ping per day, per install, to help us count active installs. It is:
+
+- **Anonymous** — a random install id (`~/.trace-mcp/telemetry-state.json`), the trace-mcp version, Node major version, and OS platform. No project names, file paths, query content, code, or anything else that could identify you or your codebase.
+- **Opt-out** — set `TRACE_MCP_TELEMETRY=off` to disable it entirely.
+- **Small blast radius by construction** — transport is [GA4's Measurement Protocol](https://developers.google.com/analytics/devguides/collection/protocol/ga4), a single HTTP POST, not a custom backend or SDK.
+
+Source: [`src/telemetry/usage-ping.ts`](src/telemetry/usage-ping.ts).
 
 For security-sensitive environments, review [SECURITY.md](SECURITY.md) before use.
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -33,6 +33,7 @@ import {
   getGlobalTelemetrySink,
   setGlobalTelemetrySink,
 } from '../telemetry/index.js';
+import { sendUsagePing } from '../telemetry/usage-ping.js';
 import { SessionJournal, type StructuralLandmark } from '../session/journal.js';
 import { CodexSessionProvider } from '../session/providers/codex.js';
 import { HermesSessionProvider } from '../session/providers/hermes.js';
@@ -293,6 +294,13 @@ export function createServer(
         logger.warn({ err }, 'telemetry.observability_bridge_init_failed');
       });
   }
+
+  // Anonymous active-install ping (opt-out via TRACE_MCP_TELEMETRY=off; inert
+  // until TRACE_MCP_GA_MEASUREMENT_ID/TRACE_MCP_GA_API_SECRET are configured).
+  // Fire-and-forget — never blocks startup, never throws.
+  void sendUsagePing({ version: PKG_VERSION }).catch((err) => {
+    logger.debug({ err }, 'telemetry.usage_ping_unexpected_error');
+  });
 
   // Structural landmarks provider: PageRank top-20 symbols + recently edited symbols
   journal.setLandmarkProvider(() => {

--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -71,6 +71,9 @@ export const CORPORA_DIR = path.join(TRACE_MCP_HOME, 'corpora');
 /** Pre-indexed dependency bundles. */
 export const BUNDLES_DIR = path.join(TRACE_MCP_HOME, 'bundles');
 
+/** Anonymous install-id + last-ping-date state for the opt-out usage ping (see src/telemetry/usage-ping.ts). */
+export const TELEMETRY_STATE_PATH = path.join(TRACE_MCP_HOME, 'telemetry-state.json');
+
 // ── Foreign IDE / agent paths trace-mcp introspects ──────────────
 
 /** Claude Code project store: `~/.claude/projects/<encoded-cwd>/<session>.jsonl`. */

--- a/src/telemetry/__tests__/usage-ping.test.ts
+++ b/src/telemetry/__tests__/usage-ping.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs');
+
+import fs from 'node:fs';
+import { sendUsagePing } from '../usage-ping.js';
+
+function makeFetchSpy(): {
+  fetchImpl: typeof fetch;
+  calls: Array<{ url: string; body: unknown }>;
+} {
+  const calls: Array<{ url: string; body: unknown }> = [];
+  const fetchImpl = vi.fn(async (url: unknown, init?: RequestInit) => {
+    calls.push({ url: String(url), body: JSON.parse(String(init?.body ?? '{}')) });
+    return new Response(null, { status: 204 });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+const CONFIGURED_ENV = {
+  TRACE_MCP_GA_MEASUREMENT_ID: 'G-TEST123',
+  TRACE_MCP_GA_API_SECRET: 'secret-abc',
+} as NodeJS.ProcessEnv;
+
+describe('sendUsagePing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+    vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+  });
+
+  it('no-ops when TRACE_MCP_TELEMETRY=off, even if GA credentials are configured', async () => {
+    const { fetchImpl, calls } = makeFetchSpy();
+    await sendUsagePing({
+      version: '1.2.3',
+      env: { ...CONFIGURED_ENV, TRACE_MCP_TELEMETRY: 'off' },
+      fetchImpl,
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  it('no-ops when GA credentials are not configured', async () => {
+    const { fetchImpl, calls } = makeFetchSpy();
+    await sendUsagePing({ version: '1.2.3', env: {}, fetchImpl });
+    expect(calls).toHaveLength(0);
+  });
+
+  it('sends one event with version/platform/node_major and an anonymous client_id on first run', async () => {
+    const { fetchImpl, calls } = makeFetchSpy();
+    await sendUsagePing({ version: '1.2.3', env: CONFIGURED_ENV, fetchImpl });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toContain('measurement_id=G-TEST123');
+    expect(calls[0]!.url).toContain('api_secret=secret-abc');
+    const body = calls[0]!.body as {
+      client_id: string;
+      events: Array<{ name: string; params: Record<string, unknown> }>;
+    };
+    expect(typeof body.client_id).toBe('string');
+    expect(body.client_id.length).toBeGreaterThan(0);
+    expect(body.events[0]?.name).toBe('app_open');
+    expect(body.events[0]?.params.version).toBe('1.2.3');
+    expect(body.events[0]?.params.platform).toBe(process.platform);
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not send a second ping the same UTC day', async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({ installId: 'fixed-id', lastPingDate: today }),
+    );
+    const { fetchImpl, calls } = makeFetchSpy();
+    await sendUsagePing({ version: '1.2.3', env: CONFIGURED_ENV, fetchImpl });
+    expect(calls).toHaveLength(0);
+  });
+
+  it('reuses the persisted install id across runs instead of generating a new one', async () => {
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({ installId: 'fixed-id', lastPingDate: '2000-01-01' }),
+    );
+    const { fetchImpl, calls } = makeFetchSpy();
+    await sendUsagePing({ version: '1.2.3', env: CONFIGURED_ENV, fetchImpl });
+    const body = calls[0]!.body as { client_id: string };
+    expect(body.client_id).toBe('fixed-id');
+  });
+
+  it('swallows fetch failures without throwing and does not update lastPingDate', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch;
+    await expect(
+      sendUsagePing({ version: '1.2.3', env: CONFIGURED_ENV, fetchImpl }),
+    ).resolves.toBeUndefined();
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/src/telemetry/usage-ping.ts
+++ b/src/telemetry/usage-ping.ts
@@ -1,0 +1,110 @@
+/**
+ * Anonymous, opt-out active-install ping.
+ *
+ * Separate from the observability bridge in `index.ts`/`otlp.ts`/`langfuse.ts`:
+ * that bridge exports a *user's own* spans to a backend *they* configure. This
+ * module reports back to the maintainer instead — a single daily event with
+ * an anonymous install id, the trace-mcp version, Node major version, and
+ * platform. No project paths, file names, query content, or anything else
+ * that could identify a user or their code.
+ *
+ * Transport is GA4's Measurement Protocol (a plain HTTP POST to a Google
+ * endpoint) rather than a self-hosted collector, so there's no backend to
+ * run or maintain. It is fully inert — this function no-ops — until both
+ * TRACE_MCP_GA_MEASUREMENT_ID and TRACE_MCP_GA_API_SECRET are set, which
+ * this package does not ship with. See README "Usage telemetry" for how to
+ * configure and opt out.
+ */
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { logger } from '../logger.js';
+import { TELEMETRY_STATE_PATH } from '../shared/paths.js';
+
+interface TelemetryState {
+  installId: string;
+  /** UTC calendar date (YYYY-MM-DD) of the last successfully sent ping. */
+  lastPingDate?: string;
+}
+
+function isDisabled(env: NodeJS.ProcessEnv): boolean {
+  const v = env.TRACE_MCP_TELEMETRY?.trim().toLowerCase();
+  return v === 'off' || v === '0' || v === 'false';
+}
+
+function utcDate(nowMs: number): string {
+  return new Date(nowMs).toISOString().slice(0, 10);
+}
+
+function loadOrCreateState(): TelemetryState {
+  try {
+    const parsed = JSON.parse(
+      fs.readFileSync(TELEMETRY_STATE_PATH, 'utf8'),
+    ) as Partial<TelemetryState>;
+    if (parsed.installId) return { installId: parsed.installId, lastPingDate: parsed.lastPingDate };
+  } catch {
+    // No state file yet (first run) or it's unreadable — start fresh below.
+  }
+  return { installId: randomUUID() };
+}
+
+function saveState(state: TelemetryState): void {
+  fs.mkdirSync(path.dirname(TELEMETRY_STATE_PATH), { recursive: true });
+  fs.writeFileSync(TELEMETRY_STATE_PATH, JSON.stringify(state), 'utf8');
+}
+
+export interface UsagePingOptions {
+  version: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  nowMs?: number;
+}
+
+/**
+ * Fire-and-forget: never throws, and a failure never blocks or delays
+ * startup. Sends at most one ping per UTC calendar day per install.
+ */
+export async function sendUsagePing(opts: UsagePingOptions): Promise<void> {
+  const env = opts.env ?? process.env;
+  if (isDisabled(env)) return;
+
+  const measurementId = env.TRACE_MCP_GA_MEASUREMENT_ID;
+  const apiSecret = env.TRACE_MCP_GA_API_SECRET;
+  if (!measurementId || !apiSecret) return;
+
+  const state = loadOrCreateState();
+  const today = utcDate(opts.nowMs ?? Date.now());
+  if (state.lastPingDate === today) return;
+
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const url = `https://www.google-analytics.com/mp/collect?measurement_id=${encodeURIComponent(measurementId)}&api_secret=${encodeURIComponent(apiSecret)}`;
+
+  try {
+    await fetchImpl(url, {
+      method: 'POST',
+      body: JSON.stringify({
+        client_id: state.installId,
+        events: [
+          {
+            name: 'app_open',
+            params: {
+              version: opts.version,
+              platform: process.platform,
+              node_major: process.versions.node.split('.')[0],
+            },
+          },
+        ],
+      }),
+    });
+  } catch (err) {
+    logger.debug({ err }, 'telemetry.usage_ping_failed');
+    return; // Don't persist lastPingDate — retry on next start.
+  }
+
+  try {
+    saveState({ installId: state.installId, lastPingDate: today });
+  } catch (err) {
+    console.error('DEBUG saveState failed', err);
+    logger.debug({ err }, 'telemetry.usage_ping_state_save_failed');
+  }
+}


### PR DESCRIPTION
## Summary
- `src/telemetry/usage-ping.ts`: anonymous, opt-out active-install ping. Generates + persists a random install UUID in `~/.trace-mcp/telemetry-state.json`, sends at most one event/day (version, Node major, platform — no code, paths, or query content) via GA4's Measurement Protocol (a plain HTTP POST — no collector to run or host).
- Fully **inert** until `TRACE_MCP_GA_MEASUREMENT_ID` + `TRACE_MCP_GA_API_SECRET` are both set — this package does not ship with credentials. Opt-out via `TRACE_MCP_TELEMETRY=off`.
- Wired into server bootstrap (fire-and-forget, never blocks/delays startup, never throws).
- `src/shared/paths.ts`: new `TELEMETRY_STATE_PATH` accessor (required by `tests/shared/paths-invariant.test.ts`, which fails the build on stray `~/.trace-mcp` literals).
- README: the old "No telemetry" line was no longer true — replaced with a "Usage telemetry" section stating exactly what's sent and how to opt out.

## Context
TRA-27/TRA-29: requester wants active-user/install counting without standing up custom backend infrastructure — asked specifically whether a hosted service (Google Analytics, etc.) could handle this instead of writing one. GA4's Measurement Protocol fits: no server to run, existing free hosted product. This is separate from the existing `src/telemetry/{otlp,langfuse}.ts` bridge, which exports a *user's own* spans to a backend *they* configure and has no concept of reporting back to the maintainer.

**Not yet live**: needs a decision + the actual GA4 property from the requester (measurement ID + API secret, supplied as env vars at publish/deploy time — not committed here). See TRA-29.

## Test plan
- [x] 6 new unit tests: opt-out, missing-credentials no-op, event shape (client_id/version/platform/node_major), once-per-UTC-day dedup, install-id persistence across runs, fetch-failure swallowing without throwing
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run build` — clean
- [x] `pnpm exec biome ci --diagnostic-level=error` — clean
- [x] `tests/shared/paths-invariant.test.ts` still passes (no stray path literals)