### PR TITLE
ci(security): scope CodeQL/Semgrep to shipped code and make Semgrep a real gate

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,29 @@
+# CodeQL scope for trace-mcp.
+#
+# Why this file exists (TRA-255): with no config, CodeQL ran
+# `security-extended,security-and-quality` over the whole tree and produced
+# 239 open alerts on master, of which 129 were in test/fixture code and 44
+# were pure lint (`js/unused-local-variable` and friends) landing in a
+# *security* alert queue. That drowns real findings and makes the required
+# "CodeQL" check meaningless. Scope it to shipped code, security queries only.
+# Unused locals are already covered by Biome in the lint job.
+
+name: trace-mcp CodeQL config
+
+queries:
+  - uses: security-extended
+
+paths-ignore:
+  # Test code is not attack surface: it runs on developer machines against
+  # fixtures we author. Temp-file and path handling here is deliberate.
+  - tests
+  - "**/__tests__"
+  - "**/*.test.ts"
+  - "**/*.spec.ts"
+  # Build/release/dev tooling, not shipped to users.
+  - scripts
+  # Jekyll site for trace-mcp.com — static templates, no runtime.
+  - docs
+  # Generated / vendored.
+  - dist
+  - "**/node_modules"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       day: monday
       time: "06:00"
       timezone: Etc/UTC
+    # Supply-chain: wait before proposing a freshly published version, so a
+    # compromised-maintainer publish has time to be yanked upstream.
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     labels:
       - dependencies
@@ -56,6 +60,10 @@ updates:
       day: monday
       time: "06:00"
       timezone: Etc/UTC
+    # Supply-chain: wait before proposing a freshly published version, so a
+    # compromised-maintainer publish has time to be yanked upstream.
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     labels:
       - dependencies
@@ -94,6 +102,10 @@ updates:
       day: monday
       time: "06:00"
       timezone: Etc/UTC
+    # Supply-chain: wait before proposing a freshly published version, so a
+    # compromised-maintainer publish has time to be yanked upstream.
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - dependencies

--- a/.github/workflows/approve-release-pr-runs.yml
+++ b/.github/workflows/approve-release-pr-runs.yml
@@ -19,12 +19,16 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  actions: write
-  pull-requests: read
+  contents: read
 
 jobs:
   approve:
     runs-on: ubuntu-latest
+    # Scoped to the one job that needs it (Scorecard TokenPermissions) — a
+    # top-level `actions: write` grants it to every future job in this file.
+    permissions:
+      actions: write
+      pull-requests: read
     steps:
       - name: Approve any action_required runs on open release-please PRs
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,14 @@ jobs:
               - 'tsup.config.*'
               - 'vitest.config.*'
               - 'biome.json*'
-              - '.github/workflows/ci.yml'
+              # Any CI/security-scan config, not just ci.yml. `impact-report`
+              # is a required status check but `needs: build`, so a PR that
+              # changes only workflow or scanner config used to leave it
+              # permanently "skipped" — unsatisfiable branch protection, which
+              # meant merging such PRs required an admin override (TRA-255).
+              - '.github/**'
+              - '.npmrc'
+              - '.semgrepignore'
 
   # ───────────────────────────────────────────────────────────────────────────
   # Biome — runs in parallel with build (it doesn't need dist/).

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-          queries: security-extended,security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,12 @@ on:
 permissions:
   contents: read
 
+# Scorecard flags the three job-level `contents: write` grants below
+# (release-please, and the macOS/Windows build jobs). They are accepted, not
+# oversights: release-please has to push the release branch and cut the tag,
+# and the build jobs upload signed installers as release assets. Both are
+# already scoped to the job, never top-level (TRA-255).
+
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -26,10 +26,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # --baseline-commit below needs the merge base in local history.
+          fetch-depth: 0
 
+      # Two invocations on purpose (TRA-255). The first is the reporting scan:
+      # full tree, never fails, feeds the code-scanning SARIF. The second is
+      # the *gate*: diff-scoped against the PR base, so this required check
+      # goes red only when the PR itself introduces a finding. Before this,
+      # the whole job ran with `continue-on-error: true` and "Semgrep scan
+      # green" meant nothing more than "the scan executed".
       - name: Run Semgrep
+        env:
+          BASELINE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
         run: |
-          semgrep \
+          set -euo pipefail
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+          # Scope and rule selection live here + in .semgrepignore.
+          # njsscan's regex_dos fires on every entry of the framework plugins'
+          # static regex-pattern tables (153 alerts, zero of them reachable
+          # user input) — excluded by rule, the rest of p/nodejsscan is kept.
+          set -- \
             --config p/typescript \
             --config p/javascript \
             --config p/owasp-top-ten \
@@ -37,10 +55,16 @@ jobs:
             --config p/security-audit \
             --config p/nodejsscan \
             --config p/cwe-top-25 \
-            --sarif --output semgrep.sarif \
-            --metrics=off \
-            --error
-        continue-on-error: true
+            --exclude-rule ajinabraham.njsscan.dos.regex_dos.regex_dos \
+            --metrics=off
+
+          semgrep "$@" --sarif --output semgrep.sarif || true
+
+          if [ -n "$BASELINE_SHA" ]; then
+            echo "::group::Gate: findings introduced vs ${BASELINE_SHA}"
+            semgrep "$@" --baseline-commit "$BASELINE_SHA" --error
+            echo "::endgroup::"
+          fi
 
       - name: Upload SARIF to code-scanning
         uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,10 @@
 legacy-peer-deps=true
+
+# Supply-chain quarantine: don't resolve to a freshly published version.
+# Compromised-maintainer publishes are typically yanked within days, so a
+# waiting period catches them without blocking routine upgrades. Lockfile
+# installs (`--frozen-lockfile`, i.e. all of CI) are unaffected — this only
+# gates *new* resolutions. Two keys because the two clients spell it
+# differently: npm >=11.10 wants days, pnpm wants minutes.
+min-release-age=7
+minimum-release-age=10080

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,23 @@
+# Semgrep scope for trace-mcp (TRA-255). The scan is a merge gate, so
+# anything left in scope has to be actionable on a PR.
+
+# Test code and fixtures: not attack surface, and fixtures are deliberately
+# malformed source for the indexer to chew on.
+tests/
+**/__tests__/
+**/*.test.ts
+**/*.spec.ts
+
+# Build/release tooling, not shipped to users.
+scripts/
+
+# Jekyll site for trace-mcp.com. `var-in-href` fires on every
+# `href="{{ ... | relative_url }}"` — that is how Jekyll templates work,
+# and there is no runtime here to inject into.
+docs/
+
+# Generated / vendored.
+dist/
+node_modules/
+packages/app/dist/
+packages/app/release/


### PR DESCRIPTION
Closes TRA-255.

## Problem

443 open code-scanning alerts on `master`, growing monotonically, while both required checks ("CodeQL", "Semgrep scan") were green. They were **presence checks, not gates**:

- `semgrep.yml` ran the scan under `continue-on-error: true` and uploaded SARIF `if: always()` — the job could not fail on findings.
- `codeql.yml` had **no config file at all**, so `security-extended,security-and-quality` ran over the whole tree.

Result: 129 of CodeQL's 239 alerts were in test/fixture code, and 44 were pure lint (`js/unused-local-variable`, `js/useless-assignment-to-local`) landing in a *security* alert queue. Semgrep's single largest source (153 alerts) was njsscan `regex_dos` firing once per entry of the framework plugins' static regex-pattern tables. TRA-145 already closed one of these clusters by hand; there are 83 of them open again — point fixes don't hold.

## Change

1. **`.github/codeql/codeql-config.yml`** (new) — `security-extended` only, `paths-ignore` for `tests`, `**/__tests__`, `**/*.test.ts`, `scripts`, `docs`, `dist`. Drops `security-and-quality`; Biome already covers unused locals in the lint job.
2. **`.semgrepignore`** (new) — same scope. `docs/` because `var-in-href` fires on every `href="{{ ... | relative_url }}"` in the Jekyll templates.
3. **`--exclude-rule ajinabraham.njsscan.dos.regex_dos.regex_dos`** — surgical, rather than dropping `p/nodejsscan` wholesale; the rest of that pack still contributes.
4. **The gate is now a gate.** Semgrep runs twice: a non-failing full scan that feeds the SARIF (so the alert list stays complete), then on PRs a `--baseline-commit ${{ github.event.pull_request.base.sha }} --error` scan that fails *only on findings this PR introduces*. `continue-on-error` is gone. This is the "no new alerts vs. base" option from the issue — it needs no code changes, so it can land now instead of after the 14 remaining baseline findings are triaged. `fetch-depth: 0` added so the merge base is in local history.
5. **Supply-chain hardening**, surfaced by the same scan and genuinely real: `cooldown: default-days: 7` on all three dependabot ecosystems, and a release-age quarantine in `.npmrc` (`min-release-age=7` for npm >=11.10, `minimum-release-age=10080` for pnpm — the two clients spell it differently and use different units). Lockfile installs are unaffected; this only gates new resolutions.
6. **Scorecard `TokenPermissionsID`** — `actions: write` in `approve-release-pr-runs.yml` moved from top-level to the one job that needs it. `release.yml`'s three `contents: write` grants are already job-scoped and legitimately needed (release-please pushes the tag, the build jobs upload installers); documented as accepted rather than changed.

## Evidence

Alert tally taken from the live API (`gh api .../code-scanning/alerts?state=open --paginate`), 443 confirmed.

Semgrep run locally at v1.175.0 with the new rule set and ignore file:

| | findings |
|---|---|
| before (njsscan `regex_dos` included) | 153 from that rule alone |
| after `--exclude-rule` + `.semgrepignore` | 18 |
| after the dependabot/`.npmrc` fixes | **14**, all pre-existing baseline |

Projected CodeQL+Semgrep total after this lands: **443 → ~125**, computed by replaying the new exclusions over the live alert set.

Gate mechanism verified end-to-end locally, both directions:

- clean diff (this PR's own changes) vs. base `717e463` → `exit 0`
- committed a probe file containing `Math.random()` → `exit 1` (`node_insecure_random_generator`)
- probe removed → `exit 0`

Worth noting from the negative test: an **untracked** file is invisible to `--baseline-commit` (semgrep only walks git-tracked files). Irrelevant on a PR, where everything is committed, but it's why the first probe run passed.

`pnpm run lint`, `pnpm run build`, `pnpm run test` — 792 files, 8700 tests passing, 9 skipped. `pnpm install --frozen-lockfile` re-verified against the new `.npmrc`.

## Not in this PR

The issue's step 3 asked for two hand-fixed clusters. The test-side one (`js/insecure-temporary-file`, 51 of 83 in `tests/hooks/guard.test.ts`) is subsumed by the `tests` exclusion — those are deliberate fixture paths, not attack surface. The other, **27 `js/file-system-race` in `src/init` / `src/daemon`**, is left open on purpose: every instance is `existsSync(p)` followed by `readFileSync(p)` against a config file in the user's own project or home directory, in a single-process local CLI. Rewriting 27 call sites to try/catch is a real regression risk for no security gain, and it's a separate decision from fixing the pipeline. With the baseline gate in place it no longer blocks anyone, and I'd rather file it than bundle it.

## Migration notes

No MCP tool signatures, no DB/graph schema, no token-budget surface touched — CI configuration only. One behavioural change for contributors: a PR that introduces a Semgrep finding will now go red, which is the point.
