### PR TITLE
fix(topology): route subproject registration through the dangerous-root guard (TRA-232)

### DIFF
--- a/src/dangerous-root.ts
+++ b/src/dangerous-root.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared "is this root obviously wrong" guard.
+ *
+ * Lives in its own dependency-free module (node:os + node:path only) so both
+ * the project registration pipeline (`project-setup.ts`) and the topology
+ * subproject store (`topology/topology-subprojects.ts`) can use the SAME rule
+ * without the store pulling in the whole detector/config stack.
+ */
+
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Reject obviously-wrong project roots: filesystem root, user home, top-level
+ * system directories. An MCP client spawned with cwd=/ would otherwise cause
+ * trace-mcp to index the entire filesystem and crash on SIP-protected paths
+ * like /Library/Bluetooth.
+ *
+ * Returns null if the path is acceptable, or a human-readable reason if it
+ * should be rejected.
+ */
+export function isDangerousProjectRoot(absRoot: string): string | null {
+  const parsed = path.parse(absRoot);
+
+  // Filesystem root: "/" on POSIX, "C:\" on Windows
+  if (absRoot === parsed.root) return 'filesystem root';
+
+  // User home directory
+  if (absRoot === os.homedir()) return 'home directory';
+
+  // Top-level system/user-container directories (POSIX + macOS)
+  const SYSTEM_DIRS = new Set([
+    '/Users',
+    '/home',
+    '/root',
+    '/System',
+    '/Library',
+    '/private',
+    '/tmp',
+    // macOS resolves the /tmp symlink to /private/tmp; some MCP clients hand
+    // trace-mcp the already-resolved cwd, which bypassed the '/tmp' check above.
+    '/private/tmp',
+    '/var',
+    '/etc',
+    '/bin',
+    '/sbin',
+    '/usr',
+    '/opt',
+    '/dev',
+    '/Volumes',
+    '/Applications',
+    '/Network',
+    '/cores',
+    '/proc',
+    '/sys',
+  ]);
+  if (SYSTEM_DIRS.has(absRoot)) return 'system directory';
+
+  return null;
+}

--- a/src/project-setup.ts
+++ b/src/project-setup.ts
@@ -7,7 +7,6 @@
  */
 
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { saveProjectConfig } from './config.js';
 import { initializeDatabase } from './db/schema.js';
@@ -18,6 +17,10 @@ import { detectProject } from './init/detector.js';
 import { logger } from './logger.js';
 import type { NewRootOverlap, RegistryEntry } from './registry.js';
 import { findOverlapForNewRoot, getProject, registerProject } from './registry.js';
+import { isDangerousProjectRoot } from './dangerous-root.js';
+
+// Re-exported so the many existing `from './project-setup.js'` importers keep working.
+export { isDangerousProjectRoot };
 
 export interface ProjectSetupResult {
   entry: RegistryEntry;
@@ -33,55 +36,6 @@ export interface ProjectSetupResult {
    * called `setupProject` since it's easy to form by accident.
    */
   overlapWarning?: NewRootOverlap;
-}
-
-/**
- * Reject obviously-wrong project roots: filesystem root, user home, top-level
- * system directories. An MCP client spawned with cwd=/ would otherwise cause
- * trace-mcp to index the entire filesystem and crash on SIP-protected paths
- * like /Library/Bluetooth.
- *
- * Returns null if the path is acceptable, or a human-readable reason if it
- * should be rejected.
- */
-export function isDangerousProjectRoot(absRoot: string): string | null {
-  const parsed = path.parse(absRoot);
-
-  // Filesystem root: "/" on POSIX, "C:\" on Windows
-  if (absRoot === parsed.root) return 'filesystem root';
-
-  // User home directory
-  if (absRoot === os.homedir()) return 'home directory';
-
-  // Top-level system/user-container directories (POSIX + macOS)
-  const SYSTEM_DIRS = new Set([
-    '/Users',
-    '/home',
-    '/root',
-    '/System',
-    '/Library',
-    '/private',
-    '/tmp',
-    // macOS resolves the /tmp symlink to /private/tmp; some MCP clients hand
-    // trace-mcp the already-resolved cwd, which bypassed the '/tmp' check above.
-    '/private/tmp',
-    '/var',
-    '/etc',
-    '/bin',
-    '/sbin',
-    '/usr',
-    '/opt',
-    '/dev',
-    '/Volumes',
-    '/Applications',
-    '/Network',
-    '/cores',
-    '/proc',
-    '/sys',
-  ]);
-  if (SYSTEM_DIRS.has(absRoot)) return 'system directory';
-
-  return null;
 }
 
 /**

--- a/src/subproject/manager.ts
+++ b/src/subproject/manager.ts
@@ -13,6 +13,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { isDangerousProjectRoot } from '../dangerous-root.js';
 import { getDbPath } from '../global.js';
 import { logger } from '../logger.js';
 import {
@@ -106,6 +107,23 @@ export interface SubprojectGraphResult {
 // Re-export so existing callers importing from manager.ts still work
 export type { SubprojectSearchItem, SubprojectSearchResult } from './subproject-search.js';
 
+/**
+ * Bail before the expensive `detectServices` filesystem walk when a root is a
+ * system/home/filesystem-root path. `upsertSubproject` refuses these rows too
+ * (that's the authoritative guard), but reaching it means having already walked
+ * something like all of /private/tmp first — which is exactly how TRA-232's 298
+ * phantom subprojects got registered.
+ */
+function assertSafeRoot(absRoot: string, kind: 'repo' | 'project'): void {
+  const reason = isDangerousProjectRoot(absRoot);
+  if (reason) {
+    throw new Error(
+      `Refusing to use "${absRoot}" as a subproject ${kind} root: ${reason}. ` +
+        'Point it at a specific source directory, not a system or root path.',
+    );
+  }
+}
+
 // ════════════════════════════════════════════════════════════════════════
 // CONTRACT RESOLUTION HELPERS
 // Pure functions extracted out of SubprojectManager#registerContracts (the
@@ -194,6 +212,8 @@ export class SubprojectManager {
     if (!fs.existsSync(absRoot)) {
       throw new Error(`Repository path does not exist: ${absRoot}`);
     }
+    assertSafeRoot(absRoot, 'repo');
+    assertSafeRoot(absProjectRoot, 'project');
 
     const repoName = opts?.name ?? path.basename(absRoot);
     const dbPath = getDbPath(absRoot);
@@ -257,6 +277,7 @@ export class SubprojectManager {
     if (!fs.existsSync(absProjectRoot)) {
       throw new Error(`Project path does not exist: ${absProjectRoot}`);
     }
+    assertSafeRoot(absProjectRoot, 'project');
 
     const detected = detectServices([absProjectRoot]);
     const results: SubprojectAddResult[] = [];

--- a/src/topology/topology-db.ts
+++ b/src/topology/topology-db.ts
@@ -19,7 +19,7 @@ import { ContractOperations } from './topology-contracts.js';
 import { EndpointOperations } from './topology-endpoints.js';
 import { EventOperations } from './topology-events.js';
 import { CrossServiceEdgeOperations } from './topology-edges.js';
-import { SubprojectOperations } from './topology-subprojects.js';
+import { SubprojectOperations, pruneDangerousSubprojects } from './topology-subprojects.js';
 import { ClientCallOperations } from './topology-client-calls.js';
 import { SnapshotOperations } from './topology-snapshots.js';
 
@@ -399,6 +399,19 @@ export class TopologyStore {
         logger.info(
           'Migration: rebuilt client_calls with correct FK references (subprojects instead of federated_repos)',
         );
+      }
+    });
+
+    // Migration (TRA-232): drop subprojects registered under a dangerous root.
+    // `upsertSubproject` now refuses these, but registries created before the
+    // guard hold hundreds of them (a Claude session started in /tmp made
+    // discoverAndRegisterSubprojects walk /private/tmp and register every
+    // scratch folder). Runs after fix_client_calls_fk_v1 so the FK detach
+    // below targets the rebuilt table.
+    this.runOnce('prune_dangerous_subprojects_v1', () => {
+      const pruned = pruneDangerousSubprojects(this.db);
+      if (pruned.subprojects > 0) {
+        logger.info(pruned, 'Migration: pruned subprojects registered under dangerous roots');
       }
     });
   }

--- a/src/topology/topology-subprojects.ts
+++ b/src/topology/topology-subprojects.ts
@@ -11,19 +11,86 @@
 
 import path from 'node:path';
 import type Database from 'better-sqlite3';
+import { isDangerousProjectRoot } from '../dangerous-root.js';
 import type { SubprojectRow } from './topology-types.js';
 
 /**
- * True when `repoRoot` IS a filesystem root ("/", "C:\"), not merely close to
- * one. A row like this makes `findSubprojectRootForPath` resolve every
- * unregistered path to it (longest-ancestor-match logic sees "/" as an
- * ancestor of everything) — see #273. Same guard class as
- * `isDangerousProjectRoot` in project-setup.ts, scoped to just the root case
- * since a subproject is always nested under a project.
+ * Reject a subproject registration whose repo_root or project_root is a
+ * filesystem root / home / system directory.
+ *
+ * repo_root="/" makes `findSubprojectRootForPath` resolve every unregistered
+ * path to it (#273). project_root="/private/tmp" is the TRA-232 case: the
+ * Claude-session discovery path (`discoverAndRegisterSubprojects`) hands
+ * `autoDiscoverSubprojects` a decoded session cwd, so a session started in
+ * /tmp made trace-mcp walk the whole scratch directory and register every
+ * throwaway folder under it as a subproject (298 phantom rows in the field).
+ * `setupProject` has refused these roots since TRA-185; the subproject table
+ * is a second registration surface that was never routed through the same
+ * guard. Returns null when acceptable, or a reason string.
  */
-function isFilesystemRoot(repoRoot: string): boolean {
-  const resolved = path.resolve(repoRoot);
-  return resolved === path.parse(resolved).root;
+function dangerousSubprojectRoot(repoRoot: string, projectRoot: string): string | null {
+  const repoReason = isDangerousProjectRoot(path.resolve(repoRoot));
+  if (repoReason) return `repo_root "${repoRoot}": ${repoReason}`;
+  const projectReason = isDangerousProjectRoot(path.resolve(projectRoot));
+  if (projectReason) return `project_root "${projectRoot}": ${projectReason}`;
+  return null;
+}
+
+/**
+ * Delete subproject rows (plus the services rooted under them) whose roots
+ * `dangerousSubprojectRoot` now rejects — self-heals registries polluted
+ * before the guard existed. Raw SQL because this runs from `TopologyStore`'s
+ * migrate(), before the operation modules are constructed.
+ */
+export function pruneDangerousSubprojects(db: Database.Database): {
+  subprojects: number;
+  services: number;
+} {
+  const rows = db.prepare('SELECT id, repo_root, project_root FROM subprojects').all() as Array<{
+    id: number;
+    repo_root: string;
+    project_root: string;
+  }>;
+  const bad = rows.filter((r) => dangerousSubprojectRoot(r.repo_root, r.project_root) !== null);
+  if (bad.length === 0) return { subprojects: 0, services: 0 };
+
+  const badIds = bad.map((r) => r.id);
+  const badIdSet = new Set(badIds);
+  // A repo_root can be shared with a still-valid subproject; only drop services
+  // whose root belongs exclusively to pruned rows.
+  const survivingRoots = new Set(rows.filter((r) => !badIdSet.has(r.id)).map((r) => r.repo_root));
+  const orphanRoots = [...new Set(bad.map((r) => r.repo_root))].filter(
+    (root) => !survivingRoots.has(root),
+  );
+
+  let services = 0;
+  db.transaction(() => {
+    if (orphanRoots.length > 0) {
+      const rootPlaceholders = orphanRoots.map(() => '?').join(',');
+      // Same FK dance as removeByRepoRoot(): client_calls.matched_endpoint_id
+      // has no ON DELETE, so detach before the service cascade drops endpoints.
+      db.prepare(
+        `UPDATE client_calls SET matched_endpoint_id = NULL
+         WHERE matched_endpoint_id IN (
+           SELECT e.id FROM api_endpoints e
+           JOIN services s ON s.id = e.service_id
+           WHERE s.repo_root IN (${rootPlaceholders})
+         )`,
+      ).run(...orphanRoots);
+      services = db
+        .prepare(`DELETE FROM services WHERE repo_root IN (${rootPlaceholders})`)
+        .run(...orphanRoots).changes;
+    }
+
+    const idPlaceholders = badIds.map(() => '?').join(',');
+    // client_calls.target_repo_id has no ON DELETE either — detach first.
+    db.prepare(
+      `UPDATE client_calls SET target_repo_id = NULL WHERE target_repo_id IN (${idPlaceholders})`,
+    ).run(...badIds);
+    db.prepare(`DELETE FROM subprojects WHERE id IN (${idPlaceholders})`).run(...badIds);
+  })();
+
+  return { subprojects: badIds.length, services };
 }
 
 export interface SubprojectOperationDeps {
@@ -45,11 +112,12 @@ export class SubprojectOperations {
     contractPaths?: string[];
     metadata?: Record<string, unknown>;
   }): number {
-    if (isFilesystemRoot(input.repoRoot)) {
+    const dangerReason = dangerousSubprojectRoot(input.repoRoot, input.projectRoot);
+    if (dangerReason) {
       throw new Error(
-        `Refusing to register subproject repo_root "${input.repoRoot}": filesystem root. ` +
-          'This is almost always a bad detection result — a subproject must point to a ' +
-          'specific repo directory, not "/".',
+        `Refusing to register subproject — ${dangerReason}. ` +
+          'This is almost always a bad detection result: a subproject must point to a ' +
+          'specific repo directory inside a specific project, not a system or root path.',
       );
     }
 

--- a/tests/topology/topology-db.test.ts
+++ b/tests/topology/topology-db.test.ts
@@ -1,8 +1,10 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import Database from 'better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { TopologyStore } from '../../src/topology/topology-db.js';
+import { pruneDangerousSubprojects } from '../../src/topology/topology-subprojects.js';
 
 describe('TopologyStore', () => {
   let store: TopologyStore;
@@ -267,6 +269,76 @@ describe('TopologyStore', () => {
         store.upsertSubproject({ name: 'root', repoRoot: '/', projectRoot: PROJECT }),
       ).toThrow(/filesystem root/);
       expect(store.getAllSubprojects()).toHaveLength(0);
+    });
+
+    it('rejects a system directory as subproject repo_root (TRA-232)', () => {
+      expect(() =>
+        store.upsertSubproject({ name: 'tmp', repoRoot: '/private/tmp', projectRoot: PROJECT }),
+      ).toThrow(/system directory/);
+      expect(store.getAllSubprojects()).toHaveLength(0);
+    });
+
+    it('rejects a system directory as subproject project_root (TRA-232)', () => {
+      expect(() =>
+        store.upsertSubproject({
+          name: 'scratch',
+          repoRoot: '/private/tmp/scratch-repo',
+          projectRoot: '/private/tmp',
+        }),
+      ).toThrow(/project_root .*system directory/);
+      expect(store.getAllSubprojects()).toHaveLength(0);
+    });
+  });
+
+  describe('dangerous-subproject pruning (TRA-232)', () => {
+    it('drops pre-guard rows rooted under a system dir, keeping valid ones', () => {
+      const good = store.upsertSubproject({
+        name: 'good',
+        repoRoot: '/project/api',
+        projectRoot: '/project',
+      });
+      // Simulate rows written before the guard existed.
+      const raw = new Database(dbPath);
+      const insert = raw.prepare(
+        `INSERT INTO subprojects (name, repo_root, project_root, added_at)
+         VALUES (?, ?, ?, datetime('now'))`,
+      );
+      insert.run('scratch', '/private/tmp/scratch-repo', '/private/tmp');
+      insert.run('', '/', '/');
+      expect(store.getAllSubprojects()).toHaveLength(3);
+
+      // Services discovered under the phantom roots go with them; the valid
+      // project's service must survive.
+      store.upsertService({
+        name: 'scratch-svc',
+        repoRoot: '/private/tmp/scratch-repo',
+        serviceType: 'api',
+        detectionSource: 'ws',
+        dbPath: '/fake/db',
+      });
+      store.upsertService({
+        name: 'good-svc',
+        repoRoot: '/project/api',
+        serviceType: 'api',
+        detectionSource: 'ws',
+        dbPath: '/fake/db',
+      });
+
+      expect(pruneDangerousSubprojects(raw)).toEqual({ subprojects: 2, services: 1 });
+      raw.close();
+
+      const remaining = store.getAllSubprojects();
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].id).toBe(good);
+      expect(store.getAllServices().map((s) => s.name)).toEqual(['good-svc']);
+    });
+
+    it('is a no-op on a clean registry', () => {
+      store.upsertSubproject({ name: 'ok', repoRoot: '/project/api', projectRoot: '/project' });
+      const raw = new Database(dbPath);
+      expect(pruneDangerousSubprojects(raw)).toEqual({ subprojects: 0, services: 0 });
+      raw.close();
+      expect(store.getAllSubprojects()).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
## Problem

TRA-185 stopped `/private/tmp` from being registered as a top-level **project**, but `subprojects` is a separate registration surface that never went through that guard. A snapshot from the field: 80 projects, **591 subprojects — 298 of them rooted at `project_root: "/private/tmp"`**, plus one legacy `{name: "", repo_root: "/", project_root: "/"}` row.

Root cause: `discoverAndRegisterSubprojects` (`src/tools/advanced/claude-sessions.ts`) decodes `~/.claude/projects/*` dir names into `session.projectPath` and hands each one to `SubprojectManager.autoDiscoverSubprojects`. A Claude session started in `/tmp` decodes to `/private/tmp`, so trace-mcp walked the entire scratch directory and registered every throwaway folder under it as a subproject. `upsertSubproject`'s only guard (#273) checked `repo_root === "/"` — `/private/tmp/some-scratch-dir` sails through.

## Change

- **`src/dangerous-root.ts` (new)** — `isDangerousProjectRoot` moved here. Depends on `node:os` + `node:path` only, so the topology store can use the *same* rule without importing the detector/config stack. `project-setup.ts` re-exports it; every existing import site is untouched.
- **`upsertSubproject`** — rejects a dangerous `repo_root` **or** `project_root`, replacing the narrower filesystem-root-only check. This is the choke point both `add()` and `autoDiscoverSubprojects()` go through.
- **`SubprojectManager.add` / `autoDiscoverSubprojects`** — bail before the `detectServices` filesystem walk, so a bad root costs nothing instead of walking all of `/private/tmp` and then failing 298 times. `discoverAndRegisterSubprojects` already catches per-session errors, so these land in its `subprojectsSkipped` list.
- **`prune_dangerous_subprojects_v1` migration** — self-heals existing registries: drops the phantom subproject rows and the `services` rooted *exclusively* under them, using the same `client_calls` FK detach dance as `removeByRepoRoot` (`matched_endpoint_id` and `target_repo_id` have no `ON DELETE`). Raw SQL because `migrate()` runs before the operation modules are constructed.

## Contract / schema

No MCP tool signature changes. No DDL changes — the migration only deletes rows that are bad data by the new (and pre-existing, for `/`) definition.

## Test evidence

`tests/topology/topology-db.test.ts` — 5 new cases:
- rejects a system directory as `repo_root`
- rejects a system directory as `project_root` (the TRA-232 case)
- prune drops a `/private/tmp` row + a legacy `/` row, keeps the valid one, and takes the orphaned service with it while sparing the valid project's service
- prune is a no-op on a clean registry
- existing #273 filesystem-root case still passes

```
pnpm run test   → 788 passed | 2 skipped (790 files), 8636 passed | 9 skipped
pnpm run build  → success
pnpm run typecheck / biome ci → clean
```

Closes TRA-232.
