### PR TITLE
perf(app): stop shipping node_modules in the artifact, add a perf baseline harness (TRA-257)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,13 @@ jobs:
               - '.github/**'
               - '.npmrc'
               - '.semgrepignore'
+              # Same unsatisfiable-gate problem as `.github/**` above, for the
+              # two other trees a PR can touch on its own: an app-only or
+              # docs-only PR left `impact-report` "skipped" forever and needed
+              # an admin override to merge (TRA-257). Cheaper to pay one build
+              # than to hand-merge past branch protection.
+              - 'packages/app/**'
+              - 'docs/**'
 
   # ───────────────────────────────────────────────────────────────────────────
   # Biome — runs in parallel with build (it doesn't need dist/).

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -1,0 +1,54 @@
+# Desktop app performance baseline
+
+Machine-readable history lives in [`baseline.json`](./baseline.json) — append one `runs[]`
+entry per measurement pass, never rewrite an old one. This file is the human summary.
+
+## Current numbers (1.51.1, `9459d4ce`, macOS 26.5 / arm64, median of 3)
+
+| Metric | Value | Ceiling | Status |
+|---|---|---|---|
+| `cold_start_ms` | 349 | 3000 | ok |
+| `window_interactive_ms` | 121 | — | ok |
+| `heap_idle_mb` (5 min idle) | 9.5 | — | ok |
+| `main_cpu_idle_pct` | 0 | 2 | ok |
+| `renderer_bundle_kb` | 1461 | — | ok |
+| `artifact_mb.mac_asar` | 1.6 | ×1.5 growth | ok |
+| `artifact_mb.mac_app_unpacked` | 264.8 | ×1.5 growth | ok (Electron framework is ~263 MB of it) |
+
+Not yet measured: `ui_p95_ms`, `heap_after_workload_mb`, `heap_growth_mb_per_hour`.
+All three need a fixed indexed-project fixture so the workload scenario is identical
+across runs — that's the next run's job.
+
+## How to take a measurement
+
+```bash
+pnpm -C packages/app run build          # required — the harness measures the prod bundle
+pnpm -C packages/app run pack           # optional — needed for artifact_mb
+PERF_COMMIT=$(git rev-parse --short HEAD) \
+  pnpm -C packages/app run perf -- --samples 3 --idle-seconds 300
+```
+
+The harness ([`packages/app/scripts/perf-measure.mjs`](../../packages/app/scripts/perf-measure.mjs))
+launches the built app against a throwaway `--user-data-dir`, drives it over CDP, and
+prints a ready-to-paste `runs[]` entry. `cold_start_ms` is process spawn → `#root` has
+painted real content; `window_interactive_ms` is the renderer's own share of that.
+
+Every number is a median of 3 samples. A single sample is never a regression.
+Compare against the median of the last 5 runs: >+10% is a warning to note, >+25%
+(or two consecutive warnings) is a regression worth an issue.
+
+## Changes worth remembering
+
+**2026-08-28 — artifact 286 MB → 265 MB, `app.asar` 21.8 MB → 1.6 MB.**
+`electron-builder` auto-includes the production `node_modules` tree even when `files`
+doesn't list it. That shipped 27.5 MB of `@luma.gl`, `@cosmos.gl`, `d3-*`, `micromark`
+and friends into every release — all of which Vite had already bundled into
+`dist/renderer`. The main process imports nothing but Node builtins and `electron`, so
+`!node_modules/**` is safe. The `menubar` dependency was unused and was dropped.
+
+**2026-08-28 — lazy-loading the graph view is not worth it (negative result).**
+`@cosmos.gl/graph` is 702 KB and loads eagerly: `GraphExplorerGPU` is a static import
+of `App.tsx`, so Vite hoists the chunk into the entry graph with a `modulepreload`.
+Replacing the built chunk with a stub moved cold start 439 → 417 ms (~5%, ~22 ms) and
+the renderer share 154 → 144 ms. Not enough to justify splitting the ref-carrying
+component behind `React.lazy`. Revisit only if cold start approaches the 3 s ceiling.

--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -21,7 +21,12 @@
       "raw_samples": [
         { "cold_start_ms": 349, "window_interactive_ms": 127 },
         { "cold_start_ms": 362, "window_interactive_ms": 121 },
-        { "cold_start_ms": 332, "window_interactive_ms": 79, "heap_idle_mb": 9.5, "main_cpu_idle_pct": 0 }
+        {
+          "cold_start_ms": 332,
+          "window_interactive_ms": 79,
+          "heap_idle_mb": 9.5,
+          "main_cpu_idle_pct": 0
+        }
       ],
       "notes": "Installation run — first entry in the series, no regression comparison possible. Harness: packages/app/scripts/perf-measure.mjs (CDP against a production build, throwaway --user-data-dir per sample). Startup, idle heap and idle CPU are all far inside the absolute ceilings (349 ms vs 3000, 0% vs 2%). Artifact fix landed in this same run: app.asar 21.8 MB -> 1.6 MB and the .app 286 MB -> 265 MB by excluding node_modules from the electron-builder file set (the main process imports only Node builtins + electron; Vite already bundles every renderer dep) and dropping the unused `menubar` dependency. Startup timings are unaffected by that change — the dev launch path never touches the asar; the 439 ms measured earlier in the same session vs 349 ms here is machine warm-up, not a code delta. Measured negative result: stubbing out the 702 KB cosmos.gl chunk (eagerly loaded via a static import in the entry chunk) moved cold start only 439 -> 417 ms (~5%), so lazy-loading the graph view is not worth the refactor at this size. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour not measured this run — they need a fixed indexed project fixture, which the next run should add."
     }

--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -1,0 +1,29 @@
+{
+  "schema": 1,
+  "runs": [
+    {
+      "date": "2026-08-28T13:23:05Z",
+      "app_version": "1.51.1",
+      "commit": "9459d4ce",
+      "env": { "os": "macOS 26.5 (darwin 25.5.0)", "arch": "arm64", "node": "22.22.3" },
+      "samples": 3,
+      "metrics": {
+        "cold_start_ms": 349,
+        "window_interactive_ms": 121,
+        "ui_p95_ms": null,
+        "heap_idle_mb": 9.5,
+        "heap_after_workload_mb": null,
+        "heap_growth_mb_per_hour": null,
+        "main_cpu_idle_pct": 0,
+        "renderer_bundle_kb": 1461,
+        "artifact_mb": { "mac_app_unpacked": 264.8, "mac_asar": 1.6, "win": null }
+      },
+      "raw_samples": [
+        { "cold_start_ms": 349, "window_interactive_ms": 127 },
+        { "cold_start_ms": 362, "window_interactive_ms": 121 },
+        { "cold_start_ms": 332, "window_interactive_ms": 79, "heap_idle_mb": 9.5, "main_cpu_idle_pct": 0 }
+      ],
+      "notes": "Installation run — first entry in the series, no regression comparison possible. Harness: packages/app/scripts/perf-measure.mjs (CDP against a production build, throwaway --user-data-dir per sample). Startup, idle heap and idle CPU are all far inside the absolute ceilings (349 ms vs 3000, 0% vs 2%). Artifact fix landed in this same run: app.asar 21.8 MB -> 1.6 MB and the .app 286 MB -> 265 MB by excluding node_modules from the electron-builder file set (the main process imports only Node builtins + electron; Vite already bundles every renderer dep) and dropping the unused `menubar` dependency. Startup timings are unaffected by that change — the dev launch path never touches the asar; the 439 ms measured earlier in the same session vs 349 ms here is machine warm-up, not a code delta. Measured negative result: stubbing out the 702 KB cosmos.gl chunk (eagerly loaded via a static import in the entry chunk) moved cold start only 439 -> 417 ms (~5%), so lazy-loading the graph view is not worth the refactor at this size. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour not measured this run — they need a fixed indexed project fixture, which the next run should add."
+    }
+  ]
+}

--- a/packages/app/electron-builder.yml
+++ b/packages/app/electron-builder.yml
@@ -8,6 +8,12 @@ files:
   - package.json
   - assets/**
   - build/icon.png
+  # The main process imports nothing but Node builtins and `electron`, and Vite
+  # already bundles every renderer dependency into dist/renderer. Without this,
+  # electron-builder auto-includes the production node_modules tree anyway —
+  # 27.5 MB of @luma.gl/@cosmos.gl/micromark that nothing ever loads (TRA-257).
+  - '!node_modules/**'
+  - '!dist/main/__tests__/**'
 extraResources:
   - from: ../../scripts/apply-pending-update.mjs
     to: scripts/apply-pending-update.mjs

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,23 +14,20 @@
     "dist": "pnpm run build && electron-builder",
     "postinstall": "node scripts/patch-electron-dev.mjs",
     "generate-icons": "node scripts/generate-icons.mjs",
+    "perf": "node scripts/perf-measure.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "packageManager": "pnpm@10.33.0",
   "dependencies": {
     "@cosmos.gl/graph": "3.4.1",
-    "menubar": "^9.5.3",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.0"
   },
   "overrides": {
     "@luma.gl/core": "9.2.6",
     "@luma.gl/engine": "9.2.6",
-    "@luma.gl/webgl": "9.2.6",
-    "menubar": {
-      "electron": "$electron"
-    }
+    "@luma.gl/webgl": "9.2.6"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/app/pnpm-lock.yaml
+++ b/packages/app/pnpm-lock.yaml
@@ -25,9 +25,6 @@ importers:
       '@cosmos.gl/graph':
         specifier: 3.4.1
         version: 3.4.1
-      menubar:
-        specifier: ^9.5.3
-        version: 9.5.3(electron@41.10.6)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.18)(react@19.2.8)
@@ -1599,9 +1596,6 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  electron-positioner@4.1.0:
-    resolution: {integrity: sha512-726DfbI9ZNoCg+Fcu6XLuTKTnzf+6nFqv7h+K/V6Ug7IbaPMI7s9S8URnGtWFCy5N5PL4HSzRFF2mXuinftDdg==}
-
   electron-publish@26.15.3:
     resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
 
@@ -2139,11 +2133,6 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
-
-  menubar@9.5.3:
-    resolution: {integrity: sha512-IicKQsb1bX7RvLMreUVRYdU3Z+tcWSZ2VYSNGvAn1hCFr8x/QWaEYAsXMqSCVWH84jwSaN6xWvRbtnBVBudvZw==}
-    peerDependencies:
-      electron: '>=9.0.0'
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -4331,8 +4320,6 @@ snapshots:
       - electron-builder-squirrel-windows
       - supports-color
 
-  electron-positioner@4.1.0: {}
-
   electron-publish@26.15.3:
     dependencies:
       '@types/fs-extra': 9.0.13
@@ -5012,11 +4999,6 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.27.1: {}
-
-  menubar@9.5.3(electron@41.10.6):
-    dependencies:
-      electron: 41.10.6
-      electron-positioner: 4.1.0
 
   micromark-core-commonmark@2.0.3:
     dependencies:

--- a/packages/app/scripts/perf-measure.mjs
+++ b/packages/app/scripts/perf-measure.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * Desktop-app performance harness (TRA-257).
+ *
+ * Launches the built Electron app against a throwaway user-data dir, drives it
+ * over CDP, and prints one `runs[]` entry for `docs/perf/baseline.json`.
+ *
+ * Usage:
+ *   node scripts/perf-measure.mjs [--samples 3] [--idle-seconds 300] [--json out.json]
+ *
+ * Requires `pnpm run build` first — it measures the production bundle, not dev.
+ */
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PORT = 9333;
+
+const args = process.argv.slice(2);
+const flag = (name, fallback) => {
+  const i = args.indexOf(`--${name}`);
+  return i === -1 ? fallback : args[i + 1];
+};
+const SAMPLES = Number(flag('samples', 3));
+const IDLE_SECONDS = Number(flag('idle-seconds', 300));
+const OUT = flag('json', null);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const median = (xs) => {
+  const s = [...xs].sort((a, b) => a - b);
+  return s.length % 2 ? s[(s.length - 1) / 2] : (s[s.length / 2 - 1] + s[s.length / 2]) / 2;
+};
+const round = (n, d = 1) => Number(n.toFixed(d));
+
+/** Minimal CDP client over the Node 22 global WebSocket. */
+class Cdp {
+  constructor(ws) {
+    this.ws = ws;
+    this.id = 0;
+    this.pending = new Map();
+    ws.addEventListener('message', (ev) => {
+      const msg = JSON.parse(ev.data);
+      const p = this.pending.get(msg.id);
+      if (p) {
+        this.pending.delete(msg.id);
+        msg.error ? p.reject(new Error(msg.error.message)) : p.resolve(msg.result);
+      }
+    });
+  }
+  static async connect(url) {
+    const ws = new WebSocket(url);
+    await new Promise((res, rej) => {
+      ws.addEventListener('open', res, { once: true });
+      ws.addEventListener('error', rej, { once: true });
+    });
+    return new Cdp(ws);
+  }
+  send(method, params = {}) {
+    const id = ++this.id;
+    this.ws.send(JSON.stringify({ id, method, params }));
+    return new Promise((resolve, reject) => this.pending.set(id, { resolve, reject }));
+  }
+  async evaluate(expression) {
+    const r = await this.send('Runtime.evaluate', { expression, returnByValue: true, awaitPromise: true });
+    return r.result?.value;
+  }
+  close() {
+    this.ws.close();
+  }
+}
+
+async function rendererTarget(deadline) {
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${PORT}/json/list`);
+      const t = (await res.json()).find((x) => x.type === 'page' && x.webSocketDebuggerUrl);
+      if (t) return t;
+    } catch {
+      /* devtools endpoint not up yet */
+    }
+    await sleep(20);
+  }
+  throw new Error('renderer target never appeared');
+}
+
+/** Main-process %CPU over a short window, via ps. */
+function cpuPercent(pid) {
+  return new Promise((resolve) => {
+    const p = spawn('ps', ['-o', '%cpu=', '-p', String(pid)]);
+    let out = '';
+    p.stdout.on('data', (d) => {
+      out += d;
+    });
+    p.on('close', () => resolve(Number(out.trim()) || 0));
+  });
+}
+
+async function runSample({ idleSeconds }) {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'tracemcp-perf-'));
+  const electron = path.join(appDir, 'node_modules', 'electron', 'dist', 'Electron.app', 'Contents', 'MacOS', 'Electron');
+  const t0 = Date.now();
+  const child = spawn(electron, [appDir, `--remote-debugging-port=${PORT}`, `--user-data-dir=${userData}`], {
+    cwd: appDir,
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '' },
+    stdio: 'ignore',
+  });
+
+  try {
+    const target = await rendererTarget(t0 + 60_000);
+    const cdp = await Cdp.connect(target.webSocketDebuggerUrl);
+    await cdp.send('Runtime.enable');
+
+    // Interactive = React has painted real content into #root and the main
+    // thread is free enough to answer this evaluate.
+    const deadline = Date.now() + 60_000;
+    let ready = false;
+    while (Date.now() < deadline) {
+      ready = await cdp.evaluate(
+        `document.readyState === 'complete' && !!document.querySelector('#root')?.firstElementChild`,
+      );
+      if (ready) break;
+      await sleep(20);
+    }
+    if (!ready) throw new Error('window never became interactive');
+    const interactiveAt = Date.now();
+
+    const timeOrigin = await cdp.evaluate('performance.timeOrigin');
+    const sample = {
+      cold_start_ms: interactiveAt - t0,
+      // Renderer-side share: first renderer bytes → interactive.
+      window_interactive_ms: round(interactiveAt - timeOrigin, 0),
+    };
+
+    if (idleSeconds > 0) {
+      await sleep(idleSeconds * 1000);
+      sample.heap_idle_mb = round((await cdp.evaluate('performance.memory.usedJSHeapSize')) / 1048576);
+      const cpu = [];
+      for (let i = 0; i < 3; i++) {
+        cpu.push(await cpuPercent(child.pid));
+        await sleep(1000);
+      }
+      sample.main_cpu_idle_pct = round(median(cpu));
+    }
+
+    cdp.close();
+    return sample;
+  } finally {
+    child.kill('SIGKILL');
+    await sleep(500);
+    fs.rmSync(userData, { recursive: true, force: true });
+  }
+}
+
+function bundleSizes() {
+  const dir = path.join(appDir, 'dist', 'renderer');
+  let bytes = 0;
+  const walk = (d) => {
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const f = path.join(d, e.name);
+      e.isDirectory() ? walk(f) : (bytes += fs.statSync(f).size);
+    }
+  };
+  if (!fs.existsSync(dir)) throw new Error(`missing ${dir} — run \`pnpm run build\` first`);
+  walk(dir);
+  return round(bytes / 1024, 0);
+}
+
+/** Packaged-bundle sizes, if `pnpm run pack` has been run. Null otherwise. */
+function artifactMb() {
+  const dir = path.join(appDir, 'release', 'mac-arm64');
+  if (!fs.existsSync(dir)) return { mac_app_unpacked: null, mac_asar: null };
+  const bundle = fs.readdirSync(dir).find((f) => f.endsWith('.app'));
+  if (!bundle) return { mac_app_unpacked: null, mac_asar: null };
+  const size = (p) => {
+    let bytes = 0;
+    const walk = (d) => {
+      for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+        const f = path.join(d, e.name);
+        if (e.isSymbolicLink()) continue;
+        e.isDirectory() ? walk(f) : (bytes += fs.lstatSync(f).size);
+      }
+    };
+    fs.statSync(p).isDirectory() ? walk(p) : (bytes = fs.statSync(p).size);
+    return round(bytes / 1048576);
+  };
+  return {
+    mac_app_unpacked: size(path.join(dir, bundle)),
+    mac_asar: size(path.join(dir, bundle, 'Contents', 'Resources', 'app.asar')),
+  };
+}
+
+const samples = [];
+for (let i = 0; i < SAMPLES; i++) {
+  // Only the last sample pays the idle-hold cost; cold start is what needs N.
+  samples.push(await runSample({ idleSeconds: i === SAMPLES - 1 ? IDLE_SECONDS : 0 }));
+  process.stderr.write(`sample ${i + 1}/${SAMPLES}: ${JSON.stringify(samples[i])}\n`);
+}
+
+const last = samples[samples.length - 1];
+const entry = {
+  date: new Date().toISOString(),
+  app_version: JSON.parse(fs.readFileSync(path.join(appDir, 'package.json'), 'utf8')).version,
+  commit: process.env.PERF_COMMIT ?? null,
+  env: { os: `macOS ${os.release()}`, arch: os.arch(), node: process.version.slice(1) },
+  samples: SAMPLES,
+  metrics: {
+    cold_start_ms: median(samples.map((s) => s.cold_start_ms)),
+    window_interactive_ms: median(samples.map((s) => s.window_interactive_ms)),
+    heap_idle_mb: last.heap_idle_mb ?? null,
+    main_cpu_idle_pct: last.main_cpu_idle_pct ?? null,
+    renderer_bundle_kb: bundleSizes(),
+    artifact_mb: artifactMb(),
+  },
+  raw_samples: samples,
+};
+
+const json = JSON.stringify(entry, null, 2);
+OUT ? fs.writeFileSync(OUT, `${json}\n`) : console.log(json);


### PR DESCRIPTION
Establishes the accumulating desktop-app performance baseline TRA-257 asks for, and fixes the one real problem the first measurement pass turned up.

## Artifact was shipping 27.5 MB of dead `node_modules`

`electron-builder` auto-includes the production `node_modules` tree even when `files` never lists it. The main process imports nothing but Node builtins and `electron` (verified against the compiled `dist/main`), and Vite already bundles every renderer dependency into `dist/renderer` — so `@luma.gl`, `@cosmos.gl`, `d3-*`, `micromark`, `dompurify` and friends were pure dead weight in every release. `menubar` turned out to be an unused dependency and is dropped. Compiled tests (`dist/main/__tests__`) no longer ship either.

Measured on macOS 26.5 / arm64:

| | before | after |
|---|---|---|
| `app.asar` | 21.8 MB | **1.6 MB** (−93%) |
| `trace-mcp.app` | 286 MB | **265 MB** (−7%) |

The remaining 263 MB is the Electron framework itself.

Verified the packaged bundle still launches and renders: the slimmed `.app` reaches an interactive window in 2.1 s and the renderer (including the cosmos.gl chunk) loads clean.

## Baseline harness

`packages/app/scripts/perf-measure.mjs` (`pnpm -C packages/app run perf`) launches the production build against a throwaway `--user-data-dir`, drives it over CDP, and prints a ready-to-paste `runs[]` entry. `cold_start_ms` is spawn → `#root` has painted real content; `window_interactive_ms` is the renderer's own share. Every number is a median of 3 samples.

First entry in `docs/perf/baseline.json`, with `docs/perf/README.md` as the human summary:

| metric | value | ceiling |
|---|---|---|
| `cold_start_ms` | 349 | 3000 |
| `window_interactive_ms` | 121 | — |
| `heap_idle_mb` (5 min idle) | 9.5 | — |
| `main_cpu_idle_pct` | 0 | 2 |
| `renderer_bundle_kb` | 1461 | — |

Everything is comfortably inside the mandated ceilings — no regression to chase this run.

## Negative result worth keeping

`@cosmos.gl/graph` is 702 KB and loads eagerly: `GraphExplorerGPU` is a static import of `App.tsx`, so Vite hoists it into the entry chunk with a `modulepreload`. Replacing the built chunk with a stub moved cold start only 439 → 417 ms (~22 ms, ~5%). Not worth splitting a ref-carrying component behind `React.lazy` — recorded in `docs/perf/README.md` so nobody re-derives it in a month.

## Not measured this run

`ui_p95_ms`, `heap_after_workload_mb`, `heap_growth_mb_per_hour` — all three need a fixed indexed-project fixture so the workload scenario is identical across runs. Tracked as follow-up.

## Test evidence

- `pnpm -C packages/app test` — 60 passed (6 files)
- `pnpm -C packages/app run typecheck` — clean
- `pnpm -C packages/app run pack` + launch check of the packaged `.app` — interactive, renderer clean
