### PR TITLE
chore(deps): ignore better-sqlite3 major bumps until 13.x prebuilds are fixed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,13 @@ updates:
         update-types:
           - version-update:semver-minor
           - version-update:semver-major
+      # better-sqlite3 13.x's N-API prebuilds segfault on `new Database()`
+      # (reproduces with a bare `require('better-sqlite3')` script, no
+      # trace-mcp code involved — see TRA-51). Re-evaluate once upstream
+      # ships a fixed 13.x release.
+      - dependency-name: "better-sqlite3"
+        update-types:
+          - version-update:semver-major
     groups:
       production-minor-patch:
         dependency-type: production


### PR DESCRIPTION
## Summary
- Dependabot PR #288 (better-sqlite3 12.10.0 → 13.0.2) segfaults CI's "Retrieval-quality baseline" job on `node dist/cli.js add . --no-index` (SIGSEGV, exit 139).
- Root-caused to better-sqlite3 itself, not trace-mcp's usage: a bare `require('better-sqlite3'); new Database(':memory:')` script with zero trace-mcp code crashes identically. Under lldb the crash is inside `napi_module_register_by_symbol`, i.e. the native addon fails during lazy dlopen/registration on first `Database()` call.
- Reproduced on macOS arm64 (Node 20.20.2, matching CI's node-version) locally; CI reproduces the same failure on ubuntu-latest. v13.0.0 was better-sqlite3's first N-API release and there's a related open upstream report of broken 13.0.2 prebuilds (WiseLibs/better-sqlite3#1509, GLIBC mismatch on linux-arm64 prebuilds), consistent with a packaging/ABI regression in this release rather than a one-off environment issue.
- `package.json` already pins `"better-sqlite3": "^12.9.0"`, which excludes 13.x — so no code change is needed there. This PR just adds a dependabot `ignore` rule (matching the existing pattern for `@types/node` / `web-tree-sitter`) so dependabot stops reproposing the 13.x major bump every week until upstream ships a fixed release.

## Test plan
- [x] Reproduced the segfault locally against better-sqlite3 13.0.2 on Node 20.20.2 (matches CI's `node-version: '20'`), both via the full `add . --no-index` CLI path and a minimal 4-line repro script.
- [x] Confirmed `master`'s `^12.9.0` range already blocks 13.x from being auto-picked up.
- No functional code changed — dependabot config only.