### PR TITLE
fix(app): normalize daemon project_status progress payload

### DIFF
--- a/packages/app/src/renderer/hooks/__tests__/useDaemon.test.ts
+++ b/packages/app/src/renderer/hooks/__tests__/useDaemon.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { type DaemonProgress, toProgressSnapshot } from '../useDaemon';
+
+/** Shape captured verbatim off `GET /api/events` for an idle project. */
+const idlePayload: DaemonProgress = {
+  indexing: { phase: 'completed', processed: 0, total: 0, percentage: null, elapsedMs: 544 },
+  summarization: { phase: 'idle', processed: 0, total: 0, percentage: null, elapsedMs: 0 },
+  embedding: { phase: 'completed', processed: 279, total: 279, percentage: 100, elapsedMs: 31389 },
+};
+
+describe('toProgressSnapshot', () => {
+  it('returns undefined when no pipeline is running', () => {
+    expect(toProgressSnapshot(idlePayload)).toBeUndefined();
+    expect(toProgressSnapshot(undefined)).toBeUndefined();
+    expect(toProgressSnapshot({} as DaemonProgress)).toBeUndefined();
+  });
+
+  it('flattens the running pipeline', () => {
+    const snap = toProgressSnapshot({
+      ...idlePayload,
+      embedding: { phase: 'running', processed: 40, total: 200, percentage: 20, elapsedMs: 100 },
+    });
+    expect(snap).toEqual({ phase: 'embedding', current: 40, total: 200, percent: 20 });
+  });
+
+  it('picks indexing over a later running pipeline', () => {
+    const snap = toProgressSnapshot({
+      indexing: { phase: 'running', processed: 1, total: 4, percentage: 25, elapsedMs: 10 },
+      embedding: { phase: 'running', processed: 40, total: 200, percentage: 20, elapsedMs: 100 },
+    });
+    expect(snap?.phase).toBe('indexing');
+  });
+
+  it('falls back to 0% when the daemon reports a null percentage', () => {
+    const snap = toProgressSnapshot({
+      indexing: { phase: 'running', processed: 0, total: 0, percentage: null, elapsedMs: 0 },
+    });
+    expect(snap).toEqual({ phase: 'indexing', current: 0, total: 0, percent: 0 });
+  });
+});

--- a/packages/app/src/renderer/hooks/useDaemon.ts
+++ b/packages/app/src/renderer/hooks/useDaemon.ts
@@ -19,6 +19,46 @@ export interface ProjectState extends ProjectInfo {
   progress?: ProgressSnapshot;
 }
 
+/**
+ * Raw `project_status.progress` payload from the daemon: one entry per
+ * pipeline, not the flat `ProgressSnapshot` the UI renders.
+ * Source of truth: `ProgressSnapshot` in `src/progress.ts`.
+ */
+export interface DaemonProgress {
+  indexing?: DaemonPipelineProgress;
+  summarization?: DaemonPipelineProgress;
+  embedding?: DaemonPipelineProgress;
+}
+
+export interface DaemonPipelineProgress {
+  phase: string;
+  processed: number;
+  total: number;
+  percentage: number | null;
+  elapsedMs: number;
+}
+
+const PIPELINES = ['indexing', 'summarization', 'embedding'] as const;
+
+/**
+ * Flatten the daemon's per-pipeline progress onto the single bar the UI
+ * shows: the first pipeline that is actually running, or `undefined` when
+ * none is — an idle project must render no bar and no phase label.
+ */
+export function toProgressSnapshot(raw: DaemonProgress | undefined): ProgressSnapshot | undefined {
+  for (const name of PIPELINES) {
+    const p = raw?.[name];
+    if (p?.phase !== 'running') continue;
+    return {
+      phase: name,
+      current: p.processed ?? 0,
+      total: p.total ?? 0,
+      percent: typeof p.percentage === 'number' ? p.percentage : 0,
+    };
+  }
+  return undefined;
+}
+
 export interface ClientInfo {
   id: string;
   name?: string;
@@ -53,7 +93,8 @@ type SSEEvent =
       project: string;
       status: string;
       error?: string;
-      progress?: ProgressSnapshot;
+      /** Nested per-pipeline shape from the daemon — see DaemonProgress. */
+      progress?: DaemonProgress;
     }
   | {
       type: 'indexing_progress';
@@ -172,7 +213,12 @@ export function useDaemon() {
         setProjects((prev) =>
           prev.map((p) =>
             p.root === event.project
-              ? { ...p, status: event.status, error: event.error, progress: event.progress }
+              ? {
+                  ...p,
+                  status: event.status,
+                  error: event.error,
+                  progress: toProgressSnapshot(event.progress),
+                }
               : p,
           ),
         );

--- a/packages/app/src/renderer/workspace/components/InlineProgress.tsx
+++ b/packages/app/src/renderer/workspace/components/InlineProgress.tsx
@@ -13,7 +13,10 @@ export interface InlineProgressProps {
  * indexing UI consistent across views. Returns `null` when no progress.
  */
 export function InlineProgress({ progress, hint }: InlineProgressProps) {
-  if (!progress) return null;
+  // Guard the fields, not just the object: a drifted daemon payload must
+  // render nothing rather than "undefined · ready NaN%" with a full bar.
+  if (!progress || typeof progress.phase !== 'string' || !Number.isFinite(progress.percent))
+    return null;
   const percent = Math.max(0, Math.min(100, progress.percent));
   const label = hint && hint !== progress.phase ? `${progress.phase} · ${hint}` : progress.phase;
   return (


### PR DESCRIPTION
## Problem

Every project row in the Workspace table rendered `undefined · ready NaN%` under a green `● OK` status, with a solid full-width blue progress bar — on all 80 registered projects at once, in both the table and compact views.

Root cause is a shape mismatch. The daemon's `project_status` SSE event carries the nested per-pipeline snapshot from `ProgressState.snapshot()` (`src/progress.ts:128`):

```json
"progress": {
  "indexing":      { "phase": "completed", "processed": 0,   "total": 0,   "percentage": null, "elapsedMs": 544 },
  "summarization": { "phase": "idle",      "processed": 0,   "total": 0,   "percentage": null, "elapsedMs": 0 },
  "embedding":     { "phase": "completed", "processed": 279, "total": 279, "percentage": 100,  "elapsedMs": 31389 }
}
```

The renderer expects a flat `ProgressSnapshot { phase, current, total, percent }` and assigned the daemon payload verbatim. So `progress.phase` was `undefined`, `progress.percent` was `undefined` → `NaN`, and `width: "NaN%"` is invalid CSS, making the bar fall back to `width: auto`. Nothing cleared it either — `progress` is only reset by `indexing_done` / `reindex_completed` / `embed_completed`, which never arrive for an already-idle project.

## Fix

Two layers:

1. **Normalize at the boundary** (`useDaemon.ts`). New exported `toProgressSnapshot()` flattens the nested payload onto the single bar the UI shows: first pipeline whose `phase` is `running` (`indexing` → `summarization` → `embedding`), or `undefined` when none is — an idle project renders nothing at all. The `SSEEvent` union now declares the real daemon shape (`DaemonProgress`) so the type system no longer blesses the bad assignment.
2. **Harden the component** (`InlineProgress.tsx`). Guard the fields, not just the object, so future payload drift degrades to no bar instead of printing `undefined`/`NaN`.

No MCP tool signature, DB schema, or token-cost change — renderer only.

## Test evidence

New `packages/app/src/renderer/hooks/__tests__/useDaemon.test.ts` (4 cases, using the payload captured verbatim off `GET /api/events`): idle payload → `undefined`; running payload → correct flat snapshot; `indexing` wins over a later running pipeline; `percentage: null` → `0`.

```
pnpm --filter trace-mcp-app test    →  Test Files 4 passed (4), Tests 50 passed (50)
pnpm --filter trace-mcp-app typecheck → clean
```

**Live render check** (not the diff alone), as the issue asked: `pnpm --filter trace-mcp-app dev` against the real local daemon on 127.0.0.1:3741 with 80 registered projects, at the app's 960×700 size. With every pipeline idle the DOM contains zero `undefined`, zero `NaN`, and zero progress-bar elements — previously all 80 rows had one. The SSE stream was confirmed to still be delivering the nested payload during the check, so the normalizer is exercised, not bypassed.

Closes TRA-227.
