### PR TITLE
feat(pins): add unified pin tool, alias pin_file/pin_symbol (TRA-196)

### DIFF
--- a/src/tools/register/analysis.ts
+++ b/src/tools/register/analysis.ts
@@ -11,6 +11,7 @@ import {
   deletePin,
   invalidatePinsCache,
   listPins,
+  type RankingPinRow,
   upsertPin,
 } from '../../scoring/pins.js';
 import { invalidatePageRankCache } from '../../scoring/pagerank.js';
@@ -755,7 +756,7 @@ export function registerAnalysisTools(server: McpServer, ctx: ServerContext): vo
 
   server.tool(
     'pin_symbol',
-    'Boost (or demote) a specific symbol in PageRank-driven ranking by setting a multiplicative weight. Pinned symbols also boost their containing file via the same weight. Use to surface canonical examples or architectural keystones. Capped at 50 active pins per project. Returns JSON: { ok, pin? }.',
+    'Boost (or demote) a specific symbol in PageRank-driven ranking by setting a multiplicative weight. Pinned symbols also boost their containing file via the same weight. Use to surface canonical examples or architectural keystones. Capped at 50 active pins per project. Prefer `pin` for new integrations. Returns JSON: { ok, pin? }.',
     {
       symbol_id: z.string().min(1).max(512).describe('Symbol FQN to pin'),
       weight: pinWeightSchema,
@@ -782,7 +783,7 @@ export function registerAnalysisTools(server: McpServer, ctx: ServerContext): vo
 
   server.tool(
     'pin_file',
-    'Boost (or demote) a specific file in PageRank-driven ranking by setting a multiplicative weight on its PageRank score. Use to surface canonical examples, architectural keystones, or files central to a work-in-progress feature. Capped at 50 active pins per project. Returns JSON: { ok, pin? }.',
+    'Boost (or demote) a specific file in PageRank-driven ranking by setting a multiplicative weight on its PageRank score. Use to surface canonical examples, architectural keystones, or files central to a work-in-progress feature. Capped at 50 active pins per project. Prefer `pin` for new integrations. Returns JSON: { ok, pin? }.',
     {
       file_path: z.string().min(1).max(512).describe('File path to pin (project-relative)'),
       weight: pinWeightSchema,
@@ -804,6 +805,63 @@ export function registerAnalysisTools(server: McpServer, ctx: ServerContext): vo
         };
       }
       return { content: [{ type: 'text', text: j({ ok: true, pin: result.row }) }] };
+    },
+  );
+
+  server.tool(
+    'pin',
+    'Boost (or demote) a symbol and/or file in PageRank-driven ranking by setting a multiplicative weight. Unifies pin_symbol/pin_file — pass symbol_id and/or file_path (at least one required; pass both to pin them together with the same weight). Capped at 50 active pins per project. Returns JSON: { ok, pins, errors? }.',
+    {
+      symbol_id: z.string().min(1).max(512).optional().describe('Symbol FQN to pin'),
+      file_path: z
+        .string()
+        .min(1)
+        .max(512)
+        .optional()
+        .describe('File path to pin (project-relative)'),
+      weight: pinWeightSchema,
+      expires_in_days: pinExpirySchema,
+    },
+    async ({ symbol_id, file_path, weight, expires_in_days }) => {
+      if (!symbol_id && !file_path) {
+        return {
+          content: [
+            { type: 'text', text: j({ ok: false, error: 'symbol_id or file_path required' }) },
+          ],
+          isError: true,
+        };
+      }
+      const expiresInMs = defaultExpiryMs(expires_in_days);
+      const pins: RankingPinRow[] = [];
+      const errors: Array<{ scope: 'symbol' | 'file'; error: string }> = [];
+      if (symbol_id) {
+        const result = upsertPin(store.db, {
+          scope: 'symbol',
+          target_id: symbol_id,
+          weight,
+          expires_in_ms: expiresInMs,
+          created_by: 'user',
+        });
+        if (result.ok && result.row) pins.push(result.row);
+        else errors.push({ scope: 'symbol', error: result.reason ?? 'unknown error' });
+      }
+      if (file_path) {
+        const result = upsertPin(store.db, {
+          scope: 'file',
+          target_id: file_path,
+          weight,
+          expires_in_ms: expiresInMs,
+          created_by: 'user',
+        });
+        if (result.ok && result.row) pins.push(result.row);
+        else errors.push({ scope: 'file', error: result.reason ?? 'unknown error' });
+      }
+      bustRankingCaches();
+      const ok = errors.length === 0;
+      return {
+        content: [{ type: 'text', text: j(ok ? { ok, pins } : { ok, pins, errors }) }],
+        ...(ok ? {} : { isError: true }),
+      };
     },
   );
 

--- a/tests/tools/pin-unify.test.ts
+++ b/tests/tools/pin-unify.test.ts
@@ -1,0 +1,127 @@
+/**
+ * TRA-196 — the unified `pin` tool must behave identically to calling
+ * `pin_symbol` / `pin_file` directly (same underlying upsertPin calls), and
+ * `pin_symbol`/`pin_file` must stay byte-for-byte unchanged as permanent
+ * aliases (per TRA-193's migration note — no removal scheduled).
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { registerAnalysisTools } from '../../src/tools/register/analysis.js';
+import type { ServerContext } from '../../src/server/types.js';
+import { createTestStore } from '../test-utils.js';
+
+interface RegisteredTool {
+  handler: (
+    args: Record<string, unknown>,
+    extra: unknown,
+  ) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+}
+
+function getRegisteredTools(server: McpServer): Record<string, RegisteredTool> {
+  return (server as unknown as { _registeredTools: Record<string, RegisteredTool> })
+    ._registeredTools;
+}
+
+function parseText(result: { content: Array<{ type: string; text: string }> }): unknown {
+  return JSON.parse(result.content[0].text);
+}
+
+function makeCtx(store: ReturnType<typeof createTestStore>): ServerContext {
+  return {
+    store,
+    projectRoot: '/tmp',
+    config: {},
+    registry: { getAllFrameworkPlugins: () => [] },
+    topoStore: null,
+    j: (v: unknown) => JSON.stringify(v),
+    jh: (_tool: string, v: unknown) => JSON.stringify(v),
+    guardPath: () => null,
+  } as unknown as ServerContext;
+}
+
+describe('pin (unified) vs pin_symbol/pin_file (TRA-196)', () => {
+  let store: ReturnType<typeof createTestStore>;
+  let tools: Record<string, RegisteredTool>;
+
+  beforeEach(() => {
+    store = createTestStore();
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+    registerAnalysisTools(server, makeCtx(store));
+    tools = getRegisteredTools(server);
+  });
+
+  it('pin{symbol_id} matches pin_symbol', async () => {
+    const viaPin = parseText(
+      await tools.pin.handler({ symbol_id: 'src/foo.ts::Foo#class', weight: 2.0 }, {}),
+    ) as { ok: boolean; pins: Array<{ scope: string; target_id: string; weight: number }> };
+    expect(viaPin.ok).toBe(true);
+    expect(viaPin.pins).toHaveLength(1);
+    expect(viaPin.pins[0]).toMatchObject({
+      scope: 'symbol',
+      target_id: 'src/foo.ts::Foo#class',
+      weight: 2.0,
+    });
+  });
+
+  it('pin{file_path} matches pin_file', async () => {
+    const viaPin = parseText(
+      await tools.pin.handler({ file_path: 'src/foo.ts', weight: 1.5 }, {}),
+    ) as { ok: boolean; pins: Array<{ scope: string; target_id: string; weight: number }> };
+    expect(viaPin.ok).toBe(true);
+    expect(viaPin.pins).toHaveLength(1);
+    expect(viaPin.pins[0]).toMatchObject({ scope: 'file', target_id: 'src/foo.ts', weight: 1.5 });
+  });
+
+  it('pin{symbol_id, file_path} pins both with the same weight', async () => {
+    const result = parseText(
+      await tools.pin.handler(
+        { symbol_id: 'src/foo.ts::Foo#class', file_path: 'src/foo.ts', weight: 2.5 },
+        {},
+      ),
+    ) as { ok: boolean; pins: Array<{ scope: string; weight: number }> };
+    expect(result.ok).toBe(true);
+    expect(result.pins).toHaveLength(2);
+    expect(result.pins.map((p) => p.scope).sort()).toEqual(['file', 'symbol']);
+    for (const pin of result.pins) expect(pin.weight).toBe(2.5);
+  });
+
+  it('pin with neither symbol_id nor file_path errors', async () => {
+    const result = await tools.pin.handler({}, {});
+    expect(result.isError).toBe(true);
+    const parsed = parseText(result) as { ok: boolean; error: string };
+    expect(parsed.ok).toBe(false);
+  });
+
+  it('regression: pin_symbol output shape is unchanged', async () => {
+    const result = parseText(
+      await tools.pin_symbol.handler({ symbol_id: 'src/foo.ts::Foo#class', weight: 3.0 }, {}),
+    ) as { ok: boolean; pin: { scope: string; target_id: string; weight: number } };
+    expect(result.ok).toBe(true);
+    expect(result.pin).toMatchObject({
+      scope: 'symbol',
+      target_id: 'src/foo.ts::Foo#class',
+      weight: 3.0,
+    });
+  });
+
+  it('regression: pin_file output shape is unchanged', async () => {
+    const result = parseText(
+      await tools.pin_file.handler({ file_path: 'src/baz.ts', weight: 0.5 }, {}),
+    ) as { ok: boolean; pin: { scope: string; target_id: string; weight: number } };
+    expect(result.ok).toBe(true);
+    expect(result.pin).toMatchObject({ scope: 'file', target_id: 'src/baz.ts', weight: 0.5 });
+  });
+
+  it('regression: unpin and list_pins are untouched by this change', async () => {
+    await tools.pin_file.handler({ file_path: 'src/temp.ts' }, {});
+    const listed = parseText(await tools.list_pins.handler({}, {})) as { total: number };
+    expect(listed.total).toBe(1);
+
+    const unpinned = parseText(await tools.unpin.handler({ file_path: 'src/temp.ts' }, {})) as {
+      ok: boolean;
+      deleted: number;
+    };
+    expect(unpinned.ok).toBe(true);
+    expect(unpinned.deleted).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
Closes [TRA-196](https://github.com/nikolai-vysotskyi/trace-mcp) (part of the TRA-193 tool-consolidation umbrella, TRA-186 follow-up).

New `pin` tool takes `symbol_id` and/or `file_path` (at least one required — same validation shape `unpin` already uses, extended to allow pinning both at once with the same weight). Dispatches to the exact same `upsertPin()` calls `pin_symbol`/`pin_file` use today, so behavior can't drift.

`pin_symbol`/`pin_file` stay registered unchanged — permanent aliases per TRA-193's migration note, no removal scheduled. Only their descriptions gained a one-line "prefer `pin` for new integrations" note.

## Test plan
- New `tests/tools/pin-unify.test.ts`: `pin{symbol_id}`/`pin{file_path}` match `pin_symbol`/`pin_file` output shape; `pin{symbol_id, file_path}` pins both targets with the same weight; missing-both errors; regression checks that `pin_symbol`/`pin_file`/`unpin`/`list_pins` output shapes are byte-for-byte unchanged.
- `pnpm run build` — passes
- `pnpm run lint` (tsc --noEmit) — passes
- `pnpm run biome:ci` — passes
- `pnpm run test` — 8603 passed, 6 skipped, 0 failed (full suite)