### PR TITLE
docs: fix the MCP registry manifest and preset sizes, guard both (TRA-259)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -443,7 +443,7 @@ The `tools.*` section controls what the MCP server injects into every session �
 
 | Option | Default | Description |
 |---|---|---|
-| `tools.preset` | `"standard"` | Tool preset: `standard` (~50 tools, default — covers >99% of real-world tool calls per session-log mining), `minimal` (~16 tools), `review`, `architecture`, or `full` (all ~170 tools, opt-in) |
+| `tools.preset` | `"standard"` | Tool preset — the number is the upper bound on the tool surface; framework-gated tools only appear when the framework is detected. `standard` (59 tools, default — covers >99% of real-world tool calls per session-log mining), `minimal` (24 tools), `review` (26 tools), `architecture` (34 tools), or `full` (every registered tool, opt-in) |
 | `tools.include` | — | Whitelist specific tools by name |
 | `tools.exclude` | — | Blacklist specific tools by name |
 | `tools.description_verbosity` | `"full"` | Per-tool description length. `minimal` = first sentence. `none` = empty |

--- a/docs/index.html
+++ b/docs/index.html
@@ -2248,7 +2248,7 @@
           <p>Tree-sitter parses symbols, plugins resolve framework edges, optional LSP enriches with compiler-grade call data. Stored locally in SQLite + FTS5.</p>
           <div class="tags">
             <span class="tag">tree-sitter</span>
-            <span class="tag">138 mcp tools</span>
+            <span class="tag">164 mcp tools</span>
             <span class="tag">local sqlite</span>
           </div>
         </div>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -795,7 +795,7 @@ The `tools.*` section controls what the MCP server injects into every session �
 
 | Option | Default | Description |
 |---|---|---|
-| `tools.preset` | `"standard"` | Tool preset: `standard` (~50 tools, default — covers >99% of real-world tool calls per session-log mining), `minimal` (~16 tools), `review`, `architecture`, or `full` (all ~164 tools, opt-in) |
+| `tools.preset` | `"standard"` | Tool preset — the number is the upper bound on the tool surface; framework-gated tools only appear when the framework is detected. `standard` (59 tools, default — covers >99% of real-world tool calls per session-log mining), `minimal` (24 tools), `review` (26 tools), `architecture` (34 tools), or `full` (every registered tool, opt-in) |
 | `tools.include` | — | Whitelist specific tools by name |
 | `tools.exclude` | — | Blacklist specific tools by name |
 | `tools.description_verbosity` | `"full"` | Per-tool description length. `minimal` = first sentence. `none` = empty |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -31,6 +31,16 @@
           "type": "json",
           "path": ".codex-plugin/marketplace.json",
           "jsonpath": "$.plugins[0].version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.packages[0].version"
         }
       ],
       "changelog-sections": [

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.nikolai-vysotskyi/trace-mcp",
-  "description": "Framework-aware code intelligence: 81 languages, 58 framework integrations, 138 tools, up to 99% token reduction",
+  "description": "Framework-aware code intelligence: 80 languages, 87 framework integrations, 164 tools, up to 99% token reduction",
   "repository": {
     "url": "https://github.com/nikolai-vysotskyi/trace-mcp",
     "source": "github"
   },
-  "version": "1.5.4",
+  "version": "1.51.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "trace-mcp",
-      "version": "1.5.4",
+      "version": "1.51.1",
       "transport": {
         "type": "stdio"
       }

--- a/tests/docs/preset-claims.test.ts
+++ b/tests/docs/preset-claims.test.ts
@@ -1,0 +1,70 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import type { TraceMcpConfig } from '../../src/config.js';
+import { createToolFilter } from '../../src/server/tool-filter.js';
+
+/**
+ * TRA-259: the documented preset sizes were never checked against the filter.
+ * `minimal` was documented as "~16 tools" (the raw TOOL_PRESETS list length)
+ * while a client is actually served 24 — the always-on meta tools are added on
+ * top of every preset. Same story for `standard` (~50 documented, 59 served)
+ * and `full` ("~170"). These are the numbers a user budgets context against,
+ * so they get a receipt.
+ */
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+
+/** Every tool name registered anywhere under src/tools/register (incl. subdirs). */
+function allToolNames(): string[] {
+  const names = new Set<string>();
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== '__tests__') walk(full);
+        continue;
+      }
+      if (!entry.name.endsWith('.ts')) continue;
+      for (const m of readFileSync(full, 'utf8').matchAll(
+        /(?:server\.tool|_originalTool)\(\s*['"]([a-zA-Z0-9_]+)['"]/g,
+      )) {
+        names.add(m[1]);
+      }
+    }
+  };
+  walk(fileURLToPath(new URL('../../src/tools/register', import.meta.url)));
+  return [...names];
+}
+
+function servedCount(preset: string): number {
+  const filter = createToolFilter({ tools: { preset } } as unknown as TraceMcpConfig);
+  return allToolNames().filter((name) => filter(name)).length;
+}
+
+const DOCS = ['docs/configuration.md', 'docs/llms-full.txt'];
+const PRESETS = ['standard', 'minimal', 'review', 'architecture'];
+
+describe('documented tool-preset sizes', () => {
+  for (const path of DOCS) {
+    it(`${path}: every "\`<preset>\` (N tools)" claim matches the tool filter`, () => {
+      const text = readFileSync(join(REPO_ROOT, path), 'utf8');
+      let checked = 0;
+      for (const preset of PRESETS) {
+        const m = text.match(new RegExp('`' + preset + '` \\((~?\\d+) tools'));
+        if (!m) continue;
+        checked++;
+        const claimed = m[1];
+        const actual = servedCount(preset);
+        if (claimed !== String(actual)) {
+          throw new Error(
+            `${path} claims preset "${preset}" is ${claimed} tools; the tool filter admits ${actual}. ` +
+              'Update the doc (or the preset).',
+          );
+        }
+      }
+      expect(checked, `no preset claims found in ${path}`).toBeGreaterThan(0);
+    });
+  }
+});

--- a/tests/docs/readme-claims.test.ts
+++ b/tests/docs/readme-claims.test.ts
@@ -97,7 +97,9 @@ function countServerResourceCalls(): number {
 function findAllClaims(unit: RegExp, text: string): Claim[] {
   const claims: Claim[] = [];
   for (const line of text.split('\n')) {
-    const re = new RegExp(`(\\d+)\\+?\\s+${unit.source}`, 'g');
+    // Case-insensitive: docs/index.html carried a stale "138 mcp tools" tag for
+    // months because the case-sensitive `MCP ` alternative never matched it.
+    const re = new RegExp(`(\\d+)\\+?\\s+${unit.source}`, 'gi');
     let m: RegExpExecArray | null;
     // biome-ignore lint/suspicious/noAssignInExpressions: standard regex-exec-loop idiom
     while ((m = re.exec(line))) {
@@ -196,6 +198,11 @@ describe('docs site numeric claims (TRA-174)', () => {
     { path: 'AGENTS.md', tolerance: 5, skipLine: /output_format|preset/ },
     { path: 'skills/README.md', tolerance: 5 },
     { path: 'skills/trace-mcp/SKILL.md', tolerance: 5, skipLine: /output_format|preset/ },
+    // TRA-259: server.json is the manifest published to the MCP registry and was
+    // never guarded — it still advertised "81 languages, 58 framework
+    // integrations, 138 tools". docs/configuration.md was unguarded too.
+    { path: 'server.json', tolerance: 5 },
+    { path: 'docs/configuration.md', tolerance: 5, skipLine: /output_format|preset/ },
   ];
 
   for (const { path, tolerance, skipLine } of docs) {

--- a/tests/plugin/manifest-sync.test.ts
+++ b/tests/plugin/manifest-sync.test.ts
@@ -56,6 +56,43 @@ describe('Claude Code plugin manifests', () => {
   });
 });
 
+/**
+ * The MCP registry manifest is published to registry.modelcontextprotocol.io
+ * and was frozen at 1.5.4 while package.json was on 1.51.1 — release-please
+ * never bumped it because it wasn't in `extra-files`. It is now; this guards
+ * the wiring.
+ */
+describe('MCP registry manifest (server.json)', () => {
+  const pkg = readJson('package.json');
+  const server = readJson('server.json');
+
+  it('manifest version matches package.json version', () => {
+    expect(server.version).toBe(pkg.version);
+  });
+
+  it('npm package entry version matches package.json version', () => {
+    const packages = server.packages as Array<{ identifier: string; version: string }>;
+    const entry = packages.find((p) => p.identifier === 'trace-mcp');
+    expect(entry).toBeDefined();
+    expect(entry?.version).toBe(pkg.version);
+  });
+
+  it('manifest name matches the mcpName declared in package.json', () => {
+    expect(server.name).toBe(pkg.mcpName);
+  });
+
+  it('release-please is configured to bump both version fields', () => {
+    const config = readJson('release-please-config.json') as {
+      packages: Record<string, { 'extra-files': Array<{ path: string; jsonpath: string }> }>;
+    };
+    const paths = config.packages['.']['extra-files']
+      .filter((f) => f.path === 'server.json')
+      .map((f) => f.jsonpath);
+    expect(paths).toContain('$.version');
+    expect(paths).toContain('$.packages[0].version');
+  });
+});
+
 describe('Codex CLI plugin manifests', () => {
   const pkg = readJson('package.json');
   const plugin = readJson('.codex-plugin', 'plugin.json');


### PR DESCRIPTION
## What

Documentation-accuracy pass (TRA-259) on surfaces no guard covered.

**`server.json` — the manifest published to the MCP registry — was stale on every field:**

| Field | Was | Actual |
|---|---|---|
| languages | 81 | 80 |
| framework integrations | 58 | 87 |
| tools | 138 | 164 |
| version (x2) | 1.5.4 | 1.51.1 |

The version froze because `server.json` was never in release-please's `extra-files` — it has been stuck since the manifest was added. Added both jsonpaths, plus `manifest-sync.test.ts` assertions on the two version fields, the `mcpName`/`name` pairing, and the release-please wiring itself.

**Documented preset sizes were the raw `TOOL_PRESETS` list lengths, not what a client is served.** Every preset also gets the always-on meta tools:

| preset | documented | admitted by the filter | served on this repo |
|---|---|---|---|
| `minimal` | ~16 | 24 | 24 |
| `standard` | ~50 | 59 | 54 |
| `review` | — | 26 | 26 |
| `architecture` | — | 34 | 34 |
| `full` | "~170" / "~164" | all | 165 |

`configuration.md` and `llms-full.txt` now state the filter numbers (upper bound; framework-gated tools only appear when detected), with `tests/docs/preset-claims.test.ts` deriving them from `createToolFilter` so they cannot drift again.

**`docs/index.html` carried a stale `138 mcp tools` tag** that the TRA-174 claims guard structurally could not see: its regex only matched an uppercase `MCP `. Made case-insensitive, and added `server.json` + `docs/configuration.md` to the guarded surfaces (neither was covered).

## Test evidence

- Measured ground truth against a real `initialize` + `tools/list` round-trip per preset: 24 / 54 / 26 / 34 / 165. Registry counts from `PluginRegistry.createWithDefaults()`: 80 languages, 87 framework plugins.
- `pnpm test`: 8728 passed, 6 skipped, 0 failed.
- `pnpm run typecheck` and `biome ci` clean.
- Negative check — perturbing `minimal` to 16 and `server.json` back to 1.5.4 fails `preset-claims` and `manifest-sync` respectively; both guards bite.

## Not in scope

`docs/comparisons.md` and `docs/ROADMAP.md` are owned by other autopilots and untouched. One deferred finding filed separately: the claims guard's tool "source of truth" globs `src/tools/register/*.ts` non-recursively (164), missing 14 tools registered in subdirectories — it happens to track the served count today (165) by coincidence, not by construction.
