### PR TITLE
fix: replace insecure /tmp literal paths in test fixtures (CodeQL #247)

### DIFF
--- a/tests/tools/ai-tools.test.ts
+++ b/tests/tools/ai-tools.test.ts
@@ -67,7 +67,7 @@ describe('AI Tools registration', () => {
         embeddingService: null,
         vectorStore: null,
         reranker: null,
-        projectRoot: '/tmp/fake',
+        projectRoot: '/nonexistent/fake',
       });
     }).not.toThrow();
   });

--- a/tests/tools/prompts.test.ts
+++ b/tests/tools/prompts.test.ts
@@ -73,7 +73,12 @@ describe('MCP Prompts', () => {
 
     const store = createMockStore();
     const registry = createMockRegistry();
-    registerPrompts(server, { store, registry, config: defaultConfig, projectRoot: '/tmp/test' });
+    registerPrompts(server, {
+      store,
+      registry,
+      config: defaultConfig,
+      projectRoot: '/nonexistent/test',
+    });
   });
 
   it('registers all 5 prompts', () => {


### PR DESCRIPTION
## Summary
- CodeQL alert #247 (`js/insecure-temporary-file`, high severity) flags `src/utils/source-reader.ts:20`'s `fs.openSync` as a taint sink fed by test fixtures that construct hardcoded `/tmp/...` fake paths (`tests/tools/ai-tools.test.ts:70`, `tests/tools/prompts.test.ts:76`).
- These paths never touch disk (they're fed into mock objects, not created via `fs.mkdtempSync`), but the literal `/tmp/` prefix trips the heuristic. Same class of finding already fixed for other test files in #356 — this closes the two that were missed.
- Fix: swap the literal `/tmp/...` fake paths for `/nonexistent/...`, matching the established pattern.
- This was blocking PR #353's CodeQL gate even though #353 doesn't touch these files, since alert #247 pre-dates it.

## Test plan
- [x] `pnpm exec biome check` clean on both files
- [x] No behavior change — values are opaque fake path strings, never touch the filesystem