### PR TITLE
fix: repoint app auto-update to trace-mcp releases

### DIFF
--- a/scripts/app-dist-repo.mjs
+++ b/scripts/app-dist-repo.mjs
@@ -2,11 +2,10 @@
  * Single source of truth for the GitHub repository that hosts the COMPILED
  * trace-mcp desktop app release assets (the mac/win zip + .exe + .sha256).
  *
- * The app SOURCE lives in a separate PRIVATE repository. Its CI builds the
- * binaries and publishes them to this PUBLIC distribution repo's Releases, so
- * the open-source core can fetch "the latest app" anonymously via the GitHub
- * Releases API (`GET /repos/<repo>/releases/latest`) — exactly as it did when
- * the app lived in the core repo, just pointed at the dist repo now.
+ * The app source lives in this same repo (`packages/app`). Its release CI
+ * builds the binaries and publishes them as assets on this repo's own
+ * Releases, so the core can fetch "the latest app" anonymously via the
+ * GitHub Releases API (`GET /repos/<repo>/releases/latest`).
  *
  * Both install paths in the core read this:
  *   - scripts/postinstall-app.mjs  (auto-update on `npm install -g trace-mcp`)
@@ -17,14 +16,11 @@
  */
 
 /**
- * Default public distribution repo (owner/name form).
+ * Default distribution repo (owner/name form).
  *
- * The app source moved to a separate private repo; its CI publishes the
- * compiled binaries to this dedicated PUBLIC dist repo, which the core fetches
- * anonymously. Cutover done once `releases/latest` was populated (v1.41.0).
  * Override via TRACE_MCP_APP_DIST_REPO for forks/staging/testing.
  */
-export const DEFAULT_APP_DIST_REPO = 'nikolai-vysotskyi/trace-mcp-app-dist';
+export const DEFAULT_APP_DIST_REPO = 'nikolai-vysotskyi/trace-mcp';
 
 const REPO_SLUG_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 


### PR DESCRIPTION
## Summary
- `trace-mcp-app-dist` was deleted (app source moved into `packages/app` of this repo; `trace-mcp-app` archived).
- `scripts/app-dist-repo.mjs::DEFAULT_APP_DIST_REPO` still pointed at the deleted `nikolai-vysotskyi/trace-mcp-app-dist`, which meant `postinstall-app.mjs` (auto-update on `npm install -g trace-mcp`) and the in-app updater were fetching a 404'd release feed.
- Release CI already publishes the desktop app binaries as assets on this repo's own GitHub Releases (verified: v1.48.4 has `trace-mcp-*-mac.zip`, `*-win.zip`, `*.exe` + `.sha256`), and `packages/app/src/main/index.ts`'s own updater already hardcodes `nikolai-vysotskyi/trace-mcp`. Only the postinstall/install-app path was still stale.
- Repointed the default to `nikolai-vysotskyi/trace-mcp`.

## Test plan
- [x] `node -e "import('./scripts/app-dist-repo.mjs').then(m => console.log(m.getAppDistRepo()))"` → prints `nikolai-vysotskyi/trace-mcp`
- [x] Confirmed no other references to `trace-mcp-app-dist` remain in the repo
- [x] Confirmed v1.48.4 release assets already match the naming the installer expects