### PR TITLE
perf(daemon): cap eager project loading at startup (TRA-278)

### DIFF
--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -5,7 +5,11 @@
       "date": "2026-08-28T13:23:05Z",
       "app_version": "1.51.1",
       "commit": "9459d4ce",
-      "env": { "os": "macOS 26.5 (darwin 25.5.0)", "arch": "arm64", "node": "22.22.3" },
+      "env": {
+        "os": "macOS 26.5 (darwin 25.5.0)",
+        "arch": "arm64",
+        "node": "22.22.3"
+      },
       "samples": 3,
       "metrics": {
         "cold_start_ms": 349,
@@ -16,11 +20,21 @@
         "heap_growth_mb_per_hour": null,
         "main_cpu_idle_pct": 0,
         "renderer_bundle_kb": 1461,
-        "artifact_mb": { "mac_app_unpacked": 264.8, "mac_asar": 1.6, "win": null }
+        "artifact_mb": {
+          "mac_app_unpacked": 264.8,
+          "mac_asar": 1.6,
+          "win": null
+        }
       },
       "raw_samples": [
-        { "cold_start_ms": 349, "window_interactive_ms": 127 },
-        { "cold_start_ms": 362, "window_interactive_ms": 121 },
+        {
+          "cold_start_ms": 349,
+          "window_interactive_ms": 127
+        },
+        {
+          "cold_start_ms": 362,
+          "window_interactive_ms": 121
+        },
         {
           "cold_start_ms": 332,
           "window_interactive_ms": 79,
@@ -29,6 +43,35 @@
         }
       ],
       "notes": "Installation run — first entry in the series, no regression comparison possible. Harness: packages/app/scripts/perf-measure.mjs (CDP against a production build, throwaway --user-data-dir per sample). Startup, idle heap and idle CPU are all far inside the absolute ceilings (349 ms vs 3000, 0% vs 2%). Artifact fix landed in this same run: app.asar 21.8 MB -> 1.6 MB and the .app 286 MB -> 265 MB by excluding node_modules from the electron-builder file set (the main process imports only Node builtins + electron; Vite already bundles every renderer dep) and dropping the unused `menubar` dependency. Startup timings are unaffected by that change — the dev launch path never touches the asar; the 439 ms measured earlier in the same session vs 349 ms here is machine warm-up, not a code delta. Measured negative result: stubbing out the 702 KB cosmos.gl chunk (eagerly loaded via a static import in the entry chunk) moved cold start only 439 -> 417 ms (~5%), so lazy-loading the graph view is not worth the refactor at this size. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour not measured this run — they need a fixed indexed project fixture, which the next run should add."
+    },
+    {
+      "date": "2026-08-28T17:15:00Z",
+      "app_version": "1.51.1",
+      "commit": "30d4de7a",
+      "env": {
+        "os": "macOS 26.5 (darwin 25.5.0)",
+        "arch": "arm64",
+        "node": "22.22.3"
+      },
+      "samples": 1,
+      "scope": "daemon-memory (TRA-278)",
+      "metrics": {
+        "tree_rss_peak_mb": 3619,
+        "tree_rss_idle_mb": 166,
+        "tree_cpu_peak_pct": 96,
+        "rss_after_index_settle_mb": 312,
+        "rss_by_role_mb": {
+          "mcp_server_http_peak": 3619,
+          "mcp_server_http_idle_no_projects": 166,
+          "mcp_server_http_one_repo_settled": 312,
+          "mcp_server_stdio_per_session": 180,
+          "app_main": 123,
+          "app_renderer": 80,
+          "app_gpu_helper": 45,
+          "app_network_utility": 19
+        }
+      },
+      "notes": "Daemon memory, not the Electron app (GPU out of scope). Source of the 3.34 GB `node` process in the Activity Monitor screenshot: `serve-http`. Identified from the daemon's own vitals heartbeat in ~/.trace-mcp/daemon.log — peak sample was rss 3619 MB / heap_used 2758 MB at uptime 66 s with projects_loaded=107, against a 166 MB idle baseline with 0 projects. Cause is startup fan-out, not a leak: loadAllRegistered() eagerly added all 110 registered projects. Controlled measurement in an isolated TRACE_MCP_DATA_DIR with 40 *empty* two-file projects: 212 MB (n=1) -> 381 MB (n=10) -> 1198 MB (n=40), i.e. ~9 MB of LIVE JS heap per loaded project (423 MB heapUsed after a forced CDP GC) before the project holds any code. Not a leak — after the idle-unload sweep dropped all 40 projects a forced GC returned heapUsed to 62 MB and RSS to 198 MB; the flat `heap_used_mb` seen in vitals on an idle daemon is stale-since-last-GC reporting, and macOS holds RSS pages well past the heap shrinking, so both Activity Monitor and vitals rss overstate. Fix: `daemon_eager_load_projects` (default 8) caps startup loading to the most recently indexed projects; the rest lazily load on first MCP connect via the existing idle-unload reload path. Same 40-project fixture after the fix: peak 378 MB (-67%), settled 253 MB, and a deferred project still serves (initialize -> 200, project reaches ready). Single real repo (this one, ~900 files) on the fixed daemon: peak 442 MB, 312 MB after a 10-minute settle. Harness: scale-probe.mjs / lazy-check.mjs / mem-probe.mjs from the TRA-278 workdir (not committed — they drive a real daemon against throwaway data dirs)."
     }
   ]
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -980,6 +980,17 @@ export const TraceMcpConfigSchema = z.object({
    */
   project_idle_unload_minutes: z.number().min(0).max(1440).default(30),
   /**
+   * How many registered projects the HTTP daemon loads eagerly at startup,
+   * most-recently-indexed first. The rest stay registered and load lazily on
+   * their first request, exactly like an idle-unloaded project.
+   *
+   * A loaded project costs ~9 MB of live JS heap before it holds any code
+   * (TRA-278), so an unbounded eager load turned ~100 registered repos into a
+   * multi-GB RSS spike at every daemon start. 0 disables the cap and restores
+   * the old load-everything behaviour.
+   */
+  daemon_eager_load_projects: z.number().int().min(0).max(1000).default(8),
+  /**
    * Per-project-connection SQLite page cache size, in MB, applied via
    * `PRAGMA cache_size` on every index DB connection (one per registered
    * project in the daemon). Memory cost scales linearly with project count —

--- a/src/daemon/__tests__/eager-load.test.ts
+++ b/src/daemon/__tests__/eager-load.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { selectEagerLoadRoots } from '../eager-load.js';
+import type { RegistryEntry } from '../../registry.js';
+
+function entry(
+  root: string,
+  lastIndexed: string | null,
+  addedAt = '2020-01-01T00:00:00.000Z',
+): RegistryEntry {
+  return { name: root, root, dbPath: `${root}.db`, lastIndexed, addedAt };
+}
+
+describe('selectEagerLoadRoots', () => {
+  it('loads everything when the registry fits under the cap', () => {
+    const entries = [entry('/a', null), entry('/b', null)];
+    const { eager, deferred } = selectEagerLoadRoots(entries, 8);
+    expect(eager).toHaveLength(2);
+    expect(deferred).toHaveLength(0);
+  });
+
+  it('keeps the most recently indexed projects and defers the rest', () => {
+    const entries = [
+      entry('/old', '2026-01-01T00:00:00.000Z'),
+      entry('/newest', '2026-08-28T00:00:00.000Z'),
+      entry('/middle', '2026-06-01T00:00:00.000Z'),
+    ];
+    const { eager, deferred } = selectEagerLoadRoots(entries, 2);
+    expect(eager.map((e) => e.root)).toEqual(['/newest', '/middle']);
+    expect(deferred.map((e) => e.root)).toEqual(['/old']);
+  });
+
+  it('falls back to addedAt for never-indexed projects', () => {
+    const entries = [
+      entry('/never-old', null, '2020-01-01T00:00:00.000Z'),
+      entry('/never-new', null, '2026-08-01T00:00:00.000Z'),
+    ];
+    const { eager } = selectEagerLoadRoots(entries, 1);
+    expect(eager.map((e) => e.root)).toEqual(['/never-new']);
+  });
+
+  it('cap 0 opts out of the cap entirely', () => {
+    const entries = Array.from({ length: 50 }, (_, i) => entry(`/p${i}`, null));
+    const { eager, deferred } = selectEagerLoadRoots(entries, 0);
+    expect(eager).toHaveLength(50);
+    expect(deferred).toHaveLength(0);
+  });
+
+  it('does not mutate the caller array', () => {
+    const entries = [
+      entry('/a', '2026-01-01T00:00:00.000Z'),
+      entry('/b', '2026-08-01T00:00:00.000Z'),
+    ];
+    selectEagerLoadRoots(entries, 1);
+    expect(entries.map((e) => e.root)).toEqual(['/a', '/b']);
+  });
+});

--- a/src/daemon/eager-load.ts
+++ b/src/daemon/eager-load.ts
@@ -1,0 +1,37 @@
+/**
+ * Startup eager-load selection for `serve-http`.
+ *
+ * The daemon used to call `addProject()` for every registered project at
+ * boot. Each loaded project costs ~9 MB of live JS heap plus its SQLite page
+ * cache / mmap window *before it holds any code* (TRA-278 measurement: 40
+ * empty two-file projects => 423 MB live heap after a forced GC), so a
+ * developer machine with ~100 registered repos paid multi-GB RSS at every
+ * daemon start for projects nobody was using.
+ *
+ * Projects left out here are not lost: a registered root that is absent from
+ * the ProjectManager is treated exactly like an idle-unloaded one — the first
+ * request lazily re-adds it and gets 503 + Retry-After while it warms (see
+ * `project_idle_unload_minutes` and cli.ts serve-http Phase 5.1).
+ */
+import type { RegistryEntry } from '../registry.js';
+
+/** Recency key: last successful index, falling back to registration time. */
+function recencyOf(entry: RegistryEntry): number {
+  const raw = entry.lastIndexed ?? entry.addedAt;
+  const t = raw ? Date.parse(raw) : Number.NaN;
+  return Number.isNaN(t) ? 0 : t;
+}
+
+/**
+ * Split registered projects into the ones to load at boot and the ones to
+ * leave for lazy load. `cap <= 0` disables the cap (loads everything, the
+ * pre-TRA-278 behaviour).
+ */
+export function selectEagerLoadRoots(
+  entries: RegistryEntry[],
+  cap: number,
+): { eager: RegistryEntry[]; deferred: RegistryEntry[] } {
+  if (cap <= 0 || entries.length <= cap) return { eager: entries, deferred: [] };
+  const ranked = [...entries].sort((a, b) => recencyOf(b) - recencyOf(a));
+  return { eager: ranked.slice(0, cap), deferred: ranked.slice(cap) };
+}

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -11,7 +11,7 @@ import {
 } from '../ai/index.js';
 import { SummarizationPipeline } from '../ai/summarization-pipeline.js';
 import type { TraceMcpConfig } from '../config.js';
-import { loadConfig } from '../config.js';
+import { loadConfig, loadGlobalConfigRaw } from '../config.js';
 import { initializeDatabase } from '../db/schema.js';
 import { Store } from '../db/store.js';
 import { ensureGlobalDirs, getDbPath, TOPOLOGY_DB_PATH } from '../global.js';
@@ -46,6 +46,7 @@ import { createServer } from '../server/server.js';
 import { SubprojectManager } from '../subproject/manager.js';
 import { TopologyStore } from '../topology/topology-db.js';
 import { trailingDebounce } from '../util/debounce.js';
+import { selectEagerLoadRoots } from './eager-load.js';
 import { serializeError } from './log-error.js';
 import {
   removeProjectArtifacts,
@@ -1102,13 +1103,25 @@ export class ProjectManager {
           'Keep the per-project registrations and `trace-mcp remove` the container root.',
       );
     }
+    // TRA-278: loading every registered project costs ~9 MB of live heap each
+    // before any code is indexed, so a machine with ~100 registered repos paid
+    // multi-GB RSS at every daemon start. Load only the most recently indexed
+    // ones; the rest load lazily on first request (same path as idle-unload).
+    const cap = loadGlobalConfigRaw().daemon_eager_load_projects;
+    const { eager, deferred } = selectEagerLoadRoots(entries, typeof cap === 'number' ? cap : 8);
+    if (deferred.length > 0) {
+      logger.info(
+        { eager: eager.length, deferred: deferred.length },
+        'Deferring cold registered projects to lazy load (daemon_eager_load_projects)',
+      );
+    }
     // Phase 5+7 audit fix: addProject() runs synchronous setup (DB open, plugin
     // registry, watcher start, ~250-500ms each) BEFORE reaching the
     // semaphore-gated indexAll(). Without a gate, N parallel addProject() calls
     // produce a thundering herd of disk I/O at boot. Cap parallel setup at 2.
     const addLimit = pLimit(2);
     const results = await Promise.allSettled(
-      entries.map((entry) => addLimit(() => this.addProject(entry.root))),
+      eager.map((entry) => addLimit(() => this.addProject(entry.root))),
     );
     for (let i = 0; i < results.length; i++) {
       if (results[i].status === 'rejected') {
@@ -1119,14 +1132,17 @@ export class ProjectManager {
         const reason = (results[i] as PromiseRejectedResult).reason;
         logger.error(
           {
-            projectRoot: entries[i].root,
-            dbPath: getDbPath(entries[i].root),
+            projectRoot: eager[i].root,
+            dbPath: getDbPath(eager[i].root),
             error: serializeError(reason),
           },
           'Failed to load registered project',
         );
       }
     }
-    logger.info({ count: this.projects.size, total: entries.length }, 'Loaded registered projects');
+    logger.info(
+      { count: this.projects.size, total: entries.length, deferred: deferred.length },
+      'Loaded registered projects',
+    );
   }
 }


### PR DESCRIPTION
## What

Caps how many registered projects the HTTP daemon loads at startup.
`loadAllRegistered()` used to `addProject()` every registry entry; new
`daemon_eager_load_projects` (default 8) keeps only the most recently indexed
ones and leaves the rest to the existing lazy-load path. `0` restores the old
load-everything behaviour.

Fixes TRA-278 (periodic multi-GB `node` spikes — 3.34 GB in Activity Monitor).

## Why

Identified the process from the daemon's own vitals heartbeat in
`~/.trace-mcp/daemon.log`. The spike is `serve-http`, and it is a startup
fan-out, not a leak:

```
rss 3619 MB  heap_used 2758 MB  uptime 66 s  projects_loaded 107   <- peak
rss  166 MB  heap_used   66 MB  uptime  3 s  projects_loaded   0   <- idle baseline
```

That machine has 110 registered projects. Controlled measurement in an isolated
`TRACE_MCP_DATA_DIR`, using 40 **empty** two-file projects so indexing work is ~0:

| registered projects | daemon RSS |
|---|---|
| 1 | 212 MB |
| 10 | 381 MB |
| 40 | 1198 MB |

≈ 9 MB of *live* JS heap per loaded project (423 MB `heapUsed` at n=40 after a
forced CDP `HeapProfiler.collectGarbage`) before the project holds a single
symbol. Extrapolated to 110 registered projects that is ~2.9 GB of baseline,
which is what the screenshot shows.

Not a leak: after the idle-unload sweep dropped all 40 projects, a forced GC
returned `heapUsed` to 62 MB and RSS to 198 MB. The flat `heap_used_mb` in
vitals on an idle daemon is stale-since-last-GC reporting, and macOS holds RSS
pages long after the heap shrinks — both Activity Monitor and the vitals
`rss_mb` overstate a quiet daemon.

## Evidence

Same 40-project fixture, before → after this change:

| | before | after |
|---|---|---|
| projects loaded at boot | 40 | 8 |
| peak RSS | 1131 MB | **378 MB** (−67%) |
| settled RSS | 799 MB | 253 MB |

Deferred projects still serve: MCP `initialize` against a deferred root returns
200, the daemon lazily adds it, and it reaches `ready` (loaded count 8 → 9).
Single real repo (this one, ~900 files) on the fixed daemon: peak 442 MB,
312 MB after a 10-minute settle.

Numbers recorded in `docs/perf/baseline.json` under the new `tree_rss_peak_mb` /
`tree_rss_idle_mb` / `tree_cpu_peak_pct` / `rss_after_index_settle_mb` /
`rss_by_role_mb` fields.

## Tests

- New `src/daemon/__tests__/eager-load.test.ts` — recency ordering, `addedAt`
  fallback, cap 0 opt-out, no caller-array mutation.
- Full suite: 8755 passed, 9 skipped. Build clean.

## Unrelated drive-by

`docs/sitemap.xml`: refreshed the stale `lastmod` on `supported-frameworks.html`
and `quality-gates.html`. Those two pages were edited in #440 without touching
the sitemap, which left `tests/docs/internal-links.test.ts` red on master — this
PR would otherwise land on top of a red suite.
