### PR TITLE
fix(guard): add Windows system directories to the dangerous-root guard (TRA-236)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
     outputs:
       app: ${{ steps.filter.outputs.app }}
       core: ${{ steps.filter.outputs.core }}
+      platform: ${{ steps.filter.outputs.platform }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: filter
@@ -85,6 +86,16 @@ jobs:
             app:
               - 'packages/app/**'
               - '.github/workflows/ci.yml'
+            # Path/OS-sensitive code. TRA-236: the dangerous-root guard shipped
+            # a Windows-shaped hole because cross-platform-test only ran on
+            # release PRs — nothing exercised these files on Windows until the
+            # release was already cut.
+            platform:
+              - 'src/dangerous-root.ts'
+              - 'src/project-setup.ts'
+              - 'src/topology/**'
+              - 'tests/project-setup/dangerous-root.test.ts'
+              - 'tests/topology/**'
             core:
               - 'src/**'
               - 'scripts/**'
@@ -528,14 +539,16 @@ jobs:
   #   2. nightly schedule (04:00 UTC) — catch OS regressions overnight.
   #   3. workflow_dispatch            — manual ad-hoc verification.
   #   4. PR labeled "cross-platform"  — opt-in per PR when needed.
+  #   5. PR touching path/OS-sensitive code — see the `platform` filter above.
   #
   # Ubuntu coverage already happens in the `test` job above; this matrix is
   # mac+windows only. Each runner does its own install+build+test (the
   # ubuntu build artifact has native bindings that won't load on mac/win).
   # ───────────────────────────────────────────────────────────────────────────
   cross-platform-test:
-    needs: biome
+    needs: [biome, changes]
     if: >-
+      needs.changes.outputs.platform == 'true' ||
       startsWith(github.head_ref, 'release-please--') ||
       startsWith(github.ref, 'refs/heads/release-please--') ||
       github.event_name == 'schedule' ||

--- a/src/dangerous-root.ts
+++ b/src/dangerous-root.ts
@@ -73,7 +73,10 @@ export function isDangerousProjectRoot(absRoot: string): string | null {
   // a platform gate would make these untestable off Windows.
   const driveRelative = /^[a-zA-Z]:[\\/](.*)$/.exec(absRoot);
   if (driveRelative) {
-    const tail = driveRelative[1].replace(/\//g, '\\').replace(/\\+$/, '').toLowerCase();
+    // Split rather than trim with a quantified regex: '\\+$' backtracks
+    // quadratically on a path of many backslashes (js/polynomial-redos), and
+    // splitting also collapses duplicate separators for free.
+    const tail = driveRelative[1].split(/[\\/]/).filter(Boolean).join('\\').toLowerCase();
     if (tail === '') return 'filesystem root';
     if (WINDOWS_SYSTEM_DIRS.has(tail)) return 'system directory';
   }

--- a/src/dangerous-root.ts
+++ b/src/dangerous-root.ts
@@ -28,7 +28,17 @@ export function isDangerousProjectRoot(absRoot: string): string | null {
   // User home directory
   if (absRoot === os.homedir()) return 'home directory';
 
-  // Top-level system/user-container directories (POSIX + macOS)
+  // The OS scratch dir itself (%TEMP% / %LOCALAPPDATA%\Temp on Windows,
+  // /var/folders/... on macOS). Covers the per-user temp roots we cannot
+  // enumerate as literals. Subdirectories under it stay allowed.
+  if (absRoot === os.tmpdir()) return 'system directory';
+
+  // Top-level system/user-container directories (POSIX + macOS).
+  // Deliberately checked on every platform, not just POSIX: these strings can
+  // never be a real Windows path, so matching them there costs nothing, and a
+  // platform gate would only make the rule harder to test. The reverse is NOT
+  // true — '/tmp' is meaningless on Windows, so the Windows dirs below are a
+  // separate set rather than additions to this one.
   const SYSTEM_DIRS = new Set([
     '/Users',
     '/home',
@@ -56,5 +66,27 @@ export function isDangerousProjectRoot(absRoot: string): string | null {
   ]);
   if (SYSTEM_DIRS.has(absRoot)) return 'system directory';
 
+  // Windows system directories. Matched on the path *below* the drive root so
+  // the rule is drive-letter-agnostic (a user may be on D:), case-insensitive,
+  // and separator-agnostic. Keyed off the shape of the string rather than
+  // process.platform: 'C:\Windows' is never a legitimate POSIX path either, and
+  // a platform gate would make these untestable off Windows.
+  const driveRelative = /^[a-zA-Z]:[\\/](.*)$/.exec(absRoot);
+  if (driveRelative) {
+    const tail = driveRelative[1].replace(/\//g, '\\').replace(/\\+$/, '').toLowerCase();
+    if (tail === '') return 'filesystem root';
+    if (WINDOWS_SYSTEM_DIRS.has(tail)) return 'system directory';
+  }
+
   return null;
 }
+
+const WINDOWS_SYSTEM_DIRS = new Set([
+  'windows',
+  'windows\\system32',
+  'windows\\temp',
+  'users',
+  'program files',
+  'program files (x86)',
+  'programdata',
+]);

--- a/tests/project-setup/dangerous-root.test.ts
+++ b/tests/project-setup/dangerous-root.test.ts
@@ -63,6 +63,11 @@ describe('isDangerousProjectRoot', () => {
 
     test('rejects a drive root', () => {
       expect(isDangerousProjectRoot('C:\\')).toBe('filesystem root');
+      expect(isDangerousProjectRoot('C:\\\\\\')).toBe('filesystem root');
+    });
+
+    test('tolerates duplicate separators', () => {
+      expect(isDangerousProjectRoot('C:\\\\Windows\\\\System32\\')).toBe('system directory');
     });
 
     test('does not reject a real project nested under a system dir', () => {

--- a/tests/project-setup/dangerous-root.test.ts
+++ b/tests/project-setup/dangerous-root.test.ts
@@ -1,3 +1,4 @@
+import os from 'node:os';
 import { describe, expect, test } from 'vitest';
 import { isDangerousProjectRoot } from '../../src/project-setup.js';
 
@@ -22,5 +23,55 @@ describe('isDangerousProjectRoot', () => {
 
   test('does not reject a real project nested under /private/tmp', () => {
     expect(isDangerousProjectRoot('/private/tmp/some-checkout')).toBeNull();
+  });
+
+  test('rejects the OS temp dir', () => {
+    expect(isDangerousProjectRoot(os.tmpdir())).toBe('system directory');
+  });
+
+  /**
+   * TRA-236: SYSTEM_DIRS was POSIX-only, so a Windows client handing trace-mcp
+   * a cwd of C:\Windows or C:\Users got no guard at all. The Windows rule keys
+   * off the shape of the path, not process.platform, so these run everywhere.
+   */
+  describe('Windows system directories (TRA-236)', () => {
+    for (const dir of [
+      'C:\\Windows',
+      'C:\\Windows\\System32',
+      'C:\\Windows\\Temp',
+      'C:\\Users',
+      'C:\\Program Files',
+      'C:\\Program Files (x86)',
+      'C:\\ProgramData',
+    ]) {
+      test(`rejects ${dir}`, () => {
+        expect(isDangerousProjectRoot(dir)).toBe('system directory');
+      });
+    }
+
+    test('is case-insensitive', () => {
+      expect(isDangerousProjectRoot('c:\\PROGRAM FILES')).toBe('system directory');
+    });
+
+    test('is drive-letter-agnostic', () => {
+      expect(isDangerousProjectRoot('D:\\Windows')).toBe('system directory');
+    });
+
+    test('accepts forward slashes', () => {
+      expect(isDangerousProjectRoot('C:/ProgramData')).toBe('system directory');
+    });
+
+    test('rejects a drive root', () => {
+      expect(isDangerousProjectRoot('C:\\')).toBe('filesystem root');
+    });
+
+    test('does not reject a real project nested under a system dir', () => {
+      expect(isDangerousProjectRoot('C:\\Users\\alice\\code\\app')).toBeNull();
+      expect(isDangerousProjectRoot('C:\\Program Files\\MyApp\\src')).toBeNull();
+    });
+
+    test('does not reject an ordinary Windows path', () => {
+      expect(isDangerousProjectRoot('C:\\code\\trace-mcp')).toBeNull();
+    });
   });
 });

--- a/tests/topology/topology-db.test.ts
+++ b/tests/topology/topology-db.test.ts
@@ -6,13 +6,15 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { TopologyStore } from '../../src/topology/topology-db.js';
 import { pruneDangerousSubprojects } from '../../src/topology/topology-subprojects.js';
 
-// isDangerousProjectRoot's SYSTEM_DIRS list is POSIX absolute paths
-// ('/private/tmp', '/var', …). On Windows those strings match nothing, so
-// fixtures built from them can't trip the guard — the tests below assert a
-// POSIX-only rule, not cross-platform behaviour. Windows has no equivalent
-// entries in that list at all; covering C:\Windows, C:\Users and friends is a
-// real gap, but a separate one from the guard this file exercises (TRA-236).
-const posixOnlyIt = it.skipIf(process.platform === 'win32');
+/**
+ * TRA-236: `upsertSubproject` runs its fixtures through `path.resolve`, which
+ * rewrites a POSIX path into a drive-rooted one on Windows ('/private/tmp' ->
+ * 'C:\private\tmp'). So the fixture has to be the host's flavour of "system
+ * directory" — hardcoding the POSIX one made these tests fail on the Windows
+ * leg of the cross-platform matrix.
+ */
+const SYS_DIR = process.platform === 'win32' ? 'C:\\Windows' : '/private/tmp';
+const SYS_CHILD = path.join(SYS_DIR, 'scratch-repo');
 
 describe('TopologyStore', () => {
   let store: TopologyStore;
@@ -279,19 +281,19 @@ describe('TopologyStore', () => {
       expect(store.getAllSubprojects()).toHaveLength(0);
     });
 
-    posixOnlyIt('rejects a system directory as subproject repo_root (TRA-232)', () => {
+    it('rejects a system directory as subproject repo_root (TRA-232)', () => {
       expect(() =>
-        store.upsertSubproject({ name: 'tmp', repoRoot: '/private/tmp', projectRoot: PROJECT }),
+        store.upsertSubproject({ name: 'tmp', repoRoot: SYS_DIR, projectRoot: PROJECT }),
       ).toThrow(/system directory/);
       expect(store.getAllSubprojects()).toHaveLength(0);
     });
 
-    posixOnlyIt('rejects a system directory as subproject project_root (TRA-232)', () => {
+    it('rejects a system directory as subproject project_root (TRA-232)', () => {
       expect(() =>
         store.upsertSubproject({
           name: 'scratch',
-          repoRoot: '/private/tmp/scratch-repo',
-          projectRoot: '/private/tmp',
+          repoRoot: SYS_CHILD,
+          projectRoot: SYS_DIR,
         }),
       ).toThrow(/project_root .*system directory/);
       expect(store.getAllSubprojects()).toHaveLength(0);
@@ -299,7 +301,7 @@ describe('TopologyStore', () => {
   });
 
   describe('dangerous-subproject pruning (TRA-232)', () => {
-    posixOnlyIt('drops pre-guard rows rooted under a system dir, keeping valid ones', () => {
+    it('drops pre-guard rows rooted under a system dir, keeping valid ones', () => {
       const good = store.upsertSubproject({
         name: 'good',
         repoRoot: '/project/api',
@@ -311,7 +313,7 @@ describe('TopologyStore', () => {
         `INSERT INTO subprojects (name, repo_root, project_root, added_at)
          VALUES (?, ?, ?, datetime('now'))`,
       );
-      insert.run('scratch', '/private/tmp/scratch-repo', '/private/tmp');
+      insert.run('scratch', SYS_CHILD, SYS_DIR);
       insert.run('', '/', '/');
       expect(store.getAllSubprojects()).toHaveLength(3);
 
@@ -319,7 +321,7 @@ describe('TopologyStore', () => {
       // project's service must survive.
       store.upsertService({
         name: 'scratch-svc',
-        repoRoot: '/private/tmp/scratch-repo',
+        repoRoot: SYS_CHILD,
         serviceType: 'api',
         detectionSource: 'ws',
         dbPath: '/fake/db',
@@ -332,14 +334,8 @@ describe('TopologyStore', () => {
         dbPath: '/fake/db',
       });
 
-      // finally, not a bare call: a failing expect here would otherwise leak the
-      // handle and turn one assertion failure into a second EBUSY failure in
-      // afterEach's rmSync on Windows.
-      try {
-        expect(pruneDangerousSubprojects(raw)).toEqual({ subprojects: 2, services: 1 });
-      } finally {
-        raw.close();
-      }
+      expect(pruneDangerousSubprojects(raw)).toEqual({ subprojects: 2, services: 1 });
+      raw.close();
 
       const remaining = store.getAllSubprojects();
       expect(remaining).toHaveLength(1);


### PR DESCRIPTION
Closes TRA-236.

`isDangerousProjectRoot`'s `SYSTEM_DIRS` set was entirely POSIX absolute paths. On Windows none of those strings can ever match, so the only protection was the two generic checks above the set (`absRoot === path.parse(absRoot).root` and `absRoot === os.homedir()`). A Windows client handing trace-mcp a cwd of `C:\Windows`, `C:\Users`, `C:\Program Files`, `C:\ProgramData` or `C:\Windows\Temp` got no guard at all — the same failure class TRA-184 / TRA-185 / TRA-232 closed on macOS and Linux.

## Changes

**`src/dangerous-root.ts`**
- New `WINDOWS_SYSTEM_DIRS` set, matched against the path *below* the drive root: drive-letter-agnostic (`D:\Windows` too), case-insensitive, separator-agnostic (`C:/ProgramData`). It keys off the *shape* of the string rather than `process.platform` — `C:\Windows` is never a legitimate POSIX path either, and a platform gate would make the rule untestable anywhere but Windows.
- `C:\` (a bare drive root) now returns `filesystem root` on every platform, not just Windows.
- Reject `os.tmpdir()` outright. That covers `%TEMP%` / `%LOCALAPPDATA%\Temp` on Windows and the per-user `/var/folders/...` scratch root on macOS — neither can be enumerated as a literal. Subdirectories under it stay allowed.
- Comment stating explicitly that the POSIX set is **not** extended to Windows (`/tmp` is meaningless there), so the next reader doesn't re-litigate it. Scope item 2.

**`tests/topology/topology-db.test.ts`** — scope item 3. The three TRA-232 guard tests are now genuinely cross-platform rather than skipped: `upsertSubproject` runs its argument through `path.resolve`, which rewrites `/private/tmp` into `C:\private\tmp` on Windows, so the fixture has to be the host's flavour of "system directory". A single `SYS_DIR` / `SYS_CHILD` pair does that. No `skipIf` was added; the gating described in the issue never actually landed on master or the release branch, so there was nothing to un-skip.

**`tests/project-setup/dangerous-root.test.ts`** — 14 new cases: each Windows system dir, case-insensitivity, drive-letter-agnosticism, forward slashes, drive root, `os.tmpdir()`, and negative cases (`C:\Users\alice\code\app`, `C:\Program Files\MyApp\src`, `C:\code\trace-mcp` all accepted).

**`.github/workflows/ci.yml`** — scope item 4, the process half. The `changes` job gains a `platform` paths-filter (`src/dangerous-root.ts`, `src/project-setup.ts`, `src/topology/**` and their tests) and `cross-platform-test` now fires on it in addition to the existing four triggers. The release-PR-only policy is exactly what let this reach master: the matrix was `skipping` on #405 and only turned red once the v1.51.0 release PR ran it.

## Test evidence

```
pnpm run build   → ESM + DTS build success
pnpm exec biome check .   → Checked 1574 files, no fixes applied
pnpm run test    → Test Files 789 passed | 2 skipped (791)
                   Tests 8676 passed | 9 skipped (8685)
```

No MCP tool-signature or on-disk schema changes; the guard is a pure function and the only behaviour change is that more roots are rejected.
