### PR TITLE
fix(registry): reject /private/tmp as a project root (TRA-185)

### DIFF
--- a/src/project-setup.ts
+++ b/src/project-setup.ts
@@ -62,6 +62,9 @@ export function isDangerousProjectRoot(absRoot: string): string | null {
     '/Library',
     '/private',
     '/tmp',
+    // macOS resolves the /tmp symlink to /private/tmp; some MCP clients hand
+    // trace-mcp the already-resolved cwd, which bypassed the '/tmp' check above.
+    '/private/tmp',
     '/var',
     '/etc',
     '/bin',

--- a/tests/project-setup/dangerous-root.test.ts
+++ b/tests/project-setup/dangerous-root.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+import { isDangerousProjectRoot } from '../../src/project-setup.js';
+
+/**
+ * TRA-185: '/private/tmp' — the real directory /tmp symlinks to on macOS —
+ * was registered as a persistent trace-mcp project because isDangerousProjectRoot
+ * only rejected the literal string '/tmp', not its resolved form. Some MCP
+ * clients hand trace-mcp an already-resolved cwd, bypassing that check.
+ */
+describe('isDangerousProjectRoot', () => {
+  test('rejects /tmp', () => {
+    expect(isDangerousProjectRoot('/tmp')).toBe('system directory');
+  });
+
+  test('rejects /private/tmp (resolved form of /tmp on macOS)', () => {
+    expect(isDangerousProjectRoot('/private/tmp')).toBe('system directory');
+  });
+
+  test('does not reject a real project nested under /tmp', () => {
+    expect(isDangerousProjectRoot('/tmp/some-checkout')).toBeNull();
+  });
+
+  test('does not reject a real project nested under /private/tmp', () => {
+    expect(isDangerousProjectRoot('/private/tmp/some-checkout')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- `isDangerousProjectRoot` rejected the literal string `/tmp` but not its macOS-resolved form `/private/tmp`. Some MCP clients hand trace-mcp an already-resolved cwd, so that resolved path slipped through and got auto-registered as a persistent project (seen in the wild as a registry entry named `tmp` rooted at `/private/tmp` — zero code-intelligence value, permanent registry slot).
- Fix: add `/private/tmp` as a literal entry in the `SYSTEM_DIRS` set alongside `/tmp` and `/private`. Subdirectories under `/tmp`/`/private/tmp` are untouched (those are legitimate — e.g. real per-run checkouts and this repo's own test fixtures, which mkdtemp under `os.tmpdir()` and register real projects there).
- The daemon already sweeps and evicts dangerous-root entries from the registry on startup (`project-manager.ts`), so this also self-heals any existing bad `/private/tmp` entry once the daemon restarts — no separate migration needed.

Note: TRA-185 also asked for (2) a prune/TTL safety net and (3) dedup on overlapping registrations. Both already exist and are wired in: `findEphemeralProjects`/`pruneStaleProjects`/`doctor --fix` prune stale and one-shot Multica workdir entries, and `findOverlapForNewRoot` is checked at every registration path via `setupProject` (TRA-95, warns on overlap). This PR only closes the remaining gap: prevention for the exact `/private/tmp` shape.

## Test plan
- [x] Added `tests/project-setup/dangerous-root.test.ts` — rejects `/tmp` and `/private/tmp`, allows real projects nested under them
- [x] `pnpm run build`
- [x] `pnpm run lint` (tsc --noEmit)
- [x] `pnpm run test` — full suite, 778 files / 8584 tests passing