### PR TITLE
chore: add .gitattributes forcing LF line endings (fixes Windows CI CRLF shebang failure)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Force LF for all text files. Without this, Windows runners checkout with
+# core.autocrlf=true and convert LF -> CRLF, which breaks shebang-line
+# stripping for .mjs scripts imported by vitest/esbuild (e.g. scripts/
+# calibrate-health-metrics.mjs imported by its test) — surfaces as
+# "SyntaxError: Invalid or unexpected token" on windows-latest CI only.
+* text=auto eol=lf


### PR DESCRIPTION
## Summary

- No `.gitattributes` existed in the repo. Windows GitHub Actions runners default to `core.autocrlf=true`, so text files (including `.mjs` scripts) checkout with CRLF line endings.
- `scripts/calibrate-health-metrics.mjs` starts with a `#!/usr/bin/env node` shebang. `tests/tools/calibrate-health-metrics.test.ts` imports it directly to unit-test its pure helpers, and vitest/esbuild's shebang-stripping doesn't tolerate the CRLF line ending — surfaces as `SyntaxError: Invalid or unexpected token` on `windows-latest` only. This has been silently blocking #310's `cross-platform-test (windows-latest)` job (unrelated to that PR's own changes — see the comment left there).
- Fix: `* text=auto eol=lf` forces LF checkout on every platform, matching how the repo is authored.

## Test plan

- [x] `pnpm run build` — clean
- [x] `tsc --noEmit` — clean
- [x] No test currently asserts CRLF content (checked via text search), so this is a non-functional, checkout-only change with no expected test diff.
- Can't reproduce the Windows-only failure locally (no Windows CI runner available in this environment) — the CI run on this PR against `windows-latest` is the actual verification.
