### PR TITLE
fix(analytics): surface _warnings when session data source is unreachable

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -50,6 +50,10 @@ Session logs (JSONL)                   Project manifests
 
 Both formats are auto-detected during sync. No configuration needed.
 
+### Local-machine scoping
+
+`get_session_analytics`, `get_optimization_report`, `get_real_savings`, and `analyze_perf` (for `window` other than `"session"`) only see session logs that physically exist on the machine running the MCP server — they read `~/.claude/projects/<encoded-path>/` and `<project>/.claw/sessions/` directly, they do not fetch data from any other machine. If you invoke them from a fresh checkout, a remote/cloud agent runtime, or a CI sandbox that never ran a local Claude Code / Claw Code session for this project, there is nothing to find and the tools report that. `get_session_analytics`/`get_optimization_report`/`get_real_savings` distinguish this from "checked, nothing to report" by adding a `_warnings` field when both the discoverable log files and the aggregated result are empty. `analyze_perf` with a persistent `window` additionally requires `telemetry.enabled: true` in config (off by default) and returns an explicit `error` when it's off.
+
 ### JSONL format differences
 
 | | Claude Code | Claw Code |

--- a/src/analytics/real-savings.ts
+++ b/src/analytics/real-savings.ts
@@ -47,6 +47,9 @@ interface RealSavingsReport {
     sessionsWithoutTraceMcp: { count: number; avgTokensPerSession: number; avgToolCalls: number };
     difference: { tokensSavedPct: number; fewerToolCallsPct: number };
   };
+
+  /** Set when zero session data was found both on disk and in the aggregation — see TRA-76. */
+  _warnings?: string[];
 }
 
 const MODEL_PRICING: Record<string, number> = {

--- a/src/analytics/rules.ts
+++ b/src/analytics/rules.ts
@@ -27,6 +27,8 @@ export interface OptimizationReport {
     costUsd: number;
     pct: number;
   };
+  /** Set when zero session data was found both on disk and in the aggregation — see TRA-76. */
+  _warnings?: string[];
 }
 
 interface Rule {

--- a/src/analytics/session-analytics.ts
+++ b/src/analytics/session-analytics.ts
@@ -1,6 +1,7 @@
 import type { AnalyticsStore } from './analytics-store.js';
+import { listAllSessions } from './log-parser.js';
 import { analyzeOptimizations, type OptimizationReport } from './rules.js';
-import { syncAnalytics, syncProjectAnalytics } from './sync.js';
+import { attachNoSessionDataWarning, syncAnalytics, syncProjectAnalytics } from './sync.js';
 
 export type { OptimizationReport } from './rules.js';
 
@@ -25,6 +26,8 @@ interface SessionAnalytics {
   topTools: { name: string; calls: number; outputTokensEst: number }[];
   topFiles: { path: string; reads: number; tokensEst: number }[];
   modelsUsed: Record<string, { sessions: number; tokens: number }>;
+  /** Set when zero session data was found both on disk and in the aggregation — see TRA-76. */
+  _warnings?: string[];
 }
 
 export function getSessionAnalytics(
@@ -44,7 +47,7 @@ export function getSessionAnalytics(
     sessionId: opts.sessionId,
   });
 
-  return {
+  const analytics: SessionAnalytics = {
     period: opts.sessionId ? `session:${opts.sessionId}` : period,
     sessionsCount: result.sessions_count,
     totals: {
@@ -77,6 +80,15 @@ export function getSessionAnalytics(
     })),
     modelsUsed: result.models_used,
   };
+
+  attachNoSessionDataWarning(
+    analytics,
+    result.sessions_count === 0,
+    listAllSessions(opts.projectPath).length === 0,
+    opts.projectPath,
+  );
+
+  return analytics;
 }
 
 export function getOptimizationReport(
@@ -96,5 +108,17 @@ export function getOptimizationReport(
     sessionId: opts.sessionId,
   });
 
-  return analyzeOptimizations(toolCallRows, opts.sessionId ? `session:${opts.sessionId}` : period);
+  const report = analyzeOptimizations(
+    toolCallRows,
+    opts.sessionId ? `session:${opts.sessionId}` : period,
+  );
+
+  attachNoSessionDataWarning(
+    report,
+    toolCallRows.length === 0,
+    listAllSessions(opts.projectPath).length === 0,
+    opts.projectPath,
+  );
+
+  return report;
 }

--- a/src/analytics/sync.ts
+++ b/src/analytics/sync.ts
@@ -2,6 +2,43 @@ import { logger } from '../logger.js';
 import type { AnalyticsStore } from './analytics-store.js';
 import { listAllSessions, parseSessionFile } from './log-parser.js';
 
+/**
+ * Warning to attach when a tool found zero session data both in the
+ * discoverable log files AND in its aggregated result — the "unreachable
+ * data source" case from TRA-76, distinct from "checked, genuinely nothing
+ * to report" (which happens when logs exist but the requested period/session
+ * has no matches).
+ */
+export function buildNoSessionDataWarning(projectPath: string | undefined): string[] {
+  const scope = projectPath ? `project path "${projectPath}"` : 'any registered project';
+  return [
+    `No session log files found for ${scope} under ~/.claude/projects or <project>/.claw/sessions. ` +
+      'These analytics tools are scoped to session logs produced on this machine — this is expected ' +
+      'when running from a fresh checkout, a remote/cloud sandbox, or CI that never ran a local ' +
+      'Claude Code / Claw Code session here, not necessarily "nothing to report."',
+  ];
+}
+
+/**
+ * Attach a `_warnings` entry to `report` only when BOTH the aggregated
+ * result is empty AND no session log files were discoverable on disk —
+ * i.e. "the data source is unreachable", not "checked, nothing to report
+ * for this period". Pure decision function so it's unit-testable without
+ * mocking the filesystem; callers do the (cheap) `listAllSessions(...)`
+ * lookup themselves. See TRA-76.
+ */
+export function attachNoSessionDataWarning<T extends { _warnings?: string[] }>(
+  report: T,
+  aggregationIsEmpty: boolean,
+  noFilesOnDisk: boolean,
+  projectPath: string | undefined,
+): T {
+  if (aggregationIsEmpty && noFilesOnDisk) {
+    report._warnings = buildNoSessionDataWarning(projectPath);
+  }
+  return report;
+}
+
 interface SyncResult {
   files_scanned: number;
   files_parsed: number;

--- a/src/tools/register/session.ts
+++ b/src/tools/register/session.ts
@@ -4,9 +4,10 @@ import { optionalNonEmptyString } from './_zod-helpers.js';
 import { OutputFormatSchema, encodeResponse } from '../_common/output-format.js';
 import { AnalyticsStore } from '../../analytics/analytics-store.js';
 import { formatBenchmarkMarkdown, runBenchmark } from '../../analytics/benchmark.js';
+import { listAllSessions } from '../../analytics/log-parser.js';
 import { analyzeRealSavings } from '../../analytics/real-savings.js';
 import { getOptimizationReport, getSessionAnalytics } from '../../analytics/session-analytics.js';
-import { syncAnalytics } from '../../analytics/sync.js';
+import { attachNoSessionDataWarning, syncAnalytics } from '../../analytics/sync.js';
 import { detectCoverage } from '../../analytics/tech-detector.js';
 import { listBundles, loadAllBundles } from '../../bundles.js';
 import { runRetriever } from '../../retrieval/index.js';
@@ -421,6 +422,12 @@ export function registerSessionTools(server: McpServer, ctx: MetaContext): void 
             period: period ?? 'week',
           });
           const result = analyzeRealSavings(store, toolCalls, period ?? 'week');
+          attachNoSessionDataWarning(
+            result,
+            toolCalls.length === 0,
+            listAllSessions(projectRoot).length === 0,
+            projectRoot,
+          );
           return { content: [{ type: 'text', text: j(result) }] };
         } finally {
           analyticsStore.close();

--- a/tests/analytics/sync.test.ts
+++ b/tests/analytics/sync.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit coverage for the TRA-76 "unreachable data source" signal:
+ * `attachNoSessionDataWarning()` / `buildNoSessionDataWarning()` in
+ * src/analytics/sync.ts.
+ */
+import { describe, expect, it } from 'vitest';
+import { attachNoSessionDataWarning, buildNoSessionDataWarning } from '../../src/analytics/sync.js';
+
+describe('buildNoSessionDataWarning()', () => {
+  it('mentions the resolved project path when provided', () => {
+    const [warning] = buildNoSessionDataWarning('/Users/me/project');
+    expect(warning).toContain('/Users/me/project');
+    expect(warning).toContain('~/.claude/projects');
+  });
+
+  it('falls back to a generic scope description when no project path is given', () => {
+    const [warning] = buildNoSessionDataWarning(undefined);
+    expect(warning).toContain('any registered project');
+  });
+});
+
+describe('attachNoSessionDataWarning()', () => {
+  it('attaches _warnings only when the aggregation is empty AND no files were found on disk', () => {
+    const report = attachNoSessionDataWarning({}, true, true, '/proj');
+    expect(report._warnings).toBeDefined();
+    expect(report._warnings?.[0]).toContain('/proj');
+  });
+
+  it('does not warn when the aggregation is empty but files exist on disk (genuinely nothing for this period)', () => {
+    const report = attachNoSessionDataWarning({}, true, false, '/proj');
+    expect(report._warnings).toBeUndefined();
+  });
+
+  it('does not warn when the aggregation has data even if no files were found on disk this run', () => {
+    const report = attachNoSessionDataWarning({}, false, true, '/proj');
+    expect(report._warnings).toBeUndefined();
+  });
+
+  it('does not warn when both signals indicate real data', () => {
+    const report = attachNoSessionDataWarning({}, false, false, '/proj');
+    expect(report._warnings).toBeUndefined();
+  });
+});

--- a/tests/tools/behavioural/get-optimization-report-warnings.behavioural.test.ts
+++ b/tests/tools/behavioural/get-optimization-report-warnings.behavioural.test.ts
@@ -1,0 +1,88 @@
+/**
+ * TRA-76 coverage for `getOptimizationReport()` (src/analytics/session-analytics.ts)
+ * — the "_warnings" signal it attaches when no session data is discoverable
+ * on disk AND the aggregated tool-call rows are empty. Companion to
+ * get-optimization-report.behavioural.test.ts, which covers the pure
+ * `analyzeOptimizations()` engine only.
+ *
+ * Same FS-mocking approach as get-session-analytics.behavioural.test.ts:
+ * mock listAllSessions to [] so the internal sync pass is a no-op, then seed
+ * (or don't seed) the store directly.
+ */
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AnalyticsStore } from '../../../src/analytics/analytics-store.js';
+import type { ParsedSession } from '../../../src/analytics/log-parser.js';
+import { createTmpDir, removeTmpDir } from '../../test-utils.js';
+
+vi.mock('../../../src/analytics/log-parser.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/analytics/log-parser.js')>(
+    '../../../src/analytics/log-parser.js',
+  );
+  return {
+    ...actual,
+    listAllSessions: () => [],
+  };
+});
+
+import { getOptimizationReport } from '../../../src/analytics/session-analytics.js';
+
+const PROJECT = '/projects/optimization-report-fixture';
+
+function seedSessionWithReads(store: AnalyticsStore): void {
+  const parsed: ParsedSession = {
+    summary: {
+      sessionId: 'sess-a',
+      projectPath: PROJECT,
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      model: 'claude-opus-4',
+      usage: { inputTokens: 1000, outputTokens: 500, cacheReadTokens: 0, cacheCreateTokens: 0 },
+      toolCallCount: 3,
+    },
+    toolCalls: ['t1', 't2', 't3'].map((id, i) => ({
+      toolId: id,
+      sessionId: 'sess-a',
+      timestamp: new Date(Date.now() + i * 1000).toISOString(),
+      model: 'claude-opus-4',
+      toolName: 'Read',
+      toolServer: 'builtin',
+      toolShortName: 'Read',
+      inputParams: {},
+      inputSizeChars: 100,
+      targetFile: 'src/foo.ts',
+    })),
+    toolResults: new Map(
+      ['t1', 't2', 't3'].map((id) => [id, { toolId: id, outputSizeChars: 1200, isError: false }]),
+    ),
+  };
+  store.storeSession(parsed);
+}
+
+describe('getOptimizationReport() — TRA-76 _warnings contract', () => {
+  let tmpDir: string;
+  let store: AnalyticsStore;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir('optimization-report-warnings-');
+    store = new AnalyticsStore(path.join(tmpDir, 'analytics.db'));
+  });
+
+  afterEach(() => {
+    store.close();
+    if (tmpDir) removeTmpDir(tmpDir);
+  });
+
+  it('attaches _warnings when zero tool calls found and no session files on disk', () => {
+    const report = getOptimizationReport(store, { period: 'all', projectPath: PROJECT });
+    expect(report.optimizations).toEqual([]);
+    expect(report._warnings).toBeDefined();
+    expect(report._warnings?.[0]).toContain(PROJECT);
+  });
+
+  it('does not attach _warnings when there is real tool-call data', () => {
+    seedSessionWithReads(store);
+    const report = getOptimizationReport(store, { period: 'all', projectPath: PROJECT });
+    expect(report._warnings).toBeUndefined();
+  });
+});

--- a/tests/tools/behavioural/get-session-analytics.behavioural.test.ts
+++ b/tests/tools/behavioural/get-session-analytics.behavioural.test.ts
@@ -230,6 +230,26 @@ describe('getSessionAnalytics() — behavioural contract', () => {
     expect(result.modelsUsed).toEqual({});
   });
 
+  it('TRA-76: zero sessionsCount + no discoverable log files → _warnings surfaces the unreachable-source signal', () => {
+    // listAllSessions is mocked to [] module-wide (see top of file), so with
+    // no data seeded into the store either, both signals are empty.
+    const result = getSessionAnalytics(store, { period: 'all', projectPath: PROJECT });
+    expect(result.sessionsCount).toBe(0);
+    expect(result._warnings).toBeDefined();
+    expect(result._warnings?.[0]).toContain(PROJECT);
+  });
+
+  it('TRA-76: no _warnings when sessionsCount is non-zero, even though listAllSessions is mocked empty', () => {
+    seedSession(store, {
+      id: 'sess-with-data',
+      projectPath: PROJECT,
+      startedAt: new Date().toISOString(),
+    });
+    const result = getSessionAnalytics(store, { period: 'all', projectPath: PROJECT });
+    expect(result.sessionsCount).toBe(1);
+    expect(result._warnings).toBeUndefined();
+  });
+
   it('top-tool entries carry { name, calls, outputTokensEst }', () => {
     seedSession(store, {
       id: 'sess-shape',


### PR DESCRIPTION
## Summary
- `get_session_analytics`, `get_optimization_report`, `get_real_savings` returned a well-formed zero-result payload with no way to tell "checked, genuinely nothing to report" from "no session logs found on this machine at all" (e.g. a fresh checkout, a remote/cloud sandbox, or CI).
- Adds a pure `attachNoSessionDataWarning()` helper (`src/analytics/sync.ts`) that attaches a `_warnings` field only when **both** the aggregated result is empty **and** zero session log files are discoverable on disk for the resolved project path — distinct from "logs exist but nothing matched this period."
- Wired into all three tools; `analyze_perf` already returns an explicit `error` for the persistent-telemetry-disabled case, so it needed no code change.
- Documents the local-machine scoping of these four analytics tools in `docs/analytics.md`.

Closes TRA-76.

## Test plan
- [x] `pnpm run build`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — full suite green (769 files / 8509 tests)
- [x] New unit tests for `attachNoSessionDataWarning`/`buildNoSessionDataWarning` (`tests/analytics/sync.test.ts`)
- [x] New/extended behavioural tests for `getSessionAnalytics()` and `getOptimizationReport()` `_warnings` contract