### PR TITLE
doctor: auto-fix bare competing-tool mentions in CLAUDE.md

### DIFF
--- a/src/init/conflict-detector.ts
+++ b/src/init/conflict-detector.ts
@@ -545,7 +545,8 @@ function scanClaudeMdFiles(projectRoot?: string): Conflict[] {
         // Avoid duplicate entries for same file+competitor
         if (conflicts.some((c) => c.id === id)) continue;
 
-        // Fixable if we have markers OR if competitor name appears in a markdown heading
+        // Fixable via marker/heading removal, or (as a fallback) by commenting
+        // out the individual matching lines — see fixClaudeMdBlock's Strategy 4.
         const hasSection = hasCompetitorSection(content, competitor);
 
         conflicts.push({
@@ -560,7 +561,8 @@ function scanClaudeMdFiles(projectRoot?: string): Conflict[] {
               : `Found references to ${competitor} tools/APIs. These instructions may cause the AI to prefer competing tools over trace-mcp.`,
           target: filePath,
           competitor,
-          fixable: !!marker || hasSection,
+          detectionPattern: pattern,
+          fixable: true,
         });
       }
     }
@@ -570,7 +572,7 @@ function scanClaudeMdFiles(projectRoot?: string): Conflict[] {
 }
 
 /** Words/phrases indicating a mention rejects/deprecates the competitor rather than directing its use. */
-const NEGATION_PATTERN =
+export const NEGATION_PATTERN =
   /\b(never|don't|do not|deprecated|stop using|instead of|avoid|reject|must not|no longer|banned|forbidden|disallow(?:ed)?)\b/i;
 
 /**

--- a/src/init/conflict-resolver.ts
+++ b/src/init/conflict-resolver.ts
@@ -524,7 +524,7 @@ function commentOutMatchingLines(content: string, pattern: RegExp): string {
     if (/^\s*<!--/.test(line)) return line; // already commented
     if (!pattern.test(line) || NEGATION_PATTERN.test(line)) return line;
     changed = true;
-    const safeText = line.replace(/-->/g, '--&gt;');
+    const safeText = line.replace(/--!?>/g, '--&gt;');
     return `<!-- trace-mcp: disabled by doctor --fix, competing-tool directive: ${safeText.trim()} -->`;
   });
   return changed ? lines.join('\n') : content;

--- a/src/init/conflict-resolver.ts
+++ b/src/init/conflict-resolver.ts
@@ -6,7 +6,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { atomicWriteJson } from '../utils/atomic-write.js';
-import type { Conflict } from './conflict-detector.js';
+import { NEGATION_PATTERN, type Conflict } from './conflict-detector.js';
 
 type FixAction = 'removed' | 'disabled' | 'cleaned' | 'skipped';
 
@@ -387,6 +387,13 @@ function fixClaudeMdBlock(conflict: Conflict, opts: { dryRun?: boolean }): FixRe
       };
     }
 
+    // Strategy 4: bare mentions with no marker/heading — comment out just the
+    // matching lines so they stop being read as instructions, instead of
+    // leaving the conflict as a manual-only fix.
+    if (updated === content && conflict.detectionPattern) {
+      updated = commentOutMatchingLines(updated, conflict.detectionPattern);
+    }
+
     // Clean up excessive blank lines left behind
     updated = `${updated.replace(/\n{3,}/g, '\n\n').trim()}\n`;
 
@@ -503,6 +510,24 @@ function removeFromMemoryIndex(deletedFilePath: string): void {
   } catch {
     /* best-effort */
   }
+}
+
+/**
+ * Comment out individual lines matching a competing-tool detection pattern,
+ * skipping lines that already reject the competitor (negated mentions) or
+ * are already wrapped in a comment. Used as a fallback when a bare mention
+ * has no marker block or heading section to remove wholesale.
+ */
+function commentOutMatchingLines(content: string, pattern: RegExp): string {
+  let changed = false;
+  const lines = content.split('\n').map((line) => {
+    if (/^\s*<!--/.test(line)) return line; // already commented
+    if (!pattern.test(line) || NEGATION_PATTERN.test(line)) return line;
+    changed = true;
+    const safeText = line.replace(/-->/g, '--&gt;');
+    return `<!-- trace-mcp: disabled by doctor --fix, competing-tool directive: ${safeText.trim()} -->`;
+  });
+  return changed ? lines.join('\n') : content;
 }
 
 /**

--- a/tests/init/conflict-resolver.test.ts
+++ b/tests/init/conflict-resolver.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest';
-import { commentOutJsonKey } from '../../src/init/conflict-resolver.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { detectConflicts } from '../../src/init/conflict-detector.js';
+import { commentOutJsonKey, fixConflict } from '../../src/init/conflict-resolver.js';
 
 describe('commentOutJsonKey', () => {
   it('comments out a multi-line server entry', () => {
@@ -104,5 +108,88 @@ describe('commentOutJsonKey', () => {
       (l) => !l.trimStart().startsWith('//') && l.includes('jcodemunch'),
     );
     expect(uncommented).toHaveLength(0);
+  });
+});
+
+describe('fixClaudeMdBlock — bare mention fallback (TRA-49)', () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function fixture(files: Record<string, string>): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-conflict-fix-'));
+    tmpDirs.push(root);
+    for (const [name, content] of Object.entries(files)) {
+      fs.writeFileSync(path.join(root, name), content);
+    }
+    return root;
+  }
+
+  it('is fixable and comments out a bare tool-reference line instead of requiring manual fix', () => {
+    const root = fixture({
+      'CLAUDE.md':
+        '# Project\n\nAlways use get_file_outline from jcodemunch for file exploration.\n',
+    });
+
+    const conflict = detectConflicts(root).conflicts.find(
+      (c) =>
+        c.category === 'claude_md' &&
+        c.competitor === 'jcodemunch-mcp' &&
+        c.target.startsWith(root),
+    )!;
+    expect(conflict).toBeDefined();
+    expect(conflict.fixable).toBe(true);
+
+    const result = fixConflict(conflict);
+    expect(result.action).toBe('cleaned');
+
+    const updated = fs.readFileSync(conflict.target, 'utf-8');
+    expect(updated).toContain('<!-- trace-mcp: disabled by doctor --fix');
+    expect(updated).not.toMatch(/^Always use get_file_outline/m);
+    // Unrelated content survives untouched.
+    expect(updated).toContain('# Project');
+  });
+
+  it('leaves negated mentions alone even inside an otherwise-fixed file', () => {
+    const root = fixture({
+      'CLAUDE.md':
+        '# Project\n\nUse get_file_outline from jcodemunch for exploration.\n' +
+        'Never call jcodemunch tools for anything else; prefer trace-mcp.\n',
+    });
+
+    const conflict = detectConflicts(root).conflicts.find(
+      (c) =>
+        c.category === 'claude_md' &&
+        c.competitor === 'jcodemunch-mcp' &&
+        c.target.startsWith(root),
+    )!;
+    const result = fixConflict(conflict);
+    expect(result.action).toBe('cleaned');
+
+    const updated = fs.readFileSync(conflict.target, 'utf-8');
+    expect(updated).toContain('Never call jcodemunch tools for anything else');
+    expect(updated).not.toMatch(/^Use get_file_outline/m);
+  });
+
+  it('dry-run reports the fix without touching the file', () => {
+    const root = fixture({
+      'CLAUDE.md': '# Project\n\nAlways use get_file_outline from jcodemunch.\n',
+    });
+
+    const conflict = detectConflicts(root).conflicts.find(
+      (c) =>
+        c.category === 'claude_md' &&
+        c.competitor === 'jcodemunch-mcp' &&
+        c.target.startsWith(root),
+    )!;
+    const original = fs.readFileSync(conflict.target, 'utf-8');
+
+    const result = fixConflict(conflict, { dryRun: true });
+    expect(result.action).toBe('cleaned');
+    expect(fs.readFileSync(conflict.target, 'utf-8')).toBe(original);
   });
 });


### PR DESCRIPTION
## Summary
- `doctor` flagged bare competing-tool mentions in CLAUDE.md/memory files (no marker block, no heading section) as `(manual fix)` with no actionable remediation via `--fix`/`--fix-interactive`.
- Adds a fallback strategy: comment out just the matching, non-negated lines with a `<!-- trace-mcp: disabled by doctor --fix, competing-tool directive: ... -->` marker, so the conflict is now auto-fixable like the other categories.
- `claude_md` conflicts are now always `fixable: true`; `--dry-run` already surfaces the preview via the existing `fixAllConflicts` path, so no `doctor.ts` changes were needed.

## Test plan
- [x] New unit tests in `tests/init/conflict-resolver.test.ts` covering: fixable bare mention gets commented out, negated mentions are left alone, `--dry-run` doesn't touch the file.
- [x] `pnpm run build`
- [x] `pnpm vitest run` (full suite, 761 files / 8458 tests passing)
- [x] `pnpm run biome:ci` on changed files

Closes TRA-49.