### PR TITLE
feat(mcp): add list_projects + call_project_tool cross-project relay (TRA-93)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -547,6 +547,17 @@ The scanner detects HTTP/gRPC/GraphQL calls in 12+ patterns across all supported
 | gRPC stubs | All | `client.GetUser()` |
 | GraphQL operations | All | `query GetUser { ... }` |
 
+### Cross-project tools
+
+Every MCP session is still attached to exactly one project (see [stdio vs HTTP](#stdio-vs-http--choosing-your-setup)) — but two tools let an agent reach across to any OTHER project already registered with trace-mcp, without opening a second MCP connection:
+
+- **`list_projects`** — lists every project in `~/.trace-mcp/registry.json` (root, name, type, last-indexed timestamp), plus known subprojects when topology is enabled for the current session.
+- **`call_project_tool { project, tool, args }`** — runs any of the ~170 normal trace-mcp tools against a DIFFERENT registered project's already-indexed data and returns that tool's response verbatim. `project` must be a root from `list_projects`; an unregistered root or an unknown `tool` name returns a structured `{ error: { code, message, data } }` payload instead of throwing.
+
+This is read-only relay wiring — it never starts indexing or a file watcher for the target project. In the HTTP daemon, a target project already warm in memory is served directly; a cold one is opened on demand via the same read-mostly path used for on-demand subprojects. Under `stdio` (no daemon), the target project's existing index database is opened directly; a project that has never been indexed cannot be relayed to.
+
+No existing tool's schema changes because of this — `call_project_tool` dispatches to the target project's own registered handler for `tool`, so that tool's contract is exactly what it is when called directly.
+
 ---
 
 ## Supported MCP clients

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -108,6 +108,15 @@ A subproject is any working repository that is part of your project's ecosystem:
 | `subproject_add_repo` | Add a subproject, bound to the current project (or specify `project` param for external subprojects) |
 | `subproject_sync` | Re-scan all subprojects: contracts, client calls, and re-link |
 
+### Cross-project
+
+Every session is attached to one project, but these two tools reach across to any OTHER project already registered with trace-mcp (`~/.trace-mcp/registry.json`) — see [Configuration](configuration.md#cross-project-tools).
+
+| Tool | What it does |
+|---|---|
+| `list_projects` | List registered project roots (name, type, last-indexed), plus known subprojects |
+| `call_project_tool` | Run any other trace-mcp tool against a DIFFERENT registered project's already-indexed data; returns that tool's response verbatim |
+
 ## Decision memory
 
 See [Decision memory](decision-memory.md) for full documentation.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,6 +64,7 @@ import { DaemonIdleMonitor } from './daemon/idle-monitor.js';
 import { MemoryScheduler } from './memory/scheduler/memory-scheduler.js';
 import { ProjectManager } from './daemon/project-manager.js';
 import type { ManagedProject } from './daemon/project-manager.js';
+import { createDaemonProjectRelay } from './daemon/project-relay.js';
 import { handleReindexFile } from './daemon/reindex-file-handler.js';
 import { StdioSession } from './daemon/router/session.js';
 import { initializeDatabase } from './db/schema.js';
@@ -658,6 +659,9 @@ program
     // disposes the project's pool entry (two SQLite handles otherwise leak per
     // removed project for the daemon's lifetime).
     projectManager.setResourcePool(resourcePool);
+    // Cross-project relay for call_project_tool — additive wiring on top of
+    // the existing ProjectManager/ProjectResourcePool, not a second pool.
+    const projectRelay = createDaemonProjectRelay(projectManager, resourcePool);
 
     // Per-session MCP transports: sessionId → transport
     // Multiple clients can connect to the same project simultaneously.
@@ -704,6 +708,7 @@ program
           broadcastEvent({ ...event, project: projectRoot } as DaemonEvent);
         },
         transport: 'http' as const,
+        projectRelay,
       };
       const handle = createServer(
         managed.store,
@@ -2764,6 +2769,7 @@ program
       }
       sessionTransports.clear();
       projectSessions.clear();
+      projectRelay.dispose();
       resourcePool.disposeAll();
       idleMonitor.stop();
       await memoryScheduler.stop();

--- a/src/daemon/__tests__/project-relay.test.ts
+++ b/src/daemon/__tests__/project-relay.test.ts
@@ -1,0 +1,145 @@
+/**
+ * TRA-93 (Option B): cross-project relay used by `call_project_tool`.
+ *
+ * Covers:
+ *  (a) successful relay — createLightweightProjectRelay().openProject() on a
+ *      registered, already-indexed project returns a handler map whose
+ *      `get_index_health` response matches calling the SAME project's own
+ *      directly-constructed server.
+ *  (d) stdio lazy-load path — opening a second already-indexed project's
+ *      read-only handle with no daemon/ProjectManager involved, and without
+ *      ever writing to a fresh DB file (registered-but-never-indexed roots
+ *      are rejected instead of silently creating an empty index).
+ *  Plus: unknown project (not registered) and registered-but-unindexed
+ *  return null instead of throwing or fabricating state.
+ */
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let tmpHome: string;
+let projectA: string;
+let projectB: string;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'trace-mcp-relay-'));
+  vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+  vi.resetModules();
+  projectA = join(tmpHome, 'project-a');
+  projectB = join(tmpHome, 'project-b');
+  mkdirSync(projectA, { recursive: true });
+  mkdirSync(projectB, { recursive: true });
+  writeFileSync(join(projectA, 'package.json'), JSON.stringify({ name: 'a' }));
+  writeFileSync(join(projectB, 'package.json'), JSON.stringify({ name: 'b' }));
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe('createLightweightProjectRelay (stdio path, TRA-93)', () => {
+  it('returns null for a root that was never registered', async () => {
+    const { createLightweightProjectRelay } = await import('../project-relay.js');
+    const relay = createLightweightProjectRelay();
+    const opened = await relay.openProject(join(tmpHome, 'never-registered'));
+    expect(opened).toBeNull();
+    relay.dispose();
+  });
+
+  it('returns null for a root that is registered but never indexed (no DB file yet)', async () => {
+    const { registerProject } = await import('../../registry.js');
+    const { createLightweightProjectRelay } = await import('../project-relay.js');
+    registerProject(projectB);
+
+    const relay = createLightweightProjectRelay();
+    const opened = await relay.openProject(projectB);
+    expect(opened).toBeNull();
+    relay.dispose();
+  });
+
+  it('lists exactly the registered roots', async () => {
+    const { registerProject } = await import('../../registry.js');
+    const { createLightweightProjectRelay } = await import('../project-relay.js');
+    registerProject(projectA);
+    registerProject(projectB);
+
+    const relay = createLightweightProjectRelay();
+    expect(relay.listRelayTargets().sort()).toEqual([projectA, projectB].sort());
+    relay.dispose();
+  });
+
+  it('opens an already-indexed project read-only and dispatches get_index_health matching a direct createServer() call on the same DB — no watcher/indexAll runs (TRA-93 d)', async () => {
+    const { registerProject, getProject } = await import('../../registry.js');
+    const { initializeDatabase } = await import('../../db/schema.js');
+    const { Store } = await import('../../db/store.js');
+    const { PluginRegistry } = await import('../../plugin-api/registry.js');
+    const { ProgressState } = await import('../../progress.js');
+    const { loadConfig } = await import('../../config.js');
+    const { createServer } = await import('../../server/server.js');
+    const { createLightweightProjectRelay } = await import('../project-relay.js');
+
+    registerProject(projectB);
+    const entry = getProject(projectB);
+    expect(entry).not.toBeNull();
+
+    // Pre-create the index DB so the project counts as "already indexed" —
+    // the relay must never index it itself.
+    const preDb = initializeDatabase(entry!.dbPath);
+    preDb.close();
+
+    const relay = createLightweightProjectRelay();
+    const opened = await relay.openProject(projectB);
+    expect(opened).not.toBeNull();
+    const relayedHandler = opened!.toolHandlers.get('get_index_health');
+    expect(relayedHandler).toBeTypeOf('function');
+    const relayedResponse = await relayedHandler!({});
+
+    // Build a completely independent, directly-constructed server against
+    // the same DB file to compare against — this is "calling it directly on
+    // that project's own server", not a re-check of the relay's own output.
+    const directDb = initializeDatabase(entry!.dbPath);
+    const directStore = new Store(directDb);
+    const directRegistry = PluginRegistry.createWithDefaults();
+    const directProgress = new ProgressState(directDb);
+    const configResult = await loadConfig(projectB);
+    if (configResult.isErr()) throw new Error('loadConfig failed');
+    const directHandle = createServer(
+      directStore,
+      directRegistry,
+      configResult.value,
+      projectB,
+      directProgress,
+      {},
+    );
+    const directHandler = directHandle.toolHandlers.get('get_index_health');
+    const directResponse = await directHandler!({});
+
+    const relayedText = relayedResponse.content?.[0]?.text;
+    const directText = directResponse.content?.[0]?.text;
+    expect(relayedText).toBeDefined();
+    expect(JSON.parse(relayedText!)).toEqual(JSON.parse(directText!));
+
+    directHandle.dispose();
+    directDb.close();
+    relay.dispose();
+  });
+
+  it('caches the opened handle — a second openProject() call for the same root returns the same handle instance', async () => {
+    const { registerProject, getProject } = await import('../../registry.js');
+    const { initializeDatabase } = await import('../../db/schema.js');
+    const { createLightweightProjectRelay } = await import('../project-relay.js');
+
+    registerProject(projectB);
+    const entry = getProject(projectB);
+    initializeDatabase(entry!.dbPath).close();
+
+    const relay = createLightweightProjectRelay();
+    const first = await relay.openProject(projectB);
+    const second = await relay.openProject(projectB);
+    expect(second).toBe(first);
+    relay.dispose();
+  });
+});

--- a/src/daemon/project-relay.ts
+++ b/src/daemon/project-relay.ts
@@ -1,0 +1,166 @@
+/**
+ * Cross-project relay for `call_project_tool` (src/tools/register/projects.ts).
+ *
+ * Two implementations, one per runtime:
+ *  - `createDaemonProjectRelay` — daemon/HTTP: reuses `ProjectManager` (a
+ *    target project already warm in the daemon is served directly; a cold
+ *    one is lazily opened via the same `addProject(root, { watch: false,
+ *    persist: false })` read-mostly path already used for on-demand
+ *    subprojects) and `ProjectResourcePool` (shared TopologyStore/
+ *    DecisionStore — no second pool is created).
+ *  - `createLightweightProjectRelay` — stdio (LocalBackend): there is no
+ *    daemon/ProjectManager to reuse (LocalBackend manages exactly one
+ *    project), so this opens the target project's ALREADY-INDEXED database
+ *    directly — no indexAll(), no FileWatcher — and caches the resulting
+ *    ServerHandle for the process's lifetime.
+ *
+ * Both cache opened handles by resolved root and expose `dispose()` for the
+ * owning runtime to release everything on shutdown.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import type Database from 'better-sqlite3';
+import { loadConfig } from '../config.js';
+import { initializeDatabase } from '../db/schema.js';
+import { Store } from '../db/store.js';
+import { PluginRegistry } from '../plugin-api/registry.js';
+import { ProgressState } from '../progress.js';
+import { getProject, listProjects, resolveRegisteredAncestor } from '../registry.js';
+import { createServer, type ServerHandle } from '../server/server.js';
+import type { ProjectRelay } from '../server/types.js';
+import type { ProjectManager } from './project-manager.js';
+import type { ProjectResourcePool } from './resource-pool.js';
+
+/** Resolve a requested root to its exact registered entry — direct match, or
+ *  a registered ancestor / multi-root parent, mirroring how registry.ts's
+ *  other consumers (e.g. the daemon's project-request routing) resolve paths. */
+function resolveRegisteredRoot(targetRoot: string): { root: string; dbPath: string } | null {
+  const abs = path.resolve(targetRoot);
+  const entry = getProject(abs) ?? resolveRegisteredAncestor(abs);
+  return entry ? { root: entry.root, dbPath: entry.dbPath } : null;
+}
+
+/**
+ * Daemon/HTTP relay. `projectManager`/`resourcePool` are the same instances
+ * cli.ts's `serve-http` command already constructs and uses for every
+ * per-session `createServer()` call (see `createSessionTransport`) — this
+ * relay is additive wiring on top of that existing machinery, not a second
+ * pool.
+ */
+export function createDaemonProjectRelay(
+  projectManager: ProjectManager,
+  resourcePool: ProjectResourcePool,
+): ProjectRelay {
+  const cache = new Map<string, ServerHandle>();
+  const acquiredRoots = new Set<string>();
+
+  return {
+    listRelayTargets() {
+      return listProjects().map((p) => p.root);
+    },
+    async openProject(targetRoot) {
+      const abs = path.resolve(targetRoot);
+      const cached = cache.get(abs);
+      if (cached) return cached;
+
+      const resolved = resolveRegisteredRoot(abs);
+      if (!resolved) return null;
+
+      let managed = projectManager.getProject(resolved.root);
+      if (!managed) {
+        try {
+          // Read-mostly: no watcher. `persist: false` is harmless here since
+          // the project is already registered (setupProject() would just
+          // re-write the same registry entry) — this mirrors the read-mostly
+          // mode ProjectManager already uses for on-demand subprojects.
+          managed = await projectManager.addProject(resolved.root, {
+            watch: false,
+            persist: false,
+          });
+        } catch {
+          return null;
+        }
+      }
+
+      const deps = resourcePool.acquire(resolved.root, managed.config);
+      acquiredRoots.add(resolved.root);
+      const handle = createServer(
+        managed.store,
+        managed.registry,
+        managed.config,
+        managed.root,
+        managed.progress,
+        deps,
+      );
+      cache.set(abs, handle);
+      return handle;
+    },
+    dispose() {
+      for (const handle of cache.values()) {
+        try {
+          handle.dispose();
+        } catch {
+          /* best-effort */
+        }
+      }
+      cache.clear();
+      for (const root of acquiredRoots) {
+        resourcePool.release(root);
+      }
+      acquiredRoots.clear();
+    },
+  };
+}
+
+/**
+ * Stdio/no-daemon relay. Opens each target project's already-indexed database
+ * read-only-in-spirit (no indexAll(), no FileWatcher) and caches the result
+ * for the caller's lifetime. Used by LocalBackend, which owns exactly one
+ * project and has no ProjectManager/ResourcePool to reuse.
+ */
+export function createLightweightProjectRelay(): ProjectRelay {
+  const cache = new Map<string, { handle: ServerHandle; db: Database.Database }>();
+
+  return {
+    listRelayTargets() {
+      return listProjects().map((p) => p.root);
+    },
+    async openProject(targetRoot) {
+      const abs = path.resolve(targetRoot);
+      const cached = cache.get(abs);
+      if (cached) return cached.handle;
+
+      const resolved = resolveRegisteredRoot(abs);
+      if (!resolved) return null;
+      // Registered but never indexed — nothing to relay to. Never trigger an
+      // index build here; this path is read-only access to an existing index.
+      if (!fs.existsSync(resolved.dbPath)) return null;
+
+      const configResult = await loadConfig(resolved.root);
+      if (configResult.isErr()) return null;
+
+      const db = initializeDatabase(resolved.dbPath);
+      const store = new Store(db);
+      const registry = PluginRegistry.createWithDefaults();
+      const progress = new ProgressState(db);
+      const handle = createServer(store, registry, configResult.value, resolved.root, progress, {});
+      cache.set(abs, { handle, db });
+      return handle;
+    },
+    dispose() {
+      for (const { handle, db } of cache.values()) {
+        try {
+          handle.dispose();
+        } catch {
+          /* best-effort */
+        }
+        try {
+          db.close();
+        } catch {
+          /* best-effort */
+        }
+      }
+      cache.clear();
+    },
+  };
+}

--- a/src/daemon/router/local-backend.ts
+++ b/src/daemon/router/local-backend.ts
@@ -31,7 +31,9 @@ import { TopologyStore } from '../../topology/topology-db.js';
 import { trailingDebounce } from '../../util/debounce.js';
 import { BackgroundLspEnricher } from '../../lsp/background-enricher.js';
 import { serializeError } from '../log-error.js';
+import { createLightweightProjectRelay } from '../project-relay.js';
 import { getReindexStats } from '../reindex-stats.js';
+import type { ProjectRelay } from '../../server/types.js';
 import { seedSessionDbFromShared, sweepOrphanedSessionDbs } from './session-db.js';
 import type { Backend } from './types.js';
 
@@ -99,6 +101,13 @@ export class LocalBackend implements Backend {
    * before the DB closes.
    */
   private lspEnricher: BackgroundLspEnricher | null = null;
+  /**
+   * Cross-project relay for call_project_tool. LocalBackend manages exactly
+   * one project and has no ProjectManager/ResourcePool to reuse, so this
+   * opens OTHER registered projects' already-indexed databases directly (no
+   * indexAll(), no watcher) — see src/daemon/project-relay.ts.
+   */
+  private readonly projectRelay: ProjectRelay = createLightweightProjectRelay();
 
   constructor(opts: LocalBackendOptions) {
     this.opts = opts;
@@ -416,6 +425,7 @@ export class LocalBackend implements Backend {
     this.handle = createServer(this.store, this.registry, config, projectRoot, this.progress, {
       topoStore: this.topoStore,
       decisionStore: this.decisionStore,
+      projectRelay: this.projectRelay,
     });
 
     const [client, server] = InMemoryTransport.createLinkedPair();
@@ -460,6 +470,13 @@ export class LocalBackend implements Backend {
       /* best-effort */
     }
     this.lspEnricher = null;
+
+    // Close any cross-project handles opened via call_project_tool.
+    try {
+      this.projectRelay.dispose();
+    } catch {
+      /* best-effort */
+    }
 
     // Stop accepting new MCP messages immediately.
     // Detach our onmessage so router never receives stale output.

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -49,6 +49,7 @@ import { registerGitTools } from '../tools/register/git.js';
 import { registerKnowledgeTools } from '../tools/register/knowledge.js';
 import { registerMemoryTools } from '../tools/register/memory.js';
 import { registerNavigationTools } from '../tools/register/navigation.js';
+import { registerProjectsTools } from '../tools/register/projects.js';
 import { registerQualityTools } from '../tools/register/quality.js';
 import { registerRetrievalTools } from '../tools/register/retrieval.js';
 import { registerRefactoringTools } from '../tools/register/refactoring.js';
@@ -61,7 +62,7 @@ import { createExploredTracker } from './explored-tracker.js';
 import { startHeartbeat } from './heartbeat.js';
 import { buildInstructions } from './instructions.js';
 import { installToolGate } from './tool-gate.js';
-import type { MetaContext, ServerContext } from './types.js';
+import type { MetaContext, ProjectRelay, ServerContext, ToolHandlerMap } from './types.js';
 
 /** Compact JSON — no pretty-printing, strip nulls; saves 25–35% tokens on every response.
  * Every string in the payload is run through {@link sanitizeValue} first to defuse
@@ -231,6 +232,13 @@ export interface ServerDeps {
    * sessions; only cli.ts's `serve-http` command passes 'http'.
    */
   transport?: 'stdio' | 'http';
+  /**
+   * Cross-project relay for `call_project_tool` (see ServerContext.projectRelay
+   * in ./types.js). Wired by cli.ts (daemon session creation) and by
+   * LocalBackend (stdio). Omitted in contexts with no relay wiring (CLI
+   * fallback commands, unit tests) — the tool then reports itself unavailable.
+   */
+  projectRelay?: ProjectRelay;
 }
 
 /**
@@ -244,6 +252,14 @@ export interface ServerHandle {
    * (GET /api/projects/journal) without reaching into createServer internals.
    */
   journal: SessionJournal;
+  /**
+   * Name → gated handler map for in-process tool dispatch without a second MCP
+   * transport/session. Same map the `batch` tool uses for same-project calls;
+   * `call_project_tool`'s cross-project relay (src/daemon/project-relay.ts)
+   * looks up a DIFFERENT project's server by this field instead of opening a
+   * second live MCP connection.
+   */
+  toolHandlers: ToolHandlerMap;
   /** Flush session data and close owned resources. Safe to call multiple times. */
   dispose: () => void;
 }
@@ -636,6 +652,7 @@ export function createServer(
     // unit tests) can register tools without crashing. cli.ts overrides
     // this with the broadcastEvent-bound callback.
     onPipelineEvent: deps?.onPipelineEvent ?? (() => {}),
+    projectRelay: deps?.projectRelay ?? null,
   };
 
   const metaCtx: MetaContext = {
@@ -671,11 +688,12 @@ export function createServer(
   registerGitTools(server, ctx);
   registerRefactoringTools(server, ctx);
   registerAdvancedTools(server, ctx);
+  registerProjectsTools(server, ctx);
   registerQualityTools(server, ctx);
   registerMemoryTools(server, ctx);
   registerRetrievalTools(server, ctx);
   registerKnowledgeTools(server, ctx);
   registerSessionTools(server, metaCtx);
 
-  return { server, journal, dispose };
+  return { server, journal, dispose, toolHandlers };
 }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -18,6 +18,38 @@ import type { TopologyStore } from '../topology/topology-db.js';
 
 export type ToolResponse = { content: [{ type: 'text'; text: string }]; isError?: boolean };
 
+/** Name → gated handler map for in-process tool dispatch without a second MCP
+ *  transport/session. Populated by `installToolGate` inside `createServer()`
+ *  and exposed on `ServerHandle.toolHandlers` — the same map the `batch` tool
+ *  (session.ts) already uses for same-project dispatch. */
+export type ToolHandlerMap = Map<
+  string,
+  (params: Record<string, unknown>) => Promise<ToolResponse>
+>;
+
+/**
+ * Cross-project relay for the `call_project_tool` MCP tool (projects.ts).
+ * Two implementations exist (src/daemon/project-relay.ts):
+ *  - the daemon/HTTP runtime reuses `ProjectManager` + `ProjectResourcePool`
+ *    (a target project already warm in the daemon is served directly; a cold
+ *    one is lazily opened via `ProjectManager.addProject(root, { watch: false,
+ *    persist: false })`, the same read-mostly path used for subprojects).
+ *  - the stdio runtime (no daemon assumed) opens the target project's
+ *    already-indexed database directly — no indexAll(), no file watcher.
+ * `undefined` when neither wiring applies (e.g. isolated unit tests) —
+ * call_project_tool then reports the relay as unavailable instead of throwing.
+ */
+export interface ProjectRelay {
+  /** Registered project roots this relay accepts as a `call_project_tool` target. */
+  listRelayTargets(): string[];
+  /** Resolve + open (or reuse a cached) target project's tool-handler map.
+   *  Returns null when `targetRoot` isn't a registered project, or is
+   *  registered but has never been indexed. */
+  openProject(targetRoot: string): Promise<{ toolHandlers: ToolHandlerMap } | null>;
+  /** Release everything this relay opened. Idempotent. */
+  dispose(): void;
+}
+
 /**
  * R09 v2 — pipeline-lifecycle event shapes emitted by MCP tools
  * (embed_repo, snapshot_graph) and relayed by the daemon to the
@@ -74,6 +106,12 @@ export interface ServerContext {
    * Wired by createServer() from ServerDeps.onPipelineEvent.
    */
   onPipelineEvent: (event: PipelineLifecycleEvent) => void;
+  /**
+   * Cross-project relay wired by cli.ts (daemon) / LocalBackend (stdio).
+   * Null when not wired (e.g. unit tests) — `call_project_tool` reports the
+   * relay as unavailable rather than throwing.
+   */
+  projectRelay: ProjectRelay | null;
 }
 
 /** Extended context for meta tools that bypass preset gate */

--- a/src/tools/register/__tests__/projects.test.ts
+++ b/src/tools/register/__tests__/projects.test.ts
@@ -1,0 +1,223 @@
+/**
+ * TRA-93 (Option B): `list_projects` + `call_project_tool`.
+ *
+ * Handlers are captured via a fake `server.tool(...)` (same convention as
+ * wave2-toon.test.ts) so these are pure unit tests of the tool logic against
+ * a stubbed `ctx.projectRelay` — no real McpServer, no real second project.
+ * Cross-project dispatch against a REAL second project (and the stdio
+ * lazy-load path) is covered by src/daemon/__tests__/project-relay.test.ts.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import type { ProjectRelay, ServerContext, ToolResponse } from '../../../server/types.js';
+import { registerProjectsTools } from '../projects.js';
+
+type Handler = (args: Record<string, unknown>) => Promise<ToolResponse>;
+
+interface CapturedTool {
+  name: string;
+  schemaShape: Record<string, z.ZodTypeAny>;
+  handler: Handler;
+}
+
+function makeCapturingServer(): { server: unknown; captured: CapturedTool[] } {
+  const captured: CapturedTool[] = [];
+  const server = {
+    tool: (
+      name: string,
+      _description: string,
+      schemaShape: Record<string, z.ZodTypeAny>,
+      handler: Handler,
+    ) => {
+      captured.push({ name, schemaShape, handler });
+    },
+  };
+  return { server, captured };
+}
+
+function findTool(captured: CapturedTool[], name: string): CapturedTool {
+  const tool = captured.find((t) => t.name === name);
+  if (!tool) throw new Error(`tool ${name} was not registered`);
+  return tool;
+}
+
+function ctxStub(overrides: Record<string, unknown> = {}): ServerContext {
+  const stub = {
+    projectRoot: '/tmp/fake-project',
+    config: {},
+    registry: { getActiveFrameworkPlugins: () => ({ isErr: () => true }) },
+    topoStore: null,
+    projectRelay: null,
+    j: (v: unknown) => JSON.stringify(v),
+    ...overrides,
+  };
+  return stub as unknown as ServerContext;
+}
+
+function parseText(response: ToolResponse): unknown {
+  return JSON.parse(response.content[0]!.text);
+}
+
+describe('list_projects', () => {
+  it('reports registered projects from the registry', async () => {
+    vi.doMock('../../../registry.js', () => ({
+      listProjects: () => [
+        { root: '/repo/a', name: 'a', type: 'single', lastIndexed: '2026-01-01T00:00:00.000Z' },
+        { root: '/repo/b', name: 'b', type: 'single', lastIndexed: null },
+      ],
+    }));
+    vi.resetModules();
+    const { registerProjectsTools: register } = await import('../projects.js');
+
+    const { server, captured } = makeCapturingServer();
+    register(server as never, ctxStub());
+    const { handler } = findTool(captured, 'list_projects');
+
+    const result = parseText(await handler({})) as { projects: unknown[]; total: number };
+    expect(result.total).toBe(2);
+    expect(result.projects).toEqual([
+      { root: '/repo/a', name: 'a', type: 'single', lastIndexed: '2026-01-01T00:00:00.000Z' },
+      { root: '/repo/b', name: 'b', type: 'single', lastIndexed: null },
+    ]);
+
+    vi.doUnmock('../../../registry.js');
+    vi.resetModules();
+  });
+
+  it('includes subprojects when ctx.topoStore is available, omits the key otherwise', async () => {
+    const { server, captured } = makeCapturingServer();
+    const topoStore = {
+      getAllSubprojects: () => [{ name: 'sub', repo_root: '/repo/sub', project_root: '/repo' }],
+    };
+    registerProjectsTools(server as never, ctxStub({ topoStore }));
+    const { handler } = findTool(captured, 'list_projects');
+
+    const result = parseText(await handler({})) as { subprojects?: unknown[] };
+    expect(result.subprojects).toEqual([
+      { name: 'sub', repo_root: '/repo/sub', project_root: '/repo' },
+    ]);
+
+    const { server: server2, captured: captured2 } = makeCapturingServer();
+    registerProjectsTools(server2 as never, ctxStub({ topoStore: null }));
+    const { handler: handler2 } = findTool(captured2, 'list_projects');
+    const result2 = parseText(await handler2({})) as { subprojects?: unknown[] };
+    expect(result2.subprojects).toBeUndefined();
+  });
+});
+
+describe('call_project_tool', () => {
+  it('reports relay_unavailable when ctx.projectRelay is not wired', async () => {
+    const { server, captured } = makeCapturingServer();
+    registerProjectsTools(server as never, ctxStub({ projectRelay: null }));
+    const { handler } = findTool(captured, 'call_project_tool');
+
+    const response = await handler({ project: '/repo/a', tool: 'get_project_map', args: {} });
+    expect(response.isError).toBe(true);
+    const body = parseText(response) as { error: { code: string } };
+    expect(body.error.code).toBe('relay_unavailable');
+  });
+
+  it('returns a structured unknown_project error listing what IS registered', async () => {
+    const relay: ProjectRelay = {
+      listRelayTargets: () => ['/repo/a', '/repo/b'],
+      openProject: vi.fn(async () => null),
+      dispose: () => undefined,
+    };
+    const { server, captured } = makeCapturingServer();
+    registerProjectsTools(server as never, ctxStub({ projectRelay: relay }));
+    const { handler } = findTool(captured, 'call_project_tool');
+
+    const response = await handler({ project: '/repo/unknown', tool: 'get_project_map', args: {} });
+    expect(response.isError).toBe(true);
+    const body = parseText(response) as {
+      error: { code: string; data: { reason: string; registered: string[]; requested: string } };
+    };
+    expect(body.error.code).toBe('unknown_project');
+    expect(body.error.data.reason).toBe('unknown_project');
+    expect(body.error.data.registered).toEqual(['/repo/a', '/repo/b']);
+    expect(body.error.data.requested).toBe('/repo/unknown');
+    // openProject must not even be attempted for a root that isn't registered.
+    expect(relay.openProject).not.toHaveBeenCalled();
+  });
+
+  it('returns unknown_project when the project is registered but openProject() cannot open it', async () => {
+    const relay: ProjectRelay = {
+      listRelayTargets: () => ['/repo/a'],
+      openProject: vi.fn(async () => null),
+      dispose: () => undefined,
+    };
+    const { server, captured } = makeCapturingServer();
+    registerProjectsTools(server as never, ctxStub({ projectRelay: relay }));
+    const { handler } = findTool(captured, 'call_project_tool');
+
+    const response = await handler({ project: '/repo/a', tool: 'get_project_map', args: {} });
+    expect(response.isError).toBe(true);
+    const body = parseText(response) as { error: { code: string; data: { reason: string } } };
+    expect(body.error.code).toBe('unknown_project');
+    expect(body.error.data.reason).toBe('project_not_opened');
+  });
+
+  it('returns a structured unknown_tool error for a tool name not registered on the target project', async () => {
+    const relay: ProjectRelay = {
+      listRelayTargets: () => ['/repo/a'],
+      openProject: vi.fn(async () => ({ toolHandlers: new Map() })),
+      dispose: () => undefined,
+    };
+    const { server, captured } = makeCapturingServer();
+    registerProjectsTools(server as never, ctxStub({ projectRelay: relay }));
+    const { handler } = findTool(captured, 'call_project_tool');
+
+    const response = await handler({ project: '/repo/a', tool: 'not_a_real_tool', args: {} });
+    expect(response.isError).toBe(true);
+    const body = parseText(response) as { error: { code: string; data: { tool: string } } };
+    expect(body.error.code).toBe('unknown_tool');
+    expect(body.error.data.tool).toBe('not_a_real_tool');
+  });
+
+  it('dispatches to the target project handler and returns its response verbatim, forwarding args', async () => {
+    const targetHandler = vi.fn(
+      async (args: Record<string, unknown>): Promise<ToolResponse> => ({
+        content: [{ type: 'text', text: JSON.stringify({ echoed: args }) }],
+      }),
+    );
+    const relay: ProjectRelay = {
+      listRelayTargets: () => ['/repo/a'],
+      openProject: vi.fn(async () => ({ toolHandlers: new Map([['get_symbol', targetHandler]]) })),
+      dispose: () => undefined,
+    };
+    const { server, captured } = makeCapturingServer();
+    registerProjectsTools(server as never, ctxStub({ projectRelay: relay }));
+    const { handler } = findTool(captured, 'call_project_tool');
+
+    const response = await handler({
+      project: '/repo/a',
+      tool: 'get_symbol',
+      args: { fqn: 'Foo.bar' },
+    });
+
+    expect(response.isError).toBeUndefined();
+    expect(targetHandler).toHaveBeenCalledWith({ fqn: 'Foo.bar' });
+    expect(parseText(response)).toEqual({ echoed: { fqn: 'Foo.bar' } });
+  });
+
+  it('resolves relative-looking project paths before checking membership (path.resolve)', async () => {
+    const mapHandler = vi.fn(
+      async (): Promise<ToolResponse> => ({
+        content: [{ type: 'text', text: '{}' }],
+      }),
+    );
+    const relay: ProjectRelay = {
+      listRelayTargets: () => [process.cwd()],
+      openProject: vi.fn(async () => ({
+        toolHandlers: new Map([['get_project_map', mapHandler]]),
+      })),
+      dispose: () => undefined,
+    };
+    const { server, captured } = makeCapturingServer();
+    registerProjectsTools(server as never, ctxStub({ projectRelay: relay }));
+    const { handler } = findTool(captured, 'call_project_tool');
+
+    const response = await handler({ project: '.', tool: 'get_project_map', args: {} });
+    expect(response.isError).toBeUndefined();
+  });
+});

--- a/src/tools/register/projects.ts
+++ b/src/tools/register/projects.ts
@@ -1,0 +1,161 @@
+import path from 'node:path';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { listProjects } from '../../registry.js';
+import type { ServerContext } from '../../server/types.js';
+
+/**
+ * Cross-project tools: `list_projects` (discover registered roots) and
+ * `call_project_tool` (relay a normal trace-mcp tool call to a DIFFERENT
+ * registered project than the one this session is attached to). See
+ * src/daemon/project-relay.ts for how `ctx.projectRelay` is wired per runtime
+ * (daemon vs stdio) and src/server/types.ts for the ProjectRelay contract.
+ *
+ * Design note (TRA-93 Option B): this is deliberately NOT a `project` param
+ * threaded onto all ~170 existing tools (Option A, out of scope) — every
+ * existing tool's schema is untouched. `call_project_tool` dispatches to the
+ * target project's own already-registered handler for `tool` and returns its
+ * response verbatim, so the target tool's contract never changes either.
+ */
+export function registerProjectsTools(server: McpServer, ctx: ServerContext): void {
+  const { j, topoStore } = ctx;
+
+  server.tool(
+    'list_projects',
+    'List projects registered with trace-mcp (~/.trace-mcp/registry.json), plus any known subprojects. Use with call_project_tool to query a project other than the one this session is attached to. Read-only. Returns JSON: { projects: [{ root, name, type, lastIndexed }], subprojects?: [{ name, repo_root, project_root }], total }.',
+    {},
+    async () => {
+      const projects = listProjects().map((p) => ({
+        root: p.root,
+        name: p.name,
+        type: p.type ?? 'single',
+        lastIndexed: p.lastIndexed,
+      }));
+      const result: Record<string, unknown> = { projects, total: projects.length };
+
+      // Subproject registrations are cheap to include when topology is
+      // enabled for this session (ctx.topoStore is already open) — no new
+      // plumbing needed. Omitted entirely otherwise rather than surfacing an
+      // empty array.
+      if (topoStore) {
+        const subprojects = topoStore.getAllSubprojects().map((s) => ({
+          name: s.name,
+          repo_root: s.repo_root,
+          project_root: s.project_root,
+        }));
+        if (subprojects.length > 0) result.subprojects = subprojects;
+      }
+
+      return { content: [{ type: 'text', text: j(result) }] };
+    },
+  );
+
+  server.tool(
+    'call_project_tool',
+    "Relay a trace-mcp tool call to a DIFFERENT registered project than this session's own (cross-project dispatch). Use list_projects first to find valid `project` roots. The named `tool` runs with its normal schema/contract against the target project's already-indexed data — no new indexing or file watching is started for it. Read-only relay (mutating tools still run their own normal effects on the TARGET project). Returns JSON: the target tool's own response verbatim, or `{ error: { code, message, data } }` when `project` isn't registered or `tool` isn't a known tool name.",
+    {
+      project: z
+        .string()
+        .min(1)
+        .max(1024)
+        .describe('Absolute root path of a registered project (see list_projects)'),
+      tool: z
+        .string()
+        .min(1)
+        .max(128)
+        .describe(
+          'Name of a trace-mcp tool to run against that project (e.g. "search", "get_symbol")',
+        ),
+      args: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe('Arguments to pass to the target tool (default: {})'),
+    },
+    async ({ project, tool, args }) => {
+      const relay = ctx.projectRelay;
+      if (!relay) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: j({
+                error: {
+                  code: 'relay_unavailable',
+                  message: 'Cross-project relay is not available in this runtime.',
+                  data: { reason: 'relay_unavailable' },
+                },
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const registered = relay.listRelayTargets();
+      const resolvedRoot = path.resolve(project);
+
+      // Mirrors the daemon's "ambiguous project" 400 shape (buildAmbiguousProjectError
+      // in src/daemon/mcp-error-response.ts) — same `reason`/`registered` fields,
+      // adapted to a tool-result payload rather than a JSON-RPC transport error.
+      if (!registered.includes(resolvedRoot)) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: j({
+                error: {
+                  code: 'unknown_project',
+                  message:
+                    `Project not registered with trace-mcp: ${project}. ` +
+                    `Registered roots: ${registered.length > 0 ? registered.join(', ') : '(none)'}`,
+                  data: { reason: 'unknown_project', requested: project, registered },
+                },
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const opened = await relay.openProject(resolvedRoot);
+      if (!opened) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: j({
+                error: {
+                  code: 'unknown_project',
+                  message: `Project is registered but could not be opened (never indexed?): ${resolvedRoot}`,
+                  data: { reason: 'project_not_opened', requested: project, registered },
+                },
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const handler = opened.toolHandlers.get(tool);
+      if (!handler) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: j({
+                error: {
+                  code: 'unknown_tool',
+                  message: `Tool "${tool}" is not registered on project ${resolvedRoot}.`,
+                  data: { reason: 'unknown_tool', tool },
+                },
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return handler(args ?? {});
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Implements TRA-93 Option B (design decided in that issue's brainstorm): lets one MCP session reach a *different* registered project without threading a `project` param onto all ~170 existing tool schemas (Option A, deferred as a larger follow-up if this proves insufficient).

- `list_projects` — lists `~/.trace-mcp/registry.json` entries, plus known subprojects when topology is enabled for the session.
- `call_project_tool { project, tool, args }` — validates `project` against the registry, opens (or reuses) that project's tool-handler map via a new `ProjectRelay`, dispatches `tool` to it, and returns the response verbatim. Unregistered projects / unknown tool names return a structured `{ error: { code, message, data } }` payload (mirrors the daemon's existing "ambiguous project" error shape) instead of throwing.

`ProjectRelay` has two implementations (`src/daemon/project-relay.ts`):
- **daemon/HTTP**: reuses `ProjectManager` + `ProjectResourcePool` (no second pool) — a cold target project opens via the existing `watch:false, persist:false` read-mostly path already used for on-demand subprojects.
- **stdio** (`LocalBackend`): no `ProjectManager` to reuse, so it opens the target project's already-indexed database directly — no `indexAll()`, no file watcher.

`ServerHandle` now exposes `toolHandlers` (the same name→handler map the `batch` tool already uses for same-project dispatch), so the relay can invoke a target project's handler directly without a second live MCP transport/session.

Closes TRA-143 / nikolai-vysotskyi/trace-mcp#199.

## Test plan
- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` clean
- [x] New tests: `src/tools/register/__tests__/projects.test.ts` (8), `src/daemon/__tests__/project-relay.test.ts` (5) — cover successful cross-project dispatch, unregistered project, unindexed-but-registered project, unknown tool, relay-unavailable, and handle caching
- [x] Full `pnpm test`: 772 files / 8549 tests passed, 0 failures
- [x] Docs updated: `docs/configuration.md`, `docs/tools-reference.md`