### PR TITLE
fix(app): make the guard onboarding dialog dismissable and quiet on first launch

### DIFF
--- a/packages/app/src/renderer/components/GuardOnboarding.tsx
+++ b/packages/app/src/renderer/components/GuardOnboarding.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { Button } from '../lattice/ui';
 
 type Step = 'detect' | 'cli-missing' | 'cli-stale' | 'install-prompt' | 'installing' | 'installed' | 'skipped';
 
@@ -20,6 +21,11 @@ interface OnboardingState {
  *           → install-prompt → installing → installed
  *                                         → skipped (user opted out)
  *
+ * Nothing renders until detection resolves — the dialog is the first thing a
+ * new user ever sees, so it must not flash an empty "Detecting…" panel over a
+ * still-loading Workspace. When Claude Code isn't installed there is nothing
+ * to offer, so we acknowledge and close without ever showing a dialog.
+ *
  * Persistence: writes ~/.claude/.trace-mcp-onboarded once the user reaches
  * a terminal state. Renderer-side via electronAPI? — actually we keep it
  * in localStorage because it's a UI hint, not a security boundary.
@@ -32,6 +38,21 @@ interface GuardOnboardingProps {
 
 export function GuardOnboarding({ onClose }: GuardOnboardingProps) {
   const [state, setState] = useState<OnboardingState>({ step: 'detect' });
+  const titleId = useId();
+
+  // Ref so the detect effect can close without re-running when App re-renders
+  // and hands us a fresh `onClose` identity.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  const dismissAndPersist = useCallback(() => {
+    try {
+      localStorage.setItem(ONBOARDING_KEY, '1');
+    } catch {
+      /* private mode? — no-op */
+    }
+    onCloseRef.current();
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -65,8 +86,9 @@ export function GuardOnboarding({ onClose }: GuardOnboardingProps) {
         return;
       }
       if (!installStatus?.claudeDetected) {
-        // Claude Code not installed; nothing to do for now.
-        setState({ step: 'skipped' });
+        // Claude Code not installed — there is nothing to offer, so don't
+        // interrupt first launch with a dialog just to say "skipped".
+        dismissAndPersist();
         return;
       }
       setState({
@@ -78,7 +100,22 @@ export function GuardOnboarding({ onClose }: GuardOnboardingProps) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [dismissAndPersist]);
+
+  // Dismissable while a dialog is actually on screen and idle — not during
+  // detection (nothing is shown yet) and not mid-install (work in flight).
+  const dismissable = state.step !== 'detect' && state.step !== 'installing';
+
+  // Escape dismisses, same as the primary action. A modal you can't get out of
+  // with the keyboard is a trap on the very first screen of the app.
+  useEffect(() => {
+    if (!dismissable) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') dismissAndPersist();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [dismissable, dismissAndPersist]);
 
   const install = async () => {
     setState((s) => ({ ...s, step: 'installing' }));
@@ -90,33 +127,31 @@ export function GuardOnboarding({ onClose }: GuardOnboardingProps) {
     setState((s) => ({ ...s, step: 'installed', scriptPath: result.scriptPath }));
   };
 
-  const dismissAndPersist = () => {
-    try {
-      localStorage.setItem(ONBOARDING_KEY, '1');
-    } catch {
-      /* private mode? — no-op */
-    }
-    onClose();
-  };
+  if (state.step === 'detect') return null;
 
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center"
       style={{ background: 'rgba(0,0,0,0.4)' }}
+      onClick={dismissable ? dismissAndPersist : undefined}
     >
+      {/* stopPropagation below keeps clicks inside the panel from reaching the
+          backdrop handler; Escape is handled globally above. */}
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
         className="rounded-lg shadow-2xl p-6 max-w-md w-full"
         style={{ background: 'var(--bg-primary)', border: '1px solid var(--border)' }}
+        onClick={(e) => e.stopPropagation()}
       >
-        <h2 className="text-base font-semibold mb-3" style={{ color: 'var(--text-primary)' }}>
+        <h2
+          id={titleId}
+          className="text-base font-semibold mb-3"
+          style={{ color: 'var(--text-primary)' }}
+        >
           Set up trace-mcp guard
         </h2>
-
-        {state.step === 'detect' && (
-          <div className="text-sm" style={{ color: 'var(--text-secondary)' }}>
-            Detecting installation…
-          </div>
-        )}
 
         {state.step === 'cli-missing' && (
           <div>
@@ -225,27 +260,15 @@ function ActionRow({ onPrimary, primaryLabel, onSecondary, secondaryLabel }: Act
   return (
     <div className="flex gap-2 justify-end">
       {onSecondary && secondaryLabel && (
-        <button
-          type="button"
-          onClick={onSecondary}
-          className="px-3 py-1.5 rounded-md text-sm font-medium"
-          style={{
-            background: 'transparent',
-            color: 'var(--text-secondary)',
-            border: '1px solid var(--border)',
-          }}
-        >
+        <Button variant="chip" onClick={onSecondary}>
           {secondaryLabel}
-        </button>
+        </Button>
       )}
-      <button
-        type="button"
-        onClick={onPrimary}
-        className="px-3 py-1.5 rounded-md text-sm font-medium"
-        style={{ background: 'var(--accent)', color: 'var(--bg-primary)' }}
-      >
+      {/* autoFocus: the dialog must own the keyboard on mount, otherwise Tab
+          and Enter act on the Workspace behind it. */}
+      <Button autoFocus variant="primary" onClick={onPrimary}>
         {primaryLabel}
-      </button>
+      </Button>
     </div>
   );
 }

--- a/packages/app/src/renderer/components/__tests__/GuardOnboarding.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/GuardOnboarding.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { GuardOnboarding, isOnboardingDone } from '../GuardOnboarding';
+
+interface GuardStubs {
+  checkCliVersion?: unknown;
+  installStatus?: unknown;
+}
+
+function stubGuard({ checkCliVersion, installStatus }: GuardStubs) {
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    guard: {
+      checkCliVersion: vi.fn().mockResolvedValue(checkCliVersion),
+      installStatus: vi.fn().mockResolvedValue(installStatus),
+      install: vi.fn().mockResolvedValue({ ok: true, scriptPath: '/tmp/hook.mjs' }),
+    },
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  vi.restoreAllMocks();
+});
+
+it('renders nothing while detection is still in flight', () => {
+  stubGuard({ checkCliVersion: new Promise(() => {}) });
+  const { container } = render(<GuardOnboarding onClose={() => {}} />);
+  expect(container.innerHTML).toBe('');
+});
+
+it('closes silently without a dialog when Claude Code is not installed', async () => {
+  stubGuard({
+    checkCliVersion: { current: '1.51.1', required: '1.51.0' },
+    installStatus: { installed: false, claudeDetected: false },
+  });
+  const onClose = vi.fn();
+  render(<GuardOnboarding onClose={onClose} />);
+
+  await waitFor(() => expect(onClose).toHaveBeenCalled());
+  expect(screen.queryByRole('dialog')).toBeNull();
+  expect(isOnboardingDone()).toBe(true);
+});
+
+it('exposes the panel as a labelled modal dialog and focuses its primary action', async () => {
+  stubGuard({ checkCliVersion: { notInstalled: true } });
+  render(<GuardOnboarding onClose={() => {}} />);
+
+  const dialog = await screen.findByRole('dialog');
+  expect(dialog.getAttribute('aria-modal')).toBe('true');
+  const labelId = dialog.getAttribute('aria-labelledby');
+  expect(labelId).toBeTruthy();
+  expect(document.getElementById(labelId as string)?.textContent).toBe('Set up trace-mcp guard');
+  await waitFor(() =>
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Got it' })),
+  );
+});
+
+it('dismisses on Escape and remembers the acknowledgement', async () => {
+  stubGuard({ checkCliVersion: { notInstalled: true } });
+  const onClose = vi.fn();
+  render(<GuardOnboarding onClose={onClose} />);
+  await screen.findByRole('dialog');
+
+  fireEvent.keyDown(window, { key: 'Escape' });
+
+  expect(onClose).toHaveBeenCalledTimes(1);
+  expect(isOnboardingDone()).toBe(true);
+});
+
+it('dismisses on backdrop click but not on a click inside the panel', async () => {
+  stubGuard({ checkCliVersion: { notInstalled: true } });
+  const onClose = vi.fn();
+  render(<GuardOnboarding onClose={onClose} />);
+  const dialog = await screen.findByRole('dialog');
+
+  fireEvent.click(dialog);
+  expect(onClose).not.toHaveBeenCalled();
+
+  fireEvent.click(dialog.parentElement as HTMLElement);
+  expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+it('does not dismiss while the hook install is in flight', async () => {
+  stubGuard({
+    checkCliVersion: { current: '1.51.1', required: '1.51.0' },
+    installStatus: { installed: false, claudeDetected: true },
+  });
+  const onClose = vi.fn();
+  const api = (window as unknown as { electronAPI: { guard: { install: unknown } } }).electronAPI;
+  api.guard.install = vi.fn(() => new Promise(() => {}));
+  render(<GuardOnboarding onClose={onClose} />);
+
+  fireEvent.click(await screen.findByRole('button', { name: 'Install' }));
+  await screen.findByText('Installing hook…');
+
+  fireEvent.keyDown(window, { key: 'Escape' });
+  fireEvent.click(screen.getByRole('dialog').parentElement as HTMLElement);
+
+  expect(onClose).not.toHaveBeenCalled();
+});
+
+it('uses the Lattice Button primitive for its actions', async () => {
+  stubGuard({
+    checkCliVersion: { current: '1.51.1', required: '1.51.0' },
+    installStatus: { installed: false, claudeDetected: true },
+  });
+  render(<GuardOnboarding onClose={() => {}} />);
+
+  const install = await screen.findByRole('button', { name: 'Install' });
+  expect(install.className).toContain('ws-primary');
+  expect(screen.getByRole('button', { name: 'Skip' }).className).toContain('ws-chipbtn');
+});


### PR DESCRIPTION
Fixes the first screen a new user ever sees. Part of TRA-242 (Electron App Design & UX); tracked as TRA-252.

`GuardOnboarding` renders on first launch of the menu window, on top of a Workspace that is still loading. Four defects, all reproduced live in the running renderer against the local daemon (not inferred from code):

1. **No exit but the one button.** Escape and backdrop clicks were both no-ops.
2. **Focus never entered the dialog.** No `role="dialog"`, no `aria-modal`, no `aria-labelledby`, no autofocus — `document.activeElement` stayed on `BODY`, so Tab walked the Workspace behind the overlay.
3. **Empty flash.** The `detect` step rendered the modal chrome plus "Detecting installation…" before it had anything to say.
4. **A modal to say nothing.** On a machine without Claude Code, detection landed on `step: 'skipped'` and showed a dialog reading "Skipped." — one forced click about a feature the user never asked for.

Plus: `ActionRow` hand-rolled its buttons with inline styles instead of the Lattice `Button` primitive, so the product's very first button was off the design system.

## Changes

- Return `null` while `step === 'detect'`.
- When Claude Code isn't detected, persist the acknowledgement and close without ever mounting a dialog (removes the `skipped`-from-detection path).
- Escape + backdrop click dismiss and persist, gated off during `installing` so an in-flight install can't be abandoned.
- `role="dialog"` / `aria-modal="true"` / `aria-labelledby={titleId}`; primary action carries `autoFocus`.
- `ActionRow` uses `Button variant="primary"` and `variant="chip"`.

`onClose` is held in a ref so the detect effect doesn't re-run when `App` hands down a fresh inline arrow.

## Tests

7 new tests in `packages/app/src/renderer/components/__tests__/GuardOnboarding.test.tsx` — detection-in-flight renders nothing, silent close without Claude Code, dialog role/label/focus, Escape dismissal + persistence, backdrop vs. inside click, no dismissal mid-install, and Lattice class assertions. The 6 that existed before the fix all failed against the old component.

## Evidence

- `packages/app`: **60/60** tests pass (53 pre-existing + 7 new)
- `pnpm lint` (`tsc --noEmit`) clean
- `pnpm biome:ci` clean — 1574 files
- `vite build` clean
- Live before/after screenshots and DOM probes attached to TRA-252

No MCP tool signatures, schemas, or on-disk formats touched — renderer-only.
