### PR TITLE
fix(ci): restore RELEASE_PLEASE_TOKEN, dropped by the #438 squash-merge (TRA-171)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,18 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      # Deliberately NOT secrets.GITHUB_TOKEN. GitHub suppresses workflow
+      # triggering from GITHUB_TOKEN-authored pushes (loop prevention), so
+      # the release PR's checks either never start or land in
+      # "action_required" on every rebase (TRA-171). A fine-grained PAT
+      # (Contents + Pull requests: read/write) is a real identity, so its
+      # pushes trigger pull_request workflows normally. No `|| GITHUB_TOKEN`
+      # fallback on purpose: if the PAT expires we want a loud failure here,
+      # not a silent slide back into the stuck-checks behaviour.
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Append upgrade instructions to release notes
         if: steps.release.outputs.release_created == 'true'
@@ -54,78 +62,6 @@ jobs:
           UPGRADE
           )
           gh release edit "$TAG" --repo "${{ github.repository }}" --notes "${BODY}${FOOTER}"
-
-  # GITHUB_TOKEN actions don't trigger pull_request events, so the CI
-  # impact-report never fires for release-please PRs.  Run it here instead.
-  impact-report:
-    needs: release-please
-    if: needs.release-please.outputs.release_created != 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      # Mirror CI workflow env so our own postinstall scripts opt out and the
-      # auto-update is disabled during the install.
-      TRACE_MCP_NO_POSTINSTALL: '1'
-      TRACE_MCP_NO_AUTO_UPDATE: '1'
-      CI: 'true'
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm run build
-      # Same exclusions as .github/workflows/ci.yml :: test step. Without
-      # them the suite hangs on the Linux CI runner (root cause documented
-      # in the CI workflow — toon-drift, debounce-abort).
-      - run: pnpm exec vitest run --exclude='tests/perf/**' --exclude='tests/fixtures/**' --exclude='tests/languages/test_xml.test.ts' --exclude='tests/integration/**' --exclude='tests/daemon/**' --exclude='src/telemetry/__tests__/**' --exclude='src/tools/register/__tests__/toon-drift.test.ts' --exclude='tests/util/debounce-abort.test.ts' --testTimeout=30000 --hookTimeout=15000 --teardownTimeout=15000
-
-      - name: Index project
-        run: node dist/cli.js index . --force
-
-      - name: Find release-please PR
-        id: pr
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          PR_JSON=$(gh pr list --search "head:release-please--branches--master" --json number --limit 1 --jq '.[0] // empty')
-          if [ -n "$PR_JSON" ]; then
-            PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
-            # Compare against the latest release tag, not merge-base
-            # (we're on master, so merge-base with master is HEAD itself)
-            LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-            if [ -n "$LAST_TAG" ]; then
-              echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-              echo "base=$LAST_TAG" >> "$GITHUB_OUTPUT"
-              echo "head=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-            fi
-          fi
-
-      - name: Generate impact report
-        if: steps.pr.outputs.number != ''
-        run: |
-          node dist/cli.js ci-report \
-            --base ${{ steps.pr.outputs.base }} \
-            --head ${{ steps.pr.outputs.head }} \
-            --format markdown \
-            --output report.md
-
-      - name: Post PR comment
-        if: steps.pr.outputs.number != '' && hashFiles('report.md') != ''
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
-        with:
-          number: ${{ steps.pr.outputs.number }}
-          path: report.md
 
   publish:
     needs: release-please


### PR DESCRIPTION
## What broke

My own squash-merge of #438 (TRA-273) reverted `.github/workflows/release.yml` back to `secrets.GITHUB_TOKEN` and resurrected the duplicate `impact-report` job — exactly the state TRA-171 fixed in 64dc7255. Root cause: #438's branch was cut before 64dc7255 landed, and the GitHub `update-branch` API call I made before squashing did not correctly carry that fix forward into the squash diff.

Confirmed on the next release PR, #447: its checks (CodeQL, Semgrep, CI, Eval, PR Title Lint) came back `action_required`, actor `github-actions[bot]` instead of the PAT identity — the exact symptom TRA-171 was tracking.

## Fix

Restored `.github/workflows/release.yml` to the exact content of 64dc7255, keeping #438's own legitimate addition (the baked-GA-credential assertion step in `publish`). Diff verified against `git show 64dc7255:.github/workflows/release.yml` — the only difference is that one kept addition.

## Test plan

- [x] `diff` against the last-known-good commit shows only the intended addition preserved
- [ ] Next release-please PR after this merges fires CodeQL/Semgrep/impact-report automatically again, no action_required