### PR TITLE
fix(docs): refresh stale sitemap lastmod and run the guard in CI (TRA-282)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history: tests/docs/internal-links.test.ts dates each docs page
+          # from git and self-skips on a shallow clone, so at fetch-depth 1 the
+          # stale-lastmod guard could never fail where it matters.
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -32,7 +32,7 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/supported-frameworks.html</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -62,7 +62,7 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/quality-gates.html</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/tests/docs/internal-links.test.ts
+++ b/tests/docs/internal-links.test.ts
@@ -59,10 +59,9 @@ describe('docs footer nav covers every indexed page', () => {
    */
   it('every lastmod is at least the source page last commit date', async () => {
     const { sourceFor, gitDate, isShallow } = await import('../../scripts/gen-sitemap.mjs');
-    // ponytail: a shallow clone dates every file to the single fetched commit,
-    // so the CI `test` job (fetch-depth 1) would flag untouched pages. The guard
-    // runs on any full clone — local `pnpm test` before a docs PR. Give the job
-    // fetch-depth: 0 if it ever needs to catch this in CI too.
+    // A shallow clone dates every file to the single fetched commit, which would
+    // flag untouched pages — so skip there. The CI `test` job checks out with
+    // fetch-depth: 0 precisely so this guard runs before a docs PR merges.
     if (isShallow()) return;
     const xml = readFileSync(join(DOCS, 'sitemap.xml'), 'utf-8');
     const stale = [


### PR DESCRIPTION
Two docs pages were advertising a stale `lastmod` to Google, and the test that catches it could not run where it mattered.

**The stale data.** Today's docs commits (TRA-272 / TRA-268 / TRA-263) edited `supported-frameworks.html` and `quality-gates.html` without regenerating `docs/sitemap.xml`, leaving both at `2026-08-26`. Regenerated with `pnpm docs:sitemap`.

**The guard.** `tests/docs/internal-links.test.ts` dates each page from git and self-skips on a shallow clone, while the CI `test` job checked out at `fetch-depth: 1` — so the check only ever fired on a full local clone, i.e. after merge. The test job now checks out with `fetch-depth: 0` (1336 commits; the clone cost is noise next to a 12-minute test job). The `isShallow()` skip stays as a safety valve for any other shallow context.

**Test evidence**

```
$ pnpm exec vitest run tests/docs/internal-links.test.ts
 ✓ tests/docs/internal-links.test.ts (4 tests) 196ms
```

Confirmed the guard actually bites — with the sitemap fix stashed:

```
AssertionError: sitemap lastmod older than the page's last commit — run `pnpm docs:sitemap`:
  /supported-frameworks.html (2026-08-26 < 2026-08-28), /quality-gates.html (2026-08-26 < 2026-08-28)
Tests  1 failed | 3 passed (4)
```

Closes TRA-282.
