### PR TITLE
fix(daemon): bound post-update forced reindex attempts (TRA-274)

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -1,5 +1,0 @@
-import {readdirSync,readFileSync,statSync} from 'fs';
-import {join} from 'path';
-const pat=new RegExp(process.argv[3]);
-function walk(d){for(const e of readdirSync(d)){if(e==='node_modules'||e==='.git'||e==='dist')continue;const p=join(d,e);const s=statSync(p);if(s.isDirectory())walk(p);else if(/\.(ts|js)$/.test(e)){const L=readFileSync(p,'utf8').split('\n');L.forEach((l,i)=>{if(pat.test(l))console.log(`${p}:${i+1}: ${l.trim().slice(0,200)}`)});}}}
-walk(process.argv[2]);

--- a/scan.mjs
+++ b/scan.mjs
@@ -1,0 +1,5 @@
+import {readdirSync,readFileSync,statSync} from 'fs';
+import {join} from 'path';
+const pat=new RegExp(process.argv[3]);
+function walk(d){for(const e of readdirSync(d)){if(e==='node_modules'||e==='.git'||e==='dist')continue;const p=join(d,e);const s=statSync(p);if(s.isDirectory())walk(p);else if(/\.(ts|js)$/.test(e)){const L=readFileSync(p,'utf8').split('\n');L.forEach((l,i)=>{if(pat.test(l))console.log(`${p}:${i+1}: ${l.trim().slice(0,200)}`)});}}}
+walk(process.argv[2]);

--- a/src/__tests__/pending-reindex-attempts.test.ts
+++ b/src/__tests__/pending-reindex-attempts.test.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// TRA-274: `pendingReindexForVersion` was cleared only after a forced rebuild
+// COMPLETED. On a machine where the daemon is restarted before that (many
+// concurrent CLI sessions sharing one launchd daemon), the flag survived every
+// restart, so every new daemon force-rebuilt every registered project again —
+// a livelock that ran 264 restarts without a single project finishing.
+// The attempt counter bounds it: after MAX_PENDING_REINDEX_ATTEMPTS tries the
+// flag is dropped and the project falls back to the cheap incremental path.
+
+describe('pending-reindex attempt bounding (TRA-274)', () => {
+  let tmpHome: string;
+  let registry: typeof import('../registry.js');
+
+  beforeEach(async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-reindex-'));
+    vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+    vi.resetModules();
+    registry = await import('../registry.js');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function addProject(name: string): string {
+    const dir = path.join(tmpHome, name);
+    fs.mkdirSync(dir, { recursive: true });
+    registry.registerProject(dir);
+    return dir;
+  }
+
+  it('counts attempts across daemon restarts and gives up after the cap', () => {
+    const root = addProject('proj');
+    registry.markAllProjectsPendingReindex('2.0.0');
+
+    for (let i = 1; i <= registry.MAX_PENDING_REINDEX_ATTEMPTS; i++) {
+      expect(registry.recordPendingReindexAttempt(root)).toBe(i);
+      // Still within budget — the forced rebuild is allowed to run.
+      expect(registry.getProject(root)?.pendingReindexForVersion).toBe('2.0.0');
+    }
+
+    // One restart past the cap: the daemon drops the flag instead of
+    // force-rebuilding forever.
+    expect(registry.recordPendingReindexAttempt(root)).toBeGreaterThan(
+      registry.MAX_PENDING_REINDEX_ATTEMPTS,
+    );
+  });
+
+  it('clearPendingReindex also clears the attempt counter', () => {
+    const root = addProject('proj');
+    registry.markAllProjectsPendingReindex('2.0.0');
+    registry.recordPendingReindexAttempt(root);
+
+    registry.clearPendingReindex(root);
+
+    const entry = registry.getProject(root);
+    expect(entry?.pendingReindexForVersion).toBeUndefined();
+    expect(entry?.pendingReindexAttempts).toBeUndefined();
+  });
+
+  it('a new version resets the attempt counter', () => {
+    const root = addProject('proj');
+    registry.markAllProjectsPendingReindex('2.0.0');
+    registry.recordPendingReindexAttempt(root);
+    registry.recordPendingReindexAttempt(root);
+
+    registry.markAllProjectsPendingReindex('2.1.0');
+
+    expect(registry.getProject(root)?.pendingReindexAttempts).toBeUndefined();
+    expect(registry.recordPendingReindexAttempt(root)).toBe(1);
+  });
+});

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -36,6 +36,8 @@ import {
   findOverlappingProjects,
   getProject,
   listProjects,
+  MAX_PENDING_REINDEX_ATTEMPTS,
+  recordPendingReindexAttempt,
   unregisterProject,
   updateLastIndexed,
 } from '../registry.js';
@@ -432,13 +434,32 @@ export class ProjectManager {
     // "trace-mcp version bump" from "reindex storm in post-update migrations",
     // which used to block the event loop long enough that the desktop app's
     // /health watchdog shot the daemon with `daemon restart`. See updater.ts.
+    // TRA-274: the flag used to be cleared only on SUCCESS. On a machine where
+    // many concurrent CLI sessions share one launchd daemon, the mass rebuild
+    // starves /health, a session restarts the daemon, and no project ever
+    // finishes — so every boot force-rebuilt every project again, forever.
+    // Burn an attempt BEFORE the rebuild starts and give up past the cap.
     const registryEntry = getProject(projectRoot);
-    const needsForcedReindex = registryEntry?.pendingReindexForVersion !== undefined;
+    let needsForcedReindex = registryEntry?.pendingReindexForVersion !== undefined;
     if (needsForcedReindex) {
-      logger.info(
-        { projectRoot, forVersion: registryEntry?.pendingReindexForVersion },
-        'Lazy post-update reindex: forcing full index rebuild for this project',
-      );
+      const attempt = recordPendingReindexAttempt(projectRoot);
+      if (attempt > MAX_PENDING_REINDEX_ATTEMPTS) {
+        needsForcedReindex = false;
+        logger.warn(
+          { projectRoot, forVersion: registryEntry?.pendingReindexForVersion, attempt },
+          'Lazy post-update reindex: giving up after repeated unfinished attempts — falling back to incremental index',
+        );
+        try {
+          clearPendingReindex(projectRoot);
+        } catch {
+          /* non-fatal — worst case we retry the cap check next boot */
+        }
+      } else {
+        logger.info(
+          { projectRoot, forVersion: registryEntry?.pendingReindexForVersion, attempt },
+          'Lazy post-update reindex: forcing full index rebuild for this project',
+        );
+      }
     }
     managed.initialIndexPromise = this.indexAllLimit!(() => pipeline.indexAll(needsForcedReindex))
       .then(async () => {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -25,6 +25,14 @@ export interface RegistryEntry {
    */
   pendingReindexForVersion?: string;
   /**
+   * How many times a daemon has *started* the forced rebuild for
+   * {@link pendingReindexForVersion} without finishing it. Bounded by
+   * {@link MAX_PENDING_REINDEX_ATTEMPTS} so a daemon that keeps getting
+   * restarted mid-rebuild eventually gives up instead of force-rebuilding
+   * every project on every boot forever (TRA-274).
+   */
+  pendingReindexAttempts?: number;
+  /**
    * ISO timestamp of the first time this root was observed missing. Set by
    * {@link sweepMissingRoots}, cleared the moment the root reappears (e.g. an
    * unmounted drive). Lets the automatic startup sweep wait out a grace period
@@ -520,6 +528,7 @@ export function markAllProjectsPendingReindex(version: string): number {
   for (const entry of Object.values(reg.projects)) {
     if (entry.pendingReindexForVersion !== version) {
       entry.pendingReindexForVersion = version;
+      delete entry.pendingReindexAttempts;
       count++;
     }
   }
@@ -527,13 +536,41 @@ export function markAllProjectsPendingReindex(version: string): number {
   return count;
 }
 
+/**
+ * Give up on the forced post-update rebuild after this many daemon starts that
+ * began it but never finished. Beyond the cap the project falls back to the
+ * cheap incremental index; a genuinely stale schema is still repaired by the
+ * FK-auto-recovery retry in ProjectManager.addProject.
+ */
+export const MAX_PENDING_REINDEX_ATTEMPTS = 3;
+
+/**
+ * Record that a daemon is starting the forced rebuild for this project and
+ * return the new attempt count. Persisted BEFORE the rebuild runs so a daemon
+ * killed mid-rebuild still burns an attempt — that is what makes the storm
+ * terminate (TRA-274).
+ */
+export function recordPendingReindexAttempt(root: string): number {
+  const absRoot = path.resolve(root);
+  const reg = loadRegistry();
+  const entry = reg.projects[absRoot];
+  if (!entry) return 0;
+  entry.pendingReindexAttempts = (entry.pendingReindexAttempts ?? 0) + 1;
+  saveRegistry(reg);
+  return entry.pendingReindexAttempts;
+}
+
 /** Clear the pending-reindex flag for one project after a successful reindex. */
 export function clearPendingReindex(root: string): void {
   const absRoot = path.resolve(root);
   const reg = loadRegistry();
   const entry = reg.projects[absRoot];
-  if (entry && entry.pendingReindexForVersion !== undefined) {
+  if (
+    entry &&
+    (entry.pendingReindexForVersion !== undefined || entry.pendingReindexAttempts !== undefined)
+  ) {
     delete entry.pendingReindexForVersion;
+    delete entry.pendingReindexAttempts;
     saveRegistry(reg);
   }
 }


### PR DESCRIPTION
Fixes TRA-274.

## Root cause

`pendingReindexForVersion` (registry.json) is stamped on **every** registered project by post-update migrations, and cleared **only after** that project's forced full rebuild completes. That is at-least-once semantics on an unbounded-cost operation, under a supervisor that restarts eagerly. On a machine with many concurrent CLI sessions sharing one launchd daemon it livelocks:

1. v2.0.0 post-update stamps all 107 registered projects.
2. Daemon boots, loads all of them, force-rebuilds each — starving the event loop so `/health` stops answering.
3. Concurrent CLI sessions see an unresponsive daemon, back off, and eventually `launchctl kickstart -k` (SIGTERM).
4. The daemon dies 5–80 s in, before nearly any project finishes, so `clearPendingReindex` never runs. Go to 2.

Field evidence from the v2.0.0 release machine:

- `launchctl print` → `runs = 264`
- daemon.log: 52 daemon starts, `"Lazy post-update reindex: forcing full index rebuild"` logged **3379** times (~107 projects × 32 boots) for a flag stamped **twice**
- 38 `"reason":"SIGTERM"` shutdowns, per-pid lifetimes 5–80 s, one peaking at 3566 MB RSS
- one hour after release: **102 of 107 projects still flagged** — 5 had ever completed
- user-visible: a fresh checkout stuck at 200/1701 files (12%) with zero progress

The existing `#237` restart-war guard (alive-process back-off before restart) doesn't help, because the rebuild takes far longer than the back-off window and then it restarts anyway.

## Fix

Bound the retry. `recordPendingReindexAttempt(root)` persists an attempt counter **before** the rebuild starts, so a daemon killed mid-rebuild still burns an attempt. Past `MAX_PENDING_REINDEX_ATTEMPTS` (3) the flag is dropped and the project falls back to the cheap incremental index. A genuinely stale schema is still repaired by the FK-auto-recovery retry already in `addProject`.

Worst case is now 3 forced-rebuild boots instead of unbounded.

## Test evidence

- New `src/__tests__/pending-reindex-attempts.test.ts` — counter survives restarts and caps; `clearPendingReindex` clears it; a new version resets it.
- `pnpm run test`: **796 files, 8743 passed**, 9 skipped, 0 failed.
- `pnpm run lint` (`tsc --noEmit`): clean. `pnpm run build`: clean.

No MCP tool-signature changes. Registry schema change is additive and optional (`pendingReindexAttempts?: number`), readable by older versions.

## Also done

Cleared the 97 stale flags in `~/.trace-mcp/registry.json` on the affected dev machine (backup at `registry.json.tra274.bak`) to stop the storm that was running now — that's an operational mitigation, not part of this diff.
