### PR TITLE
feat(init): add --scope project|global flag for MCP client config

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -20,7 +20,7 @@ import {
   cleanupLegacyHooks,
 } from '../init/hooks.js';
 import { setupLauncher } from '../init/launcher.js';
-import { configureMcpClients } from '../init/mcp-client.js';
+import { configureMcpClients, type McpScope } from '../init/mcp-client.js';
 import { writeStampedVersion } from '../init/version-stamp.js';
 
 declare const PKG_VERSION_INJECTED: string;
@@ -74,6 +74,7 @@ export const initCommand = new Command('init')
   .option('--dry-run', 'Show what would be done without writing files')
   .option('--json', 'Output results as JSON (implies --yes)')
   .option('--index', 'Also register and index the current project')
+  .option('--scope <scope>', 'Where to write the MCP client config: project | global', 'global')
   .action(
     async (opts: {
       yes?: boolean;
@@ -86,8 +87,15 @@ export const initCommand = new Command('init')
       dryRun?: boolean;
       json?: boolean;
       index?: boolean;
+      scope?: string;
     }) => {
       const nonInteractive = opts.yes || opts.json || opts.dryRun;
+
+      if (opts.scope !== undefined && opts.scope !== 'project' && opts.scope !== 'global') {
+        console.error(`Invalid --scope value: "${opts.scope}". Must be "project" or "global".`);
+        process.exit(1);
+      }
+      const mcpScope: McpScope = opts.scope === 'project' ? 'project' : 'global';
 
       // Ensure global directory structure + migrate config
       let migrationStep: InitStepResult | undefined;
@@ -350,6 +358,7 @@ export const initCommand = new Command('init')
             installTweakcc,
             agentBehavior,
             claudeMdScope,
+            scope: mcpScope,
             force: opts.force,
             dryRun: opts.dryRun,
           });
@@ -366,6 +375,7 @@ export const initCommand = new Command('init')
           installTweakcc,
           agentBehavior,
           claudeMdScope,
+          scope: mcpScope,
           force: opts.force,
           dryRun: opts.dryRun,
         });
@@ -622,6 +632,7 @@ function executeSteps(
     installTweakcc: boolean;
     agentBehavior: 'strict' | 'off';
     claudeMdScope: 'global' | 'skip';
+    scope: McpScope;
     force?: boolean;
     dryRun?: boolean;
   },
@@ -630,21 +641,24 @@ function executeSteps(
   // because the MCP registration's `command` field points at the shim path.
   steps.push(...setupLauncher({ dryRun: opts.dryRun, force: opts.force, pkgVersion: PKG_VERSION }));
 
-  // 1. MCP clients (always global)
+  // 1. MCP clients
   if (opts.selectedClients.length > 0) {
     const clientResults = configureMcpClients(opts.selectedClients, process.cwd(), {
-      scope: 'global',
+      scope: opts.scope,
       dryRun: opts.dryRun,
     });
     steps.push(...clientResults);
   }
 
   // 2. IDE rules (Cursor .mdc, Windsurf .windsurfrules)
+  const ideRulesGlobal = opts.scope === 'global';
   if (opts.selectedClients.includes('cursor')) {
-    steps.push(installCursorRules(process.cwd(), { dryRun: opts.dryRun, global: true }));
+    steps.push(installCursorRules(process.cwd(), { dryRun: opts.dryRun, global: ideRulesGlobal }));
   }
   if (opts.selectedClients.includes('windsurf')) {
-    steps.push(installWindsurfRules(process.cwd(), { dryRun: opts.dryRun, global: true }));
+    steps.push(
+      installWindsurfRules(process.cwd(), { dryRun: opts.dryRun, global: ideRulesGlobal }),
+    );
   }
 
   // 3. PreToolUse guard hook + PostToolUse auto-reindex hook

--- a/src/init/mcp-client.ts
+++ b/src/init/mcp-client.ts
@@ -81,6 +81,22 @@ const ALWAYS_LOAD_CLIENTS: ReadonlySet<DetectedMcpClient['name']> = new Set([
 ]);
 
 /**
+ * Clients whose config location is inherently global-only — `getConfigPath`
+ * returns the same user-level path regardless of `scope`. Requesting
+ * `--scope project` for one of these must not silently fall back to writing
+ * global (that would overwrite another project's entry, e.g. its `cwd`,
+ * while reporting success as if it were project-scoped).
+ */
+const GLOBAL_ONLY_CLIENTS: ReadonlySet<DetectedMcpClient['name']> = new Set([
+  'claude-desktop',
+  'hermes',
+  'cline',
+  'kilocode',
+  'antigravity',
+  'kimi',
+]);
+
+/**
  * Build the MCP command entry. All clients use the stable launcher shim at
  * ~/.trace-mcp/bin/trace-mcp — the shim resolves node + dist/cli.js at
  * runtime from launcher.env (or probe fallback), so the MCP registration
@@ -90,7 +106,7 @@ function buildMcpEntry(): { command: string } {
   return { command: getLauncherPath() };
 }
 
-type McpScope = 'global' | 'project';
+export type McpScope = 'global' | 'project';
 
 /**
  * Configure selected MCP clients to use trace-mcp.
@@ -105,6 +121,19 @@ export function configureMcpClients(
   const results: InitStepResult[] = [];
 
   for (const name of clientNames) {
+    // Reject rather than silently ignore --scope project for clients whose
+    // config location is always global (see GLOBAL_ONLY_CLIENTS) — writing
+    // global anyway would overwrite another project's entry while reporting
+    // success as if project-scoped.
+    if (opts.scope === 'project' && GLOBAL_ONLY_CLIENTS.has(name)) {
+      results.push({
+        target: name,
+        action: 'skipped',
+        detail: `${name} does not support project-scoped config; it is always configured globally. Skipped --scope project for this client.`,
+      });
+      continue;
+    }
+
     // JetBrains AI Assistant: config stored in IDE XML (llm.mcpServers.xml), not editable as JSON.
     // If Claude Desktop is also selected, user can "Import from Claude" in the IDE.
     if (name === 'jetbrains-ai') {

--- a/tests/init/mcp-client-status.test.ts
+++ b/tests/init/mcp-client-status.test.ts
@@ -60,6 +60,38 @@ describe('getMcpClientStatuses', () => {
     expect(s.staleReason).toBeUndefined();
   });
 
+  it('scope: "project" writes to <projectRoot>/.mcp.json instead of the global config', () => {
+    const [result] = configureMcpClients(['claude-code'], projectRoot, { scope: 'project' });
+    const projectConfigPath = path.join(projectRoot, '.mcp.json');
+
+    expect(result.target).toBe(projectConfigPath);
+    expect(fs.existsSync(projectConfigPath)).toBe(true);
+    expect(fs.existsSync(path.join(fakeHome, '.claude.json'))).toBe(false);
+
+    const [s] = getMcpClientStatuses(projectRoot, 'project', ['claude-code']);
+    expect(s.status).toBe('up_to_date');
+  });
+
+  it.each(['claude-desktop', 'hermes', 'cline', 'kilocode', 'antigravity', 'kimi'] as const)(
+    'skips --scope project for global-only client %s instead of overwriting the global config',
+    (client) => {
+      // Simulate an existing global entry written from a different project.
+      const otherProjectRoot = path.join(sandbox, 'other-project');
+      fs.mkdirSync(otherProjectRoot, { recursive: true });
+      configureMcpClients([client], otherProjectRoot, { scope: 'global' });
+      const [globalStatusBefore] = getMcpClientStatuses(otherProjectRoot, 'global', [client]);
+
+      const [result] = configureMcpClients([client], projectRoot, { scope: 'project' });
+
+      expect(result.action).toBe('skipped');
+      expect(result.detail).toMatch(/does not support project-scoped config/);
+
+      // The global entry (from the other project) must be untouched.
+      const [globalStatusAfter] = getMcpClientStatuses(otherProjectRoot, 'global', [client]);
+      expect(globalStatusAfter.status).toBe(globalStatusBefore.status);
+    },
+  );
+
   it('flags `stale` with reason="alwaysLoad" when the on-disk entry lacks the new flag', () => {
     // First let init write a fresh entry, then strip the alwaysLoad field —
     // simulating an installation done before the alwaysLoad fix shipped.


### PR DESCRIPTION
## Summary
- `trace-mcp init` always wrote the MCP client registration to the global config file, even though `getConfigPath` already supported a project-scoped path for every client. Adds a `--scope project|global` flag (default: `global`, preserving current behavior).
- Rejects `--scope project` upfront for global-only MCP clients (claude-desktop, hermes, cline, kilocode, antigravity, kimi) instead of silently falling back to writing the global config.

Fixes #282

## Test plan
- [x] `pnpm run build`
- [x] Existing + new tests in `tests/init/mcp-client-status.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)