### PR TITLE
docs: fix stale language/framework/tool counts in CLAUDE.md and skills (TRA-243)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What this project is
 
-trace-mcp is a framework-aware code intelligence MCP server. It indexes source code into a dependency graph with full-text search, understanding 48+ frameworks across 68 languages. It exposes MCP tools for navigation, impact analysis, and framework-specific queries.
+trace-mcp is a framework-aware code intelligence MCP server. It indexes source code into a dependency graph with full-text search, understanding 87 framework integrations across 80 languages. It exposes MCP tools for navigation, impact analysis, and framework-specific queries.
 
 ## Agent Behavior — read before every task
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -2,7 +2,7 @@
 
 Reusable [Agent Skills](https://skills.sh) that teach any MCP-compatible coding agent (Claude Code, Cursor, Windsurf, OpenCode, Codex, etc.) to use [trace-mcp](https://github.com/nikolai-vysotskyi/trace-mcp) effectively.
 
-trace-mcp is a framework-aware code intelligence MCP server that exposes 120+ tools over a cross-language dependency graph. These skills encode the routing rules, workflows, and token-efficiency best practices so your agent uses trace-mcp instead of brute-reading files with `Read`/`Grep`/`Glob`.
+trace-mcp is a framework-aware code intelligence MCP server that exposes 170 tools over a cross-language dependency graph. These skills encode the routing rules, workflows, and token-efficiency best practices so your agent uses trace-mcp instead of brute-reading files with `Read`/`Grep`/`Glob`.
 
 ## Install
 

--- a/skills/trace-mcp/SKILL.md
+++ b/skills/trace-mcp/SKILL.md
@@ -5,7 +5,7 @@ description: Use trace-mcp tools for code navigation, impact analysis, and frame
 
 # trace-mcp — Code Intelligence Routing
 
-trace-mcp is a framework-aware code intelligence MCP server. It exposes 120+ tools that return semantic, structured results over a cross-language dependency graph. When trace-mcp is available, it is almost always cheaper and more accurate than native file tools.
+trace-mcp is a framework-aware code intelligence MCP server. It exposes 170 tools that return semantic, structured results over a cross-language dependency graph. When trace-mcp is available, it is almost always cheaper and more accurate than native file tools.
 
 ## When to Use
 

--- a/tests/docs/readme-claims.test.ts
+++ b/tests/docs/readme-claims.test.ts
@@ -181,14 +181,24 @@ describe('docs site numeric claims (TRA-174)', () => {
   // competitors' language/tool counts (e.g. "158 languages", "40+ tools"),
   // so a whole-file scan would false-positive on numbers that aren't about
   // trace-mcp. It gets its own targeted, column-scoped check below instead.
-  const docs: Array<{ path: string; tolerance: number }> = [
+  //
+  // TRA-243: the site surfaces were guarded, but CLAUDE.md and the shipped
+  // skills were not — and both had drifted badly (CLAUDE.md still claimed
+  // "48+ frameworks across 68 languages"; the skills claimed "120+ tools").
+  // `skipLine` exempts lines that legitimately state a *subset* count
+  // (preset sizes, the TOON allowlist) rather than the total.
+  const docs: Array<{ path: string; tolerance: number; skipLine?: RegExp }> = [
     { path: 'docs/index.html', tolerance: 2 },
     { path: 'docs/llms.txt', tolerance: 2 },
     { path: 'docs/tools-reference.md', tolerance: 5 },
     { path: 'docs/quality-gates.md', tolerance: 5 },
+    { path: 'CLAUDE.md', tolerance: 5, skipLine: /output_format|preset/ },
+    { path: 'AGENTS.md', tolerance: 5, skipLine: /output_format|preset/ },
+    { path: 'skills/README.md', tolerance: 5 },
+    { path: 'skills/trace-mcp/SKILL.md', tolerance: 5, skipLine: /output_format|preset/ },
   ];
 
-  for (const { path, tolerance } of docs) {
+  for (const { path, tolerance, skipLine } of docs) {
     it(`${path}: every "languages" claim matches the registry (±${tolerance})`, () => {
       const text = readFileSync(join(REPO_ROOT, path), 'utf-8');
       for (const claim of findAllClaims(/languages?/, text)) {
@@ -217,6 +227,7 @@ describe('docs site numeric claims (TRA-174)', () => {
     it(`${path}: every "MCP tools" claim matches the source of truth (±${tolerance})`, () => {
       const text = readFileSync(join(REPO_ROOT, path), 'utf-8');
       for (const claim of findAllClaims(/(?:MCP )?tools?/, text)) {
+        if (skipLine?.test(claim.rawLine)) continue;
         if (!within(toolCount, claim.count, tolerance)) {
           throw new Error(
             `${path} claims ${claim.count} tools; src/tools/register/*.ts contains ${toolCount} server.tool(...) registrations. Line: "${claim.rawLine}"`,


### PR DESCRIPTION
## What

Three doc surfaces stated counts that no longer match the code:

| Surface | Claimed | Actual (live registry / `server.tool(` count) |
|---|---|---|
| `CLAUDE.md` | 48+ frameworks, 68 languages | 87 framework integrations, 80 languages |
| `skills/README.md` | 120+ tools | 170 |
| `skills/trace-mcp/SKILL.md` | 120+ tools | 170 |

`CLAUDE.md` is read by every agent working on this repo, and the two skills ship to users — so all three were teaching a wrong picture of the product's surface.

## Why it wasn't caught

The TRA-174 numeric-claims guard (`tests/docs/readme-claims.test.ts`) only covered `README.md`, `docs/index.html`, `docs/llms.txt`, `docs/tools-reference.md`, `docs/quality-gates.md` and `docs/comparisons.md`. `CLAUDE.md`, `AGENTS.md` and `skills/**` were unguarded, which is exactly where the drift accumulated.

This PR adds those surfaces to the same guard, plus a `skipLine` escape so lines that deliberately state a *subset* count (tool presets, the 14-tool TOON allowlist) aren't treated as total-count claims.

## Test evidence

- `npx vitest run tests/docs` → 30 passed (was 18 — 12 new assertions).
- Negative check: re-introducing the old `CLAUDE.md` line makes the new assertions fail with `CLAUDE.md claims 48 frameworks/integrations; registry has 87` — the guard is not a no-op.
- `npx biome check tests/docs/readme-claims.test.ts` clean.

Counts verified against `PluginRegistry.createWithDefaults()` (80 language plugins, 87 framework plugins) and the same `server.tool(` source-of-truth count the existing guard uses (171; docs claim 170, within tolerance).

Docs owned by other autopilots (`docs/comparisons.md`, `docs/ROADMAP.md`) and the site copy in `docs/index.html` / `docs/llms.txt` are untouched.

Closes TRA-243.
