### PR TITLE
fix(app): don't render KPI zeros before metrics load; use --success/--warning tokens

### DIFF
--- a/packages/app/src/renderer/workspace/Workspace.tsx
+++ b/packages/app/src/renderer/workspace/Workspace.tsx
@@ -168,6 +168,7 @@ export function Workspace() {
     <div className="flex flex-col h-full overflow-hidden relative">
       <WorkspaceHeader
         kpis={kpis}
+        metricsLoading={data.metricsLoading}
         filter={filter}
         onFilterChange={setFilter}
         view={view}

--- a/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
@@ -21,6 +21,8 @@ import {
 
 export interface WorkspaceHeaderProps {
   kpis: WorkspaceKpis;
+  /** Metric-backed KPI tiles show a placeholder instead of `0` while true. */
+  metricsLoading?: boolean;
   filter: WorkspaceFilter;
   onFilterChange: (next: WorkspaceFilter) => void;
   view: ViewMode;
@@ -72,15 +74,25 @@ interface KpiCellProps {
   active?: boolean;
   onClick?: () => void;
   accent?: 'ok' | 'warn' | 'busy';
+  /** Render a placeholder instead of `value` — the number isn't known yet. */
+  pending?: boolean;
 }
 
-function KpiCell({ label, value, compact = false, active = false, onClick, accent }: KpiCellProps) {
+function KpiCell({
+  label,
+  value,
+  compact = false,
+  active = false,
+  onClick,
+  accent,
+  pending = false,
+}: KpiCellProps) {
   const interactive = onClick !== undefined;
   const color =
     accent === 'ok'
-      ? '#34c759'
+      ? 'var(--success)'
       : accent === 'warn'
-      ? '#ff9f0a'
+      ? 'var(--warning)'
       : accent === 'busy'
       ? 'var(--accent)'
       : 'var(--text-primary)';
@@ -99,9 +111,10 @@ function KpiCell({ label, value, compact = false, active = false, onClick, accen
     >
       <span
         className="text-base font-semibold tabular-nums leading-tight"
-        style={{ color: active ? '#fff' : color }}
+        style={{ color: active ? '#fff' : pending ? 'var(--text-tertiary)' : color }}
       >
-        {compact ? formatCompact(value) : value.toLocaleString()}
+        {/* ponytail: em dash, not a shimmer block — same box, no digit, no CSS. */}
+        {pending ? '—' : compact ? formatCompact(value) : value.toLocaleString()}
       </span>
       <span
         className="text-[10px] font-medium leading-tight mt-0.5"
@@ -199,6 +212,7 @@ function Spinner() {
 
 export function WorkspaceHeader({
   kpis,
+  metricsLoading = false,
   filter,
   onFilterChange,
   view,
@@ -234,12 +248,13 @@ export function WorkspaceHeader({
             active={filter.preset === null && filter.statuses === null && filter.grades === null && filter.query === ''}
             onClick={() => onFilterChange(EMPTY_FILTER)}
           />
-          <KpiCell label="Files" value={kpis.totalFiles} compact />
-          <KpiCell label="Symbols" value={kpis.totalSymbols} compact />
+          <KpiCell label="Files" value={kpis.totalFiles} compact pending={metricsLoading} />
+          <KpiCell label="Symbols" value={kpis.totalSymbols} compact pending={metricsLoading} />
           <KpiCell
             label="Healthy"
             value={kpis.healthy}
             accent="ok"
+            pending={metricsLoading}
             active={filter.preset === 'healthy'}
             onClick={() => togglePreset('healthy')}
           />
@@ -247,6 +262,7 @@ export function WorkspaceHeader({
             label="Needs attention"
             value={kpis.needsAttention}
             accent="warn"
+            pending={metricsLoading}
             active={filter.preset === 'needs_attention'}
             onClick={() => togglePreset('needs_attention')}
           />

--- a/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { WorkspaceHeader } from '../WorkspaceHeader';
+import { EMPTY_FILTER, type WorkspaceKpis } from '../types';
+
+const ZERO_KPIS: WorkspaceKpis = {
+  totalProjects: 78,
+  totalFiles: 0,
+  totalSymbols: 0,
+  healthy: 0,
+  needsAttention: 0,
+  indexing: 0,
+};
+
+/** The KPI strip only — "Indexing" is also a filter chip in the toolbar row. */
+let strip: HTMLElement;
+
+function renderHeader(metricsLoading: boolean) {
+  const { container } = render(
+    <WorkspaceHeader
+      kpis={ZERO_KPIS}
+      metricsLoading={metricsLoading}
+      filter={EMPTY_FILTER}
+      onFilterChange={() => {}}
+      view="table"
+      onViewChange={() => {}}
+      onRefresh={() => {}}
+      refreshing={false}
+    />,
+  );
+  strip = container.querySelector<HTMLElement>('.items-stretch')!;
+}
+
+/** The KPI tile whose label is `label`. */
+function kpiTile(label: string): HTMLElement {
+  const tile = within(strip).getByText(label).closest('button');
+  if (!tile) throw new Error(`no KPI tile for ${label}`);
+  return tile;
+}
+
+/** Text of the number line of that tile. */
+function kpiValue(label: string): string {
+  return kpiTile(label).querySelector('span')?.textContent ?? '';
+}
+
+describe('WorkspaceHeader KPI strip', () => {
+  it('does not report metric zeros as facts while metrics are loading', () => {
+    renderHeader(true);
+    for (const label of ['Files', 'Symbols', 'Healthy', 'Needs attention']) {
+      expect(kpiValue(label)).not.toMatch(/\d/);
+    }
+    // Projects and Indexing come from the daemon, not the dashboard cache.
+    expect(kpiValue('Projects')).toBe('78');
+    expect(kpiValue('Indexing')).toBe('0');
+  });
+
+  it('shows the real numbers once metrics land', () => {
+    renderHeader(false);
+    expect(kpiValue('Files')).toBe('0');
+    expect(kpiValue('Healthy')).toBe('0');
+  });
+
+  it('colors accented KPI numbers with design tokens, not hardcoded hex', () => {
+    renderHeader(false);
+    expect(kpiTile('Healthy').querySelector('span')!.getAttribute('style')).toContain(
+      'var(--success)',
+    );
+    expect(kpiTile('Needs attention').querySelector('span')!.getAttribute('style')).toContain(
+      'var(--warning)',
+    );
+  });
+});

--- a/packages/app/src/renderer/workspace/useWorkspaceProjects.ts
+++ b/packages/app/src/renderer/workspace/useWorkspaceProjects.ts
@@ -54,6 +54,12 @@ export function detectCompletionInDiff(
 export interface UseWorkspaceProjectsResult {
   projects: ProjectViewModel[];
   loading: boolean;
+  /**
+   * True until the first `/api/dashboard/projects` response lands. The project
+   * list arrives seconds earlier, so `loading` is already false while every
+   * metric is still zero — consumers must not render metric numbers yet.
+   */
+  metricsLoading: boolean;
   refreshing: boolean;
   error: string | null;
   connected: boolean;
@@ -183,6 +189,7 @@ export function useWorkspaceProjects(): UseWorkspaceProjectsResult {
   return {
     projects,
     loading,
+    metricsLoading: !metricsLoaded,
     refreshing,
     error,
     connected: daemon.connected,


### PR DESCRIPTION
Fixes both defects reported in TRA-228, in one focused change.

### 1. KPI strip no longer reports zeros as facts while metrics load

`GET /api/projects` returns almost instantly while `GET /api/dashboard/projects` took a measured 16.1 s on 78 projects, so `loading` in `useWorkspaceProjects` was already `false` while `metricsLoaded` was still `false` — and the hook never exposed `metricsLoaded`, so no consumer could tell "genuinely zero" from "not fetched yet".

- `UseWorkspaceProjectsResult` gains `metricsLoading: !metricsLoaded`.
- `WorkspaceHeader` threads it into `KpiCell` as `pending`, which renders an em dash in `var(--text-tertiary)` instead of a digit. Same box, same type scale, tile stays clickable/disabled as before, so nothing reflows when values land.
- Applied to the four genuinely metric-backed tiles: **Files / Symbols / Healthy / Needs attention**. `Projects` *and* `Indexing` both come from the daemon project list (`deriveKpis` counts `indexing` off `displayStatus`, not off `hasMetrics`), so both are correct immediately and keep their numbers. The issue text listed Indexing among the metric-backed tiles but also said "four" — four is right.

### 2. `KpiCell` accents go through tokens

`'#34c759'` → `'var(--success)'`, `'#ff9f0a'` → `'var(--warning)'`. The green was the legacy iOS value TRA-134 removed; in dark mode `--success` is `#30d158`, which is what the project row status dots already render, so the two greens on the same screen now match. `--warning` is `#ff9f0a` in dark mode — no visual change to the warn tile, it just can't drift again.

### Test evidence

New `packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx` — a real jsdom render of the header (not a diff assertion):

- with `metricsLoading`, the four metric tiles contain no digit, while `Projects` shows `78` and `Indexing` shows `0`;
- once metrics land, the real numbers render;
- the Healthy / Needs attention number styles contain `var(--success)` / `var(--warning)`.

```
pnpm test       # 4 files, 49 tests passed
pnpm typecheck  # clean
pnpm build      # renderer + main clean
```

The rendered DOM in that test is the live component output, but this is not an Electron screenshot against the real daemon — @nikolai-vysotskyi offered to re-verify with an after-screenshot on the running app, which is the remaining check.
