### PR TITLE
chore(deps): document commander v15 ignore in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,13 @@ updates:
       - dependency-name: "better-sqlite3"
         update-types:
           - version-update:semver-major
+      # commander 15 is ESM-only and requires Node >=22.12, but this
+      # project's support policy is `engines: node >=20` — merging would
+      # silently break installs on Node 20/21 (decided on PR #197).
+      # Revisit once the Node floor moves to 22.
+      - dependency-name: "commander"
+        update-types:
+          - version-update:semver-major
     groups:
       production-minor-patch:
         dependency-type: production


### PR DESCRIPTION
## Summary
- Nikolai decided on #197 to hold `commander` at v14 via a per-PR `@dependabot ignore` comment: v15 is ESM-only and requires Node >=22.12, while this project's `engines` floor is `>=20`. Merging would silently break installs on Node 20/21.
- That reasoning only lived in the closed PR thread, invisible to anyone reading `dependabot.yml`. This adds a documented ignore entry mirroring the existing `better-sqlite3` pattern, so the decision and its revisit condition (Node floor moving to 22) are discoverable in-repo.
- No behavior change — dependabot was already suppressing v15 notifications for this package via the server-side ignore from #197; this just makes the config match reality and self-documenting.

## Test plan
- [x] Reviewed diff indentation matches sibling `better-sqlite3` ignore block exactly
- [x] Confirmed `engines.node` is still `>=20.0.0` in `package.json` (reason still valid)