### PR TITLE
doctor: flag stale one-shot Multica agent-run workdirs (TRA-94)

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -22,6 +22,8 @@ import {
 import { LAUNCHER_VERSION } from '../init/types.js';
 import { findProjectRoot } from '../project-root.js';
 import {
+  type EphemeralProjectCandidate,
+  findEphemeralProjects,
   findOverlappingProjects,
   findUnregisteredNestedRepos,
   inspectRegistry,
@@ -68,7 +70,8 @@ export const doctorCommand = new Command('doctor')
       const hasRegistryIssues =
         registry.staleCount > 0 ||
         registry.overlaps.length > 0 ||
-        registry.unregisteredNestedRepos.length > 0;
+        registry.unregisteredNestedRepos.length > 0 ||
+        registry.ephemeralProjects.length > 0;
 
       // --fix / --dry-run also clean up the registry itself (TRA-18): missing-root
       // entries and overlap containers have one unambiguous remediation each, so
@@ -270,6 +273,8 @@ export interface RegistryHealthReport {
   overlaps: RegistryOverlapReport[];
   /** Sibling repos (own `.git`) found under a registered root that were never registered — zero index coverage. */
   unregisteredNestedRepos: UnregisteredNestedRepoReport[];
+  /** One-shot Multica agent-run workdirs that are still registered long after their run ended (TRA-94). */
+  ephemeralProjects: EphemeralProjectCandidate[];
 }
 
 /** Open a project DB read-only and run a trivial query to confirm it's intact. */
@@ -313,6 +318,7 @@ export function diagnoseRegistry(): RegistryHealthReport {
       descendantRoot: o.descendant.root,
     })),
     unregisteredNestedRepos: findUnregisteredNestedRepos(),
+    ephemeralProjects: findEphemeralProjects(),
   };
 }
 
@@ -321,14 +327,19 @@ export interface RegistryFixResult {
   removedMissingRoots: string[];
   /** Ancestor roots removed (or previewed) because a descendant is also registered. */
   removedOverlapContainers: string[];
+  /** One-shot Multica agent-run workdirs removed (or previewed) because they're past the TTL. */
+  removedEphemeralProjects: string[];
 }
 
 /**
- * Apply (or preview, when dryRun) the two registry remediations `doctor` already
- * knows how to describe: drop entries whose folder is gone (same as `prune --apply`'s
- * registry sweep), and drop the *ancestor* of an overlapping pair — the descendant is
- * always the more specific, intentional registration, so removing the container is the
- * unambiguous fix `printRegistryReport` already tells the user to run by hand.
+ * Apply (or preview, when dryRun) the registry remediations `doctor` already knows
+ * how to describe: drop entries whose folder is gone (same as `prune --apply`'s
+ * registry sweep), drop the *ancestor* of an overlapping pair — the descendant is
+ * always the more specific, intentional registration, so removing the container is
+ * the unambiguous fix `printRegistryReport` already tells the user to run by hand —
+ * and unregister stale one-shot Multica workdirs (TRA-94). Unregistering the latter
+ * doesn't free their index DB by itself — it turns them into `orphan_unregistered`
+ * candidates for `trace-mcp prune --apply` to actually delete.
  */
 export function fixRegistryIssues(
   r: RegistryHealthReport,
@@ -336,14 +347,24 @@ export function fixRegistryIssues(
 ): RegistryFixResult {
   const missingRoots = r.entries.filter((e) => e.status === 'missing_root').map((e) => e.root);
   const overlapContainers = [...new Set(r.overlaps.map((o) => o.ancestorRoot))];
+  const ephemeralRoots = r.ephemeralProjects.map((e) => e.root);
 
   if (opts.dryRun) {
-    return { removedMissingRoots: missingRoots, removedOverlapContainers: overlapContainers };
+    return {
+      removedMissingRoots: missingRoots,
+      removedOverlapContainers: overlapContainers,
+      removedEphemeralProjects: ephemeralRoots,
+    };
   }
 
   const removedMissingRoots = pruneStaleProjects();
   for (const root of overlapContainers) unregisterProject(root);
-  return { removedMissingRoots, removedOverlapContainers: overlapContainers };
+  for (const root of ephemeralRoots) unregisterProject(root);
+  return {
+    removedMissingRoots,
+    removedOverlapContainers: overlapContainers,
+    removedEphemeralProjects: ephemeralRoots,
+  };
 }
 
 /**
@@ -377,7 +398,21 @@ export async function fixRegistryIssuesInteractive(
     }
   }
 
-  return { removedMissingRoots, removedOverlapContainers };
+  const removedEphemeralProjects: string[] = [];
+  if (r.ephemeralProjects.length > 0) {
+    const answer = await p.confirm({
+      message: `Unregister ${r.ephemeralProjects.length} one-shot Multica workdir project${r.ephemeralProjects.length === 1 ? '' : 's'} (run finished, never revisited)?`,
+      initialValue: true,
+    });
+    if (!p.isCancel(answer) && answer) {
+      for (const e of r.ephemeralProjects) {
+        unregisterProject(e.root);
+        removedEphemeralProjects.push(e.root);
+      }
+    }
+  }
+
+  return { removedMissingRoots, removedOverlapContainers, removedEphemeralProjects };
 }
 
 function printRegistryFixResult(fix: RegistryFixResult, opts: { dryRun: boolean }): void {
@@ -394,6 +429,13 @@ function printRegistryFixResult(fix: RegistryFixResult, opts: { dryRun: boolean 
       `${verb} ${fix.removedOverlapContainers.length} overlap container${fix.removedOverlapContainers.length === 1 ? '' : 's'}:`,
     );
     for (const r of fix.removedOverlapContainers) lines.push(`  ${shortPath(r)}`);
+  }
+  if (fix.removedEphemeralProjects.length > 0) {
+    lines.push(
+      `${verb} ${fix.removedEphemeralProjects.length} one-shot Multica workdir project${fix.removedEphemeralProjects.length === 1 ? '' : 's'} ` +
+        `(follow up with 'trace-mcp prune --apply' to reclaim their index DBs):`,
+    );
+    for (const r of fix.removedEphemeralProjects) lines.push(`  ${shortPath(r)}`);
   }
   if (lines.length === 0) return;
   console.log(lines.join('\n'));
@@ -457,6 +499,20 @@ function printRegistryReport(r: RegistryHealthReport): void {
     console.log(
       '  Files under these repos have zero index coverage — searches/lookups will silently ' +
         'miss them. Register each one: `trace-mcp add <nested-repo-path>`.',
+    );
+  }
+  for (const e of r.ephemeralProjects) {
+    console.log(
+      `  [WARNING (stale one-shot workdir)] "${e.name}" (${shortPath(e.root)}) — ` +
+        `added ${Math.round(e.ageHours / 24)}d ago, never revisited`,
+    );
+  }
+  if (r.ephemeralProjects.length > 0) {
+    console.log(
+      '  These look like one-shot Multica agent-run checkouts: the run that created them is ' +
+        'long finished and nothing will ever query them again, but they still get permanently ' +
+        'reindexed. Unregister with `trace-mcp remove <path>`, then `trace-mcp prune --apply` ' +
+        'to reclaim their index DBs.',
     );
   }
   console.log('');

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -349,6 +349,43 @@ export function findUnregisteredNestedRepos(maxDepth = 4): UnregisteredNestedRep
   return results;
 }
 
+/**
+ * Path shape Multica's `repo checkout` uses for one-shot agent-run workdirs:
+ * `.../multica_workspaces_<host>/<workspace-id>/<run-id>/workdir`. Each task
+ * run gets a brand-new directory, so a project matching this shape is queried
+ * exactly once, for the lifetime of that single run, and never touched again.
+ */
+const EPHEMERAL_WORKDIR_PATTERN =
+  /[/\\]multica_workspaces[^/\\]*[/\\][^/\\]+[/\\][^/\\]+[/\\]workdir$/i;
+
+export interface EphemeralProjectCandidate {
+  name: string;
+  root: string;
+  addedAt: string;
+  ageHours: number;
+}
+
+/**
+ * Registered projects whose root looks like a one-shot Multica agent-run
+ * checkout (TRA-94) and were added more than `minAgeHours` ago. Nothing else
+ * ever revisits these — the run that created them finished long ago — but
+ * they stay registered forever, permanently reindexed alongside real
+ * projects and holding onto their index DB on disk.
+ */
+export function findEphemeralProjects(minAgeHours = 24): EphemeralProjectCandidate[] {
+  const now = Date.now();
+  const out: EphemeralProjectCandidate[] = [];
+  for (const entry of listProjects()) {
+    if (!EPHEMERAL_WORKDIR_PATTERN.test(entry.root)) continue;
+    const addedMs = Date.parse(entry.addedAt);
+    if (Number.isNaN(addedMs)) continue;
+    const ageHours = (now - addedMs) / (60 * 60 * 1000);
+    if (ageHours < minAgeHours) continue;
+    out.push({ name: entry.name, root: entry.root, addedAt: entry.addedAt, ageHours });
+  }
+  return out;
+}
+
 /** Remove entries whose root directory no longer exists. Returns removed paths. */
 export function pruneStaleProjects(): string[] {
   const reg = loadRegistry();

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ensureGlobalDirs, REGISTRY_PATH } from '../src/global.js';
 import {
+  findEphemeralProjects,
   findOverlapForNewRoot,
   findOverlappingProjects,
   findUnregisteredNestedRepos,
@@ -32,6 +33,21 @@ function makeTmpRepo(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-resolve-'));
   fs.writeFileSync(path.join(dir, 'package.json'), '{}');
   return dir;
+}
+
+/** A path shaped like a one-shot Multica agent-run checkout (TRA-94). */
+function makeEphemeralWorkdir(): string {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-ephemeral-'));
+  const dir = path.join(base, 'multica_workspaces_test.multica.ai', 'ws-123', 'run-456', 'workdir');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), '{}');
+  return dir;
+}
+
+function setAddedAt(root: string, iso: string): void {
+  const reg = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
+  reg.projects[root].addedAt = iso;
+  fs.writeFileSync(REGISTRY_PATH, JSON.stringify(reg, null, 2));
 }
 
 describe('resolveRegisteredAncestor', () => {
@@ -217,5 +233,42 @@ describe('findOverlapForNewRoot', () => {
     registerProject(parent, { type: 'multi-root', children: [child] });
 
     expect(findOverlapForNewRoot(child)).toBeNull();
+  });
+});
+
+describe('findEphemeralProjects', () => {
+  it('ignores projects whose root does not look like a one-shot Multica workdir', () => {
+    const repo = makeTmpRepo();
+    registerProject(repo);
+    setAddedAt(repo, new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString());
+
+    expect(findEphemeralProjects()).toEqual([]);
+  });
+
+  it('ignores a freshly-added ephemeral workdir (younger than minAgeHours)', () => {
+    const workdir = makeEphemeralWorkdir();
+    registerProject(workdir);
+
+    expect(findEphemeralProjects()).toEqual([]);
+  });
+
+  it('flags an ephemeral workdir older than the default 24h threshold', () => {
+    const workdir = makeEphemeralWorkdir();
+    registerProject(workdir);
+    setAddedAt(workdir, new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString());
+
+    const found = findEphemeralProjects();
+    expect(found).toHaveLength(1);
+    expect(found[0].root).toBe(workdir);
+    expect(found[0].ageHours).toBeGreaterThanOrEqual(48);
+  });
+
+  it('respects a custom minAgeHours threshold', () => {
+    const workdir = makeEphemeralWorkdir();
+    registerProject(workdir);
+    setAddedAt(workdir, new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString());
+
+    expect(findEphemeralProjects(24)).toEqual([]);
+    expect(findEphemeralProjects(1)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- Closes TRA-94: 27/38 registered projects on this machine are one-shot Multica agent-run checkouts under `.../multica_workspaces_<host>/<workspace>/<run-id>/workdir`, each queried once and never touched again, permanently reindexed and holding ~253MB of dead index DBs.
- Adds `findEphemeralProjects()` to `registry.ts`: flags registered projects whose root matches the one-shot Multica workdir path shape and were added more than 24h ago (default, overridable).
- Wires it into `trace-mcp doctor` as a new registry warning (alongside overlaps / unregistered nested repos), reported in both the human and `--json` output.
- `--fix` / `--fix-interactive` unregister these projects — same remediation already used for overlap containers. Unregistering turns their index DB into an `orphan_unregistered` candidate, which `trace-mcp prune --apply` already knows how to delete (shorter-term fix #3 from the issue; no changes needed to `prune.ts`).

Out of scope (left for follow-up, per the issue's own priority ordering): an `--ephemeral`/TTL flag on `multica repo checkout` itself (issue's suggestion #1) lives outside this repo, on the Multica platform side.

## Test plan
- [x] `pnpm run test --run tests/registry.test.ts` — 22/22 passing (4 new tests covering the new detector: non-matching path, too-young, past default 24h threshold, custom threshold)
- [x] `pnpm run build` — clean
- [x] `npx tsc --noEmit` — no new errors
- [x] `npx biome check` on changed files — clean
- [x] `pnpm run test --run` (full suite) — 8519/8520 real tests pass; the sole failure is a pre-existing flaky perf/timing benchmark (`tests/perf/benchmark.test.ts`, batched-vs-individual insert timing) unrelated to this change