### PR TITLE
fix(daemon): honour the tool preset on the daemon-backed path (TRA-250)

### DIFF
--- a/src/daemon/router/__tests__/proxy-tool-preset.test.ts
+++ b/src/daemon/router/__tests__/proxy-tool-preset.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Regression guard for TRA-250: the tool preset must survive the daemon proxy.
+ *
+ * The registration-time gate (tool-gate.ts) was already correct and already
+ * guarded by tool-schema-budget.test.ts — and the shipped default path
+ * (daemon-backed) still advertised all 172 tools regardless of preset, because
+ * the daemon registers every tool once and serves many sessions. So this suite
+ * asserts on the surface that actually reaches a client: the `tools/list`
+ * response after it has passed through ProxyBackend, plus the callability of a
+ * tool the preset filtered out.
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { TraceMcpConfig } from '../../../config.js';
+import { createToolFilter, UNGATED_META_TOOLS } from '../../../server/tool-filter.js';
+import { TOOL_PRESETS } from '../../../tools/project/presets.js';
+import { ProxyBackend, type ProxyTransport } from '../proxy-backend.js';
+
+/** Every tool name the daemon would advertise — presets are subsets of this. */
+function allDaemonToolNames(): string[] {
+  const registerDir = fileURLToPath(new URL('../../../tools/register', import.meta.url));
+  const names = new Set<string>();
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== '__tests__') walk(full);
+        continue;
+      }
+      if (!entry.name.endsWith('.ts')) continue;
+      for (const m of readFileSync(full, 'utf8').matchAll(
+        /(?:server\.tool|_originalTool)\(\s*['"]([a-zA-Z0-9_]+)['"]/g,
+      )) {
+        names.add(m[1]);
+      }
+    }
+  };
+  walk(registerDir);
+  return [...names];
+}
+
+/** Stands in for the daemon: answers tools/list with its full tool surface. */
+class FakeDaemonTransport implements ProxyTransport {
+  onmessage?: (msg: JSONRPCMessage) => void;
+  onerror?: (err: Error) => void;
+  readonly forwarded: JSONRPCMessage[] = [];
+
+  constructor(private readonly toolNames: string[]) {}
+
+  async start(): Promise<void> {}
+  async close(): Promise<void> {}
+
+  async send(msg: JSONRPCMessage): Promise<void> {
+    this.forwarded.push(msg);
+    const m = msg as Record<string, unknown>;
+    if (m.method === 'tools/list') {
+      this.onmessage?.({
+        jsonrpc: '2.0',
+        id: m.id,
+        result: {
+          tools: this.toolNames.map((name) => ({
+            name,
+            description: `stub description for ${name}`,
+            inputSchema: { type: 'object', properties: {} },
+          })),
+        },
+      } as unknown as JSONRPCMessage);
+    } else if (m.method === 'tools/call') {
+      this.onmessage?.({
+        jsonrpc: '2.0',
+        id: m.id,
+        result: { content: [{ type: 'text', text: 'daemon executed the tool' }] },
+      } as unknown as JSONRPCMessage);
+    }
+  }
+}
+
+const DAEMON_TOOLS = allDaemonToolNames();
+
+const backends: ProxyBackend[] = [];
+afterEach(async () => {
+  for (const b of backends.splice(0)) await b.stop();
+  delete process.env.TRACE_MCP_PRESET;
+});
+
+async function startProxy(
+  config: TraceMcpConfig,
+): Promise<{ backend: ProxyBackend; transport: FakeDaemonTransport; toClient: JSONRPCMessage[] }> {
+  const transport = new FakeDaemonTransport(DAEMON_TOOLS);
+  const toClient: JSONRPCMessage[] = [];
+  const backend = new ProxyBackend({
+    daemonUrl: 'http://127.0.0.1:0',
+    projectRoot: '/nonexistent/fake-project',
+    clientId: 'tra-250-test',
+    toolFilter: createToolFilter(config),
+    transportFactory: () => transport,
+  });
+  backend.onmessage = (m) => toClient.push(m);
+  backends.push(backend);
+  await backend.start();
+  return { backend, transport, toClient };
+}
+
+async function proxiedToolNames(config: TraceMcpConfig): Promise<string[]> {
+  const { backend, toClient } = await startProxy(config);
+  await backend.send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} } as JSONRPCMessage);
+  const reply = toClient.at(-1) as { result?: { tools?: Array<{ name: string }> } };
+  return (reply.result?.tools ?? []).map((t) => t.name);
+}
+
+describe('daemon proxy honours the session tool preset (TRA-250)', () => {
+  it('the fake daemon advertises the full surface these presets are subsets of', () => {
+    expect(DAEMON_TOOLS.length).toBeGreaterThan(150);
+  });
+
+  for (const preset of ['minimal', 'standard', 'review', 'architecture'] as const) {
+    it(`filters the proxied tools/list down to the "${preset}" preset`, async () => {
+      const names = await proxiedToolNames({ tools: { preset } } as TraceMcpConfig);
+      const expected = new Set([...(TOOL_PRESETS[preset] as string[]), ...UNGATED_META_TOOLS]);
+      const unexpected = names.filter((n) => !expected.has(n));
+      expect(
+        unexpected,
+        `Tools leaked past the "${preset}" preset: ${unexpected.join(', ')}`,
+      ).toEqual([]);
+      expect(names.length).toBeLessThan(DAEMON_TOOLS.length);
+    });
+  }
+
+  it('passes the full surface through untouched for the "full" preset', async () => {
+    const names = await proxiedToolNames({ tools: { preset: 'full' } } as TraceMcpConfig);
+    expect(names.length).toBe(DAEMON_TOOLS.length);
+  });
+
+  it('applies the shipped default (standard) when no preset is configured', async () => {
+    const names = await proxiedToolNames({} as TraceMcpConfig);
+    const expected = new Set([...(TOOL_PRESETS.standard as string[]), ...UNGATED_META_TOOLS]);
+    expect(names.filter((n) => !expected.has(n))).toEqual([]);
+    // The whole point of the issue: the default must not be the full surface.
+    expect(names.length).toBeLessThan(DAEMON_TOOLS.length / 2);
+  });
+
+  it('lets TRACE_MCP_PRESET override the config on the proxied path', async () => {
+    process.env.TRACE_MCP_PRESET = 'minimal';
+    const names = await proxiedToolNames({ tools: { preset: 'full' } } as TraceMcpConfig);
+    const expected = new Set([...(TOOL_PRESETS.minimal as string[]), ...UNGATED_META_TOOLS]);
+    expect(names.filter((n) => !expected.has(n))).toEqual([]);
+  });
+
+  it('honours tools.exclude and tools.include over the preset', async () => {
+    const names = await proxiedToolNames({
+      tools: { preset: 'minimal', include: ['get_pagerank'], exclude: ['search_text'] },
+    } as TraceMcpConfig);
+    expect(names).toContain('get_pagerank');
+    expect(names).not.toContain('search_text');
+  });
+
+  it('keeps a filtered-out tool genuinely uncallable, not merely hidden', async () => {
+    const { backend, transport, toClient } = await startProxy({
+      tools: { preset: 'standard' },
+    } as TraceMcpConfig);
+    await backend.send({
+      jsonrpc: '2.0',
+      id: 7,
+      method: 'tools/call',
+      params: { name: 'get_pagerank', arguments: {} },
+    } as unknown as JSONRPCMessage);
+
+    const reply = toClient.at(-1) as { id?: unknown; error?: { code: number; message: string } };
+    expect(reply.id).toBe(7);
+    expect(reply.error?.code).toBe(-32601);
+    expect(reply.error?.message).toContain('get_pagerank');
+    // Never reached the daemon — hiding a tool while still executing it would
+    // leave the token win without the behavioural guarantee.
+    expect(
+      transport.forwarded.some((m) => (m as { method?: string }).method === 'tools/call'),
+    ).toBe(false);
+  });
+
+  it('still forwards a permitted tools/call to the daemon', async () => {
+    const { backend, transport, toClient } = await startProxy({
+      tools: { preset: 'standard' },
+    } as TraceMcpConfig);
+    await backend.send({
+      jsonrpc: '2.0',
+      id: 8,
+      method: 'tools/call',
+      params: { name: 'search', arguments: { query: 'x' } },
+    } as unknown as JSONRPCMessage);
+    expect(
+      transport.forwarded.some((m) => (m as { method?: string }).method === 'tools/call'),
+    ).toBe(true);
+    expect((toClient.at(-1) as { error?: unknown }).error).toBeUndefined();
+  });
+});
+
+describe('proxied tools/list token budget (TRA-250)', () => {
+  // Serialized-char ceilings on the *proxied* surface, measured against the
+  // real presets. The registration-time budget in tool-schema-budget.test.ts
+  // was green throughout the regression this suite exists to catch, because it
+  // never looked at what a daemon-backed client actually receives.
+  //
+  // Real measurement (2026-08-28, v1.51.0 daemon + `dist/cli.js serve`):
+  // minimal 32,914 chars / ~9.1k tokens, standard 68,818 / ~19.1k,
+  // full 187,790 / ~52.2k. This suite's stub descriptions are far smaller, so
+  // it asserts on tool *counts* — the ratio that produced those numbers —
+  // rather than re-deriving char totals from fake prose.
+  const PRESET_MAX_TOOLS: Record<string, number> = { minimal: 30, standard: 60 };
+
+  for (const [preset, max] of Object.entries(PRESET_MAX_TOOLS)) {
+    it(`keeps the proxied "${preset}" surface at or under ${max} tools`, async () => {
+      const names = await proxiedToolNames({ tools: { preset } } as TraceMcpConfig);
+      expect(
+        names.length,
+        `The proxied "${preset}" surface grew to ${names.length} tools. Every tool here is ` +
+          'paid in tools/list schema tokens by every session on the default daemon path (TRA-250).',
+      ).toBeLessThanOrEqual(max);
+    });
+  }
+});
+
+describe('StdioSession wires the filter into every proxy backend (TRA-250)', () => {
+  // The original regression was not a broken filter — it was the absence of
+  // one on the shipped path. A ProxyBackend constructed without `toolFilter`
+  // forwards the daemon's full surface, and every test above would still pass.
+  // Source-level assertion because buildProxyBackend is private and the real
+  // path needs a live daemon.
+  it('passes toolFilter when constructing ProxyBackend', () => {
+    const src = readFileSync(fileURLToPath(new URL('../session.ts', import.meta.url)), 'utf8');
+    const ctor = src.slice(src.indexOf('new ProxyBackend('));
+    expect(ctor.slice(0, ctor.indexOf('});')), 'session.ts must pass toolFilter').toContain(
+      'toolFilter:',
+    );
+  });
+});
+
+describe('ungated meta-tool list stays in sync with session.ts (TRA-250)', () => {
+  it('matches the tools registered through _originalTool', () => {
+    const src = readFileSync(
+      fileURLToPath(new URL('../../../tools/register/session.ts', import.meta.url)),
+      'utf8',
+    );
+    const registered = new Set(
+      [...src.matchAll(/_originalTool\(\s*['"]([a-zA-Z0-9_]+)['"]/g)].map((m) => m[1]),
+    );
+    expect(
+      [...registered].sort(),
+      'Tools registered outside the preset gate must be listed in UNGATED_META_TOOLS, ' +
+        'or the daemon-backed surface will differ from the local one for the same preset.',
+    ).toEqual([...UNGATED_META_TOOLS].sort());
+  });
+});

--- a/src/daemon/router/proxy-backend.ts
+++ b/src/daemon/router/proxy-backend.ts
@@ -35,6 +35,15 @@ export interface ProxyBackendOptions {
    */
   initializeFrame?: JSONRPCMessage;
   /**
+   * Per-session tool-surface filter (preset / tools.include / tools.exclude).
+   * The daemon serves every tool to every session — it has to, since one daemon
+   * backs many sessions with different presets — so the preset can only be
+   * honoured here, at the session boundary: `tools/list` results are filtered
+   * and `tools/call` for a filtered-out tool is rejected without forwarding
+   * (TRA-250). Omit to forward the daemon's full surface unchanged.
+   */
+  toolFilter?: (name: string) => boolean;
+  /**
    * Test seam: build a transport for the resolved /mcp URL + project root.
    * Defaults to a real StreamableHTTPClientTransport.
    */
@@ -80,6 +89,17 @@ function messageId(msg: JSONRPCMessage): string | number | undefined {
   return id === undefined || id === null ? undefined : (id as string | number);
 }
 
+/** JSON-RPC "method not found" — what an MCP client gets for an unknown tool. */
+const METHOD_NOT_FOUND = -32601;
+
+/** Name of the tool a `tools/call` frame targets, if it is one. */
+function toolCallName(msg: JSONRPCMessage): string | undefined {
+  const m = msg as Record<string, unknown>;
+  if (m.method !== 'tools/call') return undefined;
+  const name = (m.params as Record<string, unknown> | undefined)?.name;
+  return typeof name === 'string' ? name : undefined;
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
     const t = setTimeout(resolve, ms);
@@ -122,6 +142,8 @@ export class ProxyBackend implements Backend {
   /** While re-initializing, swallow the replayed initialize response by id. */
   private pendingReinitId: string | number | null = null;
   private resolveReinit: (() => void) | null = null;
+  /** Ids of in-flight `tools/list` requests, whose responses need filtering. */
+  private readonly pendingToolsListIds = new Set<string | number>();
 
   constructor(opts: ProxyBackendOptions) {
     this.opts = opts;
@@ -164,6 +186,28 @@ export class ProxyBackend implements Backend {
     if (!this.httpTransport) throw new Error('ProxyBackend not started');
     // Cache the handshake so we can replay it if the daemon session dies.
     if (isInitializeRequest(msg)) this.initializeFrame = msg;
+    if (this.opts.toolFilter) {
+      const id = messageId(msg);
+      const called = toolCallName(msg);
+      // A filtered-out tool must be genuinely uncallable, not merely hidden
+      // from tools/list — answer it here instead of forwarding (TRA-250).
+      if (called !== undefined && !this.opts.toolFilter(called)) {
+        if (id !== undefined) {
+          this.onmessage?.({
+            jsonrpc: '2.0',
+            id,
+            error: {
+              code: METHOD_NOT_FOUND,
+              message: `Tool "${called}" is not available in this session's tool preset.`,
+            },
+          } as unknown as JSONRPCMessage);
+        }
+        return;
+      }
+      if ((msg as Record<string, unknown>).method === 'tools/list' && id !== undefined) {
+        this.pendingToolsListIds.add(id);
+      }
+    }
     try {
       // Transient network blips (daemon mid-restart, dropped connection) are
       // common during a daemon respawn; retry a couple of times with short
@@ -260,6 +304,28 @@ export class ProxyBackend implements Backend {
     return this.reestablishing;
   }
 
+  /**
+   * Narrow a daemon `tools/list` reply to this session's preset. The daemon
+   * always answers with its full surface — filtering it out here is what makes
+   * the preset actually reach the client on the daemon path (TRA-250).
+   */
+  private filterToolsListResponse(msg: JSONRPCMessage): JSONRPCMessage {
+    const filter = this.opts.toolFilter;
+    const id = messageId(msg);
+    if (!filter || id === undefined || !this.pendingToolsListIds.delete(id)) return msg;
+    const result = (msg as Record<string, unknown>).result as
+      | { tools?: Array<{ name?: unknown }> }
+      | undefined;
+    if (!Array.isArray(result?.tools)) return msg;
+    const tools = result.tools.filter((t) => typeof t?.name !== 'string' || filter(t.name));
+    if (tools.length === result.tools.length) return msg;
+    logger.debug(
+      { total: result.tools.length, kept: tools.length },
+      'ProxyBackend: filtered tools/list to session preset',
+    );
+    return { ...msg, result: { ...result, tools } } as JSONRPCMessage;
+  }
+
   private wire(transport: ProxyTransport): void {
     transport.onmessage = (msg) => {
       // Swallow the replayed initialize response — the client already received
@@ -268,7 +334,7 @@ export class ProxyBackend implements Backend {
         this.resolveReinit?.();
         return;
       }
-      this.onmessage?.(msg);
+      this.onmessage?.(this.filterToolsListResponse(msg));
     };
     transport.onerror = (err) => {
       logger.warn({ err: String(err) }, 'ProxyBackend: HTTP transport error');

--- a/src/daemon/router/session.ts
+++ b/src/daemon/router/session.ts
@@ -5,6 +5,7 @@ import type { TraceMcpConfig } from '../../config.js';
 import { logger } from '../../logger.js';
 import { checkVersionDrift, versionDriftMessage } from '../../init/version-stamp.js';
 import { stripRedundantSchemaKeyword } from '../../server/schema-shim.js';
+import { createToolFilter } from '../../server/tool-filter.js';
 import { disarmStdoutGuard } from '../../server/transport-hardening.js';
 import { tryAutoSpawnDaemon } from '../lifecycle.js';
 import { PollingDaemonWatcher } from './daemon-watcher.js';
@@ -343,6 +344,10 @@ export class StdioSession {
       // session on its first request instead of surfacing "Session expired".
       // Null at bootstrap — the initial backend captures it via send() instead.
       initializeFrame: this.cachedInitialize ?? undefined,
+      // The preset is a property of *this* client session, not of the daemon
+      // (which serves every tool to everyone) — so it has to be applied here
+      // on the way out, or it never reaches a daemon-backed client (TRA-250).
+      toolFilter: createToolFilter(this.opts.config),
     });
   }
 

--- a/src/server/tool-filter.ts
+++ b/src/server/tool-filter.ts
@@ -1,0 +1,65 @@
+/**
+ * The single source of truth for "is this tool part of the surface this client
+ * session asked for" — preset + tools.include + tools.exclude.
+ *
+ * Two callers:
+ *  - the registration-time gate (src/server/tool-gate.ts), which never
+ *    registers a filtered-out tool on a local McpServer;
+ *  - the daemon proxy (src/daemon/router/proxy-backend.ts), which cannot filter
+ *    at registration — one daemon serves many sessions with different presets —
+ *    so it filters `tools/list` and rejects `tools/call` per session instead.
+ *
+ * Before TRA-250 only the first existed, so every daemon-backed session (the
+ * default path) saw the full surface regardless of its preset.
+ */
+import type { TraceMcpConfig } from '../config.js';
+import { resolvePreset } from '../tools/project/presets.js';
+
+/**
+ * Tools registered through `_originalTool` in src/tools/register/session.ts —
+ * deliberately outside the preset gate, so any session can inspect its own
+ * preset/usage and use `batch`. The proxy-side filter has to let them through
+ * as well, otherwise the daemon-backed surface would be smaller than the local
+ * one for the same preset. Kept honest by tool-filter.test.ts.
+ */
+export const UNGATED_META_TOOLS: ReadonlySet<string> = new Set([
+  'get_preset_info',
+  'get_session_analytics',
+  'get_optimization_report',
+  'get_coverage_report',
+  'get_real_savings',
+  'get_usage_trends',
+  'get_session_stats',
+  'plan_turn',
+  'batch',
+]);
+
+/** Preset name this session runs with: env beats config, default `standard`. */
+export function resolvePresetName(config: TraceMcpConfig): string {
+  return process.env.TRACE_MCP_PRESET ?? config.tools?.preset ?? 'standard';
+}
+
+/** Resolved preset set; unknown names fall back to the full surface. */
+export function resolveActivePreset(config: TraceMcpConfig): Set<string> | 'all' {
+  return resolvePreset(resolvePresetName(config)) ?? 'all';
+}
+
+/**
+ * Build the per-session predicate. `activePreset` is injectable because the
+ * server resolves it once and logs it; everyone else can let us resolve it.
+ */
+export function createToolFilter(
+  config: TraceMcpConfig,
+  activePreset: Set<string> | 'all' = resolveActivePreset(config),
+): (name: string) => boolean {
+  const includeSet = config.tools?.include ? new Set(config.tools.include) : null;
+  const excludeSet = config.tools?.exclude ? new Set(config.tools.exclude) : null;
+  return (name: string): boolean => {
+    if (excludeSet?.has(name)) return false;
+    if (includeSet?.has(name)) return true;
+    if (activePreset === 'all') return true;
+    // Meta-tools are never registered through the gate, so this branch only
+    // matters for the proxy filter — it keeps both surfaces identical.
+    return activePreset.has(name) || UNGATED_META_TOOLS.has(name);
+  };
+}

--- a/src/server/tool-gate.ts
+++ b/src/server/tool-gate.ts
@@ -16,6 +16,7 @@ import {
   type SchemaTransformConfig,
   stampAlwaysLoad,
 } from './tool-gate-helpers.js';
+import { createToolFilter } from './tool-filter.js';
 import type { ToolResponse } from './types.js';
 
 interface ToolGateResult {
@@ -55,8 +56,6 @@ export function installToolGate(
   onJournalEntry?: (data: JournalEntryCallbackData) => void,
   sessionId?: string,
 ): ToolGateResult {
-  const includeSet = config.tools?.include ? new Set(config.tools.include) : null;
-  const excludeSet = config.tools?.exclude ? new Set(config.tools.exclude) : null;
   const descriptionOverrides = config.tools?.descriptions ?? {};
   const schemaTransformConfig: SchemaTransformConfig = {
     descriptionVerbosity: config.tools?.description_verbosity ?? 'full',
@@ -68,12 +67,9 @@ export function installToolGate(
         : {},
   };
 
-  function toolAllowed(name: string): boolean {
-    if (excludeSet?.has(name)) return false;
-    if (includeSet?.has(name)) return true;
-    if (activePreset === 'all') return true;
-    return activePreset.has(name);
-  }
+  // Shared with the daemon proxy's per-session filter (TRA-250) so the local
+  // and daemon-backed surfaces cannot drift apart.
+  const toolAllowed = createToolFilter(config, activePreset);
 
   const _originalTool = server.tool.bind(server);
   const registeredToolNames: string[] = [];


### PR DESCRIPTION
Fixes TRA-250.

## The bug

`TRACE_MCP_PRESET` / `tools.preset` (default `standard`) had **zero effect on the default shipped path**. Measured on `main`, built from source, driving raw JSON-RPC `initialize` + `tools/list` against `node dist/cli.js serve`:

| preset | daemon running (default) | daemon down |
|---|---:|---:|
| minimal | **172** tools / ~52.2k tok | 24 / ~9.1k |
| standard | **172** / ~52.2k | 55 / ~18.9k |
| full | 172 / ~52.2k | 172 / ~51.6k |

The gate was never broken — `installToolGate` only ever ran on the **local** `McpServer` a session falls back to when no daemon is alive. With `auto_spawn_daemon ?? true` (`src/cli.ts:380`), that is the path almost nobody takes.

## The fix

The preset is a property of the *client session*, not of the daemon — one daemon serves many sessions, some of which legitimately want `full`. So it cannot move to daemon registration. `ProxyBackend` now applies the session's filter at the proxy boundary:

- `tools/list` replies are narrowed to the session's preset (`include`/`exclude` respected);
- `tools/call` for a filtered-out tool is answered with `-32601` **without reaching the daemon** — hidden *and* uncallable, not just hidden;
- the predicate lives in one place (`src/server/tool-filter.ts`) and is now used by both the registration gate and the proxy, so the two surfaces can't drift.

Meta-tools registered outside the gate (`batch`, `get_preset_info`, …) stay available on both paths — that is what makes minimal/standard land on exactly 24/55, matching the local column.

**Non-breaking**: no tool signature, no schema, no on-disk format change. The default surface simply becomes the one that was already configured, documented and tested.

## Test evidence

Same harness, daemon (v1.51.0, launchd) live, three consecutive runs identical:

```
daemon minimal   tools=24  ~9,143 tok   call(get_pagerank)=ERROR -32601
daemon standard  tools=55  ~19,116 tok  call(get_pagerank)=ERROR -32601
daemon full      tools=172 ~52,164 tok  call(get_pagerank)=OK (executed)
```

~33k tokens per session recovered on the default preset (~64% off `tools/list`), vs the ~6% TRA-186 moved.

New regression suite `src/daemon/router/__tests__/proxy-tool-preset.test.ts` (15 tests) asserts on the **proxied** surface, which is exactly the layer nothing was watching: per-preset contents and count ceilings, env-over-config precedence, include/exclude, uncallability of a filtered tool, that a permitted call still reaches the daemon, that `StdioSession` actually wires the filter in, and that the ungated meta-tool list stays in sync with `session.ts`. Reverting the fix turns 11 of the 15 red.

`pnpm run typecheck`, `biome ci` clean. Full suite: 8,696 passed, 1 failed — `tests/integration/eval-cli-smoke.test.ts` (`eval run --check-baseline`, 2 regressions), which **fails identically on `main` with this branch stashed**; unrelated and pre-existing.

## Note on the `standard` preset itself (acceptance item 4)

55 tools covers the search / read / impact / quality loop. The refactoring family (`apply_rename`, `apply_move`, `change_signature`, `plan_refactoring`) is *not* in it, though this repo's own CLAUDE.md prescribes those for renames and moves. I left the list unchanged here rather than widen the default surface inside a fix PR — worth a separate call with usage data behind it.
