### PR TITLE
docs(security): document code-scanning alert triage policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -114,6 +114,14 @@ Files matching `.gitignore` patterns are **indexed for graph metadata** (symbols
 
 ---
 
+## Code-Scanning Alert Triage Policy
+
+CodeQL and Semgrep run on every push/PR with `security-extended` + OWASP/nodejsscan rulesets, which surfaces a structural false-positive shape specific to this codebase: **`js/path-injection`**. Nearly every MCP tool takes a `file_path`-shaped argument, and the sanitizer (`validatePath()` / `guardPath()`, see above) runs in the tool-registration wrapper (`src/tools/register/*.ts`) one call away from the implementation function CodeQL flags — interprocedural taint tracking doesn't follow the sanitizer across that boundary. Per the precedent set in alerts #1068/#1069 ("local read-only search under the registered project root, same trust domain as the CLI/MCP user"), this bucket is dismissed in bulk as **won't fix** whenever the flagged path either passes through `validatePath()`/`guardPath()` before use, or is sourced from already-validated indexed data (e.g. `file_path` columns populated at index time). New `js/path-injection` alerts should be checked against this pattern and dismissed with the same justification rather than left to accumulate — but a path that reaches a sink *without* going through the wrapper is a real bug, not this exception.
+
+The remaining volume buckets (`ajinabraham.njsscan.dos.regex_dos`, `js/insecure-temporary-file`, `js/file-system-race`) are **not** covered by this exception — they involve regex-shape and TOCTOU analysis that has to be judged per call site, not by a single architectural argument, and a lazy blanket dismissal here would hide a real bug class (this tool is designed to scan arbitrary — including untrusted/third-party — codebases, so a crafted file triggering catastrophic backtracking in one of the scanner's own detection regexes is a plausible local DoS). These are tracked for individual review rather than dismissed.
+
+---
+
 ## Artisan Command Whitelist
 
 trace-mcp can optionally execute Laravel Artisan commands for runtime metadata (routes, models, events).


### PR DESCRIPTION
## Summary
- Bulk-dismissed the 198 open `js/path-injection` code-scanning alerts as won't-fix, applying the existing precedent from alerts #1068/#1069: the flagged path is validated via `validatePath()`/`guardPath()` before use, or sourced from already-validated indexed data — same local trust domain as the CLI/MCP user, CodeQL just can't see the sanitizer across the tool-registration-wrapper boundary. Verified the pattern holds by tracing several alert sites across different modules (`src/tools/analysis/ast-clones.ts`, `src/cli.ts`, tool-registration files) before dismissing.
- Resolved secret-scanning alert #1 (`openai_api_key`) as a false positive — it's the synthetic key fixture in `tests/tools/code-smells.test.ts:460` used to test the hardcoded-secret scanner itself.
- Documented the triage decision in `SECURITY.md` so future `js/path-injection` alerts get dismissed consistently instead of accumulating.
- Explicitly did **not** bulk-dismiss `regex_dos` (153), `js/insecure-temporary-file` (88), or `js/file-system-race` (41) — these need per-call-site review (regex-shape / TOCTOU analysis, not a single architectural exception) since this tool scans arbitrary/untrusted codebases. Documented as a deliberate "needs review" decision, tracked via TRA-133 follow-up.

Backlog: 614 open → 416 open (path-injection bucket fully cleared, largest and highest-severity bucket).

## Test plan
- [x] Docs-only change; `SECURITY.md` renders correctly
- [x] Verified via `gh api` that all 198 target alerts are now `dismissed` and no `js/path-injection` alerts remain open
- [x] Verified secret-scanning alert #1 is `resolved`/`false_positive`