### PR TITLE
feat(get_dead_code): add exports_only mode, alias get_dead_exports (TRA-199)

### DIFF
--- a/src/tools/register/git.ts
+++ b/src/tools/register/git.ts
@@ -22,6 +22,7 @@ import {
   type TaintSourceKind,
   taintAnalysis,
 } from '../quality/taint-analysis.js';
+import { getDeadExports } from '../analysis/introspect.js';
 import { getDeadCodeReachability, getDeadCodeV2 } from '../refactoring/dead-code.js';
 import { checkRenameSafe } from '../refactoring/rename-check.js';
 import { GIT_CHURN_METHODOLOGY } from '../shared/confidence.js';
@@ -122,7 +123,7 @@ export function registerGitTools(server: McpServer, ctx: ServerContext): void {
 
   server.tool(
     'get_dead_code',
-    'Dead code detection. Two modes: "multi-signal" (default) combines import graph, call graph, and barrel export analysis with confidence scores; "reachability" runs forward BFS from auto-detected entry points (tests, package.json main/bin, src/{cli,main,index}, routes, framework controllers) — stricter when entry points are enumerable. Pass entry_points for custom roots. For quick export-only scan use get_dead_exports; to remove detected code use remove_dead_code. Read-only. Returns JSON: { dead_symbols: [{ symbol_id, name, file, confidence, signals }], total }.',
+    'Dead code detection. Modes: "multi-signal" (default) combines import graph, call graph, and barrel export analysis with confidence scores; "reachability" runs forward BFS from auto-detected entry points (tests, package.json main/bin, src/{cli,main,index}, routes, framework controllers) — stricter when entry points are enumerable; "exports_only" is the fast export-keyword-only scan (same as get_dead_exports, which stays available as its own tool). Pass entry_points for custom roots. To remove detected code use remove_dead_code. Read-only. Returns JSON: { dead_symbols: [{ symbol_id, name, file, confidence, signals }], total } — exports_only mode returns { dead_exports, total_dead, total_exports, truncated? } instead (see get_dead_exports).',
     {
       file_pattern: z
         .string()
@@ -137,9 +138,15 @@ export function registerGitTools(server: McpServer, ctx: ServerContext): void {
         .describe(
           '[multi-signal mode] Min confidence to report (default: 0.5 = at least 2 of 3 signals)',
         ),
-      limit: z.number().int().min(1).max(500).optional().describe('Max results (default: 50)'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(500)
+        .optional()
+        .describe('Max results (default: 50, or 100 for exports_only)'),
       mode: z
-        .enum(['multi-signal', 'reachability'])
+        .enum(['multi-signal', 'reachability', 'exports_only'])
         .optional()
         .describe('Detection algorithm (default: multi-signal)'),
       entry_points: z
@@ -149,6 +156,10 @@ export function registerGitTools(server: McpServer, ctx: ServerContext): void {
         .describe('[reachability mode] Extra entry-point file paths (repo-relative)'),
     },
     async ({ file_pattern, threshold, limit, mode, entry_points }) => {
+      if (mode === 'exports_only') {
+        const result = getDeadExports(store, file_pattern, limit ?? 100, projectRoot);
+        return { content: [{ type: 'text', text: jh('get_dead_code', result) }] };
+      }
       const result =
         mode === 'reachability'
           ? getDeadCodeReachability(store, {

--- a/tests/tools/dead-code-exports-only-mode.test.ts
+++ b/tests/tools/dead-code-exports-only-mode.test.ts
@@ -1,0 +1,114 @@
+/**
+ * TRA-199 — `get_dead_code`'s `mode: "exports_only"` must dispatch to the
+ * exact same `getDeadExports()` call `get_dead_exports` uses, and
+ * `get_dead_exports` (the permanent alias) must stay byte-for-byte unchanged.
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { Store } from '../../src/db/store.js';
+import { IndexingPipeline } from '../../src/indexer/pipeline.js';
+import { TypeScriptLanguagePlugin } from '../../src/indexer/plugins/language/typescript/index.js';
+import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import { registerAnalysisTools } from '../../src/tools/register/analysis.js';
+import { registerGitTools } from '../../src/tools/register/git.js';
+import type { ServerContext } from '../../src/server/types.js';
+import { createTestStore, createTmpDir, writeFixtureFile } from '../test-utils.js';
+
+interface RegisteredTool {
+  handler: (
+    args: Record<string, unknown>,
+    extra: unknown,
+  ) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+}
+
+function getRegisteredTools(server: McpServer): Record<string, RegisteredTool> {
+  return (server as unknown as { _registeredTools: Record<string, RegisteredTool> })
+    ._registeredTools;
+}
+
+function parseText(result: { content: Array<{ type: string; text: string }> }): unknown {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('get_dead_code { mode: "exports_only" } (TRA-199)', () => {
+  let store: Store;
+  let tmpDir: string;
+  let tools: Record<string, RegisteredTool>;
+
+  beforeAll(async () => {
+    tmpDir = createTmpDir('trace-mcp-dead-exports-mode-');
+    // An exported symbol with zero external consumers — a dead export.
+    writeFixtureFile(
+      tmpDir,
+      'src/unused.ts',
+      'export function unusedFn(): number {\n  return 1;\n}\n',
+    );
+    // A live symbol so the store isn't trivially empty.
+    writeFixtureFile(tmpDir, 'src/used.ts', 'export function usedFn(): number {\n  return 2;\n}\n');
+    writeFixtureFile(
+      tmpDir,
+      'src/consumer.ts',
+      "import { usedFn } from './used.js';\nexport function run(): number {\n  return usedFn();\n}\n",
+    );
+
+    store = createTestStore();
+    const registry = new PluginRegistry();
+    registry.registerLanguagePlugin(new TypeScriptLanguagePlugin());
+    const config = {
+      root: tmpDir,
+      include: ['src/**/*.ts'],
+      exclude: ['node_modules/**'],
+      db: { path: ':memory:' },
+      plugins: [],
+    } as never;
+    const pipeline = new IndexingPipeline(store, registry, config, tmpDir);
+    const result = await pipeline.indexAll();
+    expect(result.errors).toBe(0);
+
+    const ctx = {
+      store,
+      projectRoot: tmpDir,
+      config: {},
+      registry,
+      guardPath: () => null,
+      j: (v: unknown) => JSON.stringify(v),
+      jh: (_tool: string, v: unknown) => JSON.stringify(v),
+    } as unknown as ServerContext;
+
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+    registerGitTools(server, ctx);
+    registerAnalysisTools(server, ctx);
+    tools = getRegisteredTools(server);
+  });
+
+  it('get_dead_code{mode: "exports_only"} matches get_dead_exports', async () => {
+    const viaDeadCode = parseText(await tools.get_dead_code.handler({ mode: 'exports_only' }, {}));
+    const viaDeadExports = parseText(await tools.get_dead_exports.handler({}, {}));
+    expect(viaDeadCode).toEqual(viaDeadExports);
+  });
+
+  it('get_dead_code{mode: "exports_only"} defaults limit to 100 like get_dead_exports', async () => {
+    const result = parseText(await tools.get_dead_code.handler({ mode: 'exports_only' }, {})) as {
+      total_dead: number;
+      total_exports: number;
+    };
+    expect(result).toHaveProperty('total_dead');
+    expect(result).toHaveProperty('total_exports');
+  });
+
+  it('regression: get_dead_code default mode (multi-signal) shape is unchanged', async () => {
+    const result = parseText(await tools.get_dead_code.handler({}, {})) as Record<string, unknown>;
+    expect(result).toHaveProperty('dead_symbols');
+    expect(result).not.toHaveProperty('dead_exports');
+  });
+
+  it('regression: get_dead_exports output shape is unchanged', async () => {
+    const result = parseText(await tools.get_dead_exports.handler({}, {})) as Record<
+      string,
+      unknown
+    >;
+    expect(result).toHaveProperty('dead_exports');
+    expect(result).toHaveProperty('total_dead');
+    expect(result).toHaveProperty('total_exports');
+  });
+});


### PR DESCRIPTION
## Summary
Closes [TRA-199](https://github.com/nikolai-vysotskyi/trace-mcp) (part of the TRA-193 tool-consolidation umbrella, TRA-186 follow-up).

`get_dead_code` gains `mode: "exports_only"`, dispatching to the exact same `getDeadExports()` call `get_dead_exports` already uses — including its `recommendation` field (`remove_export_keyword`/`delete_symbol`) and pagination (`truncated`/`total_dead`). Default limit in this mode is 100 (matching `get_dead_exports`'s own default), not `get_dead_code`'s general 50.

`get_dead_exports` stays registered unchanged as the permanent fast-path alias — its own description already cross-references `get_dead_code`, no change needed there.

## Test plan
- New `tests/tools/dead-code-exports-only-mode.test.ts`: `get_dead_code{mode:"exports_only"}` output equals calling `get_dead_exports` directly on the same fixture; default (multi-signal) mode regression-checked (still returns `dead_symbols`, not `dead_exports`); `get_dead_exports` output shape regression-checked unchanged.
- Existing dead-code/dead-exports test suites (75 + 19 tests across 10 files) pass unchanged.
- `pnpm run build` — passes
- `pnpm run lint` (tsc --noEmit) — passes
- `pnpm run biome:ci` — passes
- `pnpm run test` — 8612 passed, 6 skipped, 0 failed (full suite)