### PR TITLE
fix(daemon): ignore dangerous project hints instead of failing MCP startup (TRA-286)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -955,6 +955,13 @@ program
         // {error: '...'} body isn't a valid JSON-RPC response. (issue #168)
         const rpcId = extractRpcId(parsedBody);
 
+        if (resolution.ignoredDangerousHint) {
+          const { projectRoot: hinted, reason, via } = resolution.ignoredDangerousHint;
+          logger.warn(
+            { hinted, reason, via, resolvedAs: resolution.kind },
+            'Ignored dangerous project hint from MCP client — resolved without it (TRA-286)',
+          );
+        }
         if (resolution.kind === 'no-projects') {
           res.writeHead(404, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify(buildNoProjectsError(rpcId)));

--- a/src/daemon/mcp-project-router.ts
+++ b/src/daemon/mcp-project-router.ts
@@ -20,7 +20,16 @@
  *   5. If exactly one project is registered, use it.
  *   6. If zero projects are registered, return "no-projects".
  *   7. Otherwise return "ambiguous" — the caller renders a 400.
+ *
+ * An explicit hint (1-3) that names a dangerous root (filesystem root, home, a
+ * system directory) is IGNORED rather than honoured: clients spawned with cwd=/
+ * (Claude Cowork/Code sessions) otherwise pinned the session to "/" and the
+ * whole MCP connection failed to start with "-32002 Refusing to index /"
+ * (TRA-286). Falling through to the tracked-client / single-project steps
+ * serves the real project instead.
  */
+
+import { isDangerousProjectRoot } from '../dangerous-root.js';
 
 export interface RegisteredProjectLike {
   root: string;
@@ -31,10 +40,14 @@ export interface TrackedClientLike {
   project: string;
 }
 
-export type ProjectResolution =
+export type ProjectResolution = (
   | { kind: 'resolved'; projectRoot: string; via: ResolutionSource }
   | { kind: 'no-projects' }
-  | { kind: 'ambiguous'; registered: string[] };
+  | { kind: 'ambiguous'; registered: string[] }
+) & {
+  /** Set when an explicit hint was dropped for naming a dangerous root. */
+  ignoredDangerousHint?: { projectRoot: string; reason: string; via: ResolutionSource };
+};
 
 export type ResolutionSource = 'query' | 'header' | 'meta' | 'tracked-client' | 'single-project';
 
@@ -95,26 +108,34 @@ function looksLikeInitialize(body: unknown): boolean {
 export function resolveProjectForMcpRequest(args: ResolveProjectArgs): ProjectResolution {
   const isInit = args.isInitializeRequest ?? looksLikeInitialize;
 
+  let ignoredDangerousHint: ProjectResolution['ignoredDangerousHint'];
+  /** Honour an explicit hint unless it names a dangerous root — then record and drop it. */
+  const useHint = (value: string | undefined, via: ResolutionSource): ProjectResolution | null => {
+    if (!value) return null;
+    const reason = isDangerousProjectRoot(value);
+    if (reason) {
+      ignoredDangerousHint ??= { projectRoot: value, reason, via };
+      return null;
+    }
+    return { kind: 'resolved', projectRoot: value, via };
+  };
+
   const queryProject =
     typeof args.queryProject === 'string' && args.queryProject.length > 0
       ? args.queryProject
       : undefined;
-  if (queryProject) {
-    return { kind: 'resolved', projectRoot: queryProject, via: 'query' };
-  }
+  const fromQuery = useHint(queryProject, 'query');
+  if (fromQuery) return fromQuery;
 
   const headerProject =
     typeof args.headerProject === 'string' && args.headerProject.length > 0
       ? args.headerProject
       : undefined;
-  if (headerProject) {
-    return { kind: 'resolved', projectRoot: headerProject, via: 'header' };
-  }
+  const fromHeader = useHint(headerProject, 'header');
+  if (fromHeader) return fromHeader;
 
-  const metaProject = extractMetaProjectRoot(args.body);
-  if (metaProject) {
-    return { kind: 'resolved', projectRoot: metaProject, via: 'meta' };
-  }
+  const fromMeta = useHint(extractMetaProjectRoot(args.body), 'meta');
+  if (fromMeta) return fromMeta;
 
   if (args.body !== undefined && isInit(args.body)) {
     const clientName = extractInitializeClientName(args.body);
@@ -124,16 +145,26 @@ export function resolveProjectForMcpRequest(args: ResolveProjectArgs): ProjectRe
         (c) => c.name === clientName && registered.has(c.project),
       );
       if (matches.length === 1) {
-        return { kind: 'resolved', projectRoot: matches[0]!.project, via: 'tracked-client' };
+        return {
+          kind: 'resolved',
+          projectRoot: matches[0]!.project,
+          via: 'tracked-client',
+          ignoredDangerousHint,
+        };
       }
     }
   }
 
   if (args.projects.length === 1) {
-    return { kind: 'resolved', projectRoot: args.projects[0]!.root, via: 'single-project' };
+    return {
+      kind: 'resolved',
+      projectRoot: args.projects[0]!.root,
+      via: 'single-project',
+      ignoredDangerousHint,
+    };
   }
   if (args.projects.length === 0) {
-    return { kind: 'no-projects' };
+    return { kind: 'no-projects', ignoredDangerousHint };
   }
-  return { kind: 'ambiguous', registered: args.projects.map((p) => p.root) };
+  return { kind: 'ambiguous', registered: args.projects.map((p) => p.root), ignoredDangerousHint };
 }

--- a/tests/daemon/mcp-project-router.test.ts
+++ b/tests/daemon/mcp-project-router.test.ts
@@ -183,6 +183,84 @@ describe('resolveProjectForMcpRequest', () => {
     expect(result).toEqual({ kind: 'no-projects' });
   });
 
+  // TRA-286: Claude Cowork/Code sessions spawn the stdio proxy with cwd=/, so
+  // the proxy hinted `?project=/`. The daemon honoured it, refused to index the
+  // filesystem root, and the whole MCP connection failed to start.
+  it('ignores a dangerous ?project= hint and falls back to the single project', () => {
+    const result = resolveProjectForMcpRequest({
+      queryProject: '/',
+      headerProject: '/',
+      body: undefined,
+      projects: [{ root: PROJ_A }],
+      trackedClients: [],
+    });
+    expect(result.kind).toBe('resolved');
+    if (result.kind === 'resolved') {
+      expect(result.projectRoot).toBe(PROJ_A);
+      expect(result.via).toBe('single-project');
+    }
+    expect(result.ignoredDangerousHint).toEqual({
+      projectRoot: '/',
+      reason: 'filesystem root',
+      via: 'query',
+    });
+  });
+
+  it('ignores a dangerous hint and still resolves via tracked client', () => {
+    const body = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { clientInfo: { name: 'claude-code' } },
+    };
+    const result = resolveProjectForMcpRequest({
+      queryProject: undefined,
+      headerProject: '/',
+      body,
+      projects: TWO_PROJECTS,
+      trackedClients: [{ name: 'claude-code', project: PROJ_B }],
+    });
+    expect(result.kind).toBe('resolved');
+    if (result.kind === 'resolved') {
+      expect(result.projectRoot).toBe(PROJ_B);
+      expect(result.via).toBe('tracked-client');
+    }
+    expect(result.ignoredDangerousHint?.via).toBe('header');
+  });
+
+  it('reports the dropped hint when the fallback cannot pick a project', () => {
+    const body = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { _meta: { 'traceMcp/projectRoot': '/' } },
+    };
+    const result = resolveProjectForMcpRequest({
+      queryProject: undefined,
+      headerProject: undefined,
+      body,
+      projects: TWO_PROJECTS,
+      trackedClients: [],
+    });
+    expect(result.kind).toBe('ambiguous');
+    expect(result.ignoredDangerousHint).toEqual({
+      projectRoot: '/',
+      reason: 'filesystem root',
+      via: 'meta',
+    });
+  });
+
+  it('still honours a real project living under a system directory', () => {
+    const result = resolveProjectForMcpRequest({
+      queryProject: '/tmp/scratch-repo',
+      headerProject: undefined,
+      body: undefined,
+      projects: TWO_PROJECTS,
+      trackedClients: [],
+    });
+    expect(result).toEqual({ kind: 'resolved', projectRoot: '/tmp/scratch-repo', via: 'query' });
+  });
+
   it('precedence: query wins over header wins over meta wins over tracked-client', () => {
     const body = {
       jsonrpc: '2.0',


### PR DESCRIPTION
## Problem (TRA-286)

Claude Cowork/Code sessions spawn `trace-mcp serve` with `cwd=/`. The stdio proxy therefore hinted `?project=/`, the daemon honoured that hint, and `initialize` came back as:

```
-32002 Refusing to index / (filesystem root). Configure your MCP client to use a real project directory ...
```

The client wraps that as `Backend send failed: Streamable HTTP error` and the whole MCP connection fails to start — no tools at all, even though the machine has perfectly good registered projects.

## Fix

`resolveProjectForMcpRequest` now *ignores* an explicit hint (query param, `X-Trace-Project` header, `params._meta["traceMcp/projectRoot"]`) that names a dangerous root, instead of resolving to it. Resolution falls through to the existing tracked-client and single-project steps, so a `cwd=/` session binds to the real project. The dropped hint is returned on the resolution (`ignoredDangerousHint`) and logged by the daemon.

Unchanged: the "no silent `listProjects()[0]`" guarantee (multi-project still returns `ambiguous`), the dangerous-root guard for registration/indexing, and hints pointing at real projects that merely live under a system dir (`/tmp/scratch-repo`).

## Tests

4 new cases in `tests/daemon/mcp-project-router.test.ts` (dangerous hint → single-project, → tracked-client, → ambiguous with the hint reported, and `/tmp/scratch-repo` still honoured).

`pnpm run lint`, `pnpm run build`, `pnpm run test` — 8759 passed, 9 skipped.
