### PR TITLE
fix(docs): emit og:image on every docs page

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,3 +3,14 @@ description: A structured map of your codebase for AI agents. trace-mcp indexes 
 url: https://trace-mcp.com
 lang: en
 markdown: kramdown
+
+# Give every doc page an og:image / twitter:image. jekyll-seo-tag only reads
+# page-level `image`, not a site-level one, so inject it via defaults —
+# without it the doc pages emit twitter:card=summary with no image and
+# share as a bare link. docs/index.html has no front matter (static file),
+# so it keeps its own hand-written OG tags.
+defaults:
+  - scope:
+      path: ""
+    values:
+      image: /og-image.png

--- a/tests/docs/og-image.test.ts
+++ b/tests/docs/og-image.test.ts
@@ -1,0 +1,40 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Social-preview regression guard.
+ *
+ * A crawl of trace-mcp.com found 12 of 13 sitemap URLs emitting
+ * `twitter:card=summary` with no og:image and no twitter:image — every doc
+ * page shared on X / Slack / LinkedIn rendered as a bare link. Only the
+ * hand-written docs/index.html carried an image.
+ *
+ * jekyll-seo-tag reads `page.image` only — a site-level `image:` key is NOT
+ * a fallback (see ImageDrop#image_hash) — so the fix is a Jekyll `defaults`
+ * block injecting it into every page's front matter. This test fails if that
+ * block is removed or points at a file that no longer exists.
+ */
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const DOCS = join(REPO_ROOT, 'docs');
+
+describe('docs site social preview', () => {
+  const config = readFileSync(join(DOCS, '_config.yml'), 'utf-8');
+
+  it('_config.yml injects a page-level image default for jekyll-seo-tag', () => {
+    const match = config.match(/^\s*image:\s*(\S+)\s*$/m);
+    expect(
+      match,
+      'docs/_config.yml has no `image:` default — doc pages will ship without og:image',
+    ).not.toBeNull();
+    if (!match) return;
+    expect(config).toMatch(/^defaults:/m);
+    expect(existsSync(join(DOCS, match[1].replace(/^\//, '')))).toBe(true);
+  });
+
+  it('docs/index.html keeps its own og:image (no front matter, so defaults skip it)', () => {
+    const index = readFileSync(join(DOCS, 'index.html'), 'utf-8');
+    expect(index).toMatch(/property="og:image"/);
+  });
+});


### PR DESCRIPTION
## Problem

Crawled all 13 URLs in `sitemap.xml` on the live site. 12 of 13 emit:

```
<meta name="twitter:card" content="summary">
```

…with **no `og:image`, no `twitter:image`**. Only `docs/index.html` (hand-written `<head>`) has one. Every documentation page shared on X / Slack / LinkedIn / Discord renders as a bare link, and the same tags are what several AI crawlers read for preview cards.

## Fix

`docs/_layouts/default.html` uses `{% seo %}`, and jekyll-seo-tag reads **`page.image` only** — a site-level `image:` key is *not* a fallback ([`ImageDrop#image_hash`](https://github.com/jekyll/jekyll-seo-tag/blob/master/lib/jekyll-seo-tag/image_drop.rb) only reads `page["image"]`). So the image is injected as a front-matter default:

```yaml
defaults:
  - scope:
      path: ""
    values:
      image: /og-image.png
```

This makes jekyll-seo-tag emit `og:image`, `twitter:image` and upgrade the card to `summary_large_image` on all 12 doc pages. `docs/og-image.png` already exists (1200×630, the correct OG ratio).

`docs/index.html` has no front matter, so Jekyll copies it verbatim and `defaults` does not touch it — it keeps its existing OG block.

## Tests

`tests/docs/og-image.test.ts` — fails if the `defaults` block is dropped or points at a missing file, and asserts `index.html` keeps its own `og:image`.

```
✓ tests/docs/og-image.test.ts (2 tests)
✓ tests/docs/readme-claims.test.ts (18 tests)
```

No tool-schema or DB-schema change; docs-only + one test file.

Refs TRA-241.