### PR TITLE
fix(app): density pass — sidebar footer height, doubled pane inset, off-grid control padding (TRA-306)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -184,6 +184,11 @@ one-off `font-size`. They set family, size, leading and tracking together.
 
 Spacing tokens are `--space-2/4/6/8/12/16/20/24/32/40/48`. Nothing at 13, 17 or 25.
 
+This binds the primitives too, not just the surfaces: control padding and gaps are on
+the same scale (a 5px gap, a 9px inset, a Tailwind `2.5` half-step are all defects).
+The check is a scan of every rendered element's computed padding / gap / margin on the
+running renderer, not a read of the stylesheet.
+
 ### Control heights: 20 / 24 / 28. Nothing else.
 
 `packages/app/src/renderer/styles/controls.css` declares one geometry for every control
@@ -273,10 +278,12 @@ truncates, and an optional trailing count in tabular figures. Label text starts 
 x=38 in every row.
 
 **Anything that lives in the sidebar is a row.** Nav items are rows. Settings is a row.
-A row that *carries* a control instead of being one (Appearance) is
-`.ws-sb-row.is-static` — same box, no hover, must not read as clickable. The footer
-was the last strip running its own geometry, and putting it on the row system is what
-made the sidebar read as one thing.
+The idle update banner is a row. The footer was the last strip running its own
+geometry, and putting it on the row system is what made the sidebar read as one thing.
+
+**The sidebar carries navigation, not preferences.** The footer is *one* row —
+Settings. Appearance briefly lived there as a second row and cost 28px at the bottom of
+every window; it belongs in the Settings screen, which is where macOS puts it.
 
 Selection follows the macOS active/inactive pair: `--fill-tertiary` when the sidebar
 does not own focus, `--accent-fill` + `--on-accent` when it does
@@ -484,6 +491,8 @@ new evidence.
 | `listPending` separates "daemon hasn't answered" from "never indexed" | `status ?? 'unknown'` blamed the project for the daemon's silence. |
 | Sidebar footer is `.ws-sb-row`, not its own geometry | One row system for the whole sidebar; the footer's labels started 26px left of every other label. |
 | Appearance is Auto / Light / Dark, with Auto clearing the key | The old `toggle` only ever wrote `light` or `dark`, so one click pinned the app forever and the system listener stopped mattering. |
+| Appearance lives in Settings, not the sidebar footer | A preference is not a navigation destination, and a second footer row cost 28px at the bottom of every window. It renders in Settings' daemon-down and loading states too — the theme is localStorage, not daemon config. |
+| A surface that draws its own toolbar owns its whole pane | Wrapping it in the pane's `p-4` doubles every inset the surface already declares — the workspace KPI row started at x=32 with its first card at y=76. |
 | Paths truncate at the **head**, keeping the tail | The tail is the part that distinguishes siblings; tail-truncation hid the only useful segment. |
 | Sidebar file paths use a `dir`/`name` flex split, not `direction: rtl` | The rtl hack mangled any path containing `.` or `_` runs (`.idea/workspace.xml` → `idea/workspace.xml.`). |
 | Whitespace separates sidebar groups, not rules | Fewer lines, clearer grouping; matches the platform sidebar. |

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -28,7 +28,7 @@ import { MemoryExplorer } from './tabs/MemoryExplorer';
 import { Notebook } from './tabs/Notebook';
 import { ProjectOverview } from './tabs/ProjectOverview';
 import { Settings } from './tabs/Settings';
-import { type Appearance, APPEARANCE_OPTIONS, useTheme } from './theme.js';
+import { type Appearance, useTheme } from './theme.js';
 import { Workspace } from './workspace/Workspace';
 
 // ── URL params determine window type ──────────────────────────
@@ -354,25 +354,22 @@ function ProjectFileExplorer({
 }
 
 // ── Sidebar footer ───────────────────────────────────────────
-// Two rows pinned below the scroll region, in the SAME row system as the nav
-// above them (.ws-sb-row: 28px, 16px leading glyph at x=14, 13px label at x=38)
-// — the footer used to run its own 24px capsule with no glyph, so the last row
-// in the sidebar sat 26px to the left of every label above it.
+// ONE row pinned below the scroll region, in the SAME row system as the nav
+// above it (.ws-sb-row: 28px, 16px leading glyph at x=14, 13px label at x=38).
 //
-// Settings is a navigation destination and stays a real row. Appearance is a
-// control, so its row is static and carries a pop-up button: Auto / Light /
-// Dark, the three states macOS offers. In project windows, Settings opens the
-// menu window via IPC instead of in-place navigation.
+// TRA-305 put the footer on that row system, which was right, but it also
+// parked Appearance in a second static row — 70.5px of footer under a 38px
+// update banner, and the bottom of the sidebar read as heavy (TRA-306).
+// Appearance is a preference, not a navigation destination, and no macOS app
+// pins an appearance switcher to its sidebar: it moved to the Settings screen,
+// where Auto / Light / Dark are still all three one click away. In project
+// windows, Settings opens the menu window via IPC instead of navigating.
 function SidebarFooter({
   active,
   onOpenSettingsInPlace,
-  appearance,
-  onAppearanceChange,
 }: {
   active: boolean;
   onOpenSettingsInPlace?: () => void;
-  appearance: Appearance;
-  onAppearanceChange: (next: Appearance) => void;
 }) {
   const handleSettings = () => {
     if (onOpenSettingsInPlace) {
@@ -391,20 +388,6 @@ function SidebarFooter({
         aria-current={active ? 'page' : undefined}
         onClick={handleSettings}
       />
-      {/* Not a button: the row is a label plus a control, so it must not look
-          or behave clickable. `.is-static` drops the hover fill. */}
-      <div className="ws-sb-row is-static">
-        <span className="ws-sb-ico" aria-hidden="true">
-          <Icon name="contrast" size={16} />
-        </span>
-        <span className="ws-sb-label">Appearance</span>
-        <PopUpButton
-          options={APPEARANCE_OPTIONS}
-          value={appearance}
-          onChange={onAppearanceChange}
-          aria-label="Appearance"
-        />
-      </div>
     </div>
   );
 }
@@ -606,12 +589,22 @@ function UpdateBanner() {
 }
 
 // ── Menu content ──────────────────────────────────────────────
-function MenuContent({ tab }: { tab: GlobalTab }) {
+function MenuContent({
+  tab,
+  appearance,
+  onAppearanceChange,
+}: {
+  tab: GlobalTab;
+  appearance: Appearance;
+  onAppearanceChange: (next: Appearance) => void;
+}) {
   return (
     <>
       {tab === 'workspace' && <Workspace />}
       {tab === 'clients' && <Clients />}
-      {tab === 'settings' && <Settings />}
+      {tab === 'settings' && (
+        <Settings appearance={appearance} onAppearanceChange={onAppearanceChange} />
+      )}
     </>
   );
 }
@@ -811,8 +804,12 @@ export function App() {
   const needsFlexLayout = isProject && (projectTab === 'graph' || projectTab === 'ask');
   /* Surfaces that draw their own toolbar own the whole pane: a 16px inset turns
      a flush 52px toolbar into a floating white band with the sunken background
-     showing down both sides (TRA-293). */
-  const ownsToolbar = isProject && projectTab === 'overview';
+     showing down both sides (TRA-293). The Workspace dashboard has drawn its
+     own 52px toolbar and its own 16px gutters since TRA-292, so the pane's
+     `p-4` was doubling every inset on it — the KPI row started at x=32 and the
+     first card at y=76 (TRA-306). */
+  const ownsToolbar =
+    (isProject && projectTab === 'overview') || (!isProject && globalTab === 'workspace');
   const isGraphGpu = isGraph; // alias — the Graph tab *is* the GPU graph now
 
   return (
@@ -878,8 +875,6 @@ export function App() {
             <SidebarFooter
               active={!isProject && globalTab === 'settings'}
               onOpenSettingsInPlace={isProject ? undefined : () => setGlobalTab('settings')}
-              appearance={appearance}
-              onAppearanceChange={setAppearance}
             />
           </aside>
         )}
@@ -940,7 +935,11 @@ export function App() {
               </ErrorBoundary>
             ) : (
               <ErrorBoundary key={`menu:${globalTab}`} label={`${globalTab} tab`}>
-                <MenuContent tab={globalTab} />
+                <MenuContent
+                  tab={globalTab}
+                  appearance={appearance}
+                  onAppearanceChange={setAppearance}
+                />
               </ErrorBoundary>
             )}
           </div>

--- a/packages/app/src/renderer/app.css
+++ b/packages/app/src/renderer/app.css
@@ -136,8 +136,12 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
-  /* 6px + 8px puts the status dot on the sidebar rows' 14px glyph column. */
-  padding: 6px 8px 8px;
+  /* Same box as a sidebar row: 28px tall, 8px horizontal padding, so the
+     status dot lands on the rows' 14px glyph column and the sidebar's bottom
+     stack is three aligned 28px strips instead of 6/8 asymmetric ad-hoc
+     padding (TRA-306). */
+  height: 28px;
+  padding: 0 8px;
   margin: 0 6px;
   font-size: 11px;
   color: var(--text-secondary);

--- a/packages/app/src/renderer/styles/controls.css
+++ b/packages/app/src/renderer/styles/controls.css
@@ -22,7 +22,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 5px;
+  gap: 6px;
   flex: none;
   box-sizing: border-box;
   height: 24px;
@@ -61,7 +61,7 @@
 /* sizes ------------------------------------------------------------------- */
 .lx-btn.sz-small {
   height: 20px;
-  padding: 0 9px;
+  padding: 0 8px;
   font-size: 12px;
 }
 .lx-btn.sz-regular {
@@ -69,7 +69,7 @@
 }
 .lx-btn.sz-large {
   height: 28px;
-  padding: 0 14px;
+  padding: 0 16px;
 }
 
 /* variants ---------------------------------------------------------------- */
@@ -198,7 +198,7 @@
 }
 .lx-seg.sz-small .lx-seg-item {
   font-size: 12px;
-  padding: 0 9px;
+  padding: 0 8px;
 }
 .lx-seg .lx-seg-item:hover:not(:disabled):not(.is-active) {
   color: var(--label);
@@ -224,7 +224,7 @@
 .lx-search {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   box-sizing: border-box;
   height: 24px;
   min-width: 140px;
@@ -302,7 +302,7 @@
   box-sizing: border-box;
   height: 24px;
   min-width: 24px;
-  padding: 0 10px;
+  padding: 0 12px;
   border: 0;
   border-radius: 999px;
   background: var(--fill-quaternary);
@@ -349,7 +349,7 @@
   gap: 4px;
   box-sizing: border-box;
   height: 18px;
-  padding: 0 7px;
+  padding: 0 8px;
   border-radius: 999px;
   font-size: 11px;
   font-weight: 500;
@@ -455,7 +455,7 @@ input[type='checkbox']:disabled {
   width: 100%;
   height: 24px;
   margin: 0;
-  padding: 0 26px 0 11px;
+  padding: 0 24px 0 12px;
   border: 0;
   border-radius: 999px;
   background: var(--fill-quaternary);

--- a/packages/app/src/renderer/styles/sidebar.css
+++ b/packages/app/src/renderer/styles/sidebar.css
@@ -167,20 +167,12 @@
   background: var(--fill-tertiary, rgba(120, 120, 128, 0.24));
 }
 
-/* A row that CARRIES a control instead of being one (Appearance). Same box as
-   every other row; it just must not read as clickable. */
-.ws-sb-row.is-static {
-  cursor: default;
-}
-.ws-sb-row.is-static:hover {
-  background: transparent;
-}
-
 /* ---- Sidebar footer ----------------------------------------------------- */
 /* Pinned below .ws-sidebar-scroll, so the rows above slide under it — that is
    a scroll edge, and a scroll edge gets the hairline. Same 6px inset as the
    scroll region, so footer rows land on the same pill geometry as nav rows.
-   The 8px bottom inset reads as concentric with the 12px window corner. */
+   The 8px bottom inset reads as concentric with the 12px window corner.
+   One row only: 6 + 28 + 8 = 42.5px with the hairline (TRA-306). */
 .ws-sb-footer {
   flex: none;
   padding: 6px 6px 8px;

--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -315,7 +315,7 @@ function SkeletonRows({ rows }: { rows: number }) {
 /** Inline "we couldn't measure this" panel with the one action that helps. */
 function SectionError({ what, onRetry }: { what: string; onRetry: () => void }) {
   return (
-    <div className="flex items-center gap-2 px-3 py-2.5">
+    <div className="flex items-center gap-2 px-3 py-2">
       <Icon name="warning" size={14} />
       <span className="text-[13px] leading-4 flex-1" style={{ color: 'var(--label-secondary)' }}>
         Couldn't load {what}. The daemon may still be indexing.
@@ -544,7 +544,7 @@ export function ProjectOverview({
     <div className="flex flex-col h-full overflow-hidden">
       {/* ── Toolbar ──────────────────────────────────────────────────── */}
       <div
-        className="flex items-center gap-3 px-4 shrink-0 glass relative"
+        className="flex items-center gap-2 px-4 shrink-0 glass relative"
         style={{
           height: 52,
           borderBottom: '0.5px solid transparent',
@@ -967,7 +967,7 @@ export function ProjectOverview({
                         {groupServices.map((svc, i) => (
                           <div
                             key={svc.id}
-                            className="flex items-center gap-2.5 px-3"
+                            className="flex items-center gap-2 px-3"
                             style={{
                               minHeight: 44,
                               borderBottom:

--- a/packages/app/src/renderer/tabs/Settings.tsx
+++ b/packages/app/src/renderer/tabs/Settings.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { OllamaPanel } from '../components/OllamaPanel';
-import { StatusDot } from '../lattice/ui';
+import { PopUpButton, StatusDot } from '../lattice/ui';
 import { useDaemon } from '../hooks/useDaemon';
+import { type Appearance, APPEARANCE_OPTIONS } from '../theme.js';
 import {
   CONFIG_SCHEMA,
   computeDiff,
@@ -1670,6 +1671,43 @@ function BottomBar({
   );
 }
 
+/* Appearance — an app preference, not a daemon setting, so it is its own group
+   above the schema-driven list rather than a section inside it. It moved here
+   from the sidebar footer, which was carrying two 28px rows under a 38px update
+   banner (TRA-306). It renders in the daemon-down and loading states too: the
+   theme is stored in localStorage and has nothing to do with the daemon, so
+   losing the connection must not take the appearance switcher with it. */
+function AppearanceCard({
+  appearance,
+  onChange,
+}: {
+  appearance: Appearance;
+  onChange: (next: Appearance) => void;
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: '8px 12px',
+        background: 'var(--bg-grouped)',
+        borderRadius: 10,
+        boxShadow: 'var(--shadow-grouped)',
+        marginBottom: 12,
+      }}
+    >
+      <span style={{ flex: 1, fontSize: 13, color: 'var(--text-primary)' }}>Appearance</span>
+      <PopUpButton
+        options={APPEARANCE_OPTIONS}
+        value={appearance}
+        onChange={onChange}
+        aria-label="Appearance"
+      />
+    </div>
+  );
+}
+
 /* ═══ Main ═══════════════════════════════════════════════════════════ */
 
 type Screen =
@@ -1678,7 +1716,17 @@ type Screen =
   | { type: 'picker'; sectionKey: string; picker: PickerInfo }
   | { type: 'projects' };
 
-export function Settings() {
+export function Settings({
+  appearance,
+  onAppearanceChange,
+}: {
+  /* App-level preference, not a daemon config field: it lives in localStorage
+     and is owned by useTheme() in App.tsx, which is what applies [data-theme].
+     It is threaded in rather than read from a second useTheme() so both copies
+     cannot disagree about what the user picked (TRA-306). */
+  appearance: Appearance;
+  onAppearanceChange: (next: Appearance) => void;
+}) {
   const { settings, loading, connected, restarting, restartDaemon, updateSettings } = useDaemon();
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
@@ -1767,45 +1815,51 @@ export function Settings() {
   /* Not connected */
   if (!connected && !loading) {
     return (
-      <div className="flex flex-col items-center justify-center h-full gap-2">
-        <div className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
-          Daemon not reachable
+      <>
+        <AppearanceCard appearance={appearance} onChange={onAppearanceChange} />
+        <div className="flex flex-col items-center justify-center flex-1 gap-2">
+          <div className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
+            Daemon not reachable
+          </div>
+          <button
+            type="button"
+            onClick={() => restartDaemon()}
+            disabled={restarting}
+            className="text-[11px] px-4 py-1.5 rounded-lg font-medium transition-all"
+            style={{
+              background: 'var(--fill-control)',
+              backdropFilter: 'blur(12px)',
+              WebkitBackdropFilter: 'blur(12px)',
+              color: 'var(--accent)',
+              border: '0.5px solid var(--border)',
+              boxShadow: 'var(--shadow-control)',
+              cursor: restarting ? 'default' : 'pointer',
+              opacity: restarting ? 0.6 : 1,
+            }}
+          >
+            {restarting ? 'Starting…' : 'Restart Daemon'}
+          </button>
         </div>
-        <button
-          type="button"
-          onClick={() => restartDaemon()}
-          disabled={restarting}
-          className="text-[11px] px-4 py-1.5 rounded-lg font-medium transition-all"
-          style={{
-            background: 'var(--fill-control)',
-            backdropFilter: 'blur(12px)',
-            WebkitBackdropFilter: 'blur(12px)',
-            color: 'var(--accent)',
-            border: '0.5px solid var(--border)',
-            boxShadow: 'var(--shadow-control)',
-            cursor: restarting ? 'default' : 'pointer',
-            opacity: restarting ? 0.6 : 1,
-          }}
-        >
-          {restarting ? 'Starting…' : 'Restart Daemon'}
-        </button>
-      </div>
+      </>
     );
   }
 
   if (loading || !settings) {
     return (
-      <p
-        style={{
-          fontSize: 13,
-          textAlign: 'center',
-          padding: 32,
-          color: 'var(--text-tertiary)',
-          margin: 0,
-        }}
-      >
-        Loading…
-      </p>
+      <>
+        <AppearanceCard appearance={appearance} onChange={onAppearanceChange} />
+        <p
+          style={{
+            fontSize: 13,
+            textAlign: 'center',
+            padding: 32,
+            color: 'var(--text-tertiary)',
+            margin: 0,
+          }}
+        >
+          Loading…
+        </p>
+      </>
     );
   }
 
@@ -1985,6 +2039,10 @@ export function Settings() {
           </button>
         )}
       </div>
+
+      {(!q || 'appearance'.includes(q) || 'theme'.includes(q)) && (
+        <AppearanceCard appearance={appearance} onChange={onAppearanceChange} />
+      )}
 
       {/* Section list */}
       <SectionList

--- a/packages/app/src/renderer/tabs/__tests__/Settings.appearance.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/Settings.appearance.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+//
+// Appearance moved out of the sidebar footer and into the Settings screen
+// (TRA-306). The footer no longer offers it, so this is now the only surface
+// that does — and it has to keep offering all three states even when the
+// daemon is unreachable, because the theme lives in localStorage and has
+// nothing to do with the daemon.
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Settings } from '../Settings';
+
+beforeEach(() => {
+  const makeApiProxy = (name = ''): unknown =>
+    new Proxy(function () {} as object, {
+      get: (_t, prop) => makeApiProxy(typeof prop === 'string' ? prop : ''),
+      apply: () => (name.startsWith('on') ? () => undefined : Promise.resolve(undefined)),
+    });
+  (window as unknown as { electronAPI: unknown }).electronAPI = makeApiProxy();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.reject(new Error('daemon down'))),
+  );
+  vi.stubGlobal(
+    'EventSource',
+    class {
+      close() {}
+    },
+  );
+});
+
+describe('Settings — Appearance', () => {
+  it('offers Auto / Light / Dark even with no daemon', () => {
+    render(<Settings appearance="auto" onAppearanceChange={() => {}} />);
+    const select = screen.getByLabelText('Appearance') as HTMLSelectElement;
+    expect([...select.options].map((o) => o.text)).toEqual(['Auto', 'Light', 'Dark']);
+    expect(select.value).toBe('auto');
+  });
+
+  it('reports the picked appearance upwards', () => {
+    const onChange = vi.fn();
+    render(<Settings appearance="auto" onAppearanceChange={onChange} />);
+    const select = screen.getByLabelText('Appearance') as HTMLSelectElement;
+    select.value = 'dark';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(onChange).toHaveBeenCalledWith('dark');
+  });
+});

--- a/packages/app/src/renderer/workspace/AddProjectControl.tsx
+++ b/packages/app/src/renderer/workspace/AddProjectControl.tsx
@@ -163,7 +163,7 @@ export function AddProjectControl({ onAdd, variant = 'compact' }: AddProjectCont
           type="button"
           disabled={adding}
           onClick={() => void handlePickFolder()}
-          className="h-6 pl-2.5 pr-2 text-[11px] font-medium transition-opacity disabled:opacity-40"
+          className="h-6 px-2 text-[11px] font-medium transition-opacity disabled:opacity-40"
           style={{
             // --accent-fill, not --accent: a white label on --accent measures
             // 3.65:1 in dark. Split radii, so this cannot be a Button capsule.


### PR DESCRIPTION
Closes TRA-306. Every number below was measured on the running renderer (Electron, macOS, `--remote-debugging-port` + CDP), before and after, in both appearances.

## 1. Sidebar bottom: 108.5px → 70.5px

TRA-305 was right to put the footer on the row system. It was wrong to do it by adding a *second* row: `6 + 28 + 28 + 8 = 70.5px` of footer, sitting under a 38px update banner with its own `6px 8px 8px` padding. Three strips, three geometries, one heavy corner.

| | before | after |
|---|---|---|
| `.ws-sb-footer` | 70.5px | **42.5px** |
| `.update-idle` | 38px, padding `6/8/8/8` | **28px, padding `0 8px`** |
| bottom furniture, total | 108.5px | **70.5px** |

**Why Appearance moved to Settings** (of the three options in the issue):

- *Trailing control on the Settings row* — the row is a `<button>`; a `<select>` inside it is invalid nesting and every click on the popup would also fire "open Settings". The codebase already avoids this: the recents ✕ is a `<span>` with `stopPropagation` and a keyboard route on the row. A pop-up button has no such fallback.
- *Compact segmented control* — still needs its own 28px row. Same height, no win.
- *Settings screen* — taken. A preference is not a navigation destination, and no macOS app pins an appearance switcher to its sidebar. Auto / Light / Dark are unchanged (`APPEARANCE_OPTIONS`, `useTheme`), one click away from every window (in a project window the Settings row opens the menu window as before), and the card renders in Settings' **daemon-down and loading** states too — the theme is localStorage, not daemon config, so losing the connection must not take the switcher with it. Covered by a new test; `theme.test.tsx` is untouched and green.

`.ws-sb-row.is-static` existed only for that row and is deleted.

## 2. Top insets

**Sidebar: 44px, unchanged — and it is not padding we chose.** A real composited window screenshot (not a CDP capture) shows the traffic lights at y=18–30 *and* the native macOS tab bar both living inside that band; the first sidebar row starts exactly 44px below the window's top edge. Cutting it clips one or both. `trace-mcp-macos-design` §6 and `DESIGN.md` both specify 44px. Left alone deliberately.

**Content pane: 76px → 60px, and 32px → 16px on the left.** This was real fat. The Workspace has drawn its own 52px toolbar and its own 16px gutters since TRA-292, but `.ws-content-body` still wrapped it in `p-4`, doubling every inset the surface declares.

| | before | after |
|---|---|---|
| first KPI card | x=252, y=76 | **x=236, y=60** |
| Project Overview first pixel | y=44 | y=44 (already owned its pane) |

Workspace now joins Project Overview in owning its pane. The Workspace's own vertical rhythm (16px at the pane edges, 12px between bands) is on the grid and coherent, so it is unchanged.

## 3. Internal padding audit

A scan of **every rendered element** in both windows for computed padding / gap / margin off the `{2,4,6,8,12,16,20,24,32,40,48}` scale. Eight distinct violations before, **zero after**. All of them were in the shared control primitives, which is why they read as "странные отступы" everywhere at once rather than on one screen:

| selector | before | after |
|---|---|---|
| `.lx-btn` | `gap: 5px` | `gap: 6px` |
| `.lx-btn.sz-small` | `padding: 0 9px` | `padding: 0 8px` |
| `.lx-btn.sz-large` | `padding: 0 14px` | `padding: 0 16px` |
| `.lx-seg.sz-small .lx-seg-item` | `padding: 0 9px` | `padding: 0 8px` |
| `.lx-search` | `gap: 5px` | `gap: 6px` |
| `.lx-chip` | `padding: 0 10px` | `padding: 0 12px` |
| `.lx-badge` | `padding: 0 7px` | `padding: 0 8px` |
| `.lx-popup select` | `padding: 0 26px 0 11px` | `padding: 0 24px 0 12px` |

Plus, on the migrated surfaces only, the two Tailwind half-steps (`ProjectOverview` `py-2.5` and `gap-2.5`, `AddProjectControl` `pl-2.5` → 8px) and one inconsistency between visually equivalent containers: the 52px toolbar gap was 12px on Project Overview and 8px on the Workspace → both 8px now. `gap-1.5` (6px) is on the scale and was left alone.

The remaining half-steps in the tree are all on **unmigrated** surfaces (GraphExplorerGPU, MemoryExplorer, ToolActivity, AIActivity, FilterBar, Clients, ProjectStatsModal) and belong to their own migration PRs — this issue scopes the audit to the migrated set.

The native `<select>`'s UA padding is the one off-grid value left; it is drawn by the platform and out of our control.

`DESIGN.md` (merged hours before this branch) documented `.ws-sb-row.is-static` and stated the 4pt grid for surfaces only. Both updated in the second commit.

## Verification

- 146 tests pass (16 files), including `useTheme` and the launch smoke test; typecheck clean on both packages.
- Screenshots of the sidebar bottom, the sidebar/content top, and the full Workspace, in light and dark, before and after, attached to the issue. The sidebar is captured under Reduce Transparency: a CDP screenshot captures the web layer only, not the `NSVisualEffectView` behind it, so the material has to be forced opaque for the sidebar to be legible in a capture at all. The traffic-light claim above is from a real `screencapture` of the composited window.
