### PR TITLE
docs: single source of truth for the MCP tool count (TRA-263)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 > AI systems don't scale because they recompute instead of reuse. Every turn, the agent re-reads the same files, re-traverses the same dependencies, and re-inflates the context window with structure it already discovered. Token bills grow. Latency grows. Reasoning quality drops. The model isn't the bottleneck — the recomputation leak is.
 >
-> trace-mcp builds a framework-aware graph of your codebase **once**, then serves it through MCP so the agent reasons from a precomputed structure instead of brute-reading the repo. Ask *"what breaks if I change this model?"* — instead of 80 Grep calls and 190 file reads, the agent calls `get_change_impact` once and gets the blast radius across PHP, Vue, migrations, and DI. One tool call replaces ~42 minutes of agent exploration. 85 framework integrations across 80 languages, 164 tools.
+> trace-mcp builds a framework-aware graph of your codebase **once**, then serves it through MCP so the agent reasons from a precomputed structure instead of brute-reading the repo. Ask *"what breaks if I change this model?"* — instead of 80 Grep calls and 190 file reads, the agent calls `get_change_impact` once and gets the blast radius across PHP, Vue, migrations, and DI. One tool call replaces ~42 minutes of agent exploration. 85 framework integrations across 80 languages, 165 tools.
 >
 > **The same engine indexes markdown vaults.** `[[wikilinks]]` become first-class edges, frontmatter and `#tags` become metadata, headings become nested sections. `find_usages` returns backlinks. `apply_rename` rewrites every link to a renamed note. One MCP for code and knowledge — no second tool to plug in.
 
@@ -501,7 +501,7 @@ Source files (PHP, TS, Vue, Python, Go, Java, Kotlin, Ruby, HTML, CSS, Blade)
                      │
                      ▼
          MCP server (stdio or HTTP/SSE)
-         164 tools · 9 resources
+         165 tools · 9 resources
 ```
 
 **Incremental by default** — files are content-hashed; unchanged files are skipped on re-index.
@@ -519,7 +519,7 @@ Full docs live at **[trace-mcp.com](https://trace-mcp.com/)** (same content as `
 | Document | Description |
 |---|---|
 | [Supported frameworks](https://trace-mcp.com/supported-frameworks.html) | Complete list of languages, frameworks, ORMs, UI libraries, and what each extracts |
-| [Tools reference](https://trace-mcp.com/tools-reference.html) | All 164 MCP tools with descriptions and usage examples |
+| [Tools reference](https://trace-mcp.com/tools-reference.html) | All 165 MCP tools with descriptions and usage examples |
 | [Configuration](https://trace-mcp.com/configuration.html) | Config options, AI setup, environment variables, security settings |
 | [Architecture](https://trace-mcp.com/architecture.html) | How indexing works, plugin system, project structure, tech stack |
 | [Decision memory](https://trace-mcp.com/decision-memory.html) | Decision knowledge graph, session mining, cross-session search, wake-up context |

--- a/docs/_data/counts.yml
+++ b/docs/_data/counts.yml
@@ -1,0 +1,13 @@
+# Single source of truth for the tool-surface numbers quoted across the docs
+# site (TRA-263). Never hardcode these in a page — use {{ site.data.counts.* }}
+# so the pages cannot disagree with each other again (138 / 164 / 165 / ~170
+# were live on prod simultaneously, two of them on the same page).
+#
+# `tools` is the advertised surface a client sees in `tools/list`. Registration
+# is gated on config and detected frameworks, so there is no static list to
+# count — re-measure with `pnpm run count:tools`, do not edit it from a diff.
+#
+# Preset sizes deliberately live NOT here: tests/docs/preset-claims.test.ts
+# (TRA-259) checks those against the real tool filter, which is exact where a
+# hand-maintained number would only be a copy.
+tools: 165

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -74,7 +74,7 @@ Tools that persist context across AI agent sessions — activity logs, knowledge
 | Decision enrichment in tools | ✅ impact/plan_turn/resume | ❌ | ❌ standalone | ❌ | ❌ | ❌ | ❌ |
 | Service/subproject scoping | ✅ decisions per service | ❌ | ✅ wings per project | ❌ | ❌ | ✅ per branch | ✅ per workspace |
 | Published retrieval benchmark | ❌ | ❌ | ✅ LongMemEval / LoCoMo / MemBench | ❌ | ✅ LoCoMo / LongMemEval / BEAM | ❌ | ❌ |
-| Code intelligence included | ✅ 165 tools, 180+ edge types | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Code intelligence included | ✅ {{ site.data.counts.tools }} tools, 180+ edge types | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Works as standalone memory | ❌ code-focused | ✅ git-native, code-focused | ✅ general-purpose | ❌ Claude-specific | ✅ agent-agnostic | ✅ agent-agnostic | ✅ project-scoped |
 | Written in | TypeScript | — | Python | TypeScript | TS + Python | Go / Rust | Python |
 
@@ -111,7 +111,7 @@ _¹ mcp-local-rag and knowledge-rag are document RAG tools (PDF, DOCX, Markdown)
 | Languages | 80 | 40+ (via LSP) | 23 + Jupyter | 161 | 19 | 32 | 28 |
 | Framework integrations | 85 | ❌ | ❌ (Python entry points only) | ❌ | ❌ | ❌ | ~15 (ORM N+1 / API drift only) |
 | Cross-language edges | ✅ | ❌ | ❌ | ✅ cross-service HTTP | ✅ polyglot dep graph | ❌ | ✅ PHP↔TS API drift |
-| MCP tools advertised (default) | 165 (~51K tok) | ~55 | ~28 | 15 all / 11 `analysis` / 7 `scout` (~7K tok) | 21 | 90 | 224 |
+| MCP tools advertised (default) | {{ site.data.counts.tools }} (~51K tok) | ~55 | ~28 | 15 all / 11 `analysis` / 7 `scout` (~7K tok) | 21 | 90 | 224 |
 | Session memory | ✅ | ✅ (manual notes) | ❌ | ✅ | ❌ | ❌ | ❌ |
 | CI/PR reports | ✅ | ❌ | ✅ blast-radius GitHub Action | ❌ | ❌ | ❌ | ✅ SARIF 2.1.0 + GH/GL/Azure |
 | Multi-repo subprojects | ✅ | ❌ | ✅ multi-repo daemon | ✅ cross-service | ✅ cross-project search | ❌ | ❌ |
@@ -144,7 +144,7 @@ Both of the biggest projects in this space (by stars) made the same product call
 
 **Take:** `manage_adr` is a flat markdown document with get/update/sections modes — not code-linked memory, and no reason to copy it; trace-mcp's decisions already bind to symbol IDs and surface inside `get_change_impact`. `ingest_traces` is a genuinely missing capability (runtime-observed dynamic call edges that static analysis cannot see) but is a three-field payload — a thin veneer, worth revisiting only if users ask. The 161-language race stays out of lane, as before.
 
-**What we are taking:** a *default* tool surface small enough to be honest about. trace-mcp already has the machinery — `TOOL_PRESETS` (`minimal` 24 tools, `standard` 55, `full` 165) plus a `tools.include`/`tools.exclude` gate — and `standard` is already the coded default. Measured this pass against a real `initialize` + `tools/list` round-trip, the presets work perfectly with `TRACE_MCP_NO_DAEMON=1` (24 / 55 / 165 tools) and are **silently bypassed on the default daemon-backed path**, which pins every session at the full surface whatever the preset says. That is a bug, not a design gap, and it is tracked separately. Until it is fixed, the number in the table above is the number users actually pay.
+**What we are taking:** a *default* tool surface small enough to be honest about. trace-mcp already has the machinery — `TOOL_PRESETS` (`minimal` (24 tools), `standard` (59 tools), `full` ({{ site.data.counts.tools }} tools)) plus a `tools.include`/`tools.exclude` gate — and `standard` is already the coded default. Measured this pass against a real `initialize` + `tools/list` round-trip, the presets work perfectly with `TRACE_MCP_NO_DAEMON=1` (24 / 59 / {{ site.data.counts.tools }} tools) and are **silently bypassed on the default daemon-backed path**, which pins every session at the full surface whatever the preset says. That is a bug, not a design gap, and it is tracked separately. Until it is fixed, the number in the table above is the number users actually pay.
 
 ## Honest assessment: where competitors lead
 
@@ -163,7 +163,7 @@ No tool is uniformly ahead. trace-mcp is the only one combining framework-aware 
 
 **Still genuinely open (honest, not closed by the validation pass):**
 
-- **Advertised tool-surface cost.** Measured August 28, 2026: trace-mcp's `tools/list` is 165 tools / ~50K tokens, plus ~2.1K tokens of server instructions, paid by every client without deferred tool loading on every session. The two largest peers advertise ~1.9K and ~7K tokens respectively — 27× and 7× cheaper — by shipping a small default surface with the rest opt-in. trace-mcp has the same mechanism built and it does not take effect on the shipped path; nothing here is architecturally hard, it is simply not true today.
+- **Advertised tool-surface cost.** Measured August 28, 2026: trace-mcp's `tools/list` is {{ site.data.counts.tools }} tools / ~50K tokens, plus ~2.1K tokens of server instructions, paid by every client without deferred tool loading on every session. The two largest peers advertise ~1.9K and ~7K tokens respectively — 27× and 7× cheaper — by shipping a small default surface with the rest opt-in. trace-mcp has the same mechanism built and it does not take effect on the shipped path; nothing here is architecturally hard, it is simply not true today.
 
 - **Validated code-health metric.** A temporal-holdout calibration script now correlates `predict_bugs`/`get_risk_hotspots` against real future-fix commits on this repo (churn Spearman ≈0.34, precision@20 ≈2.1–2.4× over random) and the tool descriptions were reworded to honest "heuristic triage" language. This is evidence, not CodeScene-grade external validation — the gap to a peer-reviewed, cross-repo-validated metric remains.
 - **Worst-case decision-verification latency.** The memoization fix above only helps when decisions cluster on a handful of files; a batch fully scattered across N distinct files is still O(N) git subprocess spawns. An async/batched redesign would be needed to bound the worst case.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -582,7 +582,7 @@ The scanner detects HTTP/gRPC/GraphQL calls in 12+ patterns across all supported
 Every MCP session is still attached to exactly one project (see [stdio vs HTTP](#stdio-vs-http--choosing-your-setup)) — but two tools let an agent reach across to any OTHER project already registered with trace-mcp, without opening a second MCP connection:
 
 - **`list_projects`** — lists every project in `~/.trace-mcp/registry.json` (root, name, type, last-indexed timestamp), plus known subprojects when topology is enabled for the current session.
-- **`call_project_tool { project, tool, args }`** — runs any of the ~170 normal trace-mcp tools against a DIFFERENT registered project's already-indexed data and returns that tool's response verbatim. `project` must be a root from `list_projects`; an unregistered root or an unknown `tool` name returns a structured `{ error: { code, message, data } }` payload instead of throwing.
+- **`call_project_tool { project, tool, args }`** — runs any of the {{ site.data.counts.tools }} normal trace-mcp tools against a DIFFERENT registered project's already-indexed data and returns that tool's response verbatim. `project` must be a root from `list_projects`; an unregistered root or an unknown `tool` name returns a structured `{ error: { code, message, data } }` payload instead of throwing.
 
 This is read-only relay wiring — it never starts indexing or a file watcher for the target project. In the HTTP daemon, a target project already warm in memory is served directly; a cold one is opened on demand via the same read-mostly path used for on-demand subprojects. Under `stdio` (no daemon), the target project's existing index database is opened directly; a project that has never been indexed cannot be relayed to.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,3 +1,8 @@
+---
+# Empty front matter only so Jekyll renders the {{ site.data.counts.* }} tags
+# below (TRA-263). No layout — the page keeps its own hand-written head/OG tags.
+layout: null
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -104,7 +109,7 @@
       "Up to 2× effective capacity at the same context budget",
       "Up to 99% less redundant processing in structured tasks (code navigation, dependency traversal)",
       "Framework-aware dependency graph (85 integrations, 80 languages)",
-      "164 MCP tools for navigation, impact analysis, refactoring",
+      "{{ site.data.counts.tools }} MCP tools for navigation, impact analysis, refactoring",
       "Local-first: SQLite + bundled ONNX embeddings, zero API keys",
       "Native Model Context Protocol integration"
     ]
@@ -122,7 +127,7 @@
         "name": "What is the best MCP server for giving Claude Code codebase context?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across 80 languages) and exposes ~164 MCP tools — outline, symbol lookup, call graph, impact analysis, dead code detection — so Claude Code queries precomputed structure instead of re-reading files every turn. It runs entirely locally with no API keys, works with 85 framework integrations, and typically cuts token usage 40–50% versus raw file reads while producing more consistent answers as the codebase grows. It's open source (MIT), installs with 'npm install -g trace-mcp', and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf."
+          "text": "trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across 80 languages) and exposes {{ site.data.counts.tools }} MCP tools — outline, symbol lookup, call graph, impact analysis, dead code detection — so Claude Code queries precomputed structure instead of re-reading files every turn. It runs entirely locally with no API keys, works with 85 framework integrations, and typically cuts token usage 40–50% versus raw file reads while producing more consistent answers as the codebase grows. It's open source (MIT), installs with 'npm install -g trace-mcp', and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf."
         }
       },
       {
@@ -2084,7 +2089,7 @@
         </div>
         <div class="stat">
           <div class="stat-label">MCP Tools</div>
-          <div class="stat-value" data-count="138">0</div>
+          <div class="stat-value" data-count="{{ site.data.counts.tools }}">0</div>
           <div class="stat-trend">read-only or audited</div>
         </div>
         <div class="stat">
@@ -2248,14 +2253,14 @@
           <p>Tree-sitter parses symbols, plugins resolve framework edges, optional LSP enriches with compiler-grade call data. Stored locally in SQLite + FTS5.</p>
           <div class="tags">
             <span class="tag">tree-sitter</span>
-            <span class="tag">164 mcp tools</span>
+            <span class="tag">{{ site.data.counts.tools }} mcp tools</span>
             <span class="tag">local sqlite</span>
           </div>
         </div>
         <div class="pipe-step">
           <div class="pipe-num">03</div>
           <h3>Expose to your agents</h3>
-          <p>164 MCP tools become available in Claude Code, Cursor, Windsurf, VS Code &mdash; or any custom agent that speaks MCP over stdio or HTTP.</p>
+          <p>{{ site.data.counts.tools }} MCP tools become available in Claude Code, Cursor, Windsurf, VS Code &mdash; or any custom agent that speaks MCP over stdio or HTTP.</p>
           <div class="tags">
             <span class="tag">mcp</span>
             <span class="tag">stdio + http</span>
@@ -2278,7 +2283,7 @@
         <div class="section-meta-tag"><span class="label">005 / Core Capabilities</span></div>
         <div>
           <h2 class="section-title">The five calls that <span class="em">replace 90% of recomputation.</span></h2>
-          <p class="section-lede">Five tools from a surface of 138 &mdash; the ones agents reach for first. Each one collapses what would otherwise be a chain of Reads, Greps, and Globs into a single graph query. Token cost drops; the answer gets sharper.</p>
+          <p class="section-lede">Five tools from a surface of {{ site.data.counts.tools }} &mdash; the ones agents reach for first. Each one collapses what would otherwise be a chain of Reads, Greps, and Globs into a single graph query. Token cost drops; the answer gets sharper.</p>
         </div>
       </div>
 
@@ -2340,7 +2345,7 @@
           <span class="compare-sub">/ Agent-native trace-mcp</span>
           <h3>A precomputed graph the agent reuses</h3>
           <ul>
-            <li>164 tools that return answers, not files to read</li>
+            <li>{{ site.data.counts.tools }} tools that return answers, not files to read</li>
             <li>One incremental index, queried per task &mdash; not rebuilt per turn</li>
             <li>Single graph across every symbol, edge, and framework</li>
             <li>Native MCP protocol, zero adapter code</li>
@@ -2626,7 +2631,7 @@
             <h3>What is the best MCP server for giving Claude Code codebase context?</h3>
             <span class="toggle">+</span>
           </summary>
-          <div class="answer">trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across 80 languages) and exposes ~164 MCP tools &mdash; outline, symbol lookup, call graph, impact analysis, dead code detection &mdash; so Claude Code queries precomputed structure instead of re-reading files every turn. It runs entirely locally with no API keys, works with 85 framework integrations, and typically cuts token usage 40&ndash;50% versus raw file reads while producing more consistent answers as the codebase grows. It's open source (MIT), installs with <code>npm install -g trace-mcp</code>, and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf.</div>
+          <div class="answer">trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across 80 languages) and exposes {{ site.data.counts.tools }} MCP tools &mdash; outline, symbol lookup, call graph, impact analysis, dead code detection &mdash; so Claude Code queries precomputed structure instead of re-reading files every turn. It runs entirely locally with no API keys, works with 85 framework integrations, and typically cuts token usage 40&ndash;50% versus raw file reads while producing more consistent answers as the codebase grows. It's open source (MIT), installs with <code>npm install -g trace-mcp</code>, and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf.</div>
         </details>
         <details class="faq">
           <summary>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,3 +1,8 @@
+---
+# Front matter only so Jekyll renders the {{ site.data.counts.* }} tags below
+# (TRA-263). Stripped from the served file.
+layout: null
+---
 # trace-mcp — Full documentation
 
 > Concatenated full text of all trace-mcp docs pages, for AI systems that ingest one file instead of following links. See /llms.txt for the linked index.
@@ -6,7 +11,7 @@
 
 # Tools reference
 
-trace-mcp exposes 164 MCP tools and 9 resources.
+trace-mcp exposes {{ site.data.counts.tools }} MCP tools and 9 resources.
 
 Tools are registered dynamically based on detected frameworks — you only see tools relevant to your project.
 
@@ -283,7 +288,7 @@ Tools that persist context across AI agent sessions — activity logs, knowledge
 | Decision enrichment in tools | ✅ impact/plan_turn/resume | ❌ | ❌ standalone | ❌ | ❌ | ❌ | ❌ |
 | Service/subproject scoping | ✅ decisions per service | ❌ | ✅ wings per project | ❌ | ❌ | ✅ per branch | ✅ per workspace |
 | Published retrieval benchmark | ❌ | ❌ | ✅ LongMemEval / LoCoMo / MemBench | ❌ | ✅ LoCoMo / LongMemEval / BEAM | ❌ | ❌ |
-| Code intelligence included | ✅ 164 tools, 180+ edge types | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Code intelligence included | ✅ {{ site.data.counts.tools }} tools, 180+ edge types | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Works as standalone memory | ❌ code-focused | ✅ git-native, code-focused | ✅ general-purpose | ❌ Claude-specific | ✅ agent-agnostic | ✅ agent-agnostic | ✅ project-scoped |
 | Written in | TypeScript | — | Python | TypeScript | TS + Python | Go / Rust | Python |
 
@@ -320,7 +325,7 @@ _¹ mcp-local-rag and knowledge-rag are document RAG tools (PDF, DOCX, Markdown)
 | Languages | 80 | 40+ (via LSP) | 23 + Jupyter | 158 | 19 | 32 | 28 |
 | Framework integrations | 85 | ❌ | ❌ (Python entry points only) | ❌ | ❌ | ❌ | ~15 (ORM N+1 / API drift only) |
 | Cross-language edges | ✅ | ❌ | ❌ | ✅ cross-service HTTP | ✅ polyglot dep graph | ❌ | ✅ PHP↔TS API drift |
-| MCP tools | 164 | ~55 | ~28 | 14 | 21 | 90 | 224 |
+| MCP tools | {{ site.data.counts.tools }} | ~55 | ~28 | 14 | 21 | 90 | 224 |
 | Session memory | ✅ | ✅ (manual notes) | ❌ | ✅ | ❌ | ❌ | ❌ |
 | CI/PR reports | ✅ | ❌ | ✅ blast-radius GitHub Action | ❌ | ❌ | ❌ | ✅ SARIF 2.1.0 + GH/GL/Azure |
 | Multi-repo subprojects | ✅ | ❌ | ✅ multi-repo daemon | ✅ cross-service | ✅ cross-project search | ❌ | ❌ |
@@ -934,7 +939,7 @@ The scanner detects HTTP/gRPC/GraphQL calls in 12+ patterns across all supported
 Every MCP session is still attached to exactly one project (see [stdio vs HTTP](#stdio-vs-http--choosing-your-setup)) — but two tools let an agent reach across to any OTHER project already registered with trace-mcp, without opening a second MCP connection:
 
 - **`list_projects`** — lists every project in `~/.trace-mcp/registry.json` (root, name, type, last-indexed timestamp), plus known subprojects when topology is enabled for the current session.
-- **`call_project_tool { project, tool, args }`** — runs any of the ~164 normal trace-mcp tools against a DIFFERENT registered project's already-indexed data and returns that tool's response verbatim. `project` must be a root from `list_projects`; an unregistered root or an unknown `tool` name returns a structured `{ error: { code, message, data } }` payload instead of throwing.
+- **`call_project_tool { project, tool, args }`** — runs any of the {{ site.data.counts.tools }} normal trace-mcp tools against a DIFFERENT registered project's already-indexed data and returns that tool's response verbatim. `project` must be a root from `list_projects`; an unregistered root or an unknown `tool` name returns a structured `{ error: { code, message, data } }` payload instead of throwing.
 
 This is read-only relay wiring — it never starts indexing or a file watcher for the target project. In the HTTP daemon, a target project already warm in memory is served directly; a cold one is opened on demand via the same read-mostly path used for on-demand subprojects. Under `stdio` (no daemon), the target project's existing index database is opened directly; a project that has never been indexed cannot be relayed to.
 
@@ -1356,7 +1361,7 @@ src/
 │   ├── benchmark.ts        #   Synthetic benchmark (5 scenarios)
 │   ├── tech-detector.ts    #   Manifest parser + coverage assessment
 │   └── known-packages.ts   #   Catalog of ~200 known packages
-├── tools/                  # 164 MCP tool implementations
+├── tools/                  # {{ site.data.counts.tools }} MCP tool implementations
 ├── scoring/                # PageRank, BM25, hybrid scoring, structured assembly
 ├── plugin-api/             # Plugin registry, loader, executor, test harness
 ├── init/                   # Setup & detection (Claude Code, Claw Code, Cursor, Windsurf, Continue)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,10 +1,15 @@
+---
+# Front matter only so Jekyll renders the {{ site.data.counts.* }} tags below
+# (TRA-263). Stripped from the served file.
+layout: null
+---
 # trace-mcp
 
-> trace-mcp is a framework-aware MCP server that serves precomputed code intelligence — a dependency graph, full-text search, impact analysis, and decision memory — to cut token usage for AI coding agents. It understands 85 frameworks across 80 languages and exposes 164 MCP tools over stdio or HTTP.
+> trace-mcp is a framework-aware MCP server that serves precomputed code intelligence — a dependency graph, full-text search, impact analysis, and decision memory — to cut token usage for AI coding agents. It understands 85 frameworks across 80 languages and exposes {{ site.data.counts.tools }} MCP tools over stdio or HTTP.
 
 ## Docs
 
-- [Tools reference](https://trace-mcp.com/tools-reference.html): Full list of the 164 MCP tools and 9 resources trace-mcp exposes, registered dynamically per detected framework.
+- [Tools reference](https://trace-mcp.com/tools-reference.html): Full list of the {{ site.data.counts.tools }} MCP tools and 9 resources trace-mcp exposes, registered dynamically per detected framework.
 - [How trace-mcp compares](https://trace-mcp.com/comparisons.html): Feature-by-feature comparison against other code-graph and code-intelligence MCP servers.
 - [Configuration](https://trace-mcp.com/configuration.html): All config file options; trace-mcp works out of the box without one.
 - [Architecture](https://trace-mcp.com/architecture.html): The two-pass indexing pipeline and how the dependency graph is built and stored.

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -1,6 +1,6 @@
 ---
 title: "trace-mcp MCP Tools Reference — every code-intelligence tool, by framework"
-description: "Full reference for trace-mcp's 164 MCP tools and 9 resources — navigation, refactoring, impact analysis, security, and framework-aware queries. Tools register dynamically based on what your repo uses."
+description: "Full reference for trace-mcp's MCP tools and 9 resources — navigation, refactoring, impact analysis, security, and framework-aware queries. Tools register dynamically based on what your repo uses."
 ---
 
 # Tools reference
@@ -10,7 +10,7 @@ description: "Full reference for trace-mcp's 164 MCP tools and 9 resources — n
   "@context": "https://schema.org",
   "@type": "TechArticle",
   "headline": "Tools reference",
-  "description": "Full list of the 164 MCP tools and 9 resources trace-mcp exposes, registered dynamically per detected framework.",
+  "description": "Full list of the {{ site.data.counts.tools }} MCP tools and 9 resources trace-mcp exposes, registered dynamically per detected framework.",
   "url": "https://trace-mcp.com/tools-reference.html",
   "datePublished": "2026-04-05",
   "dateModified": "2026-04-15",
@@ -30,7 +30,7 @@ description: "Full reference for trace-mcp's 164 MCP tools and 9 resources — n
   }
 }
 </script>
-trace-mcp exposes 164 MCP tools and 9 resources.
+trace-mcp exposes {{ site.data.counts.tools }} MCP tools and 9 resources.
 
 Tools are registered dynamically based on detected frameworks — you only see tools relevant to your project.
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "format:check": "biome format",
     "biome:ci": "biome ci",
     "serve": "tsx src/cli.ts serve",
+    "count:tools": "node scripts/count-advertised-tools.mjs",
     "replay:check": "tsx scripts/replay-eval.ts",
     "replay:update-baseline": "tsx scripts/replay-eval.ts --update-baseline",
     "postinstall": "node scripts/preflight-native.mjs && node scripts/postinstall-app.mjs && node scripts/postinstall-control-plane.mjs",

--- a/scripts/count-advertised-tools.mjs
+++ b/scripts/count-advertised-tools.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Prints the advertised tool surface — the tool count an MCP client actually
+ * sees in `tools/list`, which is the number `docs/_data/counts.yml` quotes.
+ *
+ * Registration is gated on config and detected frameworks, so this has to be a
+ * real initialize + tools/list round-trip against the built server; there is no
+ * static list to count. Run after `pnpm run build`.
+ *
+ *   pnpm run count:tools [--names]
+ */
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const showNames = process.argv.includes('--names');
+
+const server = spawn('node', ['dist/cli.js', 'serve'], {
+  cwd: repoRoot,
+  env: { ...process.env, TRACE_MCP_NO_DAEMON: '1' },
+  stdio: ['pipe', 'pipe', 'ignore'],
+});
+
+const send = (msg) => server.stdin.write(`${JSON.stringify(msg)}\n`);
+
+const timeout = setTimeout(() => {
+  console.error('timed out waiting for tools/list');
+  server.kill();
+  process.exit(1);
+}, 120_000);
+
+let buffer = '';
+server.stdout.on('data', (chunk) => {
+  buffer += chunk;
+  let nl;
+  while ((nl = buffer.indexOf('\n')) >= 0) {
+    const line = buffer.slice(0, nl);
+    buffer = buffer.slice(nl + 1);
+    if (!line.trim()) continue;
+    let msg;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      continue; // server logs interleave on stdout
+    }
+    if (msg.id === 1) {
+      send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+      send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+    }
+    if (msg.id === 2) {
+      const names = msg.result.tools.map((t) => t.name).sort();
+      if (showNames) console.log(names.join('\n'));
+      console.log(names.length);
+      clearTimeout(timeout);
+      server.kill();
+      process.exit(0);
+    }
+  }
+});
+
+send({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'count-advertised-tools', version: '0' },
+  },
+});

--- a/tests/docs/preset-claims.test.ts
+++ b/tests/docs/preset-claims.test.ts
@@ -43,7 +43,10 @@ function servedCount(preset: string): number {
   return allToolNames().filter((name) => filter(name)).length;
 }
 
-const DOCS = ['docs/configuration.md', 'docs/llms-full.txt'];
+// comparisons.md stated its own preset sizes (`minimal` 24, `standard` 55) and
+// drifted for exactly as long as it was outside this list (TRA-263). Its claims
+// were reworded into the `<preset>` (N tools) shape so they land in scope here.
+const DOCS = ['docs/configuration.md', 'docs/llms-full.txt', 'docs/comparisons.md'];
 const PRESETS = ['standard', 'minimal', 'review', 'architecture'];
 
 describe('documented tool-preset sizes', () => {

--- a/tests/docs/readme-claims.test.ts
+++ b/tests/docs/readme-claims.test.ts
@@ -1,7 +1,8 @@
 import { execSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 import { PluginRegistry } from '../../src/plugin-api/registry.js';
 
 /**
@@ -22,6 +23,34 @@ import { PluginRegistry } from '../../src/plugin-api/registry.js';
 
 const REPO_ROOT = join(import.meta.dirname, '..', '..');
 const README_PATH = join(REPO_ROOT, 'README.md');
+
+/**
+ * TRA-263: the docs pages no longer hardcode the tool count — they read
+ * `docs/_data/counts.yml` through Liquid, because TRA-174's prose fix drifted
+ * again (138 / 164 / 165 / ~170 were live on prod at once, two of them on the
+ * same page). The scans below still have to see numbers, so resolve the tags
+ * the way Jekyll will. Preset sizes are NOT in that file — they get an exact
+ * receipt from tests/docs/preset-claims.test.ts instead.
+ */
+const COUNTS = parseYaml(readFileSync(join(REPO_ROOT, 'docs/_data/counts.yml'), 'utf-8')) as Record<
+  string,
+  unknown
+>;
+
+const COUNT_TAG = /\{\{\s*site\.data\.counts\.([a-z0-9_.]+)\s*\}\}/gi;
+
+function lookupCount(path: string): unknown {
+  return path
+    .split('.')
+    .reduce<unknown>((node, key) => (node as Record<string, unknown> | undefined)?.[key], COUNTS);
+}
+
+function readDoc(path: string): string {
+  return readFileSync(join(REPO_ROOT, path), 'utf-8').replace(COUNT_TAG, (whole, key: string) => {
+    const value = lookupCount(key);
+    return typeof value === 'number' ? String(value) : whole;
+  });
+}
 
 function readReadme(): string {
   return readFileSync(README_PATH, 'utf-8');
@@ -207,7 +236,7 @@ describe('docs site numeric claims (TRA-174)', () => {
 
   for (const { path, tolerance, skipLine } of docs) {
     it(`${path}: every "languages" claim matches the registry (±${tolerance})`, () => {
-      const text = readFileSync(join(REPO_ROOT, path), 'utf-8');
+      const text = readDoc(path);
       for (const claim of findAllClaims(/languages?/, text)) {
         if (!within(langPlugins, claim.count, tolerance)) {
           throw new Error(
@@ -218,7 +247,7 @@ describe('docs site numeric claims (TRA-174)', () => {
     });
 
     it(`${path}: every "frameworks/integrations" claim matches the registry (±${tolerance})`, () => {
-      const text = readFileSync(join(REPO_ROOT, path), 'utf-8');
+      const text = readDoc(path);
       for (const claim of findAllClaims(
         /(?:frameworks?|integrations?|framework integrations?)/,
         text,
@@ -232,7 +261,7 @@ describe('docs site numeric claims (TRA-174)', () => {
     });
 
     it(`${path}: every "MCP tools" claim matches the source of truth (±${tolerance})`, () => {
-      const text = readFileSync(join(REPO_ROOT, path), 'utf-8');
+      const text = readDoc(path);
       for (const claim of findAllClaims(/(?:MCP )?tools?/, text)) {
         if (skipLine?.test(claim.rawLine)) continue;
         if (!within(toolCount, claim.count, tolerance)) {
@@ -254,7 +283,7 @@ describe('docs site numeric claims (TRA-174)', () => {
       { labelPrefix: 'Code intelligence included', expected: toolCount, tolerance: 5 },
       { labelPrefix: 'MCP tools', expected: toolCount, tolerance: 5 },
     ];
-    const text = readFileSync(join(REPO_ROOT, 'docs/comparisons.md'), 'utf-8');
+    const text = readDoc('docs/comparisons.md');
     for (const line of text.split('\n')) {
       const cells = line.split('|').map((c) => c.trim());
       // Table row shape: ["", "<label>", "<trace-mcp cell>", ...competitors, ""]
@@ -273,9 +302,44 @@ describe('docs site numeric claims (TRA-174)', () => {
     }
   });
 
+  it('no docs page hardcodes its own tool count any more (TRA-263)', () => {
+    // The per-page scans above only enforce a ±tolerance against the registry,
+    // which is what let 138 / 164 / 165 / ~170 coexist. Reading all of them from
+    // one data file is the part that actually keeps the pages equal.
+    for (const path of ['docs/index.html', 'docs/llms.txt', 'docs/tools-reference.md']) {
+      COUNT_TAG.lastIndex = 0;
+      expect(
+        COUNT_TAG.test(readFileSync(join(REPO_ROOT, path), 'utf-8')),
+        `${path} no longer reads {{ site.data.counts.* }} — keep the number in docs/_data/counts.yml.`,
+      ).toBe(true);
+    }
+  });
+
+  it('every {{ site.data.counts.* }} tag in docs/ resolves to a number (TRA-263)', () => {
+    // Jekyll renders an unknown key as the empty string rather than failing the
+    // build, so a typo would ship as "trace-mcp exposes  MCP tools".
+    const broken: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name.startsWith('_') || entry.name.startsWith('.')) continue;
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+          continue;
+        }
+        if (!/\.(md|html|txt)$/.test(entry.name)) continue;
+        for (const m of readFileSync(full, 'utf-8').matchAll(COUNT_TAG)) {
+          if (typeof lookupCount(m[1]) !== 'number') broken.push(`${entry.name}: ${m[0]}`);
+        }
+      }
+    };
+    walk(join(REPO_ROOT, 'docs'));
+    expect([...new Set(broken)], 'no matching key in docs/_data/counts.yml').toEqual([]);
+  });
+
   it('llms.txt and tools-reference.md agree on the resource count', () => {
-    const llms = readFileSync(join(REPO_ROOT, 'docs/llms.txt'), 'utf-8');
-    const toolsRef = readFileSync(join(REPO_ROOT, 'docs/tools-reference.md'), 'utf-8');
+    const llms = readDoc('docs/llms.txt');
+    const toolsRef = readDoc('docs/tools-reference.md');
     for (const text of [llms, toolsRef]) {
       for (const claim of findAllClaims(/resources?/, text)) {
         if (!within(resourceCount, claim.count, 2)) {


### PR DESCRIPTION
Closes TRA-263.

## Problem

Four different tool counts were live on trace-mcp.com at once — two of them on the same page: `164 tools that return answers` and `138 mcp tools` on the homepage, `165 tools` on comparisons, `all ~170 tools` on configuration. TRA-174 fixed this class of drift by editing prose. It came back. So this PR fixes the numbers *and* removes the place where they can disagree.

## The number

**165**, measured — a real `initialize` + `tools/list` round-trip against the built server, reproduced here rather than taken from the issue or a diff. There is no static list to count: registration is gated on config and detected frameworks, so `pnpm run count:tools` (new) does the round-trip and prints the number.

## Changes

- `docs/_data/counts.yml` holds one value, `tools: 165`, and is the only place it is written.
- `index.html`, `llms.txt`, `llms-full.txt`, `tools-reference.md`, `configuration.md`, `comparisons.md` read `{{ site.data.counts.tools }}`. The three files Jekyll would otherwise pass through get empty front matter; verified all three contain no other Liquid syntax, so nothing can collide.
- `tools-reference.md`'s front-matter `description:` drops the number instead of templating it — Liquid does not run inside front matter, and a literal there would be the one thing still able to drift.
- `README.md` 164 → 165 (not Jekyll, stays literal, covered by the ±5 registry check).
- `scripts/count-advertised-tools.mjs` + `pnpm run count:tools`.

**Preset sizes are deliberately not in `counts.yml`.** TRA-259 (#427) landed while this was in progress and already checks them against the real tool filter, which is exact where a hand-maintained number is only a copy. Instead, `comparisons.md`'s stale preset claims (`minimal` 24, `standard` 55 — it was outside that guard's file list, and drifted for exactly that reason) are reworded into the `` `<preset>` (N tools) `` shape the guard matches, and `comparisons.md` is added to its list.

## Regression guard

Folded into the existing TRA-174 guard (`tests/docs/readme-claims.test.ts`) rather than a parallel file. It now:

- resolves the Liquid tags before its existing scans, so the docs numbers are still cross-checked against the live registry and the tool-registration count;
- fails if index.html / llms.txt / tools-reference.md go back to hardcoding their own count;
- fails on a `{{ site.data.counts.* }}` tag with no matching key — Jekyll renders an unknown key as an empty string rather than failing the build, so a typo would ship as "trace-mcp exposes  MCP tools".

Verified the guards fail on drift, not just pass on the happy path.

## Test evidence

CI green on `b3bee90` (test, build, biome, CodeQL, Semgrep, quality gates, eval baseline, CLA). Locally: `pnpm run typecheck` and `biome ci` clean; `pnpm run count:tools` → `165`.

## Not in this PR

Jekyll could not be rendered locally (system Ruby is 2.6, too old to install it), so the Liquid output is covered by the tag-resolution test rather than a real site build.

Two adjacent inconsistencies found while doing this, out of scope and untouched: the homepage stats panel says `Languages 79` while prose everywhere says 80, and `Integrations 58` against `85 frameworks`. Both need a measurement, not an edit.

Per the issue, this only pays off together with TRA-262 — Google currently does not see any of these pages except the homepage.
