### PR TITLE
fix(release): enforce Conventional Commit PR titles (TRA-104)

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,35 @@
+name: PR Title Lint
+
+# release-please (see release.yml) reads Conventional Commits from the
+# squash-merge commit subject, which GitHub derives from the PR title.
+# A PR title that doesn't match "type(scope): description" produces a
+# commit release-please can't classify, so it never bumps the version
+# or opens a release PR — merged fixes then sit unreleased indefinitely
+# (see TRA-104: a50aee2/b678ff4/8149659 all merged with non-conventional
+# titles and produced zero release PRs across 7+ merged commits).
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            test
+            chore
+            ci
+            build
+            revert

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -8,7 +8,7 @@ name: PR Title Lint
 # (see TRA-104: a50aee2/b678ff4/8149659 all merged with non-conventional
 # titles and produced zero release PRs across 7+ merged commits).
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
## Summary
- Root cause of TRA-104 ("merged fixes sit unreleased for 6+ days"): `release-please` derives version bumps/changelog from Conventional-Commit-formatted commit subjects, which for squash merges = the PR title. Nothing enforced that format, so PRs #332 (TRA-94), #333 (TRA-95), and #310 (TRA-73) merged with non-conventional titles and produced commits `release-please` couldn't classify. Across the 7 commits merged since `v1.47.1`, **zero** qualify as `feat`/`fix`, so no release PR was ever opened — those fixes have been sitting on `master`, shipped in source but never published to npm.
- Adds `.github/workflows/pr-title-lint.yml` (`amannn/action-semantic-pull-request`, pinned by SHA) to fail CI on non-conventional PR titles going forward.
- This PR's own title/commit uses `fix:` so merging it should also be enough to unblock `release-please` into finally opening a release PR bundling the already-merged TRA-94/TRA-95/TRA-73 fixes.

## Test plan
- [x] Verified via `npm view trace-mcp dist-tags` + `git log v1.47.1..origin/master` that the 7 unreleased commits are all non-conventional or `chore`-typed (no `feat`/`fix`), confirming the mechanism.
- [x] Validated the new workflow YAML parses cleanly (`js-yaml`).
- [ ] CI on this PR (once opened) exercises the new check against this PR's own title.

Closes TRA-104.
