### PR TITLE
Surface registry overlap at registration time (TRA-95)

### DIFF
--- a/src/project-setup.ts
+++ b/src/project-setup.ts
@@ -15,8 +15,9 @@ import { ensureGlobalDirs, getDbPath } from './global.js';
 import { generateConfig } from './init/config-generator.js';
 import type { DetectionResult } from './init/types.js';
 import { detectProject } from './init/detector.js';
-import type { RegistryEntry } from './registry.js';
-import { getProject, registerProject } from './registry.js';
+import { logger } from './logger.js';
+import type { NewRootOverlap, RegistryEntry } from './registry.js';
+import { findOverlapForNewRoot, getProject, registerProject } from './registry.js';
 
 export interface ProjectSetupResult {
   entry: RegistryEntry;
@@ -24,6 +25,14 @@ export interface ProjectSetupResult {
   dbPath: string;
   migrated: boolean;
   isNew: boolean;
+  /**
+   * Set when this root overlaps an already-registered project (ancestor or
+   * descendant, excluding declared multi-root children). Registering nested
+   * repos separately is supported (the ancestor's watcher/index excludes the
+   * descendant — see #209), but the overlap is worth surfacing to whoever
+   * called `setupProject` since it's easy to form by accident.
+   */
+  overlapWarning?: NewRootOverlap;
 }
 
 /**
@@ -81,6 +90,10 @@ export function isDangerousProjectRoot(absRoot: string): string | null {
  * 5. Register in global registry
  *
  * Idempotent when `force` is false — returns existing entry if already registered.
+ * Also checks for ancestor/descendant overlap with an already-registered
+ * project (see `findOverlapForNewRoot`) and logs a warning plus returns it as
+ * `overlapWarning` — registration still proceeds, since a nested repo
+ * registered on its own is a supported pattern, not necessarily a mistake.
  */
 export function setupProject(
   projectRoot: string,
@@ -119,6 +132,29 @@ export function setupProject(
       migrated: false,
       isNew: false,
     };
+  }
+
+  // Prevention gap (TRA-95): findOverlapForNewRoot() existed with full test
+  // coverage but nothing ever called it before writing a new registry entry,
+  // so overlapping registrations kept forming with zero signal until someone
+  // ran `doctor`. Check here, the one choke point every registration path
+  // goes through, and surface it — but don't block: a nested repo registered
+  // on its own is a supported pattern (the ancestor's watcher/index excludes
+  // it, see #209 / project-manager-ancestor-watcher.test.ts), so refusing
+  // outright would break that flow.
+  const overlap = findOverlapForNewRoot(absRoot);
+  if (overlap) {
+    const { existing, relation } = overlap;
+    const detail =
+      relation === 'existing_contains_candidate'
+        ? `nested inside the already-registered project "${existing.root}"`
+        : `would contain the already-registered project "${existing.root}"`;
+    logger.warn(
+      { candidateRoot: absRoot, existingRoot: existing.root, relation },
+      `Registering "${absRoot}": ${detail}. If unintentional, this double-indexes shared files; ` +
+        `run \`trace-mcp doctor\` to review, or register "${existing.root}" as a multi-root ` +
+        `project with "${absRoot}" listed as a child.`,
+    );
   }
 
   // 1. Detect project
@@ -169,5 +205,12 @@ export function setupProject(
   // 6. Register in global registry
   const entry = registerProject(absRoot);
 
-  return { entry, detection, dbPath, migrated, isNew: !existing };
+  return {
+    entry,
+    detection,
+    dbPath,
+    migrated,
+    isNew: !existing,
+    overlapWarning: overlap ?? undefined,
+  };
 }

--- a/tests/project-setup/overlap-prevention.test.ts
+++ b/tests/project-setup/overlap-prevention.test.ts
@@ -1,0 +1,113 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+/**
+ * TRA-95: findOverlapForNewRoot() existed (with full test coverage) but was
+ * never wired into setupProject — the single choke point every registration
+ * path (CLI add, CLI init, daemon addProject, MCP auto-register) goes
+ * through. Overlapping registrations kept silently forming because nothing
+ * checked the registry before writing a new entry, and were only ever
+ * noticed later via `doctor`.
+ *
+ * Registering a nested repo on its own is a *supported* pattern (the
+ * ancestor's watcher/index excludes it — see #209 /
+ * project-manager-ancestor-watcher.test.ts), so setupProject surfaces the
+ * overlap (log warning + `overlapWarning` on the result) instead of
+ * refusing to register.
+ */
+describe('project-setup — overlap detection at registration time', () => {
+  let fakeHome: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-setup-overlap-home-'));
+    originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  function makeRepo(root: string, name: string): string {
+    const dir = path.join(root, name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name, version: '0.0.0' }));
+    return dir;
+  }
+
+  test('registers a nested root but flags the overlap with the already-registered ancestor', async () => {
+    const container = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-setup-overlap-'));
+    fs.writeFileSync(
+      path.join(container, 'package.json'),
+      JSON.stringify({ name: 'container', version: '0.0.0' }),
+    );
+    const nested = makeRepo(container, 'nested-app');
+
+    const { setupProject } = await import('../../src/project-setup.js');
+    setupProject(container);
+
+    const result = setupProject(nested);
+    expect(result.entry.root).toBe(nested);
+    expect(result.overlapWarning?.relation).toBe('existing_contains_candidate');
+    expect(result.overlapWarning?.existing.root).toBe(container);
+
+    fs.rmSync(container, { recursive: true, force: true });
+  });
+
+  test('registers a container but flags the overlap with an already-registered descendant', async () => {
+    const container = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-setup-overlap-'));
+    fs.writeFileSync(
+      path.join(container, 'package.json'),
+      JSON.stringify({ name: 'container', version: '0.0.0' }),
+    );
+    const nested = makeRepo(container, 'nested-app');
+
+    const { setupProject } = await import('../../src/project-setup.js');
+    setupProject(nested);
+
+    const result = setupProject(container);
+    expect(result.overlapWarning?.relation).toBe('candidate_contains_existing');
+    expect(result.overlapWarning?.existing.root).toBe(nested);
+
+    fs.rmSync(container, { recursive: true, force: true });
+  });
+
+  test('does not flag a declared multi-root child', async () => {
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-setup-overlap-'));
+    fs.writeFileSync(
+      path.join(parent, 'package.json'),
+      JSON.stringify({ name: 'parent', version: '0.0.0' }),
+    );
+    const child = makeRepo(parent, 'svc-a');
+
+    const { registerProject } = await import('../../src/registry.js');
+    const { setupProject } = await import('../../src/project-setup.js');
+    registerProject(parent, { type: 'multi-root', children: [child] });
+
+    const result = setupProject(child);
+    expect(result.overlapWarning).toBeUndefined();
+
+    fs.rmSync(parent, { recursive: true, force: true });
+  });
+
+  test('does not flag disjoint roots', async () => {
+    const a = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-setup-overlap-a-'));
+    const b = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-setup-overlap-b-'));
+    fs.writeFileSync(path.join(a, 'package.json'), JSON.stringify({ name: 'a', version: '0.0.0' }));
+    fs.writeFileSync(path.join(b, 'package.json'), JSON.stringify({ name: 'b', version: '0.0.0' }));
+
+    const { setupProject } = await import('../../src/project-setup.js');
+    setupProject(a);
+    const result = setupProject(b);
+    expect(result.overlapWarning).toBeUndefined();
+
+    fs.rmSync(a, { recursive: true, force: true });
+    fs.rmSync(b, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary

TRA-95 reported ~20 unregistered nested repos and new overlapping-root pairs (`general`/`thewed*`) that had regrown since TRA-58/TRA-86 cleaned up the previous batch. The issue's suggested fix #3 asked to close the "prevention gap": have registration check for ancestor/descendant overlap before writing a new registry entry, since nothing was doing that today — the follow-up action item from TRA-58 that never landed.

Investigation found `findOverlapForNewRoot()` in `src/registry.ts` already existed with full unit-test coverage but was **never called** by anything — `setupProject()` (the single choke point every registration path goes through: CLI add, CLI init, daemon `addProject`, MCP auto-register) went straight from `getProject()` to `registerProject()` with no overlap check at all.

## What changed

- `setupProject()` now calls `findOverlapForNewRoot()` before registering. When an overlap is found it:
  - logs a `logger.warn` with the candidate/existing roots, the relation, and actionable next steps (`trace-mcp doctor`, or register as a multi-root parent/child)
  - returns the overlap as `overlapWarning` on `ProjectSetupResult` for callers that want to surface it further

## Why warn, not refuse

The issue's suggested fix said "warn/refuse". I initially implemented a hard refuse (throwing, matching the existing `isDangerousProjectRoot` pattern) but that broke 3 existing tests in `project-manager-ancestor-watcher.test.ts` (#209): registering a nested repo as its own independent project *is* a supported, actively-maintained pattern — the ancestor's watcher/index is restarted with a recomputed exclude glob so the descendant's files aren't double-indexed. Blocking that outright would have broken CLI `add` for exactly the remediation TRA-86 recommends (registering nested unregistered repos separately). Warning instead closes the actual complaint in the issue — that overlaps "kept forming silently" — without breaking a legitimate, tested workflow.

The remaining operational cleanup from TRA-95 (registering the ~20 nested repos, removing the `general`/`thewed*` double registration) is local registry state on the reporter's machine, not a code change — left for a `trace-mcp doctor` + manual `add`/`unregister` pass, which this change now nudges users toward at registration time instead of only at `doctor` time.

## Test plan
- [x] New `tests/project-setup/overlap-prevention.test.ts` (4 tests): flags ancestor overlap, flags descendant overlap, does not flag declared multi-root children, does not flag disjoint roots
- [x] `pnpm run test --run` — full suite passes (2 pre-existing, unrelated flaky tests reproduced in isolation as passing: a full-suite-only watcher-lifecycle timeout and a perf-benchmark timing assertion)
- [x] `pnpm run lint` (tsc --noEmit) clean
- [x] `pnpm run build` succeeds