### PR TITLE
feat(config): add tools.default_detail_level global verbosity default (TRA-168)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -258,6 +258,14 @@ const ToolsConfigSchema = z
      *  - 'auto': encode both, ship compact when it beats JSON by ≥15% bytes; else fall back to JSON.
      *  Per-call override: pass `_format` in tool params to opt one call into a different mode. */
     default_format: z.enum(['json', 'compact', 'auto']).default('json'),
+    /** Global default for the `detail_level` param on tools that expose one
+     *  (search, get_outline, find_usages, get_feature_context, get_task_context, ...).
+     *  Unset (default): each tool keeps its own hardcoded default ('default' —
+     *  full fields). Set to 'minimal' to make every such call terse by default
+     *  project-wide, without touching per-call behavior for callers that pass
+     *  `detail_level` explicitly — an explicit per-call value always wins over
+     *  this config default. */
+    default_detail_level: z.enum(['minimal', 'default', 'full']).optional(),
   })
   .optional();
 

--- a/src/server/__tests__/detail-level-default.test.ts
+++ b/src/server/__tests__/detail-level-default.test.ts
@@ -1,0 +1,45 @@
+/**
+ * `tools.default_detail_level` config knob (TRA-168 / GH #334 item 3) —
+ * fills in `detail_level` from config only for tools that declare the param,
+ * and only when the caller didn't already pass one explicitly.
+ */
+import { describe, expect, it } from 'vitest';
+import type { TraceMcpConfig } from '../../config.js';
+import { applyDetailLevelDefault, type GatedCallbackContext } from '../tool-gate-helpers.js';
+
+function buildCtx(
+  supportsDetailLevel: boolean,
+  defaultDetailLevel: 'minimal' | 'default' | 'full' | undefined,
+): GatedCallbackContext {
+  return {
+    name: 'search',
+    config: { tools: { default_detail_level: defaultDetailLevel } } as TraceMcpConfig,
+    supportsDetailLevel,
+  } as unknown as GatedCallbackContext;
+}
+
+describe('applyDetailLevelDefault', () => {
+  it('leaves params untouched when no config default is set', () => {
+    const params: Record<string, unknown> = { query: 'foo' };
+    applyDetailLevelDefault(buildCtx(true, undefined), params);
+    expect(params.detail_level).toBeUndefined();
+  });
+
+  it('fills in the config default when the tool supports detail_level and the caller omitted it', () => {
+    const params: Record<string, unknown> = { query: 'foo' };
+    applyDetailLevelDefault(buildCtx(true, 'minimal'), params);
+    expect(params.detail_level).toBe('minimal');
+  });
+
+  it('never overrides an explicit per-call detail_level', () => {
+    const params: Record<string, unknown> = { query: 'foo', detail_level: 'full' };
+    applyDetailLevelDefault(buildCtx(true, 'minimal'), params);
+    expect(params.detail_level).toBe('full');
+  });
+
+  it('is a no-op for tools whose schema has no detail_level param', () => {
+    const params: Record<string, unknown> = { query: 'foo' };
+    applyDetailLevelDefault(buildCtx(false, 'minimal'), params);
+    expect(params.detail_level).toBeUndefined();
+  });
+});

--- a/src/server/tool-gate-helpers.ts
+++ b/src/server/tool-gate-helpers.ts
@@ -195,6 +195,8 @@ export interface GatedCallbackContext {
   recordToolCall?: (success: boolean) => void;
   onJournalEntry?: (data: JournalEntryCallbackData) => void;
   sessionId?: string;
+  /** True when this tool's registered schema declares a `detail_level` param. */
+  supportsDetailLevel?: boolean;
 }
 
 /** Emit a journal-broadcast entry for the most recent journal record. */
@@ -249,6 +251,23 @@ function resolveWireFormat(ctx: GatedCallbackContext, params: Record<string, unk
       : undefined;
   if (callFormat !== undefined) delete params._format;
   return callFormat ?? (ctx.config.tools?.default_format as WireFormat | undefined) ?? 'json';
+}
+
+/**
+ * Fill in `params.detail_level` from `config.tools.default_detail_level` when
+ * the tool's own schema declares a `detail_level` param and the caller didn't
+ * pass one. An explicit per-call value always wins — this only ever sets the
+ * field when it is `undefined`. No-op for tools without a `detail_level` param
+ * (`ctx.supportsDetailLevel` is only true when `installToolGate` found that
+ * key in the tool's registered schema).
+ */
+export function applyDetailLevelDefault(
+  ctx: GatedCallbackContext,
+  params: Record<string, unknown>,
+): void {
+  if (!ctx.supportsDetailLevel || params.detail_level !== undefined) return;
+  const configDefault = ctx.config.tools?.default_detail_level;
+  if (configDefault !== undefined) params.detail_level = configDefault;
 }
 
 /** Dedup fast-path: returns a response when a duplicate is served, else null. */
@@ -357,6 +376,7 @@ export function createGatedCallback(
     const params =
       cbArgs[0] && typeof cbArgs[0] === 'object' ? (cbArgs[0] as Record<string, unknown>) : {};
 
+    applyDetailLevelDefault(ctx, params);
     const effectiveFormat = resolveWireFormat(ctx, params);
 
     // Budget-driven auto-defaults: at warning/critical level, silently cap

--- a/src/server/tool-gate.ts
+++ b/src/server/tool-gate.ts
@@ -12,6 +12,7 @@ import {
   createGatedCallback,
   type GatedCallbackContext,
   injectAnnotations,
+  schemaIndexOf,
   type SchemaTransformConfig,
   stampAlwaysLoad,
 } from './tool-gate-helpers.js';
@@ -112,7 +113,16 @@ export function installToolGate(
       toolHandlers.set(name, async (params: Record<string, unknown>) => {
         return (await originalCb(params)) as ToolResponse;
       });
-      args[cbIdx] = createGatedCallback(gatedCallbackContext(name), originalCb);
+      const schema = args[schemaIndexOf(args)];
+      const supportsDetailLevel = !!(
+        schema &&
+        typeof schema === 'object' &&
+        'detail_level' in schema
+      );
+      args[cbIdx] = createGatedCallback(
+        { ...gatedCallbackContext(name), supportsDetailLevel },
+        originalCb,
+      );
     }
 
     // Inject ToolAnnotations before the callback so the MCP SDK registers


### PR DESCRIPTION
## Summary

Design pass for GH #334 items 2–3 / [TRA-168](mention://issue/01a04162-21fd-784d-8e6e-c890883afb0d) (follow-up to #353 / TRA-100).

- **Item 3 (global verbosity default):** adds `tools.default_detail_level` (`minimal` | `default` | `full`, unset by default) to the existing `tools` config section — right next to `default_format`, which already solved this exact "global default + per-call override" shape for wire format. `installToolGate` detects at registration time whether a tool's schema declares `detail_level`, and the gated callback fills the config default into `params.detail_level` only when the caller omitted it. **Precedence: an explicit per-call `detail_level` always wins.**
- **Item 2 (flip the hardcoded default for `search`/`get_outline`):** deliberately *not* done here. No internal caller invokes `search`/`get_outline` in-process expecting the current full-detail default (checked — the only "internal" references are suggestion strings in `get_minimal_context`, which already recommend `detail_level: 'minimal'` explicitly), so a global flip wouldn't break anything internal. But it's still a behavior change for every external caller who doesn't pass `detail_level`, and the issue asked for that to be backed by a measured, representative-query token-savings number rather than the borrowed 40–60% CRG figure already in the tool descriptions. Item 3 gets the practical outcome GH #334 actually wants (agents/projects that want terse-by-default can now flip one config key) without forcing that risk on everyone. Recommend closing item 2 as "subsumed by item 3" rather than pursuing the hard default flip.

## Changes

- `src/config.ts`: `tools.default_detail_level` schema field.
- `src/server/tool-gate.ts`: detect `detail_level` in a tool's schema at registration time, thread `supportsDetailLevel` into the gated callback context.
- `src/server/tool-gate-helpers.ts`: `applyDetailLevelDefault` — fills `params.detail_level` from config only when supported and omitted.
- `src/server/__tests__/detail-level-default.test.ts`: covers no-config no-op, config-fills-empty, explicit-always-wins, unsupported-tool no-op.

## Test plan

- [x] `pnpm run build`
- [x] `pnpm run lint` (tsc --noEmit)
- [x] `pnpm run test` — 777 files / 8566 tests passed, 0 failed
- [x] New `detail-level-default.test.ts` passes (4/4)