### PR TITLE
fix(config): scaffold preset:standard in default global config (TRA-67)

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -204,7 +204,7 @@ export const DEFAULT_CONFIG_JSONC = `{
 
   // ── Tool exposure ────────────────────────────────────────────────
   "tools": {
-    "preset": "full",                            // "full" | "minimal" | custom preset name
+    "preset": "standard",                        // "standard" | "full" | "minimal" | custom preset name
     // "include": [],                            // whitelist specific tools
     // "exclude": [],                            // blacklist specific tools
     // "descriptions": {},                       // override tool descriptions

--- a/tests/config/default-config-jsonc.test.ts
+++ b/tests/config/default-config-jsonc.test.ts
@@ -1,0 +1,15 @@
+import { parse } from 'jsonc-parser';
+import { describe, expect, it } from 'vitest';
+import { TraceMcpConfigSchema } from '../../src/config.js';
+import { DEFAULT_CONFIG_JSONC } from '../../src/global.js';
+
+describe('DEFAULT_CONFIG_JSONC', () => {
+  it('scaffolds tools.* values matching the Zod schema defaults', () => {
+    const scaffolded = parse(DEFAULT_CONFIG_JSONC).tools;
+    const schemaDefaults = TraceMcpConfigSchema.parse({ tools: {} }).tools;
+
+    expect(scaffolded.preset).toBe(schemaDefaults.preset);
+    expect(scaffolded.description_verbosity).toBe(schemaDefaults.description_verbosity);
+    expect(scaffolded.instructions_verbosity).toBe(schemaDefaults.instructions_verbosity);
+  });
+});


### PR DESCRIPTION
## Summary
- `DEFAULT_CONFIG_JSONC` in `src/global.ts` hardcoded `"preset": "full"`, so `trace-mcp init`/`add` wrote it as an explicit value into the user's `~/.trace-mcp/.config.json` — which always wins over the Zod schema's `"standard"` default introduced by TRA-5. That meant the trimmed tool-preset default never reached a fresh install.
- `description_verbosity`/`instructions_verbosity` in the template already matched the schema's `"full"` default (TRA-5 only changed the preset default, not verbosity), so those are left unchanged.
- Added `tests/config/default-config-jsonc.test.ts`, which parses the JSONC template and asserts `tools.*` matches `TraceMcpConfigSchema`'s parsed defaults, so this can't silently drift again.

Fixes TRA-67, reported in https://github.com/nikolai-vysotskyi/trace-mcp/issues/124.

## Test plan
- [x] New regression test passes, and fails when reverted to `"preset": "full"` (verified manually)
- [x] `pnpm run build`
- [x] `pnpm run test --run` — 765 files / 8490 tests passed
- [x] `pnpm run lint` (tsc --noEmit) — clean