### PR TITLE
fix(hooks): cut clock spawns in reindex hook, make stats-write flake diagnosable

### DIFF
--- a/hooks/trace-mcp-reindex.sh
+++ b/hooks/trace-mcp-reindex.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# trace-mcp-reindex v0.4.0
+# trace-mcp-reindex v0.4.1
 # trace-mcp PostToolUse auto-reindex hook
 # Daemon-first: posts to the running daemon's /api/projects/reindex-file
 # endpoint via curl (no Node startup). Falls back to a cold subprocess
@@ -65,29 +65,46 @@ STATS_HOME="${TRACE_MCP_HOME:-$HOME/.trace-mcp}"
 STATS_FILE="$STATS_HOME/hook-stats.jsonl"
 STATS_MAX_BYTES=$((10 * 1024 * 1024))
 
-# Portable millisecond timestamp. Prefer EPOCHREALTIME (bash 5) — strip the
+# Portable millisecond clock. Prefer EPOCHREALTIME (bash 5) — strip the
 # decimal point to get ms. Fall back to GNU date, then python.
+#
+# The strategy is resolved ONCE, at load. The previous version re-probed on
+# every call, so under bash 3.2 (macOS system bash — no EPOCHREALTIME) each
+# now_ms cost three processes (date + grep + python3) and a hook run cost
+# nine, purely to read a clock. That is the slowest path in the hook and the
+# widest window for anything watching it to time out.
+if [[ -n "${EPOCHREALTIME:-}" ]]; then
+  MS_CLOCK=bash
+else
+  _ms_probe=$(date +%s%3N 2>/dev/null || true)
+  if [[ "$_ms_probe" =~ ^[0-9]+$ ]]; then
+    MS_CLOCK=date
+  else
+    MS_CLOCK=python3
+  fi
+  unset _ms_probe
+fi
+
 now_ms() {
-  if [[ -n "${EPOCHREALTIME:-}" ]]; then
-    local s="${EPOCHREALTIME%.*}"
-    local us="${EPOCHREALTIME#*.}"
-    # us is always 6 digits in bash 5; take first 3 for ms.
-    printf '%s%s' "$s" "${us:0:3}"
-    return
-  fi
-  if date +%s%3N 2>/dev/null | grep -qE '^[0-9]+$'; then
-    date +%s%3N
-    return
-  fi
-  python3 -c 'import time; print(int(time.time()*1000))' 2>/dev/null || echo 0
+  case "$MS_CLOCK" in
+    bash)
+      local s="${EPOCHREALTIME%.*}"
+      local us="${EPOCHREALTIME#*.}"
+      # us is always 6 digits in bash 5; take first 3 for ms.
+      printf '%s%s' "$s" "${us:0:3}"
+      ;;
+    date) date +%s%3N ;;
+    *) python3 -c 'import time; print(int(time.time()*1000))' 2>/dev/null || echo 0 ;;
+  esac
 }
 
 write_stat() {
   local path_kind="$1"
   local reason="$2"
   local wall_ms="$3"
-  local ts
-  ts=$(now_ms)
+  # Callers already read the clock to close out WALL_MS — reuse it rather
+  # than paying for another reading.
+  local ts="$4"
   mkdir -p "$STATS_HOME" 2>/dev/null || return 0
   # Rotate when over ~10 MB. Truncate (not delete) so concurrent appenders
   # keep their fd alive; data loss is acceptable for telemetry.
@@ -118,7 +135,7 @@ END_MS=$(now_ms)
 WALL_MS=$((END_MS - START_MS))
 
 if [[ "$HTTP_CODE" =~ ^2[0-9][0-9]$ ]]; then
-  write_stat "daemon" "ok" "$WALL_MS"
+  write_stat "daemon" "ok" "$WALL_MS" "$END_MS"
   exit 0
 fi
 
@@ -142,9 +159,9 @@ esac
 # misleading fake reindex time.
 if command -v trace-mcp >/dev/null 2>&1; then
   nohup trace-mcp index-file "$FILE_PATH" >/dev/null 2>&1 &
-  write_stat "cli" "$REASON" "$WALL_MS"
+  write_stat "cli" "$REASON" "$WALL_MS" "$END_MS"
 else
-  write_stat "skipped" "$REASON" "$WALL_MS"
+  write_stat "skipped" "$REASON" "$WALL_MS" "$END_MS"
 fi
 
 exit 0

--- a/tests/hooks/stats-write.test.ts
+++ b/tests/hooks/stats-write.test.ts
@@ -7,9 +7,26 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 const HOOK = path.resolve('hooks/trace-mcp-reindex.sh');
 
 interface RunResult {
-  status: number;
+  /** null when the child was killed rather than exiting (e.g. timeout). */
+  status: number | null;
   stdout: string;
   stderr: string;
+  signal: string | null;
+  message: string;
+}
+
+/**
+ * Assert the hook exited cleanly, reporting *why* it did not when it fails.
+ * A bare `expect(res.status).toBe(0)` collapses "script exited 1", "script was
+ * killed on timeout" and "spawn failed" into the same uninformative
+ * `expected 1 to be +0` — which is exactly what made the macOS flake in
+ * TRA-238 undiagnosable from CI logs alone.
+ */
+function expectCleanExit(res: RunResult): void {
+  expect(
+    res.status,
+    `hook did not exit 0\n  status: ${String(res.status)}\n  signal: ${String(res.signal)}\n  message: ${res.message}\n  stdout: ${JSON.stringify(res.stdout)}\n  stderr: ${JSON.stringify(res.stderr)}`,
+  ).toBe(0);
 }
 
 function runHook(opts: {
@@ -36,15 +53,29 @@ function runHook(opts: {
         HOME: opts.traceHome,
       },
       encoding: 'utf-8',
-      timeout: 10_000,
+      // Generous: the hook is a shell script that spawns ~10 subprocesses, and
+      // a shared macOS CI runner under a parallel vitest load is far slower
+      // than a developer machine. This bounds a hang, it does not assert
+      // latency — the test is about the script's exit semantics.
+      timeout: 60_000,
     });
-    return { status: 0, stdout, stderr: '' };
+    return { status: 0, stdout, stderr: '', signal: null, message: '' };
   } catch (e) {
-    const err = e as { status?: number; stdout?: Buffer; stderr?: Buffer };
+    const err = e as {
+      status?: number | null;
+      signal?: string | null;
+      message?: string;
+      stdout?: Buffer;
+      stderr?: Buffer;
+    };
     return {
-      status: err.status ?? 1,
+      // Deliberately NOT `?? 1`: a killed child has a null status, and
+      // flattening that to 1 disguises a timeout as a script failure.
+      status: err.status ?? null,
       stdout: err.stdout?.toString() ?? '',
       stderr: err.stderr?.toString() ?? '',
+      signal: err.signal ?? null,
+      message: err.message ?? '',
     };
   }
 }
@@ -116,7 +147,7 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-reindex.sh stats writer
       tool_input: { file_path: filePath },
     });
     const res = runHook({ cwd: projectDir, stubDir, traceHome, stdin });
-    expect(res.status).toBe(0);
+    expectCleanExit(res);
 
     const statsFile = path.join(traceHome, 'hook-stats.jsonl');
     expect(fs.existsSync(statsFile)).toBe(true);
@@ -141,7 +172,7 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-reindex.sh stats writer
       tool_input: { file_path: filePath },
     });
     const res = runHook({ cwd: projectDir, stubDir, traceHome, stdin });
-    expect(res.status).toBe(0);
+    expectCleanExit(res);
 
     const statsFile = path.join(traceHome, 'hook-stats.jsonl');
     const parsed = JSON.parse(
@@ -161,7 +192,7 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-reindex.sh stats writer
       tool_input: { file_path: filePath },
     });
     const res = runHook({ cwd: projectDir, stubDir, traceHome, stdin, sanitizePath: true });
-    expect(res.status).toBe(0);
+    expectCleanExit(res);
 
     const statsFile = path.join(traceHome, 'hook-stats.jsonl');
     const parsed = JSON.parse(
@@ -180,7 +211,7 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-reindex.sh stats writer
       tool_input: { file_path: filePath },
     });
     const res = runHook({ cwd: projectDir, stubDir, traceHome, stdin });
-    expect(res.status).toBe(0);
+    expectCleanExit(res);
 
     const statsFile = path.join(traceHome, 'hook-stats.jsonl');
     const parsed = JSON.parse(
@@ -201,7 +232,7 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-reindex.sh stats writer
     });
     try {
       const res = runHook({ cwd: projectDir, stubDir, traceHome, stdin });
-      expect(res.status).toBe(0);
+      expectCleanExit(res);
     } finally {
       fs.chmodSync(traceHome, 0o755);
     }


### PR DESCRIPTION
Fixes TRA-238.

## What the flake actually was

`tests/hooks/stats-write.test.ts > writes a skipped-path line when daemon refuses AND no trace-mcp CLI on PATH` failed once on `cross-platform-test (macos-latest)` with `expected 1 to be +0`, and passed on a rerun of the identical commit.

I traced `hooks/trace-mcp-reindex.sh` under the test's exact conditions (`bash -x`, sanitized `PATH=<stubs>:/usr/bin:/bin`, refusing curl stub, no `trace-mcp` on PATH). Every command that can return non-zero is guarded — `|| true`, an `if` condition, or a `case`. The script has **no reachable `exit 1`**.

The 1 was manufactured by the test harness:

```ts
status: err.status ?? 1,
```

A child that is *killed* rather than exiting has `status === null` — `?? 1` flattens that into a plain exit 1. So a 10s `execSync` timeout, a spawn failure, and a genuine script failure all render as the same uninformative `expected 1 to be +0`.

## Changes

**1. Make it diagnosable (issue scope item 2).** `runHook` preserves a null status and now also returns `signal` and `message`. `expectCleanExit` prints status / signal / stdout / stderr on failure, so the next occurrence reports *why*. The `execSync` timeout goes 10s → 60s: it exists to bound a hang, not to assert latency — the test is about the script's exit semantics.

**2. Remove the underlying fragility (issue scope item 3).** `sanitizePath: true` is the only test whose PATH resolves `bash` to `/bin/bash` — macOS system bash 3.2, which has no `EPOCHREALTIME`. `now_ms` therefore re-probed `date` (plus a `grep`) and spawned `python3` on *every* call, and it was called three times: **9 processes per hook run purely to read a clock**, on the slowest path in the hook. Now the clock strategy is resolved once at load, and `write_stat` reuses the timestamp its caller already took.

No retry, no skip, no loosened assertion.

## Test evidence

Spawn count on the sanitized path (`bash -x`, counting `date|grep|python3|jq|curl|stat|dirname|cat`), before vs after on the same input:

```
BEFORE: exit=0 spawns=17
  stats: {"ts":1787891293730,"path":"skipped","reason":"no-daemon","wallclock_ms":33}
AFTER : exit=0 spawns=11
  stats: {"ts":1787891293843,"path":"skipped","reason":"no-daemon","wallclock_ms":28}
```

Clock-related spawns 9 → 3; emitted JSONL shape unchanged (`ts`, `path`, `reason`, `wallclock_ms`), so `daemon stats` readers are unaffected.

- `vitest run tests/hooks/` — 109 passed (4 files)
- `vitest run` (full) — **8661 passed, 10 skipped, 0 failed**
- `tsc --noEmit` clean; `biome check` clean; `bash -n` clean

## Notes

No MCP tool signature, schema, or token-budget surface is touched. The hook is a general latency win beyond the test — it runs on every edit.

The related process question (running `cross-platform-test` more often / on path filters) is TRA-236 and is deliberately not decided here.
