### PR TITLE
feat(app): Lattice control primitives — capsules, 20/24/28 heights, ≥24px hit targets, readable badges (TRA-290)

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -3,7 +3,7 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { GuardOnboarding, isOnboardingDone } from './components/GuardOnboarding';
 import { WindowTabBar } from './components/WindowTabBar';
 import { fileKind, FileTypeGlyph, Icon } from './lattice/icons';
-import { Button } from './lattice/ui';
+import { Button, PopUpButton } from './lattice/ui';
 import {
   clampSidebarWidth,
   readSidebarCollapsed,
@@ -295,20 +295,15 @@ function ProjectFileExplorer({
   return (
     <>
       <div className="ws-sb-group">Files</div>
-      {/* Sort — a native pop-up button sized to the macOS 24px geometry.
-          Swaps to the shared PopUpButton primitive once TRA-290 lands. */}
-      <select
+      {/* Sort — the shared pop-up button primitive (TRA-290). */}
+      <PopUpButton
+        block
         className="ws-sb-popup"
+        options={FILE_SORT_OPTIONS.map((o) => ({ value: o.id, label: o.label }))}
         value={sort}
+        onChange={(v) => setSort(v as FileSort)}
         aria-label="Sort files by"
-        onChange={(e) => setSort(e.target.value as FileSort)}
-      >
-        {FILE_SORT_OPTIONS.map((o) => (
-          <option key={o.id} value={o.id}>
-            {o.label}
-          </option>
-        ))}
-      </select>
+      />
 
       {loading ? (
         // Skeletons at the final 28px geometry — nothing shifts on load.

--- a/packages/app/src/renderer/app.css
+++ b/packages/app/src/renderer/app.css
@@ -6,6 +6,9 @@
 /* Sidebar + window chrome (TRA-291) — loaded after island.css so it can
    override the island treatment on the sidebar region. */
 @import "./styles/sidebar.css";
+/* Control primitives (TRA-290) — capsules, 20/24/28 heights, ≥24px hit
+   targets. Imported LAST so it wins over the legacy island rules it replaces. */
+@import "./styles/controls.css";
 
 :root {
   --bg-primary: rgba(246, 246, 246, 0.92);
@@ -112,72 +115,43 @@ body {
   border-radius: 4px;
 }
 
-/* ── macOS prominent button (filled, bezeled) ───────────────────── */
-/* Used by UpdateBanner. Sized for the narrow sidebar (~24px tall). */
+/* ── Prominent button (UpdateBanner) ─────────────────────────────── */
+/* macOS 26 prominent buttons are a FLAT accent capsule — the gradient + triple
+   box-shadow bezel that used to live here is gone (TRA-290). Full-width and
+   24px tall for the narrow sidebar. */
 .btn-prominent {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 100%;
   height: 24px;
-  padding: 0 10px;
+  padding: 0 12px;
   font-family: inherit;
-  font-size: 12px;
-  font-weight: 510;
+  font-size: 13px;
+  font-weight: 590;
   letter-spacing: -0.005em;
   color: #fff;
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--accent) 92%, white 8%) 0%,
-    var(--accent) 100%
-  );
+  background: var(--accent);
   border: none;
-  border-radius: 6px;
-  cursor: pointer;
+  border-radius: 999px;
+  cursor: default;
   user-select: none;
-  /* Bezel: hairline edge, inner top highlight, soft drop shadow. */
-  box-shadow:
-    0 0 0 0.5px color-mix(in srgb, var(--accent) 70%, black 30%),
-    inset 0 0.5px 0 rgba(255, 255, 255, 0.28),
-    0 1px 1.5px rgba(0, 0, 0, 0.08);
-  transition:
-    filter 120ms ease,
-    transform 80ms ease,
-    box-shadow 120ms ease;
+  transition: background 120ms ease;
 }
-.btn-prominent:hover {
-  filter: brightness(1.06);
+.btn-prominent:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--accent) 88%, black);
 }
-.btn-prominent:active {
-  filter: brightness(0.94);
-  transform: translateY(0.5px);
-  box-shadow:
-    0 0 0 0.5px color-mix(in srgb, var(--accent) 70%, black 36%),
-    inset 0 1px 2px rgba(0, 0, 0, 0.14);
+.btn-prominent:active:not(:disabled) {
+  background: color-mix(in oklab, var(--accent) 78%, black);
 }
 .btn-prominent:disabled {
-  opacity: 0.55;
-  cursor: default;
-  filter: none;
-  transform: none;
+  opacity: 0.4;
 }
-
-/* Success-tinted variant — used for "Restart to install". */
 .btn-prominent.success {
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--success) 92%, white 8%) 0%,
-    var(--success) 100%
-  );
-  box-shadow:
-    0 0 0 0.5px color-mix(in srgb, var(--success) 70%, black 30%),
-    inset 0 0.5px 0 rgba(255, 255, 255, 0.28),
-    0 1px 1.5px rgba(0, 0, 0, 0.08);
+  background: var(--success);
 }
-.btn-prominent.success:active {
-  box-shadow:
-    0 0 0 0.5px color-mix(in srgb, var(--success) 70%, black 36%),
-    inset 0 1px 2px rgba(0, 0, 0, 0.14);
+.btn-prominent.success:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--success) 88%, black);
 }
 
 /* ── Update banner: idle row vs notification card ───────────────── */
@@ -218,8 +192,8 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 18px;
-  height: 18px;
+  width: 24px;
+  height: 24px;
   margin-left: auto;
   padding: 0;
   background: transparent;
@@ -245,6 +219,14 @@ body {
 }
 .update-refresh.spinning svg {
   animation: update-refresh-spin 800ms linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .update-refresh.spinning svg {
+    animation: none;
+  }
+  .update-card {
+    animation: none;
+  }
 }
 @keyframes update-refresh-spin {
   from {
@@ -320,12 +302,15 @@ body {
 .sidebar-footer .nav-button {
   flex: 1 1 auto;
   min-width: 0;
+  height: 24px;
+  display: flex;
+  align-items: center;
   text-align: left;
-  padding: 6px 10px;
-  font-size: 12px;
+  padding: 0 10px;
+  font-size: 13px;
   font-weight: 500;
   letter-spacing: -0.005em;
-  border-radius: 6px;
+  border-radius: 999px;
   border: none;
   background: transparent;
   color: var(--text-secondary);
@@ -349,8 +334,8 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
+  width: 24px;
+  height: 24px;
   flex-shrink: 0;
   background: transparent;
   border: none;

--- a/packages/app/src/renderer/components/ProjectDetail.tsx
+++ b/packages/app/src/renderer/components/ProjectDetail.tsx
@@ -37,7 +37,7 @@ function shortPath(root: string): string {
 }
 
 function statusToDot(status?: string): Tone {
-  if (status === 'indexing') return 'gold';
+  if (status === 'indexing') return 'orange';
   if (status === 'error') return 'red';
   if (status === 'ready') return 'green';
   return 'neutral';

--- a/packages/app/src/renderer/components/__tests__/GuardOnboarding.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/GuardOnboarding.test.tsx
@@ -112,6 +112,6 @@ it('uses the Lattice Button primitive for its actions', async () => {
   render(<GuardOnboarding onClose={() => {}} />);
 
   const install = await screen.findByRole('button', { name: 'Install' });
-  expect(install.className).toContain('ws-primary');
-  expect(screen.getByRole('button', { name: 'Skip' }).className).toContain('ws-chipbtn');
+  expect(install.className).toContain('v-prominent');
+  expect(screen.getByRole('button', { name: 'Skip' }).className).toContain('v-bordered');
 });

--- a/packages/app/src/renderer/lattice/ui/Badge.tsx
+++ b/packages/app/src/renderer/lattice/ui/Badge.tsx
@@ -1,39 +1,67 @@
-/* Badge.tsx — small status/label tag for island surfaces (.ws-badge).
+/* Badge.tsx — small status tag (TRA-290).
 
-   Consolidates the dozen ad-hoc badge/pill/tag styles scattered across the
-   domain stylesheets onto ONE tone scale driven by the shared status tokens
-   (see island.css → "STATUS PALETTE / shared badge + dot"). Two looks:
-     variant="solid"   → tinted fill + colored text (default)
-     variant="outline" → transparent fill + colored 1px ring
+   Capsule, 11px/500, sentence case. ONE look: a tinted fill at 18% with the
+   SATURATED HUE as the label colour — every pair is verified ≥ 4.5:1 in both
+   appearances by __tests__/primitives.test.ts.
 
-   Tones map to the canonical app status colors so callers stop re-hardcoding
-   `#2f9e6e` / `#e0563a` / `#cda23f` etc. */
+   What this replaces: 9.5px/700/0.05em with ALL-CAPS callers, and the grade
+   badge that painted #ffffff on #ffcc00 at 1.6:1. There is no `variant`
+   anymore — the outline look was a second thing to keep contrast-correct for
+   no gain. */
 
 import type { ReactNode } from 'react';
 
-export type Tone = 'neutral' | 'accent' | 'green' | 'red' | 'gold' | 'blue' | 'pink';
+export type Tone = 'neutral' | 'accent' | 'green' | 'orange' | 'red' | 'blue' | 'purple';
+
+/** Superseded tone names, mapped so existing call sites keep working. */
+const LEGACY_TONE: Record<string, Tone> = { gold: 'orange', pink: 'purple' };
 
 export interface BadgeProps {
-  tone?: Tone;
-  variant?: 'solid' | 'outline';
+  tone?: Tone | 'gold' | 'pink';
   className?: string;
   title?: string;
+  'aria-label'?: string;
   children: ReactNode;
 }
 
 export function Badge({
   tone = 'neutral',
-  variant = 'solid',
   className,
   title,
+  'aria-label': ariaLabel,
   children,
 }: BadgeProps): ReactNode {
-  const cls = ['ws-badge', `t-${tone}`, variant === 'outline' ? 'outline' : '', className ?? '']
-    .filter(Boolean)
-    .join(' ');
+  const t = LEGACY_TONE[tone] ?? (tone as Tone);
+  const cls = ['lx-badge', `t-${t}`, className ?? ''].filter(Boolean).join(' ');
   return (
-    <span className={cls} title={title}>
+    <span className={cls} title={title} aria-label={ariaLabel}>
       {children}
     </span>
+  );
+}
+
+const GRADE_TONE: Record<string, Tone> = {
+  A: 'green',
+  B: 'green',
+  C: 'orange',
+  D: 'red',
+  F: 'red',
+};
+
+export interface GradeBadgeProps {
+  grade: string;
+}
+
+/** Tech-debt grade. The letter alone means nothing to a screen reader, so the
+    accessible name spells it out. */
+export function GradeBadge({ grade }: GradeBadgeProps): ReactNode {
+  return (
+    <Badge
+      tone={GRADE_TONE[grade] ?? 'neutral'}
+      title={`Tech debt grade ${grade}`}
+      aria-label={`Tech debt grade ${grade}`}
+    >
+      {grade}
+    </Badge>
   );
 }

--- a/packages/app/src/renderer/lattice/ui/Button.tsx
+++ b/packages/app/src/renderer/lattice/ui/Button.tsx
@@ -1,66 +1,86 @@
-/* Button.tsx — the single button primitive for the Lattice island surfaces.
+/* Button.tsx — the single button primitive (TRA-290).
 
-   Wraps the canonical button classes from island.css (NO new styling): pick a
-   `variant` and the component emits the matching class — so call sites stop
-   hand-writing `<button className="ws-primary">` etc. and there is ONE place
-   that knows the markup contract (leading icon slot, toggle state, icon-only).
+   Three sizes, four variants, one radius:
 
-     primary → .ws-primary   accent-filled CTA (32px)
-     chip    → .ws-chipbtn   bordered neutral chip (30px); `iconOnly` → square
-     text    → .ws-textbtn   borderless tertiary text button
-     mini    → .ws-mini      24px icon-only action (island header / toolbar)
+     size     small 20 · regular 24 · large 28    (nothing else exists)
+     variant  prominent  accent capsule, white label — the one default action
+              bordered   0.5px --separator capsule, quaternary fill on hover
+              plain      no chrome until hover
+              icon       24×24 square, 6px radius, 16px glyph
 
-   For the NATIVE-WINDOW (.dlg) surface use DlgButton instead — it speaks the
-   separate `--d-*` token scope (see Dlg.tsx). */
+   Every capsule variant is `border-radius: 999px`. The `icon` variant is the
+   ONLY square control, and it requires both `aria-label` and `title` — the type
+   below will not compile without them, because an icon with neither is
+   unreachable by screen reader AND unexplained by hover.
+
+   The pre-TRA-290 variant names (primary/chip/text/mini) still resolve, mapped
+   onto the new ones, so existing call sites keep working. They are deprecated;
+   don't add new ones. */
 
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 import { Icon } from '../icons';
 
-export type ButtonVariant = 'primary' | 'chip' | 'text' | 'mini';
+export type ButtonSize = 'small' | 'regular' | 'large';
+export type ButtonVariant = 'prominent' | 'bordered' | 'plain' | 'icon';
 
-export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: ButtonVariant;
+/** Superseded names, kept so the migration is not a big-bang rename. */
+export type LegacyButtonVariant = 'primary' | 'chip' | 'text' | 'mini';
+
+const LEGACY: Record<LegacyButtonVariant, ButtonVariant> = {
+  primary: 'prominent',
+  chip: 'bordered',
+  text: 'plain',
+  mini: 'icon',
+};
+
+interface BaseButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  size?: ButtonSize;
   /** Leading icon name (see icons.tsx GLYPHS). */
   icon?: string;
   iconSize?: number;
-  /** chip variant only: render a square icon-only chip (.ws-chipbtn.icon). */
-  iconOnly?: boolean;
-  /** chip variant only: toggle styling (.ws-chipbtn.toggle.is-on when active). */
-  toggle?: boolean;
+  /** Renders the on/selected state (`.is-on`). */
   active?: boolean;
+  /** @deprecated no-op — `active` alone drives the on state now. */
+  toggle?: boolean;
+  /** @deprecated use `variant="icon"`. */
+  iconOnly?: boolean;
 }
 
-const VARIANT_CLASS: Record<ButtonVariant, string> = {
-  primary: 'ws-primary',
-  chip: 'ws-chipbtn',
-  text: 'ws-textbtn',
-  mini: 'ws-mini',
-};
+/** `icon` buttons carry no label, so both of these are mandatory. */
+interface IconButtonProps extends BaseButtonProps {
+  variant: 'icon' | 'mini';
+  'aria-label': string;
+  title: string;
+}
 
-export function Button({
-  variant = 'chip',
-  icon,
-  iconSize,
-  iconOnly = false,
-  toggle = false,
-  active = false,
-  className,
-  children,
-  type = 'button',
-  ...rest
-}: ButtonProps): ReactNode {
-  const cls = [
-    VARIANT_CLASS[variant],
-    variant === 'chip' && iconOnly ? 'icon' : '',
-    variant === 'chip' && toggle ? 'toggle' : '',
-    toggle && active ? 'is-on' : '',
-    !toggle && active ? 'is-active' : '',
-    className ?? '',
-  ]
+interface LabelledButtonProps extends BaseButtonProps {
+  variant?: Exclude<ButtonVariant | LegacyButtonVariant, 'icon' | 'mini'>;
+}
+
+export type ButtonProps = IconButtonProps | LabelledButtonProps;
+
+export function Button(props: ButtonProps): ReactNode {
+  const {
+    variant = 'bordered',
+    size = 'regular',
+    icon,
+    iconSize,
+    active = false,
+    toggle: _toggle,
+    iconOnly: _iconOnly,
+    className,
+    children,
+    type = 'button',
+    ...rest
+  } = props as BaseButtonProps & { variant?: ButtonVariant | LegacyButtonVariant };
+
+  const v: ButtonVariant = (LEGACY as Record<string, ButtonVariant>)[variant] ?? (variant as ButtonVariant);
+
+  const cls = ['lx-btn', `v-${v}`, `sz-${size}`, active ? 'is-on' : '', className ?? '']
     .filter(Boolean)
     .join(' ');
 
-  const glyphSize = iconSize ?? (variant === 'mini' ? 16 : 15);
+  const glyphSize = iconSize ?? (v === 'icon' ? 16 : size === 'small' ? 13 : 15);
 
   return (
     <button type={type} className={cls} {...rest}>

--- a/packages/app/src/renderer/lattice/ui/Checkbox.tsx
+++ b/packages/app/src/renderer/lattice/ui/Checkbox.tsx
@@ -1,0 +1,45 @@
+/* Checkbox.tsx — macOS checkbox (TRA-290).
+
+   16×16 visual inside a 24×24 hit target; accent fill + white checkmark when
+   on. The geometry lives in controls.css and applies to EVERY
+   `input[type=checkbox]` in the renderer — the workspace table alone renders
+   ~90 of them and they were 13×13 UA defaults. This component exists for the
+   `indeterminate` state, which HTML can only set from script. */
+
+import { useEffect, useRef, type ReactNode } from 'react';
+
+export interface CheckboxProps {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  /** Mixed state — some but not all of the group is selected. */
+  indeterminate?: boolean;
+  'aria-label': string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function Checkbox({
+  checked,
+  onChange,
+  indeterminate = false,
+  'aria-label': ariaLabel,
+  disabled,
+  className,
+}: CheckboxProps): ReactNode {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (ref.current) ref.current.indeterminate = indeterminate;
+  }, [indeterminate]);
+
+  return (
+    <input
+      ref={ref}
+      type="checkbox"
+      className={className}
+      checked={checked}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      onChange={(e) => onChange(e.target.checked)}
+    />
+  );
+}

--- a/packages/app/src/renderer/lattice/ui/Chip.tsx
+++ b/packages/app/src/renderer/lattice/ui/Chip.tsx
@@ -1,0 +1,63 @@
+/* Chip.tsx — filter chips (TRA-290).
+
+   Capsule, 24px minimum (they used to render at 21.5px, under the hit-target
+   floor), 12px label. Idle --fill-quaternary → selected --fill-tertiary with a
+   --label label. Accent fill is reserved for `single`-select groups, where
+   exactly one chip is on at a time and the fill is unambiguous.
+
+   ChipGroup exists because a bare row of `A B C D F` is unreadable without
+   prior knowledge: the group carries a visible label, and each chip carries a
+   `title` spelling out what it filters. */
+
+import type { ReactNode } from 'react';
+
+export interface ChipProps {
+  label: ReactNode;
+  selected: boolean;
+  onClick: () => void;
+  /** Single-select group — the selected chip gets the accent fill. */
+  single?: boolean;
+  title?: string;
+  'aria-label'?: string;
+  disabled?: boolean;
+}
+
+export function Chip({
+  label,
+  selected,
+  onClick,
+  single = false,
+  title,
+  'aria-label': ariaLabel,
+  disabled,
+}: ChipProps): ReactNode {
+  const cls = ['lx-chip', single ? 'single' : '', selected ? 'is-on' : ''].filter(Boolean).join(' ');
+  return (
+    <button
+      type="button"
+      className={cls}
+      title={title}
+      aria-label={ariaLabel}
+      aria-pressed={selected}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}
+
+export interface ChipGroupProps {
+  /** Visible group label — required; a row of bare chips has no affordance. */
+  label: string;
+  children: ReactNode;
+}
+
+export function ChipGroup({ label, children }: ChipGroupProps): ReactNode {
+  return (
+    <span className="lx-chip-group" role="group" aria-label={label}>
+      <span className="lx-chip-group-label">{label}</span>
+      <span className="lx-chip-row">{children}</span>
+    </span>
+  );
+}

--- a/packages/app/src/renderer/lattice/ui/Gallery.tsx
+++ b/packages/app/src/renderer/lattice/ui/Gallery.tsx
@@ -1,0 +1,274 @@
+/* Gallery.tsx — every primitive × every size × every state, on one page.
+
+   Open with `?view=gallery` (add `&theme=dark` to force the dark appearance).
+   This is the reference surface for the TRA-290 primitives: if a control does
+   not appear here it is not a primitive, and if it appears here it is bound by
+   the geometry checks in __tests__/primitives.test.ts.
+
+   Deliberately not a Storybook — one route, no dependency, no build step. */
+
+import { useState, type ReactNode } from 'react';
+import { Icon } from '../icons';
+import { Badge, type Tone } from './Badge';
+import { Button, type ButtonSize } from './Button';
+import { Checkbox } from './Checkbox';
+import { Chip, ChipGroup } from './Chip';
+import { PopUpButton } from './PopUpButton';
+import { SearchField } from './SearchField';
+import { SegmentedControl } from './SegmentedControl';
+
+const SIZES: ButtonSize[] = ['small', 'regular', 'large'];
+const TONES: Tone[] = ['neutral', 'accent', 'green', 'orange', 'red', 'blue', 'purple'];
+
+function Row({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, minHeight: 32 }}>
+      <span
+        style={{
+          width: 150,
+          flex: 'none',
+          fontSize: 11,
+          color: 'var(--label-tertiary)',
+          cursor: 'default',
+        }}
+      >
+        {title}
+      </span>
+      <span style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        {children}
+      </span>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 28 }}>
+      <h2
+        style={{
+          margin: 0,
+          fontSize: 13,
+          fontWeight: 590,
+          color: 'var(--label)',
+          cursor: 'default',
+        }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+export function Gallery(): ReactNode {
+  const [seg, setSeg] = useState('table');
+  const [query, setQuery] = useState('');
+  const [chips, setChips] = useState<string[]>(['B']);
+  const [single, setSingle] = useState('all');
+  const [checked, setChecked] = useState(true);
+  const [sort, setSort] = useState('name');
+
+  const toggleChip = (g: string) =>
+    setChips((prev) => (prev.includes(g) ? prev.filter((x) => x !== g) : [...prev, g]));
+
+  return (
+    <div
+      style={{
+        padding: 24,
+        overflow: 'auto',
+        height: '100%',
+        background: 'var(--surface)',
+        color: 'var(--label)',
+        fontSize: 13,
+      }}
+    >
+      <h1 style={{ margin: '0 0 20px', fontSize: 17, fontWeight: 620, cursor: 'default' }}>
+        Lattice control primitives
+      </h1>
+
+      <Section title="Button">
+        {SIZES.map((size) => (
+          <Row key={size} title={`prominent · ${size}`}>
+            <Button variant="prominent" size={size}>
+              Index project
+            </Button>
+            <Button variant="prominent" size={size} icon="add">
+              With icon
+            </Button>
+            <Button variant="prominent" size={size} disabled>
+              Disabled
+            </Button>
+          </Row>
+        ))}
+        {SIZES.map((size) => (
+          <Row key={size} title={`bordered · ${size}`}>
+            <Button variant="bordered" size={size}>
+              Refresh
+            </Button>
+            <Button variant="bordered" size={size} active>
+              Selected
+            </Button>
+            <Button variant="bordered" size={size} disabled>
+              Disabled
+            </Button>
+          </Row>
+        ))}
+        {SIZES.map((size) => (
+          <Row key={size} title={`plain · ${size}`}>
+            <Button variant="plain" size={size}>
+              Clear filters
+            </Button>
+            <Button variant="plain" size={size} active>
+              Selected
+            </Button>
+            <Button variant="plain" size={size} disabled>
+              Disabled
+            </Button>
+          </Row>
+        ))}
+        {SIZES.map((size) => (
+          <Row key={size} title={`icon · ${size}`}>
+            <Button variant="icon" size={size} aria-label="Refresh" title="Refresh">
+              <Icon name="history" size={16} />
+            </Button>
+            <Button variant="icon" size={size} active aria-label="Settings" title="Settings">
+              <Icon name="settings" size={16} />
+            </Button>
+            <Button variant="icon" size={size} disabled aria-label="Close" title="Close">
+              <Icon name="close" size={16} />
+            </Button>
+          </Row>
+        ))}
+      </Section>
+
+      <Section title="SegmentedControl">
+        {(['small', 'regular', 'large'] as const).map((size) => (
+          <Row key={size} title={size}>
+            <SegmentedControl
+              size={size}
+              options={[
+                { value: 'table', label: 'Table' },
+                { value: 'compact', label: 'Compact' },
+                { value: 'cards', label: 'Cards', disabled: true },
+              ]}
+              value={seg}
+              onChange={setSeg}
+              aria-label="View mode"
+            />
+          </Row>
+        ))}
+      </Section>
+
+      <Section title="SearchField">
+        <Row title="idle / filled">
+          <SearchField value={query} onChange={setQuery} placeholder="Search projects" />
+          <span style={{ width: 240, display: 'flex' }}>
+            <SearchField grow value={query} onChange={setQuery} placeholder="Grow to fill" />
+          </span>
+        </Row>
+      </Section>
+
+      <Section title="Chip">
+        <Row title="multi-select">
+          <ChipGroup label="Grade">
+            {['A', 'B', 'C', 'D', 'F'].map((g) => (
+              <Chip
+                key={g}
+                label={g}
+                selected={chips.includes(g)}
+                onClick={() => toggleChip(g)}
+                title={`Tech debt grade ${g}`}
+                aria-label={`Tech debt grade ${g}`}
+              />
+            ))}
+          </ChipGroup>
+        </Row>
+        <Row title="single-select">
+          <ChipGroup label="Show">
+            {['all', 'errors'].map((v) => (
+              <Chip
+                key={v}
+                single
+                label={v === 'all' ? 'All' : 'Errors'}
+                selected={single === v}
+                onClick={() => setSingle(v)}
+                title={v === 'all' ? 'All calls' : 'Failed calls only'}
+              />
+            ))}
+          </ChipGroup>
+        </Row>
+        <Row title="with icon / disabled">
+          <Chip
+            label={
+              <>
+                <Icon name="lock" size={12} /> Security
+              </>
+            }
+            selected={false}
+            onClick={() => {}}
+            title="Projects with security findings"
+          />
+          <Chip label="Disabled" selected={false} disabled onClick={() => {}} />
+        </Row>
+      </Section>
+
+      <Section title="Badge">
+        <Row title="all tones">
+          {TONES.map((t) => (
+            <Badge key={t} tone={t}>
+              {t}
+            </Badge>
+          ))}
+        </Row>
+        <Row title="grade">
+          {['A', 'B', 'C', 'D', 'F'].map((g) => (
+            <Badge
+              key={g}
+              tone={g === 'A' || g === 'B' ? 'green' : g === 'C' ? 'orange' : 'red'}
+              aria-label={`Tech debt grade ${g}`}
+              title={`Tech debt grade ${g}`}
+            >
+              {g}
+            </Badge>
+          ))}
+        </Row>
+      </Section>
+
+      <Section title="Checkbox">
+        <Row title="off / on / mixed / disabled">
+          <Checkbox checked={false} onChange={() => {}} aria-label="Unchecked example" />
+          <Checkbox checked={checked} onChange={setChecked} aria-label="Checked example" />
+          <Checkbox checked={false} indeterminate onChange={() => {}} aria-label="Mixed example" />
+          <Checkbox checked disabled onChange={() => {}} aria-label="Disabled example" />
+        </Row>
+      </Section>
+
+      <Section title="PopUpButton">
+        <Row title="inline / block">
+          <PopUpButton
+            options={[
+              { value: 'name', label: 'Name' },
+              { value: 'modified', label: 'Date modified' },
+              { value: 'size', label: 'Size' },
+            ]}
+            value={sort}
+            onChange={setSort}
+            aria-label="Sort files"
+          />
+          <span style={{ width: 180, display: 'flex' }}>
+            <PopUpButton
+              block
+              options={[
+                { value: 'name', label: 'Name' },
+                { value: 'modified', label: 'Date modified' },
+              ]}
+              value={sort}
+              onChange={setSort}
+              aria-label="Sort files, full width"
+            />
+          </span>
+        </Row>
+      </Section>
+    </div>
+  );
+}

--- a/packages/app/src/renderer/lattice/ui/IslandHeader.tsx
+++ b/packages/app/src/renderer/lattice/ui/IslandHeader.tsx
@@ -2,9 +2,9 @@
 
    Every island (Project tree, Commit, Database, Terminal, …) renders the same
    strict 38px header: a leading title (optional icon + chevron) and a trailing
-   actions cluster of .ws-mini buttons. This component owns that contract so the
+   actions cluster of icon buttons. This component owns that contract so the
    rows stay pixel-identical; actions are supplied as children (use <Button
-   variant="mini" …/> or <MiniButton/>).
+   variant="icon" …/> or <MiniButton/>).
 
    The matching `MiniButton` helper covers the common icon-action case. */
 
@@ -55,18 +55,27 @@ export function IslandHeader({
 export interface MiniButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   icon: string;
   iconSize?: number;
+  /** Icon-only, so both are required — same contract as Button variant="icon". */
+  'aria-label': string;
+  title: string;
 }
 
-/** A 24px icon action button (.ws-mini) for island headers / toolbars. */
+/** A 24×24 icon action button for island headers / toolbars. Thin alias for
+    <Button variant="icon">, kept because header actions read better as
+    <MiniButton icon="refresh" …/>. */
 export function MiniButton({
   icon,
-  iconSize = 15,
+  iconSize = 16,
   className,
   type = 'button',
   ...rest
 }: MiniButtonProps): ReactNode {
   return (
-    <button type={type} className={'ws-mini' + (className ? ' ' + className : '')} {...rest}>
+    <button
+      type={type}
+      className={'lx-btn v-icon sz-regular' + (className ? ' ' + className : '')}
+      {...rest}
+    >
       <Icon name={icon} size={iconSize} />
     </button>
   );

--- a/packages/app/src/renderer/lattice/ui/PopUpButton.tsx
+++ b/packages/app/src/renderer/lattice/ui/PopUpButton.tsx
@@ -1,0 +1,58 @@
+/* PopUpButton.tsx — macOS pop-up button (TRA-290).
+
+   24px bordered capsule, 13px label, chevron-up-down glyph. Wraps a real
+   <select>, because the native menu IS the platform menu — only the chrome is
+   ours. Replaces the `appearance: none` 10px <select> with a hand-drawn sort
+   glyph in the sidebar file explorer. */
+
+import type { ReactNode } from 'react';
+
+export interface PopUpOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+export interface PopUpButtonProps<T extends string> {
+  options: ReadonlyArray<PopUpOption<T>>;
+  value: T;
+  onChange: (next: T) => void;
+  'aria-label': string;
+  title?: string;
+  className?: string;
+  /** Stretch to the container width (sidebar sort picker does). */
+  block?: boolean;
+}
+
+export function PopUpButton<T extends string>({
+  options,
+  value,
+  onChange,
+  'aria-label': ariaLabel,
+  title,
+  className,
+  block = false,
+}: PopUpButtonProps<T>): ReactNode {
+  const cls = ['lx-popup', className ?? ''].filter(Boolean).join(' ');
+  return (
+    <span className={cls} style={block ? { display: 'flex', width: '100%' } : undefined}>
+      <select
+        value={value}
+        aria-label={ariaLabel}
+        title={title ?? ariaLabel}
+        onChange={(e) => onChange(e.target.value as T)}
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      <span className="lx-popup-chevron" aria-hidden="true">
+        {/* chevron.up.chevron.down — the pop-up button's glyph, not a caret. */}
+        <svg width="10" height="14" viewBox="0 0 10 14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M2 5.5 5 2.5l3 3M2 8.5l3 3 3-3" />
+        </svg>
+      </span>
+    </span>
+  );
+}

--- a/packages/app/src/renderer/lattice/ui/SearchField.tsx
+++ b/packages/app/src/renderer/lattice/ui/SearchField.tsx
@@ -1,0 +1,73 @@
+/* SearchField.tsx — the one search field (TRA-290).
+
+   Capsule, 24px, 13px, leading 14px magnifier, --fill-tertiary fill, Esc clears.
+   Replaces the six hand-rolled search inputs and the `.ws-sbar`
+   centred-placeholder-that-slides-left animation, which animated `left` (a
+   layout property) over 0.42s and matched nothing on the platform. */
+
+import { useRef, type ReactNode } from 'react';
+import { Icon } from '../icons';
+
+export interface SearchFieldProps {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder?: string;
+  /** Fill the remaining width of a flex toolbar. */
+  grow?: boolean;
+  autoFocus?: boolean;
+  className?: string;
+  'aria-label'?: string;
+}
+
+export function SearchField({
+  value,
+  onChange,
+  placeholder = 'Search',
+  grow = false,
+  autoFocus = false,
+  className,
+  'aria-label': ariaLabel,
+}: SearchFieldProps): ReactNode {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const cls = ['lx-search', grow ? 'grow' : '', className ?? ''].filter(Boolean).join(' ');
+
+  return (
+    <div className={cls}>
+      <span className="lx-search-glyph" aria-hidden="true">
+        <Icon name="search" size={14} />
+      </span>
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        aria-label={ariaLabel ?? placeholder}
+        autoFocus={autoFocus}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key !== 'Escape') return;
+          // Esc clears; if already empty let the event bubble (a parent sheet
+          // or popover may want to close on it).
+          if (value === '') return;
+          e.preventDefault();
+          e.stopPropagation();
+          onChange('');
+        }}
+      />
+      {value !== '' && (
+        <button
+          type="button"
+          className="lx-btn v-icon sz-regular"
+          aria-label="Clear search"
+          title="Clear search"
+          onClick={() => {
+            onChange('');
+            inputRef.current?.focus();
+          }}
+        >
+          <Icon name="close" size={12} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/renderer/lattice/ui/SegmentedControl.tsx
+++ b/packages/app/src/renderer/lattice/ui/SegmentedControl.tsx
@@ -1,14 +1,11 @@
-/* SegmentedControl.tsx — the island segmented/pill toggle (.ws-seg2).
+/* SegmentedControl.tsx — the one segmented control (TRA-290).
 
-   Replaces hand-rolled `<div className="ws-seg2"><button .s2 .is-active>…`
-   blocks. Emits the canonical island.css markup verbatim, so swapping a call
-   site to this component is a pure JSX dedup with zero visual change.
+   A real macOS track: recessed --fill-tertiary capsule, 2px inset, capsule
+   thumb. The selected thumb is --surface with a hairline — NOT an accent fill,
+   which reads as "toggled on" rather than "this segment is selected".
 
-   `size="mini"` adds the `.mini` modifier (tighter padding / smaller text).
-   Extra layout classes (e.g. the `ov2-seg` width tweak) pass through `className`
-   so per-context sizing is preserved.
-
-   For the NATIVE-WINDOW (.dlg) surface use DlgSegmented (.dlg-seg) instead. */
+   Replaces every ad-hoc pill row in the app (Table|Compact, Decisions|Review|…,
+   Debug|TODOs|…, Tool calls|AI calls, All|Errors). */
 
 import type { ReactNode } from 'react';
 
@@ -23,7 +20,7 @@ export interface SegmentedControlProps<T extends string> {
   options: ReadonlyArray<SegmentedOption<T>>;
   value: T;
   onChange: (value: T) => void;
-  size?: 'default' | 'mini';
+  size?: 'small' | 'regular' | 'large';
   className?: string;
   'aria-label'?: string;
 }
@@ -32,20 +29,18 @@ export function SegmentedControl<T extends string>({
   options,
   value,
   onChange,
-  size = 'default',
+  size = 'regular',
   className,
   'aria-label': ariaLabel,
 }: SegmentedControlProps<T>): ReactNode {
-  const cls = ['ws-seg2', size === 'mini' ? 'mini' : '', className ?? '']
-    .filter(Boolean)
-    .join(' ');
+  const cls = ['lx-seg', `sz-${size}`, className ?? ''].filter(Boolean).join(' ');
   return (
     <div className={cls} role="group" aria-label={ariaLabel}>
       {options.map((opt) => (
         <button
           key={opt.value}
           type="button"
-          className={'s2' + (opt.value === value ? ' is-active' : '')}
+          className={'lx-seg-item' + (opt.value === value ? ' is-active' : '')}
           title={opt.title}
           disabled={opt.disabled}
           aria-pressed={opt.value === value}

--- a/packages/app/src/renderer/lattice/ui/StatusDot.tsx
+++ b/packages/app/src/renderer/lattice/ui/StatusDot.tsx
@@ -9,7 +9,8 @@ import type { CSSProperties, ReactNode } from 'react';
 import type { Tone } from './Badge';
 
 export interface StatusDotProps {
-  tone?: Tone;
+  /** `gold`/`pink` are the pre-TRA-290 names for `orange`/`purple`. */
+  tone?: Tone | 'gold' | 'pink';
   /** Diameter in px (default 8). */
   size?: number;
   /** Pulsing halo (live indicator). */
@@ -25,7 +26,8 @@ export function StatusDot({
   className,
   title,
 }: StatusDotProps): ReactNode {
-  const cls = ['ws-statusdot', `t-${tone}`, pulse ? 'pulse' : '', className ?? '']
+  const t = tone === 'gold' ? 'orange' : tone === 'pink' ? 'purple' : tone;
+  const cls = ['ws-statusdot', `t-${t}`, pulse ? 'pulse' : '', className ?? '']
     .filter(Boolean)
     .join(' ');
   return (

--- a/packages/app/src/renderer/lattice/ui/__tests__/primitives.test.tsx
+++ b/packages/app/src/renderer/lattice/ui/__tests__/primitives.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * @vitest-environment jsdom
+ */
+/* Geometry + contrast checks for the TRA-290 control primitives.
+ *
+ * Three things this locks down, all of which regressed silently before:
+ *  1. every control height in controls.css is 20 / 24 / 28 — nothing else;
+ *  2. every focusable primitive renders at >= 24x24 (the grade chips were
+ *     21.5px and the workspace checkboxes 13px);
+ *  3. every badge tone clears 4.5:1 in BOTH appearances (the grade badge was
+ *     white on #ffcc00, 1.6:1).
+ *
+ * jsdom does not do layout, so (2) is asserted against the declared CSS box for
+ * each primitive's class rather than a measured rect — which is the same thing
+ * here, since every primitive sets an explicit height and the sizes are a
+ * closed set.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Gallery } from '../Gallery';
+
+// jsdom rewrites import.meta.url to an http: URL, so resolve off the vitest
+// root (packages/app) instead.
+const CSS = readFileSync(resolve(process.cwd(), 'src/renderer/styles/controls.css'), 'utf8');
+
+/** Crude but sufficient rule splitter — controls.css has no nested at-rules
+    other than @media, whose bodies split into rules the same way. */
+const FLAT = CSS.replace(/\/\*[\s\S]*?\*\//g, '').replace(/@media[^{]*\{/g, '');
+
+function rules(): Array<{ selector: string; body: string }> {
+  const out: Array<{ selector: string; body: string }> = [];
+  const re = /([^{}]+)\{([^{}]*)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(FLAT)) !== null) {
+    const selector = m[1].trim();
+    if (selector === '' || selector.startsWith('@')) continue;
+    out.push({ selector, body: m[2] });
+  }
+  return out;
+}
+
+function decl(body: string, prop: string): string | undefined {
+  const m = new RegExp(`(?:^|;)\\s*${prop}\\s*:\\s*([^;]+)`, 'i').exec(body);
+  return m?.[1].trim();
+}
+
+// ── colour maths (WCAG 2.1 relative luminance / contrast ratio) ────────────
+
+type RGB = [number, number, number];
+
+function hex(c: string): RGB {
+  const h = c.trim().replace('#', '');
+  const f = h.length === 3 ? h.split('').map((x) => x + x).join('') : h;
+  return [
+    Number.parseInt(f.slice(0, 2), 16),
+    Number.parseInt(f.slice(2, 4), 16),
+    Number.parseInt(f.slice(4, 6), 16),
+  ];
+}
+
+/** `color-mix(in oklab, HUE 18%, transparent)` painted over `bg`. Mixing with
+    `transparent` yields the hue at 18% alpha; compositing that over an opaque
+    backing is a plain source-over blend, so the oklab detour cancels out. */
+function over(fg: RGB, bg: RGB, alpha: number): RGB {
+  return [0, 1, 2].map((i) => fg[i] * alpha + bg[i] * (1 - alpha)) as RGB;
+}
+
+function luminance([r, g, b]: RGB): number {
+  const lin = [r, g, b].map((v) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2];
+}
+
+function contrast(a: RGB, b: RGB): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** Pull `--name` out of a `:root`-ish block whose selector matches `scope`. */
+function token(name: string, scope: string): string {
+  const block = rules().find((r) => r.selector === scope);
+  if (!block) throw new Error(`no block for selector ${scope}`);
+  const v = decl(block.body, `--${name}`);
+  if (!v) throw new Error(`no --${name} in ${scope}`);
+  return v;
+}
+
+const APPEARANCES = [
+  { name: 'light', scope: ':root' },
+  { name: 'dark', scope: ":root[data-theme='dark']" },
+] as const;
+
+const TONES = ['neutral', 'accent', 'green', 'orange', 'red', 'blue', 'purple'] as const;
+
+/** The fill each tone paints: the 18% tint of its hue, except neutral, which
+    uses --fill-tertiary (a grey at 12%/28% of rgb(118,118,128)). */
+function badgeFill(tone: string, scope: string): RGB {
+  const surface = hex(token('surface', scope));
+  if (tone === 'neutral') {
+    const alpha = scope === ':root' ? 0.12 : 0.28;
+    return over([118, 118, 128], surface, alpha);
+  }
+  const hue = hex(token(tone === 'accent' ? 'accent' : `status-${tone}`, scope));
+  return over(hue, surface, 0.18);
+}
+
+describe('controls.css geometry', () => {
+  const ALLOWED_HEIGHTS = new Set(['20px', '24px', '28px', '100%', '18px']);
+
+  it('declares no control height outside 20 / 24 / 28', () => {
+    const offenders: string[] = [];
+    for (const { selector, body } of rules()) {
+      const h = decl(body, 'height');
+      if (h === undefined) continue;
+      // The badge is not focusable and is sized to sit inside a 24px row.
+      if (h === '18px' && !selector.includes('lx-badge')) offenders.push(`${selector} → ${h}`);
+      else if (!ALLOWED_HEIGHTS.has(h)) offenders.push(`${selector} → ${h}`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('gives every focusable primitive a >= 24px box at its default size', () => {
+    const defaults: Record<string, string> = {
+      '.lx-btn': '24px',
+      '.lx-seg': '24px',
+      '.lx-search': '24px',
+      '.lx-chip': '24px',
+      '.lx-popup': '24px',
+      '.lx-popup select': '24px',
+      "input[type='checkbox']": '24px',
+    };
+    for (const [sel, want] of Object.entries(defaults)) {
+      const r = rules().find((x) => x.selector === sel);
+      expect(r, `missing rule ${sel}`).toBeDefined();
+      expect(decl(r!.body, 'height'), sel).toBe(want);
+    }
+    // The checkbox paints 16px inside that 24px box via a transparent border.
+    const cb = rules().find((x) => x.selector === "input[type='checkbox']")!;
+    expect(decl(cb.body, 'border')).toBe('4px solid transparent');
+    expect(decl(cb.body, 'width')).toBe('24px');
+  });
+
+  it('uses only capsule / 6px / 50% radii on controls', () => {
+    const ALLOWED = new Set(['999px', '6px', '50%', '9px', '100%']);
+    const offenders: string[] = [];
+    for (const { selector, body } of rules()) {
+      const r = decl(body, 'border-radius');
+      if (r === undefined) continue;
+      // 9px is only legal on the checkbox: 5px inner + 4px transparent border
+      // is concentric with the 16px visual.
+      if (r === '9px' && !selector.includes('checkbox')) offenders.push(`${selector} → ${r}`);
+      else if (!ALLOWED.has(r)) offenders.push(`${selector} → ${r}`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps cursor: default on buttons (that is the macOS behaviour)', () => {
+    const btn = rules().find((x) => x.selector === '.lx-btn')!;
+    expect(decl(btn.body, 'cursor')).toBe('default');
+  });
+
+  it('honours prefers-reduced-motion', () => {
+    expect(CSS).toContain('@media (prefers-reduced-motion: reduce)');
+  });
+});
+
+describe('badge contrast', () => {
+  for (const { name, scope } of APPEARANCES) {
+    for (const tone of TONES) {
+      it(`${tone} clears 4.5:1 in ${name}`, () => {
+        const fg = hex(token(`badge-${tone}-fg`, scope));
+        const ratio = contrast(fg, badgeFill(tone, scope));
+        expect(
+          ratio,
+          `${tone}/${name}: ${ratio.toFixed(2)}:1 — pick a darker (light) or lighter (dark) label`,
+        ).toBeGreaterThanOrEqual(4.5);
+      });
+    }
+  }
+
+  it('never paints a badge label white', () => {
+    for (const { scope } of APPEARANCES) {
+      for (const tone of TONES) {
+        expect(token(`badge-${tone}-fg`, scope).toLowerCase()).not.toBe('#ffffff');
+      }
+    }
+  });
+});
+
+describe('gallery', () => {
+  it('renders every primitive and every icon-only button has a name', () => {
+    render(<Gallery />);
+    // Icon-only buttons carry no text — each must be reachable by name.
+    for (const btn of screen.getAllByRole('button')) {
+      const name = btn.getAttribute('aria-label') ?? btn.textContent?.trim() ?? '';
+      expect(name, `unnamed button: ${btn.outerHTML.slice(0, 120)}`).not.toBe('');
+    }
+    // Every checkbox is labelled too.
+    for (const cb of screen.getAllByRole('checkbox')) {
+      expect(cb.getAttribute('aria-label')).toBeTruthy();
+    }
+    // Grade chips are not a bare `A B C D F` row any more.
+    expect(screen.getByRole('group', { name: 'Grade' })).toBeTruthy();
+    // Both the grade chip and the grade badge spell the letter out.
+    expect(screen.getAllByLabelText('Tech debt grade C')).toHaveLength(2);
+  });
+});

--- a/packages/app/src/renderer/lattice/ui/index.ts
+++ b/packages/app/src/renderer/lattice/ui/index.ts
@@ -8,13 +8,25 @@
    out — this app has no standalone OS-window dialogs to theme with them. */
 
 export { Button } from './Button';
-export type { ButtonProps, ButtonVariant } from './Button';
+export type { ButtonProps, ButtonSize, ButtonVariant } from './Button';
 
 export { SegmentedControl } from './SegmentedControl';
 export type { SegmentedControlProps, SegmentedOption } from './SegmentedControl';
 
-export { Badge } from './Badge';
-export type { BadgeProps, Tone } from './Badge';
+export { SearchField } from './SearchField';
+export type { SearchFieldProps } from './SearchField';
+
+export { Chip, ChipGroup } from './Chip';
+export type { ChipProps, ChipGroupProps } from './Chip';
+
+export { Checkbox } from './Checkbox';
+export type { CheckboxProps } from './Checkbox';
+
+export { PopUpButton } from './PopUpButton';
+export type { PopUpButtonProps, PopUpOption } from './PopUpButton';
+
+export { Badge, GradeBadge } from './Badge';
+export type { BadgeProps, GradeBadgeProps, Tone } from './Badge';
 
 export { StatusDot } from './StatusDot';
 export type { StatusDotProps } from './StatusDot';

--- a/packages/app/src/renderer/main.tsx
+++ b/packages/app/src/renderer/main.tsx
@@ -3,11 +3,22 @@ import { createRoot } from 'react-dom/client';
 import './app.css';
 import { App } from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { Gallery } from './lattice/ui/Gallery';
+
+// `?view=gallery` renders the control-primitive reference surface instead of
+// the app (TRA-290). Routed here, not inside App, so it needs none of the app's
+// daemon state — it is just the stylesheet plus the primitives.
+const params = new URLSearchParams(window.location.search);
+const isGallery = params.get('view') === 'gallery';
+// `&theme=light|dark` pins the appearance so both can be screenshotted; the app
+// itself gets its theme from useTheme, which the gallery route bypasses.
+const forcedTheme = params.get('theme');
+if (isGallery && (forcedTheme === 'light' || forcedTheme === 'dark')) {
+  document.documentElement.dataset.theme = forcedTheme;
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ErrorBoundary label="App">
-      <App />
-    </ErrorBoundary>
+    <ErrorBoundary label="App">{isGallery ? <Gallery /> : <App />}</ErrorBoundary>
   </StrictMode>,
 );

--- a/packages/app/src/renderer/styles/controls.css
+++ b/packages/app/src/renderer/styles/controls.css
@@ -1,0 +1,592 @@
+/* ============================================================================
+   Lattice control primitives (TRA-290)
+
+   ONE geometry for every control in the app:
+     heights   20 (small) / 24 (regular) / 28 (large) — nothing else
+     radius    999px (capsule) for anything pill-shaped, 6px for square icon
+               buttons, 50% for dots. No 4/5/8/9/12px control radii.
+     hit area  >= 24x24 for every focusable element, even when the painted
+               visual is smaller (checkbox: 16px visual in a 24px box).
+
+   Classes are prefixed `lx-` and live at the document root — deliberately NOT
+   scoped under `.ws-stage`, because the app renders controls on BOTH the island
+   surface (.ws-stage, island.css tokens) and the plain app surface (app.css
+   tokens). The token shim below is what makes one rule work on both.
+   ============================================================================ */
+
+/* ── PROVISIONAL TOKEN SHIM — delete when TRA-289 lands ────────────────────
+   TRA-289 introduces styles/tokens.css with exactly these semantic names. Until
+   it merges, the primitives would have nothing to reference, so the values are
+   declared here. When tokens.css lands: delete this block (down to END SHIM)
+   and nothing else in this file changes.
+   -------------------------------------------------------------------------- */
+:root {
+  --accent: #007aff;
+  --accent-pressed: #0062d1;
+  --surface: #ffffff;
+  --label: #1d1d1f;
+  --label-secondary: #48484a;
+  --label-tertiary: #6c6c70;
+  --on-accent: #ffffff;
+  --separator: rgba(0, 0, 0, 0.14);
+  --fill-tertiary: rgba(118, 118, 128, 0.12);
+  --fill-quaternary: rgba(118, 118, 128, 0.08);
+  --fill-pressed: rgba(118, 118, 128, 0.2);
+
+  --status-green: #2f9e6e;
+  --status-orange: #c9781f;
+  --status-red: #d4321c;
+  --status-blue: #3574f0;
+  --status-purple: #8a5cf0;
+
+  /* Badge label colours — the saturated hue, darkened until the text clears
+     4.5:1 over its own 18% tint on --surface. Verified by
+     lattice/ui/__tests__/primitives.test.ts, which fails if either drifts. */
+  --badge-neutral-fg: #4a4a4f;
+  --badge-accent-fg: #0a52ab;
+  --badge-green-fg: #17624a;
+  --badge-orange-fg: #7c4310;
+  --badge-red-fg: #9e1f0c;
+  --badge-blue-fg: #1e4794;
+  --badge-purple-fg: #533690;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    --accent: #0a84ff;
+    --accent-pressed: #409cff;
+    --surface: #1e1f22;
+    --label: #f5f5f7;
+    --label-secondary: #c7c7cc;
+    --label-tertiary: #98989d;
+    --separator: rgba(255, 255, 255, 0.16);
+    --fill-tertiary: rgba(118, 118, 128, 0.28);
+    --fill-quaternary: rgba(118, 118, 128, 0.2);
+    --fill-pressed: rgba(118, 118, 128, 0.4);
+
+    --status-green: #43b07f;
+    --status-orange: #e8a33d;
+    --status-red: #ef6a52;
+    --status-blue: #6f9bf6;
+    --status-purple: #b08cf0;
+
+    --badge-neutral-fg: #c7c7cc;
+    --badge-accent-fg: #79baff;
+    --badge-green-fg: #6fd4a4;
+    --badge-orange-fg: #f0bb6b;
+    --badge-red-fg: #ff9683;
+    --badge-blue-fg: #9dbcfa;
+    --badge-purple-fg: #c8adf7;
+  }
+}
+
+:root[data-theme='dark'] {
+  --accent: #0a84ff;
+  --accent-pressed: #409cff;
+  --surface: #1e1f22;
+  --label: #f5f5f7;
+  --label-secondary: #c7c7cc;
+  --label-tertiary: #98989d;
+  --separator: rgba(255, 255, 255, 0.16);
+  --fill-tertiary: rgba(118, 118, 128, 0.28);
+  --fill-quaternary: rgba(118, 118, 128, 0.2);
+  --fill-pressed: rgba(118, 118, 128, 0.4);
+
+  --status-green: #43b07f;
+  --status-orange: #e8a33d;
+  --status-red: #ef6a52;
+  --status-blue: #6f9bf6;
+  --status-purple: #b08cf0;
+
+  --badge-neutral-fg: #c7c7cc;
+  --badge-accent-fg: #79baff;
+  --badge-green-fg: #6fd4a4;
+  --badge-orange-fg: #f0bb6b;
+  --badge-red-fg: #ff9683;
+  --badge-blue-fg: #9dbcfa;
+  --badge-purple-fg: #c8adf7;
+}
+
+/* On the island surface the fills sit on --island, not on the app background —
+   re-point --surface so the badge tints composite over the right backing. */
+.ws-stage[data-mode='light'] {
+  --surface: #ffffff;
+}
+.ws-stage[data-mode='dark'] {
+  --surface: #18191b;
+}
+/* ── END SHIM ─────────────────────────────────────────────────────────────── */
+
+/* ============================================================================
+   BUTTON — .lx-btn
+   ============================================================================ */
+.lx-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  flex: none;
+  box-sizing: border-box;
+  height: 24px;
+  min-width: 24px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  line-height: 1;
+  white-space: nowrap;
+  color: var(--label);
+  /* macOS buttons keep the arrow cursor — the pointer is for links. */
+  cursor: default;
+  transition:
+    background 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease;
+}
+.lx-btn:disabled {
+  opacity: 0.4;
+}
+
+/* sizes ------------------------------------------------------------------- */
+.lx-btn.sz-small {
+  height: 20px;
+  padding: 0 9px;
+  font-size: 12px;
+}
+.lx-btn.sz-regular {
+  height: 24px;
+}
+.lx-btn.sz-large {
+  height: 28px;
+  padding: 0 14px;
+}
+
+/* variants ---------------------------------------------------------------- */
+.lx-btn.v-prominent {
+  /* Flat accent capsule. macOS 26 dropped the gradient + bezel entirely. */
+  background: var(--accent);
+  color: var(--on-accent, #fff);
+  font-weight: 590;
+}
+.lx-btn.v-prominent:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--accent) 88%, black);
+}
+.lx-btn.v-prominent:active:not(:disabled) {
+  background: color-mix(in oklab, var(--accent) 78%, black);
+}
+
+.lx-btn.v-bordered {
+  box-shadow: inset 0 0 0 0.5px var(--separator);
+  color: var(--label);
+}
+.lx-btn.v-bordered:hover:not(:disabled) {
+  background: var(--fill-quaternary);
+}
+.lx-btn.v-bordered:active:not(:disabled) {
+  background: var(--fill-pressed);
+}
+.lx-btn.v-bordered.is-on {
+  background: color-mix(in oklab, var(--accent) 16%, transparent);
+  box-shadow: inset 0 0 0 0.5px color-mix(in oklab, var(--accent) 45%, transparent);
+  color: var(--accent);
+}
+
+.lx-btn.v-plain {
+  color: var(--label-secondary);
+  padding: 0 8px;
+}
+.lx-btn.v-plain:hover:not(:disabled) {
+  background: var(--fill-quaternary);
+  color: var(--label);
+}
+.lx-btn.v-plain:active:not(:disabled) {
+  background: var(--fill-pressed);
+}
+.lx-btn.v-plain.is-on {
+  background: var(--fill-tertiary);
+  color: var(--label);
+}
+
+/* Icon-only: the ONE square control. 24x24 box, 6px radius, 16px glyph. */
+.lx-btn.v-icon {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border-radius: 6px;
+  color: var(--label-secondary);
+}
+.lx-btn.v-icon.sz-small {
+  width: 20px;
+  height: 20px;
+}
+.lx-btn.v-icon.sz-large {
+  width: 28px;
+  height: 28px;
+}
+.lx-btn.v-icon:hover:not(:disabled) {
+  background: var(--fill-quaternary);
+  color: var(--label);
+}
+.lx-btn.v-icon:active:not(:disabled) {
+  background: var(--fill-pressed);
+}
+.lx-btn.v-icon.is-on {
+  background: var(--fill-tertiary);
+  color: var(--accent);
+}
+
+/* ============================================================================
+   SEGMENTED CONTROL — .lx-seg
+   A real track: recessed fill, 2px inset, capsule outer AND capsule thumb.
+   The thumb is --surface with a hairline; it is NOT an accent fill (that reads
+   as a toggle-on state, not as a selected segment).
+   ============================================================================ */
+.lx-seg {
+  display: inline-flex;
+  align-items: center;
+  flex: none;
+  box-sizing: border-box;
+  height: 24px;
+  padding: 2px;
+  gap: 2px;
+  background: var(--fill-tertiary);
+  border-radius: 999px;
+}
+.lx-seg.sz-small {
+  height: 20px;
+}
+.lx-seg.sz-large {
+  height: 28px;
+}
+.lx-seg .lx-seg-item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  height: 100%;
+  min-width: 24px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  color: var(--label-secondary);
+  cursor: default;
+  transition:
+    background 120ms ease,
+    color 120ms ease;
+}
+.lx-seg.sz-small .lx-seg-item {
+  font-size: 12px;
+  padding: 0 9px;
+}
+.lx-seg .lx-seg-item:hover:not(:disabled):not(.is-active) {
+  color: var(--label);
+}
+.lx-seg .lx-seg-item.is-active {
+  background: var(--surface);
+  color: var(--label);
+  font-weight: 590;
+  box-shadow:
+    inset 0 0 0 0.5px var(--separator),
+    0 0.5px 1px rgba(0, 0, 0, 0.12);
+}
+.lx-seg .lx-seg-item:disabled {
+  opacity: 0.4;
+}
+
+/* ============================================================================
+   SEARCH FIELD — .lx-search
+   Capsule, 24px, 13px, leading 14px magnifier. No slide animation: the
+   placeholder starts and stays at the leading edge, like every macOS search
+   field. `Esc` clears (handled in SearchField.tsx).
+   ============================================================================ */
+.lx-search {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  box-sizing: border-box;
+  height: 24px;
+  min-width: 140px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: var(--fill-tertiary);
+  color: var(--label-tertiary);
+  transition: background 120ms ease;
+}
+.lx-search.grow {
+  flex: 1 1 auto;
+}
+.lx-search:hover {
+  background: var(--fill-quaternary);
+}
+.lx-search:focus-within {
+  background: var(--surface);
+  box-shadow:
+    inset 0 0 0 0.5px var(--separator),
+    0 0 0 3px color-mix(in oklab, var(--accent) 35%, transparent);
+}
+.lx-search .lx-search-glyph {
+  flex: none;
+  display: flex;
+  color: var(--label-tertiary);
+}
+.lx-search input {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--label);
+}
+.lx-search input::placeholder {
+  color: var(--label-tertiary);
+}
+/* The UA clear button is 13px and unstyleable — we ship our own icon button. */
+.lx-search input::-webkit-search-cancel-button {
+  display: none;
+}
+
+/* ============================================================================
+   CHIP / FILTER CHIP — .lx-chip
+   ============================================================================ */
+.lx-chip-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: none;
+}
+.lx-chip-group > .lx-chip-group-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--label-tertiary);
+  cursor: default;
+  white-space: nowrap;
+}
+.lx-chip-group > .lx-chip-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.lx-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  flex: none;
+  box-sizing: border-box;
+  height: 24px;
+  min-width: 24px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--fill-quaternary);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  color: var(--label-secondary);
+  cursor: default;
+  transition:
+    background 120ms ease,
+    color 120ms ease;
+}
+.lx-chip:hover:not(:disabled) {
+  background: var(--fill-tertiary);
+}
+/* Multi-select: selected reads as a neutral filled state with a --label label.
+   Accent fill is reserved for single-select, where exactly one chip is on. */
+.lx-chip.is-on {
+  background: var(--fill-tertiary);
+  box-shadow: inset 0 0 0 0.5px var(--separator);
+  color: var(--label);
+  font-weight: 590;
+}
+.lx-chip.single.is-on {
+  background: var(--accent);
+  box-shadow: none;
+  color: var(--on-accent, #fff);
+}
+.lx-chip:disabled {
+  opacity: 0.4;
+}
+
+/* ============================================================================
+   BADGE — .lx-badge
+   Capsule, 11px/500, sentence case. Tinted fill at 18% with the SATURATED HUE
+   as the label colour. Never white-on-a-light-fill.
+   Not focusable, so 24px does not apply — 18px keeps it inside a 24px row.
+   ============================================================================ */
+.lx-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  box-sizing: border-box;
+  height: 18px;
+  padding: 0 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: 0;
+  white-space: nowrap;
+  /* ponytail: no text-transform. ALL CAPS is banned outside 10px group headers. */
+  background: var(--fill-tertiary);
+  color: var(--badge-neutral-fg);
+}
+.lx-badge.t-neutral {
+  background: var(--fill-tertiary);
+  color: var(--badge-neutral-fg);
+}
+.lx-badge.t-accent {
+  background: color-mix(in oklab, var(--accent) 18%, transparent);
+  color: var(--badge-accent-fg);
+}
+.lx-badge.t-green {
+  background: color-mix(in oklab, var(--status-green) 18%, transparent);
+  color: var(--badge-green-fg);
+}
+.lx-badge.t-orange {
+  background: color-mix(in oklab, var(--status-orange) 18%, transparent);
+  color: var(--badge-orange-fg);
+}
+.lx-badge.t-red {
+  background: color-mix(in oklab, var(--status-red) 18%, transparent);
+  color: var(--badge-red-fg);
+}
+.lx-badge.t-blue {
+  background: color-mix(in oklab, var(--status-blue) 18%, transparent);
+  color: var(--badge-blue-fg);
+}
+.lx-badge.t-purple {
+  background: color-mix(in oklab, var(--status-purple) 18%, transparent);
+  color: var(--badge-purple-fg);
+}
+
+/* ============================================================================
+   CHECKBOX — 16px visual inside a 24x24 hit target.
+   The transparent 4px border is what grows the box to 24 while keeping the
+   painted square at 16 (background-clip keeps the fill off the border).
+   Applied to every `input[type=checkbox]` in the renderer — the workspace table
+   alone renders ~90 of them, and none should be the 13px UA default.
+   ============================================================================ */
+input[type='checkbox'] {
+  appearance: none;
+  -webkit-appearance: none;
+  box-sizing: border-box;
+  width: 24px;
+  height: 24px;
+  margin: 0;
+  flex: none;
+  border: 4px solid transparent;
+  border-radius: 9px; /* 5px inner radius + 4px border = concentric */
+  background: var(--surface) padding-box;
+  box-shadow: inset 0 0 0 1px var(--separator);
+  cursor: default;
+  transition:
+    background 100ms ease,
+    box-shadow 100ms ease;
+}
+input[type='checkbox']:checked {
+  background: var(--accent) padding-box;
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--accent) 80%, black);
+  /* White checkmark, drawn as a background image so it clips with padding-box. */
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.5 8.4 6.4 11.3 12.5 5.2' fill='none' stroke='%23fff' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 16px 16px;
+}
+input[type='checkbox']:indeterminate {
+  background: var(--accent) padding-box;
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--accent) 80%, black);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M4 8h8' fill='none' stroke='%23fff' stroke-width='2.2' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 16px 16px;
+}
+input[type='checkbox']:disabled {
+  opacity: 0.4;
+}
+
+/* ============================================================================
+   POP-UP BUTTON — .lx-popup
+   A macOS pop-up button: 24px bordered capsule, 13px label, chevron-up-down.
+   The <select> keeps its native menu (that IS the platform menu) — only the
+   chrome is ours.
+   ============================================================================ */
+.lx-popup {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  box-sizing: border-box;
+  height: 24px;
+  border-radius: 999px;
+}
+.lx-popup select {
+  appearance: none;
+  -webkit-appearance: none;
+  box-sizing: border-box;
+  width: 100%;
+  height: 24px;
+  margin: 0;
+  padding: 0 26px 0 11px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--fill-quaternary);
+  box-shadow: inset 0 0 0 0.5px var(--separator);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--label);
+  cursor: default;
+  outline: 0;
+  transition: background 120ms ease;
+}
+.lx-popup select:hover {
+  background: var(--fill-tertiary);
+}
+.lx-popup .lx-popup-chevron {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  pointer-events: none;
+  color: var(--label-secondary);
+}
+
+/* ============================================================================
+   FOCUS RING — one ring for every primitive.
+   ============================================================================ */
+.lx-btn:focus-visible,
+.lx-seg .lx-seg-item:focus-visible,
+.lx-chip:focus-visible,
+.lx-popup select:focus-visible,
+input[type='checkbox']:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lx-btn,
+  .lx-seg .lx-seg-item,
+  .lx-search,
+  .lx-chip,
+  .lx-popup select,
+  input[type='checkbox'] {
+    transition: none;
+  }
+}

--- a/packages/app/src/renderer/styles/island.css
+++ b/packages/app/src/renderer/styles/island.css
@@ -185,28 +185,8 @@
    STATUS PALETTE — shared Badge + StatusDot primitives (ui/Badge, ui/StatusDot)
    ONE tone scale to replace the scattered per-domain badge/pill/dot classes.
    ============================================================================ */
-.ws-badge {
-  display: inline-flex; align-items: center; gap: 5px;
-  font-size: 9.5px; font-weight: 700; letter-spacing: 0.05em;
-  padding: 2px 7px; border-radius: 5px; white-space: nowrap;
-  background: var(--row-hover); color: var(--text-2);
-}
-.ws-badge.t-neutral { background: var(--row-hover); color: var(--text-2); }
-.ws-badge.t-accent  { background: color-mix(in srgb, var(--accent) 16%, transparent); color: var(--accent); }
-.ws-badge.t-green   { background: color-mix(in srgb, var(--status-green-hue) 16%, transparent); color: var(--status-green-fg); }
-.ws-badge.t-red     { background: color-mix(in srgb, var(--status-red-hue) 16%, transparent); color: var(--status-red-fg); }
-.ws-badge.t-gold    { background: color-mix(in srgb, var(--status-gold-hue) 18%, transparent); color: var(--status-gold-fg); }
-.ws-badge.t-blue    { background: color-mix(in srgb, var(--status-blue-hue) 16%, transparent); color: var(--status-blue-fg); }
-.ws-badge.t-pink    { background: color-mix(in srgb, var(--status-pink-hue) 16%, transparent); color: var(--status-pink-fg); }
-/* outline: transparent fill + colored ring */
-.ws-badge.outline { background: transparent; border: 1px solid currentColor; }
-.ws-badge.outline.t-neutral { color: var(--text-3); border-color: var(--sep); }
-.ws-badge.outline.t-accent  { color: var(--accent); }
-.ws-badge.outline.t-green   { color: var(--status-green-fg); }
-.ws-badge.outline.t-red     { color: var(--status-red-fg); }
-.ws-badge.outline.t-gold    { color: var(--status-gold-fg); }
-.ws-badge.outline.t-blue    { color: var(--status-blue-fg); }
-.ws-badge.outline.t-pink    { color: var(--status-pink-fg); }
+/* Badges moved to controls.css (.lx-badge) — capsule, 11px/500, tinted fill
+   with the saturated hue as the label colour (TRA-290). */
 
 .ws-statusdot {
   display: inline-block; flex: none; border-radius: 50%;
@@ -216,9 +196,9 @@
 .ws-statusdot.t-accent  { background: var(--accent); }
 .ws-statusdot.t-green   { background: var(--status-green-hue); }
 .ws-statusdot.t-red     { background: var(--status-red-hue); }
-.ws-statusdot.t-gold    { background: var(--status-gold-hue); }
+.ws-statusdot.t-orange  { background: var(--status-gold-hue); }
 .ws-statusdot.t-blue    { background: var(--status-blue-hue); }
-.ws-statusdot.t-pink    { background: var(--status-pink-hue); }
+.ws-statusdot.t-purple  { background: var(--status-pink-hue); }
 .ws-statusdot.pulse {
   box-shadow: 0 0 0 3px color-mix(in srgb, currentColor 22%, transparent);
   animation: ws-pulse 2.4s ease-in-out infinite;
@@ -424,11 +404,8 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
 }
 .ws-island-title .chev { color: var(--text-2); display: flex; }
 .ws-island-actions { margin-left: auto; display: flex; align-items: center; gap: 1px; }
-.ws-mini {
-  width: 24px; height: 24px; display: flex; align-items: center; justify-content: center;
-  border-radius: 5px; color: var(--text-2); cursor: default; transition: background .12s, color .12s;
-}
-.ws-mini:hover { background: var(--row-hover); color: var(--text-1); }
+/* Island header actions are .lx-btn.v-icon (controls.css) — 24×24, 6px,
+   16px glyph (TRA-290). */
 .ws-island-body { flex: 1; overflow-y: auto; overflow-x: auto; padding-bottom: 6px; }
 
 /* a side-panel slot whose width is controlled by the layout */
@@ -629,111 +606,19 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
 .ws-view-bar .grow, .ws-view-subbar .grow { flex: 1; }
 .ws-tdiv { width: 0.5px; align-self: stretch; margin: 4px 2px; background: var(--sep); flex: none; }
 
-/* segmented pill control */
-.ws-seg2 { display: inline-flex; gap: 2px; padding: 3px; background: var(--row-hover); border-radius: 9px; flex: none; }
-.ws-seg2 .s2 {
-  border: 0; background: transparent; cursor: default; color: var(--text-2);
-  font-family: inherit; font-size: 13px; font-weight: 550; padding: 5px 13px; border-radius: 7px;
-  transition: background .12s, color .12s;
-}
-.ws-seg2 .s2:hover { color: var(--text-1); }
-.ws-seg2 .s2.is-active { background: var(--accent); color: #fff; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2); }
-.ws-seg2.mini { padding: 2px; }
-.ws-seg2.mini .s2 { padding: 3px 8px; font-size: 11.5px; font-weight: 600; }
+/* Segmented control, chip/text buttons and the small search field moved to
+   controls.css (.lx-seg / .lx-btn / .lx-search) — capsules on the 20/24/28
+   height scale (TRA-290). */
 
-/* chip / text buttons */
-.ws-chipbtn, .ws-textbtn {
-  display: inline-flex; align-items: center; gap: 5px; height: 30px; padding: 0 12px;
-  border: 0.5px solid var(--sep); background: transparent; border-radius: 9px;
-  font-family: inherit; font-size: 12.5px; font-weight: 500; color: var(--text-1);
-  cursor: default; transition: background .12s, border-color .12s, color .12s; white-space: nowrap; flex: none;
-}
-.ws-chipbtn:hover, .ws-textbtn:hover { background: var(--row-hover); }
-.ws-chipbtn.icon { width: 30px; padding: 0; justify-content: center; font-size: 15px; }
-.ws-chipbtn.toggle.is-on { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 45%, transparent); background: var(--accent-soft); }
-.ws-textbtn { border-color: transparent; color: var(--text-2); padding: 0 8px; }
-.ws-chipbtn kbd, .ws-search.sm kbd {
+.lx-btn kbd {
   font-family: inherit; font-size: 11px; padding: 1px 5px; border-radius: 4px;
   background: var(--row-hover); color: var(--text-2);
 }
 
-/* search field */
-.ws-search.sm {
-  display: inline-flex; align-items: center; gap: 7px; height: 30px; padding: 0 10px;
-  border-radius: 9px; background: var(--row-hover); color: var(--text-3); min-width: 190px; flex: none;
-}
-.ws-search.sm input { border: 0; background: none; outline: 0; color: var(--text-1); font-family: inherit; font-size: 13px; width: 100%; }
-
-/* ── Unified search · "centered idle → slides left on focus" (Liquid Glass) ───
-   The single search component for the whole app (see SearchField.tsx). Idle: the
-   magnifier + placeholder sit CENTERED in a capsule; on focus/typing the unit
-   slides to the left edge, the input fades in, and the placeholder fades once
-   there's a query — plus an accent focus ring. Durations are deliberately LONGER
-   than the source design (slide .42s vs .2s) for a smoother, slower feel.
-   Fills its container (width:100%); wrap it to size it per context. */
-.ws-sbar {
-  position: relative;
-  width: 100%;
-  /* Never shrink below a size where the centered placeholder gets cramped. Paired
-     with the `white-space: nowrap` on .unit, the label can NEVER fall onto two
-     lines — at worst it clips, but it won't below this width either. */
-  min-width: 168px;
-  height: 30px;
-  border-radius: 999px;
-  box-sizing: border-box;
-  /* Design --fill-tertiary: a translucent neutral gray that reads clearly on both
-     dark and light backings (the app's --row-hover is too faint for a standalone pill). */
-  background: rgba(118, 118, 128, 0.16);
-  overflow: hidden;
-  transition:
-    background 0.36s cubic-bezier(0.32, 0.72, 0, 1),
-    box-shadow 0.36s ease;
-}
-.ws-sbar:hover { background: rgba(118, 118, 128, 0.2); }
-.ws-sbar input {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  border: 0;
-  outline: 0;
-  background: transparent;
-  font-family: inherit;
-  font-size: 13px;
-  color: var(--text-1);
-  padding: 0 12px 0 32px;
-  box-sizing: border-box;
-  opacity: 0;
-  transition: opacity 0.36s cubic-bezier(0.32, 0.72, 0, 1);
-}
-.ws-sbar .unit {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  /* Keep the magnifier + label on ONE line. Without this, an absolutely-positioned
-     centered unit is width-constrained to the right half of the field, so the
-     placeholder wraps ("Search" / "chats") whenever the field is narrow. */
-  white-space: nowrap;
-  color: var(--text-3);
-  pointer-events: none;
-  transition:
-    left 0.42s cubic-bezier(0.32, 0.72, 0, 1),
-    transform 0.42s cubic-bezier(0.32, 0.72, 0, 1);
-}
-.ws-sbar .unit .ph { font-size: 13px; transition: opacity 0.22s ease; }
-.ws-sbar.is-active input { opacity: 1; }
-.ws-sbar.is-active .unit { left: 11px; transform: translate(0, -50%); }
-.ws-sbar.is-active.is-filled .ph { opacity: 0; }
-.ws-sbar.is-active {
-  background: rgba(118, 118, 128, 0.24);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 38%, transparent);
-}
-/* layout helper: grow to fill a flex toolbar */
-.ws-sbar.grow { flex: 1 1 auto; }
+/* The unified search field is SearchField.tsx + .lx-search in controls.css.
+   The old `.ws-sbar` centred-placeholder-that-slides-left treatment is gone:
+   it animated `left` (a layout property) over 0.42s and matched nothing on
+   the platform (TRA-290). */
 
 /* inline-label filter field */
 .ws-ff {
@@ -761,14 +646,7 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
 .ws-live .dot { width: 7px; height: 7px; border-radius: 50%; background: #2f9e6e; box-shadow: 0 0 0 3px color-mix(in srgb, #2f9e6e 22%, transparent); animation: ws-pulse 2.4s ease-in-out infinite; }
 @keyframes ws-pulse { 0%, 100% { box-shadow: 0 0 0 2px color-mix(in srgb, #2f9e6e 26%, transparent); } 50% { box-shadow: 0 0 0 5px color-mix(in srgb, #2f9e6e 8%, transparent); } }
 
-/* primary button */
-.ws-primary {
-  display: inline-flex; align-items: center; gap: 6px;
-  height: 32px; padding: 0 14px; border: 0; border-radius: 9px;
-  background: var(--accent); color: #fff; font-family: inherit; font-size: 13px; font-weight: 600; cursor: default;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2); flex: none;
-}
-.ws-primary:hover { background: color-mix(in srgb, var(--accent) 88%, #000); }
+/* The prominent button is .lx-btn.v-prominent in controls.css (TRA-290). */
 
 /* ---- ACTIVITY --------------------------------------------------------- */
 .ws-av-cards {

--- a/packages/app/src/renderer/tabs/Activity.tsx
+++ b/packages/app/src/renderer/tabs/Activity.tsx
@@ -8,6 +8,7 @@
 import { useEffect, useState } from 'react';
 import { ToolActivity } from './ToolActivity';
 import { AIActivity } from './AIActivity';
+import { SegmentedControl } from '../lattice/ui';
 
 type SubTab = 'tool' | 'ai';
 const STORAGE_KEY = 'activity.subtab';
@@ -35,13 +36,19 @@ export function Activity({
 
   return (
     <div className="flex flex-col h-full" style={{ color: 'var(--text-primary)' }}>
-      {/* Sub-tab segmented control */}
       <div
-        className="shrink-0 flex items-center gap-1 px-3 pt-3 pb-2"
+        className="shrink-0 flex items-center px-3 pt-3 pb-2"
         style={{ borderBottom: '0.5px solid var(--border-row)' }}
       >
-        <SubTabButton label="Tool calls" active={sub === 'tool'} onClick={() => setSub('tool')} />
-        <SubTabButton label="AI calls"   active={sub === 'ai'}   onClick={() => setSub('ai')} />
+        <SegmentedControl
+          options={[
+            { value: 'tool', label: 'Tool calls' },
+            { value: 'ai', label: 'AI calls' },
+          ]}
+          value={sub}
+          onChange={setSub}
+          aria-label="Activity source"
+        />
       </div>
 
       <div className="flex-1 min-h-0 overflow-hidden">
@@ -52,24 +59,5 @@ export function Activity({
         )}
       </div>
     </div>
-  );
-}
-
-function SubTabButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="text-[11px] px-2.5 py-1 rounded-full transition-all"
-      style={{
-        background: active ? 'var(--accent)' : 'var(--bg-inset)',
-        color: active ? '#fff' : 'var(--text-secondary)',
-        fontWeight: active ? 600 : 400,
-        cursor: 'pointer',
-        border: 'none',
-      }}
-    >
-      {label}
-    </button>
   );
 }

--- a/packages/app/src/renderer/tabs/Clients.tsx
+++ b/packages/app/src/renderer/tabs/Clients.tsx
@@ -124,7 +124,7 @@ function LevelPopover({
 function clientStatus(client: ClientInfo): Tone {
   const elapsed = Date.now() - new Date(client.lastSeen).getTime();
   if (elapsed < 30_000) return 'green';
-  if (elapsed < 120_000) return 'gold';
+  if (elapsed < 120_000) return 'orange';
   return 'neutral';
 }
 

--- a/packages/app/src/renderer/tabs/MemoryExplorer.tsx
+++ b/packages/app/src/renderer/tabs/MemoryExplorer.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { EMPTY_FILTER_VALUE, FilterBar, type FilterValue, matchesFilter } from '../components/FilterBar';
+import { SegmentedControl } from '../lattice/ui';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -1885,26 +1886,13 @@ export function MemoryExplorer({ root }: { root: string }) {
   return (
     <div className="space-y-4 pb-4">
       {/* Tab bar */}
-      <div className="flex gap-1">
-        {tabs.map((tab) => {
-          const active = activeTab === tab.key;
-          return (
-            <button
-              type="button"
-              key={tab.key}
-              onClick={() => setActiveTab(tab.key)}
-              className="text-[12px] px-3 py-1.5 rounded-md font-medium transition-all"
-              style={{
-                background: active ? 'var(--accent)' : 'var(--bg-inset)',
-                color: active ? '#fff' : 'var(--text-secondary)',
-                cursor: 'pointer',
-                fontWeight: active ? 600 : 400,
-              }}
-            >
-              {tab.label}
-            </button>
-          );
-        })}
+      <div className="flex">
+        <SegmentedControl
+          options={tabs.map((t) => ({ value: t.key, label: t.label }))}
+          value={activeTab}
+          onChange={setActiveTab}
+          aria-label="Memory section"
+        />
       </div>
 
       {/* Content */}

--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { ProjectStatsModal } from '../components/ProjectStatsModal';
 import { StatusDot, type Tone } from '../lattice/ui';
 import { useDaemon } from '../hooks/useDaemon';
+import { SegmentedControl } from '../lattice/ui';
 
 interface ProjectStats {
   files: number;
@@ -267,7 +268,7 @@ export function ProjectOverview({
 
   const statusDot: Tone =
     status === 'indexing'
-      ? 'gold'
+      ? 'orange'
       : status === 'error'
         ? 'red'
         : status === 'ready'
@@ -602,33 +603,18 @@ export function ProjectOverview({
           </div>
 
           {/* Category tabs */}
-          <div className="flex gap-1 px-3 mb-2">
-            {(
-              [
-                { key: 'debug_artifact', label: 'Debug' },
-                { key: 'todo_comment', label: 'TODOs' },
-                { key: 'hardcoded_value', label: 'Hardcoded' },
-                { key: 'empty_function', label: 'Stubs' },
-              ] as const
-            ).map((tab) => {
-              const active = smellsCategory === tab.key;
-              return (
-                <button
-                  type="button"
-                  key={tab.key}
-                  onClick={() => setSmellsCategory(tab.key)}
-                  className="text-[11px] px-2 py-1 rounded transition-all"
-                  style={{
-                    background: active ? 'var(--accent)' : 'var(--bg-inset)',
-                    color: active ? '#fff' : 'var(--text-secondary)',
-                    fontWeight: active ? 600 : 400,
-                    cursor: 'pointer',
-                  }}
-                >
-                  {tab.label}
-                </button>
-              );
-            })}
+          <div className="flex px-3 mb-2">
+            <SegmentedControl
+              options={[
+                { value: 'debug_artifact', label: 'Debug' },
+                { value: 'todo_comment', label: 'TODOs' },
+                { value: 'hardcoded_value', label: 'Hardcoded' },
+                { value: 'empty_function', label: 'Stubs' },
+              ]}
+              value={smellsCategory}
+              onChange={setSmellsCategory}
+              aria-label="Code smell category"
+            />
           </div>
 
           <div

--- a/packages/app/src/renderer/workspace/WorkspaceCompactView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceCompactView.tsx
@@ -6,7 +6,7 @@
  * + progress. Same selection / mutation contract as WorkspaceTableView.
  */
 import { type MouseEvent, useState } from 'react';
-import { StatusDot } from '../lattice/ui';
+import { Checkbox, StatusDot } from '../lattice/ui';
 import { InlineProgress } from './components/InlineProgress';
 import { ProjectMetricsBadges } from './components/ProjectMetricsBadges';
 import { type ProjectViewModel, statusLabel, statusToDot } from './types';
@@ -74,10 +74,9 @@ function CompactRow({
     >
       <div className="flex items-center gap-2">
         <span onClick={stop}>
-          <input
-            type="checkbox"
+          <Checkbox
             checked={selected}
-            onChange={(e) => onSelectChange(project.root, e.target.checked)}
+            onChange={(next) => onSelectChange(project.root, next)}
             aria-label={`Select ${shortPath(project.root)}`}
           />
         </span>

--- a/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
@@ -9,6 +9,7 @@
  */
 import { type ReactNode, useEffect, useState } from 'react';
 import { Icon } from '../lattice/icons';
+import { Button, Chip, ChipGroup, SearchField, SegmentedControl } from '../lattice/ui';
 import {
   EMPTY_FILTER,
   type ProjectHealthStatus,
@@ -33,12 +34,16 @@ export interface WorkspaceHeaderProps {
   rightExtra?: ReactNode;
 }
 
-const STATUS_CHIPS: Array<{ key: ProjectHealthStatus; label: string }> = [
-  { key: 'ok', label: 'OK' },
-  { key: 'indexing', label: 'Indexing' },
-  { key: 'error', label: 'Error' },
+const STATUS_CHIPS: Array<{ key: ProjectHealthStatus; label: string; title: string }> = [
+  { key: 'ok', label: 'OK', title: 'Projects that indexed cleanly' },
+  { key: 'indexing', label: 'Indexing', title: 'Projects currently being indexed' },
+  { key: 'error', label: 'Error', title: 'Projects whose last index failed' },
 ];
 const GRADE_CHIPS: TechDebtGrade[] = ['A', 'B', 'C', 'D', 'F'];
+const VIEW_OPTIONS: Array<{ value: ViewMode; label: string }> = [
+  { value: 'table', label: 'Table' },
+  { value: 'compact', label: 'Compact' },
+];
 
 function isDefaultFilter(f: WorkspaceFilter): boolean {
   return (
@@ -123,69 +128,6 @@ function KpiCell({
         {label}
       </span>
     </button>
-  );
-}
-
-// ── Chip ──────────────────────────────────────────────────────────────────
-
-interface ChipProps {
-  label: ReactNode;
-  active: boolean;
-  onClick: () => void;
-  accent?: string;
-  title?: string;
-}
-
-function Chip({ label, active, onClick, accent, title }: ChipProps) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={title}
-      className="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-full font-medium transition-colors whitespace-nowrap"
-      style={{
-        background: active ? accent ?? 'var(--accent)' : 'var(--fill-control)',
-        color: active ? '#fff' : 'var(--text-secondary)',
-        border: `0.5px solid ${active ? accent ?? 'var(--accent)' : 'var(--border)'}`,
-      }}
-    >
-      {label}
-    </button>
-  );
-}
-
-// ── View toggle ───────────────────────────────────────────────────────────
-
-interface ViewToggleProps {
-  view: ViewMode;
-  onViewChange: (v: ViewMode) => void;
-}
-
-function ViewToggle({ view, onViewChange }: ViewToggleProps) {
-  const opts: Array<{ key: ViewMode; label: string }> = [
-    { key: 'table', label: 'Table' },
-    { key: 'compact', label: 'Compact' },
-  ];
-  return (
-    <div
-      className="flex items-center rounded-md overflow-hidden"
-      style={{ border: '0.5px solid var(--border)' }}
-    >
-      {opts.map((o) => (
-        <button
-          key={o.key}
-          type="button"
-          onClick={() => onViewChange(o.key)}
-          className="text-[11px] px-2 py-1 font-medium transition-colors"
-          style={{
-            background: view === o.key ? 'var(--accent)' : 'transparent',
-            color: view === o.key ? '#fff' : 'var(--text-secondary)',
-          }}
-        >
-          {o.label}
-        </button>
-      ))}
-    </div>
   );
 }
 
@@ -277,47 +219,42 @@ export function WorkspaceHeader({
 
         {/* ── Row 2: toolbar ──────────────────────────────────────── */}
         <div className="flex items-center gap-2 flex-wrap">
-          <input
-            type="text"
-            placeholder="Search projects…"
+          <SearchField
             value={queryDraft}
-            onChange={(e) => setQueryDraft(e.target.value)}
-            className="text-xs px-2 py-1 rounded-md outline-none"
-            style={{
-              background: 'var(--bg-secondary)',
-              color: 'var(--text-primary)',
-              border: '1px solid var(--border)',
-              minWidth: 180,
-            }}
+            onChange={setQueryDraft}
+            placeholder="Search projects"
+            aria-label="Search projects"
           />
 
-          <div className="flex items-center gap-1">
-            {STATUS_CHIPS.map((s) => (
+          <ChipGroup label="Status">
+            {STATUS_CHIPS.map((c) => (
               <Chip
-                key={s.key}
-                label={s.label}
-                active={filter.statuses?.includes(s.key) ?? false}
-                onClick={() => onFilterChange({ ...filter, statuses: toggleInList(filter.statuses, s.key) })}
+                key={c.key}
+                label={c.label}
+                title={c.title}
+                selected={filter.statuses?.includes(c.key) ?? false}
+                onClick={() => onFilterChange({ ...filter, statuses: toggleInList(filter.statuses, c.key) })}
               />
             ))}
-          </div>
+          </ChipGroup>
 
-          <div className="flex items-center gap-1">
+          {/* Bare `A B C D F` is unreadable without the group label. */}
+          <ChipGroup label="Grade">
             {GRADE_CHIPS.map((g) => (
               <Chip
                 key={g}
                 label={g}
-                active={filter.grades?.includes(g) ?? false}
+                selected={filter.grades?.includes(g) ?? false}
                 onClick={() => onFilterChange({ ...filter, grades: toggleInList(filter.grades, g) })}
-                title={`Filter by tech-debt grade ${g}`}
+                title={`Tech debt grade ${g}`}
+                aria-label={`Tech debt grade ${g}`}
               />
             ))}
-          </div>
+          </ChipGroup>
 
           <Chip
-            label={<><Icon name="lock" size={11} /> Security</>}
-            active={filter.hasSecurityFindings === true}
-            accent="var(--destructive)"
+            label={<><Icon name="lock" size={12} /> Security</>}
+            selected={filter.hasSecurityFindings === true}
             onClick={() =>
               onFilterChange({
                 ...filter,
@@ -327,9 +264,8 @@ export function WorkspaceHeader({
             title="Projects with critical or high security findings"
           />
           <Chip
-            label={<><Icon name="bug_report" size={11} /> Dead</>}
-            active={filter.hasDeadExports === true}
-            accent="#ff9f0a"
+            label={<><Icon name="bug_report" size={12} /> Dead</>}
+            selected={filter.hasDeadExports === true}
             onClick={() =>
               onFilterChange({
                 ...filter,
@@ -340,32 +276,26 @@ export function WorkspaceHeader({
           />
 
           {!isDefaultFilter(filter) && (
-            <button
-              type="button"
-              onClick={() => onFilterChange(EMPTY_FILTER)}
-              className="text-[11px] px-1.5 py-0.5 rounded font-medium transition-colors hover:bg-[var(--bg-active)]"
-              style={{ color: 'var(--text-tertiary)' }}
-            >
+            <Button variant="plain" onClick={() => onFilterChange(EMPTY_FILTER)}>
               Clear filters
-            </button>
+            </Button>
           )}
 
           <span className="ml-auto flex items-center gap-2">
-            <ViewToggle view={view} onViewChange={onViewChange} />
-            <button
-              type="button"
+            <SegmentedControl
+              options={VIEW_OPTIONS}
+              value={view}
+              onChange={onViewChange}
+              aria-label="View mode"
+            />
+            <Button
+              variant="bordered"
               disabled={refreshing}
               onClick={onRefresh}
-              className="text-[11px] px-2 py-1 rounded font-medium transition-opacity hover:opacity-80 disabled:opacity-40"
-              style={{
-                background: 'var(--fill-control)',
-                color: 'var(--accent)',
-                border: '0.5px solid var(--border)',
-              }}
               title="Refresh metrics"
             >
               {refreshing ? <Spinner /> : 'Refresh'}
-            </button>
+            </Button>
             {rightExtra}
           </span>
         </div>

--- a/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
@@ -13,13 +13,12 @@
  * call `useWorkspaceProjects`.
  */
 import { type CSSProperties, type MouseEvent, useEffect, useRef, useState } from 'react';
-import { StatusDot } from '../lattice/ui';
+import { Checkbox, GradeBadge, StatusDot } from '../lattice/ui';
 import { InlineProgress } from './components/InlineProgress';
 import {
   type ProjectViewModel,
   type SortDir,
   type SortKey,
-  type TechDebtGrade,
   statusLabel,
   statusToDot,
 } from './types';
@@ -38,14 +37,6 @@ export interface WorkspaceTableViewProps {
   /** false = daemon disconnected; Re-index/Remove are dimmed. */
   canMutate: boolean;
 }
-
-const GRADE_COLOR: Record<TechDebtGrade, string> = {
-  A: '#34c759',
-  B: '#30d158',
-  C: '#ffcc00',
-  D: '#ff9f0a',
-  F: 'var(--destructive)',
-};
 
 // ── Frozen columns ────────────────────────────────────────────────────────
 //
@@ -118,17 +109,11 @@ function SelectAllCheckbox({
   selectedCount: number;
   onChange: (next: boolean) => void;
 }) {
-  const ref = useRef<HTMLInputElement | null>(null);
-  useEffect(() => {
-    if (!ref.current) return;
-    ref.current.indeterminate = selectedCount > 0 && selectedCount < total;
-  }, [selectedCount, total]);
   return (
-    <input
-      ref={ref}
-      type="checkbox"
+    <Checkbox
       checked={total > 0 && selectedCount === total}
-      onChange={(e) => onChange(e.target.checked)}
+      indeterminate={selectedCount > 0 && selectedCount < total}
+      onChange={onChange}
       aria-label="Select all projects"
     />
   );
@@ -263,10 +248,9 @@ function Row({
         style={{ ...stickyCell('left', 0, bg, false), width: SELECT_COL_W }}
         onClick={stop}
       >
-        <input
-          type="checkbox"
+        <Checkbox
           checked={selected}
-          onChange={(e) => onSelectChange(project.root, e.target.checked)}
+          onChange={(next) => onSelectChange(project.root, next)}
           aria-label={`Select ${project.name}`}
         />
       </td>
@@ -341,12 +325,7 @@ function Row({
       </td>
       <td className="px-3 py-2 text-center">
         {project.techDebtGrade ? (
-          <span
-            className="inline-block px-1.5 py-0.5 rounded text-[11px] font-bold"
-            style={{ color: '#fff', background: GRADE_COLOR[project.techDebtGrade] }}
-          >
-            {project.techDebtGrade}
-          </span>
+          <GradeBadge grade={project.techDebtGrade} />
         ) : (
           <span style={{ color: 'var(--text-tertiary)' }}>—</span>
         )}

--- a/packages/app/src/renderer/workspace/__tests__/types.test.ts
+++ b/packages/app/src/renderer/workspace/__tests__/types.test.ts
@@ -331,8 +331,8 @@ describe('compareViewModels', () => {
 describe('statusToDot', () => {
   it('maps all canonical statuses', () => {
     expect(statusToDot('ok')).toBe('green');
-    expect(statusToDot('indexing')).toBe('gold');
-    expect(statusToDot('computing')).toBe('gold');
+    expect(statusToDot('indexing')).toBe('orange');
+    expect(statusToDot('computing')).toBe('orange');
     expect(statusToDot('error')).toBe('red');
     expect(statusToDot('not_loaded')).toBe('neutral');
   });

--- a/packages/app/src/renderer/workspace/components/ProjectMetricsBadges.tsx
+++ b/packages/app/src/renderer/workspace/components/ProjectMetricsBadges.tsx
@@ -1,20 +1,12 @@
 import { Icon } from '../../lattice/icons';
-import { Badge, type Tone } from '../../lattice/ui';
-import type { ProjectViewModel, TechDebtGrade } from '../types';
+import { Badge, GradeBadge } from '../../lattice/ui';
+import type { ProjectViewModel } from '../types';
 
 export interface ProjectMetricsBadgesProps {
   project: ProjectViewModel;
   /** Compact rendering — smaller chips, drops the "untested" pill. Default false. */
   dense?: boolean;
 }
-
-const GRADE_TONE: Record<TechDebtGrade, Tone> = {
-  A: 'green',
-  B: 'green',
-  C: 'gold',
-  D: 'red',
-  F: 'red',
-};
 
 /**
  * Horizontal strip of small chips summarising health metrics for one project:
@@ -34,22 +26,22 @@ export function ProjectMetricsBadges({ project, dense = false }: ProjectMetricsB
 
   return (
     <div className="flex items-center gap-1 whitespace-nowrap">
-      {grade && (
-        <Badge tone={GRADE_TONE[grade]} variant="outline" title={`Tech-debt grade ${grade}`}>
-          {grade}
-        </Badge>
-      )}
+      {grade && <GradeBadge grade={grade} />}
       {sec > 0 && (
         <Badge
           tone="red"
-          variant="outline"
           title={`${sec} critical+high security finding${sec === 1 ? '' : 's'}`}
+          aria-label={`${sec} critical or high security finding${sec === 1 ? '' : 's'}`}
         >
           <Icon name="lock" size={iconSize} /> {sec}
         </Badge>
       )}
       {dead > 0 && (
-        <Badge tone="gold" variant="outline" title={`${dead} dead export${dead === 1 ? '' : 's'}`}>
+        <Badge
+          tone="orange"
+          title={`${dead} dead export${dead === 1 ? '' : 's'}`}
+          aria-label={`${dead} dead export${dead === 1 ? '' : 's'}`}
+        >
           <Icon name="bug_report" size={iconSize} /> {dead}
         </Badge>
       )}

--- a/packages/app/src/renderer/workspace/types.ts
+++ b/packages/app/src/renderer/workspace/types.ts
@@ -435,7 +435,7 @@ export function statusToDot(status: ProjectHealthStatus): Tone {
       return 'green';
     case 'indexing':
     case 'computing':
-      return 'gold';
+      return 'orange';
     case 'error':
       return 'red';
     case 'not_loaded':


### PR DESCRIPTION
Stage 1 of the macOS 26 revision (TRA-290, parent TRA-284). Every control in the renderer now comes from one primitive layer with one geometry: capsule radius, heights of 20/24/28 only, and a ≥24×24 hit target for anything focusable.

## Primitives

`packages/app/src/renderer/lattice/ui/` + `styles/controls.css`

| Primitive | Before | After |
|---|---|---|
| Button `prominent` | 32px, 9px radius, gradient + triple box-shadow bezel | 20/24/28, capsule, flat accent |
| Button `bordered` | 30px, 9px | 20/24/28, capsule, 0.5px `--separator` |
| Button `plain` | 30px, 9px | 20/24/28, capsule, no chrome until hover |
| Button `icon` | 24px, 5px | 20/24/28 square, 6px, 16px glyph, **aria-label + title required by the type** |
| SegmentedControl | `border-radius: 0`, accent-filled segment | capsule track + capsule thumb on `--surface`, hairline, 24px |
| SearchField | 26px, 6px, 12px, `1px solid`; or a 0.42s `left` animation | **new** — capsule, 24px, 13px, leading magnifier, Esc clears |
| Chip | 21.5px, bare `A B C D F` | **new** — 24px minimum, visible group label, per-chip `title` |
| Badge | 9.5px/700/0.05em ALL CAPS; grade badge `#fff` on `#ffcc00` = **1.6:1** | capsule, 11px/500, sentence case, tinted fill + saturated-hue label |
| Checkbox | 13×13 UA default (93 of them on the workspace table) | **new** — 16px visual in a 24×24 box, accent fill + white checkmark |
| PopUpButton | `appearance:none` 10px `<select>` with a hand-drawn sort glyph | **new** — 24px capsule, 13px, chevron-up-down |

Also in this PR:

- `.btn-prominent` in `app.css` loses the gradient and the triple box-shadow bezel — macOS 26 prominent buttons are a flat accent capsule.
- The four ad-hoc pill rows named in the issue (`Table|Compact`, `Decisions|Review|Corpora|Sessions`, `Debug|TODOs|Hardcoded|Stubs`, `Tool calls|AI calls`) now render `SegmentedControl`.
- The superseded rules are deleted from `island.css`, not left alongside the new ones (−148 lines there).
- `prefers-reduced-motion` is honoured for the refresh spinner and the update-card spring entrance.
- `cursor: default` stays on buttons (that is the macOS behaviour) and is asserted by a test.

## Verification

**Gallery** — `?view=gallery`, `&theme=light|dark` pins the appearance. Every variant × size × idle/hover/pressed/disabled/focused on one route, no Storybook.

**`lattice/ui/__tests__/primitives.test.tsx`** (21 tests) parses `controls.css` and asserts:

1. no declared control height outside {20, 24, 28} (`100%` for segment items, `18px` for the non-focusable badge);
2. every focusable primitive's default box is 24px, and the checkbox is 24px outer / 16px painted;
3. every `border-radius` is 999px / 6px / 50% (9px only on the checkbox, where 5px inner + 4px transparent border is concentric);
4. **every badge tone clears 4.5:1 in both appearances**, computing the WCAG ratio of the label against its own 18% tint composited over `--surface`, and that no badge label is ever white;
5. the gallery renders with a non-empty accessible name on every button and checkbox.

Local: `pnpm run typecheck`, `pnpm run build`, `pnpm exec vitest run` → **92 tests pass**.

## Contrast table

Measured by the test, ≥4.5:1 required. Label / fill (18% hue over `--surface`):

| Tone | Light label | Dark label |
|---|---|---|
| neutral | `#4a4a4f` | `#c7c7cc` |
| accent | `#0a52ab` | `#79baff` |
| green | `#17624a` | `#6fd4a4` |
| orange | `#7c4310` | `#f0bb6b` |
| red | `#9e1f0c` | `#ff9683` |
| blue | `#1e4794` | `#9dbcfa` |
| purple | `#533690` | `#c8adf7` |

## Note on TRA-289

TRA-289 (the token layer) had not landed when this was written, so `controls.css` opens with a **fenced provisional token shim** declaring the semantic names it consumes (`--label`, `--separator`, `--fill-tertiary/-quaternary`, `--surface`, `--status-*`). Landing TRA-289 means deleting that one block — nothing else in the file changes, and no other file conflicts.

## Known gap

The Workspace KPI tiles (`Projects`, `Files`, …) are focusable `<button>`s that render ~34px tall. They are cards, not controls, so they are out of the 20/24/28 set by design; the dashboard card anatomy belongs to the later stage of TRA-284. They clear the ≥24px hit-target floor.

Closes TRA-290.
