### PR TITLE
fix(ci): give the three full-index jobs real timeout headroom (TRA-298)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,7 @@ jobs:
     needs: build
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 12
     permissions:
       contents: read
     steps:
@@ -398,7 +398,7 @@ jobs:
   quality-gates-report:
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 12
     permissions:
       contents: read
       security-events: write
@@ -466,7 +466,7 @@ jobs:
   security-scan-report:
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 12
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
## Summary

`impact-report`, `quality-gates-report` and `security-scan-report` all run `node dist/cli.js index . --force` over the whole repo (~1700 files) under `timeout-minutes: 5`. That work lands right on the cap, so the jobs get killed mid-step and report red on a PR that is otherwise green.

Observed (TRA-298): PR #448, run 33195394890, job 98931695627 — indexing completed at 5m09s, `##[error]The operation was canceled` at 5m12s. A plain re-run of the same commit passed. That PR's diff was `release.yml` only, so nothing it changed could have affected the scan.

`impact-report` is a **required** status check, so this doesn't just add noise — it blocks merge and costs a full CI re-run to clear. It also trains us to re-run red checks reflexively, which is how a real finding eventually gets waved through.

## Change

All three jobs go from `timeout-minutes: 5` to `12`. The cap stays a runaway guard rather than a budget the happy path has to squeeze under, and it has room as the index grows.

Deliberately **not** done here: trimming the jobs so they don't need a full forced reindex. That's a real option the issue raises, but it changes what each job actually measures — worth its own issue if the 12-minute budget ever gets tight, not worth bundling into a flake fix.

## Test plan

Config-only change; the CI run on this PR exercises all three jobs.