### PR TITLE
fix(app): distinguish a project the daemon forgot from one never indexed

### DIFF
--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -496,17 +496,26 @@ export function ProjectOverview({
           ? 'green'
           : 'neutral';
 
+  /* The daemon can answer with a list that simply does not contain this project
+     while an index for it is still on disk — its registry resets, ours doesn't.
+     Calling that "Not indexed" one row above "Files indexed 2,196" is a
+     contradiction the user has to resolve; "Not tracked" is what actually
+     happened, and re-adding the project is what fixes it. */
+  const untracked = !listPending && !project && (stats?.files ?? 0) > 0;
+
   const statusLabel = listPending
     ? connected
       ? 'Checking…'
       : 'Daemon unreachable'
-    : status === 'indexing'
-      ? 'Indexing'
-      : status === 'ready'
-        ? 'Ready'
-        : status === 'error'
-          ? 'Error'
-          : 'Not indexed';
+    : untracked
+      ? 'Not tracked'
+      : status === 'indexing'
+        ? 'Indexing'
+        : status === 'ready'
+          ? 'Ready'
+          : status === 'error'
+            ? 'Error'
+            : 'Not indexed';
 
   const likelyUnknown = useMemo(
     () => coverage?.unknown.filter((u) => u.needs_plugin === 'likely') ?? [],
@@ -585,7 +594,7 @@ export function ProjectOverview({
           )
         ) : (
           <Button variant="prominent" icon="add" onClick={() => addProject(root)}>
-            Index project
+            {untracked ? 'Re-add project' : 'Index project'}
           </Button>
         )}
 

--- a/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
@@ -202,6 +202,21 @@ describe('ProjectOverview surface', () => {
     expect(screen.queryByText('Not indexed')).toBeNull();
   });
 
+  it('does not call a project the daemon forgot "not indexed"', async () => {
+    /* Seen on the shipped build: the daemon's registry reset, so the project
+       was absent from its list while the on-disk index still reported 2,196
+       files. "Status: Not indexed" sat one row above "Files indexed 2,196". */
+    daemon.projects = [];
+    daemon.loading = false;
+    daemon.connected = true;
+    mockApi({ '/stats': STATS, '/coverage': COVERAGE, '/subprojects': {}, '/smells': NO_SMELLS });
+    render(<ProjectOverview root={ROOT} />);
+
+    expect(await screen.findByText('Not tracked')).toBeTruthy();
+    expect(screen.queryByText('Not indexed')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Re-add project' })).toBeTruthy();
+  });
+
   it('says the daemon is unreachable rather than blaming the project', async () => {
     daemon.projects = [];
     daemon.loading = false;


### PR DESCRIPTION
Follow-up to #463, found by looking at the merged build rather than the diff.

TRA-293 fixed the case where the daemon has not answered yet — `status ?? 'unknown'` used to read as "never indexed" and the toolbar offered to index a project that was already indexed. There is a second case it did not cover: the daemon **answers**, its project list simply does not contain this root (its registry reset), and the on-disk index still has data.

That rendered as:

```
Status         ●  Not indexed
Files indexed          2,196
Symbols               32,306
```

with an "Index project" button in the toolbar — three statements about the same project that cannot all be true.

When the daemon has answered, does not list the project, and stats report files > 0, the surface now says **"Not tracked"** and the action reads **"Re-add project"**. That is what actually happened and what actually fixes it.

One test reproduces the exact observed state (empty project list, `connected: true`, stats reporting files) and asserts the row no longer says "Not indexed".

Local: typecheck clean · 14 files / 138 tests passed.
