### PR TITLE
fix: deep-glob fallback masked by unrelated global include pattern (TRA-184)

### DIFF
--- a/src/indexer/__tests__/file-collector-nested-root.test.ts
+++ b/src/indexer/__tests__/file-collector-nested-root.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression coverage for TRA-184 — a fresh project whose real code lives one
+ * level deeper than the registered root (e.g. a repo checked out into a
+ * subdirectory) got stuck indexing only a handful of files. collectFiles
+ * gated its "rooted patterns matched nothing, retry with a deep prefix"
+ * fallback on entries.length === 0 across ALL include patterns combined —
+ * but a global pattern like "any markdown file" can match a stray top-level
+ * file and make entries non-empty even though every directory-rooted
+ * pattern (src, lib, ...) found nothing at the project root. That masked
+ * the fallback and silently under-indexed the project.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TraceMcpConfigSchema } from '../../config.js';
+import { collectFiles } from '../file-collector.js';
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'file-collector-nested-root-'));
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('collectFiles — nested project root (TRA-184)', () => {
+  it('falls back to a deep glob when a top-level README masks rooted patterns matching nothing', async () => {
+    // A stray top-level markdown file matches the global `**/*.md` include
+    // pattern immediately, while the real source lives nested under a
+    // checked-out subdirectory the rooted `src/**` pattern never reaches.
+    writeFileSync(join(workDir, 'README.md'), '# hello\n');
+    const nestedSrc = join(workDir, 'checkout', 'src');
+    mkdirSync(nestedSrc, { recursive: true });
+    writeFileSync(join(nestedSrc, 'index.ts'), 'export const x = 1;\n');
+
+    const config = TraceMcpConfigSchema.parse({
+      include: ['src/**/*.ts', '**/*.md'],
+      exclude: [],
+    });
+
+    const entries = await collectFiles({
+      config,
+      rootPath: workDir,
+      workspaces: [],
+      traceignore: undefined,
+      maxFiles: 10_000,
+    });
+
+    expect(entries).toEqual(expect.arrayContaining(['README.md', 'checkout/src/index.ts']));
+  });
+});

--- a/src/indexer/file-collector.ts
+++ b/src/indexer/file-collector.ts
@@ -1,4 +1,5 @@
 import fg from 'fast-glob';
+import picomatch from 'picomatch';
 import type { TraceMcpConfig } from '../config.js';
 import { logger } from '../logger.js';
 import { descendantExcludeGlobs } from '../registry.js';
@@ -52,42 +53,47 @@ export async function collectFiles(params: FileCollectorParams): Promise<string[
     followSymbolicLinks: config.follow_symlinks,
   });
 
+  const rootedPatterns = config.include.filter((p) => !p.startsWith('**/'));
+
   // Monorepo / folder-of-projects: the directory-rooted include globs
   // (src/**, app/**, routes/**, ...) only match at the container root, so
   // nested subprojects are missed (e.g. `the/15carats/15carats-laravel/routes`).
   // When workspaces are detected, also discover files with those patterns
   // anchored to each workspace. Global `**/...` patterns already span the whole
-  // tree, so only re-anchor the directory-rooted ones. This is deterministic
-  // and complete — unlike the entries===0 deep-glob fallback below, which never
-  // fires when a root-level file (a stray README, a `**/*.md`) matched first.
-  if (workspaces.length > 0) {
-    const rooted = config.include.filter((p) => !p.startsWith('**/'));
-    if (rooted.length > 0) {
-      const wsPatterns = workspaces.flatMap((ws) => rooted.map((p) => `${ws.path}/${p}`));
-      const wsEntries = await fg(wsPatterns, {
-        cwd: rootPath,
-        ignore,
-        dot: false,
-        absolute: false,
-        onlyFiles: true,
-        suppressErrors: true,
-        followSymbolicLinks: config.follow_symlinks,
-      });
-      if (wsEntries.length > 0) {
-        const merged = new Set(entries);
-        for (const e of wsEntries) merged.add(e);
-        entries = [...merged];
-      }
+  // tree, so only re-anchor the directory-rooted ones.
+  if (workspaces.length > 0 && rootedPatterns.length > 0) {
+    const wsPatterns = workspaces.flatMap((ws) => rootedPatterns.map((p) => `${ws.path}/${p}`));
+    const wsEntries = await fg(wsPatterns, {
+      cwd: rootPath,
+      ignore,
+      dot: false,
+      absolute: false,
+      onlyFiles: true,
+      suppressErrors: true,
+      followSymbolicLinks: config.follow_symlinks,
+    });
+    if (wsEntries.length > 0) {
+      const merged = new Set(entries);
+      for (const e of wsEntries) merged.add(e);
+      entries = [...merged];
     }
   }
 
-  // Workspace/monorepo fallback: if nothing matched, all code is nested deeper
-  // (e.g. root/project/service/src/**). Re-try with **/<pattern> prefixed globs.
-  if (entries.length === 0) {
-    const deepPatterns = config.include.filter((p) => !p.startsWith('**/')).map((p) => `**/${p}`);
-
-    if (deepPatterns.length > 0) {
-      entries = await fg(deepPatterns, {
+  // Workspace/monorepo fallback: the rooted patterns found nothing at the
+  // project root, so all code is nested deeper (e.g. root/project/service/src/**,
+  // or a repo checked out into a subdirectory of the registered project root).
+  // Re-try those patterns with a `**/` prefix. Gated on the ROOTED patterns
+  // having zero matches specifically — not on `entries.length === 0` overall,
+  // which an unrelated GLOBAL pattern (e.g. `**/*.md` catching a stray
+  // top-level README) can make non-zero even while every rooted pattern
+  // missed completely, silently skipping this fallback and leaving the index
+  // stuck at whatever the global patterns happened to touch.
+  if (rootedPatterns.length > 0) {
+    const isRootedMatch = picomatch(rootedPatterns, { dot: true });
+    const rootedMatched = entries.some((e) => isRootedMatch(e));
+    if (!rootedMatched) {
+      const deepPatterns = rootedPatterns.map((p) => `**/${p}`);
+      const deepEntries = await fg(deepPatterns, {
         cwd: rootPath,
         ignore,
         dot: false,
@@ -96,11 +102,14 @@ export async function collectFiles(params: FileCollectorParams): Promise<string[
         suppressErrors: true,
         followSymbolicLinks: config.follow_symlinks,
       });
-      if (entries.length > 0) {
+      if (deepEntries.length > 0) {
         logger.info(
-          { count: entries.length, root: rootPath },
-          'Workspace root detected — using deep glob patterns',
+          { count: deepEntries.length, root: rootPath },
+          'Rooted include patterns found nothing at project root — using deep glob patterns',
         );
+        const merged = new Set(entries);
+        for (const e of deepEntries) merged.add(e);
+        entries = [...merged];
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes a bug where a freshly-registered project's index silently stops at a tiny fraction of the real codebase — see TRA-184.

`collectFiles()` in `src/indexer/file-collector.ts` only retried directory-rooted include patterns (`src/**`, `lib/**`, `app/**`, ...) with a `**/` prefix (the "code lives nested deeper than the project root" fallback) when the *combined* `entries` list across ALL include patterns was completely empty.

The problem: a global pattern like `**/*.{md,mdx,markdown}` matching a single stray top-level file (e.g. a README) makes `entries.length` non-zero even though every rooted pattern found nothing — so the fallback never fires, and the index is left with only whatever the global patterns happened to touch (docs, config files, etc.) while the actual source tree is never discovered.

This exactly matches the repro in TRA-184: a project root one level above a checked-out repo (`workdir/trace-mcp/src/**` vs registered root `workdir/`) indexed 67/1618 `.ts` files and reported `phase: "completed"`, staying stuck until someone manually ran `reindex(force: true)`.

## Fix

Gate the deep-glob fallback on whether the rooted patterns *specifically* matched anything (checked via `picomatch` against the collected entries), not on the combined total. When triggered, merge the deep-glob results into `entries` instead of discarding whatever the global patterns already found.

## Test plan
- [x] New regression test `src/indexer/__tests__/file-collector-nested-root.test.ts` reproduces the exact shape (top-level README + nested `checkout/src/index.ts`), fails on the pre-fix code, passes after the fix
- [x] `pnpm exec vitest run src/indexer/__tests__` — all indexer tests pass
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run build` — clean
- [x] `pnpm run test` (full suite) — 778 files / 8581 tests passed, 2/9 skipped (pre-existing), no regressions