### PR TITLE
ci: auto-approve release-please PR workflow runs (TRA-171)

### DIFF
--- a/.github/workflows/approve-release-pr-runs.yml
+++ b/.github/workflows/approve-release-pr-runs.yml
@@ -1,0 +1,41 @@
+name: Approve release-please PR runs
+
+# release-please (see release.yml) opens/rebases its release PR by pushing
+# with secrets.GITHUB_TOKEN. GitHub doesn't recognize that bot push as a
+# repo collaborator for pull_request-triggered runs, so CI/CodeQL/Semgrep/
+# Eval land in "action_required" on every rebase — even though the PR is
+# same-repo, not a fork (see TRA-171). pull_request_target runs are exempt
+# from that approval gate regardless of actor, so use one here purely to
+# call the approve-run API; it never checks out or executes PR code.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: write
+
+jobs:
+  approve:
+    if: >-
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve any action_required runs for this PR's head SHA
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          approved_any=false
+          for attempt in $(seq 1 6); do
+            run_ids=$(gh api "repos/${REPO}/actions/runs?head_sha=${HEAD_SHA}&status=action_required" --jq '.workflow_runs[].id')
+            for id in $run_ids; do
+              echo "Approving run $id"
+              gh api -X POST "repos/${REPO}/actions/runs/${id}/approve" && approved_any=true
+            done
+            if [ "$approved_any" = true ]; then
+              break
+            fi
+            sleep 15
+          done


### PR DESCRIPTION
## Summary
- The standing release-please PR keeps landing in `action_required` for CI/CodeQL/Semgrep/Eval on every rebase (2026-08-26 06:08, 18:49, 04:15), even though it's a same-repo PR (not a fork). GitHub doesn't recognize a GITHUB_TOKEN-authored bot push as a repo collaborator for `pull_request`-triggered runs, so those runs sit stuck until someone manually approves them via the API/UI — this has silently delayed releases by up to ~24h (see TRA-142/#355).
- Adds `.github/workflows/approve-release-pr-runs.yml`, a `pull_request_target`-triggered workflow scoped to `github-actions[bot]`-authored PRs on `release-please--*` branches only. `pull_request_target` runs are exempt from the approval gate regardless of actor, and this workflow never checks out or executes any PR code — it only calls the workflow-run approve API for `action_required` runs matching the PR's head SHA, with a short retry loop since those runs may not be queued yet at trigger time.
- Left the repo's fork-PR-approval policy untouched (didn't relax it globally) since this repo does take real external contributions from forks and that protection should stay in place.

## Test plan
- [x] Reviewed `head_sha`/`action_required` filtering logic against the GitHub Actions REST API docs for listing and approving workflow runs.
- [ ] Watch the next release-please rebase (or trigger one) and confirm CI/CodeQL/Semgrep/Eval go green without manual `gh api .../approve` intervention.