### PR TITLE
feat(plugins): click + marshmallow Python framework plugins

### DIFF
--- a/src/indexer/plugins/integration/all.ts
+++ b/src/indexer/plugins/integration/all.ts
@@ -48,6 +48,7 @@ import { AnthropicPythonPlugin } from './tooling/anthropic-py/index.js';
 import { AnthropicSdkPlugin } from './tooling/anthropic-sdk/index.js';
 import { CeleryPlugin } from './tooling/celery/index.js';
 import { ClackPlugin } from './tooling/clack/index.js';
+import { ClickPlugin } from './tooling/click/index.js';
 import { CommanderPlugin } from './tooling/commander/index.js';
 import { CosmiconfigPlugin } from './tooling/cosmiconfig/index.js';
 import { DataFetchingPlugin } from './tooling/data-fetching/index.js';
@@ -73,6 +74,7 @@ import { TqdmPyPlugin } from './tooling/tqdm-py/index.js';
 import { TreeSitterPlugin } from './tooling/tree-sitter/index.js';
 import { UvicornPlugin } from './tooling/uvicorn/index.js';
 import { ClassValidatorPlugin } from './validation/class-validator/index.js';
+import { MarshmallowPlugin } from './validation/marshmallow/index.js';
 import { PydanticPlugin } from './validation/pydantic/index.js';
 // --- validation ---
 import { ZodPlugin } from './validation/zod/index.js';
@@ -191,6 +193,8 @@ export function createAllIntegrationPlugins(): FrameworkPlugin[] {
     new PythonAsyncPlugin(),
     new AttrsPyPlugin(),
     new TqdmPyPlugin(),
+    new ClickPlugin(),
+    new MarshmallowPlugin(),
     // view
     new Jinja2Plugin(),
   ];

--- a/src/indexer/plugins/integration/tooling/click/index.ts
+++ b/src/indexer/plugins/integration/tooling/click/index.ts
@@ -1,0 +1,210 @@
+/**
+ * ClickPlugin — detects the click Python CLI framework and extracts the command
+ * tree: commands/groups, their options/arguments, and subcommand → group linkage.
+ */
+import { ok, type TraceMcpResult } from '../../../../../errors.js';
+import type {
+  FileParseResult,
+  FrameworkPlugin,
+  PluginManifest,
+  ProjectContext,
+  RawEdge,
+  ResolveContext,
+} from '../../../../../plugin-api/types.js';
+import { hasAnyPythonDep } from '../../_shared/python-deps.js';
+
+const PACKAGES = ['click'] as const;
+
+const IMPORT_RE = /^\s*(?:from\s+click(?:\.\w+)*\s+import|import\s+click)\b/m;
+
+/** A decorator block immediately followed by `def name(`. */
+const DECORATED_FN_RE = /((?:^[ \t]*@[^\n]*\n)+)[ \t]*def[ \t]+(\w+)[ \t]*\(/gm;
+
+/** `@click.command(...)`, `@cli.group(...)`, or bare `@command(...)` after a from-import. */
+const COMMAND_DECORATOR_RE = /^[ \t]*@\s*(?:(\w+)\s*\.\s*)?(command|group)\s*(?:\(([^)]*)\))?/gm;
+
+/** `@click.option('--x')` / `@argument('name')` */
+const PARAM_DECORATOR_RE = /^[ \t]*@\s*(?:\w+\s*\.\s*)?(option|argument)\s*\(\s*['"]([^'"]+)['"]/gm;
+
+/** `group.add_command(cmd)` / `cli.add_command(hello, name="hi")` */
+const ADD_COMMAND_RE = /\b(\w+)\s*\.\s*add_command\(\s*(\w+)/g;
+
+/** First positional string literal of a decorator call — the explicit command name. */
+const EXPLICIT_NAME_RE = /^\s*(?:name\s*=\s*)?['"]([^'"]+)['"]/;
+
+interface ClickCommand {
+  /** CLI-visible name. */
+  name: string;
+  /** Python function implementing it. */
+  function: string;
+  kind: 'command' | 'group';
+  /** Variable name of the parent group, when declared via `@parent.command()`. */
+  parent?: string;
+  params: { name: string; kind: 'option' | 'argument' }[];
+  line: number;
+}
+
+/** click derives a command name from the function name, underscores becoming dashes. */
+function defaultName(fnName: string): string {
+  return fnName.replace(/_/g, '-').replace(/^-+|-+$/g, '') || fnName;
+}
+
+function extractCommands(source: string): ClickCommand[] {
+  const commands: ClickCommand[] = [];
+  const lineOf = (idx: number) => source.slice(0, idx).split('\n').length;
+
+  for (const m of source.matchAll(DECORATED_FN_RE)) {
+    const block = m[1];
+    const fnName = m[2];
+
+    const cmdRe = new RegExp(COMMAND_DECORATOR_RE.source, 'gm');
+    const cmdMatch = cmdRe.exec(block);
+    if (!cmdMatch) continue;
+
+    const owner = cmdMatch[1];
+    // `@click.command()` is the framework itself; `@cli.command()` names a parent group.
+    const parent = owner && owner !== 'click' ? owner : undefined;
+    const explicit = cmdMatch[3]?.match(EXPLICIT_NAME_RE)?.[1];
+
+    const params: ClickCommand['params'] = [];
+    for (const p of block.matchAll(new RegExp(PARAM_DECORATOR_RE.source, 'gm'))) {
+      params.push({ name: p[2], kind: p[1] as 'option' | 'argument' });
+    }
+
+    commands.push({
+      name: explicit ?? defaultName(fnName),
+      function: fnName,
+      kind: cmdMatch[2] as 'command' | 'group',
+      parent,
+      params,
+      line: lineOf(m.index ?? 0),
+    });
+  }
+
+  return commands;
+}
+
+export class ClickPlugin implements FrameworkPlugin {
+  manifest: PluginManifest = {
+    name: 'click',
+    version: '1.0.0',
+    priority: 30,
+    category: 'tooling',
+    dependencies: [],
+  };
+
+  detect(ctx: ProjectContext): boolean {
+    return hasAnyPythonDep(ctx, PACKAGES);
+  }
+
+  registerSchema() {
+    return {
+      edgeTypes: [
+        {
+          name: 'click_command',
+          category: 'cli',
+          description: '@click.command / @click.group command entry point',
+        },
+        {
+          name: 'click_param',
+          category: 'cli',
+          description: '@click.option / @click.argument → its command',
+        },
+        {
+          name: 'click_subcommand',
+          category: 'cli',
+          description: 'Subcommand → parent click group',
+        },
+      ],
+    };
+  }
+
+  extractNodes(
+    filePath: string,
+    content: Buffer,
+    language: string,
+  ): TraceMcpResult<FileParseResult> {
+    if (language !== 'python') {
+      return ok({ status: 'ok', symbols: [] });
+    }
+
+    const source = content.toString('utf-8');
+    const hasImport = IMPORT_RE.test(source);
+    if (!hasImport) {
+      return ok({ status: 'ok', symbols: [] });
+    }
+
+    const result: FileParseResult = { status: 'ok', symbols: [], routes: [], edges: [] };
+    const lineOf = (idx: number) => source.slice(0, idx).split('\n').length;
+    const commands = extractCommands(source);
+
+    for (const cmd of commands) {
+      result.routes!.push({ method: 'CLI', uri: cmd.name });
+      result.edges!.push({
+        edgeType: 'click_command',
+        metadata: {
+          name: cmd.name,
+          function: cmd.function,
+          kind: cmd.kind,
+          filePath,
+          line: cmd.line,
+        },
+      });
+
+      for (const p of cmd.params) {
+        result.edges!.push({
+          edgeType: 'click_param',
+          metadata: {
+            command: cmd.name,
+            param: p.name,
+            kind: p.kind,
+            filePath,
+            line: cmd.line,
+          },
+        });
+      }
+
+      // `@parent.command()` — the parent is a group variable, resolved by function name.
+      if (cmd.parent) {
+        result.edges!.push({
+          edgeType: 'click_subcommand',
+          metadata: {
+            group: cmd.parent,
+            command: cmd.name,
+            function: cmd.function,
+            filePath,
+            line: cmd.line,
+          },
+        });
+      }
+    }
+
+    // `group.add_command(fn)` — the second form of the same linkage.
+    for (const m of source.matchAll(ADD_COMMAND_RE)) {
+      const fn = m[2];
+      const target = commands.find((c) => c.function === fn);
+      result.edges!.push({
+        edgeType: 'click_subcommand',
+        metadata: {
+          group: m[1],
+          command: target?.name ?? defaultName(fn),
+          function: fn,
+          filePath,
+          line: lineOf(m.index ?? 0),
+        },
+      });
+    }
+
+    if (commands.length > 0) {
+      result.frameworkRole = 'click_cli';
+    } else if (hasImport) {
+      result.frameworkRole = 'click_import';
+    }
+
+    return ok(result);
+  }
+
+  resolveEdges(_ctx: ResolveContext): TraceMcpResult<RawEdge[]> {
+    return ok([]);
+  }
+}

--- a/src/indexer/plugins/integration/validation/marshmallow/index.ts
+++ b/src/indexer/plugins/integration/validation/marshmallow/index.ts
@@ -1,0 +1,199 @@
+/**
+ * MarshmallowPlugin — detects marshmallow (4.x) and extracts schema structure:
+ * field → field type, schema → nested schema, and hook method → its schema.
+ */
+import { ok, type TraceMcpResult } from '../../../../../errors.js';
+import type {
+  FileParseResult,
+  FrameworkPlugin,
+  PluginManifest,
+  ProjectContext,
+  RawEdge,
+  ResolveContext,
+} from '../../../../../plugin-api/types.js';
+import { hasAnyPythonDep } from '../../_shared/python-deps.js';
+
+const PACKAGES = ['marshmallow'] as const;
+
+const IMPORT_RE = /^\s*(?:from\s+marshmallow(?:\.\w+)*\s+import|import\s+marshmallow)\b/m;
+
+/** `class UserSchema(Schema):` — any base whose name ends in `Schema`. */
+const CLASS_RE = /^([ \t]*)class[ \t]+(\w+)[ \t]*\(([^)]*)\)[ \t]*:/gm;
+
+/** `email = fields.Email(...)` / `email = Email(...)` after a from-import. */
+const FIELD_RE = /^[ \t]+(\w+)[ \t]*=[ \t]*(?:fields[ \t]*\.[ \t]*)?([A-Z]\w*)[ \t]*\(/gm;
+
+/** `Nested(Other)`, `Nested("Other")`, `Nested(lambda: Other(...))` */
+const NESTED_RE = /\bNested\(\s*(?:lambda\s*:\s*)?["']?([A-Za-z_]\w*)["']?/g;
+
+const HOOKS = [
+  'validates',
+  'validates_schema',
+  'pre_load',
+  'post_load',
+  'pre_dump',
+  'post_dump',
+] as const;
+
+/** A hook decorator block followed by `def name(`. */
+const HOOK_RE = new RegExp(
+  `^[ \\t]*@\\s*(?:\\w+\\s*\\.\\s*)?(${HOOKS.join('|')})\\b[^\\n]*\\n(?:[ \\t]*@[^\\n]*\\n)*[ \\t]*def[ \\t]+(\\w+)`,
+  'gm',
+);
+
+interface SchemaClass {
+  name: string;
+  body: string;
+  /** Offset of `body` within the source, for line numbers. */
+  bodyOffset: number;
+  line: number;
+}
+
+/**
+ * Slice out each `class X(...Schema):` body by indentation — the body runs until
+ * the next non-blank line indented no deeper than the class header.
+ */
+function findSchemaClasses(source: string): SchemaClass[] {
+  const classes: SchemaClass[] = [];
+  const lineOf = (idx: number) => source.slice(0, idx).split('\n').length;
+
+  for (const m of source.matchAll(CLASS_RE)) {
+    const bases = m[3];
+    if (!/\bSchema\b|\w+Schema\b/.test(bases)) continue;
+
+    const indent = m[1].length;
+    const start = (m.index ?? 0) + m[0].length;
+    const rest = source.slice(start);
+
+    let end = rest.length;
+    let cursor = 0;
+    for (const line of rest.split('\n')) {
+      if (line.trim() !== '') {
+        const lineIndent = line.length - line.trimStart().length;
+        if (lineIndent <= indent) {
+          end = cursor;
+          break;
+        }
+      }
+      cursor += line.length + 1;
+    }
+
+    classes.push({
+      name: m[2],
+      body: rest.slice(0, end),
+      bodyOffset: start,
+      line: lineOf(m.index ?? 0),
+    });
+  }
+
+  return classes;
+}
+
+export class MarshmallowPlugin implements FrameworkPlugin {
+  manifest: PluginManifest = {
+    name: 'marshmallow',
+    version: '1.0.0',
+    priority: 30,
+    category: 'validation',
+    dependencies: [],
+  };
+
+  detect(ctx: ProjectContext): boolean {
+    return hasAnyPythonDep(ctx, PACKAGES);
+  }
+
+  registerSchema() {
+    return {
+      edgeTypes: [
+        {
+          name: 'marshmallow_field_type',
+          category: 'marshmallow',
+          description: 'Schema field → its marshmallow field type',
+        },
+        {
+          name: 'marshmallow_nested',
+          category: 'marshmallow',
+          description: 'Schema → nested schema referenced via fields.Nested',
+        },
+        {
+          name: 'marshmallow_hook',
+          category: 'marshmallow',
+          description: 'Validation/lifecycle hook method → its schema',
+        },
+      ],
+    };
+  }
+
+  extractNodes(
+    filePath: string,
+    content: Buffer,
+    language: string,
+  ): TraceMcpResult<FileParseResult> {
+    if (language !== 'python') {
+      return ok({ status: 'ok', symbols: [] });
+    }
+
+    const source = content.toString('utf-8');
+    if (!IMPORT_RE.test(source)) {
+      return ok({ status: 'ok', symbols: [] });
+    }
+
+    const result: FileParseResult = { status: 'ok', symbols: [], edges: [] };
+    const schemas = findSchemaClasses(source);
+
+    for (const schema of schemas) {
+      const lineOf = (idx: number) => source.slice(0, schema.bodyOffset + idx).split('\n').length;
+
+      for (const f of schema.body.matchAll(new RegExp(FIELD_RE.source, 'gm'))) {
+        const fieldName = f[1];
+        const fieldType = f[2];
+        const line = lineOf(f.index ?? 0);
+
+        result.edges!.push({
+          edgeType: 'marshmallow_field_type',
+          metadata: { schema: schema.name, field: fieldName, fieldType, filePath, line },
+        });
+
+        // `Nested(Other)` may sit inside a wrapper such as `List(Nested(Other))`.
+        const declaration = lineTail(schema.body, f.index ?? 0);
+        for (const n of declaration.matchAll(new RegExp(NESTED_RE.source, 'g'))) {
+          result.edges!.push({
+            edgeType: 'marshmallow_nested',
+            metadata: { schema: schema.name, field: fieldName, target: n[1], filePath, line },
+          });
+        }
+      }
+
+      for (const h of schema.body.matchAll(new RegExp(HOOK_RE.source, 'gm'))) {
+        result.edges!.push({
+          edgeType: 'marshmallow_hook',
+          metadata: {
+            schema: schema.name,
+            hook: h[1],
+            method: h[2],
+            filePath,
+            line: lineOf(h.index ?? 0),
+          },
+        });
+      }
+
+      result.frameworkRole = 'marshmallow_schema';
+    }
+
+    if (!result.frameworkRole) {
+      result.frameworkRole = 'marshmallow_import';
+    }
+
+    return ok(result);
+  }
+
+  resolveEdges(_ctx: ResolveContext): TraceMcpResult<RawEdge[]> {
+    return ok([]);
+  }
+}
+
+/** Remainder of the physical line starting at `idx`. */
+function lineTail(text: string, idx: number): string {
+  const end = text.indexOf('\n', idx);
+  return text.slice(idx, end === -1 ? text.length : end);
+}

--- a/tests/frameworks/python/python-packages.test.ts
+++ b/tests/frameworks/python/python-packages.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { AnthropicPythonPlugin } from '../../../src/indexer/plugins/integration/tooling/anthropic-py/index.js';
 import { AttrsPyPlugin } from '../../../src/indexer/plugins/integration/tooling/attrs-py/index.js';
+import { ClickPlugin } from '../../../src/indexer/plugins/integration/tooling/click/index.js';
 import { OpenAIPythonPlugin } from '../../../src/indexer/plugins/integration/tooling/openai-py/index.js';
 import { PythonAsyncPlugin } from '../../../src/indexer/plugins/integration/tooling/python-async/index.js';
 import { PythonHttpClientsPlugin } from '../../../src/indexer/plugins/integration/tooling/python-http/index.js';
@@ -8,7 +9,9 @@ import { PythonImagingPlugin } from '../../../src/indexer/plugins/integration/to
 import { PythonMLPlugin } from '../../../src/indexer/plugins/integration/tooling/python-ml/index.js';
 import { PythonScientificPlugin } from '../../../src/indexer/plugins/integration/tooling/python-scientific/index.js';
 import { TqdmPyPlugin } from '../../../src/indexer/plugins/integration/tooling/tqdm-py/index.js';
+import { MarshmallowPlugin } from '../../../src/indexer/plugins/integration/validation/marshmallow/index.js';
 import { Jinja2Plugin } from '../../../src/indexer/plugins/integration/view/jinja2/index.js';
+import type { ProjectContext } from '../../../src/plugin-api/types.js';
 
 type AnyPlugin =
   | PythonHttpClientsPlugin
@@ -20,7 +23,14 @@ type AnyPlugin =
   | PythonAsyncPlugin
   | AttrsPyPlugin
   | TqdmPyPlugin
+  | ClickPlugin
+  | MarshmallowPlugin
   | Jinja2Plugin;
+
+/** A ProjectContext whose only dependency source is an in-memory requirements.txt. */
+function pyProject(requirementsTxt: string): ProjectContext {
+  return { rootPath: '/nonexistent', requirementsTxt } as ProjectContext;
+}
 
 async function extract(
   plugin: AnyPlugin,
@@ -585,5 +595,167 @@ for i in tqdm(range(10)): pass
 `,
     );
     expect(r.edges ?? []).toEqual([]);
+  });
+});
+
+describe('ClickPlugin', () => {
+  const plugin = new ClickPlugin();
+
+  it('manifest', () => {
+    expect(plugin.manifest.name).toBe('click');
+    expect(plugin.manifest.category).toBe('tooling');
+  });
+
+  it('detects the click dependency', () => {
+    expect(plugin.detect!(pyProject('click==8.3.3'))).toBe(true);
+    expect(plugin.detect!(pyProject('flask==3.0.0'))).toBe(false);
+  });
+
+  it('skips files without a click import', async () => {
+    const r = await extract(
+      plugin,
+      `
+@notclick.command()
+def hello():
+    pass
+`,
+    );
+    expect(r.edges ?? []).toEqual([]);
+  });
+
+  const CLI = `
+import click
+
+@click.group()
+@click.option("--verbose", is_flag=True)
+def cli(verbose):
+    pass
+
+@cli.command()
+@click.argument("name")
+@click.option("--greeting", default="hi")
+def say_hello(name, greeting):
+    pass
+
+@click.command("deploy")
+def deploy_cmd():
+    pass
+
+cli.add_command(deploy_cmd)
+`;
+
+  it('extracts commands and groups', async () => {
+    const r = await extract(plugin, CLI);
+    expect(r.frameworkRole).toBe('click_cli');
+    const commands = r.edges!.filter((e) => e.edgeType === 'click_command');
+    expect(commands.map((e) => e.metadata?.name).sort()).toEqual(['cli', 'deploy', 'say-hello']);
+    expect(commands.find((e) => e.metadata?.name === 'cli')?.metadata?.kind).toBe('group');
+  });
+
+  it('exposes commands as CLI routes', async () => {
+    const r = await extract(plugin, CLI);
+    expect(r.routes!.map((x) => x.uri)).toContain('say-hello');
+    expect(r.routes!.every((x) => x.method === 'CLI')).toBe(true);
+  });
+
+  it('extracts options and arguments per command', async () => {
+    const r = await extract(plugin, CLI);
+    const params = r.edges!.filter(
+      (e) => e.edgeType === 'click_param' && e.metadata?.command === 'say-hello',
+    );
+    expect(params.map((e) => `${e.metadata?.kind}:${e.metadata?.param}`).sort()).toEqual([
+      'argument:name',
+      'option:--greeting',
+    ]);
+  });
+
+  it('links subcommands to their group via decorator and add_command', async () => {
+    const r = await extract(plugin, CLI);
+    const subs = r.edges!.filter((e) => e.edgeType === 'click_subcommand');
+    expect(subs.every((e) => e.metadata?.group === 'cli')).toBe(true);
+    expect(subs.map((e) => e.metadata?.command).sort()).toEqual(['deploy', 'say-hello']);
+  });
+});
+
+describe('MarshmallowPlugin', () => {
+  const plugin = new MarshmallowPlugin();
+
+  it('manifest', () => {
+    expect(plugin.manifest.name).toBe('marshmallow');
+    expect(plugin.manifest.category).toBe('validation');
+  });
+
+  it('detects the marshmallow dependency', () => {
+    expect(plugin.detect!(pyProject('marshmallow==4.3.0'))).toBe(true);
+    expect(plugin.detect!(pyProject('flask==3.0.0'))).toBe(false);
+  });
+
+  it('skips files without a marshmallow import', async () => {
+    const r = await extract(
+      plugin,
+      `
+class UserSchema(Schema):
+    name = fields.Str()
+`,
+    );
+    expect(r.edges ?? []).toEqual([]);
+  });
+
+  const SCHEMAS = `
+from marshmallow import Schema, fields, validates, post_load
+
+class AddressSchema(Schema):
+    city = fields.Str(required=True)
+
+class UserSchema(Schema):
+    name = fields.Str(required=True)
+    age = fields.Int()
+    address = fields.Nested(AddressSchema)
+    tags = fields.List(fields.Nested("TagSchema"))
+    partner = fields.Nested(lambda: UserSchema(exclude=("partner",)))
+
+    @validates("name", "age")
+    def validate_fields(self, value, data_key):
+        pass
+
+    @post_load
+    def make_user(self, data, **kwargs):
+        return data
+`;
+
+  it('extracts field types per schema', async () => {
+    const r = await extract(plugin, SCHEMAS);
+    expect(r.frameworkRole).toBe('marshmallow_schema');
+    const typed = r.edges!.filter(
+      (e) => e.edgeType === 'marshmallow_field_type' && e.metadata?.schema === 'UserSchema',
+    );
+    expect(typed.map((e) => `${e.metadata?.field}:${e.metadata?.fieldType}`)).toEqual([
+      'name:Str',
+      'age:Int',
+      'address:Nested',
+      'tags:List',
+      'partner:Nested',
+    ]);
+  });
+
+  it('extracts schema-to-schema references from Nested', async () => {
+    const r = await extract(plugin, SCHEMAS);
+    const nested = r.edges!.filter((e) => e.edgeType === 'marshmallow_nested');
+    expect(nested.map((e) => e.metadata?.target).sort()).toEqual([
+      'AddressSchema',
+      'TagSchema',
+      'UserSchema',
+    ]);
+    expect(nested.every((e) => e.metadata?.schema === 'UserSchema')).toBe(true);
+  });
+
+  it('extracts validation and lifecycle hooks', async () => {
+    const r = await extract(plugin, SCHEMAS);
+    const hooks = r.edges!.filter((e) => e.edgeType === 'marshmallow_hook');
+    expect(hooks.map((e) => `${e.metadata?.hook}:${e.metadata?.method}`).sort()).toEqual([
+      'post_load:make_user',
+      'validates:validate_fields',
+    ]);
+    expect(hooks.every((e) => e.metadata?.schema === 'UserSchema')).toBe(true);
   });
 });


### PR DESCRIPTION
Adds two additive Python framework plugins requested on GitHub. Both follow the existing `attrs-py` / `commander` plugin shape — dependency detection via `hasAnyPythonDep`, edge emission from `extractNodes`, registration in `integration/all.ts`. No new MCP tools, no schema migration.

## click (`tooling/click`) — closes #381

Edge types:
- `click_command` — `@click.command` / `@click.group` entry point (name, function, kind)
- `click_param` — `@click.option` / `@click.argument` → its command
- `click_subcommand` — subcommand → parent group

Handles both linkage forms (`@cli.command()` and `cli.add_command(fn)`), explicit names (`@click.command("deploy")`), and click's default underscore→dash name derivation. Commands are also emitted as `CLI` routes, same as the commander plugin, so they show up in route search.

## marshmallow (`validation/marshmallow`) — closes #382

Edge types:
- `marshmallow_field_type` — schema field → its field type
- `marshmallow_nested` — schema → nested schema
- `marshmallow_hook` — `@validates` / `@validates_schema` / `@pre_load` / `@post_load` / `@pre_dump` / `@post_dump` → its schema

Patterns checked against the marshmallow 4.x API: `@validates` taking multiple field names, and all three `fields.Nested` target forms (class reference, string, `lambda:`). Nested targets are also picked up inside wrappers such as `fields.List(fields.Nested(X))`.

## Test evidence

13 new tests in `tests/frameworks/python/python-packages.test.ts` covering detection, manifests, non-Python/no-import skips, and each edge type.

```
pnpm run test    → 789 files passed | 2 skipped, 8646 tests passed | 9 skipped
pnpm run build   → success
pnpm run typecheck → clean
biome ci (changed files) → clean
```

The tool-schema budget guard is part of that suite and stays green — these add edge types only.

## Out of scope

Per the issue: click `ctx.obj` dataflow and marshmallow custom-field subclass resolution. Direct patterns first; extend if a user asks.
