### PR TITLE
docs: refresh product roadmap (TRA-188)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,56 +1,64 @@
 # Product Roadmap
 
-Strategic view of trace-mcp, revisited roughly every two weeks by the Product
-Roadmap & Vision autopilot. This file tracks *why* something should move the
+Strategic view of trace-mcp, revisited roughly weekly by the Product Roadmap
+& Vision autopilot, which also turns 2-4 of the items below into that week's
+operational focus (see the "This Week's Focus" section of the trace-mcp
+Operations project). This file tracks *why* something should move the
 product forward — not day-to-day bugs, tool tweaks, or indexing hygiene
 (those live as regular issues, tracked by other autopilots). An item is
 removed here once it ships, is superseded, or turns out not to matter.
 
 ## Where the product stands
 
-trace-mcp already covers the code-intelligence table stakes and then some —
-per `docs/comparisons.md`'s own honest self-assessment, six of seven gaps
-identified against the field in the last competitive pass have shipped and
-been adversarially re-validated. The two genuinely open technical gaps
-(a peer-reviewed bug-risk metric; CFG/taint staying line-based/lexical
+Both items that were "ready to start" in the last revision have shipped:
+**CI-native PR intelligence** (TRA-127, `.github/workflows/pr-comment.yml` —
+blast radius + quality gate comments on this repo's own PRs) and the
+**multi-project tool surface** (TRA-93/TRA-143, PR #357 — `list_projects` +
+`call_project_tool` relay, shipped as "Option B" rather than a per-tool
+`project` param retrofit). Per `docs/comparisons.md`'s own honest
+self-assessment, six of seven competitive gaps from the last deep pass are
+also shipped and adversarially re-validated. The two remaining technical
+gaps (a peer-reviewed bug-risk metric; CFG/taint staying line-based/lexical
 instead of full AST/dataflow) are known architectural ceilings, not
 low-hanging fruit — leave them tracked in `comparisons.md`, not here.
 
-The real question at this point isn't "which tool is missing" — it's
-**who trace-mcp serves and how far the current single-developer, single-repo
-model can stretch before it needs to change shape.**
+That clears the board of concrete, already-scoped work — which is exactly
+when it's worth checking a premise `comparisons.md` has been asserting as a
+strength: **170 MCP tools** is listed as a differentiator against Serena
+(~55), code-review-graph (~28), SocratiCode (~21) in every comparison table.
+Nikolai's own measurement (TRA-186) says the same number is a **~52-53k
+token tax paid at every session start** on any MCP client without deferred/
+lazy tool loading — 91% of the total tool-schema weight in a real session.
+Tool *count* as a marketing number and tool *count* as a token-start-cost
+liability are the same fact read two different ways; the fix is not "add
+more tools" or "remove tools" but making the number stop being something a
+client pays for before it's used — see item 1 below.
+
+The other standing question is unchanged: **who trace-mcp serves and how
+far the current single-developer, single-repo model can stretch before it
+needs to change shape.**
 
 ## Ready to start
 
-### 1. CI-native PR intelligence (new)
-trace-mcp's value today is only visible to whoever has the MCP client wired
-up. Every other collaborator on a PR — reviewers, teammates without the
-client configured, bots — sees nothing. `scan_security` /
-`detect_antipatterns` / `check_quality_gates` already emit SARIF, and
-`get_change_impact` / `compare_branches` already compute blast radius — but
-there's no packaged way to run these automatically on a PR and surface the
-result where people actually look (the PR itself). A thin CI wrapper
-(GitHub Action or npx script) that posts a "blast radius + quality gate"
-comment on PRs would make the tool's value visible to people who never
-touch the CLI, at low engineering cost since the underlying analysis
-already exists — it's a packaging problem, not a research problem.
+### 1. Cut the session-start tool-schema tax (TRA-186)
+Already filed with measurements attached (171 tools / ~203k chars / ~50.7k
+tokens of schemas+descriptions, before a single tool is called) and
+assigned out for an audit-and-trim pass: heaviest offenders
+(`search` ~1233 tok, `query_decisions` ~1098 tok, `plan_refactoring` ~589
+tok) get description trims, redundant/overlapping tools get flagged for
+consolidation, and MCP's lazy-registration/pagination options get evaluated
+for shrinking the always-paid baseline.
 
-**Why now:** cheap relative to payoff, and it's free dogfooding — every PR
-against trace-mcp itself becomes a live demo.
-
-### 2. Multi-project tool surface (GH #199 / TRA-93)
-Already scoped as `TRA-93` (currently `backlog`): let a single MCP session
-reach multiple registered projects via a per-call `project` argument instead
-of binding the whole session to one repo. This is the most concrete,
-already-designed-enough adoption blocker on the board — anyone with more
-than one small repo or a pseudo-monorepo hits it immediately. Promoting
-this out of backlog is the actionable step this run takes; the design pass
-itself (session vs. per-call scoping, interaction with the existing
-federation/subproject tools) still needs to happen before implementation.
+**Why now:** this is a direct product-credibility problem, not a nice-to-have
+— trace-mcp's whole pitch is cutting agent token usage, and paying 50k+
+tokens just to *see* the tool list undercuts that pitch on exactly the
+clients (Claude Desktop, other non-lazy-loading agents, local models) least
+able to absorb it. It's also cheap relative to payoff: this is schema/
+description editing and tool consolidation, not new architecture.
 
 ## Big bet — needs a design pass before any code
 
-### 3. Team-shared graph
+### 2. Team-shared graph — parked, needs Nikolai's go-ahead (TRA-128)
 trace-mcp's whole pitch is "reuse instead of recompute" — but today reuse
 only happens *within one developer's laptop, across turns*. A team of five
 engineers on the same repo each index it separately, each mine their own
@@ -58,22 +66,24 @@ decisions separately, and never see each other's "why was this built this
 way" answers. That's the same recomputation leak the product exists to
 close, just at the team level instead of the turn level.
 
-A lightweight shared-graph mode — a daemon reachable by a team instead of
-localhost-only, with a shared decision store — would turn trace-mcp from a
-personal productivity tool into a team artifact: onboarding a new engineer
-means pointing them at the team's graph, not re-indexing and re-learning
-from scratch. This is a genuine category jump (and the kind of thing that
-could eventually justify a hosted/paid tier), not an incremental feature —
-so it needs a scoping/design issue first: security model for a
-network-reachable daemon, conflict resolution when the graph or decision
-store gets concurrent writes, and whether "shared" means a synced copy or
-one authoritative server. Don't start writing code until that design
-exists.
+The design pass (TRA-128) is done: a lightweight shared-graph mode — a
+daemon reachable by a team instead of localhost-only, with a shared decision
+store — would turn trace-mcp from a personal productivity tool into a team
+artifact, and is the kind of capability that could eventually justify a
+hosted/paid tier. But the design's own recommended smallest slice is a
+network-reachable server component, which falls squarely in the one
+category this project's rules reserve for Nikolai's explicit call (no
+hosted backend / paid infra on an autopilot's own authority). **Status:
+correctly parked, not stalled** — the design stays valid and ready to
+resume the moment there's an explicit go-ahead or an actual team asking for
+it (the issue's own trigger condition). Nothing to do here until then.
 
 ## Explicitly not doing right now
 
 - Chasing competitor feature/tool-count parity for its own sake — see
-  `comparisons.md`'s "deliberately NOT chasing" list. Still holds.
+  `comparisons.md`'s "deliberately NOT chasing" list. Still holds, and item
+  1 above is the sharper version of why: count alone was never the right
+  metric to chase, in either direction.
 - Rewriting CFG/taint analysis onto a real AST/dataflow engine — real gap,
   correctly filed as a known ceiling, not a roadmap item until something
   forces the issue (e.g. a security-critical false negative in the wild).


### PR DESCRIPTION
## Summary
- CI-native PR intelligence (TRA-127) and multi-project tool surface (TRA-93) both shipped since the last roadmap revision — removed from "Ready to start".
- Added the session-start tool-schema token tax (TRA-186, already filed/measured) as the new top roadmap item: 171 tools cost ~50-53k tokens before a single tool is called, in direct tension with the "170 tools" differentiator claimed in `docs/comparisons.md`.
- Team-shared graph (TRA-128) stays as the big bet, reworded to make clear it's correctly parked pending Nikolai's explicit go-ahead (hosted-backend angle), not stalled.

## Test plan
- [x] Docs-only change; no code affected.