### PR TITLE
fix(indexer): converge coverage after major on-disk change (TRA-231)

### DIFF
--- a/src/indexer/pipeline.ts
+++ b/src/indexer/pipeline.ts
@@ -201,6 +201,12 @@ export interface IndexingPipelineDeps {
    * the pass with real timers.
    */
   reconcileDebounceMs?: number;
+  /**
+   * Debounce window (ms) before the deferred coverage reconcile fires after
+   * incremental churn. Production callers leave this undefined (60s default);
+   * tests inject a huge value and flush explicitly.
+   */
+  coverageReconcileDebounceMs?: number;
 }
 
 export class IndexingPipeline {
@@ -218,6 +224,9 @@ export class IndexingPipeline {
     }
     if (deps?.reconcileDebounceMs !== undefined) {
       this._reconcileDebounceMs = deps.reconcileDebounceMs;
+    }
+    if (deps?.coverageReconcileDebounceMs !== undefined) {
+      this._coverageDebounceMs = deps.coverageReconcileDebounceMs;
     }
     // P02 Task DAG: register the migrated passes once per pipeline instance.
     // Each Task is a thin adapter — the actual work still happens in the
@@ -498,7 +507,12 @@ export class IndexingPipeline {
         }
         relPaths.push(rel);
       }
-      return this.runPipeline(relPaths, false, start);
+      const r = await this.runPipeline(relPaths, false, start);
+      // The watcher/hook path only ever sees the events it was handed. Kick a
+      // debounced coverage check so a project whose on-disk shape changed
+      // drastically converges without an explicit forced reindex (TRA-231).
+      if (r.indexed > 0) this.scheduleCoverageReconcile();
+      return r;
     });
     this._lock = result.catch(() => {});
     return result as Promise<IndexingResult>;
@@ -537,6 +551,7 @@ export class IndexingPipeline {
       total: relPaths.length,
       startedAt: Date.now(),
       completedAt: 0,
+      scope: this._isIncremental ? 'incremental' : 'full',
     });
 
     this._projectContext = undefined;
@@ -880,6 +895,86 @@ export class IndexingPipeline {
     await this._lock;
   }
 
+  /** Debounce window before the deferred coverage reconcile (TRA-231). */
+  private static readonly COVERAGE_RECONCILE_DEBOUNCE_MS = 60_000;
+  /**
+   * Minimum candidate-vs-indexed file gap that counts as real drift. Below
+   * this the incremental path is trusted — a handful of files is what the
+   * watcher reliably delivers, and reacting to a gap of 1 would re-walk the
+   * tree after every ordinary edit.
+   *
+   * ponytail: a plain count heuristic, not a set diff. Files the walk finds
+   * but indexing legitimately drops (parse errors, binary content) inflate
+   * the gap; the cooldown below keeps that from looping. Upgrade to a real
+   * path-set diff if the count ever proves too blunt.
+   */
+  private static readonly COVERAGE_DRIFT_MIN_FILES = 10;
+  /** Minimum quiet period between two coverage reconciles. */
+  private static readonly COVERAGE_RECONCILE_COOLDOWN_MS = 5 * 60_000;
+  private _coverageDebounceMs: number = IndexingPipeline.COVERAGE_RECONCILE_DEBOUNCE_MS;
+  private _coverageTimer: ReturnType<typeof setTimeout> | null = null;
+  private _lastCoverageReconcileMs = 0;
+
+  /**
+   * Schedule a coalesced coverage check. Registration indexes the tree once;
+   * everything after that arrives as watcher-driven `indexFiles()` calls, so a
+   * project whose on-disk shape changes drastically (a repo cloned into an
+   * already-registered workdir) settles at whatever fraction of the tree the
+   * watcher managed to report — TRA-231. The check walks the include globs and
+   * compares the candidate count to the indexed file count; a real gap kicks a
+   * hash-gated `indexAll()`, which is what `reindex({force:true})` used to be
+   * needed for. Coalesced onto a single trailing timer so an edit storm costs
+   * one walk, not N.
+   */
+  private scheduleCoverageReconcile(): void {
+    if (this._coverageTimer) clearTimeout(this._coverageTimer);
+    this._coverageTimer = setTimeout(() => this.fireCoverageReconcile(), this._coverageDebounceMs);
+    // Never keep the process alive just for a pending coverage check.
+    this._coverageTimer.unref?.();
+  }
+
+  /** Timer body — walks the tree and reindexes only when coverage actually drifted. */
+  private fireCoverageReconcile(): void {
+    this._coverageTimer = null;
+    const run = (async () => {
+      if (this._disposed) return;
+      if (
+        Date.now() - this._lastCoverageReconcileMs <
+        IndexingPipeline.COVERAGE_RECONCILE_COOLDOWN_MS
+      ) {
+        return;
+      }
+      const onDisk = (await this.collectFiles()).length;
+      if (this._disposed) return;
+      const indexed = this.store.getStats().totalFiles;
+      const gap = onDisk - indexed;
+      if (gap < IndexingPipeline.COVERAGE_DRIFT_MIN_FILES) return;
+      this._lastCoverageReconcileMs = Date.now();
+      logger.info(
+        { root: this.rootPath, onDisk, indexed, gap },
+        'Coverage drift detected — running a full hash-gated reindex',
+      );
+      await this.indexAll();
+    })();
+    void run.catch((e) => {
+      logger.warn({ error: e }, 'Deferred coverage reconcile failed');
+    });
+    this._coverageReconcileRun = run.catch(() => {});
+  }
+
+  private _coverageReconcileRun: Promise<unknown> = Promise.resolve();
+
+  /**
+   * Test hook: fire a pending coverage reconcile immediately and await it.
+   * No-op when nothing is scheduled.
+   */
+  async __flushCoverageReconcileForTests(): Promise<void> {
+    if (!this._coverageTimer) return;
+    clearTimeout(this._coverageTimer);
+    this.fireCoverageReconcile();
+    await this._coverageReconcileRun;
+  }
+
   /** Pass 3: LSP enrichment — upgrade call graph edges with compiler-grade resolution. */
   private async runLspEnrichment(): Promise<void> {
     if (!this.config.lsp?.enabled) return;
@@ -1065,6 +1160,10 @@ export class IndexingPipeline {
     if (this._reconcileTimer) {
       clearTimeout(this._reconcileTimer);
       this._reconcileTimer = null;
+    }
+    if (this._coverageTimer) {
+      clearTimeout(this._coverageTimer);
+      this._coverageTimer = null;
     }
     if (this._extractPool && this._poolIsOwned) {
       await this._extractPool.terminate();

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -16,6 +16,14 @@ export interface PipelineProgress {
   startedAt: number; // epoch ms, 0 if idle
   completedAt: number; // epoch ms, 0 if not done
   error?: string;
+  /**
+   * What the run covered: 'full' = the whole project tree was walked,
+   * 'incremental' = only the files a watcher/hook/register_edit call handed
+   * in. Without this, `phase: 'completed'` after a 3-file watcher batch reads
+   * as "the project is fully indexed" (TRA-184 / TRA-231). Not persisted —
+   * it describes the live run, and is absent after a daemon restart.
+   */
+  scope?: 'full' | 'incremental';
 }
 
 export interface PipelineProgressSnapshot extends PipelineProgress {

--- a/src/tools/register/core.ts
+++ b/src/tools/register/core.ts
@@ -76,7 +76,17 @@ export function registerCoreTools(server: McpServer, ctx: ServerContext): void {
         if (blocked) return blocked;
       }
       logger.info({ path: indexPath, force, postprocess }, 'Reindex requested');
-      const pipeline = new IndexingPipeline(store, registry, config, projectRoot);
+      // Pass `progress` so this run updates the same ProgressState that
+      // `get_index_health` reports. Without it, `progress.indexing` kept
+      // showing whatever the last watcher batch did — "completed 276/276"
+      // right after a 2069-file forced reindex (TRA-231).
+      const pipeline = new IndexingPipeline(
+        store,
+        registry,
+        config,
+        projectRoot,
+        progress ?? undefined,
+      );
 
       try {
         const result = await withLock(
@@ -470,7 +480,17 @@ export function registerCoreTools(server: McpServer, ctx: ServerContext): void {
         };
       }
 
-      const pipeline = new IndexingPipeline(store, registry, config, projectRoot);
+      // Pass `progress` so this run updates the same ProgressState that
+      // `get_index_health` reports. Without it, `progress.indexing` kept
+      // showing whatever the last watcher batch did — "completed 276/276"
+      // right after a 2069-file forced reindex (TRA-231).
+      const pipeline = new IndexingPipeline(
+        store,
+        registry,
+        config,
+        projectRoot,
+        progress ?? undefined,
+      );
       let result: Awaited<ReturnType<typeof pipeline.indexFiles>>;
       try {
         // Share the reindex lock so a single-file edit cannot race with a

--- a/tests/indexer/pipeline-coverage-reconcile.test.ts
+++ b/tests/indexer/pipeline-coverage-reconcile.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for the deferred coverage-reconcile pass (TRA-231).
+ *
+ * Background: a project registered before its real code lands on disk (fresh
+ * workdir → `git clone` into a subdirectory) only ever gets the watcher's
+ * incremental `indexFiles()` events afterwards. When a burst of thousands of
+ * creates overflows the watcher, the index silently settles at a fraction of
+ * the tree and only an explicit `reindex({force:true})` recovers it.
+ *
+ * The pipeline now schedules ONE debounced coverage check after incremental
+ * churn: walk the include globs, compare the candidate count against the
+ * indexed file count, and run a hash-gated `indexAll()` when the gap is real.
+ *
+ * Determinism: the debounce is injected ABSURDLY large so it never fires on
+ * its own; tests trigger it explicitly via __flushCoverageReconcileForTests().
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TraceMcpConfig } from '../../src/config.js';
+import { IndexingPipeline } from '../../src/indexer/pipeline.js';
+import { TypeScriptLanguagePlugin } from '../../src/indexer/plugins/language/typescript/index.js';
+import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import { createTestStore } from '../test-utils.js';
+
+/** Never fires by itself — tests flush explicitly. */
+const DEBOUNCE_MS = 10 * 60_000;
+
+function makeSetup(rootDir: string) {
+  const store = createTestStore();
+  const registry = new PluginRegistry();
+  registry.registerLanguagePlugin(new TypeScriptLanguagePlugin());
+
+  const config: TraceMcpConfig = {
+    root: rootDir,
+    include: ['src/**/*.ts'],
+    exclude: [],
+    db: { path: ':memory:' },
+    plugins: [],
+  };
+
+  const pipeline = new IndexingPipeline(store, registry, config, rootDir, undefined, {
+    coverageReconcileDebounceMs: DEBOUNCE_MS,
+  });
+  return { store, pipeline };
+}
+
+/** Write `n` source files the pipeline is never told about (dropped events). */
+function writeUnannounced(rootDir: string, n: number): void {
+  for (let i = 0; i < n; i++) {
+    fs.writeFileSync(
+      path.join(rootDir, 'src', `dropped${i}.ts`),
+      `export function dropped${i}() { return ${i}; }\n`,
+    );
+  }
+}
+
+describe('deferred coverage reconcile', () => {
+  let rootDir: string;
+  let store: ReturnType<typeof createTestStore>;
+  let pipeline: IndexingPipeline;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-coverage-'));
+    fs.mkdirSync(path.join(rootDir, 'src'));
+    fs.writeFileSync(path.join(rootDir, 'src', 'a.ts'), 'export function alpha() { return 1; }\n');
+    ({ store, pipeline } = makeSetup(rootDir));
+  });
+
+  afterEach(async () => {
+    await pipeline.dispose();
+    fs.rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('recovers files the incremental path never saw', async () => {
+    await pipeline.indexAll();
+    expect(store.getStats().totalFiles).toBe(1);
+
+    // A burst lands on disk; the watcher only reports one of the new files.
+    writeUnannounced(rootDir, 30);
+    fs.writeFileSync(
+      path.join(rootDir, 'src', 'seen.ts'),
+      'export function seen() { return 0; }\n',
+    );
+    await pipeline.indexFiles(['src/seen.ts']);
+    expect(store.getStats().totalFiles).toBe(2);
+
+    await pipeline.__flushCoverageReconcileForTests();
+
+    // 1 original + 1 announced + 30 dropped
+    expect(store.getStats().totalFiles).toBe(32);
+  });
+
+  it('does not reindex when on-disk and indexed counts agree', async () => {
+    await pipeline.indexAll();
+
+    fs.writeFileSync(path.join(rootDir, 'src', 'b.ts'), 'export function beta() { return 2; }\n');
+    await pipeline.indexFiles(['src/b.ts']);
+
+    const indexAllSpy = vi.spyOn(pipeline, 'indexAll');
+    await pipeline.__flushCoverageReconcileForTests();
+    expect(indexAllSpy).not.toHaveBeenCalled();
+    indexAllSpy.mockRestore();
+  });
+
+  it('dispose() drops a pending reconcile', async () => {
+    await pipeline.indexAll();
+    writeUnannounced(rootDir, 30);
+    fs.writeFileSync(
+      path.join(rootDir, 'src', 'seen.ts'),
+      'export function seen() { return 0; }\n',
+    );
+    await pipeline.indexFiles(['src/seen.ts']);
+
+    await pipeline.dispose();
+    await pipeline.__flushCoverageReconcileForTests();
+    expect(store.getStats().totalFiles).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes TRA-231.

## Problem

A project registered before its real code shows up on disk stays badly under-indexed even after the code arrives. Repro from the issue: fresh workdir with one `CLAUDE.md` → `get_index_health()` registers it at `totalFiles: 1` → `git clone` the repo into `workdir/trace-mcp/` → subsequent tool calls settle at `totalFiles: 206` (~12% of the tree) and lookups return `not_found` for symbols that definitely exist. Only `reindex({force:true})` recovers it.

Cause: registration walks the tree once (`addProject` → `indexAll`). Everything after that is watcher-driven `indexFiles()`, which only ever sees the events it was handed — a burst of thousands of creates overflows the watcher and the dropped files are never revisited. There is no path that re-walks the tree on its own.

## Fix

`IndexingPipeline` now schedules one debounced **coverage reconcile** after incremental churn (`indexFiles` with `indexed > 0`):

- 60s trailing debounce, coalesced onto a single timer — an edit storm of N files costs one walk, not N
- walks the include globs, compares the candidate count to `store.getStats().totalFiles`
- a gap of >= 10 files kicks a hash-gated `indexAll()` — the automatic path now converges to the same coverage a forced reindex produces
- 5-minute cooldown so a persistent gap (files the walk finds but indexing legitimately drops) can't loop
- `unref()`'d and cleared by `dispose()`, so it never keeps a process alive or fires against a torn-down store

Deliberately a count heuristic rather than a path-set diff — noted in a `ponytail:` comment with the upgrade path. A gap under 10 files is left to the watcher, which delivers small changes reliably; that's what avoids re-walking the tree after every ordinary edit.

## Secondary fix: stale `progress.indexing`

Two things were wrong with the block `get_index_health` reports:

1. The `reindex` and `register_edit` tools constructed their `IndexingPipeline` **without** a `ProgressState`, so those runs never updated progress at all. That's why a 2069-file forced reindex still reported `{"phase":"completed","processed":276,"total":276}` — leftovers from the daemon's last watcher batch. Both now pass `progress`.
2. `phase: "completed"` after a 3-file incremental run reads as "the whole project was scanned" (TRA-184's original complaint). `PipelineProgress` gains a non-persisted `scope: 'full' | 'incremental'` set from `_isIncremental`, so consumers can tell the two apart. No schema change, no migration.

## Tests

New `tests/indexer/pipeline-coverage-reconcile.test.ts` (3 cases), using the same deterministic pattern as the existing edge-reconcile suite (absurdly large injected debounce + explicit flush, no wall-clock sleeps):

- 30 files land on disk with only 1 announced → after the flush the index holds all 32
- counts agree → `indexAll` is never called
- `dispose()` drops a pending reconcile

`pnpm run test`: 789 files passed, 2 skipped. `pnpm run typecheck` clean, `biome ci` clean, `pnpm run build` succeeds.

## Contract / cost

No MCP tool signature changes and no on-disk schema change. Token cost of queries is unaffected. The added background cost is one glob walk per 60s of quiet after an incremental run, and a hash-gated reindex only when coverage actually drifted.
