### PR TITLE
fix(app): make Compact denser, sort it like Table, keep the leading / in paths

### DIFF
--- a/packages/app/src/renderer/workspace/Workspace.tsx
+++ b/packages/app/src/renderer/workspace/Workspace.tsx
@@ -24,6 +24,7 @@ import {
   type ViewMode,
   type WorkspaceFilter,
   applyFilter,
+  compareViewModels,
   deriveKpis,
 } from './types';
 import { useSelection } from './useSelection';
@@ -124,6 +125,12 @@ export function Workspace() {
 
   // ── Derived ──────────────────────────────────────────────────────────
   const filtered = useMemo(() => applyFilter(data.projects, filter), [data.projects, filter]);
+  // Sort here, not inside a view: every view then renders the same order, and
+  // switching Table ↔ Compact can't silently reshuffle the list.
+  const visible = useMemo(
+    () => [...filtered].sort((a, b) => compareViewModels(a, b, sortKey, sortDir)),
+    [filtered, sortKey, sortDir],
+  );
   const kpis = useMemo(() => deriveKpis(data.projects), [data.projects]);
 
   // ── Selection ────────────────────────────────────────────────────────
@@ -162,7 +169,7 @@ export function Workspace() {
   }
 
   const showEmpty = !data.loading && data.projects.length === 0;
-  const selectedProjects = filtered.filter((p) => selection.selected.has(p.root));
+  const selectedProjects = visible.filter((p) => selection.selected.has(p.root));
 
   return (
     <div className="flex flex-col h-full overflow-hidden relative">
@@ -213,7 +220,7 @@ export function Workspace() {
         </div>
       ) : view === 'compact' ? (
         <WorkspaceCompactView
-          projects={filtered}
+          projects={visible}
           selected={selection.selected}
           canMutate={data.connected}
           onSelectChange={selection.set}
@@ -226,7 +233,7 @@ export function Workspace() {
         />
       ) : (
         <WorkspaceTableView
-          projects={filtered}
+          projects={visible}
           sortKey={sortKey}
           sortDir={sortDir}
           onSort={handleSort}
@@ -234,7 +241,7 @@ export function Workspace() {
           canMutate={data.connected}
           onSelectChange={selection.set}
           onSelectAll={(next) => {
-            if (next) selection.selectAll(filtered);
+            if (next) selection.selectAll(visible);
             else selection.clear();
           }}
           onOpen={openProjectWindow}

--- a/packages/app/src/renderer/workspace/WorkspaceCompactView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceCompactView.tsx
@@ -22,6 +22,9 @@ export interface WorkspaceCompactViewProps {
   canMutate: boolean;
 }
 
+/** U+200E LEFT-TO-RIGHT MARK — see the path element below. */
+const LRM = '\u200e';
+
 function shortPath(root: string): string {
   const trimmed = root.replace(/\/+$/, '');
   const idx = trimmed.lastIndexOf('/');
@@ -59,7 +62,7 @@ function CompactRow({
     <div
       role="button"
       tabIndex={0}
-      className="px-2 py-1.5 rounded-md cursor-pointer transition-all hover:brightness-110"
+      className="px-2 py-1 rounded-md cursor-pointer transition-all hover:brightness-110"
       style={{ background: 'var(--bg-secondary)' }}
       onClick={() => onOpen(project.root)}
       onKeyDown={(e) => {
@@ -80,31 +83,44 @@ function CompactRow({
         </span>
         <StatusDot tone={dotTone} pulse={dotTone === 'green'} />
         <div className="flex-1 min-w-0">
-          <div
-            className="text-xs font-medium truncate"
-            style={{ color: 'var(--text-primary)' }}
-            title={project.name}
-          >
-            {project.name || shortPath(project.root)}
+          {/* Name and status share one line — the dot already carries the tone,
+              so the word costs no extra row height. */}
+          <div className="flex items-baseline gap-2">
+            <div
+              className="text-xs font-medium truncate"
+              style={{ color: 'var(--text-primary)' }}
+              title={project.name}
+            >
+              {project.name || shortPath(project.root)}
+            </div>
+            <div
+              className="text-[10px] shrink-0"
+              style={{ color: 'var(--text-tertiary)' }}
+            >
+              {statusLabel(project.displayStatus)}
+            </div>
           </div>
           <div
             className="text-[10px] truncate"
             style={{
               color: 'var(--text-tertiary)',
+              // `rtl` puts the ellipsis on the left (keep the interesting tail).
+              // The LRM prefix stops the leading "/" — a bidi-neutral character
+              // at the paragraph edge — from being reordered to the far end.
               direction: 'rtl',
               textAlign: 'left',
             }}
             title={project.root}
           >
-            {project.root}
+            {LRM + project.root}
           </div>
-          {project.error ? (
-            <div className="text-[10px] truncate" style={{ color: '#ff3b30' }} title={project.error}>
+          {project.error && (
+            <div
+              className="text-[10px] truncate"
+              style={{ color: 'var(--destructive)' }}
+              title={project.error}
+            >
               {project.error}
-            </div>
-          ) : (
-            <div className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-              {statusLabel(project.displayStatus)}
             </div>
           )}
           <InlineProgress
@@ -173,7 +189,7 @@ function CompactRow({
                   setConfirm(false);
                 }}
                 className="text-[11px] px-1.5 py-0.5 rounded font-medium"
-                style={{ background: '#ff3b30', color: '#fff' }}
+                style={{ background: 'var(--destructive)', color: '#fff' }}
               >
                 Remove
               </button>

--- a/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
@@ -7,9 +7,10 @@
  *  - per-row Open / Re-index / Remove actions (Remove has two-step confirm)
  *  - dims Re-index/Remove when `canMutate === false` or `inDaemon === false`
  *
- * Data flows in via props; sorting is performed locally using
- * `compareViewModels` from `./types.ts`. The component does not call
- * `useWorkspaceProjects` — the parent shell owns that state.
+ * Data flows in via props already sorted — the parent shell owns sort state
+ * and applies it once so every view shows the same order. `sortKey`/`sortDir`
+ * are consumed only to render the header indicator. The component does not
+ * call `useWorkspaceProjects`.
  */
 import { type MouseEvent, useEffect, useRef, useState } from 'react';
 import { StatusDot } from '../lattice/ui';
@@ -19,7 +20,6 @@ import {
   type SortDir,
   type SortKey,
   type TechDebtGrade,
-  compareViewModels,
   statusLabel,
   statusToDot,
 } from './types';
@@ -357,7 +357,6 @@ export function WorkspaceTableView({
   onRemove,
   canMutate,
 }: WorkspaceTableViewProps) {
-  const sorted = [...projects].sort((a, b) => compareViewModels(a, b, sortKey, sortDir));
   const thProps = { current: sortKey, dir: sortDir, onSort };
 
   return (
@@ -410,7 +409,7 @@ export function WorkspaceTableView({
           </tr>
         </thead>
         <tbody>
-          {sorted.map((p) => (
+          {projects.map((p) => (
             <Row
               key={p.root}
               project={p}

--- a/packages/app/src/renderer/workspace/__tests__/Workspace.sort.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/Workspace.sort.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * TRA-266: sorting lives in the shell, so Table and Compact render the same
+ * order and switching views can't silently reshuffle the list.
+ */
+import { render, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Workspace } from '../Workspace';
+import type { ProjectViewModel } from '../types';
+
+const projects: ProjectViewModel[] = ['zulu', 'alpha', 'mike'].map((name) => ({
+  root: `/Users/nikolai/Projects/${name}`,
+  name,
+  displayStatus: 'ok',
+  lastIndexed: null,
+  hasMetrics: false,
+  inDaemon: true,
+}));
+
+vi.mock('../useWorkspaceProjects', () => ({
+  useWorkspaceProjects: () => ({
+    projects,
+    loading: false,
+    metricsLoading: false,
+    refreshing: false,
+    error: null,
+    connected: true,
+    restarting: false,
+    addProject: async () => {},
+    removeProject: async () => {},
+    reindexProject: async () => {},
+    reindexMany: async () => {},
+    removeMany: async () => {},
+    refresh: async () => {},
+    restartDaemon: async () => {},
+  }),
+}));
+
+/** Project names in DOM order, read off the per-row select checkboxes. */
+function renderedOrder(container: HTMLElement): string[] {
+  return [...container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')]
+    .map((c) => c.getAttribute('aria-label') ?? '')
+    .filter((l) => l.startsWith('Select ') && l !== 'Select all projects')
+    .map((l) => l.slice('Select '.length));
+}
+
+describe('Workspace ordering', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('sorts by name in the default table view', () => {
+    localStorage.setItem('trace-mcp.workspace.view', 'table');
+    const { container } = render(<Workspace />);
+    expect(renderedOrder(container)).toEqual(['alpha', 'mike', 'zulu']);
+  });
+
+  it('applies the same sort in compact view', () => {
+    localStorage.setItem('trace-mcp.workspace.view', 'compact');
+    const { container } = render(<Workspace />);
+    expect(renderedOrder(container)).toEqual(['alpha', 'mike', 'zulu']);
+  });
+
+  it('keeps the leading slash at the front of compact paths', () => {
+    localStorage.setItem('trace-mcp.workspace.view', 'compact');
+    const { container } = render(<Workspace />);
+    const path = within(container).getByTitle('/Users/nikolai/Projects/alpha');
+    // U+200E keeps the neutral "/" inside the LTR run despite direction: rtl.
+    expect(path.textContent).toBe('\u200e/Users/nikolai/Projects/alpha');
+  });
+});


### PR DESCRIPTION
Fixes TRA-266. Three defects in the Workspace **Compact** view.

### 1. Compact fit fewer projects than Table
Rows were 62px vs Table's 46px (~8 vs ~11 projects at 960×700) because each row stacked four lines — name, path, status word, progress — under `py-1.5`, while the right ~45% of the row sat empty. Status now shares the name line (the `StatusDot` already carries the tone) and the row drops to `py-1`: two content lines instead of four.

### 2. Table → Compact silently reordered the list
`Workspace.tsx` owned `sortKey`/`sortDir` but passed them only to `WorkspaceTableView`, which sorted internally. `WorkspaceCompactView` got the unsorted `filtered` array — daemon-arrival order — and offered no sort control to get the ordering back.

Sorting now happens once in the shell (`compareViewModels` over `filtered`) and both views render the same array. `WorkspaceTableView` still takes `sortKey`/`sortDir`, but only to draw the header arrow. Consistent ordering by construction, and a smaller diff than adding a sort menu to Compact.

### 3. Leading `/` moved to the end of paths
The path line uses `direction: rtl` to truncate from the left. Side effect: the leading `/` is a bidi-neutral character at the paragraph edge, so it resolved RTL and rendered at the far end — `Users/nikolai/PhpstormProjects/pixelafisha/`. Prefixing U+200E puts the slash between two strong-LTR characters, so it stays at the front; `direction: rtl` (and left truncation) is unchanged.

### Also
The two hardcoded `#ff3b30` in this file (error text, Remove-confirm button) now use `var(--destructive)` — same token-drift class as the `#34c759` fixed in TRA-134.

### Test evidence
New `packages/app/src/renderer/workspace/__tests__/Workspace.sort.test.tsx` renders the shell with a mocked `useWorkspaceProjects` and asserts Table and Compact agree on order, and that the compact path keeps its leading slash. All three assertions fail on the pre-fix code (verified by stashing the fix):

```
Test Files  1 failed | 2 passed (3)
     Tests  3 failed | 41 passed (44)
```

With the fix, in `packages/app`:

```
pnpm run typecheck   # clean
pnpm run test        # Test Files 7 passed (7) · Tests 63 passed (63)
pnpm run build       # renderer + main OK
```

No MCP tool signature or on-disk schema changes; renderer-only.
