### PR TITLE
fix(plugin): bump .codex-plugin manifest versions to match package.json

### DIFF
--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "trace-mcp",
       "source": "./.codex-plugin",
       "description": "Framework-aware code intelligence: semantic search, refactoring, change-impact, security scanning, and decision memory across 60+ frameworks and 81 languages.",
-      "version": "1.46.1",
+      "version": "1.46.2",
       "author": {
         "name": "Nikolai Vysotskyi"
       }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "trace-mcp",
-  "version": "1.46.1",
+  "version": "1.46.2",
   "description": "Framework-aware code intelligence MCP server. 60+ framework integrations, 81 languages, semantic search with Signal Fusion (BM25 + PageRank + embeddings + identity), refactoring tools (rename/move/extract/codemod), change-impact analysis, security scanning, and decision/session memory.",
   "author": {
     "name": "Nikolai Vysotskyi",


### PR DESCRIPTION
PR #278 pinned .codex-plugin manifest versions at 1.46.1; master has since moved to 1.46.2, breaking tests/plugin/manifest-sync.test.ts on master (`plugin.json version matches package.json version`). Bumps .codex-plugin/plugin.json and .codex-plugin/marketplace.json to 1.46.2.