### PR TITLE
test(cli): cover visualize --open (openInBrowser) platform branches

### DIFF
--- a/src/cli/visualize.ts
+++ b/src/cli/visualize.ts
@@ -26,7 +26,7 @@ import { visualizeGraph } from '../tools/analysis/visualize.js';
 import { visualizeSubprojectTopology } from '../tools/analysis/visualize-subproject.js';
 import { TopologyStore } from '../topology/topology-db.js';
 
-function openInBrowser(filePath: string): void {
+export function openInBrowser(filePath: string): void {
   const platform = process.platform;
   try {
     if (platform === 'darwin') execSync(`open "${filePath}"`);

--- a/tests/cli/visualize-open-in-browser.test.ts
+++ b/tests/cli/visualize-open-in-browser.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Coverage for openInBrowser() in src/cli/visualize.ts — the `--open` path
+ * of `trace-mcp visualize` (and `visualize subproject`) shells out to the
+ * OS-native "open a file" command. Previously untested: a regression here
+ * (wrong platform branch, wrong quoting, or an uncaught throw) would only
+ * surface as a silently broken `--open` flag in the field.
+ */
+import { execSync } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { openInBrowser } from '../../src/cli/visualize.js';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+const mockExecSync = vi.mocked(execSync);
+
+describe('openInBrowser', () => {
+  const origPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+  });
+
+  it('uses `open` on darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+    openInBrowser('/tmp/trace-mcp-graph.html');
+    expect(mockExecSync).toHaveBeenCalledWith('open "/tmp/trace-mcp-graph.html"');
+  });
+
+  it('uses `start` on win32', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    openInBrowser('C:\\tmp\\trace-mcp-graph.html');
+    expect(mockExecSync).toHaveBeenCalledWith('start "" "C:\\tmp\\trace-mcp-graph.html"');
+  });
+
+  it('uses `xdg-open` elsewhere', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    openInBrowser('/tmp/trace-mcp-graph.html');
+    expect(mockExecSync).toHaveBeenCalledWith('xdg-open "/tmp/trace-mcp-graph.html"');
+  });
+
+  it('swallows execSync failures instead of throwing (user can open manually)', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+    mockExecSync.mockImplementation(() => {
+      throw new Error('no GUI available');
+    });
+    expect(() => openInBrowser('/tmp/trace-mcp-graph.html')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- `openInBrowser()` in `src/cli/visualize.ts` (the `--open` path of `trace-mcp visualize` / `visualize subproject`, shelling out via `execSync` to `open`/`start`/`xdg-open`) had zero test coverage — only `visualizeGraph()` itself was tested, not the CLI wrapper.
- Export `openInBrowser` and add a focused test covering all three platform branches plus the try/catch error-swallow (execSync failures must not propagate — user can open the file manually).

Found while auditing test coverage for TRA-247 (Test & Quality Health). The command already has a security audit smoke test (`tests/tools/security-scan.repo-smoke.test.ts`) confirming its `execSync` usage is a known-safe false positive — this PR only adds behavioral coverage, no logic change.

## Test plan
- [x] `pnpm test` — 790 files / 8683 tests pass (was 788/8678)
- [x] `pnpm run lint` (tsc --noEmit) — clean
- [x] `pnpm run build` — clean
- [x] `pnpm run biome:ci` — clean