### PR TITLE
docs: fix remaining stale comments about the deleted app-dist repo

### DIFF
--- a/scripts/postinstall-app.mjs
+++ b/scripts/postinstall-app.mjs
@@ -43,8 +43,8 @@ let PENDING_ZIP = '';
 let PENDING_VERSION = '';
 let PENDING_CHECKSUM = '';
 
-// The compiled app lives in a separate PUBLIC distribution repo (the source
-// is private). See scripts/app-dist-repo.mjs. Overridable via env.
+// The compiled app is published as release assets on this repo. See
+// scripts/app-dist-repo.mjs. Overridable via env.
 const GITHUB_REPO = getAppDistRepo();
 
 if (process.env.TRACE_MCP_NO_AUTO_UPDATE === '1') process.exit(0);

--- a/src/cli/install-app.ts
+++ b/src/cli/install-app.ts
@@ -11,8 +11,8 @@ import path from 'node:path';
 import { Command } from 'commander';
 import { getAppDistRepo } from '../../scripts/app-dist-repo.mjs';
 
-// The compiled app lives in a separate PUBLIC distribution repo (the source is
-// private). See scripts/app-dist-repo.mjs. Overridable via TRACE_MCP_APP_DIST_REPO.
+// The compiled app is published as release assets on this repo. See
+// scripts/app-dist-repo.mjs. Overridable via TRACE_MCP_APP_DIST_REPO.
 const GITHUB_REPO = getAppDistRepo();
 
 const isMac = process.platform === 'darwin';


### PR DESCRIPTION
## Summary
Follow-up to #386 — two comments referencing the now-deleted `trace-mcp-app-dist` repo were left over in `scripts/postinstall-app.mjs` and `src/cli/install-app.ts`. Both scripts already correctly resolve the app repo via `getAppDistRepo()` (fixed in #386); this is a comment-only cleanup so the docs match reality.

## Test plan
- [x] Comment-only change, no behavior affected
- [x] `search_text` for "trace-mcp-app-dist" / "separate PUBLIC" / "private repo" across the repo now returns zero stale matches