### PR TITLE
test(topology): gate POSIX-only dangerous-root fixtures off Windows

### DIFF
--- a/tests/topology/topology-db.test.ts
+++ b/tests/topology/topology-db.test.ts
@@ -6,6 +6,14 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { TopologyStore } from '../../src/topology/topology-db.js';
 import { pruneDangerousSubprojects } from '../../src/topology/topology-subprojects.js';
 
+// isDangerousProjectRoot's SYSTEM_DIRS list is POSIX absolute paths
+// ('/private/tmp', '/var', …). On Windows those strings match nothing, so
+// fixtures built from them can't trip the guard — the tests below assert a
+// POSIX-only rule, not cross-platform behaviour. Windows has no equivalent
+// entries in that list at all; covering C:\Windows, C:\Users and friends is a
+// real gap, but a separate one from the guard this file exercises (TRA-236).
+const posixOnlyIt = it.skipIf(process.platform === 'win32');
+
 describe('TopologyStore', () => {
   let store: TopologyStore;
   let dbPath: string;
@@ -271,14 +279,14 @@ describe('TopologyStore', () => {
       expect(store.getAllSubprojects()).toHaveLength(0);
     });
 
-    it('rejects a system directory as subproject repo_root (TRA-232)', () => {
+    posixOnlyIt('rejects a system directory as subproject repo_root (TRA-232)', () => {
       expect(() =>
         store.upsertSubproject({ name: 'tmp', repoRoot: '/private/tmp', projectRoot: PROJECT }),
       ).toThrow(/system directory/);
       expect(store.getAllSubprojects()).toHaveLength(0);
     });
 
-    it('rejects a system directory as subproject project_root (TRA-232)', () => {
+    posixOnlyIt('rejects a system directory as subproject project_root (TRA-232)', () => {
       expect(() =>
         store.upsertSubproject({
           name: 'scratch',
@@ -291,7 +299,7 @@ describe('TopologyStore', () => {
   });
 
   describe('dangerous-subproject pruning (TRA-232)', () => {
-    it('drops pre-guard rows rooted under a system dir, keeping valid ones', () => {
+    posixOnlyIt('drops pre-guard rows rooted under a system dir, keeping valid ones', () => {
       const good = store.upsertSubproject({
         name: 'good',
         repoRoot: '/project/api',
@@ -324,8 +332,14 @@ describe('TopologyStore', () => {
         dbPath: '/fake/db',
       });
 
-      expect(pruneDangerousSubprojects(raw)).toEqual({ subprojects: 2, services: 1 });
-      raw.close();
+      // finally, not a bare call: a failing expect here would otherwise leak the
+      // handle and turn one assertion failure into a second EBUSY failure in
+      // afterEach's rmSync on Windows.
+      try {
+        expect(pruneDangerousSubprojects(raw)).toEqual({ subprojects: 2, services: 1 });
+      } finally {
+        raw.close();
+      }
 
       const remaining = store.getAllSubprojects();
       expect(remaining).toHaveLength(1);


### PR DESCRIPTION
Unblocks the v1.51.0 release PR (#399), which is currently red on `cross-platform-test (windows-latest)`.

## What broke

TRA-232's PR #405 added tests asserting `isDangerousProjectRoot`'s `SYSTEM_DIRS` rule using POSIX fixtures (`/private/tmp`). That set contains only POSIX absolute paths, so on Windows the guard correctly matches nothing and the assertions fail — 3 failures, one of which then leaked a `better-sqlite3` handle and cascaded into an `EBUSY` in `afterEach`'s `rmSync`.

`cross-platform-test` only runs on release PRs, nightly, `workflow_dispatch`, or an explicit label — it was `skipping` on #405, so this reached `master` and only surfaced when release-please's PR ran the matrix.

## Fix

- The three POSIX-fixture tests are gated with `it.skipIf(process.platform === 'win32')`. They assert a POSIX-only rule; making them "pass" on Windows would mean asserting something untrue.
- The prune assertion is wrapped in `try`/`finally` so a future failure there can't leak the raw DB handle into a second, misleading `EBUSY` failure.

## What is deliberately *not* fixed here

The guard gives Windows users **no** system-directory protection at all — `C:\Windows`, `C:\Users`, `C:\Program Files`, `%TEMP%` are all accepted as project roots. That's a real gap of the same class as TRA-184/185/232, and it's filed as **TRA-236** with scope, rather than being quietly widened into this release-unblock PR. TRA-236 also proposes running `cross-platform-test` on PRs touching `src/dangerous-root.ts` / `src/topology/**`, which is the process half of the fix.

## Test evidence

- `pnpm exec vitest run topology-db` → 29 passed locally (macOS; the three gated tests run here).
- `biome check` clean.
- Labeled `cross-platform` so the Windows/macOS matrix actually runs on this PR — the whole point being that it didn't run on #405.
