### PR TITLE
docs: fix duplicate H1, untargeted titles, unscoped tables (TRA-173)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,5 @@
+title: trace-mcp
+description: A structured map of your codebase for AI agents. trace-mcp indexes your repo once so agents stop re-reading the same files every turn — ~40–50% fewer tokens on average, faster responses, more reliable at scale. Open source, local-first, MCP-native.
+url: https://trace-mcp.com
+lang: en
+markdown: kramdown

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: 'en-US' }}">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {% seo %}
+
+    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+    <style>
+      .site-brand { font-weight: 600; font-size: 1.25em; margin-bottom: 1.5em; }
+      .site-brand a { text-decoration: none; }
+      .docs-nav { color: #57606a; font-size: 0.9em; }
+    </style>
+  </head>
+  <body>
+    <div class="container-lg px-3 my-5 markdown-body">
+      <p class="site-brand"><a href="{{ '/' | relative_url }}">trace-mcp</a></p>
+
+      {{ content }}
+
+      <hr>
+      <p class="docs-nav">
+        See also:
+        <a href="{{ '/tools-reference.html' | relative_url }}">Tools reference</a> ·
+        <a href="{{ '/architecture.html' | relative_url }}">Architecture</a> ·
+        <a href="{{ '/configuration.html' | relative_url }}">Configuration</a> ·
+        <a href="{{ '/' | relative_url }}">Home</a>
+      </p>
+    </div>
+
+    <script>
+      // ponytail: GH Pages default theme renders GFM tables with no header scope;
+      // kramdown has no scope option and custom converters aren't allowed on Pages,
+      // so patch it client-side instead of hand-editing every <th>.
+      document.querySelectorAll('table').forEach(function (table) {
+        table.querySelectorAll('thead th').forEach(function (th) {
+          th.setAttribute('scope', 'col');
+        });
+        table.querySelectorAll('tbody tr').forEach(function (row) {
+          var firstCell = row.querySelector('td, th');
+          if (firstCell && firstCell.tagName === 'TH') {
+            firstCell.setAttribute('scope', 'row');
+          }
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,3 +1,8 @@
+---
+title: "Session Analytics & Coverage Intelligence — token savings, wasteful patterns"
+description: "trace-mcp's built-in analytics engine parses AI agent session logs, tracks token savings, detects wasteful patterns, and assesses technology coverage."
+---
+
 # Session Analytics & Coverage Intelligence
 
 trace-mcp includes a built-in analytics engine that parses AI agent session logs, tracks token savings, detects wasteful patterns, and assesses technology coverage.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,8 @@
+---
+title: "trace-mcp Architecture — indexing pipeline, storage, and MCP server internals"
+description: "How trace-mcp indexes a codebase into a queryable graph: tree-sitter parsing, SQLite + FTS5 storage, optional LSP enrichment, and the MCP server that serves it all."
+---
+
 # Architecture
 
 ## Indexing pipeline

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -1,3 +1,8 @@
+---
+title: "Code Graph MCP Server Comparison: trace-mcp vs Repomix, Serena & 20+ alternatives"
+description: "Compare trace-mcp against Repomix, Serena, Kage, codebase-memory-mcp and 20+ MCP code-graph tools — capabilities, language support, GitHub stars. Last verified August 2026."
+---
+
 # How trace-mcp compares
 
 trace-mcp is not just a code intelligence server — it combines **code graph navigation**, **cross-session memory**, and **real-time code understanding** in a single tool. Other projects solve one of these; trace-mcp unifies all three.
@@ -138,3 +143,10 @@ Which entries above got a real read of their architecture/code and a concrete ta
 Priority for next deep-dive: **codebase-memory-mcp** (largest peer by stars — 40.7K — with a published benchmark preprint we haven't independently verified) and **codegraph** (68.2K stars, unverified self-reported benchmark claims) are the two highest-value surface-level entries left to profile properly.
 
 **Bottom line:** trace-mcp's moat — framework-aware graph + refactoring + code-linked memory in one local MCP — is intact and unmatched as a *combination*. Six of seven gaps identified in the June 2026 re-verification are now shipped; the adversarial validation pass that followed found and fixed 15+ real bugs (several of them "the feature silently didn't work at all," not cosmetic) rather than taking the initial implementation on faith. The one deliberately-open gap (a peer-reviewed validated health metric) is honestly labeled as such rather than oversold.
+
+## Next steps
+
+- See the full [tools reference](/tools-reference.html) for every MCP tool trace-mcp exposes, grouped by framework.
+- Read the [architecture](/architecture.html) page for how the indexing pipeline, storage, and LSP enrichment fit together.
+- Check [supported frameworks & languages](/supported-frameworks.html) to confirm your stack is covered.
+- [Get started](/#install) — trace-mcp works out of the box, no configuration required.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,3 +1,8 @@
+---
+title: "trace-mcp Configuration Reference — all config options (works with none)"
+description: "Every trace-mcp config option in .trace-mcp.json — indexing, quality gates, LSP enrichment, TOON output, telemetry. Configuration is optional; trace-mcp works out of the box for standard projects."
+---
+
 # Configuration
 
 Configuration is optional — trace-mcp works out of the box for standard projects.

--- a/docs/decision-memory.md
+++ b/docs/decision-memory.md
@@ -1,3 +1,8 @@
+---
+title: "Decision Memory — a persistent knowledge graph for architectural decisions"
+description: "trace-mcp's decision knowledge graph captures architectural decisions, tech choices, bug root causes, preferences, and conventions — linked to the code they're about."
+---
+
 # Decision memory
 
 trace-mcp includes a persistent decision knowledge graph that captures architectural decisions, tech choices, bug root causes, preferences, and conventions — linked to the code they're about.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,8 @@
+---
+title: "Contributing to trace-mcp — local setup, build, and test"
+description: "How to set up trace-mcp for local development: install, build, run the test suite, and the conventions to follow before opening a PR."
+---
+
 # Development
 
 ## Setup

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,3 +1,8 @@
+---
+title: "Quality Gates Reference — complexity, security, and coverage thresholds"
+description: "How trace-mcp's quality_gates.rules in .trace-mcp.json override CLI defaults for cyclomatic complexity, security findings, and coverage — with this project's own thresholds as a worked example."
+---
+
 # Quality gates — this project's thresholds
 
 `.trace-mcp.json`'s `quality_gates.rules` overrides the CLI's generic defaults

--- a/docs/supported-frameworks.md
+++ b/docs/supported-frameworks.md
@@ -1,3 +1,8 @@
+---
+title: "Supported Languages & Frameworks — 68 languages, 58 framework integrations"
+description: "Full list of languages and frameworks trace-mcp understands out of the box — web frameworks, ORMs, UI libraries, and tooling, across 68 languages."
+---
+
 # Supported frameworks & languages
 
 ## Languages (68)

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,3 +1,8 @@
+---
+title: "Telemetry & Observability — OpenTelemetry spans for every MCP tool call"
+description: "trace-mcp's pluggable observability bridge emits OpenTelemetry-compatible spans for every AI provider call and every MCP tool call."
+---
+
 # Telemetry & Observability
 
 trace-mcp ships a pluggable observability bridge (P13) that emits

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -1,3 +1,8 @@
+---
+title: "trace-mcp MCP Tools Reference — every code-intelligence tool, by framework"
+description: "Full reference for trace-mcp's 44+ MCP tools and 2 resources — navigation, refactoring, impact analysis, security, and framework-aware queries. Tools register dynamically based on what your repo uses."
+---
+
 # Tools reference
 
 trace-mcp exposes 44+ MCP tools and 2 resources.

--- a/docs/toon-savings.md
+++ b/docs/toon-savings.md
@@ -1,3 +1,8 @@
+---
+title: "TOON Output Format — Measured Token Savings on Real Tool Calls"
+description: "Real-world token measurements for trace-mcp's TOON (Token-Oriented Object Notation) output format across tabular MCP tool responses."
+---
+
 # TOON Token Savings — Measured
 
 This document captures real-world token measurements for the TOON output

--- a/docs/tweakcc.md
+++ b/docs/tweakcc.md
@@ -1,3 +1,8 @@
+---
+title: "System Prompt Routing via tweakcc — pairing trace-mcp with Claude Code"
+description: "How to pair trace-mcp with tweakcc to patch Claude Code's system prompts and route tool selection toward trace-mcp instead of native file reads."
+---
+
 # System Prompt Routing via tweakcc
 
 > **Requires:** [tweakcc](https://github.com/Piebald-AI/tweakcc) — a tool that patches Claude Code's system prompts directly.


### PR DESCRIPTION
## Summary

All 12 docs pages on trace-mcp.com are rendered by GitHub Pages' default Jekyll (`jekyll-theme-primer`, no custom `_config.yml` existed before this PR). That default theme is the root cause of every defect flagged in TRA-173:

- The theme's bundled `default.html` layout injects the site logo as a second `<h1>` before every page's own `# heading`.
- With no front matter, `jekyll-titles-from-headings` derives `<title>` straight from that raw heading — no query-targeting.
- Plain GFM tables get no `scope` on `<th>` (145 across the docs set, per the issue).
- `comparisons.md` (53KB of content) had only 3 outbound `<a href>` tags total.

## Changes

- **`docs/_config.yml` + `docs/_layouts/default.html`** — overrides the theme's default layout (site `_layouts/` always wins over a theme gem's layout of the same name): drops the duplicate logo `<h1>`, adds a shared "see also" footer with internal links to Tools reference / Architecture / Configuration / Home, and patches `<th>` scope client-side. GitHub Pages doesn't allow custom Jekyll plugins, so a small script in the shared layout is the smallest fix that reaches all 145 `<th>` at once — a server-rendered kramdown option doesn't exist for this.
- **Front matter (`title` + `description`) on all 12 sitemap-listed docs pages** — `comparisons.md`, `tools-reference.md`, and `configuration.md` use the exact titles/descriptions proposed in the issue; the remaining 9 follow the same `<topic> — <what it gives you>` pattern. `jekyll-seo-tag` picks these up automatically and still appends `| trace-mcp`.
- **`comparisons.md`** — added a "Next steps" block linking to tools-reference, architecture, supported-frameworks, and install, so the page's link equity actually reaches the rest of the docs set.
- Verified the homepage (`index.html`, hand-crafted, bypasses Jekyll) already has exactly one `<h1>` — no change needed there (issue item 5).

## Test plan

- [x] All 12 front matter blocks parse as valid YAML (`ruby -ryaml`, no syntax errors).
- [x] `_config.yml` parses as valid YAML.
- [x] Liquid tags in the new layout are balanced (`{% seo %}`).
- [ ] No local Jekyll/Ruby toolchain available in the agent environment to run a full `jekyll build` — recommend a quick visual check of the deployed pages after merge (GitHub Pages rebuilds automatically): confirm single `<h1>`, correct `<title>`, `scope` attributes present on table headers, and the new footer links render.