### PR TITLE
docs(tools): cross-link overlapping impact and risk tools

### DIFF
--- a/src/tools/register/advanced.ts
+++ b/src/tools/register/advanced.ts
@@ -87,7 +87,7 @@ export function registerAdvancedTools(server: McpServer, ctx: ServerContext): vo
 
     server.tool(
       'get_cross_service_impact',
-      'Analyze cross-service impact of changing an endpoint or event. Shows which services would be affected. Use before modifying a shared endpoint. For within-codebase impact use get_change_impact instead. Read-only. Returns JSON: { service, affectedServices: [{ name, reason }], total }.',
+      'Analyze cross-service impact of changing an endpoint or event. Shows which services would be affected. Use before modifying a shared endpoint. For within-codebase impact use get_change_impact instead; for the full cross-repo blast radius use get_federation_impact. Read-only. Returns JSON: { service, affectedServices: [{ name, reason }], total }.',
       {
         service: z.string().min(1).max(256).describe('Service name'),
         endpoint: optionalNonEmptyString(512).describe('Endpoint path (e.g. /api/users/{id})'),
@@ -225,7 +225,7 @@ export function registerAdvancedTools(server: McpServer, ctx: ServerContext): vo
 
     server.tool(
       'get_subproject_impact',
-      'Cross-repo impact analysis: find all client code across subprojects that would break if an endpoint changes. Resolves down to symbol level when per-repo indexes exist. Use before modifying a shared API endpoint. Read-only. Returns JSON: { endpoint, affectedClients: [{ repo, file, line, callType }], total }.',
+      'Cross-repo impact analysis: find all client code across subprojects that would break if an endpoint changes. Resolves down to symbol level when per-repo indexes exist. Use before modifying a shared API endpoint; for the full cross-repo blast radius use get_federation_impact. Read-only. Returns JSON: { endpoint, affectedClients: [{ repo, file, line, callType }], total }.',
       {
         endpoint: z
           .string()
@@ -1308,7 +1308,7 @@ export function registerAdvancedTools(server: McpServer, ctx: ServerContext): vo
 
   server.tool(
     'predict_bugs',
-    "Heuristic bug-risk triage: ranks files by git churn, fix-commit ratio, complexity, coupling, PageRank, and author count — a prioritization heuristic, NOT a validated predictor (calibration notes in the response's _methodology field). Cached 1h; refresh=true to recompute. Requires git. Use to prioritize where to look, not to certify a file as buggy. For complexity+churn only use get_risk_hotspots instead. Read-only. Returns JSON: { predictions: [{ file, score, risk, confidence_level, signals }], total }.",
+    "Heuristic bug-risk triage: ranks files by git churn, fix-commit ratio, complexity, coupling, PageRank, and author count — a prioritization heuristic, NOT a validated predictor (calibration notes in the response's _methodology field). Cached 1h; refresh=true to recompute. Requires git. Use to prioritize where to look, not to certify a file as buggy. For complexity+churn only use get_risk_hotspots, for one file's trend over time get_file_health_timeline. Read-only. Returns JSON: { predictions: [{ file, score, risk, confidence_level, signals }], total }.",
     {
       limit: z.number().int().min(1).max(200).optional().describe('Max results (default: 50)'),
       min_score: z


### PR DESCRIPTION
Closes TRA-207, closes TRA-201.

Both issues concluded the same way — the tools should **not** be merged, only cross-linked — so they land as one text-only change.

**TRA-207.** `get_cross_service_impact` and `get_subproject_impact` now point at `get_federation_impact`, which already aggregates exactly what an agent would otherwise chain by hand.

`get_cross_domain_deps` and `get_cross_workspace_impact` are deliberately left alone: per TRA-207's own analysis, federation-impact is service/contract-drift focused and does **not** aggregate business-domain coupling or monorepo-workspace coupling. Adding a "use get_federation_impact instead" pointer there would send agents to a tool that can't answer their question — so the "make it consistent across all four" step was scoped down to the two that are genuinely subsumed.

**TRA-201.** `predict_bugs` now points at `get_file_health_timeline`. The other two edges already existed (`get_risk_hotspots` → `predict_bugs`, `get_file_health_timeline` → `predict_bugs`), so this was the single missing link in the trio. The three remain separate tools — TRA-201's recommendation against merging stands; they share input signals but are distinct heuristics with different output framing and methodology disclosures.

## Test evidence

- `pnpm exec vitest run tool-schema-budget` → 14 passed. Net +139 description chars, comfortably inside the TRA-186 / TRA-211 budgets (which now cover the topology-gated group these two tools live in, as of #407).
- `biome check` clean.

No schema change, no behavior change, no tool added or removed.
