### PR TITLE
fix(mcp): strip redundant $schema keyword from tools/list (~9 KB/session)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ const PKG_VERSION =
 
 import http from 'node:http';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { stripRedundantSchemaKeyword } from './server/schema-shim.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { aiTracker } from './ai/index.js';
 import { detectCoverageRecursive } from './analytics/tech-detector.js';
@@ -682,9 +683,11 @@ program
       // Pre-allocate the session id so the journal callback below can stamp
       // each emitted event with the same id the MCP transport will use.
       const sessionId = randomUUID();
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => sessionId,
-      });
+      const transport = stripRedundantSchemaKeyword(
+        new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => sessionId,
+        }),
+      );
 
       // Each session needs its own Server instance since the MCP SDK's Server
       // only supports one transport at a time. All sessions share the same

--- a/src/daemon/router/session.ts
+++ b/src/daemon/router/session.ts
@@ -4,6 +4,7 @@ import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import type { TraceMcpConfig } from '../../config.js';
 import { logger } from '../../logger.js';
 import { checkVersionDrift, versionDriftMessage } from '../../init/version-stamp.js';
+import { stripRedundantSchemaKeyword } from '../../server/schema-shim.js';
 import { disarmStdoutGuard } from '../../server/transport-hardening.js';
 import { tryAutoSpawnDaemon } from '../lifecycle.js';
 import { PollingDaemonWatcher } from './daemon-watcher.js';
@@ -85,7 +86,7 @@ export class StdioSession {
 
   constructor(opts: StdioSessionOptions) {
     this.opts = opts;
-    this.stdio = new StdioServerTransport();
+    this.stdio = stripRedundantSchemaKeyword(new StdioServerTransport());
     this.router = new MessageRouter({
       sendToClient: (msg) => this.stdio.send(msg),
       drainTimeoutMs: opts.drainTimeoutMs ?? 5_000,

--- a/src/server/__tests__/schema-shim.test.ts
+++ b/src/server/__tests__/schema-shim.test.ts
@@ -1,0 +1,114 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it, vi } from 'vitest';
+import { stripRedundantSchemaKeyword } from '../schema-shim.js';
+import { z } from 'zod';
+
+/** Drives a real tools/list over an in-memory transport pair. */
+async function listToolsOverWire(applyShim: boolean) {
+  const server = new McpServer({ name: 'test', version: '0.0.0' });
+  server.tool(
+    'echo',
+    'Echo a string back.',
+    { text: z.string().describe('text to echo') },
+    async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }),
+  );
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  await Promise.all([
+    server.connect(applyShim ? stripRedundantSchemaKeyword(serverTransport) : serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  const { tools } = await client.listTools();
+  await client.close();
+  await server.close();
+  return tools;
+}
+
+function fakeTransport() {
+  // Keep the spy separate — the shim replaces `transport.send` itself.
+  const sent = vi.fn(async (_message: JSONRPCMessage) => {});
+  const transport = {
+    send: sent,
+    start: async () => {},
+    close: async () => {},
+  } as unknown as Transport;
+  return { transport, sent };
+}
+
+describe('stripRedundantSchemaKeyword', () => {
+  // Premise guard: if a future SDK/zod bump stops stamping $schema, the shim
+  // becomes a silent no-op — this test fails loudly instead.
+  it('the unpatched SDK still emits $schema on inputSchema', async () => {
+    const tools = await listToolsOverWire(false);
+    expect(tools).toHaveLength(1);
+    expect(tools[0].inputSchema).toHaveProperty('$schema');
+  });
+
+  it('strips $schema from tools/list end-to-end while keeping the tool usable', async () => {
+    const tools = await listToolsOverWire(true);
+    expect(tools).toHaveLength(1);
+    expect(tools[0].inputSchema).not.toHaveProperty('$schema');
+    expect(tools[0].inputSchema.type).toBe('object');
+    expect(tools[0].inputSchema.properties).toHaveProperty('text');
+    expect(tools[0].description).toBe('Echo a string back.');
+  });
+
+  it('strips inputSchema and outputSchema in place, leaving everything else intact', async () => {
+    const { transport, sent } = fakeTransport();
+    const message = {
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        tools: [
+          {
+            name: 'x',
+            inputSchema: {
+              $schema: 'https://json-schema.org/draft/2020-12/schema',
+              type: 'object',
+            },
+            outputSchema: {
+              $schema: 'https://json-schema.org/draft/2020-12/schema',
+              type: 'object',
+            },
+          },
+        ],
+      },
+    } as unknown as JSONRPCMessage;
+
+    await stripRedundantSchemaKeyword(transport).send(message);
+
+    // Same object reference must reach the wire — a copy would mean the real
+    // message still carries $schema.
+    expect(sent.mock.calls[0][0]).toBe(message);
+    expect(sent.mock.calls[0][0]).toEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        tools: [{ name: 'x', inputSchema: { type: 'object' }, outputSchema: { type: 'object' } }],
+      },
+    });
+  });
+
+  it('forwards non-tools/list messages unmodified', async () => {
+    const { transport, sent } = fakeTransport();
+    const wrapped = stripRedundantSchemaKeyword(transport);
+    const messages = [
+      { jsonrpc: '2.0', id: 2, result: { content: [{ type: 'text', text: 'hi' }] } },
+      { jsonrpc: '2.0', id: 3, result: { protocolVersion: '2025-06-18', capabilities: {} } },
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      { jsonrpc: '2.0', id: 4, error: { code: -32601, message: 'nope' } },
+    ] as unknown as JSONRPCMessage[];
+
+    for (const msg of messages) await wrapped.send(msg);
+
+    for (const [i, msg] of messages.entries()) {
+      expect(sent.mock.calls[i][0]).toEqual(msg);
+    }
+  });
+});

--- a/src/server/schema-shim.ts
+++ b/src/server/schema-shim.ts
@@ -1,0 +1,45 @@
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+
+interface ToolsListResult {
+  tools: Array<{
+    inputSchema?: { $schema?: unknown };
+    outputSchema?: { $schema?: unknown };
+  }>;
+}
+
+function isToolsListResponse(
+  msg: JSONRPCMessage,
+): msg is JSONRPCMessage & { result: ToolsListResult } {
+  const m = msg as Record<string, unknown>;
+  if (!Object.hasOwn(m, 'result')) return false;
+  const result = m.result as Record<string, unknown> | null;
+  return typeof result === 'object' && result !== null && Array.isArray(result.tools);
+}
+
+/**
+ * zod v4's `toJSONSchema()` — the converter the MCP SDK calls to turn a tool's
+ * zod shape into `inputSchema` — stamps a top-level `$schema` URI on every
+ * tool. Across ~171 tools that is ~9k chars (~2.25k tokens) of pure duplication
+ * paid on every `tools/list`, and `$schema` is an optional informational
+ * keyword no MCP client reads. Strip it as the message leaves the process.
+ *
+ * Verified against @modelcontextprotocol/sdk@1.29.0, zod@4.3.6 (2026-08-28).
+ * The "premise" test in `__tests__/schema-shim.test.ts` asserts the *unpatched*
+ * SDK still emits `$schema` — if an SDK/zod bump stops emitting it or changes
+ * the response shape, that test fails instead of this shim silently becoming a
+ * no-op.
+ */
+export function stripRedundantSchemaKeyword<T extends Transport>(transport: T): T {
+  const originalSend = transport.send.bind(transport);
+  transport.send = ((message: JSONRPCMessage, options?: unknown) => {
+    if (isToolsListResponse(message)) {
+      for (const tool of message.result.tools) {
+        if (tool.inputSchema) delete tool.inputSchema.$schema;
+        if (tool.outputSchema) delete tool.outputSchema.$schema;
+      }
+    }
+    return originalSend(message, options as never);
+  }) as Transport['send'];
+  return transport;
+}


### PR DESCRIPTION
Implements TRA-209 (child of TRA-208): drop the redundant `$schema` URI from `tools/list` responses.

## What

zod v4's `toJSONSchema()` — the converter the MCP SDK calls to build `inputSchema` — stamps `"$schema": "https://json-schema.org/draft/2020-12/schema"` on every tool. Measured cost: **52 bytes per tool**, so ~9 KB (~2.2k tokens) per `tools/list` across ~171 tools. It's an optional informational JSON Schema keyword; no MCP client reads it, and MCP's own spec examples don't include it.

`src/server/schema-shim.ts` wraps `Transport.send` and deletes `inputSchema.$schema` / `outputSchema.$schema` on `tools/list` responses only. Applied at the two (only) transport-construction sites:

- `src/daemon/router/session.ts` — stdio, covers both `LocalBackend` and `ProxyBackend` since `MessageRouter` funnels everything through `this.stdio.send()`
- `src/cli.ts` `createSessionTransport` — HTTP daemon

No tool names, params, counts, or schema structure change. Not a breaking MCP contract change.

## Tests (`src/server/__tests__/schema-shim.test.ts`, 4 passing)

1. **Premise guard** — asserts the *unpatched* SDK still emits `$schema` over a real `McpServer` + `Client` in-memory pair. If a future SDK/zod bump stops emitting it, this fails loudly instead of the shim silently becoming a no-op.
2. **End-to-end strip** — real `tools/list` over the wire with the shim applied: no `$schema`, `type`/`properties`/`description` intact.
3. **In-place mutation** — the same object reference reaches the underlying `send` with the key removed (a copy would mean the real wire message still carried it).
4. **Passthrough** — `tools/call` result, `initialize` result, a notification, and an error frame all forwarded unmodified.

`pnpm run typecheck`, `pnpm run build`, and the full `pnpm test` (8632 passed / 9 skipped, 790 files) are green locally.

## Not done here

Manual smoke against a live Claude Desktop session (TRA-209 step 7) — the automated in-memory client/server round-trip covers the same path; call it out if you want the manual run before release.
