### PR TITLE
feat(get_untested_symbols): add scope param, alias get_untested_exports (TRA-203)

### DIFF
--- a/src/tools/register/analysis.ts
+++ b/src/tools/register/analysis.ts
@@ -236,7 +236,7 @@ export function registerAnalysisTools(server: McpServer, ctx: ServerContext): vo
 
   server.tool(
     'get_untested_symbols',
-    'Find ALL symbols (not just exports) lacking test coverage. Classifies as "unreached" (no test file imports the source) or "imported_not_called" (test imports file but never references this symbol). By default only source-code languages (TypeScript, Python, Go, Ruby, …) are considered — markdown/JSON/YAML symbols are excluded. Use include_non_code=true to restore the legacy noisy behaviour. For exports-only quick scan use get_untested_exports instead. Read-only. Returns JSON: { untested: [{ symbol_id, name, kind, file, classification }], total }.',
+    'Find symbols lacking test coverage. scope="all_symbols" (default) classifies each as "unreached" (no test file imports the source) or "imported_not_called" (test imports file but never references this symbol) — by default only source-code languages (TypeScript, Python, Go, Ruby, …) are considered, use include_non_code=true to restore the legacy noisy behaviour. scope="exports_only" is the same fast scan as get_untested_exports, which stays available as its own tool. Read-only. Returns JSON: { untested: [{ symbol_id, name, kind, file, classification }], total }.',
     {
       file_pattern: z
         .string()
@@ -254,10 +254,20 @@ export function registerAnalysisTools(server: McpServer, ctx: ServerContext): vo
         .boolean()
         .optional()
         .describe(
-          'Include symbols from non-code files (markdown, json, yaml, …). Default false — only source-code symbols are considered.',
+          'Include symbols from non-code files (markdown, json, yaml, …). Default false — only source-code symbols are considered. Ignored when scope="exports_only".',
+        ),
+      scope: z
+        .enum(['all_symbols', 'exports_only'])
+        .optional()
+        .describe(
+          'all_symbols (default): full classification. exports_only: same as get_untested_exports.',
         ),
     },
-    async ({ file_pattern, max_results, include_non_code }) => {
+    async ({ file_pattern, max_results, include_non_code, scope }) => {
+      if (scope === 'exports_only') {
+        const result = getUntestedExports(store, file_pattern);
+        return { content: [{ type: 'text', text: jh('get_untested_symbols', result) }] };
+      }
       const result = getUntestedSymbols(store, file_pattern, max_results, include_non_code);
       return { content: [{ type: 'text', text: jh('get_untested_symbols', result) }] };
     },

--- a/tests/tools/untested-symbols-scope.test.ts
+++ b/tests/tools/untested-symbols-scope.test.ts
@@ -1,0 +1,107 @@
+/**
+ * TRA-203 — `get_untested_symbols`'s `scope: "exports_only"` must dispatch
+ * to the exact same `getUntestedExports()` call `get_untested_exports`
+ * uses, and `get_untested_exports` (the permanent alias) must stay
+ * byte-for-byte unchanged. `get_tests_for` is out of scope for this change
+ * entirely (different file, untouched) — not exercised here.
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { Store } from '../../src/db/store.js';
+import { IndexingPipeline } from '../../src/indexer/pipeline.js';
+import { TypeScriptLanguagePlugin } from '../../src/indexer/plugins/language/typescript/index.js';
+import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import { registerAnalysisTools } from '../../src/tools/register/analysis.js';
+import type { ServerContext } from '../../src/server/types.js';
+import { createTestStore, createTmpDir, writeFixtureFile } from '../test-utils.js';
+
+interface RegisteredTool {
+  handler: (
+    args: Record<string, unknown>,
+    extra: unknown,
+  ) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+}
+
+function getRegisteredTools(server: McpServer): Record<string, RegisteredTool> {
+  return (server as unknown as { _registeredTools: Record<string, RegisteredTool> })
+    ._registeredTools;
+}
+
+function parseText(result: { content: Array<{ type: string; text: string }> }): unknown {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('get_untested_symbols { scope: "exports_only" } (TRA-203)', () => {
+  let store: Store;
+  let tmpDir: string;
+  let tools: Record<string, RegisteredTool>;
+
+  beforeAll(async () => {
+    tmpDir = createTmpDir('trace-mcp-untested-scope-');
+    writeFixtureFile(
+      tmpDir,
+      'src/uncovered.ts',
+      'export function uncoveredFn(): number {\n  return 1;\n}\n',
+    );
+
+    store = createTestStore();
+    const registry = new PluginRegistry();
+    registry.registerLanguagePlugin(new TypeScriptLanguagePlugin());
+    const config = {
+      root: tmpDir,
+      include: ['src/**/*.ts'],
+      exclude: ['node_modules/**'],
+      db: { path: ':memory:' },
+      plugins: [],
+    } as never;
+    const pipeline = new IndexingPipeline(store, registry, config, tmpDir);
+    const result = await pipeline.indexAll();
+    expect(result.errors).toBe(0);
+
+    const ctx = {
+      store,
+      projectRoot: tmpDir,
+      config: {},
+      registry,
+      guardPath: () => null,
+      j: (v: unknown) => JSON.stringify(v),
+      jh: (_tool: string, v: unknown) => JSON.stringify(v),
+    } as unknown as ServerContext;
+
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+    registerAnalysisTools(server, ctx);
+    tools = getRegisteredTools(server);
+  });
+
+  it('get_untested_symbols{scope: "exports_only"} matches get_untested_exports', async () => {
+    const viaUntestedSymbols = parseText(
+      await tools.get_untested_symbols.handler({ scope: 'exports_only' }, {}),
+    );
+    const viaUntestedExports = parseText(await tools.get_untested_exports.handler({}, {}));
+    expect(viaUntestedSymbols).toEqual(viaUntestedExports);
+  });
+
+  it('regression: get_untested_symbols default scope (all_symbols) shape is unchanged', async () => {
+    const result = parseText(await tools.get_untested_symbols.handler({}, {})) as Record<
+      string,
+      unknown
+    >;
+    expect(result).toHaveProperty('untested');
+    expect(result).toHaveProperty('total_symbols');
+    expect(result).toHaveProperty('by_level');
+    const untested = result.untested as Array<Record<string, unknown>>;
+    if (untested.length > 0) {
+      expect(untested[0]).toHaveProperty('level');
+    }
+  });
+
+  it('regression: get_untested_exports output shape is unchanged', async () => {
+    const result = parseText(await tools.get_untested_exports.handler({}, {})) as Record<
+      string,
+      unknown
+    >;
+    expect(result).toHaveProperty('untested');
+    expect(result).toHaveProperty('total_exports');
+    expect(result).toHaveProperty('total_untested');
+  });
+});


### PR DESCRIPTION
## Summary
Closes [TRA-203](https://github.com/nikolai-vysotskyi/trace-mcp) (part of the TRA-193 tool-consolidation umbrella, TRA-186 follow-up).

`get_untested_symbols` gains `scope: "all_symbols" | "exports_only"` (default `"all_symbols"`, unchanged behavior). `"exports_only"` dispatches to the exact same `getUntestedExports()` call `get_untested_exports` already uses.

`get_untested_exports` stays registered unchanged as the permanent fast-path alias. `get_tests_for` (symbol→tests lookup, a different question from a coverage-gap listing) is untouched — out of scope per the issue's own note, lives in a different file (`framework.ts`) I didn't edit.

## Test plan
- New `tests/tools/untested-symbols-scope.test.ts`: `get_untested_symbols{scope:"exports_only"}` output equals calling `get_untested_exports` directly; default scope regression-checked (still returns `total_symbols`/`by_level`, not `total_exports`); `get_untested_exports` output shape regression-checked unchanged.
- Existing `tests/tools/behavioural/get-untested-exports.behavioural.test.ts` and `get-untested-symbols.behavioural.test.ts` pass unchanged.
- `pnpm run build` — passes
- `pnpm run lint` (tsc --noEmit) — passes
- `pnpm run biome:ci` — passes
- `pnpm run test` — 8615 passed, 6 skipped, 0 failed (full suite)