### PR TITLE
fix(registry): stable git-remote identity so repeat checkouts reuse one index (TRA-38)

### DIFF
--- a/src/__tests__/git-remote-identity.test.ts
+++ b/src/__tests__/git-remote-identity.test.ts
@@ -1,0 +1,234 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * TRA-38: project identity in trace-mcp used to be the raw, exact absolute
+ * filesystem path — nothing else. Any workflow that checks out the same
+ * logical repo to a fresh path repeatedly (most notably Multica's own
+ * `repo checkout <url>`, which lands every run under a brand-new per-run
+ * ephemeral directory) resolved to a different path hash every time, so each
+ * run spawned a brand-new registry entry + brand-new DB + full reindex,
+ * orphaning the previous checkout's entry. That's the root cause behind the
+ * TRA-35 registry duplication bug (13x/7x/7x duplicate entries observed).
+ *
+ * These tests pin the fix: a project root whose git `origin` remote matches
+ * an already-registered *different* root reuses that root's dbPath (and
+ * inherited lastIndexed) instead of building a new index — while a project
+ * with no resolvable git remote (non-git, or no `origin` configured) keeps
+ * behaving exactly as before this feature existed.
+ */
+
+function mkdirp(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function write(filePath: string, content: string): void {
+  mkdirp(path.dirname(filePath));
+  fs.writeFileSync(filePath, content, 'utf8');
+}
+
+/** Create a minimal git repo at `root`, optionally with an `origin` remote. */
+function makeGitRepo(root: string, remoteUrl?: string): void {
+  mkdirp(root);
+  mkdirp(path.join(root, '.git'));
+  write(path.join(root, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+  write(path.join(root, 'package.json'), '{"name":"fixture","version":"0.0.0"}\n');
+  if (remoteUrl) {
+    write(
+      path.join(root, '.git', 'config'),
+      [
+        '[core]',
+        '\trepositoryformatversion = 0',
+        '[remote "origin"]',
+        `\turl = ${remoteUrl}`,
+        '\tfetch = +refs/heads/*:refs/remotes/origin/*',
+        '',
+      ].join('\n'),
+    );
+  }
+}
+
+describe('git remote identity (TRA-38)', () => {
+  let tmpHome: string;
+  let tmpProjects: string;
+  let globalMod: typeof import('../global.js');
+  let registry: typeof import('../registry.js');
+
+  beforeEach(async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-identity-home-'));
+    tmpProjects = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-identity-projects-'));
+    vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+    vi.resetModules();
+    globalMod = await import('../global.js');
+    registry = await import('../registry.js');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    fs.rmSync(tmpProjects, { recursive: true, force: true });
+  });
+
+  describe('normalizeGitRemote', () => {
+    it('normalizes https, ssh, and scp-like URLs to the same canonical form', () => {
+      const expected = 'github.com/nikolai-vysotskyi/trace-mcp';
+      expect(
+        globalMod.normalizeGitRemote('https://github.com/nikolai-vysotskyi/trace-mcp.git'),
+      ).toBe(expected);
+      expect(globalMod.normalizeGitRemote('https://github.com/nikolai-vysotskyi/trace-mcp')).toBe(
+        expected,
+      );
+      expect(globalMod.normalizeGitRemote('git@github.com:nikolai-vysotskyi/trace-mcp.git')).toBe(
+        expected,
+      );
+      expect(
+        globalMod.normalizeGitRemote('ssh://git@github.com/nikolai-vysotskyi/trace-mcp.git'),
+      ).toBe(expected);
+      expect(globalMod.normalizeGitRemote('https://GitHub.com/nikolai-vysotskyi/trace-mcp/')).toBe(
+        expected,
+      );
+    });
+
+    it('returns null for a local filesystem path used as a remote', () => {
+      expect(globalMod.normalizeGitRemote('/Users/foo/bare-repo.git')).toBeNull();
+      expect(globalMod.normalizeGitRemote('../sibling-repo')).toBeNull();
+    });
+
+    it('treats different repos as different identities', () => {
+      const a = globalMod.normalizeGitRemote('https://github.com/org/repo-a.git');
+      const b = globalMod.normalizeGitRemote('https://github.com/org/repo-b.git');
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('getProjectRemoteIdentity', () => {
+    it('reads the origin remote from .git/config', () => {
+      const root = path.join(tmpProjects, 'repo-with-remote');
+      makeGitRepo(root, 'git@github.com:acme/widgets.git');
+      expect(globalMod.getProjectRemoteIdentity(root)).toBe('github.com/acme/widgets');
+    });
+
+    it('returns null for a git repo with no remote configured', () => {
+      const root = path.join(tmpProjects, 'repo-no-remote');
+      makeGitRepo(root);
+      expect(globalMod.getProjectRemoteIdentity(root)).toBeNull();
+    });
+
+    it('returns null for a non-git directory', () => {
+      const root = path.join(tmpProjects, 'plain-dir');
+      mkdirp(root);
+      expect(globalMod.getProjectRemoteIdentity(root)).toBeNull();
+    });
+  });
+
+  describe('registerProject — dbPath reuse across checkouts of the same remote', () => {
+    it("reuses the first checkout's dbPath + lastIndexed for a second checkout of the same remote", () => {
+      const remote = 'https://github.com/nikolai-vysotskyi/trace-mcp.git';
+      const first = path.join(tmpProjects, 'run-1', 'workdir');
+      const second = path.join(tmpProjects, 'run-2', 'workdir');
+      makeGitRepo(first, remote);
+      makeGitRepo(second, remote);
+
+      const firstEntry = registry.registerProject(first);
+      registry.updateLastIndexed(first);
+      const firstIndexed = registry.getProject(first)!.lastIndexed;
+      expect(firstIndexed).not.toBeNull();
+
+      const secondEntry = registry.registerProject(second);
+
+      expect(secondEntry.dbPath).toBe(firstEntry.dbPath);
+      expect(secondEntry.lastIndexed).toBe(firstIndexed);
+      expect(secondEntry.remoteIdentity).toBe('github.com/nikolai-vysotskyi/trace-mcp');
+
+      // Both remain independently registered by their literal path — the
+      // registry must still support "this literal path is registered".
+      expect(registry.getProject(first)?.root).toBe(first);
+      expect(registry.getProject(second)?.root).toBe(second);
+      expect(registry.listProjects()).toHaveLength(2);
+    });
+
+    it('reuses the sibling even when it predates the remoteIdentity cache field (pre-TRA-38 entry)', () => {
+      const remote = 'https://github.com/acme/legacy.git';
+      const first = path.join(tmpProjects, 'legacy-checkout');
+      makeGitRepo(first, remote);
+      const firstEntry = registry.registerProject(first);
+
+      // Simulate an entry that was written by a pre-TRA-38 build: no
+      // `remoteIdentity` field cached on disk, only derivable live from its
+      // .git/config (which the checkout above still has).
+      const raw = JSON.parse(fs.readFileSync(globalMod.REGISTRY_PATH, 'utf-8'));
+      delete raw.projects[first].remoteIdentity;
+      fs.writeFileSync(globalMod.REGISTRY_PATH, JSON.stringify(raw));
+
+      const second = path.join(tmpProjects, 'fresh-checkout');
+      makeGitRepo(second, remote);
+      const secondEntry = registry.registerProject(second);
+
+      expect(secondEntry.dbPath).toBe(firstEntry.dbPath);
+    });
+
+    it('falls back to the exact path-based dbPath — unchanged — for a project with no git remote', () => {
+      const root = path.join(tmpProjects, 'no-remote-project');
+      mkdirp(root);
+      const entry = registry.registerProject(root);
+      expect(entry.dbPath).toBe(globalMod.getDbPath(root));
+      expect(entry.remoteIdentity).toBeUndefined();
+    });
+
+    it('never collides two genuinely different repos', () => {
+      const a = path.join(tmpProjects, 'proj-a');
+      const b = path.join(tmpProjects, 'proj-b');
+      makeGitRepo(a, 'https://github.com/org/repo-a.git');
+      makeGitRepo(b, 'https://github.com/org/repo-b.git');
+
+      const entryA = registry.registerProject(a);
+      const entryB = registry.registerProject(b);
+
+      expect(entryA.dbPath).not.toBe(entryB.dbPath);
+    });
+
+    it('re-registering an already-registered root is unaffected — no dbPath drift', () => {
+      const root = path.join(tmpProjects, 'stable-project');
+      makeGitRepo(root, 'https://github.com/org/stable.git');
+      const first = registry.registerProject(root);
+      const again = registry.registerProject(root);
+      expect(again).toEqual(first);
+    });
+
+    it('findRegisteredEntryByRemote excludes the given root and returns null with no match', () => {
+      const root = path.join(tmpProjects, 'solo-project');
+      makeGitRepo(root, 'https://github.com/org/solo.git');
+      registry.registerProject(root);
+
+      expect(registry.findRegisteredEntryByRemote('github.com/org/solo', root)).toBeNull();
+      expect(registry.findRegisteredEntryByRemote('github.com/org/unrelated')).toBeNull();
+    });
+  });
+
+  describe('setupProject — end-to-end dbPath reuse (TRA-38)', () => {
+    it('a second checkout of an already-registered remote opens the SAME on-disk DB, not a fresh one', async () => {
+      const { setupProject } = await import('../project-setup.js');
+      const remote = 'https://github.com/nikolai-vysotskyi/trace-mcp.git';
+      const first = path.join(tmpProjects, 'setup-run-1', 'workdir');
+      const second = path.join(tmpProjects, 'setup-run-2', 'workdir');
+      makeGitRepo(first, remote);
+      makeGitRepo(second, remote);
+
+      const firstResult = setupProject(first);
+      expect(fs.existsSync(firstResult.dbPath)).toBe(true);
+
+      const secondResult = setupProject(second);
+      expect(secondResult.dbPath).toBe(firstResult.dbPath);
+      expect(secondResult.isNew).toBe(true); // the second root is still a new registry row
+
+      // No stray DB was left behind at the second root's own path-based
+      // location — the whole point of registering before initializeDatabase.
+      const strayDbPath = globalMod.getDbPath(second);
+      expect(strayDbPath).not.toBe(firstResult.dbPath);
+      expect(fs.existsSync(strayDbPath)).toBe(false);
+    });
+  });
+});

--- a/src/cli/prune.ts
+++ b/src/cli/prune.ts
@@ -148,28 +148,45 @@ function inspectProjectDb(dbPath: string): { files: number | null } {
 }
 
 interface RegistryHashIndex {
-  /** Map from projectHash → { root, exists }. */
-  byHash: Map<string, { root: string; exists: boolean }>;
+  /**
+   * Map from projectHash → every live anchor (root + exists) that resolves
+   * to it. A hash can have more than one anchor once TRA-38 dbPath sharing
+   * is in play — two checkouts of the same git remote deliberately share
+   * one index DB, so that DB's hash is "live" as long as ANY of its
+   * anchors' roots still exist, not just the one this map happened to see
+   * first.
+   */
+  byHash: Map<string, { root: string; exists: boolean }[]>;
+}
+
+function addHashAnchor(
+  byHash: Map<string, { root: string; exists: boolean }[]>,
+  hash: string,
+  root: string,
+): void {
+  const anchor = { root, exists: fs.existsSync(root) };
+  const anchors = byHash.get(hash);
+  if (anchors) anchors.push(anchor);
+  else byHash.set(hash, [anchor]);
 }
 
 function buildRegistryIndex(): RegistryHashIndex {
-  const byHash = new Map<string, { root: string; exists: boolean }>();
+  const byHash = new Map<string, { root: string; exists: boolean }[]>();
   for (const entry of listProjects()) {
     const absRoot = path.resolve(entry.root);
-    byHash.set(projectHash(absRoot), {
-      root: absRoot,
-      exists: fs.existsSync(absRoot),
-    });
+    addHashAnchor(byHash, projectHash(absRoot), absRoot);
+    // Entry-level `dbPath` hash — names in registry can drift from a fresh
+    // path-based recompute (most notably: TRA-38 dbPath sharing, where a
+    // second checkout's *own* path hashes to something no file on disk ever
+    // used), but the DB the registry actually points at is canonical.
+    const dbHash = extractHash(path.basename(entry.dbPath));
+    if (dbHash) addHashAnchor(byHash, dbHash, absRoot);
     // Multi-root: children also count as live anchors.
     if (entry.children) {
       for (const child of entry.children) {
-        const abs = path.resolve(child);
-        byHash.set(projectHash(abs), { root: abs, exists: fs.existsSync(abs) });
+        addHashAnchor(byHash, projectHash(path.resolve(child)), path.resolve(child));
       }
     }
-    // Don't forget the entry-level `dbPath` hash — names in registry can drift,
-    // but the DB the registry points at is canonical. We index by the basename
-    // pattern instead of `name-hash`.
   }
   return { byHash };
 }
@@ -207,14 +224,18 @@ export function scanIndexDir(options: PruneOptions = {}): DbCandidate[] {
 
     let category: PruneCategory;
     let registeredRoot: string | null = null;
-    const registered = hash ? registry.byHash.get(hash) : undefined;
-    if (registered) registeredRoot = registered.root;
+    const anchors = hash ? registry.byHash.get(hash) : undefined;
+    // TRA-38: a hash can have multiple anchors (dbPath shared across
+    // checkouts of the same git remote) — prefer an existing one for
+    // display, but any one of them is enough to keep this DB "live".
+    const liveAnchor = anchors?.find((a) => a.exists);
+    if (anchors && anchors.length > 0) registeredRoot = (liveAnchor ?? anchors[0]).root;
 
     if (session) {
       category = mtimeMs < ttlCutoff ? 'session_expired' : 'session_active';
-    } else if (!registered) {
+    } else if (!anchors || anchors.length === 0) {
       category = 'orphan_unregistered';
-    } else if (!registered.exists) {
+    } else if (!liveAnchor) {
       category = 'orphan_missing_root';
     } else {
       // Live project — check stray_small heuristic for very small + old DBs.

--- a/src/daemon/project-artifacts.ts
+++ b/src/daemon/project-artifacts.ts
@@ -19,6 +19,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { DECISIONS_DB_PATH, projectHash, projectName, TOPOLOGY_DB_PATH } from '../global.js';
 import { logger } from '../logger.js';
+import { getProject, listProjects } from '../registry.js';
 import { INDEX_DIR } from '../shared/paths.js';
 
 /** Result of a project artifact cleanup pass. */
@@ -174,11 +175,32 @@ export function removeProjectArtifacts(
     decisions: { decisions: 0, chunks: 0, clusters: 0, memos: 0 },
   };
 
-  const name = projectName(absRoot);
-  const hash = projectHash(absRoot);
-  const indexDbBase = path.join(INDEX_DIR, `${name}-${hash}.db`);
+  // TRA-38: use the registry's own recorded dbPath, not a fresh
+  // name+hash recomputation. Since two checkouts of the same git remote can
+  // now share one dbPath (see registerProject in registry.ts), `absRoot`'s
+  // actual DB may live at a path derived from a *different* root's hash —
+  // recomputing from absRoot would silently miss it (and miss the
+  // session/task-cache files, which are themselves named off this same
+  // dbPath — see local-backend.ts's `sharedDbPath.replace(/\.db$/, ...)`).
+  const registryEntry = getProject(absRoot);
+  const indexDbBase =
+    registryEntry?.dbPath ??
+    path.join(INDEX_DIR, `${projectName(absRoot)}-${projectHash(absRoot)}.db`);
+  const dbBasenameMatch = path.basename(indexDbBase).match(/^(.+)-([0-9a-f]{12})\.db$/i);
+  const name = dbBasenameMatch ? dbBasenameMatch[1] : projectName(absRoot);
+  const hash = dbBasenameMatch ? dbBasenameMatch[2] : projectHash(absRoot);
 
-  if (options.keepDbFiles) {
+  // This dbPath may still be in use by another registered project (a TRA-38
+  // sibling checkout of the same remote). Deleting it out from under that
+  // sibling would silently force it into a full reindex the next time it's
+  // opened, so never delete the index DB itself while another registered
+  // entry still points at it — its own topology/decision rows and
+  // session/task-cache files are still cleaned up below regardless.
+  const sharedWithSibling = listProjects().some(
+    (e) => path.resolve(e.root) !== absRoot && e.dbPath === indexDbBase,
+  );
+
+  if (options.keepDbFiles || sharedWithSibling) {
     // Inventory what we'd have deleted so callers can report it.
     for (const suffix of SQLITE_SIDECARS) {
       const full = indexDbBase + suffix;
@@ -187,9 +209,14 @@ export function removeProjectArtifacts(
   } else {
     // 1. Index DB + WAL/SHM/journal sidecars
     deleteDbWithSidecars(indexDbBase, result);
+  }
 
+  if (!options.keepDbFiles) {
     // 2. Session DBs: `<name>-<hash>-session-*.db` (+ sidecars)
     // 3. Daemon task cache DBs: `daemon-task-cache-*-<hash>.db` (+ sidecars)
+    // Always cleaned up regardless of index-DB sharing — these are
+    // per-connection caches, cheap to lose and rebuilt on next use, unlike
+    // the index DB itself.
     const sessionPrefix = `${name}-${hash}-session-`;
     const taskCacheSuffix = `-${hash}.db`;
     const taskCachePrefix = 'daemon-task-cache-';

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -236,7 +236,17 @@ export class ProjectManager {
     }
     const config = configResult.value;
 
-    const dbPath = getDbPath(indexRoot);
+    // TRA-38: prefer the registry's already-resolved dbPath (set moments ago
+    // by setupProject(), which may have reused a same-git-remote sibling's
+    // existing DB instead of a fresh one) over recomputing it from scratch.
+    // Worktrees are deliberately excluded — they already share one dbPath
+    // via `indexRoot` (the main worktree root), a separate, pre-existing
+    // mechanism this must not disturb. Read-mostly subprojects (persist
+    // false, never registered) simply find nothing and fall through to the
+    // same getDbPath() call this line has always made.
+    const dbPath = worktreeInfo
+      ? getDbPath(indexRoot)
+      : (getProject(indexRoot)?.dbPath ?? getDbPath(indexRoot));
     ensureGlobalDirs();
 
     const db = initializeDatabase(dbPath, {

--- a/src/global.ts
+++ b/src/global.ts
@@ -343,11 +343,15 @@ export function getDbPath(projectRoot: string): string {
  * resolve `.js → .ts` imports of sibling modules).
  */
 function resolveGitMetadataDir(root: string): string | null {
-  // Trust note: `root` is the project root this process was pointed at (CLI
-  // argument or cwd of a local developer tool), not a per-request value from
-  // an untrusted caller — the same trust boundary already documented for
-  // `cwd: rootPath` in tools/quality/changed-symbols.ts. Every read below is
-  // inside `<root>/.git`, and every failure is handled by returning null.
+  // Trust note (CodeQL js/path-injection): `root` is a project root — CLI
+  // argument, cwd, or the `X-Trace-Project` hint on the daemon's loopback
+  // `/mcp` endpoint. CodeQL traces that last one and calls it user-provided,
+  // which is literally true, but it is the daemon's *own* project-selection
+  // input: anyone who can reach the daemon can already ask it to index and
+  // serve that whole tree, so reading `<root>/.git/config` grants nothing
+  // extra. Reads below never leave `<root>/.git`, and every failure returns
+  // null. Whether that loopback endpoint should be authenticated at all is a
+  // separate, pre-existing question — see TRA-301.
   const gitEntry = path.join(root, '.git');
   let stat: fs.Stats;
   try {

--- a/src/global.ts
+++ b/src/global.ts
@@ -277,9 +277,11 @@ export function ensureGlobalDirs(): void {
     }
   }
 
-  // Seed default config on first run so users see all available parameters
-  if (!fs.existsSync(GLOBAL_CONFIG_PATH)) {
-    fs.writeFileSync(GLOBAL_CONFIG_PATH, DEFAULT_CONFIG_JSONC);
+  // Seed default config on first run so users see all available parameters.
+  // 'wx' = O_CREAT|O_EXCL: atomically create-only, no separate existsSync
+  // check that could race with another process creating the file first.
+  try {
+    fs.writeFileSync(GLOBAL_CONFIG_PATH, DEFAULT_CONFIG_JSONC, { flag: 'wx' });
     if (process.platform !== 'win32') {
       try {
         fs.chmodSync(GLOBAL_CONFIG_PATH, 0o600);
@@ -287,6 +289,8 @@ export function ensureGlobalDirs(): void {
         /* best-effort */
       }
     }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
   }
 }
 
@@ -306,8 +310,168 @@ export function getSnapshotPath(projectRoot: string): string {
   return path.join(TRACE_MCP_HOME, 'sessions', `${projectHash(absRoot)}-snapshot.json`);
 }
 
-/** Compute global DB path for a project root. */
+/**
+ * Compute the default (path-based) global DB path for a project root.
+ *
+ * This is deliberately NOT identity-aware (see `getProjectRemoteIdentity`
+ * below) — it stays a pure function of the absolute path so it keeps
+ * producing the exact same value it always has for every project already
+ * registered before TRA-38. Identity-based DB *reuse* (recognizing that two
+ * different absolute paths are checkouts of the same git remote, e.g. two
+ * Multica ephemeral checkouts of the same repo) is resolved one layer up, in
+ * `registerProject` (registry.ts): a brand-new root whose remote matches an
+ * already-registered different root inherits *that* entry's `dbPath` instead
+ * of one computed here. Every read path in this codebase already prefers the
+ * registry's stored `dbPath` over recomputing it (see the repeated
+ * `resolveDbPath()` helper across `src/cli/*.ts`), so this function only ever
+ * actually runs for a root that isn't registered yet — i.e. exactly the
+ * "first checkout of this repo, or a non-git / remote-less project" case.
+ */
 export function getDbPath(projectRoot: string): string {
   const absRoot = path.resolve(projectRoot);
   return path.join(INDEX_DIR, `${projectName(absRoot)}-${projectHash(absRoot)}.db`);
+}
+
+/**
+ * Resolve the `.git` metadata directory for `root`, following worktree
+ * indirection (a `.git` *file* containing `gitdir: <path>`, pointing at
+ * `<main-repo>/.git/worktrees/<name>`) the same way `detectGitWorktree` in
+ * project-root.ts does. Duplicated here rather than imported — this module
+ * must stay free of sibling `.ts` imports (see the comment on
+ * `ensureGlobalDirs` above: `tests/cli/env-overrides.test.ts` runs
+ * `global.ts` directly under `node --experimental-strip-types`, which can't
+ * resolve `.js → .ts` imports of sibling modules).
+ */
+function resolveGitMetadataDir(root: string): string | null {
+  const gitEntry = path.join(root, '.git');
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(gitEntry);
+  } catch {
+    return null;
+  }
+  if (stat.isDirectory()) return gitEntry;
+  if (!stat.isFile()) return null;
+
+  let content: string;
+  try {
+    content = fs.readFileSync(gitEntry, 'utf8').trim();
+  } catch {
+    return null;
+  }
+  const match = content.match(/^gitdir:\s*(.+)$/);
+  if (!match) return null;
+  const worktreeAdminDir = path.resolve(root, match[1].trim());
+  try {
+    const raw = fs.readFileSync(path.join(worktreeAdminDir, 'commondir'), 'utf8').trim();
+    return path.resolve(worktreeAdminDir, raw);
+  } catch {
+    // Fallback: admin dir is .git/worktrees/<name>, so ../../ is .git
+    return path.resolve(worktreeAdminDir, '../..');
+  }
+}
+
+/**
+ * Read the `origin` remote URL out of a `.git/config` file, falling back to
+ * the first `[remote "..."]` section found when there is no `origin`. A
+ * small hand-rolled INI reader (not a library, not a `git` subprocess) to
+ * keep this module dependency-free and avoid a `git` binary requirement —
+ * same rationale as `detectGitWorktree` reading `.git` files directly.
+ */
+function readGitRemoteUrl(gitDir: string): string | null {
+  let configText: string;
+  try {
+    configText = fs.readFileSync(path.join(gitDir, 'config'), 'utf8');
+  } catch {
+    return null;
+  }
+
+  let currentRemote: string | null = null;
+  let originUrl: string | null = null;
+  let firstUrl: string | null = null;
+
+  for (const line of configText.split(/\r?\n/)) {
+    const section = line.match(/^\s*\[remote\s+"([^"]+)"\]\s*$/);
+    if (section) {
+      currentRemote = section[1];
+      continue;
+    }
+    if (/^\s*\[/.test(line)) {
+      currentRemote = null; // left the remote section
+      continue;
+    }
+    if (!currentRemote) continue;
+    const urlMatch = line.match(/^\s*url\s*=\s*(.+?)\s*$/);
+    if (!urlMatch) continue;
+    if (currentRemote === 'origin') originUrl = urlMatch[1];
+    if (firstUrl === null) firstUrl = urlMatch[1];
+  }
+
+  return originUrl ?? firstUrl;
+}
+
+/**
+ * Normalize a git remote URL to a canonical `host/org/repo` form so the same
+ * repository is recognized regardless of protocol (`https://`, `ssh://`,
+ * scp-like `git@host:org/repo`) or a trailing `.git`. Returns null for
+ * anything that doesn't look like a `host` + `path` remote (e.g. a local
+ * filesystem path used as a remote) — callers fall back to path-based
+ * identity in that case, same as a repo with no remote at all.
+ */
+export function normalizeGitRemote(rawUrl: string): string | null {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return null;
+
+  let host: string;
+  let rawPath: string;
+
+  if (!trimmed.includes('://')) {
+    // scp-like syntax: [user@]host:path
+    const scpMatch = trimmed.match(/^(?:[^@/\s]+@)?([^:/\s]+):(.+)$/);
+    if (!scpMatch) return null;
+    host = scpMatch[1];
+    rawPath = scpMatch[2];
+  } else {
+    try {
+      const parsed = new URL(trimmed);
+      if (!parsed.hostname) return null;
+      host = parsed.hostname;
+      rawPath = parsed.pathname;
+    } catch {
+      return null;
+    }
+  }
+
+  // Guard against misreading a local path (e.g. `C:\repo`) as an scp-like
+  // `host:path` remote — a real git host looks like a DNS name.
+  if (!/^[A-Za-z0-9.-]+$/.test(host) || host.length < 2) return null;
+
+  const cleanedPath = rawPath
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
+    .replace(/\.git$/i, '');
+  if (!cleanedPath) return null;
+
+  return `${host.toLowerCase()}/${cleanedPath}`;
+}
+
+/**
+ * Stable identity of the repo at `projectRoot`, derived from its `origin`
+ * (or first configured) git remote and normalized so the same repo is
+ * recognized across clones/checkouts regardless of which absolute path it
+ * lives at (TRA-38) — e.g. Multica's `repo checkout` landing the same repo
+ * under a fresh per-run ephemeral directory every time.
+ *
+ * Returns null for a non-git directory or a git repo with no remote
+ * configured; callers fall back to path-based identity in that case, which
+ * is exactly today's (pre-TRA-38) behavior — so a project with no
+ * resolvable remote is completely unaffected by this function existing.
+ */
+export function getProjectRemoteIdentity(projectRoot: string): string | null {
+  const absRoot = path.resolve(projectRoot);
+  const gitDir = resolveGitMetadataDir(absRoot);
+  if (!gitDir) return null;
+  const url = readGitRemoteUrl(gitDir);
+  if (!url) return null;
+  return normalizeGitRemote(url);
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -343,10 +343,15 @@ export function getDbPath(projectRoot: string): string {
  * resolve `.js → .ts` imports of sibling modules).
  */
 function resolveGitMetadataDir(root: string): string | null {
+  // Trust note: `root` is the project root this process was pointed at (CLI
+  // argument or cwd of a local developer tool), not a per-request value from
+  // an untrusted caller — the same trust boundary already documented for
+  // `cwd: rootPath` in tools/quality/changed-symbols.ts. Every read below is
+  // inside `<root>/.git`, and every failure is handled by returning null.
   const gitEntry = path.join(root, '.git');
   let stat: fs.Stats;
   try {
-    stat = fs.statSync(gitEntry);
+    stat = fs.statSync(gitEntry); // codeql[js/path-injection]: see trust note above
   } catch {
     return null;
   }
@@ -355,6 +360,10 @@ function resolveGitMetadataDir(root: string): string | null {
 
   let content: string;
   try {
+    // codeql[js/file-system-race]: the stat above discriminates dir-vs-file,
+    // it is not an existence check — if the entry changes underneath us the
+    // read simply throws and we fall back to "not a git repo" (null).
+    // codeql[js/path-injection]: see trust note above
     content = fs.readFileSync(gitEntry, 'utf8').trim();
   } catch {
     return null;
@@ -363,6 +372,7 @@ function resolveGitMetadataDir(root: string): string | null {
   if (!match) return null;
   const worktreeAdminDir = path.resolve(root, match[1].trim());
   try {
+    // codeql[js/path-injection]: see trust note above
     const raw = fs.readFileSync(path.join(worktreeAdminDir, 'commondir'), 'utf8').trim();
     return path.resolve(worktreeAdminDir, raw);
   } catch {
@@ -381,6 +391,9 @@ function resolveGitMetadataDir(root: string): string | null {
 function readGitRemoteUrl(gitDir: string): string | null {
   let configText: string;
   try {
+    // codeql[js/path-injection]: `gitDir` comes from resolveGitMetadataDir,
+    // which only ever returns a path under the trusted project root — see the
+    // trust note there.
     configText = fs.readFileSync(path.join(gitDir, 'config'), 'utf8');
   } catch {
     return null;

--- a/src/project-setup.ts
+++ b/src/project-setup.ts
@@ -10,7 +10,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { saveProjectConfig } from './config.js';
 import { initializeDatabase } from './db/schema.js';
-import { ensureGlobalDirs, getDbPath } from './global.js';
+import { ensureGlobalDirs } from './global.js';
 import { generateConfig } from './init/config-generator.js';
 import type { DetectionResult } from './init/types.js';
 import { detectProject } from './init/detector.js';
@@ -125,9 +125,18 @@ export function setupProject(
     exclude: config.exclude,
   });
 
-  // 3. Ensure global dirs & DB path
+  // 3. Ensure global dirs, then register in the global registry. Registering
+  // here (rather than after DB init, as before TRA-38) resolves the actual
+  // dbPath first: when this root's git remote matches an already-registered
+  // *different* root, registerProject() reuses that project's existing
+  // dbPath instead of handing back a fresh path-based one. Doing this before
+  // initializeDatabase means a duplicate checkout of an already-known repo
+  // (e.g. Multica's per-run ephemeral clones) initializes the shared DB in
+  // place, rather than creating-then-abandoning an empty DB file at a
+  // path-based location nothing ends up using.
   ensureGlobalDirs();
-  const dbPath = getDbPath(absRoot);
+  const entry = registerProject(absRoot);
+  const dbPath = entry.dbPath;
 
   // 4. Migrate old local DB if requested. We treat an EMPTY (0-byte) local
   // .trace-mcp/index.db as cruft from a previous run, not as a real migration
@@ -155,12 +164,10 @@ export function setupProject(
     }
   }
 
-  // 5. Initialize database
+  // 5. Initialize database (at the dbPath resolved by registerProject above —
+  // either freshly computed or reused from a same-remote sibling entry)
   const db = initializeDatabase(dbPath);
   db.close();
-
-  // 6. Register in global registry
-  const entry = registerProject(absRoot);
 
   return {
     entry,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -5,7 +5,13 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { ensureGlobalDirs, getDbPath, projectName, REGISTRY_PATH } from './global.js';
+import {
+  ensureGlobalDirs,
+  getDbPath,
+  getProjectRemoteIdentity,
+  projectName,
+  REGISTRY_PATH,
+} from './global.js';
 import { atomicWriteJson } from './utils/atomic-write.js';
 
 export interface RegistryEntry {
@@ -40,6 +46,17 @@ export interface RegistryEntry {
    * for that path since it only runs on explicit `doctor --fix`/`prune --apply`).
    */
   missingRootSince?: string;
+  /**
+   * Normalized git remote identity (`host/org/repo`) resolved at
+   * registration time, e.g. `github.com/nikolai-vysotskyi/trace-mcp` — see
+   * `getProjectRemoteIdentity` in global.ts. Absent for non-git projects or
+   * a git repo with no remote configured. Cached here (rather than
+   * re-reading `.git/config` on every lookup) so a later registration of
+   * *another* checkout of the same repo can find this entry even if this
+   * entry's own `root` directory has since been deleted (e.g. a cleaned-up
+   * Multica ephemeral checkout) — see `findRegisteredEntryByRemote` (TRA-38).
+   */
+  remoteIdentity?: string;
 }
 
 interface Registry {
@@ -104,12 +121,27 @@ export function registerProject(
     return reg.projects[absRoot];
   }
 
+  // TRA-38: a fresh checkout of a repo that's already registered somewhere
+  // else (e.g. Multica's `repo checkout` landing the same repo under a new
+  // per-run ephemeral directory every time) should reuse that project's
+  // existing index instead of building a brand-new one from scratch. Detect
+  // this by normalized git remote identity, not by path. Repos with no
+  // resolvable remote (non-git projects, or a repo with no `origin`
+  // configured) fall through to the exact same path-based `dbPath` this
+  // function has always computed — zero behavior change for them.
+  const remoteIdentity = getProjectRemoteIdentity(absRoot);
+  const sibling = remoteIdentity ? findRegisteredEntryByRemote(remoteIdentity, absRoot) : null;
+
   const entry: RegistryEntry = {
     name: projectName(absRoot),
     root: absRoot,
-    dbPath: getDbPath(absRoot),
-    lastIndexed: null,
+    dbPath: sibling?.dbPath ?? getDbPath(absRoot),
+    // Inherit the sibling's lastIndexed so tooling doesn't present a project
+    // whose DB already has data as "never indexed" just because this
+    // particular root is a new registry row.
+    lastIndexed: sibling?.lastIndexed ?? null,
     addedAt: new Date().toISOString(),
+    ...(remoteIdentity && { remoteIdentity }),
     ...(opts?.type && { type: opts.type }),
     ...(opts?.children && { children: opts.children }),
   };
@@ -117,6 +149,34 @@ export function registerProject(
   reg.projects[absRoot] = entry;
   saveRegistry(reg);
   return entry;
+}
+
+/**
+ * Find an already-registered project (other than `excludeRoot`) whose git
+ * remote identity matches `remoteIdentity`. Used by `registerProject` to
+ * detect "this is another checkout of a repo we already know about" so the
+ * new registration can reuse the existing entry's `dbPath` instead of
+ * spawning a duplicate index (TRA-38).
+ *
+ * Falls back to computing `remoteIdentity` on the fly for entries registered
+ * before this field existed (`entry.remoteIdentity` absent) — a live re-read
+ * of that entry's `.git/config`, which is a no-op (returns null, no match)
+ * if the entry's root no longer exists on disk. No persisted index is
+ * needed: registries are small (tens to low hundreds of entries) and this
+ * only runs once per *new* registration, mirroring the existing live-scan
+ * style of `findOverlappingProjects` / `findOverlapForNewRoot` in this file.
+ */
+export function findRegisteredEntryByRemote(
+  remoteIdentity: string,
+  excludeRoot?: string,
+): RegistryEntry | null {
+  const absExclude = excludeRoot ? path.resolve(excludeRoot) : null;
+  for (const entry of listProjects()) {
+    if (absExclude && entry.root === absExclude) continue;
+    const entryIdentity = entry.remoteIdentity ?? getProjectRemoteIdentity(entry.root);
+    if (entryIdentity === remoteIdentity) return entry;
+  }
+  return null;
 }
 
 /** Find a multi-root project that contains this child root. */


### PR DESCRIPTION
## Summary

Project identity in trace-mcp was the raw, exact absolute filesystem path — nothing else. `getDbPath()`/`projectHash()` hashed `path.resolve(projectRoot)` directly, and `registry.ts` keyed every entry by that same resolved path string. Any workflow where the same logical repo gets checked out to a fresh path repeatedly (most notably Multica's own `repo checkout <url>`, which lands every run under a brand-new per-run ephemeral directory) resolved to a different hash every time → a brand-new registry entry + brand-new DB + full reindex, with the old checkout's entry left as a permanent orphan. That's the root cause behind the TRA-35 registry duplication bug (13x/7x/7x duplicate entries observed); TRA-184/TRA-185 already fixed the *symptoms* (stuck fresh-index, registry bloat pruning) — this is the root-cause fix that stops new duplicates from forming going forward.

- `registerProject()` (`src/registry.ts`) now resolves the project root's git `origin` remote via a new `getProjectRemoteIdentity()` (`src/global.ts`), normalized across `https://`, `ssh://`, and scp-like (`git@host:org/repo`) forms (`normalizeGitRemote()`), stripping a trailing `.git`. When a **different**, already-registered root has the same normalized remote, the new entry reuses that entry's `dbPath` (and inherits its `lastIndexed`) instead of computing a fresh path-based one. A new `findRegisteredEntryByRemote()` does this via a live scan over `listProjects()` (same style as the existing `findOverlappingProjects`/`findOverlapForNewRoot`), falling back to a fresh `.git/config` read for entries registered before this change (no `remoteIdentity` cached yet).
- `RegistryEntry` gains an optional `remoteIdentity` field, cached at registration time for fast lookup and so a sibling can still be found even after its own directory is deleted (e.g. a cleaned-up Multica ephemeral checkout).
- `setupProject()` (`src/project-setup.ts`) now registers *before* calling `initializeDatabase()`, so a duplicate-remote checkout initializes the shared DB in place instead of creating (and abandoning) an empty DB at a path-based location nobody uses.
- `ProjectManager.addProject()` now prefers the registry's already-resolved `dbPath` over a fresh `getDbPath()` recompute for the non-worktree case (worktrees keep their existing, unrelated `indexRoot`-based sharing mechanism untouched).
- `removeProjectArtifacts()` and `prune.ts`'s `scanIndexDir`/`buildRegistryIndex` are updated to read the registry's actual `dbPath` (not recompute it) and to treat a hash as "live" if **any** registered anchor still exists — otherwise a shared DB could be silently deleted out from under a still-registered sibling, or misclassified as orphaned just because the first-registered checkout's directory is gone.

## Why `getDbPath()` itself was intentionally left unchanged

The scope note for this issue suggested making `getDbPath()`/`projectHash()` identity-aware directly. I found that would regress **every already-registered project with a git remote**: `ProjectManager.addProject()` and (mostly) the ~8 CLI `resolveDbPath()` helpers call `getDbPath()` fresh, unconditionally, on every access. If `getDbPath()` itself started preferring the remote identity, an existing project's *next* daemon restart would compute a different path than the one already on disk — full unwanted reindex for the overwhelming majority of already-registered repos, not just new ones.

Instead, `getDbPath()` stays a pure, unchanged function of the absolute path (the exact "path fallback" the issue's migration-note ask describes), and identity-based *reuse* is resolved one layer up, in `registerProject()`, whose result every downstream reader (`getProject(root)?.dbPath`) already prefers over a fresh `getDbPath()` call. This is the existing, established pattern in this codebase (see `resolveDbPath()` repeated across `src/cli/*.ts`) — I extended it rather than working around it.

## Migration behavior for existing registry entries

- **No `registry.json` schema/version bump.** `RegistryEntry.remoteIdentity` is a new *optional* field; `version` stays `1`. No migration script, automatic or opt-in, needs to run.
- **An existing single-checkout entry is completely unaffected on first run after upgrading.** `registerProject()` short-circuits on the "already registered, no opts" fast path *before* any of the new identity logic runs — its `dbPath` is never recomputed, so its indexed data is never touched, and no reindex is triggered.
- **The new logic only ever activates for a *second* checkout of an already-known remote.** The first checkout of any repo (new or pre-existing) always falls through the sibling lookup to the exact same path-based `dbPath` computation as before this PR — a project with no resolvable git remote (non-git, or no `origin` configured) is byte-for-byte unaffected, forever.
- **A pre-upgrade sibling is still found correctly.** A second checkout of a remote whose first checkout predates this change (so it has no cached `remoteIdentity`) is matched via a live `.git/config` re-read of that older entry — no backfill/rewrite of old entries is needed for the dedup to work.

## Design judgment call worth a second look

Two checkouts of the same remote can now legitimately share one on-disk index DB (deliberately, by design — same as this codebase's pre-existing git-worktree DB sharing via `indexRoot`). If both checkouts are used **concurrently** on different branches/uncommitted state (not the common sequential-Multica-run case, but it *is* what's happening in this very repo right now between two concurrently-running agent checkouts), each one's watcher/reindex will write into the same DB, and whichever indexed last "wins" for shared file paths until the other reindexes again. I mitigated the two destructive edges I found (deleting a still-referenced shared DB in `removeProjectArtifacts`, misclassifying a shared DB as orphaned in `prune`), but I did not add cross-directory write coordination beyond what already exists for worktrees. Flagging this so it gets an explicit look rather than assuming it away.

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm exec tsc --noEmit` (`pnpm run lint`) — clean
- [x] `pnpm exec biome check` on all changed files — clean
- [x] `pnpm exec vitest run` — full suite: 797 test files / 8760 tests passed, 9 skipped. The only failures (3, in `tests/init/claude-md.test.ts`) are pre-existing and caused by an unrelated, concurrently in-progress change to `src/init/md-block.ts` from another branch in this shared workspace — confirmed by re-running that file in isolation and confirming I never touched `src/init/*`.
- [x] New `src/__tests__/git-remote-identity.test.ts` (13 tests): `normalizeGitRemote` URL-form coverage, `getProjectRemoteIdentity` reading real `.git/config` fixtures, `registerProject` reusing dbPath/lastIndexed across two temp-dir checkouts of the same remote (via the real `registerProject` path, and end-to-end via the real `setupProject`/"add" path with an on-disk DB assertion), the pre-upgrade-sibling case, the no-remote fallback staying byte-identical to `getDbPath()`, and two different remotes never colliding.
- [x] Existing `tests/cli/prune.test.ts` and `tests/project-setup/*` suites still pass unmodified — confirms no regression to prune/overlap-prevention/empty-local-db-cleanup behavior.