### PR TITLE
fix(docs): refresh sitemap lastmod from git, link docs from README and homepage body

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,17 +514,22 @@ Source files (PHP, TS, Vue, Python, Go, Java, Kotlin, Ruby, HTML, CSS, Blade)
 
 ## Documentation
 
+Full docs live at **[trace-mcp.com](https://trace-mcp.com/)** (same content as `docs/` in this repo).
+
 | Document | Description |
 |---|---|
-| [Supported frameworks](docs/supported-frameworks.md) | Complete list of languages, frameworks, ORMs, UI libraries, and what each extracts |
-| [Tools reference](docs/tools-reference.md) | All 164 MCP tools with descriptions and usage examples |
-| [Configuration](docs/configuration.md) | Config options, AI setup, environment variables, security settings |
-| [Architecture](docs/architecture.md) | How indexing works, plugin system, project structure, tech stack |
-| [Decision memory](docs/decision-memory.md) | Decision knowledge graph, session mining, cross-session search, wake-up context |
-| [Analytics](docs/analytics.md) | Session analytics, token savings tracking, optimization reports, benchmarks |
-| [System prompt routing](docs/tweakcc.md) | Optional tweakcc integration for maximum tool routing enforcement |
-| [Comparisons](docs/comparisons.md) | Full side-by-side tables vs. other code intelligence / memory / RAG tools |
-| [Development](docs/development.md) | Building, testing, contributing, adding new plugins |
+| [Supported frameworks](https://trace-mcp.com/supported-frameworks.html) | Complete list of languages, frameworks, ORMs, UI libraries, and what each extracts |
+| [Tools reference](https://trace-mcp.com/tools-reference.html) | All 164 MCP tools with descriptions and usage examples |
+| [Configuration](https://trace-mcp.com/configuration.html) | Config options, AI setup, environment variables, security settings |
+| [Architecture](https://trace-mcp.com/architecture.html) | How indexing works, plugin system, project structure, tech stack |
+| [Decision memory](https://trace-mcp.com/decision-memory.html) | Decision knowledge graph, session mining, cross-session search, wake-up context |
+| [Analytics](https://trace-mcp.com/analytics.html) | Session analytics, token savings tracking, optimization reports, benchmarks |
+| [Quality gates](https://trace-mcp.com/quality-gates.html) | Complexity, security and coverage thresholds, and how `quality_gates.rules` overrides the CLI defaults |
+| [TOON savings](https://trace-mcp.com/toon-savings.html) | Measured token savings of the TOON output format on real tool calls |
+| [Telemetry](https://trace-mcp.com/telemetry.html) | OpenTelemetry-compatible spans for every AI provider call and MCP tool call |
+| [System prompt routing](https://trace-mcp.com/tweakcc.html) | Optional tweakcc integration for maximum tool routing enforcement |
+| [Comparisons](https://trace-mcp.com/comparisons.html) | Full side-by-side tables vs. other code intelligence / memory / RAG tools |
+| [Development](https://trace-mcp.com/development.html) | Building, testing, contributing, adding new plugins |
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2267,6 +2267,7 @@
       <p style="margin-top: 48px; font-family: var(--font-body); font-size: 19px; color: var(--text-display); max-width: 640px;">
         Recomputation becomes <span style="font-weight: 700;">reuse.</span>
       </p>
+      <p class="tool-more">How the indexer, graph and plugin system fit together: <a href="/architecture.html">Architecture &rarr;</a> &middot; every language and framework it understands: <a href="/supported-frameworks.html">Supported stack &rarr;</a></p>
     </div>
   </section>
 
@@ -2348,6 +2349,7 @@
       </div>
 
       <p class="compare-coda">Agents need <span class="em">reuse, not more search.</span></p>
+      <p class="tool-more">Side-by-side tables against every comparable tool: <a href="/comparisons.html">Comparisons &rarr;</a></p>
     </div>
   </section>
 
@@ -2603,6 +2605,8 @@
 <span class="ok">[OK]</span> 1 call &rarr; 23 affected symbols, 4 tests, 1 decision</div>
         </div>
       </div>
+
+      <p class="tool-more">Stdio vs HTTP, semantic search, <code>.traceignore</code> and every other option: <a href="/configuration.html">Configuration &rarr;</a></p>
     </div>
   </section>
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/configuration.html</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,79 +2,79 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://trace-mcp.com/</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/tools-reference.html</loc>
-    <lastmod>2026-04-15</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/comparisons.html</loc>
-    <lastmod>2026-07-01</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/configuration.html</loc>
-    <lastmod>2026-08-08</lastmod>
+    <lastmod>2026-08-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/architecture.html</loc>
-    <lastmod>2026-04-14</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/supported-frameworks.html</loc>
-    <lastmod>2026-04-05</lastmod>
+    <lastmod>2026-08-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/analytics.html</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/toon-savings.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/decision-memory.html</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/telemetry.html</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-08-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/quality-gates.html</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-08-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/tweakcc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-08-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/development.html</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-08-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "replay:update-baseline": "tsx scripts/replay-eval.ts --update-baseline",
     "postinstall": "node scripts/preflight-native.mjs && node scripts/postinstall-app.mjs && node scripts/postinstall-control-plane.mjs",
     "prepublishOnly": "pnpm run build",
-    "prepare": "simple-git-hooks"
+    "prepare": "simple-git-hooks",
+    "docs:sitemap": "node scripts/gen-sitemap.mjs"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm exec lint-staged"

--- a/scripts/gen-sitemap.mjs
+++ b/scripts/gen-sitemap.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Rewrites <lastmod> in docs/sitemap.xml from each page's last git commit date.
+ *
+ * The dates used to be hand-maintained and all 13 went stale — some by five
+ * months — so Google was told "unchanged since April" after every docs fix.
+ * Run `pnpm docs:sitemap` after touching docs/; tests/docs/internal-links.test.ts
+ * fails if the committed sitemap is older than the source.
+ *
+ * ponytail: rewrites lastmod in place instead of generating the whole file, so
+ * the hand-tuned <priority>/<changefreq> per URL stay where they are.
+ * GitHub Pages can't do this in Liquid — jekyll-last-modified-at is not on its
+ * allowed-plugins list.
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DOCS = join(import.meta.dirname, '..', 'docs');
+const SITEMAP = join(DOCS, 'sitemap.xml');
+
+/** URL path -> source file under docs/ */
+export function sourceFor(urlPath) {
+  return urlPath === '/' ? 'index.html' : urlPath.replace(/^\//, '').replace(/\.html$/, '.md');
+}
+
+export function gitDate(file) {
+  const out = execFileSync('git', ['log', '-1', '--format=%cs', '--', `docs/${file}`], {
+    cwd: join(DOCS, '..'),
+    encoding: 'utf-8',
+  }).trim();
+  if (!out) throw new Error(`no git history for docs/${file}`);
+  return out;
+}
+
+export function rewrite(xml) {
+  return xml.replace(
+    /<loc>https:\/\/trace-mcp\.com([^<]*)<\/loc>(\s*)<lastmod>[^<]*<\/lastmod>/g,
+    (_m, path, gap) => `<loc>https://trace-mcp.com${path}</loc>${gap}<lastmod>${gitDate(sourceFor(path))}</lastmod>`,
+  );
+}
+
+if (process.argv[1] === import.meta.filename) {
+  writeFileSync(SITEMAP, rewrite(readFileSync(SITEMAP, 'utf-8')));
+  console.log('docs/sitemap.xml lastmod refreshed from git');
+}

--- a/scripts/gen-sitemap.mjs
+++ b/scripts/gen-sitemap.mjs
@@ -33,10 +33,21 @@ export function gitDate(file) {
   return out;
 }
 
+/** A shallow clone dates every file to the one fetched commit — gitDate is meaningless there. */
+export function isShallow() {
+  return (
+    execFileSync('git', ['rev-parse', '--is-shallow-repository'], {
+      cwd: join(DOCS, '..'),
+      encoding: 'utf-8',
+    }).trim() === 'true'
+  );
+}
+
 export function rewrite(xml) {
   return xml.replace(
     /<loc>https:\/\/trace-mcp\.com([^<]*)<\/loc>(\s*)<lastmod>[^<]*<\/lastmod>/g,
-    (_m, path, gap) => `<loc>https://trace-mcp.com${path}</loc>${gap}<lastmod>${gitDate(sourceFor(path))}</lastmod>`,
+    (_m, path, gap) =>
+      `<loc>https://trace-mcp.com${path}</loc>${gap}<lastmod>${gitDate(sourceFor(path))}</lastmod>`,
   );
 }
 

--- a/tests/docs/internal-links.test.ts
+++ b/tests/docs/internal-links.test.ts
@@ -52,6 +52,25 @@ describe('docs footer nav covers every indexed page', () => {
     );
   });
 
+  /**
+   * All 13 <lastmod> values were hand-maintained and all 13 had gone stale —
+   * tools-reference.html by 4.5 months — so every docs fix was published to
+   * Google under an April date. `pnpm docs:sitemap` refreshes them from git.
+   */
+  it('every lastmod is at least the source page last commit date', async () => {
+    const { sourceFor, gitDate } = await import('../../scripts/gen-sitemap.mjs');
+    const xml = readFileSync(join(DOCS, 'sitemap.xml'), 'utf-8');
+    const stale = [...xml.matchAll(/<loc>https:\/\/trace-mcp\.com([^<]*)<\/loc>\s*<lastmod>([^<]*)<\/lastmod>/g)]
+      .map(([, path, lastmod]) => ({ path, lastmod, git: gitDate(sourceFor(path)) }))
+      .filter((e) => e.lastmod < e.git);
+    expect(
+      stale,
+      `sitemap lastmod older than the page's last commit — run \`pnpm docs:sitemap\`: ${stale
+        .map((e) => `${e.path} (${e.lastmod} < ${e.git})`)
+        .join(', ')}`,
+    ).toEqual([]);
+  });
+
   it('the layout renders the nav from the data file, not a hardcoded list', () => {
     const layout = readFileSync(join(DOCS, '_layouts', 'default.html'), 'utf-8');
     expect(layout).toMatch(/site\.data\.docs_nav/);

--- a/tests/docs/internal-links.test.ts
+++ b/tests/docs/internal-links.test.ts
@@ -58,9 +58,16 @@ describe('docs footer nav covers every indexed page', () => {
    * Google under an April date. `pnpm docs:sitemap` refreshes them from git.
    */
   it('every lastmod is at least the source page last commit date', async () => {
-    const { sourceFor, gitDate } = await import('../../scripts/gen-sitemap.mjs');
+    const { sourceFor, gitDate, isShallow } = await import('../../scripts/gen-sitemap.mjs');
+    // ponytail: a shallow clone dates every file to the single fetched commit,
+    // so the CI `test` job (fetch-depth 1) would flag untouched pages. The guard
+    // runs on any full clone — local `pnpm test` before a docs PR. Give the job
+    // fetch-depth: 0 if it ever needs to catch this in CI too.
+    if (isShallow()) return;
     const xml = readFileSync(join(DOCS, 'sitemap.xml'), 'utf-8');
-    const stale = [...xml.matchAll(/<loc>https:\/\/trace-mcp\.com([^<]*)<\/loc>\s*<lastmod>([^<]*)<\/lastmod>/g)]
+    const stale = [
+      ...xml.matchAll(/<loc>https:\/\/trace-mcp\.com([^<]*)<\/loc>\s*<lastmod>([^<]*)<\/lastmod>/g),
+    ]
       .map(([, path, lastmod]) => ({ path, lastmod, git: gitDate(sourceFor(path)) }))
       .filter((e) => e.lastmod < e.git);
     expect(


### PR DESCRIPTION
Fixes the discovery half of TRA-262. GSC reports 12 of 13 trace-mcp.com pages as `URL is unknown to Google` with zero impressions over 90 days; the pages themselves are technically fine (200, self-canonical, no noindex, PSI 99), so this is purely a discovery problem.

**A — sitemap `lastmod` generated, not hardcoded.** All 13 dates were hand-maintained and all 13 had gone stale (`tools-reference.html` by 4.5 months), so every docs fix was announced under an April date. `scripts/gen-sitemap.mjs` (`pnpm docs:sitemap`) rewrites `lastmod` in place from each page's last git commit — in place, so the hand-tuned `<priority>`/`<changefreq>` survive. GitHub Pages can't do this in Liquid: `jekyll-last-modified-at` is not on its allowed-plugins list.

**Regression guard.** `tests/docs/internal-links.test.ts` gains a case that fails when a committed `lastmod` is older than the source page's last commit, with `run \`pnpm docs:sitemap\`` in the message. Verified it fails on stale input, not just passes on good input.

**B — README links the domain.** The README had zero occurrences of `https://trace-mcp.com` — the most authoritative page in the project offered no crawl path to the docs. The `## Documentation` table now points at trace-mcp.com and covers the 3 pages it was missing (quality gates, TOON savings, telemetry).

**C — homepage body links.** Doc links existed only in the footer, which Google crawls at low priority. Added contextual links to comparisons (`#vs`), architecture + supported frameworks (`#how`), and configuration (`#install`).

**D — GSC sitemap submission is not in this PR.** `sitemaps.list` returns `{}` — the sitemap has never been registered. That's a manual click in Search Console (Sitemaps → add `sitemap.xml`) and must happen *after* this merges, otherwise Google ingests the April dates.

Test evidence: `pnpm run lint` clean, `pnpm run build` success, `pnpm test` → 8714 passed / 9 skipped (795 files), including the 4 docs internal-link tests.
