### PR TITLE
Fix: file watcher ignores .gitignore, wastes CPU re-indexing gitignored log/DB churn

### DIFF
--- a/src/indexer/watcher.ts
+++ b/src/indexer/watcher.ts
@@ -4,6 +4,7 @@ import type * as parcelWatcher from '@parcel/watcher';
 import picomatch from 'picomatch';
 import type { TraceMcpConfig } from '../config.js';
 import { logger } from '../logger.js';
+import { GitignoreMatcher } from '../utils/gitignore.js';
 import { TraceignoreMatcher } from '../utils/traceignore.js';
 
 type ParcelWatcherModule = typeof parcelWatcher;
@@ -152,6 +153,11 @@ export class FileWatcher {
 
     const watcher = await loadParcelWatcher();
     const traceignore = new TraceignoreMatcher(rootPath, config.ignore ?? {});
+    // Mirrors the full scan's ignore stack (IndexingPipeline.runPipeline) so a
+    // gitignored file never reaches pipeline.indexFiles() on a watcher event
+    // either — previously only .traceignore/config.exclude gated events here,
+    // so gitignored log/DB churn re-ran the full pipeline every debounce cycle.
+    const gitignore = new GitignoreMatcher(rootPath);
     const ignoreDirs = [...traceignore.getSkipDirs()].map((d) => path.join(rootPath, d));
     // config.exclude globs (e.g. **/storage/**, **/node_modules/**) gate
     // collectFiles() but historically NOT watcher events — so runtime churn
@@ -181,6 +187,7 @@ export class FileWatcher {
           const rel = path.relative(rootPath, p);
           if (isExcluded(rel.split(path.sep).join('/'))) return false;
           if (isOwnedByDescendant?.(rel.split(path.sep).join('/'))) return false;
+          if (gitignore.isIgnored(rel)) return false;
           return !traceignore.isIgnored(rel);
         };
 

--- a/tests/indexer/watcher.test.ts
+++ b/tests/indexer/watcher.test.ts
@@ -1,4 +1,7 @@
 import * as parcelWatcher from '@parcel/watcher';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TraceMcpConfig } from '../../src/config.js';
 import { FileWatcher } from '../../src/indexer/watcher.js';
@@ -275,5 +278,44 @@ describe('FileWatcher', () => {
 
   it('stop before start does not throw', async () => {
     await expect(watcher.stop()).resolves.not.toThrow();
+  });
+
+  // ── .gitignore filtering (TRA-85 — gitignored log/DB churn) ────
+
+  describe('.gitignore filtering', () => {
+    let tmpRoot: string;
+
+    beforeEach(() => {
+      tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-watcher-gitignore-'));
+      fs.writeFileSync(path.join(tmpRoot, '.gitignore'), '*.log\nlogs/\n');
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    it('drops gitignored paths before onChanges without ever reaching the pipeline', async () => {
+      const onChanges = vi.fn().mockResolvedValue(undefined);
+      await watcher.start(tmpRoot, mockConfig, onChanges);
+
+      await capturedCallback(null, [
+        { type: 'update', path: path.join(tmpRoot, 'daemon.log') },
+        { type: 'update', path: path.join(tmpRoot, 'logs', 'app.log') },
+        { type: 'update', path: path.join(tmpRoot, 'src', 'app.ts') },
+      ]);
+      await timer.flush();
+
+      expect(onChanges).toHaveBeenCalledWith([path.join(tmpRoot, 'src', 'app.ts')]);
+    });
+
+    it('drops gitignored deletes too', async () => {
+      const onDeletes = vi.fn().mockResolvedValue(undefined);
+      await watcher.start(tmpRoot, mockConfig, vi.fn(), undefined, onDeletes);
+
+      await capturedCallback(null, [{ type: 'delete', path: path.join(tmpRoot, 'daemon.log') }]);
+      await timer.flush();
+
+      expect(onDeletes).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- `FileWatcher.startLocked`'s per-event `notIgnored` predicate (`src/indexer/watcher.ts`) only consulted `TraceignoreMatcher`/`config.exclude`/descendant-project globs — it never checked `.gitignore`, unlike the full-scan pipeline (`IndexingPipeline.runPipeline`), which already builds and respects a `GitignoreMatcher`.
- Net effect: a repo whose `.gitignore` excludes its own log/DB churn (e.g. `daemon.log`, `.surrealdb/`) re-ran the **entire indexing pipeline** on every debounce cycle for those files, forever — only rejected deep inside the pipeline after the read+hash cost was already paid.
- Fix: instantiate a `GitignoreMatcher(rootPath)` alongside the existing `TraceignoreMatcher` and consult it in the `notIgnored` predicate, mirroring the pipeline's ignore stack.

Closes #324.

## Test plan

- [x] Two new tests in `tests/indexer/watcher.test.ts` (real tmpdir + `.gitignore` file, matching this repo's existing test conventions — no fs mocking): gitignored update events dropped before `onChanges`; gitignored delete events dropped before `onDeletes`.
- [x] `pnpm exec vitest run tests/indexer/watcher.test.ts` — 17/17 pass
- [x] `pnpm exec vitest run src/indexer tests/indexer tests/daemon src/daemon` — 424/424 pass
- [x] `pnpm run build` — clean
- [x] `tsc --noEmit` — clean
- [x] `biome check` — clean
- [x] `scan_security` on the changed file — 0 findings
