### PR TITLE
chore(deps): close 6 Dependabot alerts (undici + postcss)

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@hono/node-server": ">=2.0.5",
     "js-yaml": "^4.2.0",
     "vite": "$vite",
-    "undici": ">=7.28.0",
+    "undici": ">=8.9.0",
     "esbuild": ">=0.28.1",
     "sharp": ">=0.35.0",
     "fast-uri": ">=3.1.4",
@@ -135,14 +135,14 @@
       "hono": ">=4.12.25",
       "@hono/node-server": ">=2.0.5",
       "js-yaml": "^4.2.0",
-      "undici": ">=7.28.0",
+      "undici": ">=8.9.0",
       "vite": ">=8.0.16",
       "esbuild": ">=0.28.1",
       "sharp": ">=0.35.0",
       "fast-uri": ">=3.1.4",
       "adm-zip": ">=0.6.0",
       "body-parser": ">=2.3.0",
-      "postcss": ">=8.5.18"
+      "postcss": ">=8.5.23"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,14 +11,14 @@ overrides:
   hono: '>=4.12.25'
   '@hono/node-server': '>=2.0.5'
   js-yaml: ^4.2.0
-  undici: '>=7.28.0'
+  undici: '>=8.9.0'
   vite: '>=8.0.16'
   esbuild: '>=0.28.1'
   sharp: '>=0.35.0'
   fast-uri: '>=3.1.4'
   adm-zip: '>=0.6.0'
   body-parser: '>=2.3.0'
-  postcss: '>=8.5.18'
+  postcss: '>=8.5.23'
 
 importers:
 
@@ -2123,7 +2123,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.5.18'
+      postcss: '>=8.5.23'
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -2135,10 +2135,6 @@ packages:
         optional: true
       yaml:
         optional: true
-
-  postcss@8.5.21:
-    resolution: {integrity: sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.25:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
@@ -2515,7 +2511,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: '>=8.5.18'
+      postcss: '>=8.5.23'
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -2554,8 +2550,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@8.5.0:
-    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
 
   unpipe@1.0.0:
@@ -3544,7 +3540,7 @@ snapshots:
       '@vue/shared': 3.5.40
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.21
+      postcss: 8.5.25
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.40':
@@ -4095,7 +4091,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 8.5.0
+      undici: 8.10.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -4385,12 +4381,6 @@ snapshots:
       postcss: 8.5.25
       tsx: 4.23.1
       yaml: 2.9.0
-
-  postcss@8.5.21:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.25:
     dependencies:
@@ -4895,7 +4885,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@8.5.0: {}
+  undici@8.10.0: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
## Summary
- Bump `undici` pnpm override from `>=7.28.0` to `>=8.9.0`, closing alerts #67-71 (CRLF injection, cache-control whitespace bypass, cookie attribute injection, retry-interceptor desync, degenerate cache-directive crash). Resolves to `undici@8.10.0` in the lockfile.
- Bump `postcss` pnpm override from `>=8.5.18` to `>=8.5.23`, closing alert #74 (incomplete fix of GHSA-6g55-p6wh-862q — arbitrary `.map` file read when `from` is unset). Resolves to `postcss@8.5.25`, deduping the previously split 8.5.21/8.5.25 versions into one.
- Both are transitive deps (`undici` via jsdom/vitest, `postcss` via @vue/compiler-sfc/tsup/vite) with no direct usage change required.

## Test plan
- [x] `pnpm install` — resolves cleanly, single deduped version for each package
- [x] `pnpm run build` — passes
- [x] `pnpm run test` — 763 files / 8481 tests passed, 2 skipped