### PR TITLE
fix(docs): link every doc page from the shared footer nav

### DIFF
--- a/docs/_data/docs_nav.yml
+++ b/docs/_data/docs_nav.yml
@@ -1,0 +1,27 @@
+# Footer "See also" nav, rendered by _layouts/default.html.
+# Keep in sync with docs/sitemap.xml — tests/docs/internal-links.test.ts fails
+# if a sitemap page is missing here.
+- title: Tools reference
+  url: /tools-reference.html
+- title: Comparisons
+  url: /comparisons.html
+- title: Supported frameworks
+  url: /supported-frameworks.html
+- title: Architecture
+  url: /architecture.html
+- title: Configuration
+  url: /configuration.html
+- title: Quality gates
+  url: /quality-gates.html
+- title: Decision memory
+  url: /decision-memory.html
+- title: Analytics
+  url: /analytics.html
+- title: TOON savings
+  url: /toon-savings.html
+- title: Telemetry
+  url: /telemetry.html
+- title: tweakcc routing
+  url: /tweakcc.html
+- title: Development
+  url: /development.html

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -23,9 +23,18 @@
       <hr>
       <p class="docs-nav">
         See also:
-        <a href="{{ '/tools-reference.html' | relative_url }}">Tools reference</a> ·
-        <a href="{{ '/architecture.html' | relative_url }}">Architecture</a> ·
-        <a href="{{ '/configuration.html' | relative_url }}">Configuration</a> ·
+        {%- comment -%}
+          Every doc page, not a hand-picked four. The old footer linked only
+          tools-reference / architecture / configuration, which left the other
+          eight pages on 1–2 inbound internal links each — comparisons.html,
+          the highest-intent page on the site, had exactly one. Driven off
+          site.data.docs_nav so adding a page means one data-file line.
+        {%- endcomment -%}
+        {%- for item in site.data.docs_nav -%}
+          {%- unless page.url == item.url -%}
+            <a href="{{ item.url | relative_url }}">{{ item.title }}</a> ·
+          {%- endunless -%}
+        {%- endfor -%}
         <a href="{{ '/' | relative_url }}">Home</a>
       </p>
     </div>

--- a/tests/docs/internal-links.test.ts
+++ b/tests/docs/internal-links.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Internal-link coverage guard.
+ *
+ * A crawl of trace-mcp.com counted inbound internal links per sitemap URL.
+ * The shared footer in _layouts/default.html linked only tools-reference,
+ * architecture and configuration, so those three had 12 inbound links each
+ * while the other eight doc pages had 1-2 — all from the homepage.
+ * comparisons.html, the highest commercial-intent page on the site, had
+ * exactly one inbound link.
+ *
+ * The footer now renders from docs/_data/docs_nav.yml. This test fails when
+ * a page is added to sitemap.xml but not to that nav, which is how the
+ * imbalance crept in.
+ */
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const DOCS = join(REPO_ROOT, 'docs');
+
+function sitemapPaths(): string[] {
+  const xml = readFileSync(join(DOCS, 'sitemap.xml'), 'utf-8');
+  return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)]
+    .map((m) => m[1].replace(/^https:\/\/trace-mcp\.com/, ''))
+    .filter((p) => p !== '/'); // homepage is linked separately in the footer
+}
+
+function navPaths(): string[] {
+  const yml = readFileSync(join(DOCS, '_data', 'docs_nav.yml'), 'utf-8');
+  return [...yml.matchAll(/^\s*url:\s*(\S+)\s*$/gm)].map((m) => m[1]);
+}
+
+describe('docs footer nav covers every indexed page', () => {
+  it('every sitemap URL appears in _data/docs_nav.yml', () => {
+    const missing = sitemapPaths().filter((p) => !navPaths().includes(p));
+    expect(
+      missing,
+      `pages in sitemap.xml but not in the footer nav: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('every nav entry is a page that is actually indexed', () => {
+    const stale = navPaths().filter((p) => !sitemapPaths().includes(p));
+    expect(stale, `footer nav links pages absent from sitemap.xml: ${stale.join(', ')}`).toEqual(
+      [],
+    );
+  });
+
+  it('the layout renders the nav from the data file, not a hardcoded list', () => {
+    const layout = readFileSync(join(DOCS, '_layouts', 'default.html'), 'utf-8');
+    expect(layout).toMatch(/site\.data\.docs_nav/);
+  });
+});

--- a/tests/docs/internal-links.test.ts
+++ b/tests/docs/internal-links.test.ts
@@ -22,9 +22,13 @@ const DOCS = join(REPO_ROOT, 'docs');
 
 function sitemapPaths(): string[] {
   const xml = readFileSync(join(DOCS, 'sitemap.xml'), 'utf-8');
-  return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)]
-    .map((m) => m[1].replace(/^https:\/\/trace-mcp\.com/, ''))
-    .filter((p) => p !== '/'); // homepage is linked separately in the footer
+  return (
+    [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)]
+      // Anchored with a lookahead on the path separator: without it the pattern
+      // also strips the prefix of a lookalike host like trace-mcp.com.example.org.
+      .map((m) => m[1].replace(/^https:\/\/trace-mcp\.com(?=\/)/, ''))
+      .filter((p) => p !== '/')
+  ); // homepage is linked separately in the footer
 }
 
 function navPaths(): string[] {


### PR DESCRIPTION
## Problem

Crawled the 13 URLs in `sitemap.xml` and counted inbound internal links per page:

| Page | Inbound internal links |
|---|---|
| `/`, `tools-reference`, `configuration`, `architecture` | 12 each |
| `supported-frameworks`, `analytics`, `decision-memory` | 2 |
| **`comparisons`**, `toon-savings`, `telemetry`, `quality-gates`, `tweakcc`, `development` | **1** (homepage only) |

The `docs-nav` footer in `_layouts/default.html` hardcoded four destinations, so those four collected a link from every page and the other eight got nothing but the homepage link.

`comparisons.html` — "trace-mcp vs Repomix, Serena & 20+ alternatives", the highest commercial-intent page on the site — sits on a single inbound internal link.

## Fix

Render the footer from `docs/_data/docs_nav.yml` and list all 12 doc pages, skipping the current one. Every page now reaches every other page in one hop. Adding a page is one data-file line.

## Tests

`tests/docs/internal-links.test.ts`:
- every `sitemap.xml` URL has a nav entry
- every nav entry is a page that is actually indexed
- the layout renders from the data file rather than a hardcoded list

Verified the guard is real by deleting the `comparisons.html` entry:

```
× every sitemap URL appears in _data/docs_nav.yml
  AssertionError: pages in sitemap.xml but not in the footer nav: /comparisons.html
```

Restored, full docs suite green (21 tests). Docs + one test file only; no tool-schema or DB-schema change.

Refs TRA-241.
