### PR TITLE
doctor: flag unregistered nested repos (own .git) as zero index coverage

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -23,6 +23,7 @@ import { LAUNCHER_VERSION } from '../init/types.js';
 import { findProjectRoot } from '../project-root.js';
 import {
   findOverlappingProjects,
+  findUnregisteredNestedRepos,
   inspectRegistry,
   pruneStaleProjects,
   unregisterProject,
@@ -64,7 +65,10 @@ export const doctorCommand = new Command('doctor')
       // stale registrations (deleted folders, missing/corrupt DBs) that would
       // otherwise only manifest as runtime "Project not found" errors.
       const registry = diagnoseRegistry();
-      const hasRegistryIssues = registry.staleCount > 0 || registry.overlaps.length > 0;
+      const hasRegistryIssues =
+        registry.staleCount > 0 ||
+        registry.overlaps.length > 0 ||
+        registry.unregisteredNestedRepos.length > 0;
 
       // --fix / --dry-run also clean up the registry itself (TRA-18): missing-root
       // entries and overlap containers have one unambiguous remediation each, so
@@ -250,6 +254,12 @@ interface RegistryOverlapReport {
   descendantRoot: string;
 }
 
+interface UnregisteredNestedRepoReport {
+  parentName: string;
+  parentRoot: string;
+  nestedRepoRoot: string;
+}
+
 export interface RegistryHealthReport {
   registryPath: string;
   registryExists: boolean;
@@ -258,6 +268,8 @@ export interface RegistryHealthReport {
   staleCount: number;
   /** Project pairs where one registered root contains another — double indexing/watching. */
   overlaps: RegistryOverlapReport[];
+  /** Sibling repos (own `.git`) found under a registered root that were never registered — zero index coverage. */
+  unregisteredNestedRepos: UnregisteredNestedRepoReport[];
 }
 
 /** Open a project DB read-only and run a trivial query to confirm it's intact. */
@@ -300,6 +312,7 @@ export function diagnoseRegistry(): RegistryHealthReport {
       descendantName: o.descendant.name,
       descendantRoot: o.descendant.root,
     })),
+    unregisteredNestedRepos: findUnregisteredNestedRepos(),
   };
 }
 
@@ -432,6 +445,18 @@ function printRegistryReport(r: RegistryHealthReport): void {
       '  Overlapping roots index and watch the same files twice — every change costs ' +
         'double CPU. Keep the per-project registrations and remove the container: ' +
         '`trace-mcp remove <container-path>`.',
+    );
+  }
+  for (const nr of r.unregisteredNestedRepos) {
+    console.log(
+      `  [WARNING (unregistered nested repo)] "${nr.parentName}" (${shortPath(nr.parentRoot)}) ` +
+        `contains an unregistered repo: ${shortPath(nr.nestedRepoRoot)}`,
+    );
+  }
+  if (r.unregisteredNestedRepos.length > 0) {
+    console.log(
+      '  Files under these repos have zero index coverage — searches/lookups will silently ' +
+        'miss them. Register each one: `trace-mcp add <nested-repo-path>`.',
     );
   }
   console.log('');

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -274,6 +274,81 @@ export function descendantExcludeGlobs(root: string): string[] {
   );
 }
 
+/** Directory names never worth descending into while scanning for nested repos. */
+const NESTED_REPO_SCAN_SKIP_DIRS = new Set([
+  'node_modules',
+  'vendor',
+  '.git',
+  'dist',
+  'build',
+  '__pycache__',
+  '.venv',
+  'venv',
+  'target',
+  '.next',
+  '.nuxt',
+  '.turbo',
+  '.cache',
+]);
+
+export interface UnregisteredNestedRepo {
+  parentName: string;
+  parentRoot: string;
+  nestedRepoRoot: string;
+}
+
+/**
+ * Find sibling repos (their own `.git`) living under a registered project's
+ * tree that were never registered themselves — the "zero index coverage" gap
+ * (TRA-86), distinct from findOverlappingProjects' "both registered, doubly
+ * indexed" case. A nested repo in a language/framework the parent's include
+ * globs don't reach (e.g. a Vue frontend sibling under a Laravel root) is
+ * invisible to search/get_symbol even though its files exist on disk, and
+ * nothing else catches it since it was never added to the registry.
+ *
+ * Bounded to `maxDepth` directories below each registered root — deep enough
+ * for the common "workspace/service-a, workspace/service-b" layout without
+ * risking a pathological walk on huge trees. Stops descending the moment it
+ * finds a `.git`, registered or not, so nested-inside-nested repos are only
+ * reported once (at the outermost unregistered boundary).
+ */
+export function findUnregisteredNestedRepos(maxDepth = 4): UnregisteredNestedRepo[] {
+  const parents = listProjects();
+  const registeredRoots = new Set(parents.map((e) => e.root));
+  const results: UnregisteredNestedRepo[] = [];
+
+  const walk = (dir: string, depth: number, parent: RegistryEntry) => {
+    if (depth > maxDepth) return;
+    let children: fs.Dirent[];
+    try {
+      children = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const child of children) {
+      if (!child.isDirectory() || NESTED_REPO_SCAN_SKIP_DIRS.has(child.name)) continue;
+      const childPath = path.join(dir, child.name);
+      if (fs.existsSync(path.join(childPath, '.git'))) {
+        if (!registeredRoots.has(childPath)) {
+          results.push({
+            parentName: parent.name,
+            parentRoot: parent.root,
+            nestedRepoRoot: childPath,
+          });
+        }
+        continue; // boundary reached either way — don't recurse past a repo root
+      }
+      walk(childPath, depth + 1, parent);
+    }
+  };
+
+  for (const parent of parents) {
+    walk(parent.root, 1, parent);
+  }
+
+  return results;
+}
+
 /** Remove entries whose root directory no longer exists. Returns removed paths. */
 export function pruneStaleProjects(): string[] {
   const reg = loadRegistry();

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -6,6 +6,7 @@ import { ensureGlobalDirs, REGISTRY_PATH } from '../src/global.js';
 import {
   findOverlapForNewRoot,
   findOverlappingProjects,
+  findUnregisteredNestedRepos,
   registerProject,
   resolveRegisteredAncestor,
 } from '../src/registry.js';
@@ -125,6 +126,56 @@ describe('findOverlappingProjects', () => {
     registerProject(b);
 
     expect(findOverlappingProjects()).toEqual([]);
+  });
+});
+
+describe('findUnregisteredNestedRepos', () => {
+  it('returns empty when a registered root has no nested repos', () => {
+    registerProject(makeTmpRepo());
+    expect(findUnregisteredNestedRepos()).toEqual([]);
+  });
+
+  it('flags a sibling repo with its own .git that was never registered', () => {
+    const parent = makeTmpRepo();
+    const sibling = path.join(parent, 'assetfeed-frontend');
+    fs.mkdirSync(path.join(sibling, '.git'), { recursive: true });
+    registerProject(parent);
+
+    const found = findUnregisteredNestedRepos();
+    expect(found).toHaveLength(1);
+    expect(found[0].parentRoot).toBe(parent);
+    expect(found[0].nestedRepoRoot).toBe(sibling);
+  });
+
+  it('does not flag a nested repo that is itself registered', () => {
+    const parent = makeTmpRepo();
+    const sibling = path.join(parent, 'assetfeed-frontend');
+    fs.mkdirSync(path.join(sibling, '.git'), { recursive: true });
+    registerProject(parent);
+    registerProject(sibling);
+
+    expect(findUnregisteredNestedRepos()).toEqual([]);
+  });
+
+  it('does not descend past a nested repo boundary (no nested-in-nested duplicates)', () => {
+    const parent = makeTmpRepo();
+    const sibling = path.join(parent, 'assetfeed-frontend');
+    const innerGit = path.join(sibling, 'vendor', 'some-lib');
+    fs.mkdirSync(path.join(sibling, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(innerGit, '.git'), { recursive: true });
+    registerProject(parent);
+
+    const found = findUnregisteredNestedRepos();
+    expect(found).toHaveLength(1);
+    expect(found[0].nestedRepoRoot).toBe(sibling);
+  });
+
+  it('skips node_modules/vendor/.git while scanning', () => {
+    const parent = makeTmpRepo();
+    fs.mkdirSync(path.join(parent, 'node_modules', 'some-pkg', '.git'), { recursive: true });
+    registerProject(parent);
+
+    expect(findUnregisteredNestedRepos()).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- `findOverlappingProjects` only compares *already-registered* project pairs, so a sibling repo with its own `.git` that was never registered at all (e.g. `assetfeed-frontend`, `assetfeed-tg-scraper` next to a registered `assetfeed-laravel`) is completely invisible — its files have zero index coverage and `search`/`get_symbol`/`get_outline` return `NOT_FOUND` even though the files exist on disk.
- Adds `findUnregisteredNestedRepos()` in `src/registry.ts`: a bounded (depth 4) directory walk under each registered root that stops at any nested `.git` boundary (registered or not), so nested-in-nested repos are reported once at the outermost unregistered boundary. Skips `node_modules`/`vendor`/`.git`/`dist`/`build`/etc.
- Wires the result into `doctor`'s `RegistryHealthReport` and `printRegistryReport`, alongside the existing overlap warning, suggesting `trace-mcp add <nested-repo-path>` per finding. No auto-fix (registering a project has real indexing side effects) — detection + suggestion only, matching the existing overlap-warning UX.

Closes TRA-86.

## Test plan
- [x] `pnpm run build` — clean
- [x] `pnpm run lint` (tsc --noEmit) — clean
- [x] `pnpm exec vitest run tests/registry.test.ts tests/cli/doctor-registry.test.ts src/__tests__/registry-health.test.ts src/cli/__tests__/doctor-registry-fix.test.ts` — 37/37 passing (5 new cases: bare nested repo, registered nested repo excluded, no double-report past a nested boundary, node_modules/vendor/.git skipped, healthy no-op)
- [x] `pnpm exec vitest run tests/cli/ src/cli/__tests__/ tests/registry.test.ts` — 149/149 passing