### PR TITLE
fix(app): don't render a failed metrics fetch as real zeros (TRA-264)

### DIFF
--- a/packages/app/src/renderer/hooks/useDaemon.ts
+++ b/packages/app/src/renderer/hooks/useDaemon.ts
@@ -133,6 +133,13 @@ type SSEEvent =
 
 const BASE = 'http://127.0.0.1:3741';
 
+/**
+ * Cap on daemon reads. A *hung* daemon (accepting the socket but never
+ * answering) would otherwise leave `loading` true indefinitely, hiding the
+ * DisconnectedBanner — the one control that can restart it (TRA-264).
+ */
+export const DAEMON_FETCH_TIMEOUT_MS = 8000;
+
 // ── Hook ───────────────────────────────────────────────────────────────
 
 export function useDaemon() {
@@ -146,7 +153,7 @@ export function useDaemon() {
   // Fetch project list
   const fetchProjects = useCallback(async () => {
     try {
-      const res = await fetch(`${BASE}/api/projects`); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      const res = await fetch(`${BASE}/api/projects`, { signal: AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS) }); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
       if (!res.ok) throw new Error(res.statusText);
       const json = await res.json();
       const data: ProjectInfo[] = json.projects ?? json;
@@ -162,7 +169,7 @@ export function useDaemon() {
   // Fetch client list
   const fetchClients = useCallback(async () => {
     try {
-      const res = await fetch(`${BASE}/api/clients`); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      const res = await fetch(`${BASE}/api/clients`, { signal: AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS) }); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
       if (!res.ok) throw new Error(res.statusText);
       const json = await res.json();
       const data: ClientInfo[] = json.clients ?? json;
@@ -175,7 +182,7 @@ export function useDaemon() {
   // Fetch settings + daemon info
   const fetchSettings = useCallback(async () => {
     try {
-      const res = await fetch(`${BASE}/api/settings`); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      const res = await fetch(`${BASE}/api/settings`, { signal: AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS) }); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
       if (!res.ok) throw new Error(res.statusText);
       const data = await res.json();
       setSettings(data);

--- a/packages/app/src/renderer/workspace/BulkActionsBar.tsx
+++ b/packages/app/src/renderer/workspace/BulkActionsBar.tsx
@@ -143,9 +143,9 @@ export function BulkActionsBar({ projects, onReindex, onRemove, onClear }: BulkA
             onClick={() => setConfirmRemove(true)}
             className={baseBtn}
             style={{
-              background: '#ff3b3018',
-              color: '#ff3b30',
-              border: '0.5px solid #ff3b3040',
+              background: 'color-mix(in srgb, var(--destructive) 9%, transparent)',
+              color: 'var(--destructive)',
+              border: '0.5px solid color-mix(in srgb, var(--destructive) 25%, transparent)',
             }}
           >
             Remove
@@ -209,7 +209,7 @@ export function BulkActionsBar({ projects, onReindex, onRemove, onClear }: BulkA
             disabled={busy}
             onClick={() => void handleRemove()}
             className={baseBtn}
-            style={{ background: '#ff3b30', color: '#fff' }}
+            style={{ background: 'var(--destructive)', color: '#fff' }}
           >
             Confirm
           </button>

--- a/packages/app/src/renderer/workspace/Workspace.tsx
+++ b/packages/app/src/renderer/workspace/Workspace.tsx
@@ -180,10 +180,22 @@ export function Workspace() {
 
       {data.error && (
         <div
-          className="mx-3 mb-2 px-3 py-1.5 rounded-md text-[11px]"
-          style={{ background: '#ff3b3018', color: '#ff3b30', border: '0.5px solid #ff3b3040' }}
+          className="mx-3 mb-2 px-3 py-1.5 rounded-md text-[11px] flex items-center gap-2"
+          style={{
+            background: 'color-mix(in srgb, var(--destructive) 9%, transparent)',
+            color: 'var(--destructive)',
+            border: '0.5px solid color-mix(in srgb, var(--destructive) 25%, transparent)',
+          }}
         >
-          {data.error}
+          <span className="flex-1">{data.error}</span>
+          <button
+            type="button"
+            onClick={() => void data.refresh()}
+            disabled={data.refreshing}
+            className="px-1.5 py-0.5 rounded font-medium hover:bg-[var(--bg-active)] disabled:opacity-50"
+          >
+            {data.refreshing ? 'Retrying…' : 'Retry'}
+          </button>
         </div>
       )}
 

--- a/packages/app/src/renderer/workspace/WorkspaceCompactView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceCompactView.tsx
@@ -99,7 +99,7 @@ function CompactRow({
             {project.root}
           </div>
           {project.error ? (
-            <div className="text-[10px] truncate" style={{ color: '#ff3b30' }} title={project.error}>
+            <div className="text-[10px] truncate" style={{ color: 'var(--destructive)' }} title={project.error}>
               {project.error}
             </div>
           ) : (
@@ -173,7 +173,7 @@ function CompactRow({
                   setConfirm(false);
                 }}
                 className="text-[11px] px-1.5 py-0.5 rounded font-medium"
-                style={{ background: '#ff3b30', color: '#fff' }}
+                style={{ background: 'var(--destructive)', color: '#fff' }}
               >
                 Remove
               </button>

--- a/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
@@ -317,7 +317,7 @@ export function WorkspaceHeader({
           <Chip
             label={<><Icon name="lock" size={11} /> Security</>}
             active={filter.hasSecurityFindings === true}
-            accent="#ff3b30"
+            accent="var(--destructive)"
             onClick={() =>
               onFilterChange({
                 ...filter,

--- a/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
@@ -44,7 +44,7 @@ const GRADE_COLOR: Record<TechDebtGrade, string> = {
   B: '#30d158',
   C: '#ffcc00',
   D: '#ff9f0a',
-  F: '#ff3b30',
+  F: 'var(--destructive)',
 };
 
 // ── Sortable header cell ──────────────────────────────────────────────────
@@ -146,7 +146,7 @@ function ActionCell({
             setConfirm(false);
           }}
           className="text-[11px] px-1.5 py-0.5 rounded font-medium"
-          style={{ background: '#ff3b30', color: '#fff' }}
+          style={{ background: 'var(--destructive)', color: '#fff' }}
         >
           Remove
         </button>
@@ -253,7 +253,7 @@ function Row({
           <span style={{ color: 'var(--text-secondary)' }}>{statusLabel(project.displayStatus)}</span>
         </div>
         {project.error && (
-          <div className="text-[10px] mt-0.5 truncate" style={{ color: '#ff3b30' }} title={project.error}>
+          <div className="text-[10px] mt-0.5 truncate" style={{ color: 'var(--destructive)' }} title={project.error}>
             {project.error}
           </div>
         )}
@@ -321,7 +321,7 @@ function Row({
         ) : (
           <span
             style={{
-              color: project.securityFindings > 0 ? '#ff3b30' : 'var(--text-tertiary)',
+              color: project.securityFindings > 0 ? 'var(--destructive)' : 'var(--text-tertiary)',
               fontWeight: project.securityFindings > 0 ? 600 : undefined,
             }}
           >

--- a/packages/app/src/renderer/workspace/__tests__/useWorkspaceProjects.test.ts
+++ b/packages/app/src/renderer/workspace/__tests__/useWorkspaceProjects.test.ts
@@ -1,0 +1,52 @@
+/**
+ * TRA-264 — a failed metrics fetch must not be reported as loaded, or the KPI
+ * strip swaps its `—` placeholders for hard zeros and presents the failure as
+ * real data.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describeMetricsError, fetchMetricsOnce } from '../useWorkspaceProjects';
+
+const setters = () => ({ setMetrics: vi.fn(), setError: vi.fn() });
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('fetchMetricsOnce', () => {
+  it('returns true and clears the error on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ projects: [{ root: '/a' }] }) }),
+    );
+    const s = setters();
+    expect(await fetchMetricsOnce(s)).toBe(true);
+    expect(s.setMetrics).toHaveBeenCalledWith([{ root: '/a' }]);
+    expect(s.setError).toHaveBeenCalledWith(null);
+  });
+
+  it('returns false on a network failure and never publishes metrics', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+    const s = setters();
+    expect(await fetchMetricsOnce(s)).toBe(false);
+    expect(s.setMetrics).not.toHaveBeenCalled();
+  });
+
+  it('returns false on a non-OK response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503, json: async () => ({}) }));
+    const s = setters();
+    expect(await fetchMetricsOnce(s)).toBe(false);
+    expect(s.setError).toHaveBeenCalledWith(expect.stringContaining('HTTP 503'));
+  });
+});
+
+describe('describeMetricsError', () => {
+  it('replaces raw transport messages with an actionable one', () => {
+    for (const raw of ['Failed to fetch', 'Load failed', 'The operation was aborted', 'timed out']) {
+      expect(describeMetricsError(new Error(raw))).toBe(
+        "Couldn't load project metrics — daemon not responding.",
+      );
+    }
+  });
+
+  it('keeps a meaningful server message', () => {
+    expect(describeMetricsError(new Error('cache rebuild failed'))).toContain('cache rebuild failed');
+  });
+});

--- a/packages/app/src/renderer/workspace/useWorkspaceProjects.ts
+++ b/packages/app/src/renderer/workspace/useWorkspaceProjects.ts
@@ -12,7 +12,7 @@
  * fallback that matches the server-side cache TTL.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useDaemon } from '../hooks/useDaemon';
+import { DAEMON_FETCH_TIMEOUT_MS, useDaemon } from '../hooks/useDaemon';
 import {
   type ProjectHealthMetrics,
   type ProjectViewModel,
@@ -78,20 +78,39 @@ interface MetricsSetters {
   setError: (e: string | null) => void;
 }
 
-/** Fetch the dashboard cache once. Exported so tests can drive it directly. */
-export async function fetchMetricsOnce(setters: MetricsSetters): Promise<void> {
+/**
+ * Turn a raw fetch rejection into something a user can act on. `Failed to
+ * fetch` / `The operation was aborted` are the browser's own words for "the
+ * socket died" and mean nothing to the person reading the banner.
+ */
+export function describeMetricsError(err: unknown): string {
+  const raw = (err as Error)?.message ?? '';
+  if (/failed to fetch|networkerror|load failed|aborted|timed? ?out/i.test(raw)) {
+    return "Couldn't load project metrics — daemon not responding.";
+  }
+  return raw ? `Couldn't load project metrics — ${raw}` : "Couldn't load project metrics.";
+}
+
+/**
+ * Fetch the dashboard cache once. Exported so tests can drive it directly.
+ * Returns true only when metrics actually landed — the caller uses that to
+ * decide whether the KPI strip may stop rendering `—` placeholders.
+ */
+export async function fetchMetricsOnce(setters: MetricsSetters): Promise<boolean> {
   try {
-    const res = await fetch(`${BASE}/api/dashboard/projects`); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+    const res = await fetch(`${BASE}/api/dashboard/projects`, { signal: AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS) }); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
     if (!res.ok) {
       const body = (await res.json().catch(() => ({}))) as { error?: string };
-      setters.setError(body.error ?? `HTTP ${res.status}`);
-      return;
+      setters.setError(`Couldn't load project metrics — ${body.error ?? `HTTP ${res.status}`}`);
+      return false;
     }
     const data = (await res.json()) as { projects: ProjectHealthMetrics[] };
     setters.setMetrics(data.projects ?? []);
     setters.setError(null);
+    return true;
   } catch (err) {
-    setters.setError((err as Error)?.message ?? 'Failed to load dashboard metrics');
+    setters.setError(describeMetricsError(err));
+    return false;
   }
 }
 
@@ -107,10 +126,12 @@ export function useWorkspaceProjects(): UseWorkspaceProjectsResult {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Single-flight metrics fetch + loaded-flag bookkeeping.
+  // Single-flight metrics fetch. Only a *successful* fetch clears the loading
+  // flag — otherwise the KPI strip would swap `—` placeholders for hard zeros
+  // and present a failed fetch as real data (TRA-264).
   const fetchMetrics = useCallback(async () => {
-    await fetchMetricsOnce({ setMetrics, setError });
-    setMetricsLoaded(true);
+    const ok = await fetchMetricsOnce({ setMetrics, setError });
+    if (ok) setMetricsLoaded(true);
   }, []);
 
   // Initial fetch + 5-min polling fallback.
@@ -146,7 +167,7 @@ export function useWorkspaceProjects(): UseWorkspaceProjectsResult {
   const refresh = useCallback(async () => {
     setRefreshing(true);
     try {
-      await fetch(`${BASE}/api/dashboard/refresh`, { method: 'POST' }); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      await fetch(`${BASE}/api/dashboard/refresh`, { method: 'POST', signal: AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS) }); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
     } catch {
       // Best-effort; still fetch even if invalidation failed.
     }


### PR DESCRIPTION
Fixes TRA-264.

A failed `GET /api/dashboard/projects` was presented as real data: the KPI strip dropped from `—` back to hard `0`s while every row cell correctly rendered `—`, and the only error text was the browser's raw `Failed to fetch`.

## Root cause

`fetchMetricsOnce` swallowed the failure into `setError` and returned normally, so `setMetricsLoaded(true)` fired unconditionally. `metricsLoading` is derived as `!metricsLoaded`, so it flipped to `false` on a *failed* fetch and `WorkspaceHeader` took the placeholder-free numeric path — the same defect TRA-228 fixed for the loading path, reappearing on the error path.

## Changes

- `fetchMetricsOnce` returns `boolean`; `fetchMetrics` only sets `metricsLoaded` on success, so a failure keeps the already-correct `—` placeholders. No component work.
- `describeMetricsError` maps transport-level messages (`Failed to fetch`, `Load failed`, aborted/timeout) to `Couldn't load project metrics — daemon not responding.`; real server messages are kept and prefixed.
- Error banner gained a **Retry** button wired to the existing `refresh()`, disabled while refreshing.
- `AbortSignal.timeout(8000)` on the daemon reads (`/api/projects`, `/api/clients`, `/api/settings`, `/api/dashboard/*`). A *hung* daemon previously left `daemon.loading` true indefinitely, hiding the `DisconnectedBanner` — the one control that can restart it. It now degrades to the disconnected state.
- Swept the hardcoded `#ff3b30` out of `workspace/` onto `var(--destructive)` (already defined in `app.css` for both light and dark), with `color-mix` for the alpha variants — same token drift TRA-134 and TRA-228 removed elsewhere.

## Test evidence

New `packages/app/src/renderer/workspace/__tests__/useWorkspaceProjects.test.ts` — 5 tests covering the return value on success / network failure / non-OK response and the error-message mapping.

```
Test Files  7 passed (7)
     Tests  65 passed (65)
```

`pnpm typecheck` and `pnpm run build:renderer` both clean.
