### PR TITLE
fix(app): replace emoji glyphs + hardcoded colors with Lattice Icon/Badge

### DIFF
--- a/packages/app/src/renderer/lattice/ui/Badge.tsx
+++ b/packages/app/src/renderer/lattice/ui/Badge.tsx
@@ -17,6 +17,7 @@ export interface BadgeProps {
   tone?: Tone;
   variant?: 'solid' | 'outline';
   className?: string;
+  title?: string;
   children: ReactNode;
 }
 
@@ -24,10 +25,15 @@ export function Badge({
   tone = 'neutral',
   variant = 'solid',
   className,
+  title,
   children,
 }: BadgeProps): ReactNode {
   const cls = ['ws-badge', `t-${tone}`, variant === 'outline' ? 'outline' : '', className ?? '']
     .filter(Boolean)
     .join(' ');
-  return <span className={cls}>{children}</span>;
+  return (
+    <span className={cls} title={title}>
+      {children}
+    </span>
+  );
 }

--- a/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
@@ -8,6 +8,7 @@
  * Receives all data + state via props; does not call useWorkspaceProjects.
  */
 import { type ReactNode, useEffect, useState } from 'react';
+import { Icon } from '../lattice/icons';
 import {
   EMPTY_FILTER,
   type ProjectHealthStatus,
@@ -115,7 +116,7 @@ function KpiCell({ label, value, compact = false, active = false, onClick, accen
 // ── Chip ──────────────────────────────────────────────────────────────────
 
 interface ChipProps {
-  label: string;
+  label: ReactNode;
   active: boolean;
   onClick: () => void;
   accent?: string;
@@ -128,7 +129,7 @@ function Chip({ label, active, onClick, accent, title }: ChipProps) {
       type="button"
       onClick={onClick}
       title={title}
-      className="text-[11px] px-2 py-0.5 rounded-full font-medium transition-colors whitespace-nowrap"
+      className="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-full font-medium transition-colors whitespace-nowrap"
       style={{
         background: active ? accent ?? 'var(--accent)' : 'var(--fill-control)',
         color: active ? '#fff' : 'var(--text-secondary)',
@@ -298,7 +299,7 @@ export function WorkspaceHeader({
           </div>
 
           <Chip
-            label="🔒 Security"
+            label={<><Icon name="lock" size={11} /> Security</>}
             active={filter.hasSecurityFindings === true}
             accent="#ff3b30"
             onClick={() =>
@@ -310,7 +311,7 @@ export function WorkspaceHeader({
             title="Projects with critical or high security findings"
           />
           <Chip
-            label="💀 Dead"
+            label={<><Icon name="bug_report" size={11} /> Dead</>}
             active={filter.hasDeadExports === true}
             accent="#ff9f0a"
             onClick={() =>

--- a/packages/app/src/renderer/workspace/components/ProjectMetricsBadges.tsx
+++ b/packages/app/src/renderer/workspace/components/ProjectMetricsBadges.tsx
@@ -1,3 +1,5 @@
+import { Icon } from '../../lattice/icons';
+import { Badge, type Tone } from '../../lattice/ui';
 import type { ProjectViewModel, TechDebtGrade } from '../types';
 
 export interface ProjectMetricsBadgesProps {
@@ -6,12 +8,12 @@ export interface ProjectMetricsBadgesProps {
   dense?: boolean;
 }
 
-const GRADE_COLOR: Record<TechDebtGrade, string> = {
-  A: '#34c759',
-  B: '#30d158',
-  C: '#ffcc00',
-  D: '#ff9f0a',
-  F: '#ff3b30',
+const GRADE_TONE: Record<TechDebtGrade, Tone> = {
+  A: 'green',
+  B: 'green',
+  C: 'gold',
+  D: 'red',
+  F: 'red',
 };
 
 /**
@@ -28,45 +30,33 @@ export function ProjectMetricsBadges({ project, dense = false }: ProjectMetricsB
   const sec = project.securityFindings ?? 0;
   const dead = project.deadExports ?? 0;
   const untested = project.untestedSymbols ?? 0;
-  const sizeClass = dense ? 'text-[10px] px-1 py-0' : 'text-[11px] px-1.5 py-0.5';
+  const iconSize = dense ? 9 : 10;
 
   return (
     <div className="flex items-center gap-1 whitespace-nowrap">
       {grade && (
-        <span
-          className={`${sizeClass} rounded font-bold`}
-          style={{ color: '#fff', background: GRADE_COLOR[grade] }}
-          title={`Tech-debt grade ${grade}`}
-        >
+        <Badge tone={GRADE_TONE[grade]} variant="outline" title={`Tech-debt grade ${grade}`}>
           {grade}
-        </span>
+        </Badge>
       )}
       {sec > 0 && (
-        <span
-          className={`${sizeClass} rounded font-medium tabular-nums`}
-          style={{ color: '#ff3b30', background: '#ff3b3014', border: '0.5px solid #ff3b3040' }}
+        <Badge
+          tone="red"
+          variant="outline"
           title={`${sec} critical+high security finding${sec === 1 ? '' : 's'}`}
         >
-          🔒 {sec}
-        </span>
+          <Icon name="lock" size={iconSize} /> {sec}
+        </Badge>
       )}
       {dead > 0 && (
-        <span
-          className={`${sizeClass} rounded font-medium tabular-nums`}
-          style={{ color: '#ff9f0a', background: '#ff9f0a14', border: '0.5px solid #ff9f0a40' }}
-          title={`${dead} dead export${dead === 1 ? '' : 's'}`}
-        >
-          💀 {dead}
-        </span>
+        <Badge tone="gold" variant="outline" title={`${dead} dead export${dead === 1 ? '' : 's'}`}>
+          <Icon name="bug_report" size={iconSize} /> {dead}
+        </Badge>
       )}
       {!dense && untested > 0 && (
-        <span
-          className={`${sizeClass} rounded tabular-nums`}
-          style={{ color: 'var(--text-secondary)', background: 'var(--fill-control)' }}
-          title={`${untested} untested symbol${untested === 1 ? '' : 's'}`}
-        >
+        <Badge tone="neutral" title={`${untested} untested symbol${untested === 1 ? '' : 's'}`}>
           untested {untested}
-        </span>
+        </Badge>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- `ProjectMetricsBadges.tsx`'s grade/security/dead-exports chips used hand-rolled `<span style={...}>` pills with hardcoded iOS colors (`#34c759`, `#ff3b30`, `#ff9f0a`, …) and `🔒`/`💀` emoji glyphs — replaced with the shared `Badge` primitive (tone mapped to the canonical `--status-green/gold/red-hue` tokens) and `Icon` (`lock` / `bug_report`).
- The "Security"/"Dead" filter toggle pills also used `🔒`/`💀` — they actually live in `WorkspaceHeader.tsx`'s local `Chip` component, not `FilterBar.tsx` as the issue described (verified by grep across the renderer tree). Widened `Chip`'s `label` prop to `ReactNode` and swapped in `Icon`.
- `Badge` gained an optional `title` prop (tooltip passthrough) since none of the ad-hoc spans it replaces dropped their `title` attribute.

Closes TRA-135.

## Test plan
- [x] `pnpm run typecheck` (packages/app) — clean
- [x] `pnpm run build:renderer` — builds
- [ ] Visual check in the running app (not run here — no local daemon available in this environment)