### PR TITLE
fix(daemon): require --allow-remote for a non-loopback bind (TRA-301)

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ trace-mcp runs entirely on your machine. Your source code is never the product.
 - **Semantic search is offline by default** — bundled ONNX embeddings, no API keys, no outbound calls. Switch to Ollama (local) or OpenAI (opt-in) via config.
 - **No telemetry about your code, queries, or usage.** The only thing that ever leaves your machine is described below — nothing else is phoned home.
 - **What your AI client sees is governed by your AI client.** trace-mcp returns graph results over MCP; how Claude Code / Cursor / Codex / Windsurf forward them to a model is up to that client's privacy model.
+- **The daemon trusts loopback and nothing else.** `serve-http` is unauthenticated by design: a caller on `127.0.0.1` is already you. A non-loopback `--host` is therefore refused unless you pass `--allow-remote` and front the port with your own auth — see [Configuration](docs/configuration.md#http-daemon--one-warm-index-shared-across-many-projects).
 - **To wipe everything**, delete `~/.trace-mcp/`. That is the entire footprint.
 
 ### Usage telemetry

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -665,6 +665,8 @@ http://127.0.0.1:3741/mcp?project=/absolute/path/to/repo
 
 The daemon multiplexes projects — one process serves all of them — but each MCP registration is bound to a single project via `?project=` (or, for clients that cannot append a query string, the `X-Trace-Project` header or `params._meta["traceMcp/projectRoot"]`). Pick this when you want one warm index reused across sessions and tools and you're comfortable managing the per-registration URL. For one-session-per-repo workflows, stdio is simpler.
 
+> **The daemon's trust boundary is loopback.** `serve-http` has no authentication: every `/api` route and `/mcp` itself trust the caller, and `?project=` / `X-Trace-Project` / `params._meta["traceMcp/projectRoot"]` can name any directory on the machine — the daemon will index and serve it. On `127.0.0.1` that grants nothing extra, because anything able to reach the port already runs as you and can read those files directly. Binding elsewhere hands that power to the network, so a non-loopback `--host` is refused unless you also pass `--allow-remote`, and even then you are expected to put your own authentication (SSH tunnel, reverse proxy, VPN) in front of the port.
+
 > **One project per session.** Both transports resolve exactly one project per MCP session — stdio from the working directory, HTTP from `?project=`. A single session cannot query across repositories today; to work with several repos, register each (`trace-mcp add <path>`) and add one MCP entry per repo (HTTP) or open one session per repo (stdio). Cross-repo queries inside a single session — useful for multi-repo/pseudo-monorepo setups — are tracked as an enhancement in [#199](https://github.com/nikolai-vysotskyi/trace-mcp/issues/199).
 
 | | stdio | HTTP daemon |
@@ -722,7 +724,8 @@ trace-mcp upgrade [dir]        # Upgrade all projects (or specific one) — migr
 trace-mcp serve                # Start MCP server (stdio transport)
 trace-mcp serve-http           # Start HTTP/SSE server (default: 127.0.0.1:3741)
   -p, --port <port>            # Custom port
-  --host <host>                # Custom host
+  --host <host>                # Custom host (loopback only unless --allow-remote)
+  --allow-remote               # Permit a non-loopback --host (see the trust boundary note)
 
 # Manual indexing
 trace-mcp index <dir>          # Index a project directory

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,6 +91,7 @@ import {
 } from './init/hooks.js';
 import { attachFileLogging, logger } from './logger.js';
 import { ensureInitialized, warmUpGrammars } from './parser/tree-sitter.js';
+import { checkBindHost, isLoopbackHost } from './daemon/bind-host.js';
 import { PluginRegistry } from './plugin-api/registry.js';
 import { detectGitWorktree, findProjectRoot, hasRootMarkers } from './project-root.js';
 import { isDangerousProjectRoot, setupProject } from './project-setup.js';
@@ -463,7 +464,11 @@ program
   )
   .option('-p, --port <port>', 'Port to listen on', '3741')
   .option('--host <host>', 'Host to bind to', '127.0.0.1')
-  .action(async (opts: { port: string; host: string }) => {
+  .option(
+    '--allow-remote',
+    'Permit a non-loopback --host. The daemon is unauthenticated — only use behind your own auth.',
+  )
+  .action(async (opts: { port: string; host: string; allowRemote?: boolean }) => {
     // A single unhandled rejection must not take down the daemon serving every
     // registered project — log and stay alive.
     installProcessSafetyNet('serve-http');
@@ -785,6 +790,22 @@ program
 
     const port = parseInt(opts.port, 10);
     const host = opts.host;
+
+    // TRA-301: the daemon has no authentication, so loopback IS the trust
+    // boundary. Widening it must be deliberate.
+    const bindRefusal = checkBindHost(host, opts.allowRemote === true);
+    if (bindRefusal) {
+      logger.error({ host, port }, bindRefusal);
+      process.stderr.write(`${bindRefusal}\n`);
+      process.exit(1);
+    }
+    if (!isLoopbackHost(host)) {
+      logger.warn(
+        { host, port },
+        'Daemon bound to a non-loopback host with --allow-remote. There is NO authentication ' +
+          'on /mcp or /api: any reachable client can index and read arbitrary directories.',
+      );
+    }
 
     // Simple per-IP rate limiter (token bucket). Localhost is exempt because
     // the Electron app and local tooling legitimately make bursts of requests

--- a/src/daemon/__tests__/bind-host.test.ts
+++ b/src/daemon/__tests__/bind-host.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { checkBindHost, isLoopbackHost } from '../bind-host.js';
+
+describe('isLoopbackHost', () => {
+  it.each(['127.0.0.1', '127.1.2.3', 'localhost', 'LOCALHOST', '::1', '[::1]', '::ffff:127.0.0.1'])(
+    'treats %s as loopback',
+    (host) => {
+      expect(isLoopbackHost(host)).toBe(true);
+    },
+  );
+
+  it.each(['0.0.0.0', '::', '192.168.1.10', '10.0.0.1', 'example.com', '128.0.0.1'])(
+    'treats %s as remote',
+    (host) => {
+      expect(isLoopbackHost(host)).toBe(false);
+    },
+  );
+});
+
+describe('checkBindHost', () => {
+  it('allows the default loopback bind', () => {
+    expect(checkBindHost('127.0.0.1', false)).toBeNull();
+  });
+
+  it('refuses a non-loopback bind without the opt-in', () => {
+    const refusal = checkBindHost('0.0.0.0', false);
+    expect(refusal).toContain('0.0.0.0');
+    expect(refusal).toContain('--allow-remote');
+  });
+
+  it('allows a non-loopback bind with the explicit opt-in', () => {
+    expect(checkBindHost('0.0.0.0', true)).toBeNull();
+  });
+});

--- a/src/daemon/bind-host.ts
+++ b/src/daemon/bind-host.ts
@@ -1,0 +1,39 @@
+/**
+ * Bind-host guard for the daemon's HTTP listener (TRA-301).
+ *
+ * The daemon has no authentication: every /api route and the /mcp endpoint
+ * trust the caller completely. On loopback that is fine — anything that can
+ * reach 127.0.0.1:3741 already runs as this user and can read the same files
+ * directly, so `?project=` / `X-Trace-Project` naming an arbitrary directory
+ * grants an attacker nothing new.
+ *
+ * Binding a non-loopback address deletes that boundary: the whole daemon,
+ * arbitrary-path indexing included, becomes reachable by anyone on the
+ * network. That must be a deliberate act, not the consequence of a stray
+ * `--host 0.0.0.0`, so it requires an explicit `--allow-remote` opt-in.
+ */
+
+/** Loopback literals plus the 127.0.0.0/8 range. */
+export function isLoopbackHost(host: string): boolean {
+  const h = host
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, '');
+  if (h === 'localhost' || h === '::1' || h === '') return true;
+  const v4 = h.startsWith('::ffff:') ? h.slice(7) : h;
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(v4);
+}
+
+/**
+ * @returns an operator-facing error message when this bind must be refused,
+ * or `null` when it is allowed.
+ */
+export function checkBindHost(host: string, allowRemote: boolean): string | null {
+  if (isLoopbackHost(host) || allowRemote) return null;
+  return (
+    `Refusing to bind --host ${host}: the trace-mcp daemon is unauthenticated. ` +
+    'Anyone able to reach a non-loopback address could index and read arbitrary ' +
+    'directories on this machine. Pass --allow-remote if that is what you intend, ' +
+    'and put your own authentication in front of the port.'
+  );
+}


### PR DESCRIPTION
Closes the TRA-301 escalation: which of the four options is right for the daemon's HTTP `/mcp` trust boundary.

## Ruling: option 4

The taint CodeQL traced from `X-Trace-Project` is real but the endpoint is the wrong place to fix it. `?project=` has exactly the same power as the header, so restricting only the header would be theatre; and the daemon has **no authentication at all** — every `/api` route is as open as `/mcp`. The header is a symptom, not the disease.

On loopback the disease is benign: anything that can reach `127.0.0.1:3741` already runs as this user and can read the same files directly, so naming an arbitrary project root grants an attacker nothing new. What actually deletes the boundary is `--host 0.0.0.0`, and today that is one stray flag away.

So: refuse a non-loopback bind unless the operator passes `--allow-remote`, warn loudly when they do, and document the boundary.

Rejected:

- **Option 2 (restrict hints to registered roots)** — breaks header-based auto-registration for IDE clients that cannot pass `?project=`, the exact case `mcp-project-router.ts` exists for, and leaves `?project=` equally powerful.
- **Option 3 (loopback token)** — correct in the abstract, but it is real work across every client, the Electron app and the stdio proxy, to defend a boundary that only disappears once you have deliberately widened the bind. Reconsider if we ever ship a remote/shared daemon.

The five CodeQL `js/path-injection` alerts stay dismissed as won't-fix. CodeQL cannot model the bind gate, and under the documented boundary the flow is not a vulnerability.

## Changes

- `src/daemon/bind-host.ts` — `isLoopbackHost` / `checkBindHost`, with the rationale in the module header.
- `src/cli.ts` — `--allow-remote` flag on `serve-http`; refuse + exit 1 on an ungated non-loopback host; warn when opted in.
- `README.md`, `docs/configuration.md` — the trust boundary written down.

## Test evidence

- `src/daemon/__tests__/bind-host.test.ts` — 16 tests covering loopback literals, `127.0.0.0/8`, `::ffff:` and bracketed IPv6, plus the three gate outcomes.
- `pnpm run test` — 8775 passed, 9 skipped, 0 failed.
- `pnpm run typecheck` and `biome ci` clean; `pnpm run build` succeeds.

## Compatibility

The default bind is `127.0.0.1`, so every existing setup is unaffected. Anyone deliberately running `--host 0.0.0.0` must now add `--allow-remote` — a deliberate break, and the error message says exactly what to do.
