### PR TITLE
feat(search): add retriever param to unify with search_with_mode (TRA-200)

### DIFF
--- a/src/tools/register/navigation/search-tools.ts
+++ b/src/tools/register/navigation/search-tools.ts
@@ -31,6 +31,8 @@ import {
 import { OutputFormatSchema, encodeResponse } from '../../_common/output-format.js';
 import { createSearchToolRetriever } from '../../../retrieval/retrievers/search-tool-retriever.js';
 import { runRetriever } from '../../../retrieval/types.js';
+import { SEARCH_MODE_NAMES } from '../../../retrieval/modes/registry.js';
+import { runNamedSearchMode } from '../retrieval.js';
 
 /**
  * Registers `search` and `suggest_queries` — the entry-point search tools.
@@ -45,7 +47,7 @@ export function registerSearchTools(server: McpServer, ctx: ServerContext): void
 
   server.tool(
     'search',
-    'Search symbols by name, kind, or text. Use instead of Grep for functions, classes, methods, variables. For raw text/comment search use search_text; for references to a known symbol use find_usages. Filters: kind/language/file_pattern/implements/extends/decorator. fuzzy=true for typo-tolerant search. semantic="on" for conceptual queries (needs an AI provider + embed_repo run once). fusion=true for multi-channel ranking (BM25 + PageRank + embeddings + identity match). See the `mode` param for retrieval strategy (single/tiered/drill/flat/get). Read-only. Returns JSON: { items: [{ symbol_id, name, kind, fqn, signature, file, line, score }], total, search_mode } — mode-specific shape when mode!=single. Supports `output_format: "toon"`.',
+    'Search symbols by name, kind, or text. Use instead of Grep for functions, classes, methods, variables. For raw text/comment search use search_text; for references to a known symbol use find_usages. Filters: kind/language/file_pattern/implements/extends/decorator. fuzzy=true for typo-tolerant search. semantic="on" for conceptual queries (needs an AI provider + embed_repo run once). fusion=true for multi-channel ranking (BM25 + PageRank + embeddings + identity match). See the `mode` param for retrieval strategy (single/tiered/drill/flat/get), or `retriever` for a single named algorithm instead. Read-only. Returns JSON: { items: [{ symbol_id, name, kind, fqn, signature, file, line, score }], total, search_mode } — mode-specific shape when mode!=single. Supports `output_format: "toon"`.',
     {
       query: z.string().min(1).max(500).describe('Search query'),
       kind: z
@@ -141,6 +143,12 @@ export function registerSearchTools(server: McpServer, ctx: ServerContext): void
         .describe(
           'Drill scope for mode="drill" — a file path or symbol_id. Results are restricted to the subtree rooted here.',
         ),
+      retriever: z
+        .enum(SEARCH_MODE_NAMES)
+        .optional()
+        .describe(
+          'Run one named retrieval algorithm (lexical/semantic/hybrid/summary/feeling_lucky/graph_completion) instead of the mode-based dispatcher — same as search_with_mode. Ignores mode/filters/fuzzy/fusion; response is { retriever, items, total }.',
+        ),
       detail_level: DetailLevelSchema,
       output_format: OutputFormatSchema.describe(
         '"json" (default) or "toon" (lossless, 30-60% fewer tokens). "markdown" is unsupported here and behaves as json.',
@@ -166,11 +174,43 @@ export function registerSearchTools(server: McpServer, ctx: ServerContext): void
       fusion_debug,
       mode,
       drill_from,
+      retriever,
       detail_level,
       output_format,
     }) => {
       const encode = (payload: unknown): string =>
         output_format === 'toon' ? encodeResponse(payload, 'toon') : jh('search', payload);
+
+      // Named-retriever path: bypasses the mode-based shaping dispatcher below
+      // entirely, mirroring `search_with_mode`'s own (simpler) behavior exactly —
+      // both call the same `runNamedSearchMode` helper, so they can't drift.
+      if (retriever) {
+        const result = await runNamedSearchMode(ctx, { query, mode: retriever, limit });
+        if (!result.ok) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: encode({
+                  error: 'unknown_mode',
+                  retriever: result.mode,
+                  available: result.available,
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
+        return {
+          content: [
+            {
+              type: 'text',
+              text: encode({ retriever: result.mode, items: result.items, total: result.total }),
+            },
+          ],
+        };
+      }
+
       // Resolve effective mode. Explicit `mode` wins; otherwise heuristic.
       // (Kept here so the zero-index / tiered branches below can branch on it
       // before the retriever runs. The retriever recomputes the same value
@@ -226,13 +266,13 @@ export function registerSearchTools(server: McpServer, ctx: ServerContext): void
       // helpers used previously — no behavioural change. See
       // src/retrieval/retrievers/search-tool-retriever.ts and the equivalence
       // tests in src/retrieval/__tests__/search-tool-equivalence.test.ts.
-      const retriever = createSearchToolRetriever({
+      const searchToolRetriever = createSearchToolRetriever({
         store,
         vectorStore: vectorStore ?? null,
         embeddingService: embeddingService ?? null,
         reranker: reranker ?? null,
       });
-      const retrieverResults = await runRetriever(retriever, {
+      const retrieverResults = await runRetriever(searchToolRetriever, {
         query,
         filters: {
           kind,

--- a/src/tools/register/retrieval.ts
+++ b/src/tools/register/retrieval.ts
@@ -22,13 +22,49 @@ import type { FeelingLuckyResult } from '../../retrieval/retrievers/feeling-luck
 
 type AnyResult = LexicalResult | SemanticResult | HybridResult | SummaryResult | FeelingLuckyResult;
 
-interface NormalizedItem {
+export interface NormalizedItem {
   symbol_id: string;
   name: string | null;
   file: string | null;
   line: number | null;
   score: number;
   snippet?: string;
+}
+
+export type NamedSearchModeResult =
+  | { ok: true; mode: string; items: NormalizedItem[]; total: number }
+  | { ok: false; mode: string; available: readonly string[] };
+
+/**
+ * Shared dispatch for the named-retriever search modes (TRA-200 — used by
+ * both `search_with_mode` and `search`'s `retriever` param, so the two
+ * surfaces can never drift in behavior). Not a class/registry singleton —
+ * cheap to construct per call, same as the original `search_with_mode`
+ * handler did.
+ */
+export async function runNamedSearchMode(
+  ctx: ServerContext,
+  { query, mode, limit }: { query: string; mode: string; limit?: number },
+): Promise<NamedSearchModeResult> {
+  const modes = createDefaultSearchModeRegistry({
+    store: ctx.store,
+    embedding: ctx.embeddingService,
+    vectorStore: ctx.vectorStore,
+  });
+  const retriever = modes.getMode(mode);
+  if (!retriever) {
+    return { ok: false, mode, available: modes.listModes() };
+  }
+  // The retrievers do not share a single query-input shape: most consume `text`,
+  // but the graph-completion retriever reads `query`. Pass both so any retriever
+  // gets the field it expects without the dispatcher needing per-mode branches.
+  const items = (await runRetriever(retriever, {
+    text: query,
+    query,
+    limit,
+  } as unknown as Parameters<typeof runRetriever>[1])) as AnyResult[];
+  const normalized = items.map((it) => normalize(it, ctx));
+  return { ok: true, mode, items: normalized, total: normalized.length };
 }
 
 /**
@@ -84,11 +120,6 @@ const SEARCH_WITH_MODE_DESCRIPTION = [
 
 export function registerRetrievalTools(server: McpServer, ctx: ServerContext): void {
   const { j } = ctx;
-  const modes = createDefaultSearchModeRegistry({
-    store: ctx.store,
-    embedding: ctx.embeddingService,
-    vectorStore: ctx.vectorStore,
-  });
 
   server.tool(
     'search_with_mode',
@@ -102,43 +133,23 @@ export function registerRetrievalTools(server: McpServer, ctx: ServerContext): v
       limit: z.number().int().min(1).max(200).optional().describe('Max results (default 20)'),
     },
     async ({ query, mode, limit }) => {
-      const resolvedMode = mode ?? 'feeling_lucky';
-      const retriever = modes.getMode(resolvedMode);
-      if (!retriever) {
+      const result = await runNamedSearchMode(ctx, { query, mode: mode ?? 'feeling_lucky', limit });
+      if (!result.ok) {
         return {
           content: [
             {
               type: 'text',
-              text: j({
-                error: 'unknown_mode',
-                mode: resolvedMode,
-                available: modes.listModes(),
-              }),
+              text: j({ error: 'unknown_mode', mode: result.mode, available: result.available }),
             },
           ],
           isError: true,
         };
       }
-
-      // The retrievers do not share a single query-input shape: most consume `text`,
-      // but the graph-completion retriever reads `query`. Pass both so any retriever
-      // gets the field it expects without the dispatcher needing per-mode branches.
-      const items = (await runRetriever(retriever, {
-        text: query,
-        query,
-        limit,
-      } as unknown as Parameters<typeof runRetriever>[1])) as AnyResult[];
-      const normalized = items.map((it) => normalize(it, ctx));
-
       return {
         content: [
           {
             type: 'text',
-            text: j({
-              mode: resolvedMode,
-              items: normalized,
-              total: normalized.length,
-            }),
+            text: j({ mode: result.mode, items: result.items, total: result.total }),
           },
         ],
       };

--- a/tests/tools/search-retriever-param.test.ts
+++ b/tests/tools/search-retriever-param.test.ts
@@ -1,0 +1,130 @@
+/**
+ * TRA-200 — `search`'s `retriever` param must dispatch through the exact
+ * same code path as `search_with_mode` (both call `runNamedSearchMode`),
+ * so their outputs can never drift, and `search`'s default (no `retriever`)
+ * behavior must stay byte-for-byte unchanged.
+ */
+import path from 'node:path';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { TraceMcpConfig } from '../../src/config.js';
+import type { Store } from '../../src/db/store.js';
+import { IndexingPipeline } from '../../src/indexer/pipeline.js';
+import { PhpLanguagePlugin } from '../../src/indexer/plugins/language/php/index.js';
+import { TypeScriptLanguagePlugin } from '../../src/indexer/plugins/language/typescript/index.js';
+import { VueLanguagePlugin } from '../../src/indexer/plugins/language/vue/index.js';
+import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import { registerSearchTools } from '../../src/tools/register/navigation/search-tools.js';
+import { registerRetrievalTools } from '../../src/tools/register/retrieval.js';
+import type { ServerContext } from '../../src/server/types.js';
+import { createTestStore } from '../test-utils.js';
+
+const FIXTURE_DIR = path.resolve(__dirname, '../fixtures/no-framework');
+
+function makeConfig(): TraceMcpConfig {
+  return {
+    root: FIXTURE_DIR,
+    include: ['app/**/*.php', 'src/**/*.ts', 'components/**/*.vue'],
+    exclude: ['vendor/**', 'node_modules/**'],
+    db: { path: ':memory:' },
+    plugins: [],
+  };
+}
+
+interface RegisteredTool {
+  handler: (
+    args: Record<string, unknown>,
+    extra: unknown,
+  ) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+}
+
+function getRegisteredTools(server: McpServer): Record<string, RegisteredTool> {
+  return (server as unknown as { _registeredTools: Record<string, RegisteredTool> })
+    ._registeredTools;
+}
+
+function parseText(result: { content: Array<{ type: string; text: string }> }): unknown {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('search { retriever } param (TRA-200)', () => {
+  let store: Store;
+  let ctx: ServerContext;
+  let tools: Record<string, RegisteredTool>;
+
+  beforeAll(async () => {
+    store = createTestStore();
+    const registry = new PluginRegistry();
+    registry.registerLanguagePlugin(new PhpLanguagePlugin());
+    registry.registerLanguagePlugin(new TypeScriptLanguagePlugin());
+    registry.registerLanguagePlugin(new VueLanguagePlugin());
+
+    const config = makeConfig();
+    const pipeline = new IndexingPipeline(store, registry, config, FIXTURE_DIR);
+    await pipeline.indexAll();
+
+    ctx = {
+      store,
+      projectRoot: FIXTURE_DIR,
+      embeddingService: null,
+      vectorStore: null,
+      reranker: null,
+      topoStore: null,
+      rankingLedger: null,
+      j: (v: unknown) => JSON.stringify(v),
+      jh: (_tool: string, v: unknown) => JSON.stringify(v),
+    } as unknown as ServerContext;
+
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+    registerSearchTools(server, ctx);
+    registerRetrievalTools(server, ctx);
+    tools = getRegisteredTools(server);
+  });
+
+  it('search{retriever: "lexical"} returns the same items as search_with_mode{mode: "lexical"}', async () => {
+    const viaSearch = parseText(
+      await tools.search.handler({ query: 'User', retriever: 'lexical' }, {}),
+    ) as { retriever: string; items: unknown[]; total: number };
+    const viaSearchWithMode = parseText(
+      await tools.search_with_mode.handler({ query: 'User', mode: 'lexical' }, {}),
+    ) as { mode: string; items: unknown[]; total: number };
+
+    expect(viaSearch.retriever).toBe('lexical');
+    expect(viaSearchWithMode.mode).toBe('lexical');
+    expect(viaSearch.items).toEqual(viaSearchWithMode.items);
+    expect(viaSearch.total).toBe(viaSearchWithMode.total);
+  });
+
+  it('search{retriever: "feeling_lucky"} matches search_with_mode default', async () => {
+    const viaSearch = parseText(
+      await tools.search.handler({ query: 'add', retriever: 'feeling_lucky' }, {}),
+    ) as { items: unknown[] };
+    const viaSearchWithMode = parseText(
+      await tools.search_with_mode.handler({ query: 'add' }, {}),
+    ) as { items: unknown[] };
+
+    expect(viaSearch.items).toEqual(viaSearchWithMode.items);
+  });
+
+  it('search{retriever} response omits the mode-shaping fields (search_mode, buckets, parent)', async () => {
+    const result = parseText(
+      await tools.search.handler({ query: 'User', retriever: 'lexical' }, {}),
+    ) as Record<string, unknown>;
+    expect(result).not.toHaveProperty('search_mode');
+    expect(result).not.toHaveProperty('mode');
+    expect(result).not.toHaveProperty('buckets');
+  });
+
+  it('regression: search with no retriever behaves exactly as before (mode-based dispatch)', async () => {
+    const result = parseText(await tools.search.handler({ query: 'User' }, {})) as Record<
+      string,
+      unknown
+    >;
+    expect(result).toHaveProperty('search_mode');
+    expect(result).toHaveProperty('mode', 'single');
+    expect(result).not.toHaveProperty('retriever');
+  });
+});


### PR DESCRIPTION
## Summary
Closes [TRA-200](https://github.com/nikolai-vysotskyi/trace-mcp) (part of the TRA-193 tool-consolidation umbrella, TRA-186 follow-up).

`search` gains an optional `retriever` param — one of `lexical`/`semantic`/`hybrid`/`summary`/`feeling_lucky`/`graph_completion` — that dispatches through the exact same `runNamedSearchMode()` helper `search_with_mode` uses, so an agent no longer has to know two different tools exist to run a named retrieval algorithm.

**Design correction from the original TRA-200 scoping**: the issue originally proposed folding `search_with_mode`'s modes into `search`'s existing `mode` enum. That's not coherent — `search`'s `mode` controls *result-shaping strategy* (single/tiered/drill/flat/get), while `search_with_mode`'s `mode` controls *which retrieval algorithm* runs. They're orthogonal axes (`mode: "tiered"` + a named-retriever value would be meaningless as one enum). This PR adds `retriever` as a separate param instead of merging enums — same discoverability win, correct data model.

`search_with_mode` stays registered unchanged and permanent (per TRA-193's migration note — not deprecated by this PR).

## Implementation
- Extracted `runNamedSearchMode()` from `search_with_mode`'s handler into a shared exported function in `src/tools/register/retrieval.ts` (refactor commit, no behavior change).
- Added `retriever` param + early-dispatch branch to `search` in `src/tools/register/navigation/search-tools.ts`, calling the same shared function (feat commit).
- `search`'s top-level description note added; detail moved into `retriever`'s own `.describe()` to stay under the 800-char per-tool ceiling (`tool-schema-budget.test.ts`).

## Test plan
- New `tests/tools/search-retriever-param.test.ts`: `search{retriever: "lexical"}` output byte-for-byte equals `search_with_mode{mode: "lexical"}`; same for `feeling_lucky` default; response omits mode-shaping fields (`search_mode`/`mode`/`buckets`); regression check that `search` with no `retriever` behaves exactly as before.
- Existing `tests/tools/search-with-mode-dispatch.test.ts` passes unchanged (proves `search_with_mode` is byte-identical pre/post).
- `pnpm run build` — passes
- `pnpm run lint` (tsc --noEmit) — passes
- `pnpm run biome:ci` — passes
- `pnpm run test` — 8596 passed, 6 skipped, 0 failed (full suite)