### PR TITLE
feat(app): put the sidebar footer on the row system, add Light/Dark/Auto (TRA-305)

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -3,7 +3,7 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { GuardOnboarding, isOnboardingDone } from './components/GuardOnboarding';
 import { WindowTabBar } from './components/WindowTabBar';
 import { fileKind, FileTypeGlyph, Icon } from './lattice/icons';
-import { Button, PopUpButton } from './lattice/ui';
+import { PopUpButton } from './lattice/ui';
 import {
   clampSidebarWidth,
   readSidebarCollapsed,
@@ -28,6 +28,7 @@ import { MemoryExplorer } from './tabs/MemoryExplorer';
 import { Notebook } from './tabs/Notebook';
 import { ProjectOverview } from './tabs/ProjectOverview';
 import { Settings } from './tabs/Settings';
+import { type Appearance, APPEARANCE_OPTIONS, useTheme } from './theme.js';
 import { Workspace } from './workspace/Workspace';
 
 // ── URL params determine window type ──────────────────────────
@@ -352,120 +353,26 @@ function ProjectFileExplorer({
   );
 }
 
-// ── Theme override ────────────────────────────────────────────
-// Default = follow system (`prefers-color-scheme`). One click stores an
-// explicit preference in localStorage and sets [data-theme] on <html>; the
-// CSS in app.css gives that attribute higher specificity than the @media
-// rule, so the override wins. Cross-window: when the menu and a project
-// window are both open, a `storage` event syncs them automatically.
-const THEME_KEY = 'trace-mcp-theme';
-type Theme = 'light' | 'dark';
-
-function readStoredTheme(): Theme | null {
-  try {
-    const v = localStorage.getItem(THEME_KEY);
-    return v === 'light' || v === 'dark' ? v : null;
-  } catch {
-    return null;
-  }
-}
-
-function systemTheme(): Theme {
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-}
-
-function useTheme() {
-  const [override, setOverride] = useState<Theme | null>(() => readStoredTheme());
-  const [system, setSystem] = useState<Theme>(() => systemTheme());
-
-  // Apply / remove the data-theme attribute on every change.
-  useEffect(() => {
-    const html = document.documentElement;
-    if (override) html.setAttribute('data-theme', override);
-    else html.removeAttribute('data-theme');
-  }, [override]);
-
-  // Track system theme for the "no override" case.
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    const handler = () => setSystem(mq.matches ? 'dark' : 'light');
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
-  }, []);
-
-  // Cross-window sync: another window stored a new value → reflect it here.
-  useEffect(() => {
-    const onStorage = (e: StorageEvent) => {
-      if (e.key !== THEME_KEY) return;
-      setOverride(e.newValue === 'light' || e.newValue === 'dark' ? e.newValue : null);
-    };
-    window.addEventListener('storage', onStorage);
-    return () => window.removeEventListener('storage', onStorage);
-  }, []);
-
-  const effective: Theme = override ?? system;
-  const toggle = useCallback(() => {
-    const next: Theme = effective === 'dark' ? 'light' : 'dark';
-    try {
-      localStorage.setItem(THEME_KEY, next);
-    } catch {}
-    setOverride(next);
-  }, [effective]);
-
-  return { theme: effective, toggle };
-}
-
-function ThemeToggle({ theme, toggle }: { theme: Theme; toggle: () => void }) {
-  // Show the icon for the destination, not the current state — matches the
-  // user's mental model ("click moon → it gets dark").
-  const goingTo: Theme = theme === 'dark' ? 'light' : 'dark';
-  const label = goingTo === 'dark' ? 'Switch to dark mode' : 'Switch to light mode';
-  return (
-    <Button variant="mini" onClick={toggle} aria-label={label} title={label}>
-      {goingTo === 'dark' ? (
-        // Moon (crescent) — currently light, click to go dark.
-        <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
-          <path
-            d="M13.2 9.6A5.6 5.6 0 1 1 6.4 2.8a4.6 4.6 0 0 0 6.8 6.8z"
-            stroke="currentColor"
-            strokeWidth="1.4"
-            strokeLinejoin="round"
-          />
-        </svg>
-      ) : (
-        // Sun (circle + rays) — currently dark, click to go light.
-        <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
-          <circle cx="8" cy="8" r="2.8" stroke="currentColor" strokeWidth="1.4" />
-          <g stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
-            <line x1="8" y1="1.6" x2="8" y2="3.2" />
-            <line x1="8" y1="12.8" x2="8" y2="14.4" />
-            <line x1="1.6" y1="8" x2="3.2" y2="8" />
-            <line x1="12.8" y1="8" x2="14.4" y2="8" />
-            <line x1="3.5" y1="3.5" x2="4.6" y2="4.6" />
-            <line x1="11.4" y1="11.4" x2="12.5" y2="12.5" />
-            <line x1="3.5" y1="12.5" x2="4.6" y2="11.4" />
-            <line x1="11.4" y1="4.6" x2="12.5" y2="3.5" />
-          </g>
-        </svg>
-      )}
-    </Button>
-  );
-}
-
 // ── Sidebar footer ───────────────────────────────────────────
-// Always-visible row at the bottom of the sidebar with Settings on the left
-// and the theme toggle on the right. In project windows, Settings opens the
+// Two rows pinned below the scroll region, in the SAME row system as the nav
+// above them (.ws-sb-row: 28px, 16px leading glyph at x=14, 13px label at x=38)
+// — the footer used to run its own 24px capsule with no glyph, so the last row
+// in the sidebar sat 26px to the left of every label above it.
+//
+// Settings is a navigation destination and stays a real row. Appearance is a
+// control, so its row is static and carries a pop-up button: Auto / Light /
+// Dark, the three states macOS offers. In project windows, Settings opens the
 // menu window via IPC instead of in-place navigation.
 function SidebarFooter({
   active,
   onOpenSettingsInPlace,
-  theme,
-  onToggleTheme,
+  appearance,
+  onAppearanceChange,
 }: {
   active: boolean;
   onOpenSettingsInPlace?: () => void;
-  theme: Theme;
-  onToggleTheme: () => void;
+  appearance: Appearance;
+  onAppearanceChange: (next: Appearance) => void;
 }) {
   const handleSettings = () => {
     if (onOpenSettingsInPlace) {
@@ -476,11 +383,28 @@ function SidebarFooter({
     }
   };
   return (
-    <div className="sidebar-footer">
-      <Button variant="text" active={active} onClick={handleSettings}>
-        Settings
-      </Button>
-      <ThemeToggle theme={theme} toggle={onToggleTheme} />
+    <div className="ws-sb-footer">
+      <SidebarRow
+        icon="settings"
+        label="Settings"
+        selected={active}
+        aria-current={active ? 'page' : undefined}
+        onClick={handleSettings}
+      />
+      {/* Not a button: the row is a label plus a control, so it must not look
+          or behave clickable. `.is-static` drops the hover fill. */}
+      <div className="ws-sb-row is-static">
+        <span className="ws-sb-ico" aria-hidden="true">
+          <Icon name="contrast" size={16} />
+        </span>
+        <span className="ws-sb-label">Appearance</span>
+        <PopUpButton
+          options={APPEARANCE_OPTIONS}
+          value={appearance}
+          onChange={onAppearanceChange}
+          aria-label="Appearance"
+        />
+      </div>
     </div>
   );
 }
@@ -745,7 +669,7 @@ function ProjectContent({
 export function App() {
   const { view, tab, root } = getUrlParams();
   const isProject = view === 'project' && root !== null;
-  const { theme, toggle: toggleTheme } = useTheme();
+  const { theme, appearance, setAppearance } = useTheme();
 
   const [globalTab, setGlobalTab] = useState<GlobalTab>(normalizeGlobalTab(tab));
   const [projectTab, setProjectTab] = useState<ProjectTab>('overview');
@@ -954,8 +878,8 @@ export function App() {
             <SidebarFooter
               active={!isProject && globalTab === 'settings'}
               onOpenSettingsInPlace={isProject ? undefined : () => setGlobalTab('settings')}
-              theme={theme}
-              onToggleTheme={toggleTheme}
+              appearance={appearance}
+              onAppearanceChange={setAppearance}
             />
           </aside>
         )}

--- a/packages/app/src/renderer/__tests__/theme.test.tsx
+++ b/packages/app/src/renderer/__tests__/theme.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @vitest-environment jsdom
+ */
+/* The bug this locks down (TRA-305): the old toggle only ever wrote 'light' or
+ * 'dark', so one click pinned the app forever and the system-appearance
+ * listener stopped mattering. Auto must be reachable again, and reaching it
+ * must clear the stored key rather than store a third value. */
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { APPEARANCE_OPTIONS, THEME_KEY, useTheme } from '../theme.js';
+
+/** matchMedia is not implemented in jsdom — stand in a controllable one. */
+let systemDark = false;
+const listeners = new Set<() => void>();
+
+beforeEach(() => {
+  systemDark = false;
+  listeners.clear();
+  localStorage.clear();
+  document.documentElement.removeAttribute('data-theme');
+  vi.stubGlobal(
+    'matchMedia',
+    (query: string) =>
+      ({
+        media: query,
+        get matches() {
+          return query.includes('dark') && systemDark;
+        },
+        addEventListener: (_: string, fn: () => void) => listeners.add(fn),
+        removeEventListener: (_: string, fn: () => void) => listeners.delete(fn),
+      }) as unknown as MediaQueryList,
+  );
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+function setSystem(dark: boolean) {
+  systemDark = dark;
+  act(() => {
+    for (const fn of listeners) fn();
+  });
+}
+
+describe('useTheme', () => {
+  it('offers exactly Auto / Light / Dark', () => {
+    expect(APPEARANCE_OPTIONS.map((o) => o.value)).toEqual(['auto', 'light', 'dark']);
+  });
+
+  it('starts on Auto and follows the system', () => {
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.appearance).toBe('auto');
+    expect(result.current.theme).toBe('light');
+
+    setSystem(true);
+    expect(result.current.theme).toBe('dark');
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+  });
+
+  it('pins the appearance when Light or Dark is picked', () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => result.current.setAppearance('light'));
+
+    expect(result.current.theme).toBe('light');
+    expect(localStorage.getItem(THEME_KEY)).toBe('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+
+    // Pinned means pinned: the system flipping no longer moves it.
+    setSystem(true);
+    expect(result.current.theme).toBe('light');
+  });
+
+  it('gets back to Auto, and Auto clears the stored key', () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => result.current.setAppearance('dark'));
+    act(() => result.current.setAppearance('auto'));
+
+    expect(result.current.appearance).toBe('auto');
+    expect(localStorage.getItem(THEME_KEY)).toBeNull();
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+
+    setSystem(true);
+    expect(result.current.theme).toBe('dark');
+  });
+
+  it('restores a stored choice on mount, and ignores junk', () => {
+    localStorage.setItem(THEME_KEY, 'dark');
+    expect(renderHook(() => useTheme()).result.current.appearance).toBe('dark');
+
+    localStorage.setItem(THEME_KEY, 'aubergine');
+    expect(renderHook(() => useTheme()).result.current.appearance).toBe('auto');
+  });
+
+  it('syncs from another window, including a clear back to Auto', () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', { key: THEME_KEY, newValue: 'dark' }));
+    });
+    expect(result.current.appearance).toBe('dark');
+
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', { key: THEME_KEY, newValue: null }));
+    });
+    expect(result.current.appearance).toBe('auto');
+  });
+});

--- a/packages/app/src/renderer/app.css
+++ b/packages/app/src/renderer/app.css
@@ -136,8 +136,9 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 10px 8px;
-  margin: 0 2px;
+  /* 6px + 8px puts the status dot on the sidebar rows' 14px glyph column. */
+  padding: 6px 8px 8px;
+  margin: 0 6px;
   font-size: 11px;
   color: var(--text-secondary);
   letter-spacing: -0.005em;
@@ -218,7 +219,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  margin: 4px 4px 2px;
+  margin: 4px 6px 6px;
   padding: 10px;
   background: var(--bg-tertiary);
   border: 0.5px solid var(--border);
@@ -266,72 +267,6 @@ body {
   color: var(--success);
 }
 
-/* ── Sidebar footer: settings button + icon-only theme toggle ───── */
-.sidebar-footer {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 0 4px;
-  margin-bottom: 2px;
-}
-.sidebar-footer .nav-button {
-  flex: 1 1 auto;
-  min-width: 0;
-  height: 24px;
-  display: flex;
-  align-items: center;
-  text-align: left;
-  padding: 0 10px;
-  font-size: 13px;
-  font-weight: 500;
-  letter-spacing: -0.005em;
-  border-radius: 999px;
-  border: none;
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition:
-    background 120ms ease,
-    color 120ms ease;
-  -webkit-app-region: no-drag;
-}
-.sidebar-footer .nav-button:hover {
-  background: var(--bg-active);
-  color: var(--text-primary);
-}
-.sidebar-footer .nav-button.active {
-  background: var(--bg-active);
-  color: var(--text-primary);
-}
-
-/* Square icon button — used for the theme toggle. */
-.icon-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  flex-shrink: 0;
-  background: transparent;
-  border: none;
-  border-radius: 6px;
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition:
-    background 120ms ease,
-    color 120ms ease,
-    transform 120ms ease;
-  -webkit-app-region: no-drag;
-}
-.icon-button:hover {
-  background: var(--bg-active);
-  color: var(--text-primary);
-}
-.icon-button:active {
-  transform: scale(0.92);
-}
-.icon-button svg {
-  width: 14px;
-  height: 14px;
-  display: block;
-}
+/* The sidebar footer lives in styles/sidebar.css now, with the row system it
+   belongs to (TRA-305). `.sidebar-footer` / `.nav-button` / `.icon-button` were
+   already dead: the footer renders Lattice `.lx-btn` primitives, not these. */

--- a/packages/app/src/renderer/styles/sidebar.css
+++ b/packages/app/src/renderer/styles/sidebar.css
@@ -167,6 +167,27 @@
   background: var(--fill-tertiary, rgba(120, 120, 128, 0.24));
 }
 
+/* A row that CARRIES a control instead of being one (Appearance). Same box as
+   every other row; it just must not read as clickable. */
+.ws-sb-row.is-static {
+  cursor: default;
+}
+.ws-sb-row.is-static:hover {
+  background: transparent;
+}
+
+/* ---- Sidebar footer ----------------------------------------------------- */
+/* Pinned below .ws-sidebar-scroll, so the rows above slide under it — that is
+   a scroll edge, and a scroll edge gets the hairline. Same 6px inset as the
+   scroll region, so footer rows land on the same pill geometry as nav rows.
+   The 8px bottom inset reads as concentric with the 12px window corner. */
+.ws-sb-footer {
+  flex: none;
+  padding: 6px 6px 8px;
+  border-top: 0.5px solid var(--separator, var(--sep));
+  -webkit-app-region: no-drag;
+}
+
 /* File-explorer row: <dir>/<name> where the DIRECTORY truncates and the
    filename never does. Replaces the `direction: rtl` hack, which mangled
    any path containing `.` or `_` runs. */

--- a/packages/app/src/renderer/theme.ts
+++ b/packages/app/src/renderer/theme.ts
@@ -1,0 +1,84 @@
+/* Appearance: Auto / Light / Dark (TRA-305).
+
+   Default = Auto, i.e. follow `prefers-color-scheme`. Picking Light or Dark
+   stores that in localStorage and sets [data-theme] on <html>; tokens.css gives
+   that attribute higher specificity than the @media rule, so the choice wins.
+   Picking Auto REMOVES the key — absence of a stored value is what Auto means,
+   so there is no third value to write and no way to get stuck on an override.
+
+   Cross-window: when the menu and a project window are both open, a `storage`
+   event syncs them (a cleared key arrives as newValue === null).
+
+   Lives outside App.tsx so it is testable without pulling in the whole
+   renderer — same reason sidebar-prefs.ts and recent-projects.ts do. */
+
+import { useCallback, useEffect, useState } from 'react';
+
+export const THEME_KEY = 'trace-mcp-theme';
+
+/** The appearance actually being rendered. */
+export type Theme = 'light' | 'dark';
+/** What the user picked. `auto` = follow the system, and is the default. */
+export type Appearance = 'auto' | Theme;
+
+export const APPEARANCE_OPTIONS: ReadonlyArray<{ value: Appearance; label: string }> = [
+  { value: 'auto', label: 'Auto' },
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+];
+
+export function readStoredAppearance(): Appearance {
+  try {
+    const v = localStorage.getItem(THEME_KEY);
+    return v === 'light' || v === 'dark' ? v : 'auto';
+  } catch {
+    return 'auto';
+  }
+}
+
+export function systemTheme(): Theme {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function useTheme(): {
+  theme: Theme;
+  appearance: Appearance;
+  setAppearance: (next: Appearance) => void;
+} {
+  const [appearance, setStored] = useState<Appearance>(() => readStoredAppearance());
+  const [system, setSystem] = useState<Theme>(() => systemTheme());
+
+  // Apply / remove the data-theme attribute on every change.
+  useEffect(() => {
+    const html = document.documentElement;
+    if (appearance === 'auto') html.removeAttribute('data-theme');
+    else html.setAttribute('data-theme', appearance);
+  }, [appearance]);
+
+  // Track the system theme — it still matters while the choice is Auto.
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = () => setSystem(mq.matches ? 'dark' : 'light');
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== THEME_KEY) return;
+      setStored(e.newValue === 'light' || e.newValue === 'dark' ? e.newValue : 'auto');
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  const setAppearance = useCallback((next: Appearance) => {
+    try {
+      if (next === 'auto') localStorage.removeItem(THEME_KEY);
+      else localStorage.setItem(THEME_KEY, next);
+    } catch {}
+    setStored(next);
+  }, []);
+
+  return { theme: appearance === 'auto' ? system : appearance, appearance, setAppearance };
+}


### PR DESCRIPTION
The bottom strip of the sidebar was the one place that did not follow the row
system the rest of the macOS 26 revision landed on. Measured on the running
renderer before this change (220px sidebar, dark):

| | nav row (`.ws-sb-row`) | footer Settings | theme toggle |
|---|---|---|---|
| height | 28px | 24px | 24px |
| radius | 6px | 999px | 6px |
| leading glyph | 16px at x=14 | none | — |
| label starts at | x=38 | **x=12** | — |
| label colour | `--label` (.92) | **`--label-secondary` (.55)** | — |
| box | x=6 w=207 | x=4 w=67 | x=75 w=24 |

So the last row in the sidebar was shorter, dimmer, a different shape, the only
nav item in the app without an icon, and its label sat 26px to the left of every
label above it — with a bare unlabelled sun/moon icon button stranded beside it
and 120px of empty sidebar to its right. The strip also had no bottom edge: it
floated under the update banner on `margin-bottom: 2px`.

## What changed

**Geometry.** The footer is two `.ws-sb-row`s now. After, measured on the same
render: both rows `x=6 w=207 h=28`, radius 6px, glyph at x=14, label at x=38 —
identical to the nav rows above. `.ws-sb-footer` moved to `styles/sidebar.css`
next to the row system it belongs to, with a 0.5px scroll-edge hairline (the
scroll region's rows slide under it, so that edge is a scroll edge), the same
6px inset as `.ws-sidebar-scroll`, and an 8px bottom inset.

**Settings** stays a navigation destination, so it stays a real row — with the
house `settings` glyph, and `aria-current="page"` when it is the active tab.

**Appearance** is a control, not a destination, so its row is static (no hover
fill, no click target) and carries the shared `PopUpButton`: **Auto / Light /
Dark**. The old `toggle` only ever wrote `'light'` or `'dark'`, so one click
pinned the app forever and the `prefers-color-scheme` listener stopped
mattering — there was no way back to following the system. Auto now *removes*
the key, which is what its absence has always meant, so there is no third value
to get stuck on. `src/renderer/__tests__/theme.test.tsx` covers all of it:
default is Auto and tracks the system, Light/Dark pin, Auto un-pins and clears
storage, junk in storage falls back to Auto, and the cross-window `storage`
sync handles a cleared key.

**Icons.** The hand-drawn 8-ray sun and crescent moon are gone; the row glyphs
come from the house set (`settings`, `contrast` — the circle-lefthalf-filled
that macOS itself uses for Appearance).

**Dead CSS deleted.** `.sidebar-footer`, `.sidebar-footer .nav-button` and
`.icon-button` in `app.css` had not applied to anything since the footer
switched to the Lattice `.lx-btn` primitives.

**Update banner** insets moved from 2px/4px to 6px so the status dot lands on
the rows' 14px glyph column.

The theme hook moved out of `App.tsx` into `renderer/theme.ts` so it can be
tested without importing the whole renderer — the same reason `sidebar-prefs.ts`
and `recent-projects.ts` live outside it.

## Verified on the running renderer

Screenshots taken before and after in light and dark, plus Reduce Transparency
and Increase Contrast, at 220px and at the 180px minimum sidebar width, and in
the collapsed state (attached on TRA-305).

Keyboard: tabbing from the nav rows lands on `update-refresh` → Settings row
(207×28, focus ring visible) → Appearance pop-up (69×24, 2px accent ring) →
resize handle → content. Every stop ≥24px tall with a visible ring.

At the 180px minimum the "Appearance" label ellipsizes to "Appea…" — the label
is `flex: 1` with `text-overflow: ellipsis` and the pop-up keeps its full width,
which is the standard behaviour for a narrow macOS sidebar.

## Not changed

Collapsing the sidebar unmounts it whole, so Settings and Appearance disappear
along with every other nav row. That is what collapsing means, and adding a
duplicate appearance control to the content header would be a different change.

`pnpm run test` (130 passed), `pnpm run typecheck`, `pnpm run build` all green
in `packages/app`.

Closes TRA-305.
