### PR TITLE
fix(docs): reconcile the README language count and guard every occurrence (TRA-272)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ trace-mcp combines **code graph navigation**, **cross-session memory**, and **re
 - **vs. token-efficient exploration** (Repomix, jCodeMunch, cymbal) — trace-mcp adds framework edges, refactoring, security, and subprojects on top of symbol lookup.
 - **vs. session-memory tools** (MemPalace, claude-mem, ConPort) — trace-mcp links decisions to specific symbols/files, so they surface automatically in impact analysis.
 - **vs. RAG / doc-gen** (DeepContext, smart-coding-mcp) — trace-mcp answers "show me the execution path, deps, and tests," not "find code similar to this query."
-- **vs. code-graph MCP servers** (Serena, Roam-Code) — trace-mcp has the broadest language coverage (81) and is the only one with cross-language framework edges.
+- **vs. code-graph MCP servers** (Serena, Roam-Code) — trace-mcp has the broadest language coverage (80 languages) and is the only one with cross-language framework edges.
 
 > Full side-by-side tables with GitHub stars, languages, and per-capability coverage: [docs/comparisons.md](docs/comparisons.md).
 
@@ -249,7 +249,7 @@ benchmark_project  # runs against the current project
 
 ### Supported stack
 
-**Languages (81):** PHP, TypeScript, JavaScript, Python, Go, Java, Kotlin, Ruby, Rust, C, C++, C#, Swift, Objective-C, Objective-C++, Dart, Scala, Groovy, Elixir, Erlang, Haskell, Gleam, Bash, Lua, Perl, GDScript, R, Julia, Nix, SQL, PL/SQL, HCL/Terraform, Protocol Buffers, GraphQL, Prisma, Vue SFC, HTML, CSS/SCSS/SASS/LESS, XML/XUL/XSD, YAML, JSON, TOML, Assembly, Fortran, AutoHotkey, Verse, AL, Blade, EJS, Zig, OCaml, Clojure, F#, Elm, CUDA, COBOL, Verilog/SystemVerilog, GLSL, Meson, Vim Script, Common Lisp, Emacs Lisp, Dockerfile, Makefile, CMake, INI, Svelte, Markdown, MATLAB, Lean 4, FORM, Magma, Wolfram/Mathematica, Ada, Apex, D, Nim, Pascal, PowerShell, Solidity, Tcl
+**Languages:** PHP, TypeScript, JavaScript, Python, Go, Java, Kotlin, Ruby, Rust, C, C++, C#, Swift, Objective-C, Objective-C++, Dart, Scala, Groovy, Elixir, Erlang, Haskell, Gleam, Bash, Lua, Perl, GDScript, R, Julia, Nix, SQL, PL/SQL, HCL/Terraform, Protocol Buffers, GraphQL, Prisma, Vue SFC, HTML, CSS/SCSS/SASS/LESS, XML/XUL/XSD, YAML, JSON, TOML, Assembly, Fortran, AutoHotkey, Verse, AL, Blade, EJS, Zig, OCaml, Clojure, F#, Elm, CUDA, COBOL, Verilog/SystemVerilog, GLSL, Meson, Vim Script, Common Lisp, Emacs Lisp, Dockerfile, Makefile, CMake, INI, Svelte, Astro, Markdown, MATLAB, Lean 4, FORM, Magma, Wolfram/Mathematica, Ada, Apex, D, Nim, Pascal, PowerShell, Solidity, Tcl
 
 **Frameworks:** Laravel (+ Livewire, Nova, Filament, Pennant), Django (+ DRF), FastAPI, Flask, Express, NestJS, Fastify, Hono, Next.js, Nuxt, Rails, Spring, tRPC
 

--- a/tests/docs/readme-claims.test.ts
+++ b/tests/docs/readme-claims.test.ts
@@ -161,15 +161,19 @@ describe('README numeric claims', () => {
     }
   });
 
-  it('languages count in README matches registered language plugins (±2)', () => {
-    const claim = findClaim(/languages?/, readme, 'languages count');
-    expect(claim, 'no "X languages" claim found in README').not.toBeNull();
-    if (!claim) return;
-    if (!within(langPlugins, claim.count, 2)) {
-      throw new Error(
-        `README claims ${claim.count} languages; registry has ${langPlugins}. ` +
-          `Update README.md line: "${claim.rawLine}"`,
-      );
+  it('every languages count in README matches registered language plugins (±2)', () => {
+    // TRA-272: first-match-only let README say "80 languages" on line 36 and
+    // "language coverage (81)" further down for months. Scan every occurrence,
+    // the way the docs-site block already does.
+    const claims = findAllClaims(/languages?/, readme);
+    expect(claims.length, 'no "X languages" claim found in README').toBeGreaterThan(0);
+    for (const claim of claims) {
+      if (!within(langPlugins, claim.count, 2)) {
+        throw new Error(
+          `README claims ${claim.count} languages; registry has ${langPlugins}. ` +
+            `Update README.md line: "${claim.rawLine}"`,
+        );
+      }
     }
   });
 


### PR DESCRIPTION
Closes TRA-272 (in-repo half).

README stated its language count twice and disagreed with itself — line 36 said "80 languages", line 151 said "language coverage (81)", and the language list was labelled "(81)". The registry has **80** language plugins.

The existing guard never caught it for two reasons, both fixed here:

1. The README block used `findClaim()`, which returns the **first** match only. The docs-site block already switched to `findAllClaims()` for exactly this reason (TRA-174 found llms.txt contradicting itself in one file); the README block never got the same treatment.
2. `(81)` doesn't match `(\d+)\s+languages?`, so even a full scan would have missed it. Line 151 now reads "(80 languages)" — a shape the guard can see.

The language list itself is user-facing names, not plugins (Objective-C / Objective-C++ and TypeScript / JavaScript are one plugin each), so it can never equal the plugin count. Dropped the number instead of restating it wrongly, and added **Astro**, which ships as a language plugin but was missing from the list.

## Test evidence

- `npx vitest run tests/docs/readme-claims.test.ts` — 38 passed.
- Negative check: planting "91 languages" on line 151 fails with `README claims 91 languages; registry has 80`, then passes again on the real value. The old first-match check did not fail on that line at all.
- Full suite: `pnpm run test` — 8738 passed, 9 skipped, 795 files.
- `pnpm run build` clean, biome clean.

No tool-count changes here — those belong to #433 (TRA-268), which this deliberately does not touch to avoid a conflict in `docs/_data/counts.yml`.

## Outside this repo

The other half of TRA-272 is numbers that already escaped: [davila7/claude-code-templates#844](https://github.com/davila7/claude-code-templates/pull/844) refreshes the component catalog's stale "60 framework integrations and 81 languages" and qualifies its unconditional "up to 99% token reduction" into the session-average / per-call-peak split our own README uses.
