### PR TITLE
feat(check_edit_safe): add depth param to unify with assess_change_risk / get_change_impact (TRA-197)

### DIFF
--- a/src/tools/register/quality.ts
+++ b/src/tools/register/quality.ts
@@ -11,6 +11,10 @@ import { generateDocs } from '../project/generate-docs.js';
 import { getPackageDeps } from '../project/package-deps.js';
 import { auditConfig, scanInstalledSkills } from '../quality/audit-config.js';
 import { compareBranches, getChangedSymbols } from '../quality/changed-symbols.js';
+import { assessChangeRisk } from '../analysis/predictive-intelligence.js';
+import { getChangeImpact } from '../analysis/impact.js';
+import { decisionsForImpact } from '../../memory/enrichment.js';
+import { CHANGE_IMPACT_METHODOLOGY } from '../shared/confidence.js';
 import { checkEditSafe } from '../quality/check-edit-safe.js';
 import { collectCoChanges, getCoChanges, persistCoChanges } from '../quality/co-changes.js';
 import {
@@ -45,7 +49,7 @@ function collectRegisteredToolNames(server: McpServer): Set<string> {
 }
 
 export function registerQualityTools(server: McpServer, ctx: ServerContext): void {
-  const { store, registry, config, projectRoot, j } = ctx;
+  const { store, registry, config, projectRoot, j, jh, decisionStore } = ctx;
 
   // --- Co-Change Analysis ---
   server.tool(
@@ -683,16 +687,73 @@ export function registerQualityTools(server: McpServer, ctx: ServerContext): voi
   // --- Edit-Safety Preflight ---
   server.tool(
     'check_edit_safe',
-    'Edit-safety preflight: before modifying a symbol or file, get one verdict for "is this safe to edit and what must I preserve". Fuses signature impact, cyclomatic complexity, and test coverage into a verdict tier (safe_to_edit / untested / complexity_risk / signature_impact) with ranked blockers and a recommended action. Complements assess_change_risk (continuous score) by naming the dominant blocker. Read-only. Returns JSON: { verdict, recommended_action, blockers: [{ signal, severity, detail }], confidence, signals }.',
+    'Edit-safety preflight: before modifying a symbol or file, get one verdict for "is this safe to edit and what must I preserve". Fuses signature impact, cyclomatic complexity, and test coverage into a verdict tier (safe_to_edit / untested / complexity_risk / signature_impact) with ranked blockers and a recommended action. See `depth` to escalate to a continuous risk score or the full impact report instead. Read-only. Returns JSON: { verdict, recommended_action, blockers: [{ signal, severity, detail }], confidence, signals }.',
     {
       file_path: optionalNonEmptyString(512).describe('File path to check before editing'),
       symbol_id: optionalNonEmptyString(512).describe('Symbol ID to check before editing'),
+      depth: z
+        .enum(['verdict', 'score', 'full'])
+        .optional()
+        .describe(
+          'verdict (default): blocker-tier verdict. score: same as assess_change_risk (continuous risk score + factors). full: same as get_change_impact (dependents, affected tests, breaking changes).',
+        ),
     },
-    async ({ file_path, symbol_id }) => {
+    async ({ file_path, symbol_id, depth }) => {
       if (file_path) {
         const blocked = ctx.guardPath(file_path);
         if (blocked) return blocked;
       }
+
+      if (depth === 'score') {
+        const result = assessChangeRisk(store, projectRoot, {
+          filePath: file_path,
+          symbolId: symbol_id,
+          sinceDays: config.predictive?.git_since_days,
+          weights: config.predictive?.weights?.change_risk,
+        });
+        if (result.isErr())
+          return {
+            content: [{ type: 'text', text: j(formatToolError(result.error)) }],
+            isError: true,
+          };
+        return { content: [{ type: 'text', text: j(result.value) }] };
+      }
+
+      if (depth === 'full') {
+        const result = getChangeImpact(
+          store,
+          { filePath: file_path, symbolId: symbol_id },
+          3,
+          200,
+          projectRoot,
+        );
+        if (result.isErr())
+          return {
+            content: [{ type: 'text', text: j(formatToolError(result.error)) }],
+            isError: true,
+          };
+        const includeMethodology =
+          result.value.totalAffected === 0 ||
+          result.value.risk?.level === 'high' ||
+          result.value.risk?.level === 'critical';
+        const payload: Record<string, unknown> = includeMethodology
+          ? { ...result.value, _methodology: CHANGE_IMPACT_METHODOLOGY }
+          : { ...result.value };
+        if (decisionStore) {
+          const linkedDecisions = decisionsForImpact(
+            decisionStore,
+            projectRoot,
+            { symbolId: symbol_id, filePath: file_path },
+            result.value.dependents?.map((d) => d.path),
+            undefined,
+            undefined,
+            store,
+          );
+          if (linkedDecisions.length > 0) payload.linked_decisions = linkedDecisions;
+        }
+        return { content: [{ type: 'text', text: jh('get_change_impact', payload) }] };
+      }
+
       const result = checkEditSafe(
         store,
         { filePath: file_path, symbolId: symbol_id },

--- a/tests/tools/check-edit-safe-depth.test.ts
+++ b/tests/tools/check-edit-safe-depth.test.ts
@@ -1,0 +1,138 @@
+/**
+ * TRA-197 — `check_edit_safe`'s `depth` param must dispatch to the exact
+ * same implementations `assess_change_risk` (depth: "score") and
+ * `get_change_impact` (depth: "full") use, and the default (no `depth`)
+ * behavior must stay byte-for-byte unchanged.
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { Store } from '../../src/db/store.js';
+import { IndexingPipeline } from '../../src/indexer/pipeline.js';
+import { TypeScriptLanguagePlugin } from '../../src/indexer/plugins/language/typescript/index.js';
+import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import { registerAdvancedTools } from '../../src/tools/register/advanced.js';
+import { registerLookupTools } from '../../src/tools/register/navigation/lookup-tools.js';
+import { registerQualityTools } from '../../src/tools/register/quality.js';
+import type { ServerContext } from '../../src/server/types.js';
+import { createTestStore, createTmpDir, writeFixtureFile } from '../test-utils.js';
+
+interface RegisteredTool {
+  handler: (
+    args: Record<string, unknown>,
+    extra: unknown,
+  ) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+}
+
+function getRegisteredTools(server: McpServer): Record<string, RegisteredTool> {
+  return (server as unknown as { _registeredTools: Record<string, RegisteredTool> })
+    ._registeredTools;
+}
+
+function parseText(result: { content: Array<{ type: string; text: string }> }): unknown {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('check_edit_safe { depth } param (TRA-197)', () => {
+  let store: Store;
+  let tmpDir: string;
+  let tools: Record<string, RegisteredTool>;
+
+  beforeAll(async () => {
+    tmpDir = createTmpDir('trace-mcp-edit-safe-depth-');
+    writeFixtureFile(
+      tmpDir,
+      'src/hub.ts',
+      'export function hub(x: number): number {\n  return x;\n}\n',
+    );
+    writeFixtureFile(
+      tmpDir,
+      'src/consumer.ts',
+      "import { hub } from './hub.js';\nexport function use(): number {\n  return hub(1);\n}\n",
+    );
+
+    store = createTestStore();
+    const registry = new PluginRegistry();
+    registry.registerLanguagePlugin(new TypeScriptLanguagePlugin());
+    const config = {
+      root: tmpDir,
+      include: ['src/**/*.ts'],
+      exclude: ['node_modules/**'],
+      db: { path: ':memory:' },
+      plugins: [],
+    } as never;
+    const pipeline = new IndexingPipeline(store, registry, config, tmpDir);
+    const result = await pipeline.indexAll();
+    expect(result.errors).toBe(0);
+
+    const ctx = {
+      store,
+      projectRoot: tmpDir,
+      config: {},
+      registry: { getAllFrameworkPlugins: () => [] },
+      decisionStore: null,
+      topoStore: null,
+      guardPath: () => null,
+      j: (v: unknown) => JSON.stringify(v),
+      jh: (_tool: string, v: unknown) => JSON.stringify(v),
+    } as unknown as ServerContext;
+
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+    registerQualityTools(server, ctx);
+    registerAdvancedTools(server, ctx);
+    registerLookupTools(server, ctx);
+    tools = getRegisteredTools(server);
+  });
+
+  it('check_edit_safe{depth: "score"} matches assess_change_risk', async () => {
+    const viaCheckEditSafe = parseText(
+      await tools.check_edit_safe.handler(
+        { symbol_id: 'src/hub.ts::hub#function', depth: 'score' },
+        {},
+      ),
+    );
+    const viaAssessChangeRisk = parseText(
+      await tools.assess_change_risk.handler({ symbol_id: 'src/hub.ts::hub#function' }, {}),
+    );
+    expect(viaCheckEditSafe).toEqual(viaAssessChangeRisk);
+  });
+
+  it('check_edit_safe{depth: "full"} matches get_change_impact', async () => {
+    const viaCheckEditSafe = parseText(
+      await tools.check_edit_safe.handler(
+        { symbol_id: 'src/hub.ts::hub#function', depth: 'full' },
+        {},
+      ),
+    );
+    const viaGetChangeImpact = parseText(
+      await tools.get_change_impact.handler({ symbol_id: 'src/hub.ts::hub#function' }, {}),
+    );
+    expect(viaCheckEditSafe).toEqual(viaGetChangeImpact);
+  });
+
+  it('regression: check_edit_safe with no depth behaves exactly as before (verdict tier)', async () => {
+    const result = parseText(
+      await tools.check_edit_safe.handler({ symbol_id: 'src/hub.ts::hub#function' }, {}),
+    ) as Record<string, unknown>;
+    expect(result).toHaveProperty('verdict');
+    expect(result).toHaveProperty('blockers');
+    expect(result).not.toHaveProperty('risk_score');
+    expect(result).not.toHaveProperty('dependents');
+  });
+
+  it('regression: assess_change_risk output shape is unchanged', async () => {
+    const result = parseText(
+      await tools.assess_change_risk.handler({ symbol_id: 'src/hub.ts::hub#function' }, {}),
+    ) as Record<string, unknown>;
+    expect(result).toHaveProperty('risk_score');
+    expect(result).toHaveProperty('risk_level');
+    expect(result).toHaveProperty('factors');
+  });
+
+  it('regression: get_change_impact output shape is unchanged', async () => {
+    const result = parseText(
+      await tools.get_change_impact.handler({ symbol_id: 'src/hub.ts::hub#function' }, {}),
+    ) as Record<string, unknown>;
+    expect(result).toHaveProperty('dependents');
+    expect(result).toHaveProperty('totalAffected');
+  });
+});


### PR DESCRIPTION
## Summary
Closes [TRA-197](https://github.com/nikolai-vysotskyi/trace-mcp) (part of the TRA-193 tool-consolidation umbrella, TRA-186 follow-up).

`check_edit_safe` gains an optional `depth` param:
- `"verdict"` (default) — unchanged blocker-tier verdict.
- `"score"` — dispatches to the same `assessChangeRisk()` call `assess_change_risk` uses.
- `"full"` — dispatches to the same `getChangeImpact()` call `get_change_impact` uses (including the methodology note and linked-decisions enrichment).

All three tools stay independently registered — this is a discoverability addition on top of `check_edit_safe`, not a merge. `assess_change_risk` and `get_change_impact` are untouched.

## Test plan
- New `tests/tools/check-edit-safe-depth.test.ts`: `check_edit_safe{depth:"score"}`/`{depth:"full"}` outputs equal calling `assess_change_risk`/`get_change_impact` directly on the same target; default (no `depth`) behavior regression-checked (verdict-tier shape, no `risk_score`/`dependents` leaking in); `assess_change_risk`/`get_change_impact` output shapes regression-checked unchanged.
- Existing `tests/tools/check-edit-safe.test.ts`, `tests/tools/behavioural/assess-change-risk.behavioural.test.ts`, `tests/tools/behavioural/get-change-impact.behavioural.test.ts`, `tests/tools/change-impact-output-budget.test.ts` all pass unchanged.
- `pnpm run build` — passes
- `pnpm run lint` (tsc --noEmit) — passes
- `pnpm run biome:ci` — passes
- `pnpm run test` — 8608 passed, 6 skipped, 0 failed (full suite)