### PR TITLE
fix(daemon): periodic npm registry check for long-lived daemons

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2913,6 +2913,33 @@ program
       }
     }
 
+    // ── Registry auto-update watchdog (TRA-180) ──────────────────
+    // checkAndInstallUpdate only runs once, at process startup. A daemon kept
+    // alive for weeks by launchd/tray or a long-lived stdio client that never
+    // reconnects therefore never re-hits the npm registry, so it can silently
+    // sit on a stale version indefinitely (unlike the local-staleness check
+    // above, which only catches upgrades installed by some *other* process).
+    // Poll on the same cadence as the configured check interval — the cache
+    // inside checkAndInstallUpdate makes this a cheap no-op between real
+    // registry checks.
+    if (PKG_VERSION !== '0.0.0-dev' && globalRaw.auto_update !== false) {
+      const intervalHours =
+        typeof globalRaw.auto_update_check_interval_hours === 'number'
+          ? globalRaw.auto_update_check_interval_hours
+          : 12;
+      const updateWatchdog = setInterval(() => {
+        void checkAndInstallUpdate({ checkIntervalHours: intervalHours }).then((updated) => {
+          if (updated) {
+            logger.info(
+              'Auto-update: new version installed — shutting down so supervisor respawns',
+            );
+            void shutdown('auto-update');
+          }
+        });
+      }, intervalHours * 3_600_000);
+      updateWatchdog.unref();
+    }
+
     httpServer.listen(port, host, () => {
       const projectCount = projectManager.listProjects().length;
       logger.info(


### PR DESCRIPTION
## Summary
- `checkAndInstallUpdate()` (the existing auto-update mechanism — rate-limited registry check, ENOTEMPTY-safe reinstall, failure backoff) only ran once, at process startup (`serve` / `serve-http`).
- A daemon kept alive for weeks (launchd `KeepAlive`, tray watchdog, or an MCP client that keeps the same stdio session open) never spawns a fresh `serve` process, so it never re-hits the npm registry and can sit on a stale version indefinitely — this is how TRA-180 was discovered (two long-running global installs stuck on 1.47.1 while 1.48.1, containing the TRA-158/169 prompt-cache fix, was already published).
- The existing 10-minute "self-staleness" timer next to this change only detects upgrades some *other* process already wrote to the local `package.json` — it doesn't itself call the registry, so it doesn't help here.

## Fix
Add a periodic watchdog inside `serve-http`'s daemon startup, on the same cadence as the already-configurable `auto_update_check_interval_hours`. It calls the same `checkAndInstallUpdate()` used at startup — its internal cache makes repeated ticks a cheap no-op between real checks — and on a successful install, shuts the daemon down so the existing supervisor respawn path picks up the fresh binary, exactly like the local-staleness path already does.

No new config surface, no new command: reuses `auto_update` / `auto_update_check_interval_hours` from `~/.trace-mcp/.config.json`, and respects the existing `TRACE_MCP_NO_AUTO_UPDATE=1` opt-out and dev-checkout skip inside `checkAndInstallUpdate` itself.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run biome:ci` / `pnpm run format`
- [x] `pnpm run test --run tests/cli tests/daemon` — 46 files / 353 tests pass
- [x] `pnpm run test --run updater` — 17 tests pass (unmodified, confirms no regression to the reused function)

Closes TRA-180