### PR TITLE
feat(app): native vibrancy sidebar + hiddenInset window chrome (TRA-291)

### DIFF
--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -73,16 +73,14 @@ function getRendererUrl(params?: Record<string, string>): string {
   return `${base}?${qs}`;
 }
 
-function getTitleBarColor(): string {
-  return nativeTheme.shouldUseDarkColors ? '#1e1e1e' : '#f6f6f6';
-}
-
 function createWindowOptions(
   extraOpts?: Partial<Electron.BrowserWindowConstructorOptions>,
 ): Electron.BrowserWindowConstructorOptions {
   const opts: Electron.BrowserWindowConstructorOptions = {
     width: 960,
     height: 700,
+    minWidth: 640,
+    minHeight: 420,
     show: false,
     icon: APP_ICON,
     resizable: true,
@@ -90,7 +88,9 @@ function createWindowOptions(
     maximizable: true,
     fullscreenable: true,
     skipTaskbar: false,
-    backgroundColor: getTitleBarColor(),
+    // Non-mac keeps an opaque backing (only ever visible for the frame before
+    // the renderer's first paint); macOS gets the NSVisualEffectView below.
+    backgroundColor: nativeTheme.shouldUseDarkColors ? '#1e1e1e' : '#f5f5f7',
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
@@ -98,9 +98,21 @@ function createWindowOptions(
     },
     ...extraOpts,
   };
-  // tabbingIdentifier is macOS-only
   if (isMac) {
+    // tabbingIdentifier is macOS-only
     opts.tabbingIdentifier = TABBING_ID;
+    // Native NSVisualEffectView behind the whole window. The renderer paints
+    // the content pane opaque and leaves the sidebar region transparent, so
+    // only the sidebar reads as vibrant. `visualEffectState: 'followWindow'`
+    // desaturates it when the window loses key, and macOS honours Reduce
+    // Transparency for free — no CSS backdrop-filter fallback needed.
+    opts.titleBarStyle = 'hiddenInset';
+    // y=18 centres the 12px lights on the 44px title strip the sidebar reserves.
+    opts.trafficLightPosition = { x: 14, y: 18 };
+    opts.vibrancy = 'sidebar';
+    opts.visualEffectState = 'followWindow';
+    opts.backgroundColor = '#00000000';
+    opts.transparent = false;
   }
   return opts;
 }
@@ -591,20 +603,13 @@ export function createTray(): Tray {
   checkHealth();
   healthInterval = setInterval(checkHealth, 5_000);
 
-  // Update title bar color + tray icon when system theme changes
-  nativeTheme.on('updated', () => {
-    const color = getTitleBarColor();
-    const allWindows = [menuWindow, ...projectWindows.values()];
-    for (const win of allWindows) {
-      if (win && !win.isDestroyed()) {
-        win.setBackgroundColor(color);
-      }
-    }
-    // On Windows, tray icon color needs to match the taskbar theme
-    if (!isMac) {
+  // On Windows, tray icon color needs to match the taskbar theme. macOS window
+  // chrome needs no repaint — the vibrancy view follows the system appearance.
+  if (!isMac) {
+    nativeTheme.on('updated', () => {
       setTrayIcon(daemonReachable);
-    }
-  });
+    });
+  }
 
   return tray;
 }

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -2,7 +2,18 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { GuardOnboarding, isOnboardingDone } from './components/GuardOnboarding';
 import { WindowTabBar } from './components/WindowTabBar';
+import { fileKind, FileTypeGlyph, Icon } from './lattice/icons';
 import { Button } from './lattice/ui';
+import {
+  clampSidebarWidth,
+  readSidebarCollapsed,
+  readSidebarWidth,
+  SIDEBAR_MAX,
+  SIDEBAR_MIN,
+  splitPath,
+  writeSidebarCollapsed,
+  writeSidebarWidth,
+} from './sidebar-prefs.js';
 import { Activity } from './tabs/Activity';
 import { AskTab } from './tabs/AskTab';
 import { Clients } from './tabs/Clients';
@@ -26,9 +37,9 @@ import { Workspace } from './workspace/Workspace';
 type GlobalTab = 'workspace' | 'clients' | 'settings';
 // Settings lives in the sidebar footer (always-visible bottom row), not the top
 // nav. Keep it in the type union so existing routing/state code keeps working.
-const GLOBAL_TABS: { id: GlobalTab; label: string }[] = [
-  { id: 'workspace', label: 'Workspace' },
-  { id: 'clients', label: 'MCP Clients' },
+const GLOBAL_TABS: { id: GlobalTab; label: string; icon: string }[] = [
+  { id: 'workspace', label: 'Workspace', icon: 'grid_view' },
+  { id: 'clients', label: 'MCP Clients', icon: 'cable' },
 ];
 
 /**
@@ -42,15 +53,21 @@ function normalizeGlobalTab(value: string | null | undefined): GlobalTab {
 }
 
 type ProjectTab = 'overview' | 'ask' | 'graph' | 'activity' | 'memory' | 'notebook' | 'insights';
-const PROJECT_TABS: { id: ProjectTab; label: string }[] = [
-  { id: 'overview', label: 'Overview' },
-  { id: 'ask', label: 'Ask' },
-  { id: 'graph', label: 'Graph' },
-  { id: 'activity', label: 'Activity' },
-  { id: 'memory', label: 'Memory' },
-  { id: 'notebook', label: 'Notebook' },
-  { id: 'insights', label: 'Insights' },
+const PROJECT_TABS: { id: ProjectTab; label: string; icon: string }[] = [
+  { id: 'overview', label: 'Overview', icon: 'grid_view' },
+  { id: 'ask', label: 'Ask', icon: 'forum' },
+  { id: 'graph', label: 'Graph', icon: 'hub' },
+  { id: 'activity', label: 'Activity', icon: 'timeline' },
+  { id: 'memory', label: 'Memory', icon: 'neurology' },
+  { id: 'notebook', label: 'Notebook', icon: 'add_note' },
+  { id: 'insights', label: 'Insights', icon: 'monitoring' },
 ];
+
+/** macOS-only chrome (inset traffic lights, native vibrancy). Synchronous —
+ *  `getPlatform()` is an async IPC round-trip and this gates first paint. */
+function isMacPlatform(): boolean {
+  return /Mac/i.test(navigator.userAgent);
+}
 
 function getUrlParams() {
   const params = new URLSearchParams(window.location.search);
@@ -60,10 +77,6 @@ function getUrlParams() {
     root: params.get('root'),
   };
 }
-
-const SIDEBAR_MIN = 100;
-const SIDEBAR_MAX = 360;
-const SIDEBAR_DEFAULT = 180;
 
 const BASE = 'http://127.0.0.1:3741';
 
@@ -78,6 +91,51 @@ import {
 
 export { removeRecentProject };
 
+/** One 28px sidebar row: 16px leading glyph, 13px label, optional trailing. */
+function SidebarRow({
+  icon,
+  glyph,
+  label,
+  selected = false,
+  onClick,
+  onKeyDown,
+  title,
+  count,
+  trailing,
+  rowRef,
+  ...aria
+}: {
+  icon?: string;
+  glyph?: React.ReactNode;
+  label: React.ReactNode;
+  selected?: boolean;
+  onClick: () => void;
+  onKeyDown?: (e: React.KeyboardEvent) => void;
+  title?: string;
+  count?: React.ReactNode;
+  trailing?: React.ReactNode;
+  rowRef?: React.Ref<HTMLButtonElement>;
+} & React.AriaAttributes & { role?: string; tabIndex?: number }) {
+  return (
+    <button
+      type="button"
+      ref={rowRef}
+      className={`ws-sb-row${selected ? ' is-selected' : ''}`}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      title={title}
+      {...aria}
+    >
+      <span className="ws-sb-ico" aria-hidden="true">
+        {glyph ?? (icon ? <Icon name={icon} size={16} /> : null)}
+      </span>
+      {typeof label === 'string' ? <span className="ws-sb-label">{label}</span> : label}
+      {count !== undefined && <span className="ws-sb-count">{count}</span>}
+      {trailing}
+    </button>
+  );
+}
+
 function RecentProjects() {
   const [recent, setRecent] = useState<string[]>(getRecentProjects);
 
@@ -88,71 +146,64 @@ function RecentProjects() {
     return () => window.removeEventListener('focus', onFocus);
   }, []);
 
-  if (recent.length === 0) {
-    return (
-      <div className="px-2.5 py-1 text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-        No recent projects
-      </div>
-    );
-  }
-
   const openProject = (root: string) => {
     addRecentProject(root);
     const api = window.electronAPI;
     api?.openProjectTab(root);
   };
 
-  return (
-    <div
-      className="flex flex-col gap-0.5"
-      style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-    >
-      <div
-        className="px-2.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider"
-        style={{ color: 'var(--text-tertiary)' }}
-      >
-        Recent
+  const pickProject = async () => {
+    const api = window.electronAPI;
+    const picked = await api?.selectFolder?.();
+    if (picked) openProject(picked);
+  };
+
+  if (recent.length === 0) {
+    return (
+      <div className="ws-sb-empty">
+        <Icon name="folder" size={20} className="gi" />
+        <span>No projects opened yet.</span>
+        <button type="button" className="act" onClick={pickProject}>
+          Open a project…
+        </button>
       </div>
+    );
+  }
+
+  return (
+    <>
       {recent.map((root) => (
-        <div
+        <SidebarRow
           key={root}
-          className="group flex items-center rounded-md transition-colors hover:bg-[var(--bg-active)]"
-        >
-          <button
-            type="button"
-            onClick={() => openProject(root)}
-            className="text-left flex-1 min-w-0 px-2.5 py-1 text-[11px] truncate"
-            style={{ color: 'var(--text-secondary)' }}
-            title={root}
-          >
-            {root.split(/[/\\]/).filter(Boolean).pop()}
-          </button>
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              removeRecentProject(root);
-              setRecent(getRecentProjects());
-            }}
-            className="shrink-0 mr-1.5 w-4 h-4 flex items-center justify-center rounded opacity-0 group-hover:opacity-100 transition-opacity hover:bg-[var(--bg-secondary)]"
-            style={{ color: 'var(--text-tertiary)' }}
-            title="Remove from recent"
-          >
-            <svg
-              width="8"
-              height="8"
-              viewBox="0 0 8 8"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
+          icon="folder"
+          label={root.split(/[/\\]/).filter(Boolean).pop() ?? root}
+          title={root}
+          onClick={() => openProject(root)}
+          // Keyboard route for the remove affordance — the row is itself a
+          // button, so the ✕ can't be one too (nested interactive content).
+          onKeyDown={(e) => {
+            if (e.key !== 'Delete' && e.key !== 'Backspace') return;
+            e.preventDefault();
+            removeRecentProject(root);
+            setRecent(getRecentProjects());
+          }}
+          trailing={
+            <span
+              className="ws-sb-trailing"
+              aria-hidden="true"
+              title="Remove from recent (⌫)"
+              onClick={(e) => {
+                e.stopPropagation();
+                removeRecentProject(root);
+                setRecent(getRecentProjects());
+              }}
             >
-              <path d="M1 1l6 6M7 1l-6 6" />
-            </svg>
-          </button>
-        </div>
+              <Icon name="close" size={12} />
+            </span>
+          }
+        />
       ))}
-    </div>
+    </>
   );
 }
 
@@ -185,6 +236,8 @@ function ProjectFileExplorer({
   const [sort, setSort] = useState<FileSort>('symbols');
   const [files, setFiles] = useState<FileEntry[]>([]);
   const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<string | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
   const LIMIT = 30;
 
   // Debounce scope to avoid fetching on every keystroke
@@ -227,88 +280,80 @@ function ProjectFileExplorer({
     return p;
   };
 
-  return (
-    <div
-      className="flex flex-col gap-0.5 min-h-0 flex-1"
-      style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-    >
-      {/* Sort picker */}
-      <div className="px-1.5 mb-0.5 relative">
-        <svg
-          width="10"
-          height="10"
-          viewBox="0 0 16 16"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none"
-          style={{ color: 'var(--text-tertiary)' }}
-        >
-          <path d="M2 4h12M4 8h8M6 12h4" />
-        </svg>
-        <select
-          value={sort}
-          onChange={(e) => setSort(e.target.value as FileSort)}
-          className="w-full text-[10px] pl-5 pr-1.5 py-1 rounded-md appearance-none"
-          style={{
-            background: 'var(--bg-secondary)',
-            color: 'var(--text-secondary)',
-            border: '0.5px solid var(--border)',
-            outline: 'none',
-          }}
-        >
-          {FILE_SORT_OPTIONS.map((o) => (
-            <option key={o.id} value={o.id}>
-              {o.label}
-            </option>
-          ))}
-        </select>
-      </div>
+  // ↑/↓ move the selection, ⏎ opens — standard macOS list keyboard model.
+  const onRowKeyDown = (e: React.KeyboardEvent, index: number) => {
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+    e.preventDefault();
+    const next = e.key === 'ArrowDown' ? index + 1 : index - 1;
+    if (next < 0 || next >= files.length) return;
+    setSelected(files[next].path);
+    listRef.current
+      ?.querySelectorAll<HTMLButtonElement>('.ws-sb-row')
+      [next]?.focus();
+  };
 
-      {/* File list */}
-      <div
-        className="flex-1 overflow-y-auto overflow-x-hidden"
-        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+  return (
+    <>
+      <div className="ws-sb-group">Files</div>
+      {/* Sort — a native pop-up button sized to the macOS 24px geometry.
+          Swaps to the shared PopUpButton primitive once TRA-290 lands. */}
+      <select
+        className="ws-sb-popup"
+        value={sort}
+        aria-label="Sort files by"
+        onChange={(e) => setSort(e.target.value as FileSort)}
       >
-        {loading ? (
-          <div
-            className="px-2.5 py-2 text-[10px] text-center"
-            style={{ color: 'var(--text-tertiary)' }}
-          >
-            Loading…
-          </div>
-        ) : files.length === 0 ? (
-          <div
-            className="px-2.5 py-2 text-[10px] text-center"
-            style={{ color: 'var(--text-tertiary)' }}
-          >
-            No files
-          </div>
-        ) : (
-          files.map((f) => (
-            <button
-              type="button"
-              key={f.path}
-              onClick={() => onFileClick(f.path)}
-              className="w-full text-left px-2.5 py-1 text-[10px] truncate rounded-md transition-colors hover:bg-[var(--bg-active)] flex items-center gap-1"
-              style={{ color: 'var(--text-secondary)' }}
-              title={`${shortPath(f.path)} — ${f.symbols} symbols, ${f.edges} edges`}
-            >
-              <span className="truncate flex-1" style={{ direction: 'rtl', textAlign: 'left' }}>
-                {shortPath(f.path)}
-              </span>
-              <span
-                className="shrink-0 text-[9px] tabular-nums"
-                style={{ color: 'var(--text-tertiary)' }}
-              >
-                {sort === 'edges' ? f.edges : f.symbols}
-              </span>
-            </button>
-          ))
-        )}
-      </div>
-    </div>
+        {FILE_SORT_OPTIONS.map((o) => (
+          <option key={o.id} value={o.id}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+
+      {loading ? (
+        // Skeletons at the final 28px geometry — nothing shifts on load.
+        <div aria-busy="true" aria-label="Loading files">
+          {Array.from({ length: 6 }, (_, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length placeholder list, no identity
+            <div key={i} className="ws-sb-skeleton" />
+          ))}
+        </div>
+      ) : files.length === 0 ? (
+        <div className="ws-sb-empty">
+          <Icon name="description" size={20} className="gi" />
+          <span>No indexed files match this scope.</span>
+        </div>
+      ) : (
+        <div role="tree" aria-label="Project files" ref={listRef}>
+          {files.map((f, i) => {
+            const display = shortPath(f.path);
+            const { dir, name } = splitPath(display);
+            return (
+              <SidebarRow
+                key={f.path}
+                role="treeitem"
+                aria-selected={selected === f.path}
+                selected={selected === f.path}
+                glyph={<FileTypeGlyph ftype={fileKind(f.path).ftype} size={16} />}
+                label={
+                  <span className="ws-sb-path">
+                    {dir && <span className="dir">{dir}</span>}
+                    <span className="name">{name}</span>
+                  </span>
+                }
+                count={sort === 'edges' ? f.edges : f.symbols}
+                title={`${display} — ${f.symbols} symbols, ${f.edges} edges`}
+                onClick={() => {
+                  setSelected(f.path);
+                  onFileClick(f.path);
+                }}
+                onKeyDown={(e) => onRowKeyDown(e, i)}
+              />
+            );
+          })}
+        </div>
+      )}
+    </>
   );
 }
 
@@ -709,7 +754,8 @@ export function App() {
 
   const [globalTab, setGlobalTab] = useState<GlobalTab>(normalizeGlobalTab(tab));
   const [projectTab, setProjectTab] = useState<ProjectTab>('overview');
-  const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT);
+  const [sidebarWidth, setSidebarWidth] = useState(readSidebarWidth);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(readSidebarCollapsed);
   const [_isFullscreen, setIsFullscreen] = useState(false);
   const dragging = useRef(false);
   const graphRef = useRef<GraphExplorerGPUHandle | null>(null);
@@ -755,14 +801,26 @@ export function App() {
     document.body.style.userSelect = 'none'; // nosemgrep: ajinabraham.njsscan.generic.hardcoded_secrets.node_username -- CSS `userSelect` property name matched the "username" secret heuristic; no credential involved.
   }, []);
 
+  // One place that owns a width change: state → localStorage → other windows.
+  const applySidebarWidth = useCallback((width: number) => {
+    const clamped = clampSidebarWidth(width);
+    setSidebarWidth(clamped);
+    writeSidebarWidth(clamped);
+    window.electronAPI?.syncSidebarWidth(clamped);
+    return clamped;
+  }, []);
+
+  const toggleSidebar = useCallback(() => {
+    setSidebarCollapsed((prev) => {
+      writeSidebarCollapsed(!prev);
+      return !prev;
+    });
+  }, []);
+
   useEffect(() => {
     const onMouseMove = (e: MouseEvent) => {
       if (!dragging.current) return;
-      const newWidth = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, e.clientX));
-      setSidebarWidth(newWidth);
-      // Sync to other tabs
-      const api = window.electronAPI;
-      api?.syncSidebarWidth(newWidth);
+      applySidebarWidth(e.clientX);
     };
     const onMouseUp = () => {
       if (!dragging.current) return;
@@ -776,15 +834,51 @@ export function App() {
       window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('mouseup', onMouseUp);
     };
-  }, []);
+  }, [applySidebarWidth]);
 
   // Receive sidebar width from other tabs
   useEffect(() => {
     const api = window.electronAPI;
     if (api?.onSidebarWidthChanged) {
-      return api.onSidebarWidthChanged((w: number) => setSidebarWidth(w));
+      return api.onSidebarWidthChanged((w: number) => setSidebarWidth(clampSidebarWidth(w)));
     }
   }, []);
+
+  // Cross-window sync of the persisted prefs (same-process tabs).
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === 'trace-mcp-sidebar-width' && e.newValue !== null) {
+        setSidebarWidth(clampSidebarWidth(Number(e.newValue)));
+      } else if (e.key === 'trace-mcp-sidebar-collapsed') {
+        setSidebarCollapsed(e.newValue === '1');
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  // ⌘⌥S toggles the sidebar; ⌘1…⌘9 select the nth primary section.
+  useEffect(() => {
+    const sections: string[] = isProject
+      ? PROJECT_TABS.map((t) => t.id)
+      : GLOBAL_TABS.map((t) => t.id);
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.altKey && (e.key === 's' || e.key === 'S' || e.code === 'KeyS')) {
+        e.preventDefault();
+        toggleSidebar();
+        return;
+      }
+      if (e.altKey || e.shiftKey) return;
+      const n = Number(e.key);
+      if (!Number.isInteger(n) || n < 1 || n > 9 || n > sections.length) return;
+      e.preventDefault();
+      if (isProject) setProjectTab(sections[n - 1] as ProjectTab);
+      else setGlobalTab(sections[n - 1] as GlobalTab);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [isProject, toggleSidebar]);
 
   // Track fullscreen state
   useEffect(() => {
@@ -802,77 +896,61 @@ export function App() {
     <div
       className="ws-stage flex flex-col h-screen"
       data-mode={theme}
-      style={{ background: 'var(--frame)' }}
+      data-platform={isMacPlatform() ? 'mac' : 'other'}
     >
       {showOnboarding && <GuardOnboarding onClose={() => setShowOnboarding(false)} />}
       {/* Windows custom tab bar (hidden on macOS — native tabs handle it) */}
       <WindowTabBar />
 
-      <div className="flex flex-1 min-h-0" style={{ padding: 8, gap: 0 }}>
-        {/* Left sidebar */}
-        <div
-          className="shrink-0 relative"
-          style={
-            {
-              width: sidebarWidth,
-              WebkitAppRegion: 'drag',
-            } as React.CSSProperties
-          }
-        >
+      <div className={`ws-shell${sidebarCollapsed ? ' is-collapsed' : ''}`}>
+        {!sidebarCollapsed && (
           <aside
-            className="ws-island flex flex-col pt-3 pb-3 px-1.5 gap-0.5 h-full"
-            style={
-              {
-                WebkitAppRegion: 'no-drag',
-              } as React.CSSProperties
-            }
+            className="ws-sidebar"
+            aria-label="Sidebar"
+            style={{ width: sidebarWidth } as React.CSSProperties}
           >
-            {isProject ? (
-              <>
-                {PROJECT_TABS.map((t) => (
-                  <Button
-                    key={t.id}
-                    variant="text"
-                    active={projectTab === t.id}
-                    onClick={() => setProjectTab(t.id)}
-                    className="w-full text-left"
-                    style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-                  >
-                    {t.label}
-                  </Button>
-                ))}
+            {/* 44px strip the traffic lights live in — and the only draggable
+                part of the sidebar. macOS only: elsewhere there are no inset
+                lights to make room for. */}
+            {isMacPlatform() && <div className="ws-sidebar-titlebar" />}
 
-                {/* Divider + File explorer */}
-                <div style={{ borderTop: '1px solid var(--border-row)', margin: '6px 8px' }} />
-                <ProjectFileExplorer
-                  root={root!}
-                  scope={graphGpuSettings.scope}
-                  onFileClick={openFileInGraph}
-                />
-              </>
-            ) : (
-              <>
-                {GLOBAL_TABS.map((t) => (
-                  <Button
-                    key={t.id}
-                    variant="text"
-                    active={globalTab === t.id}
-                    onClick={() => setGlobalTab(t.id)}
-                    className="w-full text-left"
-                    style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-                  >
-                    {t.label}
-                  </Button>
-                ))}
+            <nav className="ws-sidebar-scroll" aria-label="Sections">
+              {isProject ? (
+                <>
+                  {PROJECT_TABS.map((t) => (
+                    <SidebarRow
+                      key={t.id}
+                      icon={t.icon}
+                      label={t.label}
+                      selected={projectTab === t.id}
+                      aria-current={projectTab === t.id ? 'page' : undefined}
+                      onClick={() => setProjectTab(t.id)}
+                    />
+                  ))}
+                  <ProjectFileExplorer
+                    root={root!}
+                    scope={graphGpuSettings.scope}
+                    onFileClick={openFileInGraph}
+                  />
+                </>
+              ) : (
+                <>
+                  {GLOBAL_TABS.map((t) => (
+                    <SidebarRow
+                      key={t.id}
+                      icon={t.icon}
+                      label={t.label}
+                      selected={globalTab === t.id}
+                      aria-current={globalTab === t.id ? 'page' : undefined}
+                      onClick={() => setGlobalTab(t.id)}
+                    />
+                  ))}
+                  <div className="ws-sb-group">Recent</div>
+                  <RecentProjects />
+                </>
+              )}
+            </nav>
 
-                {/* Divider + Recent projects */}
-                <div style={{ borderTop: '1px solid var(--border-row)', margin: '6px 8px' }} />
-                <RecentProjects />
-              </>
-            )}
-
-            {/* Spacer to push footer to bottom */}
-            <div style={{ flex: 1 }} />
             <UpdateBanner />
             <SidebarFooter
               active={!isProject && globalTab === 'settings'}
@@ -881,44 +959,49 @@ export function App() {
               onToggleTheme={toggleTheme}
             />
           </aside>
+        )}
 
-          {/* Resize handle */}
+        {/* Resize handle — draggable AND keyboard-operable, so the ARIA
+            separator role is honest. */}
+        {!sidebarCollapsed && (
           <div
+            className="ws-sb-resize"
             role="separator"
             aria-orientation="vertical"
             aria-label="Resize sidebar"
             aria-valuenow={sidebarWidth}
             aria-valuemin={SIDEBAR_MIN}
             aria-valuemax={SIDEBAR_MAX}
-            tabIndex={-1}
+            tabIndex={0}
             onMouseDown={onMouseDown}
-            style={
-              {
-                position: 'absolute',
-                top: 0,
-                right: -3,
-                width: 6,
-                height: '100%',
-                cursor: 'col-resize',
-                zIndex: 50,
-                WebkitAppRegion: 'no-drag',
-              } as React.CSSProperties
-            }
+            onKeyDown={(e) => {
+              const step = e.shiftKey ? 40 : 10;
+              if (e.key === 'ArrowLeft') applySidebarWidth(sidebarWidth - step);
+              else if (e.key === 'ArrowRight') applySidebarWidth(sidebarWidth + step);
+              else if (e.key === 'Home') applySidebarWidth(SIDEBAR_MIN);
+              else if (e.key === 'End') applySidebarWidth(SIDEBAR_MAX);
+              else return;
+              e.preventDefault();
+            }}
           />
-        </div>
+        )}
 
         {/* Main content */}
-        <main
-          className={`flex-1 flex flex-col min-h-0 ${isGraphGpu ? 'p-2' : needsFlexLayout ? 'p-1 pt-2' : 'p-4 overflow-y-auto'}`}
-          style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
-        >
+        <main className="ws-content">
+          <div className="ws-content-head">
+            <button
+              type="button"
+              className="ws-chrome-toggle"
+              onClick={toggleSidebar}
+              aria-label={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
+              aria-expanded={!sidebarCollapsed}
+              title={`${sidebarCollapsed ? 'Show' : 'Hide'} sidebar (⌘⌥S)`}
+            >
+              <Icon name="dock_to_right" size={16} />
+            </button>
+          </div>
           <div
-            className={
-              needsFlexLayout
-                ? 'flex-1 min-h-0 flex flex-col overflow-hidden'
-                : 'flex-1 flex flex-col min-h-0'
-            }
-            style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+            className={`ws-content-body ${isGraphGpu ? 'p-2' : needsFlexLayout ? 'p-1 pt-2' : 'p-4 overflow-y-auto'}`}
           >
             {isProject ? (
               <ErrorBoundary key={`project:${projectTab}`} label={`${projectTab} tab`}>

--- a/packages/app/src/renderer/__tests__/sidebar-prefs.test.ts
+++ b/packages/app/src/renderer/__tests__/sidebar-prefs.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  clampSidebarWidth,
+  readSidebarCollapsed,
+  readSidebarWidth,
+  SIDEBAR_DEFAULT,
+  SIDEBAR_MAX,
+  SIDEBAR_MIN,
+  splitPath,
+  writeSidebarCollapsed,
+  writeSidebarWidth,
+} from '../sidebar-prefs';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('sidebar width', () => {
+  it('clamps to the 180–320 resize range', () => {
+    expect(clampSidebarWidth(100)).toBe(SIDEBAR_MIN);
+    expect(clampSidebarWidth(9999)).toBe(SIDEBAR_MAX);
+    expect(clampSidebarWidth(240)).toBe(240);
+    expect(clampSidebarWidth(Number.NaN)).toBe(SIDEBAR_DEFAULT);
+  });
+
+  it('defaults to 220 and survives a round trip', () => {
+    expect(readSidebarWidth()).toBe(SIDEBAR_DEFAULT);
+    writeSidebarWidth(260);
+    expect(readSidebarWidth()).toBe(260);
+  });
+
+  it('clamps values persisted by an older build', () => {
+    // 180 was the old default and 100 the old minimum — both out of range now.
+    localStorage.setItem('trace-mcp-sidebar-width', '100');
+    expect(readSidebarWidth()).toBe(SIDEBAR_MIN);
+  });
+
+  it('persists the collapsed state', () => {
+    expect(readSidebarCollapsed()).toBe(false);
+    writeSidebarCollapsed(true);
+    expect(readSidebarCollapsed()).toBe(true);
+    writeSidebarCollapsed(false);
+    expect(readSidebarCollapsed()).toBe(false);
+  });
+});
+
+describe('splitPath', () => {
+  // The `direction: rtl` truncation this replaces rendered these two as
+  // `idea/workspace.xml.` and `…l__/_root/php.synthetic__`.
+  it('keeps the filename intact and leaves only the directory truncatable', () => {
+    expect(splitPath('.idea/workspace.xml')).toEqual({
+      dir: '.idea/',
+      name: 'workspace.xml',
+    });
+    expect(splitPath('__external__/_root/php.synthetic')).toEqual({
+      dir: '__external__/_root/',
+      name: 'php.synthetic',
+    });
+  });
+
+  it('handles a bare filename and Windows separators', () => {
+    expect(splitPath('README.md')).toEqual({ dir: '', name: 'README.md' });
+    expect(splitPath('src\\main\\tray.ts')).toEqual({ dir: 'src\\main\\', name: 'tray.ts' });
+  });
+});

--- a/packages/app/src/renderer/app.css
+++ b/packages/app/src/renderer/app.css
@@ -3,6 +3,9 @@
    entirely under `.ws-stage[data-mode="dark"|"light"]`, so it cannot leak
    into or collide with the tokens below. */
 @import "./styles/island.css";
+/* Sidebar + window chrome (TRA-291) — loaded after island.css so it can
+   override the island treatment on the sidebar region. */
+@import "./styles/sidebar.css";
 
 :root {
   --bg-primary: rgba(246, 246, 246, 0.92);
@@ -17,11 +20,6 @@
   --border-row: rgba(0, 0, 0, 0.08);
   --bg-active: rgba(0, 0, 0, 0.06);
   --sidebar-border: rgba(0, 0, 0, 0.12);
-  --sidebar-bg: linear-gradient(
-    135deg,
-    rgba(255, 255, 255, 0.35) 0%,
-    rgba(255, 255, 255, 0.18) 100%
-  );
   --accent: #007aff;
   --accent-hover: #0062d1;
   --destructive: #ff3b30;
@@ -47,11 +45,6 @@
     --border-row: rgba(255, 255, 255, 0.06);
     --bg-active: rgba(255, 255, 255, 0.1);
     --sidebar-border: rgba(255, 255, 255, 0.1);
-    --sidebar-bg: linear-gradient(
-      135deg,
-      rgba(255, 255, 255, 0.1) 0%,
-      rgba(255, 255, 255, 0.04) 100%
-    );
     --accent: #0a84ff;
     --accent-hover: #409cff;
     --destructive: #ff453a;
@@ -78,11 +71,6 @@
   --border-row: rgba(255, 255, 255, 0.06);
   --bg-active: rgba(255, 255, 255, 0.1);
   --sidebar-border: rgba(255, 255, 255, 0.1);
-  --sidebar-bg: linear-gradient(
-    135deg,
-    rgba(255, 255, 255, 0.1) 0%,
-    rgba(255, 255, 255, 0.04) 100%
-  );
   --accent: #0a84ff;
   --accent-hover: #409cff;
   --destructive: #ff453a;

--- a/packages/app/src/renderer/sidebar-prefs.ts
+++ b/packages/app/src/renderer/sidebar-prefs.ts
@@ -1,0 +1,67 @@
+/* sidebar-prefs.ts — sidebar geometry + the persistence of it (TRA-291).
+
+   Width and collapsed state survive a relaunch (localStorage) and stay in sync
+   across open windows: `storage` events cover same-process tabs, the existing
+   `sync-sidebar-width` IPC covers separate BrowserWindows.
+
+   Kept out of App.tsx so it is unit-testable without mounting the renderer. */
+
+/** macOS NavigationSplitView sidebar: 220pt default, resizable 180–320. */
+export const SIDEBAR_MIN = 180;
+export const SIDEBAR_MAX = 320;
+export const SIDEBAR_DEFAULT = 220;
+
+export const SIDEBAR_WIDTH_KEY = 'trace-mcp-sidebar-width';
+export const SIDEBAR_COLLAPSED_KEY = 'trace-mcp-sidebar-collapsed';
+
+export function clampSidebarWidth(width: number): number {
+  if (!Number.isFinite(width)) return SIDEBAR_DEFAULT;
+  return Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, Math.round(width)));
+}
+
+export function readSidebarWidth(): number {
+  try {
+    const raw = localStorage.getItem(SIDEBAR_WIDTH_KEY);
+    if (raw === null) return SIDEBAR_DEFAULT;
+    return clampSidebarWidth(Number(raw));
+  } catch {
+    return SIDEBAR_DEFAULT;
+  }
+}
+
+export function writeSidebarWidth(width: number): void {
+  try {
+    localStorage.setItem(SIDEBAR_WIDTH_KEY, String(clampSidebarWidth(width)));
+  } catch {}
+}
+
+export function readSidebarCollapsed(): boolean {
+  try {
+    return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function writeSidebarCollapsed(collapsed: boolean): void {
+  try {
+    localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? '1' : '0');
+  } catch {}
+}
+
+/**
+ * Split a path into a truncatable directory part and the filename, which must
+ * never be truncated.
+ *
+ * The previous implementation truncated with `direction: rtl`, which reorders
+ * the trailing punctuation of a path under the bidi algorithm — that is why
+ * `.idea/workspace.xml` rendered as `idea/workspace.xml.` and
+ * `__external__/_root/php.synthetic` as `…l__/_root/php.synthetic__`. Splitting
+ * here and ellipsising only `dir` in plain LTR gets head-truncation with no
+ * bidi involvement at all.
+ */
+export function splitPath(displayPath: string): { dir: string; name: string } {
+  const idx = Math.max(displayPath.lastIndexOf('/'), displayPath.lastIndexOf('\\'));
+  if (idx < 0) return { dir: '', name: displayPath };
+  return { dir: displayPath.slice(0, idx + 1), name: displayPath.slice(idx + 1) };
+}

--- a/packages/app/src/renderer/styles/island.css
+++ b/packages/app/src/renderer/styles/island.css
@@ -237,7 +237,10 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  background: var(--frame);
+  /* Transparent, NOT --frame: on macOS the native NSVisualEffectView behind
+     the window is the sidebar's material (TRA-291), and anything painted here
+     covers it. Non-mac stages paint themselves opaque (rule below). */
+  background: transparent;
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Inter", system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
 }
@@ -249,7 +252,7 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  background: var(--frame);
+  background: transparent;
   overflow: hidden;
 }
 
@@ -267,11 +270,9 @@
   -webkit-app-region: drag;
 }
 .ws-topbar > * { -webkit-app-region: no-drag; }
-.ws-lights { display: flex; align-items: center; gap: 8px; padding-right: 6px; }
-.ws-light { width: 12px; height: 12px; border-radius: 50%; display: block; }
-.ws-light.c { background: #ff5f57; }
-.ws-light.m { background: #febc2e; }
-.ws-light.z { background: #28c840; }
+/* NOTE: the hand-drawn `.ws-lights` / `.ws-light` circles that used to live
+   here are gone (TRA-291) — the window is `titleBarStyle: 'hiddenInset'` and
+   renders the REAL traffic lights. Never re-draw them in CSS. */
 
 .ws-ptabs { display: flex; align-items: center; gap: 3px; flex: 1; min-width: 0; overflow: hidden; }
 .ws-ptab {

--- a/packages/app/src/renderer/styles/sidebar.css
+++ b/packages/app/src/renderer/styles/sidebar.css
@@ -1,0 +1,357 @@
+/* ============================================================================
+   Sidebar + window chrome — macOS 26 (Tahoe) NavigationSplitView (TRA-291)
+
+   The window is `titleBarStyle: 'hiddenInset'` with a native `vibrancy:
+   'sidebar'` NSVisualEffectView behind the whole frame (see main/tray.ts).
+   This stylesheet's job is to keep the SIDEBAR region transparent so that
+   material shows through, and to paint everything else opaque.
+
+   Every colour here reads from the macOS-26 semantic token set (TRA-289) with
+   the current island.css value as the fallback, so the file is correct both
+   before and after the token layer lands.
+   ============================================================================ */
+
+/* island.css leaves `.ws-stage` transparent for the macOS vibrancy view;
+   everywhere else the stage must paint itself. */
+.ws-stage:not([data-platform="mac"]) {
+  background: var(--surface-sunken, var(--island));
+}
+
+.ws-shell {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+/* ---- Sidebar ------------------------------------------------------------ */
+/* Flush to the window edge, no radius, no shadow: the hairline separator and
+   the material are the edge. Background stays transparent so the native
+   NSVisualEffectView shows through. */
+.ws-sidebar {
+  position: relative;
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  /* Opaque by default — only macOS has an NSVisualEffectView behind the
+     window to show through. */
+  background: var(--surface, var(--island));
+  border-right: 0.5px solid var(--separator, var(--sep));
+  -webkit-app-region: no-drag;
+}
+.ws-stage[data-platform="mac"] .ws-sidebar {
+  background: transparent;
+}
+
+/* 44px strip that the traffic lights sit in. Drag region — this and the
+   content pane's header are the ONLY draggable areas. */
+.ws-sidebar-titlebar {
+  height: 44px;
+  flex: none;
+  display: flex;
+  align-items: center;
+  -webkit-app-region: drag;
+}
+
+.ws-sidebar-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0 6px 6px;
+}
+
+/* Group header — whitespace separates groups, not rules. */
+.ws-sb-group {
+  padding: 20px 8px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 14px;
+  letter-spacing: 0.01em;
+  /* --label-secondary, not --label-tertiary: a group header is text a user
+     reads, and tertiary is decoration-only (2.21:1 today). */
+  color: var(--label-secondary, var(--text-2));
+}
+.ws-sb-group:first-child {
+  padding-top: 4px;
+}
+
+/* Row — 28px, 6px radius pill inset 6px from the sidebar edges (the 6px
+   padding on .ws-sidebar-scroll provides the inset). */
+.ws-sb-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  height: 28px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--label, var(--text-1));
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 16px;
+  text-align: left;
+  cursor: default;
+  transition: background 120ms ease;
+  -webkit-app-region: no-drag;
+}
+.ws-sb-row:hover {
+  background: var(--fill-quaternary, var(--row-hover));
+}
+.ws-sb-row .ws-sb-ico {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  color: var(--label-secondary, var(--text-2));
+}
+.ws-sb-row .ws-sb-ico svg {
+  width: 16px;
+  height: 16px;
+  display: block;
+}
+.ws-sb-row .ws-sb-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ws-sb-row .ws-sb-count {
+  flex: none;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--label-secondary, var(--text-2));
+}
+
+/* Selected: accent fill when the sidebar owns focus, neutral fill when not —
+   the standard macOS "active vs inactive selection" pair. */
+.ws-sb-row.is-selected {
+  background: var(--fill-tertiary, rgba(120, 120, 128, 0.24));
+  font-weight: 500;
+}
+.ws-sidebar:focus-within .ws-sb-row.is-selected {
+  background: var(--accent);
+  color: #fff;
+}
+.ws-sidebar:focus-within .ws-sb-row.is-selected .ws-sb-ico,
+.ws-sidebar:focus-within .ws-sb-row.is-selected .ws-sb-count {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+/* Trailing affordance revealed on hover (remove-from-recents). */
+.ws-sb-row .ws-sb-trailing {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--label-secondary, var(--text-2));
+  opacity: 0;
+  transition: opacity 120ms ease, background 120ms ease;
+}
+.ws-sb-row:hover .ws-sb-trailing,
+.ws-sb-row .ws-sb-trailing:focus-visible {
+  opacity: 1;
+}
+.ws-sb-row .ws-sb-trailing:hover {
+  background: var(--fill-tertiary, rgba(120, 120, 128, 0.24));
+}
+
+/* File-explorer row: <dir>/<name> where the DIRECTORY truncates and the
+   filename never does. Replaces the `direction: rtl` hack, which mangled
+   any path containing `.` or `_` runs. */
+.ws-sb-path {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  align-items: baseline;
+}
+/* The directory absorbs essentially all of the shrink (999 vs 1), so the
+   filename only ever truncates once the directory is down to nothing. */
+.ws-sb-path .dir {
+  flex: 0 999 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--label-secondary, var(--text-2));
+}
+.ws-sb-path .name {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Sidebar empty / loading states. */
+.ws-sb-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 12px 8px;
+  font-size: 13px;
+  line-height: 17px;
+  color: var(--label-secondary, var(--text-2));
+}
+.ws-sb-empty .gi {
+  width: 20px;
+  height: 20px;
+  color: var(--label-secondary, var(--text-2));
+}
+.ws-sb-empty .act {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--accent);
+  cursor: default;
+}
+.ws-sb-empty .act:hover {
+  text-decoration: underline;
+}
+
+/* Skeleton rows share the final 28px geometry, so nothing shifts on load. */
+.ws-sb-skeleton {
+  height: 28px;
+  margin: 0 0 2px;
+  border-radius: 6px;
+  background: var(--fill-quaternary, var(--row-hover));
+  animation: ws-sb-shimmer 1.4s ease-in-out infinite;
+}
+.ws-sb-skeleton:nth-child(2n) {
+  width: 78%;
+}
+.ws-sb-skeleton:nth-child(3n) {
+  width: 62%;
+}
+@keyframes ws-sb-shimmer {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+
+/* Sort control — native <select> sized to the macOS pop-up button geometry.
+   Swaps to the shared PopUpButton primitive once TRA-290 lands. */
+/* No `appearance: none`: the UA draws the real macOS pop-up button, chevron
+   and all, and picks up `color-scheme` for dark mode. */
+.ws-sb-popup {
+  width: 100%;
+  height: 24px;
+  margin: 4px 0 6px;
+  font-family: inherit;
+  font-size: 13px;
+  cursor: default;
+}
+
+/* Resize handle — 6px hit strip straddling the separator, keyboard operable. */
+.ws-sb-resize {
+  flex: none;
+  width: 6px;
+  margin: 0 -3px;
+  z-index: 5;
+  cursor: col-resize;
+  background: transparent;
+  -webkit-app-region: no-drag;
+}
+.ws-sb-resize:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: 3px;
+}
+
+/* ---- Content pane ------------------------------------------------------- */
+/* Opaque — vibrancy stops at the sidebar's trailing edge. */
+.ws-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--surface-sunken, var(--island));
+}
+
+/* Minimal 44px header: balances the sidebar title strip, carries the sidebar
+   toggle and owns the content pane's drag region. The full toolbar spec is a
+   separate issue — this is chrome, not a toolbar. */
+.ws-content-head {
+  height: 44px;
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  -webkit-app-region: drag;
+}
+.ws-content-head > * {
+  -webkit-app-region: no-drag;
+}
+/* Collapsed sidebar on macOS: the traffic lights land on this header instead. */
+.ws-stage[data-platform="mac"] .ws-shell.is-collapsed .ws-content-head {
+  padding-left: 78px;
+}
+.ws-content-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  -webkit-app-region: no-drag;
+}
+
+.ws-chrome-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 24px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--label-secondary, var(--text-2));
+  cursor: default;
+  transition: background 120ms ease, color 120ms ease;
+}
+.ws-chrome-toggle:hover {
+  background: var(--fill-quaternary, var(--row-hover));
+  color: var(--label, var(--text-1));
+}
+
+/* ---- Accessibility ------------------------------------------------------ */
+/* Reduce Transparency: the sidebar must be opaque and readable. macOS turns
+   the NSVisualEffectView opaque on its own; this covers the web layer too. */
+@media (prefers-reduced-transparency: reduce) {
+  /* Must out-specify `.ws-stage[data-platform="mac"] .ws-sidebar` above. */
+  .ws-stage[data-platform="mac"] .ws-sidebar {
+    background: var(--surface, var(--island));
+  }
+}
+@media (prefers-contrast: more) {
+  .ws-stage .ws-sidebar {
+    border-right-color: var(--label-secondary, var(--text-2));
+  }
+  .ws-sb-row.is-selected {
+    outline: 1px solid var(--accent);
+    outline-offset: -1px;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ws-sb-row,
+  .ws-sb-trailing,
+  .ws-chrome-toggle {
+    transition: none;
+  }
+  .ws-sb-skeleton {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Stage 2 of the macOS 26 revision (TRA-291, parent TRA-284). Sidebar and window chrome migrated together — the traffic lights, the drag region and the sidebar material are the same 44px of pixels.

## Window chrome — `packages/app/src/main/tray.ts`

`hiddenInset` title bar, `trafficLightPosition: { x: 14, y: 18 }`, `vibrancy: 'sidebar'`, `visualEffectState: 'followWindow'`, all guarded behind `isMac`. Native `NSVisualEffectView`, so Reduce Transparency and the system appearance are honoured by the OS — **no `electron-liquid-glass` dependency**, per the parent issue's assessment.

`getTitleBarColor()` and the `nativeTheme.on('updated')` → `setBackgroundColor` loop are gone: vibrancy follows the appearance on its own, and the non-mac `backgroundColor` is only ever visible before the renderer's first paint. Added `minWidth/minHeight` 640×420.

## Renderer

New `styles/sidebar.css`. The sidebar is transparent **on macOS only** so the material shows through; the content pane paints `--surface-sunken`. `.ws-stage` / `.ws-win` no longer paint `--frame`, and non-mac stages paint themselves opaque (`data-platform` on `.ws-stage`).

Every colour reads a macOS-26 semantic token from TRA-289 with the current `island.css` value as the fallback (`var(--label-secondary, var(--text-2))`), so this file is correct both before and after the token layer lands and the two branches don't collide. **The final light-mode contrast on secondary text depends on TRA-289** — today's fallback `--text-2` is `#818594` (~3.4:1 on white); TRA-289's `--label-secondary` at `rgb(0 0 0 / .50)` clears AA.

| | Before | Now |
|---|---|---|
| Width / range | 180, 100–360, not persisted | 220, 180–320, persisted + synced |
| Collapse | — | ⌘⌥S + a header toggle, persisted |
| Material | opaque island, 12px radius, drop shadow | glass, flush to the window edge, no shadow |
| Row | 30px, 12.5px label, 9px radius, no icon | 28px, 13px label, 6px pill inset 6px, 16px icon |
| Groups | 1px hairline dividers | whitespace + 11px/600 headers |
| Resize handle | `tabIndex={-1}` under a `role="separator"` | tabbable, ←/→/Home/End, focus ring |
| File paths | `direction: rtl` (mangled names) | dir/name split, filename never truncates |
| Loading | the word `Loading…` at 10px | skeleton rows at the final 28px geometry |
| Drag region | the whole of `<main>` + the 8px gutter | sidebar's top 44px + the content header |

Deleted: the dead `.ws-lights` / `.ws-light` CSS traffic-light circles and the unused `--sidebar-bg` token.

Keyboard: ⌘⌥S toggles the sidebar, ⌘1…⌘9 select a section, ↑↓ walk the file tree (`role="tree"` / `aria-selected`), ⌫ removes a recent project.

Sort is still a native `<select>`, now sized to the 24px pop-up-button geometry with the UA's own chevron — it swaps to the shared PopUpButton primitive once TRA-290 lands.

## Test evidence

- `pnpm run typecheck` ✅, `pnpm run test` ✅ (10 files / 77 tests), `pnpm run build` ✅.
- New `src/renderer/__tests__/sidebar-prefs.test.ts` (6 tests): clamp + persist round trip, migration of widths written by older builds (100 → 180), and `splitPath` against both paths the issue cites as visibly mangled (`.idea/workspace.xml`, `__external__/_root/php.synthetic`).
- Driven in the real built app over CDP against a throwaway profile: light, dark, `prefers-reduced-transparency: reduce`, `prefers-contrast: more`, collapsed, width 300 persisted across reloads, 640px viewport, and the project window's file explorer. Screenshots are on the issue.

Caveat on the screenshots: the Screen Recording permission is not granted to this runtime, so they are CDP web-contents captures — the native traffic lights and the vibrancy material itself are not in frame. Traffic-light alignment against the 44px strip needs one human look on a real Mac.

Closes TRA-291.
