### PR TITLE
fix(update): recover an app bundle swap interrupted by a reboot (TRA-280)

### DIFF
--- a/scripts/apply-pending-update.mjs
+++ b/scripts/apply-pending-update.mjs
@@ -12,7 +12,10 @@
  *   5. Launch the new app via `open -a` and clear the pending markers.
  *
  * All errors are swallowed silently — a failed apply leaves the previous
- * installation untouched, and the next postinstall run will retry.
+ * installation untouched, and the next postinstall run will retry. A hard
+ * kill inside the swap itself (reboot, power loss) is not an error we can
+ * catch, so both this script and the postinstall call
+ * `recoverInterruptedSwap()` first to put the backup back.
  *
  * Usage: node apply-pending-update.mjs <parent-pid>
  *
@@ -26,7 +29,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { APP_NAME, locateInstalledApp } from './locate-app.mjs';
+import { APP_NAME, locateInstalledApp, recoverInterruptedSwap } from './locate-app.mjs';
 
 // Resolved by main() via locateInstalledApp(). Pending-zip and version markers
 // must live next to the actual `.app` (atomic `fs.renameSync` requires the
@@ -241,6 +244,12 @@ async function main() {
     log('abort: not darwin');
     return;
   }
+  // Settle a previously interrupted swap before resolving: restore the backup
+  // if a crash left no live bundle, drop it if it is just a leftover.
+  for (const { action, path: target } of recoverInterruptedSwap()) {
+    log(`recover: ${action} ${target}`);
+  }
+
   const located = locateInstalledApp();
   if (!located) {
     log('abort: locateInstalledApp returned null (no bundle resolved)');

--- a/scripts/locate-app.mjs
+++ b/scripts/locate-app.mjs
@@ -101,6 +101,97 @@ export function locateInstalledApp(options = {}) {
 }
 
 /**
+ * Repair an update swap that died halfway through.
+ *
+ * Both swap sites (`postinstall-app.mjs` and `apply-pending-update.mjs`) do:
+ *
+ *     rename(trace-mcp.app -> trace-mcp.app.bak-<pid>)   <-- crash window
+ *     rename(<staged>      -> trace-mcp.app)
+ *     rm -rf trace-mcp.app.bak-<pid>                     <-- crash window
+ *
+ * A reboot, SIGKILL or power loss inside the first window leaves the user with
+ * NO bundle at all — only `trace-mcp.app.bak-<pid>`, which macOS treats as a
+ * plain folder. `locateInstalledApp()` then returns null forever, so both
+ * scripts abort at their first gate and nothing ever retries: the install is
+ * bricked until the user reinstalls by hand. A crash inside the second window
+ * leaks a full Electron bundle (hundreds of MB) that nothing cleans up.
+ *
+ * This scans the directories we could have swapped in and settles both cases:
+ * restore the backup when the live bundle is missing, delete it when it is
+ * not. Only `<appName>.bak-<digits>` is touched — that name is written by us
+ * and by nothing else.
+ *
+ * Best-effort by design: every filesystem error is swallowed, exactly like the
+ * callers that invoke it.
+ *
+ * @param {LocateOptions} [options]
+ * @returns {Array<{ action: 'restored' | 'reclaimed', path: string }>}
+ */
+export function recoverInterruptedSwap(options = {}) {
+  const platform = options.platform ?? process.platform;
+  if (platform !== 'darwin') return [];
+
+  const home = options.homeDir ?? os.homedir();
+  const appName = options.appName ?? APP_NAME;
+  const bundleId = options.bundleId ?? BUNDLE_ID;
+  const plistBuddyBin = options.plistBuddyBin ?? '/usr/libexec/PlistBuddy';
+  const fallbackDirs = options.fallbackDirs ?? [path.join(home, 'Applications'), '/Applications'];
+
+  // The marker's directory is where a drag-installed bundle actually lives, so
+  // it must be scanned too — but the marker cannot be resolved through
+  // locateInstalledApp() here, because after an interrupted swap the path it
+  // names no longer validates. Read the raw path instead.
+  const dirs = new Set(fallbackDirs);
+  const markerAppPath = readMarkerAppPath(path.join(home, '.trace-mcp', LOCATION_MARKER_FILENAME));
+  if (markerAppPath) dirs.add(path.dirname(markerAppPath));
+
+  const backupPattern = new RegExp(`^${escapeRegExp(appName)}\\.bak-\\d+$`);
+  const actions = [];
+
+  for (const dir of dirs) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir);
+    } catch {
+      continue;
+    }
+    const appPath = path.join(dir, appName);
+    for (const entry of entries) {
+      if (!backupPattern.test(entry)) continue;
+      const backupPath = path.join(dir, entry);
+      try {
+        if (fs.existsSync(appPath)) {
+          fs.rmSync(backupPath, { recursive: true, force: true });
+          actions.push({ action: 'reclaimed', path: backupPath });
+        } else if (isValidAppBundle(backupPath, bundleId, plistBuddyBin)) {
+          // Only restore something that really is our bundle — never promote
+          // a half-extracted directory into the install path.
+          fs.renameSync(backupPath, appPath);
+          actions.push({ action: 'restored', path: appPath });
+        }
+      } catch {
+        /* best-effort; the next run retries */
+      }
+    }
+  }
+
+  return actions;
+}
+
+function readMarkerAppPath(markerPath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(markerPath, 'utf-8'));
+    return typeof parsed?.appPath === 'string' ? parsed.appPath : null;
+  } catch {
+    return null;
+  }
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
  * Write the location marker. Called by Electron main on every startup with
  * `process.execPath`-derived path. Best-effort: failures are swallowed
  * because losing the marker degrades gracefully to mdfind fallback.

--- a/scripts/postinstall-app.mjs
+++ b/scripts/postinstall-app.mjs
@@ -30,7 +30,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { getAppDistRepo } from './app-dist-repo.mjs';
-import { APP_NAME, locateInstalledApp } from './locate-app.mjs';
+import { APP_NAME, locateInstalledApp, recoverInterruptedSwap } from './locate-app.mjs';
 
 // Resolved at top-level after the platform/no-update gates run. `null` means
 // no install was found — the script then exits 0 like the old hardcoded
@@ -88,6 +88,15 @@ function stopRunningDaemon() {
 stopRunningDaemon();
 
 if (process.platform !== 'darwin') process.exit(0);
+
+// Settle any swap that a reboot or kill interrupted before we try to resolve
+// the bundle — otherwise a half-swapped install resolves to nothing and this
+// script exits below, leaving the user permanently without an app. This is
+// the recovery path that actually fires in practice: the daemon's self-update
+// re-runs the postinstall even when the .app cannot be launched at all.
+for (const { action, path: target } of recoverInterruptedSwap()) {
+  console.log(`  trace-mcp: ${action} ${target} (interrupted update)`);
+}
 
 const located = locateInstalledApp();
 if (!located) process.exit(0);

--- a/tests/scripts/locate-app-recovery.test.ts
+++ b/tests/scripts/locate-app-recovery.test.ts
@@ -1,0 +1,177 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const MODULE_PATH = path.join(REPO_ROOT, 'scripts', 'locate-app.mjs');
+
+const BUNDLE_ID = 'com.trace-mcp.app';
+
+function createBundleAt(appPath: string, bundleId: string = BUNDLE_ID): string {
+  const contents = path.join(appPath, 'Contents');
+  fs.mkdirSync(contents, { recursive: true });
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>${bundleId}</string>
+</dict>
+</plist>
+`;
+  fs.writeFileSync(path.join(contents, 'Info.plist'), plist);
+  return appPath;
+}
+
+function runRecover(opts: {
+  homeDir: string;
+  fallbackDirs: string[];
+  platform?: NodeJS.Platform;
+}): Array<{ action: string; path: string }> {
+  const harness = `
+import { recoverInterruptedSwap } from ${JSON.stringify(MODULE_PATH)};
+const opts = JSON.parse(process.argv[2]);
+process.stdout.write(JSON.stringify(recoverInterruptedSwap(opts)));
+`;
+  const harnessPath = path.join(opts.homeDir, 'recover-harness.mjs');
+  fs.writeFileSync(harnessPath, harness);
+  const stdout = execFileSync(process.execPath, [harnessPath, JSON.stringify(opts)], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+    timeout: 15_000,
+  });
+  return JSON.parse(stdout);
+}
+
+function runLocate(opts: {
+  homeDir: string;
+  fallbackDirs: string[];
+  platform?: NodeJS.Platform;
+}): { appPath: string; source: string } | null {
+  const harness = `
+import { locateInstalledApp } from ${JSON.stringify(MODULE_PATH)};
+const opts = JSON.parse(process.argv[2]);
+// Neutralise Spotlight so the test only sees the fixture directories.
+opts.mdfindBin = '/nonexistent/mdfind';
+process.stdout.write(JSON.stringify(locateInstalledApp(opts)));
+`;
+  const harnessPath = path.join(opts.homeDir, 'locate-harness.mjs');
+  fs.writeFileSync(harnessPath, harness);
+  const stdout = execFileSync(process.execPath, [harnessPath, JSON.stringify(opts)], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+    timeout: 15_000,
+  });
+  return JSON.parse(stdout);
+}
+
+// The recovery helper reads .app bundle layouts; it is a no-op on Windows and
+// the fixtures below assume POSIX rename semantics, so skip on win32 hosts.
+describe.skipIf(process.platform === 'win32')('recoverInterruptedSwap', () => {
+  let home: string;
+  let installDir: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-recover-'));
+    installDir = path.join(home, 'Applications');
+    fs.mkdirSync(installDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('restores the backup when the swap was interrupted after the first rename', () => {
+    // The exact on-disk state left behind when the machine reboots between
+    // `rename(app -> app.bak-PID)` and `rename(staged -> app)`.
+    const appPath = path.join(installDir, 'trace-mcp.app');
+    createBundleAt(`${appPath}.bak-4242`);
+
+    const actions = runRecover({ homeDir: home, fallbackDirs: [installDir], platform: 'darwin' });
+
+    expect(actions).toEqual([{ action: 'restored', path: appPath }]);
+    expect(fs.existsSync(path.join(appPath, 'Contents', 'Info.plist'))).toBe(true);
+    expect(fs.existsSync(`${appPath}.bak-4242`)).toBe(false);
+  });
+
+  it('reclaims a leftover backup when the live bundle is already in place', () => {
+    const appPath = path.join(installDir, 'trace-mcp.app');
+    createBundleAt(appPath);
+    createBundleAt(`${appPath}.bak-99`);
+
+    const actions = runRecover({ homeDir: home, fallbackDirs: [installDir], platform: 'darwin' });
+
+    expect(actions).toEqual([{ action: 'reclaimed', path: `${appPath}.bak-99` }]);
+    expect(fs.existsSync(`${appPath}.bak-99`)).toBe(false);
+    // The live bundle must be untouched.
+    expect(fs.existsSync(path.join(appPath, 'Contents', 'Info.plist'))).toBe(true);
+  });
+
+  it('leaves a backup that is not a real bundle alone', () => {
+    const appPath = path.join(installDir, 'trace-mcp.app');
+    fs.mkdirSync(`${appPath}.bak-7`, { recursive: true });
+
+    const actions = runRecover({ homeDir: home, fallbackDirs: [installDir], platform: 'darwin' });
+
+    expect(actions).toEqual([]);
+    expect(fs.existsSync(`${appPath}.bak-7`)).toBe(true);
+    expect(fs.existsSync(appPath)).toBe(false);
+  });
+
+  it('ignores directories that only look like our backups', () => {
+    const appPath = path.join(installDir, 'trace-mcp.app');
+    createBundleAt(path.join(installDir, 'trace-mcp.app.backup'));
+    createBundleAt(path.join(installDir, 'trace-mcp.app.bak-old'));
+
+    const actions = runRecover({ homeDir: home, fallbackDirs: [installDir], platform: 'darwin' });
+
+    expect(actions).toEqual([]);
+    expect(fs.existsSync(path.join(installDir, 'trace-mcp.app.backup'))).toBe(true);
+    expect(fs.existsSync(path.join(installDir, 'trace-mcp.app.bak-old'))).toBe(true);
+    expect(fs.existsSync(appPath)).toBe(false);
+  });
+
+  it('recovers in the marker directory even when it is not a conventional install dir', () => {
+    const markerDir = path.join(home, 'custom-apps');
+    fs.mkdirSync(markerDir, { recursive: true });
+    const appPath = path.join(markerDir, 'trace-mcp.app');
+    createBundleAt(`${appPath}.bak-11`);
+    fs.mkdirSync(path.join(home, '.trace-mcp'), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, '.trace-mcp', 'app-location.json'),
+      JSON.stringify({ appPath, bundleId: BUNDLE_ID, writtenAt: Date.now() }),
+    );
+
+    const actions = runRecover({ homeDir: home, fallbackDirs: [installDir], platform: 'darwin' });
+
+    expect(actions).toEqual([{ action: 'restored', path: appPath }]);
+    expect(fs.existsSync(path.join(appPath, 'Contents', 'Info.plist'))).toBe(true);
+  });
+
+  it('turns a bricked install back into one locateInstalledApp can resolve', () => {
+    // Regression guard for the actual user-visible symptom: with only the
+    // .bak- directory on disk, resolution fails and every caller aborts.
+    const appPath = path.join(installDir, 'trace-mcp.app');
+    createBundleAt(`${appPath}.bak-4242`);
+    const opts = { homeDir: home, fallbackDirs: [installDir], platform: 'darwin' as const };
+
+    expect(runLocate(opts)).toBeNull();
+    runRecover(opts);
+    expect(runLocate(opts)?.appPath).toBe(appPath);
+  });
+
+  it('is a no-op on non-darwin platforms', () => {
+    const appPath = path.join(installDir, 'trace-mcp.app');
+    createBundleAt(`${appPath}.bak-1`);
+
+    const actions = runRecover({ homeDir: home, fallbackDirs: [installDir], platform: 'linux' });
+
+    expect(actions).toEqual([]);
+    expect(fs.existsSync(`${appPath}.bak-1`)).toBe(true);
+  });
+});


### PR DESCRIPTION
## The failure

Both update swap sites — `scripts/postinstall-app.mjs` and `scripts/apply-pending-update.mjs` — do the same three steps:

```
rename(trace-mcp.app -> trace-mcp.app.bak-<pid>)   <-- crash window 1
rename(<staged>      -> trace-mcp.app)
rm -rf trace-mcp.app.bak-<pid>                     <-- crash window 2
```

A reboot, power loss or SIGKILL inside **window 1** leaves the user with no bundle at all — only `trace-mcp.app.bak-<pid>`, which macOS treats as a plain folder. `locateInstalledApp()` then returns null forever (marker path no longer validates, mdfind hits are rejected by the `Info.plist` check, fallback dirs are empty), so both scripts abort at their first gate and **nothing ever retries**. The install stays bricked until the user reinstalls by hand. The `apply-pending-update.mjs` docstring claiming "a failed apply leaves the previous installation untouched" was not true for this window — `try/catch` can't catch a kill.

A crash in **window 2** leaks a full Electron bundle (hundreds of MB) that nothing cleans up.

This is the "reboot during update" scenario from TRA-280's brief. Neither window had any recovery path in the tree — `grep` for `bak-` finds only the two writers.

## The fix

`recoverInterruptedSwap()` in `scripts/locate-app.mjs`, called ahead of resolution in both scripts:

- live bundle missing + a valid `<appName>.bak-<digits>` present → rename it back;
- live bundle present + a leftover backup → delete it;
- backup that isn't a real bundle → left alone (never promote a half-extracted dir into the install path).

Scans the conventional install dirs plus the *raw* path from `~/.trace-mcp/app-location.json` (it can't go through `locateInstalledApp()` — after an interrupted swap that path no longer validates, which is the whole problem). Only the pid-suffixed name we write is matched; `trace-mcp.app.backup` and `trace-mcp.app.bak-old` are ignored.

The recovery that actually fires in practice is the postinstall one: the daemon's self-update re-runs `npm install -g trace-mcp` even when the `.app` can't be launched, so a bricked install heals itself without the user doing anything.

## Test evidence

New `tests/scripts/locate-app-recovery.test.ts`, 7 cases including the end-to-end symptom guard:

```
expect(runLocate(opts)).toBeNull();   // bricked: only .bak- on disk
runRecover(opts);
expect(runLocate(opts)?.appPath).toBe(appPath);   // resolves again
```

```
✓ tests/scripts/locate-app-recovery.test.ts (7 tests)
✓ tests/scripts/locate-app.test.ts (9 tests)
✓ tests/scripts/apply-pending-update.test.ts (4 tests)
✓ tests/scripts/postinstall-control-plane.test.ts (4 tests)
```

Full suite: `796 passed | 1 failed | 2 skipped`. The one failure is `tests/docs/internal-links.test.ts` "every lastmod is at least the source page last commit date" — pre-existing, reproduced on a clean stash of this branch, unrelated to this change, and skipped in CI (the guard no-ops on shallow clones). Someone needs to run `pnpm docs:sitemap` after today's docs commits.

`pnpm run build` and `pnpm run lint` clean. No MCP tool signature or schema changes; no token-cost impact.

Closes TRA-280 scope item "reboot during update".
