### PR TITLE
test(docs): count MCP tools recursively, not with a top-level glob (TRA-268)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 > AI systems don't scale because they recompute instead of reuse. Every turn, the agent re-reads the same files, re-traverses the same dependencies, and re-inflates the context window with structure it already discovered. Token bills grow. Latency grows. Reasoning quality drops. The model isn't the bottleneck — the recomputation leak is.
 >
-> trace-mcp builds a framework-aware graph of your codebase **once**, then serves it through MCP so the agent reasons from a precomputed structure instead of brute-reading the repo. Ask *"what breaks if I change this model?"* — instead of 80 Grep calls and 190 file reads, the agent calls `get_change_impact` once and gets the blast radius across PHP, Vue, migrations, and DI. One tool call replaces ~42 minutes of agent exploration. 85 framework integrations across 80 languages, 165 tools.
+> trace-mcp builds a framework-aware graph of your codebase **once**, then serves it through MCP so the agent reasons from a precomputed structure instead of brute-reading the repo. Ask *"what breaks if I change this model?"* — instead of 80 Grep calls and 190 file reads, the agent calls `get_change_impact` once and gets the blast radius across PHP, Vue, migrations, and DI. One tool call replaces ~42 minutes of agent exploration. 85 framework integrations across 80 languages, 169 tools.
 >
 > **The same engine indexes markdown vaults.** `[[wikilinks]]` become first-class edges, frontmatter and `#tags` become metadata, headings become nested sections. `find_usages` returns backlinks. `apply_rename` rewrites every link to a renamed note. One MCP for code and knowledge — no second tool to plug in.
 
@@ -501,7 +501,7 @@ Source files (PHP, TS, Vue, Python, Go, Java, Kotlin, Ruby, HTML, CSS, Blade)
                      │
                      ▼
          MCP server (stdio or HTTP/SSE)
-         165 tools · 9 resources
+         169 tools · 9 resources
 ```
 
 **Incremental by default** — files are content-hashed; unchanged files are skipped on re-index.
@@ -519,7 +519,7 @@ Full docs live at **[trace-mcp.com](https://trace-mcp.com/)** (same content as `
 | Document | Description |
 |---|---|
 | [Supported frameworks](https://trace-mcp.com/supported-frameworks.html) | Complete list of languages, frameworks, ORMs, UI libraries, and what each extracts |
-| [Tools reference](https://trace-mcp.com/tools-reference.html) | All 165 MCP tools with descriptions and usage examples |
+| [Tools reference](https://trace-mcp.com/tools-reference.html) | All 169 MCP tools with descriptions and usage examples |
 | [Configuration](https://trace-mcp.com/configuration.html) | Config options, AI setup, environment variables, security settings |
 | [Architecture](https://trace-mcp.com/architecture.html) | How indexing works, plugin system, project structure, tech stack |
 | [Decision memory](https://trace-mcp.com/decision-memory.html) | Decision knowledge graph, session mining, cross-session search, wake-up context |

--- a/docs/_data/counts.yml
+++ b/docs/_data/counts.yml
@@ -3,11 +3,18 @@
 # so the pages cannot disagree with each other again (138 / 164 / 165 / ~170
 # were live on prod simultaneously, two of them on the same page).
 #
-# `tools` is the advertised surface a client sees in `tools/list`. Registration
-# is gated on config and detected frameworks, so there is no static list to
-# count — re-measure with `pnpm run count:tools`, do not edit it from a diff.
+# `tools` is every tool registered under src/tools/register, minus the ones
+# gated behind `if (has('vue', ...))` — no repo is ever served all of those.
+# tests/docs/tool-surface.ts computes it, tests/docs/readme-claims.test.ts
+# enforces it, and the failure message prints the number to write here.
+#
+# TRA-268: this is deliberately NOT a live `tools/list` count. That varies with
+# the repo's detected frameworks and the user's own config — measured 150 / 165
+# / 172 across three environments — so it cannot be a number in a doc.
+# `pnpm run count:tools` still reports the live surface of your local install;
+# it answers a different question and is not the source for this file.
 #
 # Preset sizes deliberately live NOT here: tests/docs/preset-claims.test.ts
 # (TRA-259) checks those against the real tool filter, which is exact where a
 # hand-maintained number would only be a copy.
-tools: 165
+tools: 169

--- a/scripts/count-advertised-tools.mjs
+++ b/scripts/count-advertised-tools.mjs
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 /**
- * Prints the advertised tool surface — the tool count an MCP client actually
- * sees in `tools/list`, which is the number `docs/_data/counts.yml` quotes.
+ * Prints the tool surface THIS install serves — a real initialize + tools/list
+ * round-trip against the built server. Run after `pnpm run build`.
  *
- * Registration is gated on config and detected frameworks, so this has to be a
- * real initialize + tools/list round-trip against the built server; there is no
- * static list to count. Run after `pnpm run build`.
+ * TRA-268: this is not the number `docs/_data/counts.yml` quotes. Registration
+ * is gated on detected frameworks and on config, so the answer here changes
+ * with the repo and the machine (measured 150 / 165 / 172 across three
+ * environments). The documented number is derived statically instead — see
+ * tests/docs/tool-surface.ts.
  *
  *   pnpm run count:tools [--names]
  */

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.nikolai-vysotskyi/trace-mcp",
-  "description": "Framework-aware code intelligence: 80 languages, 87 framework integrations, 164 tools, up to 99% token reduction",
+  "description": "Framework-aware code intelligence: 80 languages, 87 framework integrations, 169 tools, up to 99% token reduction",
   "repository": {
     "url": "https://github.com/nikolai-vysotskyi/trace-mcp",
     "source": "github"

--- a/skills/README.md
+++ b/skills/README.md
@@ -2,7 +2,7 @@
 
 Reusable [Agent Skills](https://skills.sh) that teach any MCP-compatible coding agent (Claude Code, Cursor, Windsurf, OpenCode, Codex, etc.) to use [trace-mcp](https://github.com/nikolai-vysotskyi/trace-mcp) effectively.
 
-trace-mcp is a framework-aware code intelligence MCP server that exposes 164 tools over a cross-language dependency graph. These skills encode the routing rules, workflows, and token-efficiency best practices so your agent uses trace-mcp instead of brute-reading files with `Read`/`Grep`/`Glob`.
+trace-mcp is a framework-aware code intelligence MCP server that exposes 169 tools over a cross-language dependency graph. These skills encode the routing rules, workflows, and token-efficiency best practices so your agent uses trace-mcp instead of brute-reading files with `Read`/`Grep`/`Glob`.
 
 ## Install
 

--- a/skills/trace-mcp/SKILL.md
+++ b/skills/trace-mcp/SKILL.md
@@ -5,7 +5,7 @@ description: Use trace-mcp tools for code navigation, impact analysis, and frame
 
 # trace-mcp — Code Intelligence Routing
 
-trace-mcp is a framework-aware code intelligence MCP server. It exposes 164 tools that return semantic, structured results over a cross-language dependency graph. When trace-mcp is available, it is almost always cheaper and more accurate than native file tools.
+trace-mcp is a framework-aware code intelligence MCP server. It exposes 169 tools that return semantic, structured results over a cross-language dependency graph. When trace-mcp is available, it is almost always cheaper and more accurate than native file tools.
 
 ## When to Use
 

--- a/tests/docs/preset-claims.test.ts
+++ b/tests/docs/preset-claims.test.ts
@@ -1,9 +1,9 @@
-import { readdirSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import type { TraceMcpConfig } from '../../src/config.js';
 import { createToolFilter } from '../../src/server/tool-filter.js';
+import { allToolNames } from './tool-surface.js';
 
 /**
  * TRA-259: the documented preset sizes were never checked against the filter.
@@ -15,28 +15,6 @@ import { createToolFilter } from '../../src/server/tool-filter.js';
  */
 
 const REPO_ROOT = join(import.meta.dirname, '..', '..');
-
-/** Every tool name registered anywhere under src/tools/register (incl. subdirs). */
-function allToolNames(): string[] {
-  const names = new Set<string>();
-  const walk = (dir: string): void => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const full = join(dir, entry.name);
-      if (entry.isDirectory()) {
-        if (entry.name !== '__tests__') walk(full);
-        continue;
-      }
-      if (!entry.name.endsWith('.ts')) continue;
-      for (const m of readFileSync(full, 'utf8').matchAll(
-        /(?:server\.tool|_originalTool)\(\s*['"]([a-zA-Z0-9_]+)['"]/g,
-      )) {
-        names.add(m[1]);
-      }
-    }
-  };
-  walk(fileURLToPath(new URL('../../src/tools/register', import.meta.url)));
-  return [...names];
-}
 
 function servedCount(preset: string): number {
   const filter = createToolFilter({ tools: { preset } } as unknown as TraceMcpConfig);

--- a/tests/docs/readme-claims.test.ts
+++ b/tests/docs/readme-claims.test.ts
@@ -1,9 +1,14 @@
-import { execSync } from 'node:child_process';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { parse as parseYaml } from 'yaml';
 import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import {
+  advertisedToolCount,
+  allToolNames,
+  frameworkGatedToolNames,
+  resourceCount as countServerResourceCalls,
+} from './tool-surface.js';
 
 /**
  * README-claims regression test.
@@ -82,40 +87,10 @@ function within(actual: number, claim: number, tolerance: number): boolean {
   return Math.abs(actual - claim) <= tolerance;
 }
 
-function countServerToolCalls(): number {
-  // Grep via Node fs rather than shelling out so the test stays portable.
-  const out = execSync(
-    `grep -lE "server\\.tool\\(" ${join(REPO_ROOT, 'src/tools/register')}/*.ts`,
-    { encoding: 'utf-8' },
-  )
-    .trim()
-    .split('\n')
-    .filter(Boolean);
-  let total = 0;
-  for (const file of out) {
-    const body = readFileSync(file, 'utf-8');
-    const matches = body.match(/server\.tool\(/g);
-    if (matches) total += matches.length;
-  }
-  return total;
-}
-
-function countServerResourceCalls(): number {
-  const out = execSync(
-    `grep -lE "server\\.resource\\(" ${join(REPO_ROOT, 'src/tools/register')}/*.ts`,
-    { encoding: 'utf-8' },
-  )
-    .trim()
-    .split('\n')
-    .filter(Boolean);
-  let total = 0;
-  for (const file of out) {
-    const body = readFileSync(file, 'utf-8');
-    const matches = body.match(/server\.resource\(/g);
-    if (matches) total += matches.length;
-  }
-  return total;
-}
+// TRA-268: both counts used to come from a non-recursive `grep .../register/*.ts`,
+// which never saw src/tools/register/navigation/. They now come from
+// ./tool-surface.ts, which walks the tree.
+const countServerToolCalls = advertisedToolCount;
 
 /**
  * Every `<NUMBER>+? <unit>` occurrence in the text, not just the first —
@@ -179,10 +154,42 @@ describe('README numeric claims', () => {
     if (!claim) return;
     if (!within(toolCount, claim.count, 5)) {
       throw new Error(
-        `README claims ${claim.count} tools; src/tools/register/*.ts contains ` +
-          `${toolCount} server.tool(...) registrations. Update README.md line: "${claim.rawLine}"`,
+        `README claims ${claim.count} tools; src/tools/register/ registers ${toolCount} ` +
+          `framework-agnostic tools. Update README.md line: "${claim.rawLine}"`,
       );
     }
+  });
+
+  it('counts tools registered in subdirectories of src/tools/register (TRA-268)', () => {
+    // The old glob was `src/tools/register/*.ts`, so everything under
+    // src/tools/register/navigation/ was invisible and the count only matched
+    // the docs by coincidence.
+    const names = new Set(allToolNames());
+    for (const subdirTool of ['search', 'get_symbol', 'get_outline', 'get_task_context']) {
+      expect(names.has(subdirTool), `${subdirTool} is registered but not counted`).toBe(true);
+    }
+  });
+
+  it('the framework-gate detection still finds the framework-only tools (TRA-268)', () => {
+    // advertisedToolCount() subtracts the tools registered inside
+    // `if (has('vue', ...))`. If framework.ts ever stops using that shape, the
+    // subtraction silently becomes a no-op and the advertised number jumps by
+    // ~13 with no other signal. Fail here instead, where the cause is obvious.
+    const gated = frameworkGatedToolNames();
+    expect(
+      gated.size,
+      'no framework-gated tools found under src/tools/register — the `if (has(...))` ' +
+        'gate shape in framework.ts changed; update frameworkGatedToolNames() in ' +
+        'tests/docs/tool-surface.ts.',
+    ).toBeGreaterThan(5);
+    // A spot-check that we are matching the gate, not every tool in the file:
+    // these three sit in framework.ts but outside any `if (has(...))` block.
+    for (const alwaysOn of ['find_usages', 'get_call_graph', 'get_tests_for']) {
+      expect(gated.has(alwaysOn), `${alwaysOn} is always registered, not framework-gated`).toBe(
+        false,
+      );
+    }
+    expect(gated.has('get_component_tree')).toBe(true);
   });
 
   it('package.json version is referenced consistently in plugin manifests', () => {
@@ -266,7 +273,7 @@ describe('docs site numeric claims (TRA-174)', () => {
         if (skipLine?.test(claim.rawLine)) continue;
         if (!within(toolCount, claim.count, tolerance)) {
           throw new Error(
-            `${path} claims ${claim.count} tools; src/tools/register/*.ts contains ${toolCount} server.tool(...) registrations. Line: "${claim.rawLine}"`,
+            `${path} claims ${claim.count} tools; src/tools/register/ registers ${toolCount} framework-agnostic tools. Line: "${claim.rawLine}"`,
           );
         }
       }
@@ -344,7 +351,7 @@ describe('docs site numeric claims (TRA-174)', () => {
       for (const claim of findAllClaims(/resources?/, text)) {
         if (!within(resourceCount, claim.count, 2)) {
           throw new Error(
-            `claims ${claim.count} resources; src/tools/register/*.ts contains ${resourceCount} server.resource(...) registrations. Line: "${claim.rawLine}"`,
+            `claims ${claim.count} resources; src/tools/register/ contains ${resourceCount} server.resource(...) registrations. Line: "${claim.rawLine}"`,
           );
         }
       }

--- a/tests/docs/tool-surface.ts
+++ b/tests/docs/tool-surface.ts
@@ -1,0 +1,103 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * TRA-268: the numeric-claims guard derived its "how many tools do we ship"
+ * number from `grep -lE "server\.tool\(" src/tools/register/*.ts` — a
+ * non-recursive glob, so the nine tools registered under
+ * `src/tools/register/navigation/` were invisible to it. The number it
+ * produced (164) tracked the number the docs advertise (165) by coincidence,
+ * not by construction: a batch of tools added in a subdirectory moves the
+ * served surface without moving the guard, and a subdirectory refactor of
+ * existing registrations drops the guard by nine and fails CI on docs that
+ * were never wrong.
+ *
+ * This module is the single place both `readme-claims.test.ts` and
+ * `preset-claims.test.ts` get the registered surface from.
+ */
+
+const REGISTER_DIR = fileURLToPath(new URL('../../src/tools/register', import.meta.url));
+
+/** `server.tool('name', ...)` and the `_originalTool` meta-tool wrappers. */
+const TOOL_NAME = /(?:server\.tool|_originalTool)\(\s*['"]([a-zA-Z0-9_]+)['"]/g;
+
+function registerSources(): Array<{ path: string; body: string }> {
+  const out: Array<{ path: string; body: string }> = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== '__tests__') walk(full);
+        continue;
+      }
+      if (entry.name.endsWith('.ts')) out.push({ path: full, body: readFileSync(full, 'utf8') });
+    }
+  };
+  walk(REGISTER_DIR);
+  return out;
+}
+
+/** Byte ranges of every `if (has(...)) { ... }` block — the framework gates. */
+function frameworkGateRanges(body: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  for (const m of body.matchAll(/if \(\s*has\(/g)) {
+    const open = body.indexOf('{', m.index);
+    if (open < 0) continue;
+    let depth = 0;
+    for (let i = open; i < body.length; i++) {
+      if (body[i] === '{') depth++;
+      else if (body[i] === '}' && --depth === 0) {
+        ranges.push([open, i]);
+        break;
+      }
+    }
+  }
+  return ranges;
+}
+
+/** Every tool name registered anywhere under src/tools/register (incl. subdirs). */
+export function allToolNames(): string[] {
+  const names = new Set<string>();
+  for (const { body } of registerSources()) {
+    for (const m of body.matchAll(TOOL_NAME)) names.add(m[1]);
+  }
+  return [...names];
+}
+
+/**
+ * Tools registered only when a framework is detected (`if (has('vue', ...))`).
+ * No single repo is ever served all of them, so they don't belong in the
+ * number the docs advertise.
+ */
+export function frameworkGatedToolNames(): Set<string> {
+  const gated = new Set<string>();
+  for (const { body } of registerSources()) {
+    const ranges = frameworkGateRanges(body);
+    if (ranges.length === 0) continue;
+    for (const m of body.matchAll(TOOL_NAME)) {
+      if (ranges.some(([a, b]) => a <= m.index && m.index <= b)) gated.add(m[1]);
+    }
+  }
+  return gated;
+}
+
+/**
+ * The number the docs advertise: every registered tool a client gets on any
+ * repo, framework-specific ones excluded. Deterministic — unlike a live
+ * `tools/list`, which varies with the repo's detected frameworks and the
+ * user's config (measured 150 / 165 / 172 across three environments).
+ */
+export function advertisedToolCount(): number {
+  const gated = frameworkGatedToolNames();
+  return allToolNames().filter((name) => !gated.has(name)).length;
+}
+
+/** `server.resource(...)` registrations, recursive for the same reason. */
+export function resourceCount(): number {
+  let total = 0;
+  for (const { body } of registerSources()) {
+    total += (body.match(/server\.resource\(/g) ?? []).length;
+  }
+  return total;
+}


### PR DESCRIPTION
Closes TRA-268. Stacked on #431 (merged mid-work; this is rebased on top of it).

## Problem

`tests/docs/readme-claims.test.ts` derived the tool count from

```
grep -lE "server\.tool\(" src/tools/register/*.ts
```

Non-recursive, so the nine tools under `src/tools/register/navigation/` (`search`, `get_symbol`, `get_outline`, `get_change_impact`, `get_related_symbols`, `get_context_bundle`, `get_feature_context`, `get_task_context`, `suggest_queries`) were invisible to the guard that is supposed to keep the docs honest about them.

## What number should the docs advertise

The issue proposed a served-style number derived deterministically. I measured a live `initialize` + `tools/list` in three environments to check that was viable:

| Environment | `tools/list` |
|---|---|
| Schema-default config, this repo | 150 |
| Whatever #431 measured on | 165 |
| My local install (`node dist/cli.js serve`) | 172 |

The spread is real: 17 tools are framework-gated, another 22 only register under non-default config (topology, subprojects, API contracts), and 7 aliases exist that no source scan sees. **A live count cannot be a number in a document** — it is a property of the reader's machine. #431's `pnpm run count:tools` measures exactly this, which is why it produced 165 there and 172 here.

So the documented number is derived statically instead: **every tool name registered anywhere under `src/tools/register`, minus the ones registered inside an `if (has('vue', ...))` block** — no repo is ever served all of those. That is 169, deterministic, and independent of both the repo and the config.

## Changes

- `tests/docs/tool-surface.ts` (new) — recursive walk, `allToolNames()` / `frameworkGatedToolNames()` / `advertisedToolCount()` / `resourceCount()`. `preset-claims.test.ts` (#427) had its own copy of the recursive walk; it now imports this one.
- `readme-claims.test.ts` — both grep helpers replaced; `execSync` import gone, so the test no longer shells out at all.
- `docs/_data/counts.yml` 165 → 169, with the derivation and the reason a live count is not it. `README.md`, `server.json`, `skills/README.md`, `skills/trace-mcp/SKILL.md` are not Jekyll-rendered, so their literals move too.
- `scripts/count-advertised-tools.mjs` — kept (it answers "what does *my* install serve"), header now says it is not the source for `counts.yml`.

## Regression guard

Two new tests:

- subdirectory tools are counted — asserts `search` / `get_symbol` / `get_outline` / `get_task_context` are in the name set;
- the framework-gate detection still finds gates — if `framework.ts` stops using `if (has(...))` the subtraction silently becomes a no-op and the advertised number jumps by 13 with no other signal, so it fails here where the cause is obvious. Also spot-checks that `find_usages` / `get_call_graph` / `get_tests_for` (in framework.ts but ungated) are *not* counted as gated.

Verified the guard actually catches what it was blind to: adding six `server.tool('__probe_N', ...)` registrations in `src/tools/register/navigation/search-tools.ts` turns 8 assertions red with `registers 175 framework-agnostic tools`. On main that edit was invisible.

## Test evidence

- `pnpm run test`: 8733 passed, 1 failed — `tests/integration/eval-cli-smoke.test.ts` `eval run --check-baseline`, which I confirmed fails identically on a stashed clean tree in this environment (retrieval eval baseline, unrelated). A rerun also flaked `tests/perf/benchmark.test.ts` on a timing assertion; it passed on the first run.
- `pnpm run typecheck` clean, `biome ci .` clean.
- `npx vitest run tests/docs/` — 49 passed.

## Note on #431

`counts.yml` said "re-measure with `pnpm run count:tools`, do not edit it from a diff". That instruction produces a different number on every machine, which is the drift it was written to prevent. This PR replaces it with a derivation the test computes and prints in its own failure message.
