### PR TITLE
fix(registry): doctor --fix-interactive handles registry issues too

### DIFF
--- a/src/cli/__tests__/doctor-registry-fix.test.ts
+++ b/src/cli/__tests__/doctor-registry-fix.test.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// TRA-50: `doctor --fix` already sweeps stale/overlapping registry entries
+// non-interactively; `--fix-interactive` didn't touch the registry at all,
+// leaving overlap cleanup to a manual `trace-mcp remove <path>` step. This
+// pins the interactive counterpart: one confirm for the missing-root sweep,
+// one per overlapping pair, and a decline leaves the entry registered.
+
+const confirmMock = vi.fn();
+vi.mock('@clack/prompts', () => ({
+  confirm: (...args: unknown[]) => confirmMock(...args),
+  isCancel: (v: unknown) => v === Symbol.for('clack:cancel'),
+}));
+
+describe('fixRegistryIssuesInteractive (TRA-50)', () => {
+  let tmpHome: string;
+  let registry: typeof import('../../registry.js');
+  let doctor: typeof import('../doctor.js');
+
+  beforeEach(async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-doctor-fix-'));
+    vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+    vi.resetModules();
+    confirmMock.mockReset();
+    registry = await import('../../registry.js');
+    doctor = await import('../doctor.js');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function makeProjectDir(name: string): string {
+    const dir = path.join(tmpHome, name);
+    fs.mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  it('removes the overlap container when confirmed, keeps it when declined', async () => {
+    const umbrella = makeProjectDir('ws');
+    const child = makeProjectDir('ws/child');
+    registry.registerProject(umbrella);
+    registry.registerProject(child);
+
+    const health = doctor.diagnoseRegistry();
+    expect(health.overlaps).toHaveLength(1);
+
+    confirmMock.mockResolvedValueOnce(false);
+    const declined = await doctor.fixRegistryIssuesInteractive(health);
+    expect(declined.removedOverlapContainers).toEqual([]);
+    expect(registry.listProjects().map((e) => e.root)).toContain(umbrella);
+
+    confirmMock.mockResolvedValueOnce(true);
+    const accepted = await doctor.fixRegistryIssuesInteractive(health);
+    expect(accepted.removedOverlapContainers).toEqual([umbrella]);
+    expect(registry.listProjects().map((e) => e.root)).not.toContain(umbrella);
+  });
+
+  it('prunes missing-root entries only on confirmation', async () => {
+    const gone = makeProjectDir('gamma');
+    registry.registerProject(gone);
+    fs.rmSync(gone, { recursive: true, force: true });
+
+    const health = doctor.diagnoseRegistry();
+    expect(health.staleCount).toBe(1);
+
+    confirmMock.mockResolvedValueOnce(true);
+    const result = await doctor.fixRegistryIssuesInteractive(health);
+    expect(result.removedMissingRoots).toEqual([gone]);
+    expect(registry.listProjects()).toEqual([]);
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -99,7 +99,11 @@ export const doctorCommand = new Command('doctor')
       }
 
       printRegistryReport(registry);
-      if (registryFix) printRegistryFixResult(registryFix, { dryRun: !!opts.dryRun });
+      if (registryFix) {
+        printRegistryFixResult(registryFix, { dryRun: !!opts.dryRun });
+      } else if (opts.fixInteractive && hasRegistryIssues) {
+        printRegistryFixResult(await fixRegistryIssuesInteractive(registry), { dryRun: false });
+      }
 
       // --- No conflicts ---
       if (conflicts.length === 0) {
@@ -327,6 +331,40 @@ export function fixRegistryIssues(
   const removedMissingRoots = pruneStaleProjects();
   for (const root of overlapContainers) unregisterProject(root);
   return { removedMissingRoots, removedOverlapContainers: overlapContainers };
+}
+
+/**
+ * Interactive counterpart to {@link fixRegistryIssues}: asks once for the missing-root
+ * sweep and once per overlapping pair, so `--fix-interactive` covers registry issues too
+ * instead of leaving them to a separate manual `prune`/`remove` step.
+ */
+export async function fixRegistryIssuesInteractive(
+  r: RegistryHealthReport,
+): Promise<RegistryFixResult> {
+  const removedMissingRoots: string[] = [];
+  const missingRoots = r.entries.filter((e) => e.status === 'missing_root');
+  if (missingRoots.length > 0) {
+    const answer = await p.confirm({
+      message: `Remove ${missingRoots.length} stale registry entr${missingRoots.length === 1 ? 'y' : 'ies'} (folder deleted)?`,
+      initialValue: true,
+    });
+    if (!p.isCancel(answer) && answer) removedMissingRoots.push(...pruneStaleProjects());
+  }
+
+  const removedOverlapContainers: string[] = [];
+  const overlapsByContainer = new Map(r.overlaps.map((o) => [o.ancestorRoot, o]));
+  for (const o of overlapsByContainer.values()) {
+    const answer = await p.confirm({
+      message: `Remove overlap container "${o.ancestorName}" (${shortPath(o.ancestorRoot)}), keeping "${o.descendantName}"?`,
+      initialValue: true,
+    });
+    if (!p.isCancel(answer) && answer) {
+      unregisterProject(o.ancestorRoot);
+      removedOverlapContainers.push(o.ancestorRoot);
+    }
+  }
+
+  return { removedMissingRoots, removedOverlapContainers };
 }
 
 function printRegistryFixResult(fix: RegistryFixResult, opts: { dryRun: boolean }): void {


### PR DESCRIPTION
## Summary
- `doctor --fix`/`--dry-run` already sweep stale (folder-deleted) registry entries and remove overlap containers (#267). `--fix-interactive` skipped the registry entirely, leaving overlap/stale cleanup as a manual `prune --apply` / `trace-mcp remove <path>` step even though `doctor`'s own report already names the fix.
- Adds `fixRegistryIssuesInteractive`: one confirm for the missing-root sweep, one confirm per overlapping pair (removing the ancestor, keeping the more-specific descendant, matching the non-interactive behavior and doctor's printed guidance).

Closes TRA-50.

## Test plan
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec biome check` on touched files
- [x] `pnpm run test` (full suite, 8456 tests passing)
- [x] `pnpm run build`
- [x] New unit test `src/cli/__tests__/doctor-registry-fix.test.ts` covers confirm/decline for both missing-root sweep and overlap-container removal