### PR TITLE
feat(app): rebuild Project Overview on the macOS 26 layer (TRA-293)

### DIFF
--- a/packages/app/scripts/token-guard.baseline.json
+++ b/packages/app/scripts/token-guard.baseline.json
@@ -17,12 +17,6 @@
   "src/renderer/tabs/Insights.tsx": 2,
   "src/renderer/tabs/MemoryExplorer.tsx": 37,
   "src/renderer/tabs/Notebook.tsx": 1,
-  "src/renderer/tabs/ProjectOverview.tsx": 16,
   "src/renderer/tabs/Settings.tsx": 7,
-  "src/renderer/tabs/ToolActivity.tsx": 33,
-  "src/renderer/workspace/AddProjectControl.tsx": 3,
-  "src/renderer/workspace/BulkActionsBar.tsx": 1,
-  "src/renderer/workspace/WorkspaceCompactView.tsx": 1,
-  "src/renderer/workspace/WorkspaceHeader.tsx": 2,
-  "src/renderer/workspace/WorkspaceTableView.tsx": 2
+  "src/renderer/tabs/ToolActivity.tsx": 33
 }

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -885,6 +885,10 @@ export function App() {
 
   const isGraph = isProject && projectTab === 'graph';
   const needsFlexLayout = isProject && (projectTab === 'graph' || projectTab === 'ask');
+  /* Surfaces that draw their own toolbar own the whole pane: a 16px inset turns
+     a flush 52px toolbar into a floating white band with the sunken background
+     showing down both sides (TRA-293). */
+  const ownsToolbar = isProject && projectTab === 'overview';
   const isGraphGpu = isGraph; // alias — the Graph tab *is* the GPU graph now
 
   return (
@@ -996,7 +1000,7 @@ export function App() {
             </button>
           </div>
           <div
-            className={`ws-content-body ${isGraphGpu ? 'p-2' : needsFlexLayout ? 'p-1 pt-2' : 'p-4 overflow-y-auto'}`}
+            className={`ws-content-body ${isGraphGpu ? 'p-2' : needsFlexLayout ? 'p-1 pt-2' : ownsToolbar ? '' : 'p-4 overflow-y-auto'}`}
           >
             {isProject ? (
               <ErrorBoundary key={`project:${projectTab}`} label={`${projectTab} tab`}>

--- a/packages/app/src/renderer/lattice/ui/EmptyState.tsx
+++ b/packages/app/src/renderer/lattice/ui/EmptyState.tsx
@@ -19,6 +19,12 @@ export interface EmptyStateProps {
   subtitle?: ReactNode;
   /** Call-to-action (e.g. <Button variant="primary"/>). */
   action?: ReactNode;
+  /**
+   * Inline variant for an empty section INSIDE a card, rather than an empty
+   * pane. The hero proportions (46px glyph, 17px title, 40px padding) build a
+   * ~186px block around one sentence, which dwarfs the section it sits in.
+   */
+  compact?: boolean;
   className?: string;
   /** Plain content (used when none of the structured props are given). */
   children?: ReactNode;
@@ -26,15 +32,18 @@ export interface EmptyStateProps {
 
 export function EmptyState({
   icon,
-  iconSize = 40,
+  iconSize,
   glyph,
   title,
   subtitle,
   action,
+  compact = false,
   className,
   children,
 }: EmptyStateProps): ReactNode {
-  const cls = 'ws-center-empty' + (className ? ' ' + className : '');
+  iconSize ??= compact ? 20 : 40;
+  const cls =
+    'ws-center-empty' + (compact ? ' compact' : '') + (className ? ' ' + className : '');
   if (children != null && !title && !subtitle && !icon && !glyph && !action) {
     return <div className={cls}>{children}</div>;
   }

--- a/packages/app/src/renderer/lattice/ui/Menu.tsx
+++ b/packages/app/src/renderer/lattice/ui/Menu.tsx
@@ -14,9 +14,24 @@
    control in one click. <ConfirmPopover> is the paired destructive-action
    confirmation; it deliberately KEEPS a click-eating scrim (see comment there). */
 
-import { useEffect, useRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ButtonHTMLAttributes, type ReactNode } from 'react';
 import { FloatingLayer } from '../FloatingLayer';
 import { Icon } from '../icons';
+
+/** Anchors a Menu under the button held in `ref`, or at an explicit point.
+    Lives here rather than next to one surface because every surface with an
+    overflow or row menu needs the same three lines. */
+export function useMenuAnchor() {
+  const ref = useRef<HTMLButtonElement | null>(null);
+  const [at, setAt] = useState<{ x: number; y: number } | null>(null);
+  const open = (): void => {
+    const r = ref.current?.getBoundingClientRect();
+    setAt(r ? { x: r.right, y: r.bottom + 4 } : { x: 0, y: 52 });
+  };
+  /** For menus opened from a row button rather than a fixed toolbar anchor. */
+  const openAt = (point: { x: number; y: number }): void => setAt(point);
+  return { ref, at, open, openAt, close: () => setAt(null) };
+}
 
 export interface MenuProps {
   x: number;

--- a/packages/app/src/renderer/lattice/ui/index.ts
+++ b/packages/app/src/renderer/lattice/ui/index.ts
@@ -37,5 +37,5 @@ export type { IslandHeaderProps, MiniButtonProps } from './IslandHeader';
 export { EmptyState } from './EmptyState';
 export type { EmptyStateProps } from './EmptyState';
 
-export { Menu, MenuItem, MenuSection, MenuSeparator, ConfirmPopover } from './Menu';
+export { Menu, MenuItem, MenuSection, MenuSeparator, ConfirmPopover, useMenuAnchor } from './Menu';
 export type { MenuProps, MenuItemProps, ConfirmPopoverProps } from './Menu';

--- a/packages/app/src/renderer/styles/controls.css
+++ b/packages/app/src/renderer/styles/controls.css
@@ -48,6 +48,15 @@
 .lx-btn:disabled {
   opacity: 0.4;
 }
+/* A disabled button whose LABEL is the status readout ("Indexing…", "Daemon
+   unreachable") is not an inert control — dimming it to 0.4 put the only
+   progress text on the Project Overview toolbar at 2.3:1, measured. `is-status`
+   keeps it unpressable and keeps the sentence readable. The hairline is an
+   inset box-shadow on --separator, so it stays a hairline at full opacity. */
+.lx-btn.is-status:disabled {
+  opacity: 1;
+  color: var(--label-secondary);
+}
 
 /* sizes ------------------------------------------------------------------- */
 .lx-btn.sz-small {
@@ -483,6 +492,36 @@ input[type='checkbox']:disabled {
 input[type='checkbox']:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+
+/* ============================================================================
+   HIT TARGETS for the 20px tier (TRA-293)
+
+   `small` buttons and segmented-control segments are painted 20px tall on
+   purpose — that is the macOS small-control size. The HIT TARGET still has to
+   be 24px, so an overflowing pseudo-element grows the clickable box without
+   moving a single painted pixel. Measured before this on the running Project
+   Overview: five controls reported 20px against a 24px floor.
+   ============================================================================ */
+.lx-btn.sz-small,
+.lx-seg .lx-seg-item {
+  position: relative;
+}
+.lx-btn.sz-small::after {
+  /* All four sides: a small ICON button is painted 20x20, so it is under the
+     floor on both axes. Text buttons are already wider than 24px; the extra
+     2px each side is slack inside the surrounding gap, not an overlap. */
+  content: '';
+  position: absolute;
+  inset: -2px;
+}
+.lx-seg .lx-seg-item::after {
+  /* Vertical only. A segment already clears 24px wide (min-width), and the
+     2px gap between segments is not wide enough to share. -2px vertical
+     exactly fills the 24px track over its 2px padding. */
+  content: '';
+  position: absolute;
+  inset: -2px 0;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/packages/app/src/renderer/styles/island.css
+++ b/packages/app/src/renderer/styles/island.css
@@ -581,6 +581,13 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
 .ws-center-empty .s { font-size: 13px; color: var(--text-3); max-width: 380px; line-height: 1.5; }
 .ws-center-empty .ws-primary { margin-top: 6px; }
 
+/* Compact variant (TRA-293) — an empty SECTION inside a card, not an empty
+   pane. Same anatomy (glyph, line, sentence, action), a third of the height. */
+.ws-center-empty.compact { gap: 6px; padding: 20px 16px; }
+.ws-center-empty.compact .gi { width: 20px; height: 20px; }
+.ws-center-empty.compact .t { font-size: 13px; font-weight: 600; }
+.ws-center-empty.compact .s { font-size: 13px; line-height: 16px; }
+
 /* ============================================================================
    INTELLIGENCE VIEWS — Graph · Activity · Memory (center-stage)
    ============================================================================ */

--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -440,9 +440,7 @@ export function ProjectOverview({
     try {
       const folder = await api.selectFolder();
       if (!folder) return;
-      // BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
-      // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request
-      await fetch(`${BASE}/api/projects/subprojects`, {
+      await fetch(`${BASE}/api/projects/subprojects`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ repoPath: folder, project: root }),
@@ -471,9 +469,7 @@ export function ProjectOverview({
 
   const handleUpdateGroup = async (serviceId: number, projectGroup: string | null) => {
     try {
-      // BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
-      // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request
-      const res = await fetch(`${BASE}/api/projects/services`, {
+      const res = await fetch(`${BASE}/api/projects/services`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ serviceId, projectGroup: projectGroup || null }),

--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -440,8 +440,9 @@ export function ProjectOverview({
     try {
       const folder = await api.selectFolder();
       if (!folder) return;
+      // BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request
       await fetch(`${BASE}/api/projects/subprojects`, {
-        // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ repoPath: folder, project: root }),
@@ -470,8 +471,9 @@ export function ProjectOverview({
 
   const handleUpdateGroup = async (serviceId: number, projectGroup: string | null) => {
     try {
+      // BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request
       const res = await fetch(`${BASE}/api/projects/services`, {
-        // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ serviceId, projectGroup: projectGroup || null }),

--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -1,8 +1,46 @@
-import { useCallback, useEffect, useState } from 'react';
+/**
+ * ProjectOverview — the project window's landing surface (TRA-293).
+ *
+ * Layout:
+ *   Toolbar  — 52px glass row: status + project name + path on the left, the
+ *              single prominent action (Reindex) and an overflow menu on the
+ *              right. Indexing progress is a 2px determinate bar on the
+ *              toolbar's bottom edge, not a full-bleed accent band across the
+ *              content.
+ *   Content  — inset grouped lists capped at a readable measure and centred:
+ *              Index · Coverage · Quality · Services.
+ *
+ * What this replaces, measured on the running app before the rewrite:
+ *   - "Re-index Project" as a 1640px-wide accent-filled bar spanning the whole
+ *     content width, and the same slot rendering "Indexing..." as a solid
+ *     periwinkle band with centred white text at ~2:1.
+ *   - Seven font sizes on one screen, 61 of 100 text nodes at 9–10px, eight
+ *     distinct radii, and 35 of 51 controls under the 24×24 hit-target floor.
+ *   - Three empty states that were a single grey line at --text-tertiary
+ *     (2.21:1), and row actions that only existed on hover.
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ProjectStatsModal } from '../components/ProjectStatsModal';
-import { StatusDot, type Tone } from '../lattice/ui';
 import { useDaemon } from '../hooks/useDaemon';
-import { SegmentedControl } from '../lattice/ui';
+import { Icon } from '../lattice/icons';
+import {
+  Badge,
+  Button,
+  ConfirmPopover,
+  EmptyState,
+  Menu,
+  MenuItem,
+  MenuSeparator,
+  SegmentedControl,
+  StatusDot,
+  useMenuAnchor,
+  type Tone,
+} from '../lattice/ui';
+// ponytail: Skeleton lives next to the workspace surface that introduced it.
+// It is a general primitive and wants to move to lattice/ui, but that means
+// editing four freshly-merged files for no visual change — do it when a third
+// surface needs it.
+import { Skeleton } from '../workspace/components/Skeleton';
 
 interface ProjectStats {
   files: number;
@@ -36,15 +74,121 @@ interface CoverageReport {
   unknown: UnknownPackage[];
 }
 
+interface SmellFinding {
+  category: 'todo_comment' | 'empty_function' | 'hardcoded_value' | 'debug_artifact';
+  priority: 'high' | 'medium' | 'low';
+  tag?: string;
+  file: string;
+  line: number;
+  snippet: string;
+  description: string;
+}
+
+interface SmellReport {
+  files_scanned: number;
+  findings: SmellFinding[];
+  summary: Record<SmellFinding['category'], number>;
+  total: number;
+}
+
+interface SubprojectInfo {
+  name: string;
+  repoRoot: string;
+  services: number;
+  endpoints: number;
+}
+
+interface ServiceInfo {
+  id: number;
+  name: string;
+  repoRoot: string;
+  serviceType: string | null;
+  projectGroup: string | null;
+  endpointCount: number;
+}
+
+/** A fetch that finished and failed is not still loading — the two states read
+    differently (an em dash vs a skeleton), so they are tracked separately. */
+type Load = 'idle' | 'loading' | 'ready' | 'failed';
+
 const BASE = 'http://127.0.0.1:3741';
 const GITHUB_REPO = 'nikolai-vysotskyi/trace-mcp';
+/** Findings past this are summarised rather than listed — the surface is an
+    overview, not a results table. */
+const FINDING_LIMIT = 25;
 
-function shortPath(root: string): string {
+const SMELL_CATEGORIES: { value: SmellFinding['category']; label: string }[] = [
+  { value: 'debug_artifact', label: 'Debug' },
+  { value: 'todo_comment', label: 'TODOs' },
+  { value: 'hardcoded_value', label: 'Hardcoded' },
+  { value: 'empty_function', label: 'Stubs' },
+];
+
+/** Sentence-case names for the empty states — "No empty_function findings" was
+    leaking the API's own enum into the UI. */
+const SMELL_NOUN: Record<SmellFinding['category'], string> = {
+  debug_artifact: 'debug artifacts',
+  todo_comment: 'TODO comments',
+  hardcoded_value: 'hardcoded values',
+  empty_function: 'empty functions',
+};
+
+const PRIORITY_TONE: Record<string, Tone> = {
+  high: 'red',
+  likely: 'red',
+  medium: 'orange',
+  maybe: 'orange',
+  low: 'neutral',
+};
+
+export function shortPath(root: string): string {
   return root
     .replace(/^\/Users\/[^/]+/, '~')
     .replace(/^\/home\/[^/]+/, '~')
     .replace(/^[A-Z]:\\Users\\[^\\]+/, '~');
 }
+
+export function relativeTime(then: number, now: number): string {
+  const s = Math.max(0, Math.round((now - then) / 1000));
+  if (s < 60) return 'just now';
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m} minute${m === 1 ? '' : 's'} ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h} hour${h === 1 ? '' : 's'} ago`;
+  const d = Math.round(h / 24);
+  return `${d} day${d === 1 ? '' : 's'} ago`;
+}
+
+/** "2 hours ago · Aug 28, 5:01 PM" — the relative form answers "is this
+    stale?", the absolute one answers "which run was that?". The old value was
+    a bare `8/28/2026, 5:01:49 PM`, which answers neither at a glance. */
+export function formatIndexedAt(iso: string, now: number = Date.now()): string {
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return 'Unknown';
+  const abs = new Date(t).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+  return `${relativeTime(t, now)} · ${abs}`;
+}
+
+export function coverageTone(pct: number): Tone {
+  if (pct >= 100) return 'green';
+  if (pct >= 80) return 'orange';
+  return 'red';
+}
+
+const TONE_VAR: Record<Tone, string> = {
+  neutral: 'var(--label-secondary)',
+  accent: 'var(--accent)',
+  green: 'var(--status-green)',
+  orange: 'var(--status-orange)',
+  red: 'var(--status-red)',
+  blue: 'var(--status-blue)',
+  purple: 'var(--status-purple)',
+};
 
 function openInBrowser(url: string): void {
   const api = window.electronAPI;
@@ -65,68 +209,125 @@ function buildIssueUrl(gap: CoverageGap | UnknownPackage): string {
   return `https://github.com/${GITHUB_REPO}/issues/new?${new URLSearchParams({ title, body, labels })}`;
 }
 
-function coverageColor(pct: number): string {
-  if (pct >= 100) return 'var(--green, #22c55e)';
-  if (pct >= 80) return 'var(--yellow, #eab308)';
-  return 'var(--red, #ef4444)';
-}
+// ── Section scaffolding ─────────────────────────────────────────────────────
 
-function priorityBadge(priority: string) {
-  const colors: Record<string, { bg: string; text: string }> = {
-    high: { bg: 'rgba(239,68,68,0.15)', text: '#ef4444' },
-    medium: { bg: 'rgba(234,179,8,0.15)', text: '#eab308' },
-    low: { bg: 'rgba(107,114,128,0.15)', text: '#9ca3af' },
-    likely: { bg: 'rgba(239,68,68,0.15)', text: '#ef4444' },
-    maybe: { bg: 'rgba(234,179,8,0.15)', text: '#eab308' },
-  };
-  const c = colors[priority] ?? colors.low;
+/** A titled group. Grouping is whitespace + a caption, never a rule. */
+function Section({
+  title,
+  count,
+  trailing,
+  children,
+}: {
+  title: string;
+  count?: number;
+  trailing?: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
-    <span
-      className="text-[9px] px-1.5 py-0.5 rounded font-medium uppercase"
-      style={{ background: c.bg, color: c.text }}
-    >
-      {priority}
-    </span>
+    <section className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2 px-1 min-h-6">
+        <h3
+          className="flex items-baseline gap-1.5 text-[11px] leading-[13px] font-semibold"
+          style={{ color: 'var(--label-secondary)' }}
+        >
+          {title}
+          {count !== undefined && count > 0 && (
+            <span className="tabular-nums" style={{ color: 'var(--label-secondary)' }}>
+              {count.toLocaleString()}
+            </span>
+          )}
+        </h3>
+        {trailing}
+      </div>
+      {children}
+    </section>
   );
 }
 
-interface SubprojectInfo {
-  name: string;
-  repoRoot: string;
-  services: number;
-  endpoints: number;
+/** Inset grouped-list container. Content, so: opaque, hairline, no shadow. */
+function Card({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div
+      className={`overflow-hidden${className ? ` ${className}` : ''}`}
+      style={{
+        background: 'var(--surface)',
+        borderRadius: 12,
+        border: '0.5px solid var(--separator)',
+      }}
+    >
+      {children}
+    </div>
+  );
 }
 
-interface SmellFinding {
-  category: 'todo_comment' | 'empty_function' | 'hardcoded_value' | 'debug_artifact';
-  priority: 'high' | 'medium' | 'low';
-  tag?: string;
-  file: string;
-  line: number;
-  snippet: string;
-  description: string;
+/** One label/value row of a grouped list. 32px, 13px both sides. */
+function ListRow({
+  label,
+  value,
+  last = false,
+}: {
+  label: string;
+  value: React.ReactNode;
+  last?: boolean;
+}) {
+  return (
+    <div
+      className="flex items-center justify-between gap-3 px-3"
+      style={{
+        minHeight: 32,
+        borderBottom: last ? 'none' : '0.5px solid var(--separator)',
+      }}
+    >
+      <span className="text-[13px] leading-4" style={{ color: 'var(--label)' }}>
+        {label}
+      </span>
+      <span
+        className="text-[13px] leading-4 tabular-nums truncate"
+        style={{ color: 'var(--label-secondary)' }}
+      >
+        {value}
+      </span>
+    </div>
+  );
 }
 
-interface SmellReport {
-  files_scanned: number;
-  findings: SmellFinding[];
-  summary: {
-    todo_comment: number;
-    empty_function: number;
-    hardcoded_value: number;
-    debug_artifact: number;
-  };
-  total: number;
+/** Rows at the real 32px geometry so nothing moves when the data lands. */
+function SkeletonRows({ rows }: { rows: number }) {
+  return (
+    <div role="status" aria-label="Loading">
+      {Array.from({ length: rows }, (_, i) => (
+        <div
+          key={i}
+          className="flex items-center justify-between px-3"
+          style={{
+            minHeight: 32,
+            borderBottom: i === rows - 1 ? 'none' : '0.5px solid var(--separator)',
+          }}
+        >
+          <Skeleton width={92 + ((i * 29) % 40)} height={11} />
+          <Skeleton width={48 + ((i * 17) % 32)} height={11} />
+        </div>
+      ))}
+    </div>
+  );
 }
 
-interface ServiceInfo {
-  id: number;
-  name: string;
-  repoRoot: string;
-  serviceType: string | null;
-  projectGroup: string | null;
-  endpointCount: number;
+/** Inline "we couldn't measure this" panel with the one action that helps. */
+function SectionError({ what, onRetry }: { what: string; onRetry: () => void }) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2.5">
+      <Icon name="warning" size={14} />
+      <span className="text-[13px] leading-4 flex-1" style={{ color: 'var(--label-secondary)' }}>
+        Couldn't load {what}. The daemon may still be indexing.
+      </span>
+      <Button size="small" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  );
 }
+
+// ── Surface ─────────────────────────────────────────────────────────────────
 
 export function ProjectOverview({
   root,
@@ -135,78 +336,96 @@ export function ProjectOverview({
   root: string;
   onNavigateToService?: (serviceName: string) => void;
 }) {
-  const { projects, reindexProject, addProject } = useDaemon();
+  const { projects, loading: daemonLoading, connected, reindexProject, addProject } = useDaemon();
   const project = projects.find((p) => p.root === root);
   const status = project?.status ?? 'unknown';
   const progress = project?.progress;
+  /* "We haven't heard from the daemon yet" is not "this project was never
+     indexed". Without this the panel offered "Index project" for a project it
+     was simultaneously reporting 78 files and 700 symbols for. */
+  const listPending = !project && (daemonLoading || !connected);
 
   const [stats, setStats] = useState<ProjectStats | null>(null);
+  const [statsLoad, setStatsLoad] = useState<Load>('loading');
   const [coverage, setCoverage] = useState<CoverageReport | null>(null);
-  const [coverageLoading, setCoverageLoading] = useState(false);
-  const [_services, setServices] = useState<SubprojectInfo[]>([]);
+  const [coverageLoad, setCoverageLoad] = useState<Load>('loading');
+  const [, setRepos] = useState<SubprojectInfo[]>([]);
   const [svcList, setSvcList] = useState<ServiceInfo[]>([]);
+  const [servicesLoad, setServicesLoad] = useState<Load>('loading');
   const [addingService, setAddingService] = useState(false);
   const [editingGroup, setEditingGroup] = useState<number | null>(null);
   const [groupInput, setGroupInput] = useState('');
   const [smells, setSmells] = useState<SmellReport | null>(null);
-  const [smellsLoading, setSmellsLoading] = useState(false);
+  const [smellsLoad, setSmellsLoad] = useState<Load>('loading');
   const [smellsCategory, setSmellsCategory] = useState<SmellFinding['category']>('debug_artifact');
   const [statsModalOpen, setStatsModalOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
+
+  const overflowMenu = useMenuAnchor();
+  const rowMenu = useMenuAnchor();
+  const [rowMenuFor, setRowMenuFor] = useState<ServiceInfo | null>(null);
+  const [confirmRemove, setConfirmRemove] = useState<{
+    service: ServiceInfo;
+    x: number;
+    y: number;
+  } | null>(null);
 
   const fetchStats = useCallback(async () => {
+    setStatsLoad('loading');
     try {
       const res = await fetch(`${BASE}/api/projects/stats?project=${encodeURIComponent(root)}`);
-      if (res.ok) setStats(await res.json());
+      if (!res.ok) throw new Error(String(res.status));
+      setStats(await res.json());
+      setStatsLoad('ready');
     } catch {
-      /* optional */
+      setStatsLoad('failed');
     }
   }, [root]);
 
   const fetchCoverage = useCallback(async () => {
-    setCoverageLoading(true);
+    setCoverageLoad('loading');
     try {
       const res = await fetch(`${BASE}/api/projects/coverage?project=${encodeURIComponent(root)}`);
-      if (res.ok) setCoverage(await res.json());
+      if (!res.ok) throw new Error(String(res.status));
+      setCoverage(await res.json());
+      setCoverageLoad('ready');
     } catch {
-      /* optional */
+      setCoverageLoad('failed');
     }
-    setCoverageLoading(false);
   }, [root]);
 
   const fetchServices = useCallback(async () => {
+    setServicesLoad('loading');
     try {
       const params = new URLSearchParams({ project: root });
       const res = await fetch(`${BASE}/api/projects/subprojects?${params}`);
-      if (res.ok) {
-        const data = await res.json();
-        setServices(data.repos ?? []);
-        setSvcList(data.services ?? []);
-      }
+      if (!res.ok) throw new Error(String(res.status));
+      const data = await res.json();
+      setRepos(data.repos ?? []);
+      setSvcList(data.services ?? []);
+      setServicesLoad('ready');
     } catch {
-      /* optional */
+      setServicesLoad('failed');
     }
   }, [root]);
 
   const fetchSmells = useCallback(
     async (category: SmellFinding['category']) => {
-      setSmellsLoading(true);
+      setSmellsLoad('loading');
       try {
-        const params = new URLSearchParams({
-          project: root,
-          category,
-          limit: '500',
-        });
+        const params = new URLSearchParams({ project: root, category, limit: '500' });
         const res = await fetch(`${BASE}/api/projects/smells?${params}`);
-        if (res.ok) setSmells(await res.json());
+        if (!res.ok) throw new Error(String(res.status));
+        setSmells(await res.json());
+        setSmellsLoad('ready');
       } catch {
-        /* optional */
+        setSmellsLoad('failed');
       }
-      setSmellsLoading(false);
     },
     [root],
   );
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: status is an intentional trigger — refetches the project overview after the project transitions out of 'indexing' so the panel reflects the new totals.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: status is an intentional trigger — refetches after the project leaves 'indexing' so the panel reflects the new totals.
   useEffect(() => {
     fetchStats();
     fetchCoverage();
@@ -221,14 +440,15 @@ export function ProjectOverview({
     try {
       const folder = await api.selectFolder();
       if (!folder) return;
-      await fetch(`${BASE}/api/projects/subprojects`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      await fetch(`${BASE}/api/projects/subprojects`, {
+        // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ repoPath: folder, project: root }),
       });
       fetchServices();
     } catch {
-      /* optional */
+      /* the list simply stays as it was */
     } finally {
       setAddingService(false);
     }
@@ -240,17 +460,18 @@ export function ProjectOverview({
         method: 'DELETE',
       });
       if (res.ok) {
-        setServices((prev) => prev.filter((s) => s.name !== name));
+        setRepos((prev) => prev.filter((s) => s.name !== name));
         setSvcList((prev) => prev.filter((s) => s.name !== name));
       }
     } catch {
-      /* optional */
+      /* the row stays; the next fetch reconciles */
     }
   };
 
   const handleUpdateGroup = async (serviceId: number, projectGroup: string | null) => {
     try {
-      const res = await fetch(`${BASE}/api/projects/services`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      const res = await fetch(`${BASE}/api/projects/services`, {
+        // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ serviceId, projectGroup: projectGroup || null }),
@@ -261,12 +482,14 @@ export function ProjectOverview({
         );
       }
     } catch {
-      /* optional */
+      /* keep the previous group */
     }
     setEditingGroup(null);
   };
 
-  const statusDot: Tone =
+  const projectName = root.split(/[/\\]/).filter(Boolean).pop() ?? root;
+
+  const statusTone: Tone =
     status === 'indexing'
       ? 'orange'
       : status === 'error'
@@ -275,606 +498,500 @@ export function ProjectOverview({
           ? 'green'
           : 'neutral';
 
-  const hasGaps =
-    coverage &&
-    (coverage.gaps.length > 0 ||
-      coverage.unknown.filter((u) => u.needs_plugin === 'likely').length > 0);
-
-  const statusLabel =
-    status === 'indexing'
-      ? 'Indexing…'
+  const statusLabel = listPending
+    ? connected
+      ? 'Checking…'
+      : 'Daemon unreachable'
+    : status === 'indexing'
+      ? 'Indexing'
       : status === 'ready'
         ? 'Ready'
         : status === 'error'
           ? 'Error'
-          : status;
+          : 'Not indexed';
+
+  const likelyUnknown = useMemo(
+    () => coverage?.unknown.filter((u) => u.needs_plugin === 'likely') ?? [],
+    [coverage],
+  );
+  const hasGaps = (coverage?.gaps.length ?? 0) > 0 || likelyUnknown.length > 0;
+
+  const groups = useMemo(() => {
+    const map = new Map<string, ServiceInfo[]>();
+    for (const svc of svcList) {
+      const key = svc.projectGroup ?? '';
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(svc);
+    }
+    const keys = [...map.keys()].sort((a, b) => (!a ? 1 : !b ? -1 : a.localeCompare(b)));
+    return { map, keys };
+  }, [svcList]);
+  const existingGroups = groups.keys.filter(Boolean);
+  /* A lone unnamed group is not a group — "Ungrouped" was a system word
+     labelling the only row on screen. */
+  const showGroupHeaders = groups.keys.length > 1 || Boolean(groups.keys[0]);
+
+  const visibleFindings = smells?.findings.slice(0, FINDING_LIMIT) ?? [];
 
   return (
-    <>
-    <div className="space-y-5 pb-4">
-      {/* ── Hero header ──────────────────────────────── */}
-      <div className="pt-1">
-        <div className="flex items-center gap-2.5">
-          <StatusDot tone={statusDot} pulse={statusDot === 'green'} />
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* ── Toolbar ──────────────────────────────────────────────────── */}
+      <div
+        className="flex items-center gap-3 px-4 shrink-0 glass relative"
+        style={{
+          height: 52,
+          borderBottom: '0.5px solid transparent',
+          borderBottomColor: scrolled ? 'var(--separator)' : 'transparent',
+          transition: 'border-bottom-color var(--dur-standard) var(--ease-out)',
+        }}
+      >
+        <StatusDot tone={statusTone} pulse={status === 'indexing'} />
+        <div className="min-w-0 flex-1">
           <h2
-            className="text-[17px] font-semibold leading-tight truncate flex-1 min-w-0"
-            style={{ color: 'var(--text-primary)', letterSpacing: '-0.022em' }}
-            title={root.split(/[/\\]/).filter(Boolean).pop()}
+            className="text-[17px] leading-[22px] font-semibold truncate"
+            style={{ color: 'var(--label)', letterSpacing: '-0.01em' }}
+            title={projectName}
           >
-            {root.split(/[/\\]/).filter(Boolean).pop()}
+            {projectName}
           </h2>
-          <button
-            type="button"
-            onClick={() => setStatsModalOpen(true)}
-            className="shrink-0 text-[11px] px-2 py-1 rounded font-medium transition-opacity hover:opacity-80"
-            style={{
-              background: 'var(--fill-control)',
-              color: 'var(--accent)',
-              border: '0.5px solid var(--border)',
-            }}
-            title="Open the project stats modal (7 sections)"
+          <div
+            className="text-[11px] leading-[13px] truncate"
+            style={{ color: 'var(--label-secondary)', fontFamily: 'var(--font-mono)' }}
+            title={root}
           >
-            View Stats
-          </button>
-        </div>
-        <div
-          className="text-[11px] mt-1 ml-[18px] truncate"
-          style={{ color: 'var(--text-tertiary)', fontFamily: 'SF Mono, Menlo, monospace' }}
-          title={root}
-        >
-          {shortPath(root)}
+            {shortPath(root)}
+          </div>
         </div>
 
-        {/* Indexing progress inline under header */}
+        {listPending ? (
+          /* Offering "Index project" before the daemon has answered invites the
+             user to re-index something that may already be indexed. The toolbar
+             always renders, so the daemon-down wording lives here rather than in
+             the Status row, which is itself missing when the fetch failed. */
+          <Button className="is-status" disabled>
+            {connected ? 'Checking…' : 'Daemon unreachable'}
+          </Button>
+        ) : project ? (
+          /* While indexing the action is unavailable, and a DISABLED prominent
+             button is white-on-40%-accent — 2.2:1, measured. A bordered button
+             marked `is-status` is unpressable but still readable, because this
+             label — not the button — is what reports the phase. */
+          status === 'indexing' ? (
+            <Button className="is-status" icon="refresh" disabled>
+              Indexing…
+            </Button>
+          ) : (
+            <Button variant="prominent" icon="refresh" onClick={() => reindexProject(root)}>
+              Reindex
+            </Button>
+          )
+        ) : (
+          <Button variant="prominent" icon="add" onClick={() => addProject(root)}>
+            Index project
+          </Button>
+        )}
+
+        <Button
+          ref={overflowMenu.ref}
+          variant="icon"
+          icon="more_horiz"
+          onClick={() => (overflowMenu.at ? overflowMenu.close() : overflowMenu.open())}
+          aria-haspopup="menu"
+          aria-expanded={overflowMenu.at !== null}
+          aria-label="More actions"
+          title="More actions"
+        />
+
+        {/* Indexing progress rides the toolbar's bottom edge — a 2px accent
+            rule, not a full-bleed band with centred white text on it. */}
         {status === 'indexing' && progress?.percent != null && (
-          <div className="mt-3 ml-[18px]">
+          <div
+            className="absolute left-0 right-0 bottom-0"
+            style={{ height: 2, background: 'var(--fill-quaternary)' }}
+          >
             <div
-              className="flex justify-between text-[10px] mb-1"
-              style={{ color: 'var(--text-tertiary)' }}
-            >
-              <span className="truncate">{progress.phase}</span>
-              <span className="tabular-nums">{progress.percent}%</span>
-            </div>
-            <div
-              className="h-1 rounded-full overflow-hidden"
-              style={{ background: 'var(--bg-inset)' }}
-            >
-              <div
-                className="h-full rounded-full transition-all duration-300"
-                style={{ width: `${progress.percent}%`, background: 'var(--accent)' }}
-              />
-            </div>
+              role="progressbar"
+              aria-valuenow={progress.percent}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label="Indexing progress"
+              style={{
+                height: '100%',
+                width: `${progress.percent}%`,
+                background: 'var(--accent)',
+                transition: 'width var(--dur-standard) var(--ease-out)',
+              }}
+            />
           </div>
         )}
       </div>
 
-      {/* ── Primary action ───────────────────────────── */}
-      {project ? (
-        <button
-          type="button"
-          onClick={() => reindexProject(root)}
-          disabled={status === 'indexing'}
-          className="w-full text-[13px] font-medium transition-all disabled:opacity-40 hover:brightness-110 active:brightness-95"
-          style={{
-            background: 'var(--accent)',
-            color: '#fff',
-            borderRadius: 8,
-            height: 30,
-            boxShadow:
-              '0 0 0 0.5px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08), inset 0 0.5px 0 rgba(255,255,255,0.25)',
-            cursor: status === 'indexing' ? 'default' : 'pointer',
-            letterSpacing: '-0.005em',
-          }}
-        >
-          {status === 'indexing' ? 'Indexing…' : 'Re-index Project'}
-        </button>
-      ) : (
-        <button
-          type="button"
-          onClick={() => addProject(root)}
-          className="w-full text-[13px] font-medium transition-all hover:brightness-110 active:brightness-95"
-          style={{
-            background: 'var(--success)',
-            color: '#fff',
-            borderRadius: 8,
-            height: 30,
-            boxShadow:
-              '0 0 0 0.5px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08), inset 0 0.5px 0 rgba(255,255,255,0.25)',
-            letterSpacing: '-0.005em',
-          }}
-        >
-          Index Project
-        </button>
-      )}
-
-      {/* ── Index stats (grouped list) ───────────────── */}
-      {stats && (
-        <div>
-          <div
-            className="text-[11px] mb-1.5 px-3"
-            style={{ color: 'var(--text-secondary)', letterSpacing: '-0.01em' }}
-          >
-            Index
-          </div>
-          <div
-            style={{
-              background: 'var(--bg-grouped)',
-              borderRadius: 10,
-              boxShadow: 'var(--shadow-grouped)',
-              overflow: 'hidden',
+      {overflowMenu.at && (
+        <Menu x={overflowMenu.at.x} y={overflowMenu.at.y} align="end" onClose={overflowMenu.close}>
+          <MenuItem
+            icon="monitoring"
+            onClick={() => {
+              setStatsModalOpen(true);
+              overflowMenu.close();
             }}
           >
-            <SettingsRow label="Status" value={statusLabel} />
-            <SettingsRow label="Files indexed" value={stats.files.toLocaleString()} />
-            <SettingsRow label="Symbols" value={stats.symbols.toLocaleString()} />
-            <SettingsRow label="Edges" value={stats.edges.toLocaleString()} />
-            {stats.lastIndexed && (
-              <SettingsRow
-                label="Last indexed"
-                value={new Date(stats.lastIndexed).toLocaleString()}
-                last
-              />
-            )}
-          </div>
-        </div>
+            View stats
+          </MenuItem>
+          <MenuItem
+            icon="add"
+            disabled={addingService}
+            onClick={() => {
+              overflowMenu.close();
+              handleAddService();
+            }}
+          >
+            Add service…
+          </MenuItem>
+          <MenuSeparator />
+          <MenuItem
+            icon="folder_open"
+            onClick={() => {
+              window.electronAPI?.openInEditor?.(root);
+              overflowMenu.close();
+            }}
+          >
+            Open in editor
+          </MenuItem>
+        </Menu>
       )}
 
-      {/* ── Technology Coverage (grouped list) ───────── */}
-      {coverage && (
-        <div>
-          <div className="flex items-baseline justify-between mb-1.5 px-3">
+      {/* ── Content ──────────────────────────────────────────────────── */}
+      <div
+        className="flex-1 overflow-auto"
+        onScroll={(e) => setScrolled((e.target as HTMLElement).scrollTop > 0)}
+      >
+        <div className="flex flex-col gap-6 px-4 py-4 mx-auto w-full" style={{ maxWidth: 720 }}>
+          {/* Indexing caption — the phase in words, next to the bar above. */}
+          {status === 'indexing' && progress?.phase && (
             <div
-              className="text-[11px]"
-              style={{ color: 'var(--text-secondary)', letterSpacing: '-0.01em' }}
+              className="text-[13px] leading-4 -mb-2 px-1 flex items-center gap-1.5"
+              style={{ color: 'var(--label-secondary)' }}
             >
-              Coverage
+              <Icon name="refresh" size={13} />
+              <span className="truncate">{progress.phase}</span>
+              {progress.percent != null && (
+                <span className="tabular-nums">· {progress.percent}%</span>
+              )}
             </div>
-            <span
-              className="text-[11px] font-semibold tabular-nums"
-              style={{ color: coverageColor(coverage.coverage.coverage_pct) }}
-            >
-              {coverage.coverage.coverage_pct}%
-            </span>
-          </div>
-          <div
-            style={{
-              background: 'var(--bg-grouped)',
-              borderRadius: 10,
-              boxShadow: 'var(--shadow-grouped)',
-              overflow: 'hidden',
-            }}
-          >
-            {/* Progress row */}
-            <div className="px-3 py-2.5" style={{ borderBottom: '0.5px solid var(--border-row)' }}>
-              <div
-                className="h-1.5 rounded-full overflow-hidden"
-                style={{ background: 'var(--bg-inset)' }}
-              >
-                <div
-                  className="h-full rounded-full transition-all duration-500"
-                  style={{
-                    width: `${coverage.coverage.coverage_pct}%`,
-                    background: coverageColor(coverage.coverage.coverage_pct),
-                  }}
+          )}
+
+          {/* ── Index ──────────────────────────────────────────────── */}
+          <Section title="Index">
+            <Card>
+              {statsLoad === 'loading' && !stats ? (
+                <SkeletonRows rows={5} />
+              ) : statsLoad === 'failed' && !stats ? (
+                <SectionError what="the index summary" onRetry={fetchStats} />
+              ) : stats ? (
+                <>
+                  <ListRow
+                    label="Status"
+                    value={
+                      <span className="inline-flex items-center gap-1.5">
+                        <StatusDot tone={statusTone} />
+                        {statusLabel}
+                      </span>
+                    }
+                  />
+                  <ListRow label="Files indexed" value={stats.files.toLocaleString()} />
+                  <ListRow label="Symbols" value={stats.symbols.toLocaleString()} />
+                  <ListRow label="Edges" value={stats.edges.toLocaleString()} />
+                  <ListRow
+                    label="Last indexed"
+                    value={stats.lastIndexed ? formatIndexedAt(stats.lastIndexed) : 'Never'}
+                    last
+                  />
+                </>
+              ) : (
+                <EmptyState
+                  compact
+                  icon="database"
+                  title="Not indexed yet"
+                  subtitle="Index this project to explore its symbols, edges and history."
+                  action={
+                    <Button variant="prominent" icon="add" onClick={() => addProject(root)}>
+                      Index project
+                    </Button>
+                  }
                 />
-              </div>
-              <div className="flex justify-between mt-1.5">
-                <span className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>
-                  {coverage.coverage.covered} of {coverage.coverage.total_significant} covered
+              )}
+            </Card>
+          </Section>
+
+          {/* ── Coverage ───────────────────────────────────────────── */}
+          <Section
+            title="Coverage"
+            trailing={
+              coverage && coverage.coverage.total_significant > 0 ? (
+                <span
+                  className="text-[11px] leading-[13px] font-semibold tabular-nums"
+                  style={{ color: TONE_VAR[coverageTone(coverage.coverage.coverage_pct)] }}
+                >
+                  {coverage.coverage.coverage_pct}%
                 </span>
-              </div>
-            </div>
-
-            {/* Gaps */}
-            {coverage.gaps.map((gap, i) => {
-              const isLast =
-                i === coverage.gaps.length - 1 &&
-                coverage.unknown.filter((u) => u.needs_plugin === 'likely').length === 0;
-              return (
-                <div
-                  key={gap.name}
-                  className="flex items-center justify-between gap-2 px-3 py-2"
-                  style={{ borderBottom: isLast ? 'none' : '0.5px solid var(--border-row)' }}
-                >
-                  <div className="flex items-center gap-1.5 min-w-0">
-                    {priorityBadge(gap.priority)}
-                    <span className="text-[12px] truncate" style={{ color: 'var(--text-primary)' }}>
-                      {gap.name}
-                    </span>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => openInBrowser(buildIssueUrl(gap))}
-                    className="shrink-0 text-[11px] font-medium transition-colors hover:opacity-80"
-                    style={{
-                      background: 'var(--accent)',
-                      color: '#fff',
-                      borderRadius: 6,
-                      padding: '2px 10px',
-                    }}
-                    title={`Request plugin support for ${gap.name}`}
-                  >
-                    Request
-                  </button>
+              ) : undefined
+            }
+          >
+            <Card>
+              {coverageLoad === 'loading' && !coverage ? (
+                <div className="px-3 py-3 flex flex-col gap-2">
+                  <Skeleton width="100%" height={6} radius={3} />
+                  <Skeleton width={140} height={11} />
                 </div>
-              );
-            })}
-
-            {/* Unknown packages that likely need plugins */}
-            {coverage.unknown
-              .filter((u) => u.needs_plugin === 'likely')
-              .map((pkg, i, arr) => (
-                <div
-                  key={pkg.name}
-                  className="flex items-center justify-between gap-2 px-3 py-2"
-                  style={{
-                    borderBottom: i === arr.length - 1 ? 'none' : '0.5px solid var(--border-row)',
-                  }}
-                >
-                  <div className="flex items-center gap-1.5 min-w-0">
-                    {priorityBadge(pkg.needs_plugin)}
-                    <span className="text-[12px] truncate" style={{ color: 'var(--text-primary)' }}>
-                      {pkg.name}
-                    </span>
-                    <span
-                      className="text-[10px] shrink-0"
-                      style={{ color: 'var(--text-tertiary)' }}
+              ) : coverageLoad === 'failed' && !coverage ? (
+                <SectionError what="dependency coverage" onRetry={fetchCoverage} />
+              ) : coverage && coverage.coverage.total_significant === 0 ? (
+                /* Nothing to cover is not 100% covered. A full green meter over
+                   "0 of 0 dependencies covered" claims a result nobody measured. */
+                <EmptyState
+                  compact
+                  icon="cable"
+                  title="No dependencies detected"
+                  subtitle="Coverage appears once this project has a dependency manifest in the index."
+                />
+              ) : coverage ? (
+                <>
+                  <div
+                    className="px-3 py-3"
+                    style={{
+                      borderBottom: hasGaps ? '0.5px solid var(--separator)' : 'none',
+                    }}
+                  >
+                    <div
+                      className="overflow-hidden"
+                      style={{ height: 6, borderRadius: 3, background: 'var(--fill-quaternary)' }}
                     >
-                      {pkg.ecosystem}
-                    </span>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => openInBrowser(buildIssueUrl(pkg))}
-                    className="shrink-0 text-[11px] font-medium transition-colors hover:opacity-80"
-                    style={{
-                      background: 'var(--accent)',
-                      color: '#fff',
-                      borderRadius: 6,
-                      padding: '2px 10px',
-                    }}
-                    title={`Request catalog addition for ${pkg.name}`}
-                  >
-                    Request
-                  </button>
-                </div>
-              ))}
-
-            {/* All covered message */}
-            {!hasGaps && coverage.coverage.total_significant > 0 && (
-              <div
-                className="text-[12px] text-center px-3 py-2"
-                style={{ color: 'var(--success)', borderTop: '0.5px solid var(--border-row)' }}
-              >
-                All significant dependencies are covered
-              </div>
-            )}
-          </div>
-        </div>
-      )}
-
-      {coverageLoading && !coverage && (
-        <div>
-          <div
-            className="text-[11px] mb-1.5 px-3"
-            style={{ color: 'var(--text-secondary)', letterSpacing: '-0.01em' }}
-          >
-            Coverage
-          </div>
-          <div
-            className="px-3 py-3 text-[11px] text-center"
-            style={{
-              background: 'var(--bg-grouped)',
-              borderRadius: 10,
-              boxShadow: 'var(--shadow-grouped)',
-              color: 'var(--text-tertiary)',
-            }}
-          >
-            Analyzing technology coverage…
-          </div>
-        </div>
-      )}
-
-      {/* ── Quality (debug artifacts, TODOs, hardcoded values, empty functions) ── */}
-      {(smells || smellsLoading) && (
-        <div>
-          <div className="flex items-baseline justify-between mb-1.5 px-3">
-            <div
-              className="text-[11px]"
-              style={{ color: 'var(--text-secondary)', letterSpacing: '-0.01em' }}
-            >
-              Quality
-            </div>
-            {smells && (
-              <span
-                className="text-[11px] font-semibold tabular-nums"
-                style={{
-                  color:
-                    smells.total === 0
-                      ? 'var(--green, #22c55e)'
-                      : smells.total > 20
-                        ? 'var(--red, #ef4444)'
-                        : 'var(--yellow, #eab308)',
-                }}
-              >
-                {smells.total} finding{smells.total === 1 ? '' : 's'}
-              </span>
-            )}
-          </div>
-
-          {/* Category tabs */}
-          <div className="flex px-3 mb-2">
-            <SegmentedControl
-              options={[
-                { value: 'debug_artifact', label: 'Debug' },
-                { value: 'todo_comment', label: 'TODOs' },
-                { value: 'hardcoded_value', label: 'Hardcoded' },
-                { value: 'empty_function', label: 'Stubs' },
-              ]}
-              value={smellsCategory}
-              onChange={setSmellsCategory}
-              aria-label="Code smell category"
-            />
-          </div>
-
-          <div
-            style={{
-              background: 'var(--bg-grouped)',
-              borderRadius: 10,
-              boxShadow: 'var(--shadow-grouped)',
-              overflow: 'hidden',
-            }}
-          >
-            {smellsLoading && !smells && (
-              <div
-                className="px-3 py-3 text-[12px] text-center"
-                style={{ color: 'var(--text-tertiary)' }}
-              >
-                Scanning…
-              </div>
-            )}
-            {smells && smells.findings.length === 0 && (
-              <div
-                className="px-3 py-3 text-[12px] text-center"
-                style={{ color: 'var(--text-tertiary)' }}
-              >
-                No {smellsCategory.replace('_', ' ')} findings
-              </div>
-            )}
-            {smells?.findings.slice(0, 25).map((f, i) => {
-              const isLast = i === Math.min(smells.findings.length, 25) - 1;
-              return (
-                <button
-                  type="button"
-                  // biome-ignore lint/suspicious/noArrayIndexKey: composite key (file+line) may collide for multiple smells in the same line; index disambiguates within a stable, sliced 25-item list.
-                  key={`${f.file}:${f.line}:${i}`}
-                  onClick={() => {
-                    const api = window.electronAPI;
-                    if (api?.openInEditor) api.openInEditor(`${root}/${f.file}:${f.line}`);
-                  }}
-                  className="flex items-start justify-between gap-2 px-3 py-2 w-full text-left hover:brightness-110"
-                  style={{
-                    borderBottom: isLast ? 'none' : '0.5px solid var(--border-row)',
-                    cursor: 'pointer',
-                  }}
-                >
-                  <div className="flex items-start gap-1.5 min-w-0 flex-1">
-                    {priorityBadge(f.priority)}
-                    <div className="min-w-0 flex-1">
                       <div
-                        className="text-[12px] truncate"
+                        role="progressbar"
+                        aria-valuenow={coverage.coverage.coverage_pct}
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                        aria-label="Dependency coverage"
                         style={{
-                          color: 'var(--text-primary)',
-                          fontFamily: 'SF Mono, Menlo, monospace',
+                          height: '100%',
+                          borderRadius: 3,
+                          width: `${coverage.coverage.coverage_pct}%`,
+                          background: TONE_VAR[coverageTone(coverage.coverage.coverage_pct)],
+                          transition: 'width var(--dur-large) var(--ease-out)',
                         }}
-                      >
-                        {f.snippet}
-                      </div>
-                      <div
-                        className="text-[10px] mt-0.5 truncate"
-                        style={{ color: 'var(--text-tertiary)' }}
-                      >
-                        {f.file}:{f.line}
-                        {f.tag ? ` · ${f.tag}` : ''}
-                      </div>
+                      />
+                    </div>
+                    {/* Status arrives with a glyph and a left-aligned sentence,
+                        never as centred green prose. */}
+                    <div
+                      className="flex items-center gap-1.5 mt-2 text-[13px] leading-4"
+                      style={{ color: 'var(--label-secondary)' }}
+                    >
+                      <Icon name={hasGaps ? 'warning' : 'check'} size={13} />
+                      <span className="tabular-nums">
+                        {coverage.coverage.covered} of {coverage.coverage.total_significant}{' '}
+                        dependencies covered
+                      </span>
                     </div>
                   </div>
-                </button>
-              );
-            })}
-            {smells && smells.findings.length > 25 && (
-              <div
-                className="px-3 py-1.5 text-[10px] text-center"
-                style={{
-                  color: 'var(--text-tertiary)',
-                  borderTop: '0.5px solid var(--border-row)',
-                }}
-              >
-                + {smells.findings.length - 25} more
-              </div>
-            )}
-          </div>
-        </div>
-      )}
 
-      {/* ── Services (native grouped list with group headers) ── */}
-      {(() => {
-        // Group services by projectGroup
-        const grouped = new Map<string, ServiceInfo[]>();
-        const existingGroups: string[] = [];
-        for (const svc of svcList) {
-          const key = svc.projectGroup ?? '';
-          if (!grouped.has(key)) {
-            grouped.set(key, []);
-            existingGroups.push(key);
-          }
-          grouped.get(key)!.push(svc);
-        }
-        const groupKeys = [...grouped.keys()].sort((a, b) => {
-          if (!a) return 1; // ungrouped last
-          if (!b) return -1;
-          return a.localeCompare(b);
-        });
+                  {coverage.gaps.map((gap, i) => (
+                    <CoverageRow
+                      key={gap.name}
+                      name={gap.name}
+                      tone={PRIORITY_TONE[gap.priority] ?? 'neutral'}
+                      badge={gap.priority}
+                      last={i === coverage.gaps.length - 1 && likelyUnknown.length === 0}
+                      onRequest={() => openInBrowser(buildIssueUrl(gap))}
+                    />
+                  ))}
+                  {likelyUnknown.map((pkg, i) => (
+                    <CoverageRow
+                      key={pkg.name}
+                      name={pkg.name}
+                      meta={pkg.ecosystem}
+                      tone={PRIORITY_TONE[pkg.needs_plugin] ?? 'neutral'}
+                      badge={pkg.needs_plugin}
+                      last={i === likelyUnknown.length - 1}
+                      onRequest={() => openInBrowser(buildIssueUrl(pkg))}
+                    />
+                  ))}
+                </>
+              ) : (
+                <EmptyState
+                  compact
+                  icon="cable"
+                  title="No dependencies found"
+                  subtitle="Coverage appears once the project has a dependency manifest indexed."
+                />
+              )}
+            </Card>
+          </Section>
 
-        const totalCount = svcList.length;
-
-        return (
-          <div>
-            {/* Section header with + Add button */}
-            <div className="flex items-baseline justify-between mb-1.5 px-3">
-              <div className="flex items-baseline gap-1.5">
-                <span
-                  className="text-[11px]"
-                  style={{ color: 'var(--text-secondary)', letterSpacing: '-0.01em' }}
-                >
-                  Services
-                </span>
-                {totalCount > 0 && (
-                  <span
-                    className="text-[11px] tabular-nums"
-                    style={{ color: 'var(--text-tertiary)' }}
-                  >
-                    {totalCount}
-                  </span>
-                )}
-              </div>
-              <button
-                type="button"
-                onClick={handleAddService}
-                disabled={addingService}
-                className="text-[12px] transition-colors disabled:opacity-40 flex items-center gap-1 hover:opacity-80"
-                style={{ color: 'var(--accent)' }}
-                title="Add external service"
-              >
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2.5"
-                  strokeLinecap="round"
-                >
-                  <line x1="12" y1="5" x2="12" y2="19" />
-                  <line x1="5" y1="12" x2="19" y2="12" />
-                </svg>
-                Add
-              </button>
+          {/* ── Quality ────────────────────────────────────────────── */}
+          <Section
+            title="Quality"
+            trailing={
+              smells ? (
+                <Badge tone={smells.total === 0 ? 'green' : smells.total > 20 ? 'red' : 'orange'}>
+                  {smells.total.toLocaleString()} finding{smells.total === 1 ? '' : 's'}
+                </Badge>
+              ) : undefined
+            }
+          >
+            <div className="px-1">
+              <SegmentedControl
+                options={SMELL_CATEGORIES}
+                value={smellsCategory}
+                onChange={(v) => setSmellsCategory(v as SmellFinding['category'])}
+                aria-label="Finding category"
+              />
             </div>
+            <Card>
+              {smellsLoad === 'loading' && !smells ? (
+                <SkeletonRows rows={4} />
+              ) : smellsLoad === 'failed' && !smells ? (
+                <SectionError what="the quality scan" onRetry={() => fetchSmells(smellsCategory)} />
+              ) : visibleFindings.length === 0 ? (
+                <EmptyState
+                  compact
+                  icon="check"
+                  title={`No ${SMELL_NOUN[smellsCategory]}`}
+                  subtitle={`Nothing to clean up in this category across ${(smells?.files_scanned ?? 0).toLocaleString()} scanned files.`}
+                />
+              ) : (
+                <>
+                  {visibleFindings.map((f, i) => (
+                    <button
+                      type="button"
+                      // biome-ignore lint/suspicious/noArrayIndexKey: file+line can repeat for several findings on one line; the index disambiguates within a stable sliced list.
+                      key={`${f.file}:${f.line}:${i}`}
+                      onClick={() =>
+                        window.electronAPI?.openInEditor?.(`${root}/${f.file}:${f.line}`)
+                      }
+                      className="flex items-start gap-2 px-3 py-2 w-full text-left"
+                      style={{
+                        borderBottom:
+                          i === visibleFindings.length - 1 && smells!.findings.length <= FINDING_LIMIT
+                            ? 'none'
+                            : '0.5px solid var(--separator)',
+                        cursor: 'default',
+                      }}
+                      title={`Open ${f.file}:${f.line} in your editor`}
+                    >
+                      <Badge tone={PRIORITY_TONE[f.priority] ?? 'neutral'}>{f.priority}</Badge>
+                      <span className="min-w-0 flex-1">
+                        <span
+                          className="block text-[13px] leading-4 truncate"
+                          style={{ color: 'var(--label)', fontFamily: 'var(--font-mono)' }}
+                        >
+                          {f.snippet}
+                        </span>
+                        <span
+                          className="block text-[11px] leading-[13px] truncate mt-0.5"
+                          style={{ color: 'var(--label-secondary)' }}
+                        >
+                          {f.file}:{f.line}
+                          {f.tag ? ` · ${f.tag}` : ''}
+                        </span>
+                      </span>
+                    </button>
+                  ))}
+                  {smells && smells.findings.length > FINDING_LIMIT && (
+                    <div
+                      className="px-3 py-2 text-[11px] leading-[13px]"
+                      style={{ color: 'var(--label-secondary)' }}
+                    >
+                      {(smells.findings.length - FINDING_LIMIT).toLocaleString()} more not shown
+                    </div>
+                  )}
+                </>
+              )}
+            </Card>
+          </Section>
 
-            {totalCount === 0 ? (
-              <div
-                className="px-3 py-3 text-[12px] text-center"
-                style={{
-                  background: 'var(--bg-grouped)',
-                  borderRadius: 10,
-                  boxShadow: 'var(--shadow-grouped)',
-                  color: 'var(--text-tertiary)',
-                }}
-              >
-                No services detected.
-                <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
-                  Re-index the project or add manually.
-                </div>
-              </div>
+          {/* ── Services ───────────────────────────────────────────── */}
+          <Section
+            title="Services"
+            count={svcList.length}
+            trailing={
+              <Button size="small" icon="add" disabled={addingService} onClick={handleAddService}>
+                Add
+              </Button>
+            }
+          >
+            {servicesLoad === 'loading' && svcList.length === 0 ? (
+              <Card>
+                <SkeletonRows rows={2} />
+              </Card>
+            ) : servicesLoad === 'failed' && svcList.length === 0 ? (
+              <Card>
+                <SectionError what="the service list" onRetry={fetchServices} />
+              </Card>
+            ) : svcList.length === 0 ? (
+              <Card>
+                <EmptyState
+                  compact
+                  icon="db_server"
+                  title="No services detected"
+                  subtitle="Services are found when the project is indexed, or you can point at a repository yourself."
+                  action={
+                    <Button icon="add" disabled={addingService} onClick={handleAddService}>
+                      Add service…
+                    </Button>
+                  }
+                />
+              </Card>
             ) : (
-              <div className="space-y-3.5">
-                {groupKeys.map((groupKey) => {
-                  const groupServices = grouped.get(groupKey)!;
+              <div className="flex flex-col gap-4">
+                {groups.keys.map((groupKey) => {
+                  const groupServices = groups.map.get(groupKey)!;
                   return (
-                    <div key={groupKey || '__ungrouped__'}>
-                      {/* Group sub-header */}
-                      <div
-                        className="text-[11px] font-medium mb-1 px-3"
-                        style={{
-                          color: groupKey ? 'var(--accent)' : 'var(--text-tertiary)',
-                          letterSpacing: '-0.01em',
-                        }}
-                      >
-                        {groupKey || 'Ungrouped'}
-                      </div>
-
-                      {/* Service list card */}
-                      <div
-                        style={{
-                          background: 'var(--bg-grouped)',
-                          borderRadius: 10,
-                          boxShadow: 'var(--shadow-grouped)',
-                          overflow: 'hidden',
-                        }}
-                      >
-                        {groupServices.map((svc, i) => {
-                          const isLast = i === groupServices.length - 1;
-                          return (
-                            <div
-                              key={svc.id}
-                              className="group flex items-center gap-2 px-3 py-2 transition-colors hover:bg-[var(--bg-active)]"
+                    <div key={groupKey || '__ungrouped__'} className="flex flex-col gap-1.5">
+                      {showGroupHeaders && (
+                        <div
+                          className="text-[11px] leading-[13px] font-medium px-1"
+                          style={{ color: 'var(--label-secondary)' }}
+                        >
+                          {groupKey || 'No group'}
+                        </div>
+                      )}
+                      <Card>
+                        {groupServices.map((svc, i) => (
+                          <div
+                            key={svc.id}
+                            className="flex items-center gap-2.5 px-3"
+                            style={{
+                              minHeight: 44,
+                              borderBottom:
+                                i === groupServices.length - 1
+                                  ? 'none'
+                                  : '0.5px solid var(--separator)',
+                            }}
+                          >
+                            <span
+                              className="shrink-0 inline-flex items-center justify-center"
                               style={{
-                                borderBottom: isLast ? 'none' : '0.5px solid var(--border-row)',
+                                width: 24,
+                                height: 24,
+                                borderRadius: 6,
+                                background: 'var(--fill-quaternary)',
+                                color: 'var(--label-secondary)',
                               }}
                             >
-                              {/* Service icon */}
-                              <div
-                                className="shrink-0 w-6 h-6 rounded-md flex items-center justify-center"
-                                style={{
-                                  background: 'var(--bg-inset)',
-                                  color: 'var(--text-secondary)',
-                                }}
-                              >
-                                <svg
-                                  width="12"
-                                  height="12"
-                                  viewBox="0 0 24 24"
-                                  fill="none"
-                                  stroke="currentColor"
-                                  strokeWidth="1.8"
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                >
-                                  <rect x="3" y="3" width="18" height="6" rx="1" />
-                                  <rect x="3" y="15" width="18" height="6" rx="1" />
-                                  <line x1="7" y1="6" x2="7.01" y2="6" />
-                                  <line x1="7" y1="18" x2="7.01" y2="18" />
-                                </svg>
-                              </div>
+                              <Icon name="db_server" size={14} />
+                            </span>
 
-                              {/* Service info */}
-                              <div className="flex-1 min-w-0">
-                                <div
-                                  className="text-[13px] truncate leading-tight"
-                                  style={{ color: 'var(--text-primary)' }}
-                                >
-                                  {svc.name}
-                                </div>
-                                <div
-                                  className="text-[10px] truncate mt-0.5"
-                                  style={{
-                                    color: 'var(--text-tertiary)',
-                                    fontFamily: 'SF Mono, Menlo, monospace',
-                                  }}
-                                  title={svc.repoRoot}
-                                >
-                                  {shortPath(svc.repoRoot)}
-                                  {svc.endpointCount > 0 && (
-                                    <span style={{ fontFamily: 'inherit' }}>
-                                      {' · '}
-                                      {svc.endpointCount} endpoints
-                                    </span>
-                                  )}
-                                </div>
-                              </div>
-
-                              {/* Group badge / editor */}
+                            <span className="flex-1 min-w-0">
                               {editingGroup === svc.id ? (
                                 <form
-                                  className="shrink-0 flex items-center"
                                   onSubmit={(e) => {
                                     e.preventDefault();
                                     handleUpdateGroup(svc.id, groupInput);
                                   }}
                                 >
                                   <input
-                                    // biome-ignore lint/a11y/noAutofocus: input only mounts when user clicks the group badge (editingGroup === svc.id); auto-focus is the expected UX for inline editors.
+                                    // biome-ignore lint/a11y/noAutofocus: the input only mounts after the user picks "Set group…", where focus is the expected next step.
                                     autoFocus
                                     value={groupInput}
                                     onChange={(e) => setGroupInput(e.target.value)}
@@ -886,165 +1003,184 @@ export function ProjectOverview({
                                       }
                                     }}
                                     placeholder="Group name"
+                                    aria-label={`Group for ${svc.name}`}
                                     list={`group-options-${svc.id}`}
-                                    className="w-28 text-[12px] outline-none"
+                                    className="w-full text-[13px] outline-none"
                                     style={{
-                                      background: 'var(--bg-primary)',
-                                      border: '0.5px solid var(--accent)',
-                                      borderRadius: 6,
-                                      padding: '3px 8px',
-                                      color: 'var(--text-primary)',
-                                      boxShadow: '0 0 0 2px rgba(0,122,255,0.15)',
+                                      background: 'var(--surface)',
+                                      border: '0.5px solid var(--separator)',
+                                      borderRadius: 999,
+                                      height: 24,
+                                      padding: '0 10px',
+                                      color: 'var(--label)',
                                     }}
                                   />
                                   <datalist id={`group-options-${svc.id}`}>
-                                    {existingGroups.filter(Boolean).map((g) => (
+                                    {existingGroups.map((g) => (
                                       <option key={g} value={g} />
                                     ))}
                                   </datalist>
                                 </form>
                               ) : (
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    setEditingGroup(svc.id);
-                                    setGroupInput(svc.projectGroup ?? '');
-                                  }}
-                                  className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity text-[11px] font-medium flex items-center gap-1"
-                                  style={{
-                                    color: svc.projectGroup
-                                      ? 'var(--accent)'
-                                      : 'var(--text-secondary)',
-                                    background: 'var(--fill-control)',
-                                    border: '0.5px solid var(--border)',
-                                    borderRadius: 6,
-                                    padding: '2px 8px',
-                                    boxShadow: 'var(--shadow-control)',
-                                  }}
-                                  title={
-                                    svc.projectGroup
-                                      ? `Group: ${svc.projectGroup} · click to change`
-                                      : 'Assign to a group'
-                                  }
-                                >
-                                  <svg
-                                    width="10"
-                                    height="10"
-                                    viewBox="0 0 24 24"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    strokeWidth="2"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
+                                <>
+                                  <span
+                                    className="block text-[13px] leading-4 truncate"
+                                    style={{ color: 'var(--label)' }}
                                   >
-                                    <path d="M20.59 13.41l-7.17 7.17a2 2 0 01-2.83 0L2 12V2h10l8.59 8.59a2 2 0 010 2.82z" />
-                                    <line x1="7" y1="7" x2="7.01" y2="7" />
-                                  </svg>
-                                  {svc.projectGroup || 'Group'}
-                                </button>
-                              )}
-
-                              {/* Graph button */}
-                              {onNavigateToService && (
-                                <button
-                                  type="button"
-                                  onClick={() => onNavigateToService(svc.name)}
-                                  className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity w-[26px] h-[22px] flex items-center justify-center"
-                                  style={{
-                                    color: 'var(--text-secondary)',
-                                    background: 'var(--fill-control)',
-                                    border: '0.5px solid var(--border)',
-                                    borderRadius: 6,
-                                    boxShadow: 'var(--shadow-control)',
-                                  }}
-                                  title="Open in graph"
-                                >
-                                  <svg
-                                    width="12"
-                                    height="12"
-                                    viewBox="0 0 24 24"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    strokeWidth="2"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
+                                    {svc.name}
+                                  </span>
+                                  <span
+                                    className="block text-[11px] leading-[13px] truncate"
+                                    style={{ color: 'var(--label-secondary)' }}
+                                    title={svc.repoRoot}
                                   >
-                                    <circle cx="6" cy="6" r="2.5" />
-                                    <circle cx="18" cy="18" r="2.5" />
-                                    <circle cx="18" cy="6" r="2.5" />
-                                    <path d="M8.5 8.5l7 7M8.5 6H15" />
-                                  </svg>
-                                </button>
+                                    <span style={{ fontFamily: 'var(--font-mono)' }}>
+                                      {shortPath(svc.repoRoot)}
+                                    </span>
+                                    {svc.endpointCount > 0 &&
+                                      ` · ${svc.endpointCount.toLocaleString()} endpoint${svc.endpointCount === 1 ? '' : 's'}`}
+                                  </span>
+                                </>
                               )}
+                            </span>
 
-                              {/* Remove button */}
-                              <button
-                                type="button"
-                                onClick={() => handleRemoveService(svc.name)}
-                                className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity w-[22px] h-[22px] flex items-center justify-center rounded-full"
-                                style={{ color: 'var(--text-tertiary)' }}
-                                onMouseEnter={(e) => {
-                                  (e.currentTarget as HTMLElement).style.background =
-                                    'var(--destructive)';
-                                  (e.currentTarget as HTMLElement).style.color = '#fff';
-                                }}
-                                onMouseLeave={(e) => {
-                                  (e.currentTarget as HTMLElement).style.background = 'transparent';
-                                  (e.currentTarget as HTMLElement).style.color =
-                                    'var(--text-tertiary)';
-                                }}
-                                title="Remove service"
-                              >
-                                <svg
-                                  width="10"
-                                  height="10"
-                                  viewBox="0 0 10 10"
-                                  fill="none"
-                                  stroke="currentColor"
-                                  strokeWidth="1.75"
-                                  strokeLinecap="round"
-                                >
-                                  <path d="M2 2l6 6M8 2l-6 6" />
-                                </svg>
-                              </button>
-                            </div>
-                          );
-                        })}
-                      </div>
+                            {/* Always visible: hover was the only way to find
+                                these three actions before. */}
+                            <Button
+                              variant="icon"
+                              icon="more_horiz"
+                              aria-label={`Actions for ${svc.name}`}
+                              title={`Actions for ${svc.name}`}
+                              aria-haspopup="menu"
+                              ref={rowMenuFor?.id === svc.id ? rowMenu.ref : undefined}
+                              onClick={(e) => {
+                                const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                                setRowMenuFor(svc);
+                                rowMenu.openAt({ x: r.right, y: r.bottom + 4 });
+                              }}
+                            />
+                          </div>
+                        ))}
+                      </Card>
                     </div>
                   );
                 })}
               </div>
             )}
-          </div>
-        );
-      })()}
+          </Section>
+        </div>
+      </div>
+
+      {rowMenu.at && rowMenuFor && (
+        <Menu
+          x={rowMenu.at.x}
+          y={rowMenu.at.y}
+          align="end"
+          onClose={() => {
+            rowMenu.close();
+            setRowMenuFor(null);
+          }}
+        >
+          {onNavigateToService && (
+            <MenuItem
+              icon="hub"
+              onClick={() => {
+                onNavigateToService(rowMenuFor.name);
+                rowMenu.close();
+              }}
+            >
+              Open in graph
+            </MenuItem>
+          )}
+          <MenuItem
+            icon="tune"
+            onClick={() => {
+              setEditingGroup(rowMenuFor.id);
+              setGroupInput(rowMenuFor.projectGroup ?? '');
+              rowMenu.close();
+            }}
+          >
+            Set group…
+          </MenuItem>
+          <MenuSeparator />
+          <MenuItem
+            danger
+            icon="close"
+            onClick={() => {
+              setConfirmRemove({ service: rowMenuFor, x: rowMenu.at!.x, y: rowMenu.at!.y });
+              rowMenu.close();
+            }}
+          >
+            Remove service…
+          </MenuItem>
+        </Menu>
+      )}
+
+      {confirmRemove && (
+        <ConfirmPopover
+          x={confirmRemove.x}
+          y={confirmRemove.y}
+          align="end"
+          danger
+          title={`Remove ${confirmRemove.service.name}?`}
+          body="The service stops being tracked here. Nothing on disk changes."
+          confirmLabel="Remove service"
+          onConfirm={() => {
+            handleRemoveService(confirmRemove.service.name);
+            setConfirmRemove(null);
+            setRowMenuFor(null);
+          }}
+          onCancel={() => {
+            setConfirmRemove(null);
+            setRowMenuFor(null);
+          }}
+        />
+      )}
+
+      {statsModalOpen && <ProjectStatsModal root={root} onClose={() => setStatsModalOpen(false)} />}
     </div>
-    {statsModalOpen && (
-      <ProjectStatsModal root={root} onClose={() => setStatsModalOpen(false)} />
-    )}
-    </>
   );
 }
 
-function SettingsRow({ label, value, last }: { label: string; value: string; last?: boolean }) {
+/** One uncovered dependency. The "Request" action repeats down the list, so it
+    is bordered — prominence is for the one action per region, not for twelve. */
+function CoverageRow({
+  name,
+  meta,
+  tone,
+  badge,
+  last,
+  onRequest,
+}: {
+  name: string;
+  meta?: string;
+  tone: Tone;
+  badge: string;
+  last: boolean;
+  onRequest: () => void;
+}) {
   return (
     <div
-      className="flex items-center justify-between px-3"
-      style={{
-        borderBottom: last ? 'none' : '0.5px solid var(--border-row)',
-        minHeight: 32,
-      }}
+      className="flex items-center justify-between gap-2 px-3"
+      style={{ minHeight: 36, borderBottom: last ? 'none' : '0.5px solid var(--separator)' }}
     >
-      <span className="text-[13px]" style={{ color: 'var(--text-primary)' }}>
-        {label}
+      <span className="flex items-center gap-2 min-w-0">
+        <Badge tone={tone}>{badge}</Badge>
+        <span className="text-[13px] leading-4 truncate" style={{ color: 'var(--label)' }}>
+          {name}
+        </span>
+        {meta && (
+          <span
+            className="text-[11px] leading-[13px] shrink-0"
+            style={{ color: 'var(--label-secondary)' }}
+          >
+            {meta}
+          </span>
+        )}
       </span>
-      <span
-        className="text-[13px] tabular-nums truncate ml-2"
-        style={{ color: 'var(--text-secondary)' }}
-      >
-        {value}
-      </span>
+      <Button size="small" onClick={onRequest} title={`Open a plugin request for ${name}`}>
+        Request
+      </Button>
     </div>
   );
 }

--- a/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * TRA-293. These assert the things the rewrite exists to fix, so they fail if
+ * the surface drifts back: the primary action is a capsule and not a full-bleed
+ * bar, states are designed rather than a grey line, row actions exist without
+ * hover, and the timestamp answers "is this stale?".
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ProjectOverview,
+  coverageTone,
+  formatIndexedAt,
+  relativeTime,
+  shortPath,
+} from '../ProjectOverview';
+
+const ROOT = '/Users/someone/code/demo-app';
+
+const daemon = {
+  projects: [] as { root: string; status: string; progress?: { phase: string; percent: number } }[],
+  loading: false,
+  connected: true,
+  reindexProject: vi.fn(),
+  addProject: vi.fn(),
+};
+
+vi.mock('../../hooks/useDaemon', () => ({
+  useDaemon: () => daemon,
+}));
+
+/** Route each overview endpoint to a canned payload; `null` = a failed fetch. */
+function mockApi(routes: Record<string, unknown | null>) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) => {
+      const key = Object.keys(routes).find((k) => String(url).includes(k));
+      if (key === undefined || routes[key] === null) {
+        return { ok: false, status: 503, json: async () => ({}) } as unknown as Response;
+      }
+      return { ok: true, status: 200, json: async () => routes[key] } as unknown as Response;
+    }),
+  );
+}
+
+const STATS = { files: 77, symbols: 337, edges: 280, lastIndexed: '2026-08-28T17:01:49.000Z' };
+const COVERAGE = {
+  coverage: { total_significant: 4, covered: 4, coverage_pct: 100 },
+  gaps: [],
+  unknown: [],
+};
+const NO_SMELLS = {
+  files_scanned: 77,
+  findings: [],
+  summary: { todo_comment: 0, empty_function: 0, hardcoded_value: 0, debug_artifact: 0 },
+  total: 0,
+};
+
+beforeEach(() => {
+  daemon.projects = [{ root: ROOT, status: 'ready' }];
+  daemon.loading = false;
+  daemon.connected = true;
+  daemon.reindexProject.mockClear();
+  daemon.addProject.mockClear();
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('formatting helpers', () => {
+  it('renders a path relative to the home directory', () => {
+    expect(shortPath('/Users/someone/code/demo-app')).toBe('~/code/demo-app');
+    expect(shortPath('/opt/src/thing')).toBe('/opt/src/thing');
+  });
+
+  it('describes recency in words, singular and plural', () => {
+    const now = Date.UTC(2026, 7, 28, 12, 0, 0);
+    expect(relativeTime(now - 30_000, now)).toBe('just now');
+    expect(relativeTime(now - 60_000, now)).toBe('1 minute ago');
+    expect(relativeTime(now - 7_200_000, now)).toBe('2 hours ago');
+    expect(relativeTime(now - 172_800_000, now)).toBe('2 days ago');
+  });
+
+  it('pairs the relative form with an absolute one', () => {
+    const iso = '2026-08-28T10:00:00.000Z';
+    const out = formatIndexedAt(iso, new Date(iso).getTime() + 7_200_000);
+    expect(out.startsWith('2 hours ago · ')).toBe(true);
+    /* The absolute half must not be a bare locale dump like "8/28/2026". */
+    expect(out).not.toMatch(/\d+\/\d+\/\d{4}/);
+  });
+
+  it('does not crash on an unparseable timestamp', () => {
+    expect(formatIndexedAt('not-a-date')).toBe('Unknown');
+  });
+
+  it('grades coverage on the same thresholds the meter is painted with', () => {
+    expect(coverageTone(100)).toBe('green');
+    expect(coverageTone(85)).toBe('orange');
+    expect(coverageTone(40)).toBe('red');
+  });
+});
+
+describe('ProjectOverview surface', () => {
+  it('offers reindex as a capsule button, not a full-bleed accent bar', async () => {
+    mockApi({ '/stats': STATS, '/coverage': COVERAGE, '/subprojects': {}, '/smells': NO_SMELLS });
+    const { container } = render(<ProjectOverview root={ROOT} />);
+
+    const button = await screen.findByRole('button', { name: 'Reindex' });
+    /* The old bar was `w-full` with an 8px radius and a 1640px span. */
+    expect(button.className).toContain('lx-btn');
+    expect(button.className).toContain('v-prominent');
+    expect(button.className).not.toContain('w-full');
+
+    /* And it is the ONLY prominent control on the surface — one per region. */
+    expect(container.querySelectorAll('.lx-btn.v-prominent')).toHaveLength(1);
+  });
+
+  it('shows the indexing phase as a progress bar with an accessible value', async () => {
+    daemon.projects = [{ root: ROOT, status: 'indexing', progress: { phase: 'Resolving edges', percent: 42 } }];
+    mockApi({ '/stats': STATS, '/coverage': COVERAGE, '/subprojects': {}, '/smells': NO_SMELLS });
+    render(<ProjectOverview root={ROOT} />);
+
+    const bar = await screen.findByRole('progressbar', { name: 'Indexing progress' });
+    expect(bar.getAttribute('aria-valuenow')).toBe('42');
+    expect(await screen.findByText('Resolving edges')).toBeTruthy();
+    /* The button reports the state rather than inviting a second reindex — and
+       carries `is-status`, without which :disabled dims the only progress text
+       on the toolbar to 2.3:1. */
+    const action = screen.getByRole('button', { name: 'Indexing…' });
+    expect(action).toHaveProperty('disabled', true);
+    expect(action.className).toContain('is-status');
+  });
+
+  it('gives the empty services list real anatomy, not one grey line', async () => {
+    mockApi({
+      '/stats': STATS,
+      '/coverage': COVERAGE,
+      '/subprojects': { repos: [], services: [] },
+      '/smells': NO_SMELLS,
+    });
+    render(<ProjectOverview root={ROOT} />);
+
+    expect(await screen.findByText('No services detected')).toBeTruthy();
+    expect(
+      screen.getByText(/Services are found when the project is indexed/),
+    ).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Add service/ })).toBeTruthy();
+  });
+
+  it('names the finding category in words instead of leaking the API enum', async () => {
+    mockApi({
+      '/stats': STATS,
+      '/coverage': COVERAGE,
+      '/subprojects': { repos: [], services: [] },
+      '/smells': NO_SMELLS,
+    });
+    render(<ProjectOverview root={ROOT} />);
+
+    expect(await screen.findByText('No debug artifacts')).toBeTruthy();
+    expect(screen.queryByText(/debug_artifact/)).toBeNull();
+  });
+
+  it('exposes every service action without a hover', async () => {
+    mockApi({
+      '/stats': STATS,
+      '/coverage': COVERAGE,
+      '/subprojects': {
+        repos: [],
+        services: [
+          {
+            id: 1,
+            name: 'demo-api',
+            repoRoot: '/Users/someone/code/demo-app',
+            serviceType: null,
+            projectGroup: null,
+            endpointCount: 13,
+          },
+        ],
+      },
+      '/smells': NO_SMELLS,
+    });
+    render(<ProjectOverview root={ROOT} />);
+
+    /* Previously three buttons that only existed at opacity 0 until hover. */
+    const actions = await screen.findByRole('button', { name: 'Actions for demo-api' });
+    expect(actions.getAttribute('title')).toBe('Actions for demo-api');
+    /* A single unnamed group is not a group worth labelling. */
+    expect(screen.queryByText('Ungrouped')).toBeNull();
+    expect(screen.queryByText('No group')).toBeNull();
+  });
+
+  it('does not call an unanswered daemon "not indexed"', async () => {
+    /* Reproduces what the running app showed: "Status: Not indexed" and
+       "Index project" sitting directly above "Files indexed 78". */
+    daemon.projects = [];
+    daemon.loading = true;
+    mockApi({ '/stats': STATS, '/coverage': COVERAGE, '/subprojects': {}, '/smells': NO_SMELLS });
+    render(<ProjectOverview root={ROOT} />);
+
+    expect(await screen.findByText('Checking…')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Index project' })).toBeNull();
+    expect(screen.queryByText('Not indexed')).toBeNull();
+  });
+
+  it('says the daemon is unreachable rather than blaming the project', async () => {
+    daemon.projects = [];
+    daemon.loading = false;
+    daemon.connected = false;
+    mockApi({ '/stats': null, '/coverage': null, '/subprojects': null, '/smells': null });
+    render(<ProjectOverview root={ROOT} />);
+
+    /* The toolbar always renders, so it carries the diagnosis even when every
+       section fetch failed and the Status row never appeared. */
+    const action = await screen.findByRole('button', { name: 'Daemon unreachable' });
+    expect(action).toHaveProperty('disabled', true);
+    expect(action.className).toContain('is-status');
+    expect(screen.queryByRole('button', { name: 'Index project' })).toBeNull();
+  });
+
+  it('keeps the chrome and offers a retry when a section fails', async () => {
+    mockApi({ '/stats': null, '/coverage': COVERAGE, '/subprojects': {}, '/smells': NO_SMELLS });
+    render(<ProjectOverview root={ROOT} />);
+
+    await waitFor(() => expect(screen.getByText(/Couldn't load the index summary/)).toBeTruthy());
+    /* The toolbar does not disappear when one section fails. */
+    expect(screen.getByRole('button', { name: 'Reindex' })).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: 'Retry' }).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
@@ -21,6 +21,7 @@ import {
   MenuSeparator,
   SearchField,
   SegmentedControl,
+  useMenuAnchor,
 } from '../lattice/ui';
 import { KpiTile } from './components/KpiTile';
 import {
@@ -112,19 +113,6 @@ function toggleInList<T>(list: T[] | null, value: T): T[] | null {
 function share(n: number, total: number): string {
   if (total === 0) return 'no projects yet';
   return `${Math.round((n / total) * 100)}% of ${total.toLocaleString()} projects`;
-}
-
-// ── Toolbar bits ──────────────────────────────────────────────────────────
-
-/** Anchors a Menu under a toolbar button. */
-function useMenuAnchor() {
-  const ref = useRef<HTMLButtonElement | null>(null);
-  const [at, setAt] = useState<{ x: number; y: number } | null>(null);
-  const open = () => {
-    const r = ref.current?.getBoundingClientRect();
-    setAt(r ? { x: r.right, y: r.bottom + 4 } : { x: 0, y: 52 });
-  };
-  return { ref, at, open, close: () => setAt(null) };
 }
 
 // ── Header ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Third surface of the macOS 26 revision (TRA-284), after the token layer (#458) and the workspace dashboard (#461). Project Overview is migrated **whole**: toolbar, every section, and the empty / loading / error states.

Closes TRA-293.

## Structure

A 52px glass toolbar that owns the pane — status dot, project name, `~`-shortened path, one prominent action, one overflow menu — over an opaque content column capped at 720px. Cards are `--surface` with a 0.5px `--separator` and a 12px radius: no shadow, no glass. Glass appears exactly once, on the toolbar.

## What was wrong, measured on the running renderer

| | before | after |
|---|---|---|
| Daemon has not answered yet | "Status: Not indexed" + "Index project" rendered directly above "Files indexed 78" | "Checking…" / "Daemon unreachable"; the project is never blamed for the daemon |
| Disabled action while indexing | white on 40% accent, **2.2:1** | bordered `is-status`, **4.76:1** on surface / **4.66:1** on sunken |
| Coverage with no dependencies | full green meter over "0 of 0 dependencies covered" | an empty state — nothing to cover is not 100% covered |
| Section empty state | hero proportions inside a card, **186px** tall around one sentence, 46px glyph, 17px title | `EmptyState compact`: **120px**, 20px glyph, 13px title |
| Service row actions | three buttons at `opacity: 0` until hover | one always-visible overflow button → `Menu`, `ConfirmPopover` on the destructive item |
| Finding category | `debug_artifact` | "No debug artifacts" |
| Failed section fetch | a skeleton pulsing forever | per-section load state → error + Retry, chrome intact |
| Small-tier controls | five at **20×20 / 65×20**, under the 24px hit floor | painted size unchanged; an overflowing pseudo-element grows the hit box — `elementFromPoint` now resolves 1px above and below each |

`status ?? 'unknown'` was the root cause of the first row: it collapsed "the daemon has not answered" into "never indexed". `listPending` separates them.

## Shared pieces

- `useMenuAnchor` moves out of `WorkspaceHeader` into the `Menu` primitive, with an `openAt(point)` for menus opened from a row rather than a fixed toolbar anchor. Both surfaces now share one anchor.
- `EmptyState` gains `compact`, for an empty section inside a card rather than an empty pane.
- `.lx-btn.is-status:disabled` in `controls.css`: a disabled button whose *label is the status readout* is not an inert control, so it keeps full opacity and steps the label down to `--label-secondary` instead.
- `App.tsx` stops wrapping a surface that draws its own toolbar in a 16px inset — that turned a flush toolbar into a floating white band.

## Verification

Measured on the running renderer via CDP, not read off the CSS:

- 0 unlabeled focusables; no control under 24×24 except the sidebar splitter, which belongs to the shell.
- Type sizes resolve to 13/11/17px only; radii to 6/12/999px (plus the icon circles).
- All three accessibility media queries present; `.glass` `backdrop-filter` active and confined to the toolbar.
- Light: full healthy surface. Dark: toolbar, sections, segmented control, skeletons and the error state — the local daemon dropped its project registry partway through the run, so the dark capture shows the degraded path rather than populated content.

`token-guard` baseline drops `ProjectOverview.tsx` (16 → 0) and five workspace files already cleared by #461.

Local: typecheck clean · 14 files / 137 tests passed · token guard exit 0 · build green.
