### PR TITLE
Activate GA4 active-install ping in published builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,11 @@ jobs:
       TRACE_MCP_NO_POSTINSTALL: '1'
       TRACE_MCP_NO_AUTO_UPDATE: '1'
       CI: 'true'
+      # Baked into the published build's anonymous active-install ping
+      # (src/telemetry/usage-ping.ts) via tsup.config.ts's `define` block.
+      # TRACE_MCP_TELEMETRY=off still disables it at runtime.
+      TRACE_MCP_GA_MEASUREMENT_ID: ${{ secrets.TRACE_MCP_GA_MEASUREMENT_ID }}
+      TRACE_MCP_GA_API_SECRET: ${{ secrets.TRACE_MCP_GA_API_SECRET }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/src/telemetry/usage-ping.ts
+++ b/src/telemetry/usage-ping.ts
@@ -10,16 +10,24 @@
  *
  * Transport is GA4's Measurement Protocol (a plain HTTP POST to a Google
  * endpoint) rather than a self-hosted collector, so there's no backend to
- * run or maintain. It is fully inert — this function no-ops — until both
- * TRACE_MCP_GA_MEASUREMENT_ID and TRACE_MCP_GA_API_SECRET are set, which
- * this package does not ship with. See README "Usage telemetry" for how to
- * configure and opt out.
+ * run or maintain. TRACE_MCP_GA_MEASUREMENT_ID/TRACE_MCP_GA_API_SECRET
+ * override at runtime; published builds fall back to credentials baked in
+ * at build time via tsup's `define` (same mechanism as PKG_VERSION_INJECTED)
+ * so installs report without per-user setup. See README "Usage telemetry"
+ * for how to opt out (TRACE_MCP_TELEMETRY=off).
  */
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { logger } from '../logger.js';
 import { TELEMETRY_STATE_PATH } from '../shared/paths.js';
+
+declare const GA_MEASUREMENT_ID_INJECTED: string;
+const GA_MEASUREMENT_ID_DEFAULT =
+  typeof GA_MEASUREMENT_ID_INJECTED !== 'undefined' ? GA_MEASUREMENT_ID_INJECTED : '';
+declare const GA_API_SECRET_INJECTED: string;
+const GA_API_SECRET_DEFAULT =
+  typeof GA_API_SECRET_INJECTED !== 'undefined' ? GA_API_SECRET_INJECTED : '';
 
 interface TelemetryState {
   installId: string;
@@ -68,8 +76,8 @@ export async function sendUsagePing(opts: UsagePingOptions): Promise<void> {
   const env = opts.env ?? process.env;
   if (isDisabled(env)) return;
 
-  const measurementId = env.TRACE_MCP_GA_MEASUREMENT_ID;
-  const apiSecret = env.TRACE_MCP_GA_API_SECRET;
+  const measurementId = env.TRACE_MCP_GA_MEASUREMENT_ID || GA_MEASUREMENT_ID_DEFAULT;
+  const apiSecret = env.TRACE_MCP_GA_API_SECRET || GA_API_SECRET_DEFAULT;
   if (!measurementId || !apiSecret) return;
 
   const state = loadOrCreateState();

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -106,5 +106,14 @@ const require = __tmcpCreateRequire(import.meta.url);`,
   },
   define: {
     PKG_VERSION_INJECTED: JSON.stringify(version),
+    // Default GA4 Measurement Protocol credentials for the anonymous
+    // active-install ping (src/telemetry/usage-ping.ts), supplied by CI as
+    // build-time secrets (TRACE_MCP_GA_MEASUREMENT_ID/TRACE_MCP_GA_API_SECRET
+    // in the `npm` GitHub Actions environment) — never committed here. Local
+    // dev builds get empty strings, so the ping stays inert unless the
+    // runtime env vars of the same name are set. Fully disabled at runtime
+    // via TRACE_MCP_TELEMETRY=off.
+    GA_MEASUREMENT_ID_INJECTED: JSON.stringify(process.env.TRACE_MCP_GA_MEASUREMENT_ID ?? ''),
+    GA_API_SECRET_INJECTED: JSON.stringify(process.env.TRACE_MCP_GA_API_SECRET ?? ''),
   },
 });


### PR DESCRIPTION
## Summary
- Closes TRA-29's remaining activation gap: `usage-ping.ts` now falls back to build-injected `GA_MEASUREMENT_ID_INJECTED`/`GA_API_SECRET_INJECTED` constants (same `define` mechanism as `PKG_VERSION_INJECTED`) when the `TRACE_MCP_GA_*` env vars aren't set at runtime.
- `tsup.config.ts` sources those defines from `process.env.TRACE_MCP_GA_MEASUREMENT_ID`/`TRACE_MCP_GA_API_SECRET`, which the `publish` job in `release.yml` now passes through from GitHub Actions **environment secrets** (`npm` environment) — the actual GA4 credentials are not committed anywhere in this diff.
- Local/dev builds get empty-string defaults, so the ping stays fully inert unless the runtime env vars are explicitly set. `TRACE_MCP_TELEMETRY=off` still disables it entirely.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec vitest run src/telemetry/__tests__/usage-ping.test.ts` — all 6 existing tests pass unchanged
- [x] `pnpm run build` succeeds; confirmed `dist/*.js` contains no leaked secret in a local build (env vars unset)
- [x] Set `TRACE_MCP_GA_MEASUREMENT_ID`/`TRACE_MCP_GA_API_SECRET` as `npm`-environment GitHub Actions secrets on the repo (verified via `gh secret list --env npm`)