### PR TITLE
fix(install-app): verify SHA-256 before extracting or executing release assets (TRA-219)

### DIFF
--- a/src/cli/install-app.ts
+++ b/src/cli/install-app.ts
@@ -4,6 +4,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import https from 'node:https';
 import os from 'node:os';
@@ -110,10 +111,11 @@ function fetchLatestRelease(
   });
 }
 
-/** Download a file from URL, following redirects */
-function downloadFile(url: string, dest: string, timeoutMs = 60000): Promise<void> {
+/** Download a file from URL, following redirects. Resolves with its SHA-256 digest. */
+function downloadFile(url: string, dest: string, timeoutMs = 60000): Promise<string> {
   return new Promise((resolve, reject) => {
     const file = fs.createWriteStream(dest);
+    const hash = crypto.createHash('sha256');
     const doGet = (targetUrl: string, redirects = 0) => {
       if (redirects > 5) {
         reject(new Error('Too many redirects'));
@@ -130,10 +132,11 @@ function downloadFile(url: string, dest: string, timeoutMs = 60000): Promise<voi
             reject(new Error(`Download failed: HTTP ${res.statusCode}`));
             return;
           }
+          res.on('data', (chunk) => hash.update(chunk));
           res.pipe(file);
           file.on('finish', () => {
             file.close();
-            resolve();
+            resolve(hash.digest('hex'));
           });
         })
         .on('error', (err) => {
@@ -143,6 +146,55 @@ function downloadFile(url: string, dest: string, timeoutMs = 60000): Promise<voi
     };
     doGet(url);
   });
+}
+
+/**
+ * Locate the `<asset>.sha256` sibling published alongside every release asset.
+ * Exported so the fail-closed behaviour can be asserted without the network.
+ */
+export function findChecksumAsset<T extends { name: string }>(
+  assets: T[],
+  assetName: string,
+): T | undefined {
+  return assets.find((a) => a.name === `${assetName}.sha256`);
+}
+
+/**
+ * Parse a `.sha256` manifest: either a bare digest or `<digest>  <filename>`
+ * (sha256sum format). Mirrors scripts/postinstall-app.mjs::parseSha256Manifest.
+ */
+export function parseSha256Manifest(text: string, assetName: string): string | null {
+  const lines = text
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+  for (const line of lines) {
+    const bare = line.match(/^([a-f0-9]{64})$/i);
+    if (bare) return bare[1].toLowerCase();
+    const pair = line.match(/^([a-f0-9]{64})\s+\*?(.+)$/i);
+    if (pair && path.basename(pair[2]) === assetName) return pair[1].toLowerCase();
+  }
+  return null;
+}
+
+/**
+ * Fail closed: throws unless `actualDigest` matches the digest the manifest
+ * publishes for `assetName`. An unparseable manifest is treated as a mismatch.
+ */
+export function assertDigestMatches(
+  actualDigest: string,
+  manifestText: string,
+  assetName: string,
+): void {
+  const expected = parseSha256Manifest(manifestText, assetName);
+  if (!expected) {
+    throw new Error(`Checksum manifest for ${assetName} is unreadable — refusing to install`);
+  }
+  if (expected !== actualDigest.toLowerCase()) {
+    throw new Error(
+      `Checksum mismatch for ${assetName}: expected ${expected}, got ${actualDigest.toLowerCase()} — refusing to install`,
+    );
+  }
 }
 
 /** Pin the app to the macOS Dock (persistent-apps) if not already present. */
@@ -311,10 +363,30 @@ export async function installGuiApp(opts: InstallGuiAppOptions = {}): Promise<In
       };
     }
 
-    // 2. Download to temp
+    // 2. Refuse to install anything we cannot verify. Every release asset ships
+    //    a `<name>.sha256` sibling; no sibling means no install (same
+    //    fail-closed rule as scripts/postinstall-app.mjs).
+    const checksumAsset = findChecksumAsset(release!.assets, asset.name);
+    if (!checksumAsset) {
+      return {
+        installed: false,
+        error: `No ${asset.name}.sha256 checksum published for release ${release!.tag} — refusing to install an unverified artifact`,
+      };
+    }
+
+    // 3. Download to temp and verify before anything is executed or extracted
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-app-'));
     const archivePath = path.join(tmpDir, asset.name);
-    await downloadFile(asset.url, archivePath);
+    try {
+      const actualDigest = await downloadFile(asset.url, archivePath);
+      const manifestPath = path.join(tmpDir, checksumAsset.name);
+      await downloadFile(checksumAsset.url, manifestPath, 15_000);
+      assertDigestMatches(actualDigest, fs.readFileSync(manifestPath, 'utf-8'), asset.name);
+    } catch (err) {
+      // Never leave an unverified artifact behind for anything else to pick up.
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      throw err;
+    }
 
     // 3. Ensure install dir exists
     fs.mkdirSync(INSTALL_DIR, { recursive: true });

--- a/tests/cli/install-app-checksum.test.ts
+++ b/tests/cli/install-app-checksum.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression tests for TRA-219: `trace-mcp install-app` downloaded a release
+ * asset and immediately unzipped it (macOS) or executed it (Windows NSIS
+ * `.exe`) without ever verifying its SHA-256, while the sibling auto-update
+ * path (`scripts/postinstall-app.mjs`) has always verified and aborted on a
+ * missing or mismatched digest.
+ *
+ * `findChecksumAsset`, `parseSha256Manifest`, and `assertDigestMatches` are
+ * exported so the fail-closed behaviour can be asserted directly, without
+ * mocking the network/download layer — same approach as
+ * install-app-security.test.ts.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  assertDigestMatches,
+  findChecksumAsset,
+  parseSha256Manifest,
+} from '../../src/cli/install-app.js';
+
+const DIGEST = 'a'.repeat(64);
+const OTHER_DIGEST = 'b'.repeat(64);
+
+// Real asset shapes, confirmed against the v1.48.x releases.
+const MAC_ASSET = 'trace-mcp-1.48.5-arm64-mac.zip';
+const WIN_EXE_ASSET = 'trace-mcp.Setup.1.48.5.exe';
+
+describe('install-app checksum verification (TRA-219)', () => {
+  describe('findChecksumAsset', () => {
+    it('finds the .sha256 sibling for a macOS zip', () => {
+      const assets = [
+        { name: MAC_ASSET, url: 'https://x/mac.zip' },
+        { name: `${MAC_ASSET}.sha256`, url: 'https://x/mac.zip.sha256' },
+      ];
+      expect(findChecksumAsset(assets, MAC_ASSET)?.url).toBe('https://x/mac.zip.sha256');
+    });
+
+    it('finds the .sha256 sibling for the Windows NSIS installer', () => {
+      const assets = [
+        { name: WIN_EXE_ASSET, url: 'https://x/setup.exe' },
+        { name: `${WIN_EXE_ASSET}.sha256`, url: 'https://x/setup.exe.sha256' },
+      ];
+      expect(findChecksumAsset(assets, WIN_EXE_ASSET)?.url).toBe('https://x/setup.exe.sha256');
+    });
+
+    it('returns undefined when no checksum is published (install must fail closed)', () => {
+      const assets = [
+        { name: MAC_ASSET, url: 'https://x/mac.zip' },
+        { name: WIN_EXE_ASSET, url: 'https://x/setup.exe' },
+        // A checksum for a *different* asset must not be accepted.
+        { name: 'trace-mcp-1.48.5-mac.zip.sha256', url: 'https://x/other.sha256' },
+      ];
+      expect(findChecksumAsset(assets, MAC_ASSET)).toBeUndefined();
+      expect(findChecksumAsset(assets, WIN_EXE_ASSET)).toBeUndefined();
+    });
+  });
+
+  describe('parseSha256Manifest', () => {
+    it('accepts the bare-digest format the releases actually publish', () => {
+      expect(parseSha256Manifest(`${DIGEST}\n`, MAC_ASSET)).toBe(DIGEST);
+    });
+
+    it('accepts sha256sum `<digest>  <filename>` lines matching the asset', () => {
+      expect(parseSha256Manifest(`${DIGEST}  ${MAC_ASSET}\n`, MAC_ASSET)).toBe(DIGEST);
+      expect(parseSha256Manifest(`${DIGEST} *${WIN_EXE_ASSET}\r\n`, WIN_EXE_ASSET)).toBe(DIGEST);
+    });
+
+    it('rejects a sha256sum line naming a different asset', () => {
+      expect(parseSha256Manifest(`${DIGEST}  some-other-asset.zip`, MAC_ASSET)).toBeNull();
+    });
+
+    it('returns null for garbage', () => {
+      expect(parseSha256Manifest('not a digest', MAC_ASSET)).toBeNull();
+      expect(parseSha256Manifest('', MAC_ASSET)).toBeNull();
+    });
+  });
+
+  describe('assertDigestMatches', () => {
+    it('passes when the macOS zip digest matches', () => {
+      expect(() => assertDigestMatches(DIGEST, `${DIGEST}\n`, MAC_ASSET)).not.toThrow();
+    });
+
+    it('is case-insensitive about the digest encoding', () => {
+      expect(() =>
+        assertDigestMatches(DIGEST.toUpperCase(), `${DIGEST}\n`, MAC_ASSET),
+      ).not.toThrow();
+    });
+
+    it('throws on a mismatched macOS zip digest', () => {
+      expect(() => assertDigestMatches(OTHER_DIGEST, `${DIGEST}\n`, MAC_ASSET)).toThrow(
+        /Checksum mismatch/,
+      );
+    });
+
+    it('throws on a mismatched Windows installer digest (never executes the .exe)', () => {
+      expect(() =>
+        assertDigestMatches(OTHER_DIGEST, `${DIGEST}  ${WIN_EXE_ASSET}`, WIN_EXE_ASSET),
+      ).toThrow(/Checksum mismatch/);
+    });
+
+    it('throws when the manifest is unreadable rather than falling through', () => {
+      expect(() => assertDigestMatches(DIGEST, 'corrupted', MAC_ASSET)).toThrow(/unreadable/);
+    });
+  });
+});


### PR DESCRIPTION
Closes TRA-219.

`trace-mcp install-app` downloaded the picked release asset and immediately unzipped it (macOS) or ran the NSIS `.exe` silently (Windows) with **no integrity check** — the highest-severity variant being an unverified `.exe` executed via `runNsisInstaller()`. The sibling auto-update path, `scripts/postinstall-app.mjs`, has always verified the SHA-256 and aborted when the checksum asset is missing or the digest mismatches; `install-app.ts` never got the same treatment.

## Change

- `downloadFile()` now streams through `crypto.createHash('sha256')` and resolves the digest (same pattern as `postinstall-app.mjs::downloadFile`).
- `installGuiApp()` resolves the `<asset>.sha256` sibling every release publishes. **No checksum asset → no install** — it returns an error instead of proceeding, matching postinstall's fail-closed rule.
- The digest is compared *before* `unzipMac` / `runNsisInstaller` / `expandArchiveWindows` is reached. On mismatch or unreadable manifest, the temp dir is wiped and the install fails.
- `findChecksumAsset`, `parseSha256Manifest`, `assertDigestMatches` exported so the fail-closed paths are testable without mocking the network — the same approach `install-app-security.test.ts` already uses.

Scope note: the issue also suggested extracting a shared `download-verified.mjs` helper across `postinstall-app.mjs` / `install-app.ts` / `apply-pending-update.mjs`. That dedup is deliberately **not** in this PR — it widens the blast radius across the update path for no security gain. The hole itself is closed here; the dedup can be a separate cleanup.

## Test evidence

New `tests/cli/install-app-checksum.test.ts` (12 tests) covers, for a real macOS zip asset shape and a real Windows NSIS `.exe` asset shape:
- checksum sibling found; a checksum for a *different* asset is not accepted
- missing checksum → `undefined` (install fails closed)
- bare-digest and `<digest>  <filename>` manifest formats; wrong filename and garbage → `null`
- digest match passes, mismatch throws, unreadable manifest throws

Local: `pnpm run build`, `pnpm run typecheck`, `pnpm run biome:ci` clean; `pnpm run test` — **8628 passed, 9 skipped, 0 failed** (789 files).
