### PR TITLE
fix(docs): our own surfaces said 85 framework integrations, the registry has 87 (TRA-272)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 > AI systems don't scale because they recompute instead of reuse. Every turn, the agent re-reads the same files, re-traverses the same dependencies, and re-inflates the context window with structure it already discovered. Token bills grow. Latency grows. Reasoning quality drops. The model isn't the bottleneck — the recomputation leak is.
 >
-> trace-mcp builds a framework-aware graph of your codebase **once**, then serves it through MCP so the agent reasons from a precomputed structure instead of brute-reading the repo. Ask *"what breaks if I change this model?"* — instead of 80 Grep calls and 190 file reads, the agent calls `get_change_impact` once and gets the blast radius across PHP, Vue, migrations, and DI. One tool call replaces ~42 minutes of agent exploration. 85 framework integrations across 80 languages, 169 tools.
+> trace-mcp builds a framework-aware graph of your codebase **once**, then serves it through MCP so the agent reasons from a precomputed structure instead of brute-reading the repo. Ask *"what breaks if I change this model?"* — instead of 80 Grep calls and 190 file reads, the agent calls `get_change_impact` once and gets the blast radius across PHP, Vue, migrations, and DI. One tool call replaces ~42 minutes of agent exploration. 87 framework integrations across 80 languages, 169 tools.
 >
 > **The same engine indexes markdown vaults.** `[[wikilinks]]` become first-class edges, frontmatter and `#tags` become metadata, headings become nested sections. `find_usages` returns backlinks. `apply_rename` rewrites every link to a renamed note. One MCP for code and knowledge — no second tool to plug in.
 
@@ -76,7 +76,7 @@ We started with code intelligence — the hardest, noisiest context most agents 
 
 **Four things no other tool does:**
 
-1. **Framework-aware edges** — trace-mcp understands that `Inertia::render('Users/Show')` connects PHP to Vue, that `@Injectable()` creates a DI dependency, that `$user->posts()` means a `posts` table from migrations. 85 framework integrations.
+1. **Framework-aware edges** — trace-mcp understands that `Inertia::render('Users/Show')` connects PHP to Vue, that `@Injectable()` creates a DI dependency, that `$user->posts()` means a `posts` table from migrations. 87 framework integrations.
 
 2. **Code-linked decision memory** — when you record "chose PostgreSQL for JSONB support", it's linked to `src/db/connection.ts::Pool#class`. When someone runs `get_change_impact` on that symbol, they see the decision. MemPalace stores decisions as text; trace-mcp ties them to the dependency graph.
 
@@ -143,7 +143,7 @@ The app talks to the same `trace-mcp` daemon (`http://127.0.0.1:3741`) that MCP 
 
 ## How trace-mcp compares
 
-trace-mcp combines **code graph navigation**, **cross-session memory**, and **real-time code understanding** in a single tool. Most adjacent projects solve one of these — trace-mcp unifies all three and is the only one with **framework-aware cross-language edges** (85 integrations) and **code-linked decision memory**.
+trace-mcp combines **code graph navigation**, **cross-session memory**, and **real-time code understanding** in a single tool. Most adjacent projects solve one of these — trace-mcp unifies all three and is the only one with **framework-aware cross-language edges** (87 framework integrations) and **code-linked decision memory**.
 
 - **vs. token-efficient exploration** (Repomix, jCodeMunch, cymbal) — trace-mcp adds framework edges, refactoring, security, and subprojects on top of symbol lookup.
 - **vs. session-memory tools** (MemPalace, claude-mem, ConPort) — trace-mcp links decisions to specific symbols/files, so they surface automatically in impact analysis.

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -44,7 +44,7 @@ Tools that help AI agents read code with fewer tokens — AST parsing, outlines,
 | Tree-sitter AST parsing | ✅ 80 languages | ✅ compress only (~20) | ❌ no code parsing | ✅ 23 langs + Jupyter | ✅ 70+ languages | ✅ 161 languages | ✅ 22 languages |
 | Token-efficient symbol lookup | ✅ outlines, symbols, bundles | ❌ packs entire files | ✅ sandboxed output (98% reduction) | ✅ | ✅ core focus (~95% reduction) | ✅ | ✅ outline/show/context |
 | Cross-file dependency graph | ✅ directed edge graph | ❌ | ❌ | ✅ incremental knowledge graph | ✅ import graph | ✅ knowledge graph | ✅ refs/importers |
-| Framework-aware edges | ✅ 85 integrations | ❌ | ❌ | ❌ | ✅ 21 frameworks (route/middleware) | partial (REST routes) | ❌ |
+| Framework-aware edges | ✅ 87 integrations | ❌ | ❌ | ❌ | ✅ 21 frameworks (route/middleware) | partial (REST routes) | ❌ |
 | Impact analysis | ✅ reverse dep traversal + decorator filter | ❌ | ❌ | ✅ blast-radius + Leiden communities | ✅ blast radius + decorator filter | ✅ detect_changes | ✅ impact command |
 | Call graph | ✅ bidirectional, graph-based | ❌ | ❌ | ✅ graph-based | ✅ AST-based, bidirectional | ✅ trace_call_path | ✅ refs/importers |
 | Refactoring tools | ✅ rename, extract, dead code, codemod | ❌ | ❌ | ❌ | ❌ (dead code detect only) | ❌ | ❌ |

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,7 +75,7 @@ layout: null
     "@type": "SoftwareApplication",
     "name": "trace-mcp",
     "alternateName": "trace-mcp — Recomputation → Reuse for AI Systems",
-    "description": "AI agents recompute the same work every turn — re-reading files, re-traversing dependencies, re-inflating context. trace-mcp makes them reuse instead. 40–50% fewer tokens on average, up to 2× effective capacity, up to 99% less redundant processing. Framework-aware dependency graph via MCP, 80 languages, 85 integrations.",
+    "description": "AI agents recompute the same work every turn — re-reading files, re-traversing dependencies, re-inflating context. trace-mcp makes them reuse instead. 40–50% fewer tokens on average, up to 2× effective capacity, up to 99% less redundant processing. Framework-aware dependency graph via MCP, 80 languages, 87 integrations.",
     "url": "https://trace-mcp.com/",
     "image": "https://trace-mcp.com/og-image.png",
     "applicationCategory": "DeveloperApplication",
@@ -108,7 +108,7 @@ layout: null
       "40–50% fewer tokens on average across real agent workflows",
       "Up to 2× effective capacity at the same context budget",
       "Up to 99% less redundant processing in structured tasks (code navigation, dependency traversal)",
-      "Framework-aware dependency graph (85 integrations, 80 languages)",
+      "Framework-aware dependency graph (87 integrations, 80 languages)",
       "{{ site.data.counts.tools }} MCP tools for navigation, impact analysis, refactoring",
       "Local-first: SQLite + bundled ONNX embeddings, zero API keys",
       "Native Model Context Protocol integration"
@@ -127,7 +127,7 @@ layout: null
         "name": "What is the best MCP server for giving Claude Code codebase context?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across 80 languages) and exposes {{ site.data.counts.tools }} MCP tools — outline, symbol lookup, call graph, impact analysis, dead code detection — so Claude Code queries precomputed structure instead of re-reading files every turn. It runs entirely locally with no API keys, works with 85 framework integrations, and typically cuts token usage 40–50% versus raw file reads while producing more consistent answers as the codebase grows. It's open source (MIT), installs with 'npm install -g trace-mcp', and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf."
+          "text": "trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across 80 languages) and exposes {{ site.data.counts.tools }} MCP tools — outline, symbol lookup, call graph, impact analysis, dead code detection — so Claude Code queries precomputed structure instead of re-reading files every turn. It runs entirely locally with no API keys, works with 87 framework integrations, and typically cuts token usage 40–50% versus raw file reads while producing more consistent answers as the codebase grows. It's open source (MIT), installs with 'npm install -g trace-mcp', and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf."
         }
       },
       {
@@ -175,7 +175,7 @@ layout: null
         "name": "What about my framework? Is it supported?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "80 languages and 85 framework integrations ship out of the box. For unsupported frameworks, the plugin API is open — write a custom plugin in TypeScript, register it via ~/.trace-mcp/plugins/. Most plugins are ~200–500 lines."
+          "text": "80 languages and 87 framework integrations ship out of the box. For unsupported frameworks, the plugin API is open — write a custom plugin in TypeScript, register it via ~/.trace-mcp/plugins/. Most plugins are ~200–500 lines."
         }
       },
       {
@@ -2185,7 +2185,7 @@ layout: null
         <div class="def-text">
           <h3>This is how agents stop <span class="em">recomputing and start reusing.</span></h3>
           <p><strong>Computed once</strong> &mdash; every symbol, every edge, across 80 languages in one directed graph. The agent queries it instead of rediscovering it each turn.</p>
-          <p><strong>Framework-aware</strong> &mdash; routes to controllers, Inertia to Vue, Eloquent to migrations. 85 integrations capture edges the agent would otherwise reconstruct from raw files.</p>
+          <p><strong>Framework-aware</strong> &mdash; routes to controllers, Inertia to Vue, Eloquent to migrations. 87 integrations capture edges the agent would otherwise reconstruct from raw files.</p>
           <p><strong>Compiler-grade where it matters</strong> &mdash; optional LSP enrichment with <code>tsserver</code>, <code>pyright</code>, <code>gopls</code> for call resolution that survives across calls.</p>
           <p><strong>Reused, not rebuilt</strong> &mdash; 300ms file-watcher debounce and content-hashed incremental reindex keep the graph fresh without redoing finished work.</p>
         </div>
@@ -2371,7 +2371,7 @@ layout: null
       <div class="diff-block reveal">
         <ul class="diff-list">
           <li><span class="num">/ 01</span><span><strong>Computed once, queried many times</strong> &mdash; a graph, not a text index that gets re-ranked every turn.</span></li>
-          <li><span class="num">/ 02</span><span><strong>Framework-aware edges</strong> across 85 integrations &mdash; routes, ORMs, views, DI captured up front, not rediscovered from raw files.</span></li>
+          <li><span class="num">/ 02</span><span><strong>Framework-aware edges</strong> across 87 integrations &mdash; routes, ORMs, views, DI captured up front, not rediscovered from raw files.</span></li>
           <li><span class="num">/ 03</span><span><strong>Tools that return answers</strong>, not snippets to read &mdash; <code>get_change_impact</code>, <code>get_call_graph</code>, <code>find_usages</code> over a precomputed structure.</span></li>
           <li><span class="num">/ 04</span><span><strong>Reuse survives the session</strong> &mdash; incremental reindex, decision memory, agent-behavior rules keep cost from rebounding.</span></li>
         </ul>
@@ -2485,7 +2485,7 @@ layout: null
       <div class="section-meta">
         <div class="section-meta-tag"><span class="label">011 / Ecosystem</span></div>
         <div>
-          <h2 class="section-title">85 integrations. <span class="em">80 languages.</span></h2>
+          <h2 class="section-title">87 integrations. <span class="em">80 languages.</span></h2>
           <p class="section-lede">Each integration adds framework-specific edges &mdash; routes, components, migrations, queries &mdash; not just syntax parsing. Plugin API is open: write your own for a niche framework in under a day.</p>
         </div>
       </div>
@@ -2631,7 +2631,7 @@ layout: null
             <h3>What is the best MCP server for giving Claude Code codebase context?</h3>
             <span class="toggle">+</span>
           </summary>
-          <div class="answer">trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across 80 languages) and exposes {{ site.data.counts.tools }} MCP tools &mdash; outline, symbol lookup, call graph, impact analysis, dead code detection &mdash; so Claude Code queries precomputed structure instead of re-reading files every turn. It runs entirely locally with no API keys, works with 85 framework integrations, and typically cuts token usage 40&ndash;50% versus raw file reads while producing more consistent answers as the codebase grows. It's open source (MIT), installs with <code>npm install -g trace-mcp</code>, and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf.</div>
+          <div class="answer">trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across 80 languages) and exposes {{ site.data.counts.tools }} MCP tools &mdash; outline, symbol lookup, call graph, impact analysis, dead code detection &mdash; so Claude Code queries precomputed structure instead of re-reading files every turn. It runs entirely locally with no API keys, works with 87 framework integrations, and typically cuts token usage 40&ndash;50% versus raw file reads while producing more consistent answers as the codebase grows. It's open source (MIT), installs with <code>npm install -g trace-mcp</code>, and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf.</div>
         </details>
         <details class="faq">
           <summary>
@@ -2673,7 +2673,7 @@ layout: null
             <h3>What about my framework? Is it supported?</h3>
             <span class="toggle">+</span>
           </summary>
-          <div class="answer">80 languages and 85 framework integrations ship out of the box. For unsupported frameworks, the plugin API is open &mdash; write a custom plugin in TypeScript, register it via <code>~/.trace-mcp/plugins/</code>. Most plugins are ~200&ndash;500 lines.</div>
+          <div class="answer">80 languages and 87 framework integrations ship out of the box. For unsupported frameworks, the plugin API is open &mdash; write a custom plugin in TypeScript, register it via <code>~/.trace-mcp/plugins/</code>. Most plugins are ~200&ndash;500 lines.</div>
         </details>
         <details class="faq">
           <summary>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -258,7 +258,7 @@ Tools that help AI agents read code with fewer tokens — AST parsing, outlines,
 | Tree-sitter AST parsing | ✅ 80 languages | ✅ compress only (~20) | ❌ no code parsing | ✅ 23 langs + Jupyter | ✅ 70+ languages | ✅ 158 languages | ✅ 22 languages |
 | Token-efficient symbol lookup | ✅ outlines, symbols, bundles | ❌ packs entire files | ✅ sandboxed output (98% reduction) | ✅ | ✅ core focus (~95% reduction) | ✅ | ✅ outline/show/context |
 | Cross-file dependency graph | ✅ directed edge graph | ❌ | ❌ | ✅ incremental knowledge graph | ✅ import graph | ✅ knowledge graph | ✅ refs/importers |
-| Framework-aware edges | ✅ 85 integrations | ❌ | ❌ | ❌ | ✅ 21 frameworks (route/middleware) | partial (REST routes) | ❌ |
+| Framework-aware edges | ✅ 87 integrations | ❌ | ❌ | ❌ | ✅ 21 frameworks (route/middleware) | partial (REST routes) | ❌ |
 | Impact analysis | ✅ reverse dep traversal + decorator filter | ❌ | ❌ | ✅ blast-radius + Leiden communities | ✅ blast radius + decorator filter | ✅ detect_changes | ✅ impact command |
 | Call graph | ✅ bidirectional, graph-based | ❌ | ❌ | ✅ graph-based | ✅ AST-based, bidirectional | ✅ trace_call_path | ✅ refs/importers |
 | Refactoring tools | ✅ rename, extract, dead code, codemod | ❌ | ❌ | ❌ | ❌ (dead code detect only) | ❌ | ❌ |
@@ -2499,7 +2499,7 @@ these after any large refactor round — don't treat them as permanent.
 ## max_cyclomatic_complexity: 130 (warning)
 
 The generic default of 30 fires on nearly every language/framework plugin in
-this repo — dispatch tables for 80 languages and 85 frameworks are
+this repo — dispatch tables for 80 languages and 87 frameworks are
 inherently branchy. After decomposing every class that was a genuine
 god-object (`DecisionStore` 262→96, `TopologyStore` 125→49,
 `IndexingPipeline` 137→115, plus tool-gate/api-routes/memory-tools splits),

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,7 +5,7 @@ layout: null
 ---
 # trace-mcp
 
-> trace-mcp is a framework-aware MCP server that serves precomputed code intelligence — a dependency graph, full-text search, impact analysis, and decision memory — to cut token usage for AI coding agents. It understands 85 frameworks across 80 languages and exposes {{ site.data.counts.tools }} MCP tools over stdio or HTTP.
+> trace-mcp is a framework-aware MCP server that serves precomputed code intelligence — a dependency graph, full-text search, impact analysis, and decision memory — to cut token usage for AI coding agents. It understands 87 frameworks across 80 languages and exposes {{ site.data.counts.tools }} MCP tools over stdio or HTTP.
 
 ## Docs
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -38,7 +38,7 @@ these after any large refactor round — don't treat them as permanent.
 ## max_cyclomatic_complexity: 130 (warning)
 
 The generic default of 30 fires on nearly every language/framework plugin in
-this repo — dispatch tables for 80 languages and 85 frameworks are
+this repo — dispatch tables for 80 languages and 87 frameworks are
 inherently branchy. After decomposing every class that was a genuine
 god-object (`DecisionStore` 262→96, `TopologyStore` 125→49,
 `IndexingPipeline` 137→115, plus tool-gate/api-routes/memory-tools splits),

--- a/docs/supported-frameworks.md
+++ b/docs/supported-frameworks.md
@@ -1,5 +1,5 @@
 ---
-title: "Supported Languages & Frameworks — 80 languages, 85 framework integrations"
+title: "Supported Languages & Frameworks — 80 languages, 87 framework integrations"
 description: "Full list of languages and frameworks trace-mcp understands out of the box — web frameworks, ORMs, UI libraries, and tooling, across 80 languages."
 ---
 

--- a/tests/docs/readme-claims.test.ts
+++ b/tests/docs/readme-claims.test.ts
@@ -124,15 +124,18 @@ describe('README numeric claims', () => {
   const fwPlugins = registry.getAllFrameworkPlugins().length;
   const toolCount = countServerToolCalls();
 
-  it('frameworks count in README is within tolerance of registered framework plugins', () => {
-    const claim = findClaim(/framework integrations?/, readme, 'frameworks-integration count');
-    expect(claim, 'no "X framework integrations" claim found in README').not.toBeNull();
-    if (!claim) return;
-    if (!within(fwPlugins, claim.count, 5)) {
-      throw new Error(
-        `README claims ${claim.count} framework integrations; registry has ${fwPlugins}. ` +
-          `Update README.md line: "${claim.rawLine}"`,
-      );
+  it('every frameworks count in README is within tolerance of registered framework plugins', () => {
+    // TRA-272: same first-match-only gap as the languages check below — README
+    // states this number twice and only the first one was ever verified.
+    const claims = findAllClaims(/framework integrations?/, readme);
+    expect(claims.length, 'no "X framework integrations" claim found in README').toBeGreaterThan(0);
+    for (const claim of claims) {
+      if (!within(fwPlugins, claim.count, 5)) {
+        throw new Error(
+          `README claims ${claim.count} framework integrations; registry has ${fwPlugins}. ` +
+            `Update README.md line: "${claim.rawLine}"`,
+        );
+      }
     }
   });
 


### PR DESCRIPTION
Follow-up to #437, same issue (TRA-272).

TRA-272 is about numbers that escaped the repo into third-party listings. While fixing the catalog entry (davila7/claude-code-templates#844) I had to state the real framework count — and found our own surfaces all say **85** while the registry has **87**:

| Surface | Occurrences |
|---|---|
| `README.md` | 2 |
| `docs/index.html` | 9 |
| `docs/llms-full.txt` | 2 |
| `docs/llms.txt`, `docs/comparisons.md`, `docs/quality-gates.md`, `docs/supported-frameworks.md` | 1 each |

The guard's ±5 tolerance meant nothing ever failed, so the whole set sat two off. That's the exact re-seeding mechanism this issue is about: external listings copy our headline, so leaving our pages on 85 while the catalog PR says 87 would recreate the drift the day it merges.

Two changes:

1. **Swept 85 → 87 across every surface.** README's `(85 integrations)` becomes `(87 framework integrations)` — the bare parenthetical is the same blind spot that hid `language coverage (81)` in #437, since `(\d+)\s+framework integrations?` never matched it.
2. **Widened the README frameworks check** from `findClaim()` (first match only) to `findAllClaims()`, mirroring what #437 did for languages. README states this number twice and only the first was ever verified.

## Test evidence

- `npx vitest run tests/docs/` — 49 passed.
- Full suite: 8740 passed, 9 skipped, 795 files.
- biome clean.

## Not done here

The structural fix is to move `languages` and `frameworks` into `docs/_data/counts.yml` next to `tools` and have the pages read them through Liquid, the way TRA-263 did for the tool count — a sweep like this one will otherwise be needed on every plugin add. That's a bigger diff (≈15 prose sites on the homepage alone) and belongs in its own PR.
