### PR TITLE
fix(daemon): record why a silent exit happened (TRA-267)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,6 +67,7 @@ import { ProjectManager } from './daemon/project-manager.js';
 import type { ManagedProject } from './daemon/project-manager.js';
 import { createDaemonProjectRelay } from './daemon/project-relay.js';
 import { handleReindexFile } from './daemon/reindex-file-handler.js';
+import { startVitalsLog } from './daemon/vitals-log.js';
 import { StdioSession } from './daemon/router/session.js';
 import { initializeDatabase } from './db/schema.js';
 import { Store } from './db/store.js';
@@ -2833,6 +2834,19 @@ program
           teardownProjectBookkeeping(root);
           broadcastEvent({ type: 'project_status', project: root, status: 'unloaded' });
         }
+      },
+    });
+    // Vitals breadcrumb (TRA-267): an OS-level kill or native crash runs no JS
+    // handler, so the safety net logs nothing and daemon.log's last line is an
+    // ordinary indexing message. A periodic memory/project line makes the
+    // trajectory before such a gap readable after the fact.
+    startVitalsLog({
+      getCounts: () => {
+        const loaded = projectManager.listProjects();
+        return {
+          loaded: loaded.length,
+          indexing: loaded.filter((p) => p.status === 'indexing' || p.status === 'starting').length,
+        };
       },
     });
     // Track activity: wrap the client/session/SSE mutation points in-place via

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -5,6 +5,8 @@ import { getDaemonHealth } from '../daemon/client.js';
 import {
   enableDaemon,
   ensureDaemon,
+  formatLaunchdLastExit,
+  getLaunchdLastExit,
   isDaemonDisabled,
   restartDaemon,
   stopDaemon,
@@ -141,6 +143,9 @@ daemonCommand
         const loaded = isPlistLoaded();
         console.log(`  launchd plist: ${loaded ? 'loaded' : 'not loaded'}`);
         console.log(`  Plist path: ${LAUNCHD_PLIST_PATH}`);
+        // Post-mortem (TRA-267): the daemon can vanish without writing anything
+        // to daemon.log. launchd still knows how the last run ended.
+        for (const line of formatLaunchdLastExit(getLaunchdLastExit())) console.log(line);
       }
       if (disabled) {
         console.log(`  Auto-spawn: disabled (opt-out file: ${DAEMON_DISABLED_PATH})`);
@@ -156,6 +161,8 @@ daemonCommand
     }
 
     console.log(`Daemon is running on port ${port}.`);
+    // A KeepAlive restart hides the previous death — show how it ended.
+    for (const line of formatLaunchdLastExit(getLaunchdLastExit())) console.log(line);
     if (health.version) console.log(`  Version: ${health.version}`);
     if (health.pid != null) console.log(`  PID: ${health.pid}`);
     if (health.uptime != null) {

--- a/src/daemon/__tests__/silent-exit-diagnostics.test.ts
+++ b/src/daemon/__tests__/silent-exit-diagnostics.test.ts
@@ -66,7 +66,10 @@ describe('vitals log', () => {
   it('emits immediately and on every interval tick, and stops on demand', () => {
     vi.useFakeTimers();
     vi.mocked(logger.info).mockClear();
-    const stop = startVitalsLog({ getCounts: () => ({ loaded: 1, indexing: 0 }), intervalMs: 1000 });
+    const stop = startVitalsLog({
+      getCounts: () => ({ loaded: 1, indexing: 0 }),
+      intervalMs: 1000,
+    });
     expect(logger.info).toHaveBeenCalledTimes(1);
     vi.advanceTimersByTime(2500);
     expect(logger.info).toHaveBeenCalledTimes(3);

--- a/src/daemon/__tests__/silent-exit-diagnostics.test.ts
+++ b/src/daemon/__tests__/silent-exit-diagnostics.test.ts
@@ -1,0 +1,91 @@
+/**
+ * TRA-267: the daemon exited twice with nothing in daemon.log. These are the
+ * two breadcrumbs that make the next such exit diagnosable — a periodic vitals
+ * line, and launchd's record of how the previous run ended.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { formatLaunchdLastExit, parseLaunchdLastExit } from '../lifecycle.js';
+import { buildVitals, startVitalsLog } from '../vitals-log.js';
+
+vi.mock('../../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { logger } = await import('../../logger.js');
+
+describe('parseLaunchdLastExit', () => {
+  it('reads a signalled death from `last exit code`', () => {
+    const out = [
+      'com.trace-mcp.server = {',
+      '\tactive count = 0',
+      '\tstate = not running',
+      '\truns = 4',
+      '\tlast exit code = 9',
+      '}',
+    ].join('\n');
+    expect(parseLaunchdLastExit(out)).toEqual({ exitCode: 9, runs: 4 });
+  });
+
+  it('accepts the older `last exit status` spelling and a reason line', () => {
+    const out = '\tlast exit status = 1\n\tlast exit reason = Killed: 9\n';
+    expect(parseLaunchdLastExit(out)).toEqual({ exitCode: 1, reason: 'Killed: 9' });
+  });
+
+  it('returns an empty record when launchd printed nothing useful', () => {
+    expect(parseLaunchdLastExit('state = running\n')).toEqual({});
+  });
+});
+
+describe('formatLaunchdLastExit', () => {
+  it('flags a SIGKILL-shaped exit code — the fingerprint of an OS memory kill', () => {
+    const lines = formatLaunchdLastExit({ exitCode: 9, runs: 4 });
+    expect(lines[0]).toContain('code 9');
+    expect(lines[0]).toContain('SIGKILL');
+    expect(lines).toContain('  launchd start count: 4');
+  });
+
+  it('does not add a signal hint to a clean exit', () => {
+    expect(formatLaunchdLastExit({ exitCode: 0 })).toEqual(['  Last exit (launchd): code 0']);
+  });
+
+  it('says nothing when there is no record', () => {
+    expect(formatLaunchdLastExit(null)).toEqual([]);
+  });
+});
+
+describe('vitals log', () => {
+  it('reports memory and project counts', () => {
+    const v = buildVitals({ loaded: 45, indexing: 39 });
+    expect(v.projects_loaded).toBe(45);
+    expect(v.projects_indexing).toBe(39);
+    expect(v.rss_mb).toBeGreaterThan(0);
+    expect(v.heap_used_mb).toBeGreaterThan(0);
+    expect(v.uptime_s).toBeGreaterThanOrEqual(0);
+  });
+
+  it('emits immediately and on every interval tick, and stops on demand', () => {
+    vi.useFakeTimers();
+    vi.mocked(logger.info).mockClear();
+    const stop = startVitalsLog({ getCounts: () => ({ loaded: 1, indexing: 0 }), intervalMs: 1000 });
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(2500);
+    expect(logger.info).toHaveBeenCalledTimes(3);
+    stop();
+    vi.advanceTimersByTime(5000);
+    expect(logger.info).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+  });
+
+  it('never lets a failing counter kill the daemon', () => {
+    vi.mocked(logger.warn).mockClear();
+    expect(() =>
+      startVitalsLog({
+        getCounts: () => {
+          throw new Error('project manager exploded');
+        },
+        intervalMs: 60_000,
+      })(),
+    ).not.toThrow();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -300,7 +300,8 @@ export function getLaunchdLastExit(): LaunchdLastExit | null {
   if (!isMac) return null;
   let out: string;
   try {
-    out = execSync(`launchctl print ${getLaunchdDomain()}/${PLIST_LABEL}`, {
+    // execFileSync, not a shell string — no interpolation into a command line.
+    out = execFileSync('launchctl', ['print', `${getLaunchdDomain()}/${PLIST_LABEL}`], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
     });

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -14,6 +14,7 @@
 
 import { execSync, execFileSync, spawn } from 'node:child_process';
 import fs from 'node:fs';
+import { constants as osConstants } from 'node:os';
 import path from 'node:path';
 import {
   DAEMON_DISABLED_PATH,
@@ -255,6 +256,85 @@ function ensurePlistInstalled(port: number): { ok: boolean; error?: string; rege
     return { ok: false, error: (err as Error).message, regenerated: false };
   }
   return { ok: true, regenerated: true };
+}
+
+// ── Post-mortem: what launchd recorded about the last exit (TRA-267) ─
+// When the daemon dies without running a JS handler (OS kill, native crash),
+// daemon.log holds no clue. launchd does: it keeps the previous run's exit
+// code and, on newer macOS, a termination reason. Surfacing that in
+// `daemon status` is the difference between "it vanished" and "SIGKILL".
+
+export interface LaunchdLastExit {
+  /** Numeric value launchd reported for the last exit, when it reported one. */
+  exitCode?: number;
+  /** Free-form reason string when launchd printed one (newer macOS). */
+  reason?: string;
+  /** Number of times launchd has started the job, when reported. */
+  runs?: number;
+}
+
+/**
+ * Parse the relevant lines out of `launchctl print <domain>/<label>`.
+ * Exported for tests — the output format differs across macOS releases, so
+ * everything here is best-effort and absent fields are simply omitted.
+ */
+export function parseLaunchdLastExit(printOutput: string): LaunchdLastExit {
+  const out: LaunchdLastExit = {};
+  // "last exit code = 9" (older releases say "last exit status").
+  const code = printOutput.match(/last exit (?:code|status)\s*=\s*(-?\d+)/);
+  if (code) out.exitCode = parseInt(code[1], 10);
+  // "last exit reason = <dictionary> ..." / "... = Killed: 9"
+  const reason = printOutput.match(/last exit reason\s*=\s*(.+)/);
+  if (reason) out.reason = reason[1].trim();
+  const runs = printOutput.match(/^\s*runs\s*=\s*(\d+)/m);
+  if (runs) out.runs = parseInt(runs[1], 10);
+  return out;
+}
+
+/**
+ * Read launchd's record of the daemon's last exit. macOS only; returns null
+ * on other platforms, when the job isn't loaded, or when launchd reported
+ * nothing useful.
+ */
+export function getLaunchdLastExit(): LaunchdLastExit | null {
+  if (!isMac) return null;
+  let out: string;
+  try {
+    out = execSync(`launchctl print ${getLaunchdDomain()}/${PLIST_LABEL}`, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    return null;
+  }
+  const parsed = parseLaunchdLastExit(out);
+  if (parsed.exitCode === undefined && parsed.reason === undefined) return null;
+  return parsed;
+}
+
+/**
+ * Human-readable lines describing launchd's last-exit record, for
+ * `trace-mcp daemon status`. Returns [] when there's nothing to say.
+ *
+ * launchd reports a signalled death and a plain non-zero exit with the same
+ * field, so a small-numbered code gets a "possibly SIGx" hint rather than a
+ * claim. A SIGKILL here is the fingerprint of an OS memory kill.
+ */
+export function formatLaunchdLastExit(info: LaunchdLastExit | null): string[] {
+  if (!info) return [];
+  const lines: string[] = [];
+  if (info.exitCode !== undefined) {
+    const sig = osConstants.signals as Record<string, number>;
+    const name = Object.keys(sig).find((k) => sig[k] === info.exitCode);
+    const hint =
+      info.exitCode !== 0 && name
+        ? ` (possibly ${name} — launchd reports a signalled death and a plain exit code alike)`
+        : '';
+    lines.push(`  Last exit (launchd): code ${info.exitCode}${hint}`);
+  }
+  if (info.reason) lines.push(`  Last exit reason: ${info.reason}`);
+  if (info.runs !== undefined) lines.push(`  launchd start count: ${info.runs}`);
+  return lines;
 }
 
 /** Rotate daemon.log once it exceeds this size (bytes). */

--- a/src/daemon/vitals-log.ts
+++ b/src/daemon/vitals-log.ts
@@ -1,0 +1,69 @@
+/**
+ * Periodic vitals breadcrumb for the long-lived daemon (TRA-267).
+ *
+ * Why this exists: `process-safety-net.ts` catches errors that reach a JS
+ * handler, but an OS-level kill (macOS Jetsam / OOM killer, SIGKILL) or a
+ * native crash in better-sqlite3 / onnxruntime runs no JS at all. The process
+ * just disappears and daemon.log's last line is an ordinary indexing message —
+ * which is exactly what was observed when the daemon exited twice under a
+ * 45-project registry. Nothing in the log said whether memory was the cause.
+ *
+ * A periodic memory line turns that silence into evidence: the trajectory in
+ * the minutes before the gap says whether RSS was climbing, and how many
+ * projects were loaded/indexing at the time.
+ */
+import { logger } from '../logger.js';
+
+export interface DaemonVitals {
+  rss_mb: number;
+  heap_used_mb: number;
+  heap_total_mb: number;
+  external_mb: number;
+  uptime_s: number;
+  projects_loaded: number;
+  projects_indexing: number;
+}
+
+export interface ProjectCounts {
+  loaded: number;
+  indexing: number;
+}
+
+const toMb = (bytes: number): number => Math.round(bytes / 1024 / 1024);
+
+/** Snapshot process memory + project counts. Pure apart from two cheap syscalls. */
+export function buildVitals(counts: ProjectCounts): DaemonVitals {
+  const mem = process.memoryUsage();
+  return {
+    rss_mb: toMb(mem.rss),
+    heap_used_mb: toMb(mem.heapUsed),
+    heap_total_mb: toMb(mem.heapTotal),
+    external_mb: toMb(mem.external),
+    uptime_s: Math.round(process.uptime()),
+    projects_loaded: counts.loaded,
+    projects_indexing: counts.indexing,
+  };
+}
+
+/**
+ * Log one vitals line now, then every `intervalMs` (default 60s). The timer is
+ * unref'd so it never keeps the process alive on its own. Returns a stop
+ * function.
+ */
+export function startVitalsLog(opts: {
+  getCounts: () => ProjectCounts;
+  intervalMs?: number;
+}): () => void {
+  const emit = (): void => {
+    try {
+      logger.info(buildVitals(opts.getCounts()), 'Daemon vitals');
+    } catch (err) {
+      // A vitals line must never be the thing that kills the daemon.
+      logger.warn({ err: String(err) }, 'Daemon vitals snapshot failed (non-fatal)');
+    }
+  };
+  emit();
+  const timer = setInterval(emit, opts.intervalMs ?? 60_000);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}


### PR DESCRIPTION
## Problem

TRA-267: the daemon exited silently twice under a 45-project registry. `daemon logs` had no error, no stack trace, no shutdown message — the last entries were ordinary `indexing progress` lines.

That silence is itself the finding. `src/server/process-safety-net.ts` already installs `uncaughtException`/`unhandledRejection` for `serve-http`, and the daemon has no `process.exit()` path of its own, so an exception would have been logged. A death with *nothing* logged means no JS handler ran: an OS-level kill (macOS Jetsam / OOM), or a native crash in better-sqlite3 / onnxruntime / tree-sitter. Neither leaves a trace we currently capture.

The fan-out framing in the issue is partly a log artifact: the `Lazy post-update reindex` lines are emitted at `addProject()` time, but `indexAll` is already gated by a semaphore of 2 (`indexer.parallel_initial_index`), and the idle-unload sweep is wired and on by default (30 min). So this PR adds **no policy** — it adds the evidence needed to tell whether memory was actually the cause.

## Change

- **`src/daemon/vitals-log.ts`** (new) — `startVitalsLog()` logs one line immediately and every 60s: `rss_mb`, `heap_used_mb`, `heap_total_mb`, `external_mb`, `uptime_s`, `projects_loaded`, `projects_indexing`. Unref'd timer; a throwing counter is caught and logged rather than propagated. Wired into the `serve-http` bootstrap in `src/cli.ts`. After this, the log preceding a silent gap shows the memory trajectory.
- **`parseLaunchdLastExit` / `getLaunchdLastExit` / `formatLaunchdLastExit`** in `src/daemon/lifecycle.ts` — reads `launchctl print gui/<uid>/com.trace-mcp.server` for the previous run's exit code, reason, and start count. Surfaced by `trace-mcp daemon status` in **both** branches: the unreachable one, and the running one (a `KeepAlive` restart otherwise hides the death entirely). A small-numbered code gets a `possibly SIGKILL`-style hint rather than a claim, since launchd reports a signalled death and a plain exit code in the same field.

## Tests

`src/daemon/__tests__/silent-exit-diagnostics.test.ts` — 9 tests covering both `launchctl print` output spellings (`last exit code` / `last exit status`), the reason line, the empty case, the SIGKILL hint, clean-exit formatting, vitals content, immediate + interval emission with stop, and the throwing-counter path.

Local: `pnpm run test` → **8734 passed / 9 skipped (797 files)**. `pnpm run build` and `pnpm run lint` (`tsc --noEmit`) clean.

## Scope note

No MCP tool signature, on-disk schema, or token-budget change. One extra `logger.info` per minute in the daemon log — negligible against the existing indexing-progress volume, and `daemon.log` is size-rotated at 20 MB.

Closes TRA-267.
