### PR TITLE
ci: authenticate release-please with RELEASE_PLEASE_TOKEN (TRA-171)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,18 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      # Deliberately NOT secrets.GITHUB_TOKEN. GitHub suppresses workflow
+      # triggering from GITHUB_TOKEN-authored pushes (loop prevention), so
+      # the release PR's checks either never start or land in
+      # "action_required" on every rebase (TRA-171). A fine-grained PAT
+      # (Contents + Pull requests: read/write) is a real identity, so its
+      # pushes trigger pull_request workflows normally. No `|| GITHUB_TOKEN`
+      # fallback on purpose: if the PAT expires we want a loud failure here,
+      # not a silent slide back into the stuck-checks behaviour.
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Append upgrade instructions to release notes
         if: steps.release.outputs.release_created == 'true'


### PR DESCRIPTION
## Summary
- Swaps the `release-please-action` `token:` from `secrets.GITHUB_TOKEN` to the newly provisioned `secrets.RELEASE_PLEASE_TOKEN` (fine-grained PAT, `Contents` + `Pull requests` read/write).
- Root cause (TRA-171): GitHub deliberately suppresses workflow triggering from `GITHUB_TOKEN`-authored pushes as loop prevention. That's why the release PR's checks either never appeared on the head SHA or sat in `action_required` after every rebase — and it's the same restriction `release.yml`'s hand-duplicated `impact-report` job already documents working around.
- No `|| secrets.GITHUB_TOKEN` fallback on purpose: if the PAT expires we want a loud failure, not a silent slide back into stuck checks.

## Not in this PR
`approve-release-pr-runs.yml` (cron auto-approver) and the duplicated `impact-report` job in `release.yml` both exist solely because of this restriction. Leaving them as a safety net until 2-3 release cycles confirm the token swap holds, then removing both in a follow-up.

## Test plan
- [x] `RELEASE_PLEASE_TOKEN` confirmed present in repo secrets.
- [x] One-line change verified as the only diff against `master`.
- [ ] Merging this pushes to `master` and runs the Release workflow under the PAT; verify the resulting release-please PR's checks start on their own with no `action_required` and no cron approval.

Supersedes #434 (branch got tangled by a force-push).