### PR TITLE
docs: document solo-maintainer review model

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,10 @@ The full CLA text is available in [CLA.md](CLA.md). Key points:
 - You represent that the work is original and you have authority to contribute it.
 - All contributions remain subject to the [Ethical Use Addendum](LICENSE).
 
+## Review Model
+
+trace-mcp currently has a single maintainer with commit access. `master` is protected by required status checks (CodeQL, Semgrep, `impact-report`) — these run on every PR and must pass before merge. There is no required-approving-review count: with one collaborator, a "1 approval" rule can never be satisfied by anyone but the PR author, so it was dropped rather than kept as a check that always reads "satisfied" without anyone having looked. If a second maintainer joins, review requirements will be reinstated.
+
 ## How to Contribute
 
 1. Fork the repository


### PR DESCRIPTION
## Summary
- Fixes TRA-132: `master`'s branch protection required 1 approving review, but the repo has exactly one collaborator (the PR author), so the requirement could never be satisfied by anyone else — a false gate that also tanked OSSF Scorecard's Code-Review check (0/10).
- Dropped the unenforceable review requirement via the GitHub branch protection API. Required status checks (CodeQL, Semgrep scan, impact-report) remain the real, enforced merge gate — unchanged.
- Documented this as a deliberate solo-maintainer model in CONTRIBUTING.md, with a note to reinstate review requirements if a second maintainer joins.

## Out of scope
- `allow_force_pushes` on `master` is still `true`. Attempted to disable it via the same branch protection PUT (and confirmed via raw `curl`, not a `gh` quirk) — GitHub silently ignores the field for this repo/branch. Flagging as a manual follow-up via the repo Settings UI; not blocking this fix since it's a separate, secondary gap from the one this PR addresses.

## Test plan
- [x] Verified via `gh api repos/nikolai-vysotskyi/trace-mcp/branches/master/protection` that `required_pull_request_reviews` is now `null` and `required_status_checks` contexts are unchanged.
- [x] Verified `enforce_admins` is still `false` (single admin collaborator — issue explicitly said not to flip this).