### PR TITLE
Surface skipped top-level folders after indexing, document un-skip path

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,7 +109,25 @@ These directories are always skipped (no configuration needed):
 
 `node_modules`, `.git`, `dist`, `build`, `.next`, `__pycache__`, `.venv`, `vendor`, `.trace-mcp`, `coverage`, `.turbo`
 
-You can add more via `.traceignore` or the `ignore.directories` config key.
+You can add **more** directory names to skip via `.traceignore` or the `ignore.directories` config key — both only *add* to the skip list, they don't remove anything from it.
+
+`trace-mcp add` / `trace-mcp index` print a "Skipped top-level folders" line after indexing listing every top-level directory that got skipped this way, so a folder missing from the index isn't a silent surprise.
+
+### Getting a skipped folder indexed
+
+Two different things can leave a folder out of the index — check which one applies:
+
+1. **The folder name collides with a built-in skip dir** (e.g. you have your own `vendor/` or `build/` with real source in it). There's currently no per-project way to un-skip a built-in name — rename the folder, or [open an issue](https://github.com/nikolai-vysotskyi/trace-mcp/issues) if this collision is common enough to warrant a config override.
+2. **The folder just isn't a built-in skip dir, but nothing in `include` matches its files** (e.g. a `k8s/` folder of YAML manifests — no default `include` pattern covers `*.yaml`). Add an explicit pattern:
+
+   ```jsonc
+   // .trace-mcp/.config.json
+   {
+     "include": ["k8s/**/*.{yaml,yml}"]
+   }
+   ```
+
+   `include` in a per-project config file **replaces** the built-in list rather than adding to it (config merge is shallow) — copy the defaults from [`src/config.ts`](../src/config.ts) alongside your addition if you still want the rest of the project indexed.
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3049,6 +3049,14 @@ program
     const pipeline = new IndexingPipeline(store, registry, config, resolvedDir);
     const result = await pipeline.indexAll(opts.force ?? false);
     logger.info(result, 'Indexing completed');
+    const skippedDirs = pipeline.getSkippedTopLevelDirs();
+    if (skippedDirs.length > 0) {
+      logger.info(
+        { skippedDirs },
+        'Top-level folders skipped by built-in/config ignore rules — see ' +
+          '"Getting a skipped folder indexed" in docs/configuration.md',
+      );
+    }
     updateLastIndexed(resolvedDir);
 
     // Auto-discover subprojects: register this project, scan contracts & client calls

--- a/src/cli/add.ts
+++ b/src/cli/add.ts
@@ -31,7 +31,13 @@ import {
 async function runIndexing(
   projectRoot: string,
   opts: { json?: boolean },
-): Promise<{ indexed: number; skipped: number; errors: number; durationMs: number } | null> {
+): Promise<{
+  indexed: number;
+  skipped: number;
+  errors: number;
+  durationMs: number;
+  skippedDirs: string[];
+} | null> {
   const configResult = await loadConfig(projectRoot);
   if (configResult.isErr()) {
     if (!opts.json) {
@@ -54,6 +60,7 @@ async function runIndexing(
       skipped: result.skipped,
       errors: result.errors,
       durationMs: result.durationMs,
+      skippedDirs: pipeline.getSkippedTopLevelDirs(),
     };
   } catch (err) {
     if (!opts.json) {
@@ -221,6 +228,12 @@ async function handleMultiRoot(
         `Indexed: ${indexResult.indexed} files (${indexResult.skipped} skipped, ${indexResult.errors} errors)`,
       );
       lines.push(`Duration: ${formatDuration(indexResult.durationMs)}`);
+      if (indexResult.skippedDirs.length > 0) {
+        lines.push(
+          `Skipped top-level folders: ${indexResult.skippedDirs.join(', ')}\n` +
+            `  (built-in/config skip rules — see "Getting a skipped folder indexed" in docs/configuration.md)`,
+        );
+      }
     }
     p.note(lines.join('\n'), existing ? 'Re-registered' : 'Registered');
     if (indexResult) {
@@ -438,6 +451,12 @@ export const addCommand = new Command('add')
             `Indexed: ${indexResult.indexed} files (${indexResult.skipped} skipped, ${indexResult.errors} errors)`,
           );
           lines.push(`Duration: ${formatDuration(indexResult.durationMs)}`);
+          if (indexResult.skippedDirs.length > 0) {
+            lines.push(
+              `Skipped top-level folders: ${indexResult.skippedDirs.join(', ')}\n` +
+                `  (un-skip via "ignore.directories" in .trace-mcp/.config.json — see docs/configuration.md)`,
+            );
+          }
         }
         p.note(lines.join('\n'), existing ? 'Re-registered' : 'Registered');
         if (indexResult) {

--- a/src/indexer/pipeline.ts
+++ b/src/indexer/pipeline.ts
@@ -290,6 +290,16 @@ export class IndexingPipeline {
     return this._dag;
   }
 
+  /**
+   * Top-level directories under the project root skipped by default ignore
+   * rules (built-in skip dirs, `ignore.directories` config, `.traceignore`).
+   * Only meaningful after `indexAll()` has run at least once, since that's
+   * when `_traceignore` is built.
+   */
+  getSkippedTopLevelDirs(): string[] {
+    return this._traceignore?.getSkippedTopLevelDirs(this.rootPath) ?? [];
+  }
+
   getPipelineState(): PipelineState {
     return {
       store: this.store,

--- a/src/utils/__tests__/traceignore.test.ts
+++ b/src/utils/__tests__/traceignore.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Coverage for `TraceignoreMatcher.getSkippedTopLevelDirs` — the "which
+ * folders got skipped" summary surfaced after indexing (#124 / TRA-68).
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TraceignoreMatcher } from '../traceignore.js';
+
+describe('TraceignoreMatcher.getSkippedTopLevelDirs', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'traceignore-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function mkdirs(...names: string[]): void {
+    for (const name of names) fs.mkdirSync(path.join(root, name));
+  }
+
+  it('reports top-level dirs matched by default skip dirs', () => {
+    mkdirs('src', 'node_modules', 'vendor');
+    const matcher = new TraceignoreMatcher(root);
+    expect(matcher.getSkippedTopLevelDirs(root)).toEqual(['node_modules', 'vendor']);
+  });
+
+  it('reports dirs added via config.directories', () => {
+    mkdirs('src', 'k8s');
+    const matcher = new TraceignoreMatcher(root, { directories: ['k8s'] });
+    expect(matcher.getSkippedTopLevelDirs(root)).toEqual(['k8s']);
+  });
+
+  it('returns nothing when no top-level dir is skipped', () => {
+    mkdirs('src', 'app');
+    const matcher = new TraceignoreMatcher(root);
+    expect(matcher.getSkippedTopLevelDirs(root)).toEqual([]);
+  });
+});

--- a/src/utils/traceignore.ts
+++ b/src/utils/traceignore.ts
@@ -122,6 +122,24 @@ export class TraceignoreMatcher {
     return this.skipDirs;
   }
 
+  /**
+   * Top-level directories directly under `rootPath` that this matcher would
+   * skip entirely — used to tell users after indexing "your k8s/ folder was
+   * never scanned" instead of leaving skips invisible (#124).
+   */
+  getSkippedTopLevelDirs(rootPath: string): string[] {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(rootPath, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+    return entries
+      .filter((e) => e.isDirectory() && this.isIgnored(e.name))
+      .map((e) => e.name)
+      .sort();
+  }
+
   /** Convert rules to fast-glob ignore patterns for collectFiles. */
   toFastGlobIgnore(): string[] {
     const patterns: string[] = [];


### PR DESCRIPTION
## Summary
- `trace-mcp add` / `trace-mcp index` now print a "Skipped top-level folders" line after indexing, listing top-level directories skipped by built-in defaults, `ignore.directories` config, or `.traceignore` — so a missing `k8s/` or `app/` folder isn't a silent surprise (nikolai-vysotskyi/trace-mcp#124).
- Adds `TraceignoreMatcher.getSkippedTopLevelDirs()` and `IndexingPipeline.getSkippedTopLevelDirs()` to compute the list; wired into both the interactive and `--json` output of `add`, and into `index`'s log output.
- Documents the actual mechanics in `docs/configuration.md`: `ignore.directories` only *adds* to the skip list (can't remove built-ins), and a folder can be missing for two different reasons — name collision with a built-in skip dir vs. no matching `include` glob — each needs a different fix. (The original issue framed `ignore.directories` as an "un-exclude" knob; it isn't, so the docs explain the real mechanism instead of documenting something that doesn't work.)

Scope is CLI output + docs only, per the issue — no changes to scanning/include logic.

## Test plan
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm run build` — clean
- [x] `pnpm run test --run` — 765 files / 8492 tests passed, 2 skipped (pre-existing, unrelated)
- [x] New unit test: `src/utils/__tests__/traceignore.test.ts`
- [x] Manual smoke test: `trace-mcp add --json` on a scratch repo with `k8s/`, `node_modules/`, `.git/` correctly reports `skippedDirs: [".git", "node_modules"]` (not `k8s`, since it isn't a built-in skip dir); interactive mode renders the same summary in the `p.note` block

Closes nikolai-vysotskyi/trace-mcp#124