### PR TITLE
fix: resolve Windows CI failure in call_project_tool tests (path.resolve mismatch)

### DIFF
--- a/src/tools/register/__tests__/projects.test.ts
+++ b/src/tools/register/__tests__/projects.test.ts
@@ -7,10 +7,19 @@
  * Cross-project dispatch against a REAL second project (and the stdio
  * lazy-load path) is covered by src/daemon/__tests__/project-relay.test.ts.
  */
+import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import type { ProjectRelay, ServerContext, ToolResponse } from '../../../server/types.js';
 import { registerProjectsTools } from '../projects.js';
+
+// `call_project_tool` compares path.resolve(project) against the registered
+// list, so tests must resolve these the same way — a hardcoded POSIX literal
+// like '/repo/a' never matches on Windows, where path.resolve normalizes it
+// to a drive-letter path.
+const REPO_A = path.resolve('/repo/a');
+const REPO_B = path.resolve('/repo/b');
+const REPO_UNKNOWN = path.resolve('/repo/unknown');
 
 type Handler = (args: Record<string, unknown>) => Promise<ToolResponse>;
 
@@ -111,7 +120,7 @@ describe('call_project_tool', () => {
     registerProjectsTools(server as never, ctxStub({ projectRelay: null }));
     const { handler } = findTool(captured, 'call_project_tool');
 
-    const response = await handler({ project: '/repo/a', tool: 'get_project_map', args: {} });
+    const response = await handler({ project: REPO_A, tool: 'get_project_map', args: {} });
     expect(response.isError).toBe(true);
     const body = parseText(response) as { error: { code: string } };
     expect(body.error.code).toBe('relay_unavailable');
@@ -119,7 +128,7 @@ describe('call_project_tool', () => {
 
   it('returns a structured unknown_project error listing what IS registered', async () => {
     const relay: ProjectRelay = {
-      listRelayTargets: () => ['/repo/a', '/repo/b'],
+      listRelayTargets: () => [REPO_A, REPO_B],
       openProject: vi.fn(async () => null),
       dispose: () => undefined,
     };
@@ -127,22 +136,22 @@ describe('call_project_tool', () => {
     registerProjectsTools(server as never, ctxStub({ projectRelay: relay }));
     const { handler } = findTool(captured, 'call_project_tool');
 
-    const response = await handler({ project: '/repo/unknown', tool: 'get_project_map', args: {} });
+    const response = await handler({ project: REPO_UNKNOWN, tool: 'get_project_map', args: {} });
     expect(response.isError).toBe(true);
     const body = parseText(response) as {
       error: { code: string; data: { reason: string; registered: string[]; requested: string } };
     };
     expect(body.error.code).toBe('unknown_project');
     expect(body.error.data.reason).toBe('unknown_project');
-    expect(body.error.data.registered).toEqual(['/repo/a', '/repo/b']);
-    expect(body.error.data.requested).toBe('/repo/unknown');
+    expect(body.error.data.registered).toEqual([REPO_A, REPO_B]);
+    expect(body.error.data.requested).toBe(REPO_UNKNOWN);
     // openProject must not even be attempted for a root that isn't registered.
     expect(relay.openProject).not.toHaveBeenCalled();
   });
 
   it('returns unknown_project when the project is registered but openProject() cannot open it', async () => {
     const relay: ProjectRelay = {
-      listRelayTargets: () => ['/repo/a'],
+      listRelayTargets: () => [REPO_A],
       openProject: vi.fn(async () => null),
       dispose: () => undefined,
     };
@@ -150,7 +159,7 @@ describe('call_project_tool', () => {
     registerProjectsTools(server as never, ctxStub({ projectRelay: relay }));
     const { handler } = findTool(captured, 'call_project_tool');
 
-    const response = await handler({ project: '/repo/a', tool: 'get_project_map', args: {} });
+    const response = await handler({ project: REPO_A, tool: 'get_project_map', args: {} });
     expect(response.isError).toBe(true);
     const body = parseText(response) as { error: { code: string; data: { reason: string } } };
     expect(body.error.code).toBe('unknown_project');
@@ -159,7 +168,7 @@ describe('call_project_tool', () => {
 
   it('returns a structured unknown_tool error for a tool name not registered on the target project', async () => {
     const relay: ProjectRelay = {
-      listRelayTargets: () => ['/repo/a'],
+      listRelayTargets: () => [REPO_A],
       openProject: vi.fn(async () => ({ toolHandlers: new Map() })),
       dispose: () => undefined,
     };
@@ -167,7 +176,7 @@ describe('call_project_tool', () => {
     registerProjectsTools(server as never, ctxStub({ projectRelay: relay }));
     const { handler } = findTool(captured, 'call_project_tool');
 
-    const response = await handler({ project: '/repo/a', tool: 'not_a_real_tool', args: {} });
+    const response = await handler({ project: REPO_A, tool: 'not_a_real_tool', args: {} });
     expect(response.isError).toBe(true);
     const body = parseText(response) as { error: { code: string; data: { tool: string } } };
     expect(body.error.code).toBe('unknown_tool');
@@ -181,7 +190,7 @@ describe('call_project_tool', () => {
       }),
     );
     const relay: ProjectRelay = {
-      listRelayTargets: () => ['/repo/a'],
+      listRelayTargets: () => [REPO_A],
       openProject: vi.fn(async () => ({ toolHandlers: new Map([['get_symbol', targetHandler]]) })),
       dispose: () => undefined,
     };
@@ -190,7 +199,7 @@ describe('call_project_tool', () => {
     const { handler } = findTool(captured, 'call_project_tool');
 
     const response = await handler({
-      project: '/repo/a',
+      project: REPO_A,
       tool: 'get_symbol',
       args: { fqn: 'Foo.bar' },
     });


### PR DESCRIPTION
## Summary
- Nightly `CI` workflow on `master` failed the `windows-latest` leg of `cross-platform-test` with 3 failures in `src/tools/register/__tests__/projects.test.ts` (run [32929680029](https://github.com/nikolai-vysotskyi/trace-mcp/actions/runs/32929680029)).
- Test-only bug introduced by #357 (TRA-143): `call_project_tool`'s handler compares `path.resolve(project)` against the mocked `registered` list, but the tests hardcoded POSIX literals like `/repo/a` on both sides. On Windows `path.resolve('/repo/a')` normalizes to a drive-letter path, so the comparison never matched. Not a production bug — real registered roots and `path.resolve(project)` both go through the same OS-native normalization in prod.
- Fix: compute `REPO_A`/`REPO_B`/`REPO_UNKNOWN` via `path.resolve(...)` once at module scope and reuse them on both sides of every affected assertion.

Closes TRA-151.

## Test plan
- [x] `pnpm run lint` (tsc --noEmit) — clean
- [x] `pnpm run build` — clean
- [x] `pnpm run test` — 776 files / 8559 tests passed, 2 files / 9 tests skipped