### PR TITLE
feat(app): rebuild MCP clients, Settings and the onboarding sheet (TRA-295)

### DIFF
--- a/packages/app/scripts/token-guard.baseline.json
+++ b/packages/app/scripts/token-guard.baseline.json
@@ -2,8 +2,6 @@
   "src/renderer/components/ErrorBoundary.tsx": 1,
   "src/renderer/components/FilterBar.tsx": 2,
   "src/renderer/components/GuardBadge.tsx": 7,
-  "src/renderer/components/GuardOnboarding.tsx": 1,
-  "src/renderer/components/OllamaPanel.tsx": 1,
   "src/renderer/components/ProjectDetail.tsx": 1,
   "src/renderer/components/ProjectRow.tsx": 2,
   "src/renderer/components/ProjectStatsModal.tsx": 7,
@@ -12,10 +10,8 @@
   "src/renderer/styles/island.css": 83,
   "src/renderer/tabs/AIActivity.tsx": 6,
   "src/renderer/tabs/AskTab.tsx": 5,
-  "src/renderer/tabs/Clients.tsx": 7,
   "src/renderer/tabs/GraphExplorerGPU.tsx": 51,
   "src/renderer/tabs/MemoryExplorer.tsx": 37,
   "src/renderer/tabs/Notebook.tsx": 1,
-  "src/renderer/tabs/Settings.tsx": 7,
   "src/renderer/tabs/ToolActivity.tsx": 33
 }

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -807,9 +807,11 @@ export function App() {
      showing down both sides (TRA-293). The Workspace dashboard has drawn its
      own 52px toolbar and its own 16px gutters since TRA-292, so the pane's
      `p-4` was doubling every inset on it — the KPI row started at x=32 and the
-     first card at y=76 (TRA-306). */
-  const ownsToolbar =
-    (isProject && projectTab === 'overview') || (!isProject && globalTab === 'workspace');
+     first card at y=76 (TRA-306). MCP clients and Settings drew their own
+     toolbars in TRA-295 and joined them. */
+  const ownsToolbar = isProject
+    ? projectTab === 'overview'
+    : globalTab === 'workspace' || globalTab === 'clients' || globalTab === 'settings';
   const isGraphGpu = isGraph; // alias — the Graph tab *is* the GPU graph now
 
   return (

--- a/packages/app/src/renderer/app.css
+++ b/packages/app/src/renderer/app.css
@@ -274,3 +274,116 @@ body {
 /* The sidebar footer lives in styles/sidebar.css now, with the row system it
    belongs to (TRA-305). `.sidebar-footer` / `.nav-button` / `.icon-button` were
    already dead: the footer renders Lattice `.lx-btn` primitives, not these. */
+
+/* ── Sheet (TRA-295) ─────────────────────────────────────────────── */
+/* A macOS sheet, not a centred web modal: it is attached to the window's top
+   edge (square top corners, 12px bottom corners), slides out of that edge, and
+   is the ONE floating layer that gets a shadow. Content behind it is dimmed. */
+.lx-sheet-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  background: rgb(0 0 0 / 0.32);
+  animation: lx-scrim-in var(--dur-standard) var(--ease-out);
+}
+@keyframes lx-scrim-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.lx-sheet {
+  box-sizing: border-box;
+  width: min(440px, calc(100vw - 32px));
+  padding: 20px;
+  background: var(--surface);
+  border: 0.5px solid var(--separator);
+  border-top: 0;
+  border-radius: 0 0 var(--radius-panel) var(--radius-panel);
+  box-shadow: var(--shadow-panel);
+  animation: lx-sheet-in var(--dur-large) var(--ease-spring);
+}
+@keyframes lx-sheet-in {
+  from {
+    transform: translateY(-100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+.lx-sheet-title {
+  margin: 0 0 8px;
+  font: var(--weight-semibold) var(--text-title-2) / var(--leading-title-2) var(--font-ui);
+  color: var(--label);
+}
+.lx-sheet-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.lx-sheet-text {
+  margin: 0;
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+  color: var(--label-secondary);
+}
+.lx-sheet-note {
+  margin: -4px 0 0;
+  font-size: var(--text-caption);
+  line-height: var(--leading-caption);
+  color: var(--label-secondary);
+}
+.lx-sheet-error {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+  color: var(--status-red);
+}
+.lx-sheet-text code,
+.lx-sheet-note code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+}
+
+/* The command field. `user-select: text` is not a nicety: body sets
+   `user-select: none` app-wide, so without this the one thing the sheet asks
+   the user to run cannot be selected, let alone copied. */
+.lx-sheet-command {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 6px 6px 10px;
+  background: var(--surface-sunken);
+  border: 0.5px solid var(--separator);
+  border-radius: var(--radius-input);
+}
+.lx-sheet-command code {
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-callout);
+  line-height: var(--leading-callout);
+  color: var(--label);
+  white-space: nowrap;
+  user-select: text;
+  -webkit-user-select: text;
+  cursor: text;
+}
+
+.lx-sheet-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}

--- a/packages/app/src/renderer/components/GuardOnboarding.tsx
+++ b/packages/app/src/renderer/components/GuardOnboarding.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { Icon } from '../lattice/icons';
 import { Button } from '../lattice/ui';
 
 type Step = 'detect' | 'cli-missing' | 'cli-stale' | 'install-prompt' | 'installing' | 'installed' | 'skipped';
@@ -12,23 +13,29 @@ interface OnboardingState {
 }
 
 /**
- * One-time onboarding wizard for the trace-mcp guard.
+ * One-time onboarding sheet for the trace-mcp guard.
  * Shown the first time the app launches without a recorded acknowledgement.
  *
  * Flow:
- *   detect  → cli-missing  (terminal — link to install instructions)
- *           → cli-stale    (terminal — prompt to upgrade)
+ *   detect  → cli-missing  (terminal — the install command, with a copy button)
+ *           → cli-stale    (terminal — the upgrade command)
  *           → install-prompt → installing → installed
  *                                         → skipped (user opted out)
  *
- * Nothing renders until detection resolves — the dialog is the first thing a
+ * Nothing renders until detection resolves — the sheet is the first thing a
  * new user ever sees, so it must not flash an empty "Detecting…" panel over a
  * still-loading Workspace. When Claude Code isn't installed there is nothing
- * to offer, so we acknowledge and close without ever showing a dialog.
+ * to offer, so we acknowledge and close without ever showing a sheet.
  *
- * Persistence: writes ~/.claude/.trace-mcp-onboarded once the user reaches
- * a terminal state. Renderer-side via electronAPI? — actually we keep it
- * in localStorage because it's a UI hint, not a security boundary.
+ * Presentation (TRA-295): a macOS sheet, not a centred web modal. It slides
+ * out of the window's top edge, keeps square top corners because it is
+ * attached to that edge, dims what is behind it, traps focus, and closes on
+ * Escape and on a backdrop press. The command it asks the user to run is a
+ * selectable monospace field with a copy button — `user-select: none` is set
+ * globally on `body`, so before this the one thing the dialog existed to
+ * communicate could not be copied.
+ *
+ * Persistence: localStorage, because it is a UI hint, not a security boundary.
  */
 const ONBOARDING_KEY = 'trace-mcp.onboarded.v1';
 
@@ -39,6 +46,8 @@ interface GuardOnboardingProps {
 export function GuardOnboarding({ onClose }: GuardOnboardingProps) {
   const [state, setState] = useState<OnboardingState>({ step: 'detect' });
   const titleId = useId();
+  const bodyId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
 
   // Ref so the detect effect can close without re-running when App re-renders
   // and hands us a fresh `onClose` identity.
@@ -59,11 +68,7 @@ export function GuardOnboarding({ onClose }: GuardOnboardingProps) {
     const detect = async () => {
       const cliCheck = await window.electronAPI?.guard.checkCliVersion();
       if (cancelled) return;
-      if (!cliCheck) {
-        setState({ step: 'cli-missing' });
-        return;
-      }
-      if (cliCheck.notInstalled) {
+      if (!cliCheck || cliCheck.notInstalled) {
         setState({ step: 'cli-missing' });
         return;
       }
@@ -87,14 +92,11 @@ export function GuardOnboarding({ onClose }: GuardOnboardingProps) {
       }
       if (!installStatus?.claudeDetected) {
         // Claude Code not installed — there is nothing to offer, so don't
-        // interrupt first launch with a dialog just to say "skipped".
+        // interrupt first launch with a sheet just to say "skipped".
         dismissAndPersist();
         return;
       }
-      setState({
-        step: 'install-prompt',
-        cliVersion: cliCheck.current,
-      });
+      setState({ step: 'install-prompt', cliVersion: cliCheck.current });
     };
     detect();
     return () => {
@@ -102,20 +104,51 @@ export function GuardOnboarding({ onClose }: GuardOnboardingProps) {
     };
   }, [dismissAndPersist]);
 
-  // Dismissable while a dialog is actually on screen and idle — not during
+  // Dismissable while a sheet is actually on screen and idle — not during
   // detection (nothing is shown yet) and not mid-install (work in flight).
   const dismissable = state.step !== 'detect' && state.step !== 'installing';
+  const open = state.step !== 'detect';
 
-  // Escape dismisses, same as the primary action. A modal you can't get out of
-  // with the keyboard is a trap on the very first screen of the app.
+  // Escape dismisses, and Tab cycles inside the sheet. A modal you can't get
+  // out of with the keyboard, or that leaks Tab to the Workspace behind it, is
+  // a trap on the very first screen of the app.
   useEffect(() => {
-    if (!dismissable) return;
+    if (!open) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') dismissAndPersist();
+      if (e.key === 'Escape') {
+        if (!dismissable) return;
+        e.preventDefault();
+        dismissAndPersist();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusables = [
+        ...panel.querySelectorAll<HTMLElement>(
+          'button:not(:disabled), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ),
+      ];
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (!active || !panel.contains(active)) {
+        e.preventDefault();
+        first.focus();
+        return;
+      }
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [dismissable, dismissAndPersist]);
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [open, dismissable, dismissAndPersist]);
 
   const install = async () => {
     setState((s) => ({ ...s, step: 'installing' }));
@@ -127,124 +160,174 @@ export function GuardOnboarding({ onClose }: GuardOnboardingProps) {
     setState((s) => ({ ...s, step: 'installed', scriptPath: result.scriptPath }));
   };
 
-  if (state.step === 'detect') return null;
+  if (!open) return null;
+
+  const { title, body } = content(state, install, dismissAndPersist, () =>
+    setState({ step: 'skipped' }),
+  );
 
   return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: the scrim is a dismissal affordance, not a control — Escape and the sheet's own buttons are the keyboard paths, and the sheet traps focus above it.
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center"
-      style={{ background: 'rgba(0,0,0,0.4)' }}
+      className="lx-sheet-scrim"
       onClick={dismissable ? dismissAndPersist : undefined}
     >
-      {/* stopPropagation below keeps clicks inside the panel from reaching the
-          backdrop handler; Escape is handled globally above. */}
+      {/* stopPropagation keeps presses inside the sheet from reaching the
+          scrim's dismiss handler; Escape is handled globally above. */}
       <div
+        ref={panelRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
-        className="rounded-lg shadow-2xl p-6 max-w-md w-full"
-        style={{ background: 'var(--bg-primary)', border: '1px solid var(--border)' }}
+        aria-describedby={bodyId}
+        className="lx-sheet"
         onClick={(e) => e.stopPropagation()}
       >
-        <h2
-          id={titleId}
-          className="text-base font-semibold mb-3"
-          style={{ color: 'var(--text-primary)' }}
-        >
-          Set up trace-mcp guard
+        <h2 id={titleId} className="lx-sheet-title">
+          {title}
         </h2>
+        <div id={bodyId} className="lx-sheet-body">
+          {body}
+        </div>
+      </div>
+    </div>
+  );
+}
 
-        {state.step === 'cli-missing' && (
-          <div>
-            <p className="text-sm mb-3" style={{ color: 'var(--text-secondary)' }}>
-              The <code>trace-mcp</code> CLI isn't on your PATH. Install it first:
+/** Per-step title and body. Split out so the sheet chrome above stays one
+    shape regardless of which of the six states is showing. */
+function content(
+  state: OnboardingState,
+  install: () => void,
+  dismiss: () => void,
+  skip: () => void,
+): { title: string; body: React.ReactNode } {
+  switch (state.step) {
+    case 'cli-missing':
+      return {
+        title: 'Install the trace-mcp CLI',
+        body: (
+          <>
+            <p className="lx-sheet-text">
+              The app talks to your projects through the <code>trace-mcp</code> command, and it
+              isn't on your PATH yet. Run this in a terminal, then reopen the app.
             </p>
-            <pre
-              className="text-xs px-2 py-1.5 rounded mb-3"
-              style={{ background: 'var(--bg-secondary)', color: 'var(--text-primary)' }}
-            >
-              npm install -g trace-mcp
-            </pre>
-            <ActionRow onPrimary={dismissAndPersist} primaryLabel="Got it" />
-          </div>
-        )}
-
-        {state.step === 'cli-stale' && (
-          <div>
-            <p className="text-sm mb-3" style={{ color: 'var(--text-secondary)' }}>
-              Installed CLI is <code>{state.cliVersion}</code> — this app expects ≥{' '}
-              <code>{state.requiredVersion}</code>. Upgrade:
+            <CommandField command="npm install -g trace-mcp" />
+            <ActionRow onPrimary={dismiss} primaryLabel="Done" />
+          </>
+        ),
+      };
+    case 'cli-stale':
+      return {
+        title: 'Update the trace-mcp CLI',
+        body: (
+          <>
+            <p className="lx-sheet-text">
+              You have <code>{state.cliVersion}</code>; this app needs{' '}
+              <code>{state.requiredVersion}</code> or newer. Run this in a terminal, then reopen
+              the app.
             </p>
-            <pre
-              className="text-xs px-2 py-1.5 rounded mb-3"
-              style={{ background: 'var(--bg-secondary)', color: 'var(--text-primary)' }}
-            >
-              npm install -g trace-mcp@latest
-            </pre>
-            <ActionRow onPrimary={dismissAndPersist} primaryLabel="Got it" />
-          </div>
-        )}
-
-        {state.step === 'install-prompt' && (
-          <div>
-            <p className="text-sm mb-3" style={{ color: 'var(--text-secondary)' }}>
-              Install the trace-mcp guard hook into Claude Code? This routes
-              Read/Grep/Glob/Bash through trace-mcp instead of raw file
-              reads — saves ~30–50% of tokens per session. New projects
-              start in <strong>Coach</strong> mode (hints only, never
-              blocks) and auto-promote to Strict after 7 days.
+            <CommandField command="npm install -g trace-mcp@latest" />
+            <ActionRow onPrimary={dismiss} primaryLabel="Done" />
+          </>
+        ),
+      };
+    case 'install-prompt':
+      return {
+        title: 'Set up the trace-mcp guard',
+        body: (
+          <>
+            <p className="lx-sheet-text">
+              The guard routes Claude Code's Read, Grep, Glob and Bash calls through trace-mcp
+              instead of raw file reads, which saves roughly 30–50% of the tokens in a session.
+              New projects start in Coach mode — hints only, never blocking — and move to Strict
+              after seven days.
             </p>
-            <p className="text-[11px] mb-4" style={{ color: 'var(--text-tertiary)' }}>
-              We'll back up <code>~/.claude/settings.json</code> to{' '}
-              <code>settings.json.bak</code> before editing.
+            <p className="lx-sheet-note">
+              <code>~/.claude/settings.json</code> is backed up to <code>settings.json.bak</code>{' '}
+              before anything is written.
             </p>
             {state.error && (
-              <div className="text-xs mb-2" style={{ color: '#ff3b30' }}>
+              <p className="lx-sheet-error" role="alert">
+                <Icon name="warning" size={14} />
                 {state.error}
-              </div>
+              </p>
             )}
             <ActionRow
               onPrimary={install}
-              primaryLabel="Install"
-              onSecondary={() => {
-                setState({ step: 'skipped' });
-              }}
-              secondaryLabel="Skip"
+              primaryLabel="Install guard"
+              onSecondary={skip}
+              secondaryLabel="Not now"
             />
-          </div>
-        )}
-
-        {state.step === 'installing' && (
-          <div className="text-sm" style={{ color: 'var(--text-secondary)' }}>
-            Installing hook…
-          </div>
-        )}
-
-        {state.step === 'installed' && (
-          <div>
-            <p className="text-sm mb-3" style={{ color: 'var(--text-secondary)' }}>
-              Guard installed.
-              {state.scriptPath && (
-                <>
-                  {' '}Hook at <code>{state.scriptPath}</code>.
-                </>
-              )}
-            </p>
-            <p className="text-[11px] mb-4" style={{ color: 'var(--text-tertiary)' }}>
+          </>
+        ),
+      };
+    case 'installing':
+      return {
+        title: 'Installing the guard',
+        body: (
+          <p className="lx-sheet-text" role="status">
+            Writing the hook into Claude Code's settings…
+          </p>
+        ),
+      };
+    case 'installed':
+      return {
+        title: 'Guard installed',
+        body: (
+          <>
+            <p className="lx-sheet-text">
               Restart Claude Code so it picks up the new hook configuration.
             </p>
-            <ActionRow onPrimary={dismissAndPersist} primaryLabel="Done" />
-          </div>
-        )}
-
-        {state.step === 'skipped' && (
-          <div>
-            <p className="text-sm mb-3" style={{ color: 'var(--text-secondary)' }}>
-              Skipped. You can install the guard later from Settings.
+            {state.scriptPath && <CommandField command={state.scriptPath} label="Hook script" />}
+            <ActionRow onPrimary={dismiss} primaryLabel="Done" />
+          </>
+        ),
+      };
+    case 'skipped':
+      return {
+        title: 'Guard not installed',
+        body: (
+          <>
+            <p className="lx-sheet-text">
+              You can install it later from Settings, under AI / embeddings.
             </p>
-            <ActionRow onPrimary={dismissAndPersist} primaryLabel="Close" />
-          </div>
-        )}
-      </div>
+            <ActionRow onPrimary={dismiss} primaryLabel="Close" />
+          </>
+        ),
+      };
+    default:
+      return { title: '', body: null };
+  }
+}
+
+/** A command the user is meant to run. Selectable (the global
+    `user-select: none` on body is overridden here) and copyable in one click —
+    a command you cannot copy is a screenshot, not an instruction. */
+function CommandField({ command, label }: { command: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard denied — the text is selectable, so ⌘C still works */
+    }
+  };
+
+  return (
+    <div className="lx-sheet-command">
+      <code>{command}</code>
+      <Button
+        variant="icon"
+        size="small"
+        icon={copied ? 'check' : 'content_copy'}
+        onClick={copy}
+        aria-label={copied ? 'Copied' : `Copy ${label ?? 'command'}`}
+        title={copied ? 'Copied' : `Copy ${label ?? 'command'}`}
+      />
     </div>
   );
 }
@@ -258,15 +341,15 @@ interface ActionRowProps {
 
 function ActionRow({ onPrimary, primaryLabel, onSecondary, secondaryLabel }: ActionRowProps) {
   return (
-    <div className="flex gap-2 justify-end">
+    <div className="lx-sheet-actions">
       {onSecondary && secondaryLabel && (
-        <Button variant="chip" onClick={onSecondary}>
+        <Button size="large" onClick={onSecondary}>
           {secondaryLabel}
         </Button>
       )}
-      {/* autoFocus: the dialog must own the keyboard on mount, otherwise Tab
+      {/* autoFocus: the sheet must own the keyboard on mount, otherwise Tab
           and Enter act on the Workspace behind it. */}
-      <Button autoFocus variant="primary" onClick={onPrimary}>
+      <Button autoFocus size="large" variant="prominent" onClick={onPrimary}>
         {primaryLabel}
       </Button>
     </div>

--- a/packages/app/src/renderer/components/OllamaPanel.tsx
+++ b/packages/app/src/renderer/components/OllamaPanel.tsx
@@ -1,10 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button, ConfirmPopover, EmptyState, StatusDot } from '../lattice/ui';
 
 /** Rendered at the bottom of the AI settings section when provider=ollama.
  *
  *  Shape: daemon status row + two lists (running now / installed). The lists
  *  auto-refresh every 2.5s but pause while a mutation is in-flight so the
  *  optimistic state doesn't get clobbered by a stale poll response.
+ *
+ *  Migrated onto the macOS 26 layer with the rest of Settings (TRA-295): the
+ *  local 11px/6px-radius `Btn` is the Lattice Button, separators are 0.5px
+ *  hairlines, section captions match the surface's 11px sentence-case form
+ *  instead of 10px ALL CAPS, and deleting a model asks in a popover rather
+ *  than a blocking `window.confirm`.
  */
 
 type Status = { running: boolean; version?: string; baseUrl: string; error?: string };
@@ -39,6 +46,9 @@ export function OllamaPanel({ baseUrl }: { baseUrl?: string }) {
   const [running, setRunning] = useState<OllamaRunningModel[]>([]);
   const [busy, setBusy] = useState<string | null>(null); // key identifying which op is in-flight
   const [notice, setNotice] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<{ name: string; x: number; y: number } | null>(
+    null,
+  );
   const pollBusy = useRef(false);
 
   const refresh = useCallback(async () => {
@@ -85,127 +95,92 @@ export function OllamaPanel({ baseUrl }: { baseUrl?: string }) {
   const onStart = () =>
     withBusy('daemon:start', async () => {
       const r = await api!.start(baseUrl);
-      if (!r.ok) setNotice(`Start failed: ${r.error ?? 'unknown'}`);
+      if (!r.ok) setNotice(`Couldn't start Ollama: ${r.error ?? 'unknown error'}`);
     });
   const onStop = () =>
     withBusy('daemon:stop', async () => {
       const r = await api!.stop(baseUrl);
-      if (!r.ok) setNotice(`Stop failed: ${r.error ?? 'unknown'}`);
+      if (!r.ok) setNotice(`Couldn't stop Ollama: ${r.error ?? 'unknown error'}`);
     });
   const onUnload = (name: string) =>
     withBusy(`unload:${name}`, async () => {
       const r = await api!.unload(name, baseUrl);
-      if (!r.ok) setNotice(`Unload failed: ${r.error ?? 'unknown'}`);
+      if (!r.ok) setNotice(`Couldn't unload ${name}: ${r.error ?? 'unknown error'}`);
     });
-  const onDelete = (name: string) => {
-    if (!confirm(`Delete model "${name}"? This removes it from disk.`)) return;
-    return withBusy(`delete:${name}`, async () => {
+  const onDelete = (name: string) =>
+    withBusy(`delete:${name}`, async () => {
       const r = await api!.delete(name, baseUrl);
-      if (!r.ok) setNotice(`Delete failed: ${r.error ?? 'unknown'}`);
+      if (!r.ok) setNotice(`Couldn't delete ${name}: ${r.error ?? 'unknown error'}`);
     });
-  };
 
   if (!api) {
     return (
-      <div style={{ marginTop: 20, fontSize: 12, color: 'var(--text-tertiary)' }}>
+      <p className="text-[13px] leading-4 px-1" style={{ color: 'var(--label-secondary)' }}>
         Ollama control is only available inside the trace-mcp app.
-      </div>
+      </p>
     );
   }
 
-  const dot = status?.running ? 'var(--success)' : 'var(--destructive)';
-
   return (
-    <div style={{ marginTop: 20 }}>
-      <div
-        className="text-[10px] font-semibold uppercase tracking-wider"
-        style={{ color: 'var(--text-tertiary)', marginBottom: 8 }}
-      >
-        Ollama
-      </div>
-
-      {/* Status + daemon controls */}
-      <div
-        style={{
-          background: 'var(--bg-grouped)',
-          borderRadius: 10,
-          boxShadow: 'var(--shadow-grouped)',
-          padding: '10px 12px',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 10,
-        }}
-      >
-        <span style={{ width: 8, height: 8, borderRadius: 4, background: dot, flexShrink: 0 }} />
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ fontSize: 13, color: 'var(--text-primary)' }}>
-            {status?.running ? `Running · ${status.version ?? 'unknown version'}` : 'Not running'}
+    <div className="flex flex-col gap-4">
+      <Section title="Ollama">
+        <Card>
+          <div className="flex items-center gap-2.5 px-3" style={{ minHeight: 44 }}>
+            <StatusDot
+              tone={status?.running ? 'green' : 'neutral'}
+              title={status?.running ? 'Running' : 'Not running'}
+            />
+            <div className="flex-1 min-w-0">
+              <div className="text-[13px] leading-4" style={{ color: 'var(--label)' }}>
+                {status?.running ? `Running · ${status.version ?? 'unknown version'}` : 'Not running'}
+              </div>
+              <div
+                className="text-[11px] leading-[13px] truncate"
+                style={{ color: 'var(--label-secondary)' }}
+              >
+                {status?.baseUrl ?? baseUrl ?? 'http://localhost:11434'}
+                {!status?.running && status?.error ? ` · ${status.error}` : ''}
+              </div>
+            </div>
+            {status?.running ? (
+              <Button size="small" disabled={busy === 'daemon:stop'} onClick={onStop}>
+                {busy === 'daemon:stop' ? 'Stopping…' : 'Stop'}
+              </Button>
+            ) : (
+              <Button size="small" disabled={busy === 'daemon:start'} onClick={onStart}>
+                {busy === 'daemon:start' ? 'Starting…' : 'Start'}
+              </Button>
+            )}
           </div>
-          <div
-            style={{
-              fontSize: 11,
-              color: 'var(--text-tertiary)',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {status?.baseUrl ?? baseUrl ?? 'http://localhost:11434'}
-            {!status?.running && status?.error ? ` · ${status.error}` : ''}
-          </div>
-        </div>
-        {status?.running ? (
-          <Btn onClick={onStop} busy={busy === 'daemon:stop'} variant="destructive">
-            Stop
-          </Btn>
-        ) : (
-          <Btn onClick={onStart} busy={busy === 'daemon:start'} variant="primary">
-            Start
-          </Btn>
-        )}
-      </div>
+        </Card>
+      </Section>
 
       {notice && (
-        <div
-          style={{
-            marginTop: 8,
-            padding: '6px 10px',
-            borderRadius: 6,
-            fontSize: 11,
-            background: 'var(--fill-control)',
-            color: 'var(--destructive)',
-          }}
+        <p
+          className="text-[13px] leading-4 px-1"
+          style={{ color: 'var(--status-red)' }}
+          role="alert"
         >
           {notice}
-        </div>
+        </p>
       )}
 
-      {/* Running models */}
       {status?.running && (
         <>
-          <div
-            className="text-[10px] font-semibold uppercase tracking-wider"
-            style={{ color: 'var(--text-tertiary)', marginTop: 16, marginBottom: 8 }}
-          >
-            Loaded in memory ({running.length})
-          </div>
-          {running.length === 0 ? (
-            <div
-              style={{
-                fontSize: 12,
-                color: 'var(--text-tertiary)',
-                padding: '8px 12px',
-                background: 'var(--bg-grouped)',
-                borderRadius: 10,
-              }}
-            >
-              No models currently loaded.
-            </div>
-          ) : (
-            <ModelList>
-              {running.map((m, i) => (
-                <Row key={m.name} last={i === running.length - 1}>
-                  <RowInfo
+          <Section title="Loaded in memory" count={running.length}>
+            <Card>
+              {running.length === 0 ? (
+                <EmptyState
+                  compact
+                  icon="database"
+                  title="Nothing loaded"
+                  subtitle="A model appears here while it is held in memory."
+                />
+              ) : (
+                running.map((m, i) => (
+                  <Row
+                    key={m.name}
+                    last={i === running.length - 1}
                     title={m.name}
                     subtitle={[
                       `${fmtBytes(m.size_vram)} VRAM`,
@@ -214,39 +189,35 @@ export function OllamaPanel({ baseUrl }: { baseUrl?: string }) {
                     ]
                       .filter(Boolean)
                       .join(' · ')}
+                    action={
+                      <Button
+                        size="small"
+                        disabled={busy === `unload:${m.name}`}
+                        onClick={() => onUnload(m.name)}
+                      >
+                        {busy === `unload:${m.name}` ? 'Unloading…' : 'Unload'}
+                      </Button>
+                    }
                   />
-                  <Btn onClick={() => onUnload(m.name)} busy={busy === `unload:${m.name}`}>
-                    Unload
-                  </Btn>
-                </Row>
-              ))}
-            </ModelList>
-          )}
+                ))
+              )}
+            </Card>
+          </Section>
 
-          {/* Installed models */}
-          <div
-            className="text-[10px] font-semibold uppercase tracking-wider"
-            style={{ color: 'var(--text-tertiary)', marginTop: 16, marginBottom: 8 }}
-          >
-            Installed on disk ({installed.length})
-          </div>
-          {installed.length === 0 ? (
-            <div
-              style={{
-                fontSize: 12,
-                color: 'var(--text-tertiary)',
-                padding: '8px 12px',
-                background: 'var(--bg-grouped)',
-                borderRadius: 10,
-              }}
-            >
-              No models installed. Run <code>ollama pull &lt;name&gt;</code> in a terminal.
-            </div>
-          ) : (
-            <ModelList>
-              {installed.map((m, i) => (
-                <Row key={m.name} last={i === installed.length - 1}>
-                  <RowInfo
+          <Section title="Installed on disk" count={installed.length}>
+            <Card>
+              {installed.length === 0 ? (
+                <EmptyState
+                  compact
+                  icon="database"
+                  title="No models installed"
+                  subtitle="Run ollama pull <name> in a terminal to add one."
+                />
+              ) : (
+                installed.map((m, i) => (
+                  <Row
+                    key={m.name}
+                    last={i === installed.length - 1}
                     title={m.name}
                     subtitle={[
                       fmtBytes(m.size),
@@ -255,126 +226,119 @@ export function OllamaPanel({ baseUrl }: { baseUrl?: string }) {
                     ]
                       .filter(Boolean)
                       .join(' · ')}
+                    action={
+                      <Button
+                        size="small"
+                        disabled={busy === `delete:${m.name}`}
+                        onClick={(e) => {
+                          const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                          setConfirmDelete({ name: m.name, x: r.right, y: r.bottom + 4 });
+                        }}
+                      >
+                        {busy === `delete:${m.name}` ? 'Deleting…' : 'Delete'}
+                      </Button>
+                    }
                   />
-                  <Btn
-                    onClick={() => onDelete(m.name)}
-                    busy={busy === `delete:${m.name}`}
-                    variant="destructive"
-                  >
-                    Delete
-                  </Btn>
-                </Row>
-              ))}
-            </ModelList>
-          )}
+                ))
+              )}
+            </Card>
+          </Section>
         </>
       )}
-    </div>
-  );
-}
 
-// ── Small presentational primitives, local to this file ──
-
-function ModelList({ children }: { children: React.ReactNode }) {
-  return (
-    <div
-      style={{
-        background: 'var(--bg-grouped)',
-        borderRadius: 10,
-        boxShadow: 'var(--shadow-grouped)',
-        overflow: 'hidden',
-      }}
-    >
-      {children}
-    </div>
-  );
-}
-
-function Row({ children, last }: { children: React.ReactNode; last: boolean }) {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 10,
-        padding: '8px 12px',
-        minHeight: 36,
-        borderBottom: last ? 'none' : '1px solid var(--border-row)',
-      }}
-    >
-      {children}
-    </div>
-  );
-}
-
-function RowInfo({ title, subtitle }: { title: string; subtitle?: string }) {
-  return (
-    <div style={{ flex: 1, minWidth: 0 }}>
-      <div
-        style={{
-          fontSize: 13,
-          color: 'var(--text-primary)',
-          whiteSpace: 'nowrap',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-        }}
-      >
-        {title}
-      </div>
-      {subtitle && (
-        <div
-          style={{
-            fontSize: 11,
-            color: 'var(--text-tertiary)',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
+      {/* A blocking window.confirm() is not a macOS affordance for a row
+          action. The popover names the object it destroys, per ux-writing. */}
+      {confirmDelete && (
+        <ConfirmPopover
+          x={confirmDelete.x}
+          y={confirmDelete.y}
+          align="end"
+          danger
+          title={`Delete ${confirmDelete.name}?`}
+          body="The model is removed from disk. Pulling it again re-downloads it."
+          confirmLabel="Delete model"
+          onConfirm={() => {
+            const { name } = confirmDelete;
+            setConfirmDelete(null);
+            onDelete(name);
           }}
-        >
-          {subtitle}
-        </div>
+          onCancel={() => setConfirmDelete(null)}
+        />
       )}
     </div>
   );
 }
 
-function Btn({
+// ── Local presentation, matching the Settings surface it renders inside ──
+
+function Section({
+  title,
+  count,
   children,
-  onClick,
-  busy,
-  variant,
 }: {
+  title: string;
+  count?: number;
   children: React.ReactNode;
-  onClick: () => void;
-  busy?: boolean;
-  variant?: 'primary' | 'destructive';
 }) {
-  const color =
-    variant === 'destructive'
-      ? 'var(--destructive)'
-      : variant === 'primary'
-        ? '#fff'
-        : 'var(--text-primary)';
-  const bg = variant === 'primary' ? 'var(--accent)' : 'var(--fill-control)';
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={busy}
+    <section className="flex flex-col gap-2">
+      <h3
+        className="flex items-baseline gap-1.5 px-1 min-h-6 text-[11px] leading-[13px] font-semibold"
+        style={{ color: 'var(--label-secondary)' }}
+      >
+        {title}
+        {count !== undefined && count > 0 && <span className="tabular-nums">{count}</span>}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function Card({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="overflow-hidden"
       style={{
-        fontSize: 11,
-        fontWeight: 500,
-        padding: '4px 10px',
-        borderRadius: 6,
-        background: bg,
-        color,
-        border: '0.5px solid var(--border)',
-        cursor: busy ? 'default' : 'pointer',
-        opacity: busy ? 0.5 : 1,
-        flexShrink: 0,
+        background: 'var(--surface)',
+        borderRadius: 12,
+        border: '0.5px solid var(--separator)',
       }}
     >
-      {busy ? '…' : children}
-    </button>
+      {children}
+    </div>
+  );
+}
+
+function Row({
+  title,
+  subtitle,
+  action,
+  last,
+}: {
+  title: string;
+  subtitle?: string;
+  action: React.ReactNode;
+  last: boolean;
+}) {
+  return (
+    <div
+      className="flex items-center gap-2.5 px-3"
+      style={{ minHeight: 44, borderBottom: last ? 'none' : '0.5px solid var(--separator)' }}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="text-[13px] leading-4 truncate" style={{ color: 'var(--label)' }}>
+          {title}
+        </div>
+        {subtitle && (
+          <div
+            className="text-[11px] leading-[13px] truncate"
+            style={{ color: 'var(--label-secondary)' }}
+          >
+            {subtitle}
+          </div>
+        )}
+      </div>
+      {action}
+    </div>
   );
 }

--- a/packages/app/src/renderer/components/__tests__/GuardOnboarding.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/GuardOnboarding.test.tsx
@@ -33,7 +33,7 @@ it('renders nothing while detection is still in flight', () => {
   expect(container.innerHTML).toBe('');
 });
 
-it('closes silently without a dialog when Claude Code is not installed', async () => {
+it('closes silently without a sheet when Claude Code is not installed', async () => {
   stubGuard({
     checkCliVersion: { current: '1.51.1', required: '1.51.0' },
     installStatus: { installed: false, claudeDetected: false },
@@ -46,17 +46,20 @@ it('closes silently without a dialog when Claude Code is not installed', async (
   expect(isOnboardingDone()).toBe(true);
 });
 
-it('exposes the panel as a labelled modal dialog and focuses its primary action', async () => {
+it('exposes the panel as a labelled modal sheet and focuses its primary action', async () => {
   stubGuard({ checkCliVersion: { notInstalled: true } });
   render(<GuardOnboarding onClose={() => {}} />);
 
   const dialog = await screen.findByRole('dialog');
   expect(dialog.getAttribute('aria-modal')).toBe('true');
+  expect(dialog.className).toContain('lx-sheet');
   const labelId = dialog.getAttribute('aria-labelledby');
   expect(labelId).toBeTruthy();
-  expect(document.getElementById(labelId as string)?.textContent).toBe('Set up trace-mcp guard');
+  expect(document.getElementById(labelId as string)?.textContent).toBe(
+    'Install the trace-mcp CLI',
+  );
   await waitFor(() =>
-    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Got it' })),
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Done' })),
   );
 });
 
@@ -72,7 +75,7 @@ it('dismisses on Escape and remembers the acknowledgement', async () => {
   expect(isOnboardingDone()).toBe(true);
 });
 
-it('dismisses on backdrop click but not on a click inside the panel', async () => {
+it('dismisses on backdrop click but not on a click inside the sheet', async () => {
   stubGuard({ checkCliVersion: { notInstalled: true } });
   const onClose = vi.fn();
   render(<GuardOnboarding onClose={onClose} />);
@@ -95,8 +98,8 @@ it('does not dismiss while the hook install is in flight', async () => {
   api.guard.install = vi.fn(() => new Promise(() => {}));
   render(<GuardOnboarding onClose={onClose} />);
 
-  fireEvent.click(await screen.findByRole('button', { name: 'Install' }));
-  await screen.findByText('Installing hook…');
+  fireEvent.click(await screen.findByRole('button', { name: 'Install guard' }));
+  await screen.findByText("Writing the hook into Claude Code's settings…");
 
   fireEvent.keyDown(window, { key: 'Escape' });
   fireEvent.click(screen.getByRole('dialog').parentElement as HTMLElement);
@@ -111,7 +114,51 @@ it('uses the Lattice Button primitive for its actions', async () => {
   });
   render(<GuardOnboarding onClose={() => {}} />);
 
-  const install = await screen.findByRole('button', { name: 'Install' });
+  const install = await screen.findByRole('button', { name: 'Install guard' });
   expect(install.className).toContain('v-prominent');
-  expect(screen.getByRole('button', { name: 'Skip' }).className).toContain('v-bordered');
+  expect(screen.getByRole('button', { name: 'Not now' }).className).toContain('v-bordered');
+});
+
+/* TRA-295: `user-select: none` is set globally on body, so before this the one
+   thing the sheet exists to communicate could not be selected, let alone
+   copied. The command is a selectable field with a copy button. */
+it('renders the install command as a selectable, copyable field', async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+  stubGuard({ checkCliVersion: { notInstalled: true } });
+  render(<GuardOnboarding onClose={() => {}} />);
+
+  const code = await screen.findByText('npm install -g trace-mcp');
+  expect(code.closest('.lx-sheet-command')).not.toBeNull();
+
+  fireEvent.click(screen.getByRole('button', { name: 'Copy command' }));
+  await waitFor(() => expect(writeText).toHaveBeenCalledWith('npm install -g trace-mcp'));
+});
+
+/* A modal that leaks Tab to the Workspace behind it is a trap on the very
+   first screen of the app. */
+it('traps Tab inside the sheet', async () => {
+  stubGuard({
+    checkCliVersion: { current: '1.51.1', required: '1.51.0' },
+    installStatus: { installed: false, claudeDetected: true },
+  });
+  const outside = document.createElement('button');
+  outside.textContent = 'behind the sheet';
+  document.body.appendChild(outside);
+
+  render(<GuardOnboarding onClose={() => {}} />);
+  const dialog = await screen.findByRole('dialog');
+  const focusables = [...dialog.querySelectorAll('button')];
+  expect(focusables.length).toBeGreaterThan(1);
+
+  // Tab off the last control wraps to the first, rather than reaching `outside`.
+  focusables[focusables.length - 1].focus();
+  fireEvent.keyDown(window, { key: 'Tab' });
+  expect(document.activeElement).toBe(focusables[0]);
+
+  // Shift-Tab off the first wraps to the last.
+  fireEvent.keyDown(window, { key: 'Tab', shiftKey: true });
+  expect(document.activeElement).toBe(focusables[focusables.length - 1]);
+
+  outside.remove();
 });

--- a/packages/app/src/renderer/styles/controls.css
+++ b/packages/app/src/renderer/styles/controls.css
@@ -486,14 +486,27 @@ input[type='checkbox']:disabled {
 
 /* ============================================================================
    FOCUS RING — one ring for every primitive.
+
+   The house ring from tokens.css (`--focus-ring`), not a hard `2px solid
+   accent` outline. On an accent-filled button the hard outline drew blue on
+   blue with a dark gap between them (TRA-295); the soft ring reads as a halo
+   on every variant and matches what the rest of the app already uses via the
+   `*:focus-visible` rule in app.css.
    ============================================================================ */
 .lx-btn:focus-visible,
 .lx-seg .lx-seg-item:focus-visible,
 .lx-chip:focus-visible,
 .lx-popup select:focus-visible,
 input[type='checkbox']:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+/* Variants that already carry an inset hairline keep it under the ring. */
+.lx-btn.v-bordered:focus-visible,
+.lx-chip.is-on:focus-visible {
+  box-shadow:
+    inset 0 0 0 0.5px var(--separator),
+    var(--focus-ring);
 }
 
 /* ============================================================================

--- a/packages/app/src/renderer/tabs/Clients.tsx
+++ b/packages/app/src/renderer/tabs/Clients.tsx
@@ -1,5 +1,42 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { StatusDot, type Tone } from '../lattice/ui';
+/**
+ * Clients — the menu window's "MCP clients" surface (TRA-295).
+ *
+ * Layout:
+ *   Toolbar  — 52px glass row: the screen title on the left, one icon button
+ *              (Refresh) on the right. The screen used to have neither a title
+ *              nor a toolbar, and each section carried its own unlabelled 18px
+ *              refresh glyph in its top-right corner.
+ *   Content  — two inset grouped lists capped at a readable measure:
+ *              Supported clients · Active sessions.
+ *
+ * What this replaces, measured on the running app before the rewrite:
+ *   - Ten accent-filled `Connect` buttons stacked vertically — a wall of blue
+ *     far past the ~5% accent budget. Every row action is a bordered button
+ *     now, and NOTHING on this screen is prominent.
+ *   - Rows floating on the bare frame: a leading grey dot, a 12px name, ~1000px
+ *     of dead width, then the button. They are 44px rows of one grouped list.
+ *   - A leading dot that was grey for every supported client and therefore
+ *     unreadable. Connection state is now a dot PLUS the word "Connected", and
+ *     a client with nothing to report carries no dot at all.
+ *   - `Manual` as a right-aligned grey word for JetBrains AI Assistant and
+ *     Warp — an undocumented convention. It is a "Set up manually…" button that
+ *     discloses the actual steps.
+ *   - `401b97c5 http` as a session's primary label: a raw id where the name
+ *     goes. The project leads, the id is a monospace caption.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Badge,
+  Button,
+  EmptyState,
+  Menu,
+  MenuItem,
+  MenuSection,
+  StatusDot,
+  useMenuAnchor,
+  type Tone,
+} from '../lattice/ui';
+import { Skeleton } from '../workspace/components/Skeleton';
 import { type ClientInfo, useDaemon } from '../hooks/useDaemon';
 
 // ── All supported MCP clients (same order as CLI init) ────────────
@@ -40,7 +77,7 @@ const MANUAL_CLIENTS = new Set<ClientName>(['jetbrains-ai', 'warp']);
 
 const MANUAL_HINTS: Partial<Record<ClientName, string>> = {
   'jetbrains-ai': 'Settings → Tools → AI Assistant → MCP → Add → Command: trace-mcp, Args: serve',
-  warp: 'Settings → Agents → MCP servers → + Add → paste { mcpServers: { "trace-mcp": ... } }',
+  warp: 'Settings → Agents → MCP servers → + Add → paste { mcpServers: { "trace-mcp": … } }',
 };
 
 interface DetectedClient {
@@ -58,69 +95,16 @@ interface RichClientStatus {
   staleReason?: string;
 }
 
-// ── Enforcement level popover ─────────────────────────────────────
+// ── Enforcement levels ────────────────────────────────────────────
 type EnforcementLevel = 'base' | 'standard' | 'max';
 
 const LEVELS: { value: EnforcementLevel; label: string; hint: string }[] = [
   { value: 'base', label: 'Base', hint: 'CLAUDE.md only — soft routing rules' },
-  { value: 'standard', label: 'Standard', hint: 'CLAUDE.md + hooks' },
-  { value: 'max', label: 'Max', hint: 'CLAUDE.md + hooks + tweakcc (recommended)' },
+  { value: 'standard', label: 'Standard', hint: 'CLAUDE.md and hooks' },
+  { value: 'max', label: 'Max', hint: 'CLAUDE.md, hooks and tweakcc — recommended' },
 ];
 
-function LevelPopover({
-  onSelect,
-  onClose,
-}: {
-  onSelect: (level: EnforcementLevel) => void;
-  onClose: () => void;
-}) {
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [onClose]);
-
-  return (
-    <div
-      ref={ref}
-      className="absolute right-0 top-full mt-1 z-50 rounded-lg overflow-hidden"
-      style={{
-        background: 'var(--bg-secondary)',
-        border: '1px solid var(--border)',
-        boxShadow: '0 4px 16px rgba(0,0,0,0.3)',
-        minWidth: 220,
-      }}
-    >
-      {LEVELS.map((l, i) => (
-        <button
-          type="button"
-          key={l.value}
-          onClick={() => onSelect(l.value)}
-          className="w-full text-left px-3 py-2 transition-colors hover:brightness-110"
-          style={{
-            background: l.value === 'max' ? 'var(--bg-active)' : 'transparent',
-            borderBottom: i < LEVELS.length - 1 ? '0.5px solid var(--border)' : 'none',
-          }}
-        >
-          <div className="text-xs font-medium" style={{ color: 'var(--text-primary)' }}>
-            {l.label}
-          </div>
-          <div className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-            {l.hint}
-          </div>
-        </button>
-      ))}
-    </div>
-  );
-}
-
-// ── Connected-client helpers ──────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────────────
 function clientStatus(client: ClientInfo): Tone {
   const elapsed = Date.now() - new Date(client.lastSeen).getTime();
   if (elapsed < 30_000) return 'green';
@@ -142,42 +126,114 @@ const CLIENT_LABELS: Record<string, string> = Object.fromEntries(
   ALL_CLIENTS.map((c) => [c.name, c.label]),
 );
 
-function clientDisplayName(client: ClientInfo): string {
+/** The row's primary label: the project being worked on, then the client that
+    is working on it. The session id is neither, so it is never the headline. */
+function sessionTitle(client: ClientInfo): string {
+  if (client.project) return client.project.split(/[/\\]/).filter(Boolean).pop() ?? client.project;
   if (client.name) return CLIENT_LABELS[client.name] ?? client.name;
-  return client.id.slice(0, 8);
+  return 'Unnamed session';
+}
+
+function shortPath(p: string): string {
+  return p.replace(/^\/Users\/[^/]+/, '~').replace(/^\/home\/[^/]+/, '~');
+}
+
+// ── Section scaffolding (same idiom as Project Overview) ──────────
+
+/** A titled group. Grouping is whitespace and a caption, never a rule. */
+function Section({
+  title,
+  count,
+  children,
+}: {
+  title: string;
+  count?: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-2">
+      <h3
+        className="flex items-baseline gap-1.5 px-1 min-h-6 text-[11px] leading-[13px] font-semibold"
+        style={{ color: 'var(--label-secondary)' }}
+      >
+        {title}
+        {count !== undefined && count > 0 && <span className="tabular-nums">{count}</span>}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+/** Inset grouped-list container. Content, so: opaque, hairline, no shadow. */
+function Card({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="overflow-hidden"
+      style={{
+        background: 'var(--surface)',
+        borderRadius: 12,
+        border: '0.5px solid var(--separator)',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Rows at the real 44px geometry so nothing moves when the data lands. */
+function SkeletonRows({ rows, label }: { rows: number; label: string }) {
+  return (
+    <div role="status" aria-label={label}>
+      {Array.from({ length: rows }, (_, i) => (
+        <div
+          key={i}
+          className="flex items-center justify-between px-3"
+          style={{
+            height: 44,
+            borderBottom: i === rows - 1 ? 'none' : '0.5px solid var(--separator)',
+          }}
+        >
+          <Skeleton width={96 + ((i * 31) % 56)} height={11} />
+          <Skeleton width={64} height={11} />
+        </div>
+      ))}
+    </div>
+  );
 }
 
 // ── Row for a connected session ───────────────────────────────────
-function ConnectedClientRow({ client }: { client: ClientInfo }) {
-  const status = clientStatus(client);
+function ConnectedClientRow({ client, last }: { client: ClientInfo; last: boolean }) {
+  const tone = clientStatus(client);
+  const state = tone === 'green' ? 'Active' : tone === 'orange' ? 'Idle' : 'Stale';
 
   return (
     <div
-      className="flex items-center gap-2 px-2 py-1.5 rounded-md"
-      style={{ background: 'var(--bg-secondary)' }}
+      className="flex items-center gap-2.5 px-3"
+      style={{ height: 44, borderBottom: last ? 'none' : '0.5px solid var(--separator)' }}
     >
-      <StatusDot tone={status} pulse={status === 'green'} />
+      <StatusDot tone={tone} pulse={tone === 'green'} title={state} />
       <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-1.5">
-          <span className="text-xs font-medium truncate" style={{ color: 'var(--text-primary)' }}>
-            {clientDisplayName(client)}
-          </span>
-          <span className="text-[10px] shrink-0" style={{ color: 'var(--text-tertiary)' }}>
-            {client.transport}
-          </span>
+        <div
+          className="text-[13px] leading-4 truncate"
+          style={{ color: 'var(--label)' }}
+          title={client.project ?? undefined}
+        >
+          {sessionTitle(client)}
         </div>
-        {client.project && (
-          <div
-            className="text-[10px] truncate"
-            style={{ color: 'var(--text-secondary)' }}
-            title={client.project}
-          >
-            {client.project.split(/[/\\]/).filter(Boolean).pop()}
-          </div>
-        )}
+        <div
+          className="text-[11px] leading-[13px] truncate"
+          style={{ color: 'var(--label-secondary)', fontFamily: 'var(--font-mono)' }}
+        >
+          {client.id.slice(0, 8)} · {client.transport}
+        </div>
       </div>
-      <span className="text-[10px] shrink-0" style={{ color: 'var(--text-tertiary)' }}>
-        {timeAgo(client.lastSeen)}
+      {/* The dot's colour is never the only carrier of the state — the word is
+          right next to it, and the timestamp is tabular so the column lines up. */}
+      <span
+        className="text-[11px] leading-[13px] shrink-0"
+        style={{ color: 'var(--label-secondary)' }}
+      >
+        {state} · <span className="tabular-nums">{timeAgo(client.lastSeen)}</span>
       </span>
     </div>
   );
@@ -191,6 +247,7 @@ function SupportedClientRow({
   configPath,
   staleReason,
   configuring,
+  last,
   onConnect,
   onConnectWithLevel,
 }: {
@@ -198,136 +255,132 @@ function SupportedClientRow({
   label: string;
   /**
    * Drives the right-hand control:
-   *   missing       → "Connect" / level popover
-   *   up_to_date    → "Configured"
-   *   stale         → "Update" (rewrites the entry to current expectations)
-   *   unmanageable  → "Manual"
-   *   unknown       → "Configured" (presence-only — Codex TOML, can't compare safely)
+   *   missing       → "Connect" (level menu for the Claude family)
+   *   up_to_date    → a green dot + the word "Connected"
+   *   stale         → "Update available" badge + "Update"
+   *   unmanageable  → "Set up manually…", which discloses the steps
+   *   unknown       → "Connected" (presence-only — Codex TOML, can't compare)
    */
   status: ClientConfigStatus;
   configPath?: string | null;
   staleReason?: string;
   configuring: boolean;
+  last: boolean;
   onConnect: () => void;
   onConnectWithLevel: (level: EnforcementLevel) => void;
 }) {
-  const isManual = MANUAL_CLIENTS.has(name);
-  const hasClaude = CLAUDE_CLIENTS.has(name);
-  const [showLevels, setShowLevels] = useState(false);
+  const isManual = MANUAL_CLIENTS.has(name) || status === 'unmanageable';
+  const hasLevels = CLAUDE_CLIENTS.has(name);
+  const levelMenu = useMenuAnchor();
+  const [showSteps, setShowSteps] = useState(false);
 
+  const connected = status === 'up_to_date' || status === 'unknown';
   const handleConnect = () => {
-    if (hasClaude) {
-      setShowLevels(true);
-    } else {
-      onConnect();
-    }
+    if (hasLevels) levelMenu.open();
+    else onConnect();
   };
 
-  const isPresent = status === 'up_to_date' || status === 'unknown';
-  const dotColor =
-    status === 'up_to_date' || status === 'unknown'
-      ? '#34c759' // green: integration is healthy
-      : status === 'stale'
-        ? '#ff9500' // amber: present but drifted — update available
-        : 'var(--text-tertiary)'; // gray: missing or unmanageable
+  /* One caption slot, and only when there is something to say: where the entry
+     lives, or the manual steps the user asked to see. */
+  const caption =
+    isManual && showSteps
+      ? MANUAL_HINTS[name]
+      : (connected || status === 'stale') && configPath
+        ? shortPath(configPath)
+        : null;
 
   return (
     <div
-      className="flex items-center gap-2 px-2 py-1.5 rounded-md relative"
-      style={{ background: 'var(--bg-secondary)' }}
+      className="flex items-center gap-2.5 px-3"
+      style={{
+        minHeight: 44,
+        paddingTop: caption ? 8 : 0,
+        paddingBottom: caption ? 8 : 0,
+        borderBottom: last ? 'none' : '0.5px solid var(--separator)',
+      }}
     >
-      <div
-        className="w-1.5 h-1.5 rounded-full shrink-0"
-        style={{
-          background: dotColor,
-          opacity: isPresent || status === 'stale' ? 1 : 0.4,
-        }}
-      />
       <div className="flex-1 min-w-0">
-        <span
-          className="text-xs font-medium"
-          style={{
-            color: isPresent || status === 'stale' ? 'var(--text-primary)' : 'var(--text-secondary)',
-          }}
-        >
+        <div className="text-[13px] leading-4 truncate" style={{ color: 'var(--label)' }}>
           {label}
-        </span>
-        {(isPresent || status === 'stale') && configPath && (
-          <div className="text-[10px] truncate" style={{ color: 'var(--text-tertiary)' }}>
-            {configPath.replace(/^\/Users\/[^/]+/, '~')}
-            {status === 'stale' && staleReason && (
-              <span style={{ color: '#ff9500' }}> · drift: {staleReason}</span>
-            )}
-          </div>
-        )}
-        {status === 'missing' && isManual && MANUAL_HINTS[name] && (
-          <div className="text-[10px] truncate" style={{ color: 'var(--text-tertiary)' }}>
-            {MANUAL_HINTS[name]}
+        </div>
+        {caption && (
+          <div
+            className="text-[11px] leading-[13px] truncate"
+            style={{ color: 'var(--label-secondary)' }}
+            title={caption}
+          >
+            {caption}
           </div>
         )}
       </div>
-      {status === 'up_to_date' || status === 'unknown' ? (
-        <span className="text-[10px] shrink-0 font-medium" style={{ color: '#34c759' }}>
-          Configured
-        </span>
-      ) : status === 'unmanageable' || isManual ? (
-        <span className="text-[10px] shrink-0" style={{ color: 'var(--text-tertiary)' }}>
-          Manual
+
+      {connected ? (
+        /* Colour alone never carries the state: the dot is paired with the word. */
+        <span
+          className="flex items-center gap-1.5 text-[13px] leading-4 shrink-0"
+          style={{ color: 'var(--label-secondary)' }}
+        >
+          <StatusDot tone="green" />
+          Connected
         </span>
       ) : status === 'stale' ? (
-        <button
-          type="button"
-          onClick={handleConnect}
-          disabled={configuring}
-          title={staleReason ? `Drifted field: ${staleReason}` : 'Refresh trace-mcp config'}
-          className="text-[10px] px-2 py-0.5 rounded font-medium transition-colors shrink-0"
-          style={{
-            background: '#ff9500',
-            color: '#fff',
-            opacity: configuring ? 0.6 : 1,
-            cursor: configuring ? 'default' : 'pointer',
-          }}
-        >
-          {configuring ? 'Updating…' : 'Update'}
-        </button>
-      ) : (
         <>
-          <button
-            type="button"
-            onClick={handleConnect}
-            disabled={configuring}
-            className="text-[10px] px-2 py-0.5 rounded font-medium transition-colors shrink-0"
-            style={{
-              background: 'var(--accent)',
-              color: '#fff',
-              opacity: configuring ? 0.6 : 1,
-              cursor: configuring ? 'default' : 'pointer',
-            }}
-          >
-            {configuring ? 'Connecting…' : 'Connect'}
-          </button>
-          {showLevels && (
-            <LevelPopover
-              onSelect={(level) => {
-                setShowLevels(false);
-                onConnectWithLevel(level);
-              }}
-              onClose={() => setShowLevels(false)}
-            />
-          )}
+          <Badge tone="orange" title={staleReason ? `Drifted field: ${staleReason}` : undefined}>
+            Update available
+          </Badge>
+          <Button disabled={configuring} onClick={handleConnect}>
+            {configuring ? 'Updating…' : 'Update'}
+          </Button>
         </>
+      ) : isManual ? (
+        <Button
+          active={showSteps}
+          aria-expanded={showSteps}
+          onClick={() => setShowSteps((v) => !v)}
+        >
+          {showSteps ? 'Hide steps' : 'Set up manually…'}
+        </Button>
+      ) : (
+        <Button
+          ref={levelMenu.ref}
+          disabled={configuring}
+          aria-haspopup={hasLevels ? 'menu' : undefined}
+          aria-expanded={hasLevels ? levelMenu.at !== null : undefined}
+          onClick={handleConnect}
+        >
+          {configuring ? 'Connecting…' : 'Connect'}
+        </Button>
+      )}
+
+      {levelMenu.at && (
+        <Menu x={levelMenu.at.x} y={levelMenu.at.y} align="end" onClose={levelMenu.close}>
+          <MenuSection>Enforcement level</MenuSection>
+          {LEVELS.map((l) => (
+            <MenuItem
+              key={l.value}
+              title={l.hint}
+              onClick={() => {
+                levelMenu.close();
+                onConnectWithLevel(l.value);
+              }}
+            >
+              {l.label}
+            </MenuItem>
+          ))}
+        </Menu>
       )}
     </div>
   );
 }
 
-// ── Main component ────────────────────────────────────────────────
+// ── Surface ───────────────────────────────────────────────────────
 export function Clients() {
   const { clients, loading, connected, restarting, restartDaemon, fetchClients } = useDaemon();
   const [detected, setDetected] = useState<DetectedClient[]>([]);
   const [statuses, setStatuses] = useState<RichClientStatus[]>([]);
   const [detecting, setDetecting] = useState(true);
   const [configuringClient, setConfiguringClient] = useState<string | null>(null);
+  const [scrolled, setScrolled] = useState(false);
 
   const detectClients = useCallback(async () => {
     setDetecting(true);
@@ -378,41 +431,20 @@ export function Clients() {
     }
   };
 
-  if (!connected && !loading) {
-    return (
-      <div className="flex flex-col items-center justify-center h-full gap-2">
-        <div className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
-          Daemon not reachable
-        </div>
-        <button
-          type="button"
-          onClick={() => restartDaemon()}
-          disabled={restarting}
-          className="text-[11px] px-4 py-1.5 rounded-lg font-medium transition-all"
-          style={{
-            background: 'var(--fill-control)',
-            backdropFilter: 'blur(12px)',
-            WebkitBackdropFilter: 'blur(12px)',
-            color: 'var(--accent)',
-            border: '0.5px solid var(--border)',
-            boxShadow: 'var(--shadow-control)',
-            cursor: restarting ? 'default' : 'pointer',
-            opacity: restarting ? 0.6 : 1,
-          }}
-        >
-          {restarting ? 'Starting…' : 'Restart Daemon'}
-        </button>
-      </div>
-    );
-  }
+  const refreshAll = () => {
+    detectClients();
+    fetchClients();
+  };
+
+  /* The toolbar owns the pane and always renders — a surface that swaps its
+     whole chrome for an error panel reads as a different screen. */
+  const daemonDown = !connected && !loading;
 
   // Build configured set (client name → best config entry)
   const configuredMap = new Map<string, DetectedClient>();
   for (const d of detected) {
-    if (d.hasTraceMcp) {
-      if (!configuredMap.has(d.name)) {
-        configuredMap.set(d.name, d);
-      }
+    if (d.hasTraceMcp && !configuredMap.has(d.name)) {
+      configuredMap.set(d.name, d);
     }
   }
   const statusMap = new Map<string, RichClientStatus>();
@@ -454,122 +486,106 @@ export function Clients() {
         return 3;
     }
   };
-  const sortedClients = [...ALL_CLIENTS].sort((a, b) => {
-    const ra = sortRank(resolveStatus(a.name).status);
-    const rb = sortRank(resolveStatus(b.name).status);
-    return ra - rb;
-  });
+  const sortedClients = [...ALL_CLIENTS].sort(
+    (a, b) => sortRank(resolveStatus(a.name).status) - sortRank(resolveStatus(b.name).status),
+  );
+
+  const sessions = [...clients].sort(
+    (a, b) => new Date(b.connectedAt).getTime() - new Date(a.connectedAt).getTime(),
+  );
 
   return (
-    <div className="flex flex-col flex-1 min-h-0 gap-4">
-      {/* Section 1: Supported clients / configuration */}
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <h2 className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
-            Supported Clients
-          </h2>
-          <button
-            type="button"
-            onClick={() => detectClients()}
-            className="p-1 rounded-md transition-colors hover:opacity-80"
-            style={{ color: 'var(--text-secondary)' }}
-            title="Refresh"
-          >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 16 16"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M1.5 1.5v4h4" />
-              <path d="M1.5 5.5A6.5 6.5 0 0 1 14.5 8" />
-              <path d="M14.5 14.5v-4h-4" />
-              <path d="M14.5 10.5A6.5 6.5 0 0 1 1.5 8" />
-            </svg>
-          </button>
-        </div>
-
-        {detecting ? (
-          <div className="text-xs py-2 text-center" style={{ color: 'var(--text-tertiary)' }}>
-            Detecting clients…
-          </div>
-        ) : (
-          <div className="space-y-1">
-            {sortedClients.map((c) => {
-              const s = resolveStatus(c.name);
-              return (
-                <SupportedClientRow
-                  key={c.name}
-                  name={c.name}
-                  label={c.label}
-                  status={s.status}
-                  configPath={s.configPath}
-                  staleReason={s.staleReason}
-                  configuring={configuringClient === c.name}
-                  onConnect={() => handleConnect(c.name)}
-                  onConnectWithLevel={(level) => handleConnect(c.name, level)}
-                />
-              );
-            })}
-          </div>
-        )}
+    <div className="flex flex-col h-full min-h-0">
+      {/* ── Toolbar ──────────────────────────────────────────────────── */}
+      <div
+        className="flex items-center gap-3 px-4 shrink-0 glass"
+        style={{
+          height: 52,
+          borderBottom: '0.5px solid transparent',
+          borderBottomColor: scrolled ? 'var(--separator)' : 'transparent',
+          transition: 'border-bottom-color var(--dur-standard) var(--ease-out)',
+        }}
+      >
+        <h2
+          className="flex-1 min-w-0 text-[17px] leading-[22px] font-semibold truncate"
+          style={{ color: 'var(--label)', letterSpacing: '-0.01em' }}
+        >
+          MCP clients
+        </h2>
+        <Button
+          variant="icon"
+          icon="refresh"
+          onClick={refreshAll}
+          aria-label="Refresh clients"
+          title="Refresh clients"
+        />
       </div>
 
-      {/* Section 2: Live connected sessions */}
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <h2 className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
-            Active Sessions
-          </h2>
-          <button
-            type="button"
-            onClick={() => fetchClients()}
-            className="p-1 rounded-md transition-colors hover:opacity-80"
-            style={{ color: 'var(--text-secondary)' }}
-            title="Refresh"
-          >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 16 16"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M1.5 1.5v4h4" />
-              <path d="M1.5 5.5A6.5 6.5 0 0 1 14.5 8" />
-              <path d="M14.5 14.5v-4h-4" />
-              <path d="M14.5 10.5A6.5 6.5 0 0 1 1.5 8" />
-            </svg>
-          </button>
-        </div>
-
-        {loading ? (
-          <div className="text-xs py-2 text-center" style={{ color: 'var(--text-tertiary)' }}>
-            Loading…
-          </div>
-        ) : clients.length === 0 ? (
-          <div className="text-xs py-2 text-center" style={{ color: 'var(--text-secondary)' }}>
-            No active MCP sessions.
-            <br />
-            <span style={{ color: 'var(--text-tertiary)' }}>
-              Sessions appear when a client connects via trace-mcp serve.
-            </span>
+      {/* ── Content ──────────────────────────────────────────────────── */}
+      <div
+        className="flex-1 overflow-auto"
+        onScroll={(e) => setScrolled((e.target as HTMLElement).scrollTop > 0)}
+      >
+        {daemonDown ? (
+          <div className="flex items-center justify-center h-full">
+            <EmptyState
+              icon="cable"
+              title="Daemon not reachable"
+              subtitle="trace-mcp clients connect through the local daemon. Start it to see and configure them."
+              action={
+                <Button variant="prominent" disabled={restarting} onClick={() => restartDaemon()}>
+                  {restarting ? 'Starting…' : 'Start daemon'}
+                </Button>
+              }
+            />
           </div>
         ) : (
-          <div className="space-y-1">
-            {[...clients]
-              .sort((a, b) => new Date(b.connectedAt).getTime() - new Date(a.connectedAt).getTime())
-              .map((c) => (
-                <ConnectedClientRow key={c.id} client={c} />
-              ))}
-          </div>
+        <div className="flex flex-col gap-6 px-4 py-4 mx-auto w-full" style={{ maxWidth: 720 }}>
+          <Section title="Supported clients">
+            <Card>
+              {detecting && !statuses.length && !detected.length ? (
+                <SkeletonRows rows={6} label="Detecting clients" />
+              ) : (
+                sortedClients.map((c, i) => {
+                  const s = resolveStatus(c.name);
+                  return (
+                    <SupportedClientRow
+                      key={c.name}
+                      name={c.name}
+                      label={c.label}
+                      status={s.status}
+                      configPath={s.configPath}
+                      staleReason={s.staleReason}
+                      configuring={configuringClient === c.name}
+                      last={i === sortedClients.length - 1}
+                      onConnect={() => handleConnect(c.name)}
+                      onConnectWithLevel={(level) => handleConnect(c.name, level)}
+                    />
+                  );
+                })
+              )}
+            </Card>
+          </Section>
+
+          <Section title="Active sessions" count={sessions.length}>
+            <Card>
+              {loading && sessions.length === 0 ? (
+                <SkeletonRows rows={2} label="Loading sessions" />
+              ) : sessions.length === 0 ? (
+                <EmptyState
+                  compact
+                  icon="hub"
+                  title="No active sessions"
+                  subtitle="A session appears here when a client connects to the daemon."
+                />
+              ) : (
+                sessions.map((c, i) => (
+                  <ConnectedClientRow key={c.id} client={c} last={i === sessions.length - 1} />
+                ))
+              )}
+            </Card>
+          </Section>
+        </div>
         )}
       </div>
     </div>

--- a/packages/app/src/renderer/tabs/Settings.tsx
+++ b/packages/app/src/renderer/tabs/Settings.tsx
@@ -1,6 +1,48 @@
+/**
+ * Settings — the menu window's configuration surface (TRA-295).
+ *
+ * Layout:
+ *   Toolbar  — 52px glass row: a back button when a section is open, the screen
+ *              title, the search field, and an overflow menu that holds the
+ *              raw-config escape hatch. Nothing here is accent-filled.
+ *   Content  — inset grouped lists capped at a readable measure, each group
+ *              under an 11px caption.
+ *   Bottom   — the unsaved-changes bar, scoped to this pane rather than fixed
+ *              across the whole window (it used to run under the sidebar too).
+ *
+ * What this replaces, measured on the running app before the rewrite:
+ *   - Seven unlabelled groups. macOS settings groups carry titles; these now do.
+ *   - `Edit JSON` as the single most prominent control on the screen — an
+ *     accent-filled button for a raw-config escape hatch. It is a menu item.
+ *   - A 7px blue dot as the only signal that a section differs from its
+ *     defaults, with no legend anywhere. It is the word "Modified".
+ *   - `PID 64806 · Port 3741 · 22s` as the daemon card's headline. The state
+ *     leads; the PID moved behind "Copy daemon details".
+ *   - Title Case section names (`Quality Gates`, `Ignore Rules`, `Tool
+ *     Exposure`, `Per-project Overrides`) — sentence case throughout now.
+ *   - A 928px-wide, 28px-tall, 7px-radius grey search rectangle — the
+ *     SearchField primitive, in the toolbar where a search field belongs.
+ *   - A `?` tooltip glyph that was a 14px non-focusable span: field help is a
+ *     caption under the label, readable without a hover.
+ *   - The `lsp` section, which existed in the schema and was silently dropped
+ *     because it belonged to no group and groups are what the list renders.
+ */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { OllamaPanel } from '../components/OllamaPanel';
-import { PopUpButton, StatusDot } from '../lattice/ui';
+import { Icon } from '../lattice/icons';
+import {
+  Badge,
+  Button,
+  Chip,
+  EmptyState,
+  Menu,
+  MenuItem,
+  MenuSeparator,
+  PopUpButton,
+  SearchField,
+  StatusDot,
+  useMenuAnchor,
+} from '../lattice/ui';
 import { useDaemon } from '../hooks/useDaemon';
 import { type Appearance, APPEARANCE_OPTIONS } from '../theme.js';
 import {
@@ -66,26 +108,64 @@ function fmt(v: unknown): string {
   return String(v);
 }
 
-/* No icon library — clean list like macOS (without icons looks better than fake icons) */
-
-/* Section groups — semantic grouping like macOS System Settings */
-const SECTION_GROUPS: string[][] = [
-  ['_root'], // General (alone)
-  ['ai', 'predictive', 'intent'], // Intelligence
-  ['security', 'quality_gates', 'ignore'], // Quality & Security
-  ['runtime', 'topology'], // Infrastructure
-  ['tools', 'frameworks'], // Development
-  ['logging', 'watch'], // Monitoring
+/* Groups carry titles — macOS System Settings has no unlabelled group, and
+   seven of them in a row read as one undifferentiated list. `lsp` is in
+   Infrastructure: a section that belongs to no group never renders at all. */
+const SECTION_GROUPS: { title: string; keys: string[] }[] = [
+  { title: 'General', keys: ['_root'] },
+  { title: 'Intelligence', keys: ['ai', 'predictive', 'intent'] },
+  { title: 'Quality and security', keys: ['security', 'quality_gates', 'ignore'] },
+  { title: 'Infrastructure', keys: ['runtime', 'topology', 'lsp'] },
+  { title: 'Development', keys: ['tools', 'frameworks'] },
+  { title: 'Monitoring', keys: ['logging', 'watch'] },
 ];
 
-/* ═══ Toggle (38×22) ══════════════════════════════════════════════════ */
+/* ═══ Layout primitives ═══════════════════════════════════════════════
+   The same three shapes the other migrated surfaces use: a captioned Section,
+   an opaque Card with hairline separators, and 36px rows. */
 
-function Toggle({ on, onChange }: { on: boolean; onChange: (v: boolean) => void }) {
+function Section({ title, children }: { title?: string; children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-2">
+      {title && (
+        <h3
+          className="px-1 min-h-6 flex items-center text-[11px] leading-[13px] font-semibold"
+          style={{ color: 'var(--label-secondary)' }}
+        >
+          {title}
+        </h3>
+      )}
+      {children}
+    </section>
+  );
+}
+
+function Card({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="overflow-hidden"
+      style={{
+        background: 'var(--surface)',
+        borderRadius: 12,
+        border: '0.5px solid var(--separator)',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+const rowBorder = (last: boolean): string => (last ? 'none' : '0.5px solid var(--separator)');
+
+/* ═══ Toggle (38×22 — the AppKit switch size) ═════════════════════════ */
+
+function Toggle({ on, onChange, label }: { on: boolean; onChange: (v: boolean) => void; label: string }) {
   return (
     <button
       type="button"
       role="switch"
       aria-checked={on}
+      aria-label={label}
       onClick={() => onChange(!on)}
       style={{
         position: 'relative',
@@ -93,10 +173,10 @@ function Toggle({ on, onChange }: { on: boolean; onChange: (v: boolean) => void 
         height: 22,
         borderRadius: 11,
         padding: 0,
-        background: on ? 'var(--accent)' : 'var(--fill-toggle-off)',
+        background: on ? 'var(--accent-fill)' : 'var(--fill-tertiary)',
         border: 'none',
-        cursor: 'pointer',
-        transition: 'background .2s ease',
+        cursor: 'default',
+        transition: 'background var(--dur-standard) var(--ease-out)',
         flexShrink: 0,
       }}
     >
@@ -108,138 +188,38 @@ function Toggle({ on, onChange }: { on: boolean; onChange: (v: boolean) => void 
           height: 18,
           borderRadius: 9,
           left: on ? 18 : 2,
-          background: '#fff',
-          boxShadow: '0 1px 2px rgba(0,0,0,.2), 0 0 0 .5px rgba(0,0,0,.04)',
-          transition: 'left .2s cubic-bezier(.4,0,.2,1)',
+          /* The AppKit switch knob is white in BOTH appearances, so this is the
+             one place --accent-contrast is right regardless of the track. */
+          background: 'var(--accent-contrast)',
+          boxShadow: '0 1px 2px rgb(0 0 0 / 0.2), 0 0 0 0.5px rgb(0 0 0 / 0.04)',
+          transition: 'left var(--dur-standard) var(--ease-out)',
         }}
       />
     </button>
-  );
-}
-
-/* ═══ Back button ════════════════════════════════════════════════════ */
-
-function BackButton({ label, onClick }: { label: string; onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 3,
-        fontSize: 13,
-        color: 'var(--accent)',
-        background: 'none',
-        border: 'none',
-        cursor: 'pointer',
-        padding: '0 0 10px',
-        margin: 0,
-      }}
-    >
-      <svg width="7" height="12" viewBox="0 0 7 12" fill="none">
-        <path
-          d="M6 1L1 6L6 11"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-      {label}
-    </button>
-  );
-}
-
-/* ═══ Tooltip ═══════════════════════════════════════════════════════ */
-
-function Tooltip({ text }: { text: string }) {
-  const [show, setShow] = useState(false);
-  const ref = useRef<HTMLSpanElement>(null);
-  return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: tooltip wrapper has no click — onMouseEnter/Leave only show the tooltip; keyboard users get parity via onFocus/onBlur on the inner ⓘ icon.
-    <span
-      ref={ref}
-      style={{ position: 'relative', display: 'inline-flex' }}
-      onMouseEnter={() => setShow(true)}
-      onMouseLeave={() => setShow(false)}
-      onFocus={() => setShow(true)}
-      onBlur={() => setShow(false)}
-    >
-      <span
-        style={{
-          fontSize: 10,
-          color: 'var(--text-tertiary)',
-          width: 14,
-          height: 14,
-          borderRadius: 7,
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          background: 'var(--bg-inset)',
-          cursor: 'help',
-          flexShrink: 0,
-          fontWeight: 600,
-        }}
-      >
-        ?
-      </span>
-      {show && (
-        <span
-          style={{
-            position: 'absolute',
-            bottom: '100%',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            marginBottom: 6,
-            padding: '6px 10px',
-            borderRadius: 6,
-            background: 'var(--bg-popover, #1a1a1a)',
-            color: 'var(--text-popover, #e0e0e0)',
-            fontSize: 11,
-            lineHeight: '15px',
-            whiteSpace: 'normal',
-            width: 220,
-            boxShadow: '0 4px 12px rgba(0,0,0,.3), 0 0 0 .5px rgba(255,255,255,.08)',
-            zIndex: 100,
-            pointerEvents: 'none',
-          }}
-        >
-          {text}
-        </span>
-      )}
-    </span>
   );
 }
 
 /* ═══ Right chevron ══════════════════════════════════════════════════ */
-
+/* Decoration next to a labelled row, so --label-tertiary is correct here. */
 function ChevronRight() {
   return (
-    <svg width="7" height="12" viewBox="0 0 7 12" fill="none" style={{ flexShrink: 0 }}>
-      <path
-        d="M1 1L6 6L1 11"
-        stroke="var(--text-tertiary)"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
+    <span style={{ display: 'flex', color: 'var(--label-tertiary)', flexShrink: 0 }}>
+      <Icon name="chevron_right" size={14} />
+    </span>
   );
 }
 
-/* ═══ Grouped row ════════════════════════════════════════════════════ */
+/* ═══ Field controls ═════════════════════════════════════════════════ */
 
 const inputBase: React.CSSProperties = {
   fontSize: 13,
   fontFamily: 'inherit',
-  height: 22,
-  padding: '0 6px',
-  borderRadius: 5,
-  border: '1px solid var(--border)',
-  background: 'var(--fill-control)',
-  color: 'var(--text-primary)',
-  boxShadow: 'var(--shadow-control)',
+  height: 24,
+  padding: '0 8px',
+  borderRadius: 'var(--radius-input)',
+  border: '0.5px solid var(--separator)',
+  background: 'var(--fill-quaternary)',
+  color: 'var(--label)',
 };
 
 function FieldControl({
@@ -256,32 +236,40 @@ function FieldControl({
   sectionData?: Record<string, unknown>;
 }) {
   const err = validateField(field, value);
-  const errS = err ? { borderColor: 'var(--destructive)' } : {};
+  const errS = err ? { borderColor: 'var(--status-red)' } : {};
   const hint = err ? (
-    <div style={{ fontSize: 11, color: 'var(--destructive)', marginTop: 2 }}>{err}</div>
+    <div
+      className="text-[11px] leading-[13px] mt-1"
+      style={{ color: 'var(--status-red)' }}
+      role="alert"
+    >
+      {err}
+    </div>
   ) : null;
 
   switch (field.type) {
     case 'boolean':
-      return <Toggle on={!!value} onChange={(v) => onChange(v)} />;
+      return <Toggle on={!!value} onChange={(v) => onChange(v)} label={field.label} />;
     case 'select':
       return (
         <button
           type="button"
           onClick={onOpenPicker}
+          aria-label={`${field.label}: ${(value as string) || 'not set'}`}
           style={{
             display: 'flex',
             alignItems: 'center',
             gap: 4,
+            minHeight: 24,
             background: 'none',
             border: 'none',
-            cursor: 'pointer',
+            cursor: 'default',
             padding: 0,
+            fontSize: 13,
+            color: 'var(--label-secondary)',
           }}
         >
-          <span style={{ fontSize: 13, color: 'var(--text-secondary)' }}>
-            {(value as string) || '—'}
-          </span>
+          {(value as string) || 'Not set'}
           <ChevronRight />
         </button>
       );
@@ -292,6 +280,7 @@ function FieldControl({
             type="number"
             value={value != null ? String(value) : ''}
             placeholder={field.placeholder}
+            aria-label={field.label}
             min={field.min}
             max={field.max}
             onChange={(e) => {
@@ -310,6 +299,7 @@ function FieldControl({
             type={field.sensitive ? 'password' : 'text'}
             value={(value as string) ?? ''}
             placeholder={field.placeholder}
+            aria-label={field.label}
             onChange={(e) => onChange(e.target.value || undefined)}
             style={{ ...inputBase, ...errS, width: '100%', textAlign: 'right' }}
           />
@@ -331,12 +321,13 @@ function FieldControl({
       return (
         <ArrayCtrl
           value={value as string[] | undefined}
+          label={field.label}
           placeholder={field.placeholder}
           onChange={onChange}
         />
       );
     case 'json':
-      return <JsonCtrl value={value} placeholder={field.description} onChange={onChange} />;
+      return <JsonCtrl value={value} label={field.label} onChange={onChange} />;
     default:
       return null;
   }
@@ -344,10 +335,12 @@ function FieldControl({
 
 function ArrayCtrl({
   value,
+  label,
   placeholder,
   onChange,
 }: {
   value: string[] | undefined;
+  label: string;
   placeholder?: string;
   onChange: (v: unknown) => void;
 }) {
@@ -357,6 +350,7 @@ function ArrayCtrl({
       type="text"
       value={text}
       placeholder={placeholder}
+      aria-label={label}
       onChange={(e) => setText(e.target.value)}
       onBlur={() => {
         const items = text
@@ -365,18 +359,18 @@ function ArrayCtrl({
           .filter(Boolean);
         onChange(items.length ? items : undefined);
       }}
-      style={{ ...inputBase, width: '100%', textAlign: 'left', height: 24 }}
+      style={{ ...inputBase, width: '100%', textAlign: 'left' }}
     />
   );
 }
 
 function JsonCtrl({
   value,
-  placeholder,
+  label,
   onChange,
 }: {
   value: unknown;
-  placeholder?: string;
+  label: string;
   onChange: (v: unknown) => void;
 }) {
   const [text, setText] = useState(() => (value != null ? JSON.stringify(value, null, 2) : ''));
@@ -385,7 +379,7 @@ function JsonCtrl({
     <div style={{ width: '100%' }}>
       <textarea
         value={text}
-        placeholder={placeholder}
+        aria-label={label}
         rows={3}
         onChange={(e) => {
           setText(e.target.value);
@@ -406,25 +400,30 @@ function JsonCtrl({
         }}
         style={{
           fontSize: 12,
-          fontFamily: 'SF Mono, Menlo, monospace',
+          fontFamily: 'var(--font-mono)',
           width: '100%',
-          padding: 6,
-          borderRadius: 5,
+          padding: 8,
+          borderRadius: 'var(--radius-input)',
           resize: 'vertical',
-          border: `1px solid ${error ? 'var(--destructive)' : 'var(--border)'}`,
-          background: 'var(--fill-control)',
-          color: 'var(--text-primary)',
-          boxShadow: 'var(--shadow-control)',
+          border: `0.5px solid ${error ? 'var(--status-red)' : 'var(--separator)'}`,
+          background: 'var(--fill-quaternary)',
+          color: 'var(--label)',
         }}
       />
       {error && (
-        <div style={{ fontSize: 11, color: 'var(--destructive)', marginTop: 2 }}>Invalid JSON</div>
+        <div
+          className="text-[11px] leading-[13px] mt-1"
+          style={{ color: 'var(--status-red)' }}
+          role="alert"
+        >
+          Invalid JSON
+        </div>
       )}
     </div>
   );
 }
 
-/* ═══ Multiselect (checkbox list) ═══════════════════════════════════ */
+/* ═══ Multiselect ═══════════════════════════════════════════════════ */
 
 function MultiselectCtrl({
   field,
@@ -444,32 +443,10 @@ function MultiselectCtrl({
     onChange(next.size > 0 ? [...next] : undefined);
   };
   return (
-    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, padding: '4px 0' }}>
-      {options.map((opt) => {
-        const active = selected.has(opt);
-        return (
-          <button
-            key={opt}
-            type="button"
-            onClick={() => toggle(opt)}
-            style={{
-              fontSize: 11,
-              padding: '3px 8px',
-              borderRadius: 5,
-              cursor: 'pointer',
-              border: `1px solid ${active ? 'var(--accent)' : 'var(--border)'}`,
-              background: active
-                ? 'color-mix(in srgb, var(--accent) 15%, transparent)'
-                : 'var(--fill-control)',
-              color: active ? 'var(--accent)' : 'var(--text-secondary)',
-              fontWeight: active ? 600 : 400,
-              transition: 'all .15s ease',
-            }}
-          >
-            {opt}
-          </button>
-        );
-      })}
+    <div className="flex flex-wrap gap-1.5">
+      {options.map((opt) => (
+        <Chip key={opt} label={opt} selected={selected.has(opt)} onClick={() => toggle(opt)} />
+      ))}
     </div>
   );
 }
@@ -604,11 +581,9 @@ function useProviderModels(
       // ── All OpenAI-compatible providers ──
       else if (OPENAI_COMPAT_PROVIDERS.has(provider)) {
         const url = baseUrl || defaults?.baseUrl || '';
-        // LM Studio doesn't need an API key, others strip /v1 from baseUrl for fetch
-        const resolvedUrl = url.replace(/\/+$/, '');
-        // Ensure we have /v1 in the path for the models endpoint
-        const modelsUrl = resolvedUrl.endsWith('/v1') ? resolvedUrl : resolvedUrl;
-        setModels(await fetchOpenAICompatModels(modelsUrl, key, label, ctrl.signal));
+        setModels(
+          await fetchOpenAICompatModels(url.replace(/\/+$/, ''), key, label, ctrl.signal),
+        );
       }
     } catch (e) {
       const err = e as Error;
@@ -661,55 +636,50 @@ function ModelSelectCtrl({
     ? models.filter((m) => m.name.toLowerCase().includes(filter.toLowerCase()))
     : models;
 
+  const optionRow: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+    width: '100%',
+    minHeight: 28,
+    padding: '0 10px',
+    border: 'none',
+    cursor: 'default',
+    textAlign: 'left',
+    fontSize: 13,
+  };
+
   return (
     <div ref={wrapRef} style={{ position: 'relative', minWidth: 0 }}>
       <button
         type="button"
         onClick={() => setOpen(!open)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={`${field.label}: ${current || 'not set'}`}
         style={{
           display: 'flex',
           alignItems: 'center',
           gap: 4,
+          minHeight: 24,
           background: 'none',
           border: 'none',
-          cursor: 'pointer',
+          cursor: 'default',
           padding: 0,
           maxWidth: 180,
+          fontSize: 13,
+          color: 'var(--label-secondary)',
         }}
       >
-        <span
-          style={{
-            fontSize: 13,
-            color: current ? 'var(--text-secondary)' : 'var(--text-tertiary)',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {current || field.placeholder || 'Select model…'}
+        <span className="truncate">{current || field.placeholder || 'Select model…'}</span>
+        <span style={{ display: 'flex', color: 'var(--label-tertiary)', flexShrink: 0 }}>
+          <Icon name={open ? 'expand_less' : 'expand_more'} size={14} />
         </span>
-        <svg
-          width="8"
-          height="5"
-          viewBox="0 0 8 5"
-          fill="none"
-          style={{
-            flexShrink: 0,
-            transform: open ? 'rotate(180deg)' : undefined,
-            transition: 'transform .15s',
-          }}
-        >
-          <path
-            d="M1 1L4 4L7 1"
-            stroke="var(--text-tertiary)"
-            strokeWidth="1.2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
       </button>
       {open && (
         <div
+          role="listbox"
+          aria-label={field.label}
           style={{
             position: 'absolute',
             top: '100%',
@@ -718,72 +688,57 @@ function ModelSelectCtrl({
             zIndex: 200,
             width: 260,
             maxHeight: 280,
-            background: 'var(--bg-popover, var(--bg-grouped))',
-            borderRadius: 8,
-            boxShadow: '0 8px 24px rgba(0,0,0,.25), 0 0 0 .5px rgba(255,255,255,.08)',
+            background: 'var(--surface)',
+            borderRadius: 'var(--radius-popover)',
+            border: '0.5px solid var(--separator)',
+            boxShadow: 'var(--shadow-panel)',
             overflow: 'hidden',
             display: 'flex',
             flexDirection: 'column',
           }}
         >
-          {/* Search */}
-          <div style={{ padding: '6px 8px', borderBottom: '1px solid var(--border-row)' }}>
-            <input
-              type="text"
-              value={filter}
-              // biome-ignore lint/a11y/noAutofocus: search input only renders inside the model picker dropdown after the user opens it; auto-focus is the expected UX.
+          <div style={{ padding: 8, borderBottom: '0.5px solid var(--separator)' }}>
+            <SearchField
+              grow
               autoFocus
-              placeholder="Filter models…"
-              onChange={(e) => setFilter(e.target.value)}
-              style={{ ...inputBase, width: '100%', height: 26, textAlign: 'left', fontSize: 12 }}
+              value={filter}
+              onChange={setFilter}
+              placeholder="Filter models"
+              aria-label="Filter models"
             />
           </div>
-          {/* List */}
           <div style={{ flex: 1, overflowY: 'auto', maxHeight: 200 }}>
             {loading && (
               <div
-                style={{
-                  padding: '12px 10px',
-                  fontSize: 12,
-                  color: 'var(--text-tertiary)',
-                  textAlign: 'center',
-                }}
+                className="text-[13px] leading-4 text-center"
+                style={{ padding: 12, color: 'var(--label-secondary)' }}
+                role="status"
               >
                 Loading models…
               </div>
             )}
             {error && (
-              <div style={{ padding: '8px 10px', fontSize: 11 }}>
-                <div style={{ color: 'var(--destructive)', marginBottom: 4 }}>{error}</div>
-                <button
-                  type="button"
-                  onClick={refresh}
-                  style={{
-                    fontSize: 11,
-                    color: 'var(--accent)',
-                    background: 'none',
-                    border: 'none',
-                    cursor: 'pointer',
-                    padding: 0,
-                  }}
+              <div style={{ padding: 8 }}>
+                <div
+                  className="text-[11px] leading-[13px] mb-1.5"
+                  style={{ color: 'var(--status-red)' }}
+                  role="alert"
                 >
+                  {error}
+                </div>
+                <Button size="small" onClick={refresh}>
                   Retry
-                </button>
+                </Button>
               </div>
             )}
             {!loading && !error && filtered.length === 0 && (
               <div
-                style={{
-                  padding: '12px 10px',
-                  fontSize: 12,
-                  color: 'var(--text-tertiary)',
-                  textAlign: 'center',
-                }}
+                className="text-[13px] leading-4 text-center"
+                style={{ padding: 12, color: 'var(--label-secondary)' }}
               >
                 {models.length === 0 ? 'No models found' : 'No matches'}
               </div>
             )}
-            {/* Clear option */}
             {!loading && !error && current && (
               <button
                 type="button"
@@ -793,109 +748,67 @@ function ModelSelectCtrl({
                   setFilter('');
                 }}
                 style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  width: '100%',
-                  padding: '6px 10px',
+                  ...optionRow,
                   background: 'none',
-                  border: 'none',
-                  borderBottom: '1px solid var(--border-row)',
-                  cursor: 'pointer',
-                  textAlign: 'left',
+                  borderBottom: '0.5px solid var(--separator)',
+                  color: 'var(--label-secondary)',
                 }}
               >
-                <span style={{ fontSize: 12, color: 'var(--text-tertiary)', fontStyle: 'italic' }}>
-                  Clear selection
-                </span>
+                Clear selection
               </button>
             )}
             {filtered.map((m) => (
               <button
                 type="button"
                 key={m.name}
+                role="option"
+                aria-selected={m.name === current}
                 onClick={() => {
                   onChange(m.name);
                   setOpen(false);
                   setFilter('');
                 }}
                 style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 6,
-                  width: '100%',
-                  padding: '6px 10px',
+                  ...optionRow,
+                  color: 'var(--label)',
                   background:
                     m.name === current
-                      ? 'color-mix(in srgb, var(--accent) 12%, transparent)'
+                      ? 'color-mix(in oklab, var(--accent) 12%, transparent)'
                       : 'none',
-                  border: 'none',
-                  cursor: 'pointer',
-                  textAlign: 'left',
-                  borderBottom: '1px solid var(--border-row)',
                 }}
               >
-                <span
-                  style={{
-                    flex: 1,
-                    fontSize: 12,
-                    color: 'var(--text-primary)',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                  }}
-                >
-                  {m.name}
-                </span>
+                <span className="flex-1 truncate">{m.name}</span>
                 {m.size && (
-                  <span style={{ fontSize: 10, color: 'var(--text-tertiary)', flexShrink: 0 }}>
+                  <span
+                    className="text-[11px] tabular-nums shrink-0"
+                    style={{ color: 'var(--label-secondary)' }}
+                  >
                     {m.size}
                   </span>
                 )}
                 {m.name === current && (
-                  <svg
-                    width="12"
-                    height="12"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    style={{ flexShrink: 0 }}
-                  >
-                    <path
-                      d="M5 13l4 4L19 7"
-                      stroke="var(--accent)"
-                      strokeWidth="2.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
+                  <span style={{ display: 'flex', color: 'var(--accent)', flexShrink: 0 }}>
+                    <Icon name="check" size={14} />
+                  </span>
                 )}
               </button>
             ))}
           </div>
-          {/* Manual input fallback */}
-          <div
-            style={{
-              padding: '6px 8px',
-              borderTop: '1px solid var(--border-row)',
-              display: 'flex',
-              gap: 4,
-              alignItems: 'center',
-            }}
-          >
+          <div style={{ padding: 8, borderTop: '0.5px solid var(--separator)' }}>
             <input
               type="text"
-              placeholder="Or type model name…"
+              placeholder="Or type a model name…"
+              aria-label="Type a model name"
               defaultValue=""
               onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  const v = (e.target as HTMLInputElement).value.trim();
-                  if (v) {
-                    onChange(v);
-                    setOpen(false);
-                    setFilter('');
-                  }
-                }
+                if (e.key !== 'Enter') return;
+                const v = (e.target as HTMLInputElement).value.trim();
+                if (!v) return;
+                onChange(v);
+                setOpen(false);
+                setFilter('');
               }}
-              style={{ ...inputBase, flex: 1, height: 24, textAlign: 'left', fontSize: 11 }}
+              style={{ ...inputBase, width: '100%', textAlign: 'left' }}
             />
           </div>
         </div>
@@ -904,20 +817,23 @@ function ModelSelectCtrl({
   );
 }
 
-/* ═══ Screen: Section list (top level) ═══════════════════════════════ */
+/* ═══ Screen: Section list ═══════════════════════════════════════════ */
 
 function SectionList({
   sections,
   config,
   onOpen,
+  onOpenProjects,
+  projectOverrides,
   search,
 }: {
   sections: SectionDef[];
   config: Record<string, unknown>;
   onOpen: (key: string) => void;
+  onOpenProjects: () => void;
+  projectOverrides: number;
   search: string;
 }) {
-  const sectionKeys = new Set(sections.map((s) => s.key));
   const sectionMap = new Map(sections.map((s) => [s.key, s]));
 
   const renderRow = (section: SectionDef, isLast: boolean) => {
@@ -933,73 +849,98 @@ function SectionList({
         style={{
           display: 'flex',
           alignItems: 'center',
-          gap: 10,
+          gap: 8,
           width: '100%',
-          padding: '8px 12px',
+          minHeight: 36,
+          padding: '0 12px',
           background: 'none',
           border: 'none',
-          borderBottom: isLast ? 'none' : '1px solid var(--border-row)',
-          cursor: 'pointer',
+          borderBottom: rowBorder(isLast),
+          cursor: 'default',
           textAlign: 'left',
         }}
       >
-        <span style={{ flex: 1, fontSize: 13, fontWeight: 400, color: 'var(--text-primary)' }}>
+        <span className="flex-1 text-[13px] leading-4" style={{ color: 'var(--label)' }}>
           {section.label}
         </span>
-        {errors > 0 && <span style={{ fontSize: 11, color: 'var(--destructive)' }}>{errors}</span>}
-        {modified > 0 && !errors && (
-          <span
-            style={{
-              width: 7,
-              height: 7,
-              borderRadius: 4,
-              background: 'var(--accent)',
-              flexShrink: 0,
-            }}
-          />
-        )}
+        {errors > 0 ? (
+          <Badge tone="red">
+            {errors} {errors === 1 ? 'issue' : 'issues'}
+          </Badge>
+        ) : modified > 0 ? (
+          /* The blue dot this replaces was a colour with no legend anywhere in
+             the app. The word says what the colour meant. */
+          <span className="text-[11px] leading-[13px]" style={{ color: 'var(--label-secondary)' }}>
+            Modified
+          </span>
+        ) : null}
         <ChevronRight />
       </button>
     );
   };
 
-  // Build visible groups: filter each group to only include sections matching search
-  const visibleGroups = SECTION_GROUPS.map((group) =>
-    group.filter((key) => sectionKeys.has(key)).map((key) => sectionMap.get(key)!),
-  ).filter((group) => group.length > 0);
+  const visibleGroups = SECTION_GROUPS.map((g) => ({
+    title: g.title,
+    sections: g.keys.map((k) => sectionMap.get(k)).filter((s): s is SectionDef => s !== undefined),
+  })).filter((g) => g.sections.length > 0);
+
+  const showProjects = !search || 'per-project overrides'.includes(search);
+
+  if (visibleGroups.length === 0 && !showProjects) {
+    return (
+      <p
+        className="text-[13px] leading-4 text-center"
+        style={{ padding: 24, color: 'var(--label-secondary)', margin: 0 }}
+      >
+        No settings match “{search}”.
+      </p>
+    );
+  }
 
   return (
-    <div>
-      {visibleGroups.map((group, gi) => (
-        <div
-          // biome-ignore lint/suspicious/noArrayIndexKey: groups are derived from a static config slice with stable order; no insert/reorder.
-          key={gi}
-          style={{
-            background: 'var(--bg-grouped)',
-            borderRadius: 10,
-            boxShadow: 'var(--shadow-grouped)',
-            overflow: 'hidden',
-            marginBottom: 12,
-          }}
-        >
-          {group.map((s, i) => renderRow(s, i === group.length - 1))}
-        </div>
+    <>
+      {visibleGroups.map((group) => (
+        <Section key={group.title} title={group.title}>
+          <Card>{group.sections.map((s, i) => renderRow(s, i === group.sections.length - 1))}</Card>
+        </Section>
       ))}
 
-      {search && !sections.length && (
-        <p
-          style={{
-            fontSize: 13,
-            textAlign: 'center',
-            padding: 24,
-            color: 'var(--text-tertiary)',
-            margin: 0,
-          }}
-        >
-          No settings match &ldquo;{search}&rdquo;
-        </p>
+      {showProjects && (
+        <Section title="Advanced">
+          <Card>
+            <button
+              type="button"
+              onClick={onOpenProjects}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                width: '100%',
+                minHeight: 36,
+                padding: '0 12px',
+                background: 'none',
+                border: 'none',
+                cursor: 'default',
+                textAlign: 'left',
+              }}
+            >
+              <span className="flex-1 text-[13px] leading-4" style={{ color: 'var(--label)' }}>
+                Per-project overrides
+              </span>
+              {projectOverrides > 0 && (
+                <span
+                  className="text-[11px] leading-[13px] tabular-nums"
+                  style={{ color: 'var(--label-secondary)' }}
+                >
+                  {projectOverrides}
+                </span>
+              )}
+              <ChevronRight />
+            </button>
+          </Card>
+        </Section>
       )}
-    </div>
+    </>
   );
 }
 
@@ -1015,48 +956,37 @@ function SectionDetail({
   section,
   data,
   onUpdate,
-  onBack,
   onOpenPicker,
 }: {
   section: SectionDef;
   data: Record<string, unknown>;
   onUpdate: (k: string, d: Record<string, unknown>) => void;
-  onBack: () => void;
   onOpenPicker: (p: PickerInfo) => void;
 }) {
   const modified = countModifiedFields(section, data);
   const visible = section.fields.filter((f) => isFieldVisible(f, data));
 
   return (
-    <div>
-      <BackButton label="Settings" onClick={onBack} />
+    <>
+      {section.description && (
+        <p
+          className="text-[13px] leading-4 px-1 -mb-2"
+          style={{ color: 'var(--label-secondary)', margin: 0 }}
+        >
+          {section.description}
+        </p>
+      )}
 
-      {/* Header */}
-      <div style={{ marginBottom: 16 }}>
-        <div style={{ fontSize: 17, fontWeight: 700, color: 'var(--text-primary)' }}>
-          {section.label}
-        </div>
-        {section.description && (
-          <div style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 4 }}>
-            {section.description}
-          </div>
-        )}
-      </div>
-
-      {/* Fields */}
-      <div
-        style={{
-          background: 'var(--bg-grouped)',
-          borderRadius: 10,
-          boxShadow: 'var(--shadow-grouped)',
-          overflow: 'hidden',
-        }}
-      >
+      <Card>
         {visible.map((field, i) => {
           const value = gv(data, field);
           const hasDef = field.defaultValue !== undefined;
-          const isModified = hasDef && JSON.stringify(value) !== JSON.stringify(field.defaultValue);
           const isSet = value !== undefined && value !== null && value !== '';
+          /* An unset field IS at its default — the daemon applies the default
+             when the key is absent. Comparing `undefined` against the default
+             put a Reset button on almost every row (TRA-295). */
+          const isModified =
+            hasDef && isSet && JSON.stringify(value) !== JSON.stringify(field.defaultValue);
           const isBlock =
             field.type === 'json' || field.type === 'array' || field.type === 'multiselect';
           const changeFn = (v: unknown) => onUpdate(section.key, sv(data, field, v));
@@ -1066,57 +996,38 @@ function SectionDetail({
             <div
               key={`${field.nested ?? ''}.${field.key}.${field.showIf ?? ''}`}
               style={{
-                padding: '0 12px',
-                borderBottom: i < visible.length - 1 ? '1px solid var(--border-row)' : 'none',
+                padding: isBlock ? '8px 12px' : '6px 12px',
+                borderBottom: rowBorder(i === visible.length - 1),
               }}
             >
               <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                  gap: 12,
-                  minHeight: 36,
-                  padding: isBlock ? '8px 0 4px' : '0',
-                }}
+                className="flex items-center justify-between gap-3"
+                style={{ minHeight: 24 }}
               >
-                <div
-                  style={{ display: 'flex', alignItems: 'center', gap: 5, minWidth: 0, flex: 1 }}
-                >
-                  <span
-                    style={{ fontSize: 13, color: 'var(--text-primary)', whiteSpace: 'nowrap' }}
-                  >
-                    {field.nested && (
-                      <span style={{ color: 'var(--text-tertiary)' }}>{field.nested}.</span>
-                    )}
+                <div className="min-w-0 flex-1">
+                  {/* The nested key used to be printed inline at label size —
+                      "features.Use embeddings" reads as a typo, and the section
+                      the row lives in already scopes it. */}
+                  <div className="text-[13px] leading-4" style={{ color: 'var(--label)' }}>
                     {field.label}
-                  </span>
-                  {field.description && !isBlock && <Tooltip text={field.description} />}
-                </div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
-                  {showReset && (
-                    <button
-                      type="button"
-                      onClick={() => changeFn(field.defaultValue)}
-                      style={{
-                        fontSize: 11,
-                        color: 'var(--accent)',
-                        background: 'none',
-                        border: 'none',
-                        cursor: 'pointer',
-                        padding: 0,
-                        opacity: 0.7,
-                        flexShrink: 0,
-                      }}
-                      onMouseEnter={(e) => {
-                        e.currentTarget.style.opacity = '1';
-                      }}
-                      onMouseLeave={(e) => {
-                        e.currentTarget.style.opacity = '0.7';
-                      }}
+                  </div>
+                  {/* Help is a caption, not a hover: the `?` glyph it replaces
+                      was a 14px non-focusable span, so keyboard users never
+                      reached it and pointer users had to guess it existed. */}
+                  {field.description && (
+                    <div
+                      className="text-[11px] leading-[13px] mt-0.5"
+                      style={{ color: 'var(--label-secondary)' }}
                     >
+                      {field.description}
+                    </div>
+                  )}
+                </div>
+                <div className="flex items-center gap-1.5 shrink-0">
+                  {showReset && (
+                    <Button size="small" variant="plain" onClick={() => changeFn(field.defaultValue)}>
                       Reset
-                    </button>
+                    </Button>
                   )}
                   {!isBlock && (
                     <FieldControl
@@ -1134,12 +1045,7 @@ function SectionDetail({
                 </div>
               </div>
               {isBlock && (
-                <div style={{ paddingBottom: 8 }}>
-                  {field.description && (
-                    <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginBottom: 4 }}>
-                      {field.description}
-                    </div>
-                  )}
+                <div className="mt-2">
                   <FieldControl
                     field={field}
                     value={value}
@@ -1151,24 +1057,15 @@ function SectionDetail({
             </div>
           );
         })}
-      </div>
+      </Card>
 
-      {/* Reset all */}
       {modified > 0 && (
-        <div style={{ marginTop: 12, textAlign: 'center' }}>
-          <button
-            type="button"
-            onClick={() => onUpdate(section.key, getSectionDefaults(section))}
-            style={{
-              fontSize: 13,
-              color: 'var(--destructive)',
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-            }}
-          >
-            Reset All to Defaults
-          </button>
+        <div className="flex justify-center">
+          {/* Bordered, not plain: centred plain text with no chrome reads as a
+              caption, and this one throws away the section's settings. */}
+          <Button onClick={() => onUpdate(section.key, getSectionDefaults(section))}>
+            Reset this section to defaults
+          </Button>
         </div>
       )}
 
@@ -1179,108 +1076,68 @@ function SectionDetail({
       {section.key === 'ai' && data.provider === 'ollama' && (
         <OllamaPanel baseUrl={typeof data.base_url === 'string' ? data.base_url : undefined} />
       )}
-    </div>
+    </>
   );
 }
 
 /* ═══ Screen: Picker (select options) ════════════════════════════════ */
 
-function PickerScreen({
-  picker,
-  sectionLabel,
-  onBack,
-}: {
-  picker: PickerInfo;
-  sectionLabel: string;
-  onBack: () => void;
-}) {
+function PickerScreen({ picker, onBack }: { picker: PickerInfo; onBack: () => void }) {
   const options = picker.field.options ?? [];
+  const row = (isLast: boolean): React.CSSProperties => ({
+    display: 'flex',
+    alignItems: 'center',
+    width: '100%',
+    minHeight: 36,
+    padding: '0 12px',
+    background: 'none',
+    border: 'none',
+    borderBottom: rowBorder(isLast),
+    cursor: 'default',
+    textAlign: 'left',
+  });
+  const check = (
+    <span style={{ display: 'flex', color: 'var(--accent)' }}>
+      <Icon name="check" size={15} />
+    </span>
+  );
+
   return (
-    <div>
-      <BackButton label={sectionLabel} onClick={onBack} />
-      <div
-        style={{ fontSize: 15, fontWeight: 700, color: 'var(--text-primary)', marginBottom: 12 }}
-      >
-        {picker.field.label}
-      </div>
-      <div
-        style={{
-          background: 'var(--bg-grouped)',
-          borderRadius: 10,
-          boxShadow: 'var(--shadow-grouped)',
-          overflow: 'hidden',
+    <Card>
+      <button
+        type="button"
+        role="option"
+        aria-selected={picker.value == null || picker.value === ''}
+        onClick={() => {
+          picker.onChange(undefined);
+          onBack();
         }}
+        style={row(false)}
       >
-        {/* None option */}
+        <span className="flex-1 text-[13px] leading-4" style={{ color: 'var(--label-secondary)' }}>
+          Not set
+        </span>
+        {(picker.value == null || picker.value === '') && check}
+      </button>
+      {options.map((opt, i) => (
         <button
           type="button"
+          key={opt}
+          role="option"
+          aria-selected={picker.value === opt}
           onClick={() => {
-            picker.onChange(undefined);
+            picker.onChange(opt);
             onBack();
           }}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            width: '100%',
-            padding: '0 12px',
-            minHeight: 36,
-            background: 'none',
-            border: 'none',
-            borderBottom: '1px solid var(--border-row)',
-            cursor: 'pointer',
-            textAlign: 'left',
-          }}
+          style={row(i === options.length - 1)}
         >
-          <span style={{ flex: 1, fontSize: 13, color: 'var(--text-tertiary)' }}>None</span>
-          {(picker.value == null || picker.value === '') && (
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none">
-              <path
-                d="M5 13l4 4L19 7"
-                stroke="var(--accent)"
-                strokeWidth="2.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          )}
+          <span className="flex-1 text-[13px] leading-4" style={{ color: 'var(--label)' }}>
+            {opt}
+          </span>
+          {picker.value === opt && check}
         </button>
-        {options.map((opt, i) => (
-          <button
-            type="button"
-            key={opt}
-            onClick={() => {
-              picker.onChange(opt);
-              onBack();
-            }}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              width: '100%',
-              padding: '0 12px',
-              minHeight: 36,
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              textAlign: 'left',
-              borderBottom: i < options.length - 1 ? '1px solid var(--border-row)' : 'none',
-            }}
-          >
-            <span style={{ flex: 1, fontSize: 13, color: 'var(--text-primary)' }}>{opt}</span>
-            {picker.value === opt && (
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none">
-                <path
-                  d="M5 13l4 4L19 7"
-                  stroke="var(--accent)"
-                  strokeWidth="2.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            )}
-          </button>
-        ))}
-      </div>
-    </div>
+      ))}
+    </Card>
   );
 }
 
@@ -1289,11 +1146,9 @@ function PickerScreen({
 function ProjectsScreen({
   config,
   onUpdate,
-  onBack,
 }: {
   config: Record<string, unknown>;
   onUpdate: (c: Record<string, unknown>) => void;
-  onBack: () => void;
 }) {
   const projects = (config.projects ?? {}) as Record<string, unknown>;
   const [newPath, setNewPath] = useState('');
@@ -1312,91 +1167,60 @@ function ProjectsScreen({
   };
 
   return (
-    <div>
-      <BackButton label="Settings" onClick={onBack} />
-      <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--text-primary)', marginBottom: 4 }}>
-        Per-project Overrides
-      </div>
-      <div style={{ fontSize: 12, color: 'var(--text-tertiary)', marginBottom: 16 }}>
-        Override global settings for specific projects. Values merge on top.
-      </div>
+    <>
+      <p
+        className="text-[13px] leading-4 px-1 -mb-2"
+        style={{ color: 'var(--label-secondary)', margin: 0 }}
+      >
+        Override global settings for specific projects. Values merge on top of the global config.
+      </p>
 
       {paths.length > 0 && (
-        <div
-          style={{
-            background: 'var(--bg-grouped)',
-            borderRadius: 10,
-            boxShadow: 'var(--shadow-grouped)',
-            overflow: 'hidden',
-            marginBottom: 16,
-          }}
-        >
+        <Card>
           {paths.map((p, i) => (
-            <div
-              key={p}
-              style={{
-                padding: '8px 12px',
-                borderBottom: i < paths.length - 1 ? '1px solid var(--border-row)' : 'none',
-              }}
-            >
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <div key={p} style={{ padding: '8px 12px', borderBottom: rowBorder(i === paths.length - 1) }}>
+              <div className="flex items-center gap-2">
                 <span
-                  style={{
-                    fontSize: 12,
-                    fontFamily: 'SF Mono, Menlo, monospace',
-                    color: 'var(--text-primary)',
-                    flex: 1,
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                  }}
+                  className="flex-1 min-w-0 truncate text-[13px] leading-4"
+                  style={{ fontFamily: 'var(--font-mono)', color: 'var(--label)' }}
                   title={p}
                 >
                   {p}
                 </span>
-                <button
-                  type="button"
+                <Button
+                  size="small"
+                  active={editKey === p}
+                  aria-expanded={editKey === p}
                   onClick={() => {
-                    if (editKey === p) setEditKey(null);
-                    else {
-                      setEditKey(p);
-                      setEditJson(JSON.stringify(projects[p], null, 2));
-                      setEditError(false);
+                    if (editKey === p) {
+                      setEditKey(null);
+                      return;
                     }
-                  }}
-                  style={{
-                    fontSize: 12,
-                    color: 'var(--accent)',
-                    background: 'none',
-                    border: 'none',
-                    cursor: 'pointer',
+                    setEditKey(p);
+                    setEditJson(JSON.stringify(projects[p], null, 2));
+                    setEditError(false);
                   }}
                 >
                   {editKey === p ? 'Done' : 'Edit'}
-                </button>
-                <button
-                  type="button"
+                </Button>
+                <Button
+                  size="small"
+                  variant="plain"
                   onClick={() => {
                     const u = { ...projects };
                     delete u[p];
                     onUpdate({ ...config, projects: u });
                     if (editKey === p) setEditKey(null);
                   }}
-                  style={{
-                    fontSize: 12,
-                    color: 'var(--destructive)',
-                    background: 'none',
-                    border: 'none',
-                    cursor: 'pointer',
-                  }}
                 >
                   Remove
-                </button>
+                </Button>
               </div>
               {editKey === p && (
-                <div style={{ marginTop: 6 }}>
+                <div className="mt-2">
                   <textarea
                     value={editJson}
+                    aria-label={`Overrides for ${p}`}
                     rows={4}
                     onChange={(e) => {
                       setEditJson(e.target.value);
@@ -1404,85 +1228,65 @@ function ProjectsScreen({
                     }}
                     style={{
                       fontSize: 12,
-                      fontFamily: 'SF Mono, Menlo, monospace',
+                      fontFamily: 'var(--font-mono)',
                       width: '100%',
-                      padding: 6,
-                      borderRadius: 5,
+                      padding: 8,
+                      borderRadius: 'var(--radius-input)',
                       resize: 'vertical',
-                      border: `1px solid ${editError ? 'var(--destructive)' : 'var(--border)'}`,
-                      background: 'var(--fill-control)',
-                      color: 'var(--text-primary)',
+                      border: `0.5px solid ${editError ? 'var(--status-red)' : 'var(--separator)'}`,
+                      background: 'var(--fill-quaternary)',
+                      color: 'var(--label)',
                     }}
                   />
                   {editError && (
-                    <div style={{ fontSize: 11, color: 'var(--destructive)', marginTop: 2 }}>
+                    <div
+                      className="text-[11px] leading-[13px] mt-1"
+                      style={{ color: 'var(--status-red)' }}
+                      role="alert"
+                    >
                       Invalid JSON
                     </div>
                   )}
-                  <button
-                    type="button"
-                    onClick={() => {
-                      try {
-                        onUpdate({
-                          ...config,
-                          projects: { ...projects, [p]: JSON.parse(editJson) },
-                        });
-                        setEditError(false);
-                      } catch {
-                        setEditError(true);
-                      }
-                    }}
-                    style={{
-                      marginTop: 6,
-                      fontSize: 13,
-                      fontWeight: 500,
-                      color: '#fff',
-                      background: 'var(--accent)',
-                      border: 'none',
-                      borderRadius: 6,
-                      padding: '5px 14px',
-                      cursor: 'pointer',
-                    }}
-                  >
-                    Apply
-                  </button>
+                  <div className="mt-2">
+                    <Button
+                      size="small"
+                      onClick={() => {
+                        try {
+                          onUpdate({
+                            ...config,
+                            projects: { ...projects, [p]: JSON.parse(editJson) },
+                          });
+                          setEditError(false);
+                        } catch {
+                          setEditError(true);
+                        }
+                      }}
+                    >
+                      Apply
+                    </Button>
+                  </div>
                 </div>
               )}
             </div>
           ))}
-        </div>
+        </Card>
       )}
 
-      {/* Add */}
-      <div style={{ display: 'flex', gap: 8 }}>
+      <div className="flex gap-2">
         <input
           type="text"
           value={newPath}
           placeholder="/path/to/project"
+          aria-label="Project path"
           onChange={(e) => setNewPath(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && add()}
-          style={{ ...inputBase, flex: 1, height: 28 }}
+          style={{ ...inputBase, flex: 1 }}
         />
-        <button
-          type="button"
-          onClick={add}
-          disabled={!newPath.trim()}
-          style={{
-            fontSize: 13,
-            fontWeight: 500,
-            color: '#fff',
-            background: 'var(--accent)',
-            border: 'none',
-            borderRadius: 6,
-            padding: '5px 14px',
-            cursor: 'pointer',
-            opacity: newPath.trim() ? 1 : 0.4,
-          }}
-        >
+        <Button disabled={!newPath.trim()} onClick={add}>
           Add
-        </button>
+        </Button>
       </div>
-    </div>
+    </>
   );
 }
 
@@ -1491,74 +1295,41 @@ function ProjectsScreen({
 function DiffPanel({ entries, onClose }: { entries: DiffEntry[]; onClose: () => void }) {
   if (!entries.length) return null;
   return (
-    <div
-      style={{
-        background: 'var(--bg-grouped)',
-        borderRadius: 10,
-        boxShadow: 'var(--shadow-grouped)',
-        padding: '10px 12px',
-        marginBottom: 16,
-      }}
-    >
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          marginBottom: 6,
-        }}
-      >
-        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>
-          Pending Changes
-        </span>
-        <button
-          type="button"
-          onClick={onClose}
-          style={{
-            fontSize: 12,
-            color: 'var(--accent)',
-            background: 'none',
-            border: 'none',
-            cursor: 'pointer',
-          }}
-        >
-          Done
-        </button>
-      </div>
-      <div style={{ maxHeight: 140, overflowY: 'auto' }}>
-        {entries.map((e, i) => (
-          <div
-            key={`${e.section}.${e.field}`}
-            style={{
-              fontSize: 12,
-              fontFamily: 'SF Mono, Menlo, monospace',
-              padding: '3px 0',
-              display: 'flex',
-              gap: 6,
-              alignItems: 'baseline',
-              borderBottom: i < entries.length - 1 ? '1px solid var(--border-row)' : 'none',
-            }}
-          >
-            <span style={{ color: 'var(--text-tertiary)', flexShrink: 0 }}>{e.section}</span>
-            <span
+    <Section title="Pending changes">
+      <Card>
+        <div className="flex items-center justify-end px-3 py-1.5" style={{ borderBottom: '0.5px solid var(--separator)' }}>
+          <Button size="small" variant="plain" onClick={onClose}>
+            Hide
+          </Button>
+        </div>
+        <div style={{ maxHeight: 160, overflowY: 'auto' }}>
+          {entries.map((e, i) => (
+            <div
+              key={`${e.section}.${e.field}`}
+              className="flex items-baseline gap-1.5 px-3 py-1 text-[11px] leading-[13px]"
               style={{
-                color: 'var(--text-secondary)',
-                flex: 1,
-                minWidth: 0,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
+                fontFamily: 'var(--font-mono)',
+                borderBottom: rowBorder(i === entries.length - 1),
               }}
             >
-              {e.field}
-            </span>
-            <span style={{ color: 'var(--destructive)', flexShrink: 0 }}>{fmt(e.from)}</span>
-            <span style={{ color: 'var(--text-tertiary)' }}>&rarr;</span>
-            <span style={{ color: 'var(--success)', flexShrink: 0 }}>{fmt(e.to)}</span>
-          </div>
-        ))}
-      </div>
-    </div>
+              <span className="shrink-0" style={{ color: 'var(--label-secondary)' }}>
+                {e.section}
+              </span>
+              <span className="flex-1 min-w-0 truncate" style={{ color: 'var(--label)' }}>
+                {e.field}
+              </span>
+              <span className="shrink-0" style={{ color: 'var(--status-red)' }}>
+                {fmt(e.from)}
+              </span>
+              <span style={{ color: 'var(--label-secondary)' }}>→</span>
+              <span className="shrink-0" style={{ color: 'var(--status-green)' }}>
+                {fmt(e.to)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </Card>
+    </Section>
   );
 }
 
@@ -1587,86 +1358,41 @@ function BottomBar({
 }) {
   if (!dirty) return null;
   const msg = hasErrors
-    ? 'Fix issues before saving'
+    ? 'Fix the issues above before saving'
     : saveStatus === 'saved'
       ? 'Saved'
       : saveStatus === 'error'
-        ? 'Save failed'
+        ? "Couldn't save — the daemon rejected the change"
         : `${diffCount} unsaved change${diffCount !== 1 ? 's' : ''}`;
-  const btn: React.CSSProperties = {
-    fontSize: 13,
-    fontWeight: 500,
-    border: 'none',
-    borderRadius: 6,
-    padding: '5px 14px',
-    cursor: 'pointer',
-    transition: 'background .15s',
-  };
   return (
+    /* Scoped to this pane. The old bar was `position: fixed` across the whole
+       window, so it ran under the sidebar as well. */
     <div
-      style={{
-        position: 'fixed',
-        bottom: 0,
-        left: 0,
-        right: 0,
-        display: 'flex',
-        alignItems: 'center',
-        gap: 8,
-        padding: '8px 16px',
-        background: 'var(--bg-primary)',
-        borderTop: '1px solid var(--border)',
-        backdropFilter: 'blur(20px)',
-        WebkitBackdropFilter: 'blur(20px)',
-      }}
+      className="flex items-center gap-2 px-4 shrink-0 glass"
+      role="status"
+      style={{ height: 52, borderTop: '0.5px solid var(--separator)' }}
     >
       <span
+        className="flex-1 min-w-0 truncate text-[13px] leading-4"
         style={{
-          fontSize: 12,
-          flex: 1,
           color: hasErrors
-            ? 'var(--destructive)'
+            ? 'var(--status-red)'
             : saveStatus === 'saved'
-              ? 'var(--success)'
-              : 'var(--text-secondary)',
+              ? 'var(--status-green)'
+              : 'var(--label-secondary)',
         }}
       >
         {msg}
       </span>
       {diffCount > 0 && !hasErrors && (
-        <button
-          type="button"
-          onClick={onToggleDiff}
-          style={{
-            fontSize: 12,
-            color: 'var(--accent)',
-            background: 'none',
-            border: 'none',
-            cursor: 'pointer',
-          }}
-        >
-          {showDiff ? 'Hide' : 'Review'}
-        </button>
+        <Button variant="plain" active={showDiff} onClick={onToggleDiff}>
+          {showDiff ? 'Hide changes' : 'Review changes'}
+        </Button>
       )}
-      <button
-        type="button"
-        onClick={onDiscard}
-        style={{ ...btn, color: 'var(--text-primary)', background: 'var(--bg-inset)' }}
-      >
-        Discard
-      </button>
-      <button
-        type="button"
-        onClick={onSave}
-        disabled={saving || hasErrors}
-        style={{
-          ...btn,
-          color: '#fff',
-          background: hasErrors ? 'var(--text-tertiary)' : 'var(--accent)',
-          opacity: saving ? 0.6 : 1,
-        }}
-      >
+      <Button onClick={onDiscard}>Discard</Button>
+      <Button variant="prominent" disabled={saving || hasErrors} onClick={onSave}>
         {saving ? 'Saving…' : 'Save'}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -1685,26 +1411,21 @@ function AppearanceCard({
   onChange: (next: Appearance) => void;
 }) {
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 10,
-        padding: '8px 12px',
-        background: 'var(--bg-grouped)',
-        borderRadius: 10,
-        boxShadow: 'var(--shadow-grouped)',
-        marginBottom: 12,
-      }}
-    >
-      <span style={{ flex: 1, fontSize: 13, color: 'var(--text-primary)' }}>Appearance</span>
-      <PopUpButton
-        options={APPEARANCE_OPTIONS}
-        value={appearance}
-        onChange={onChange}
-        aria-label="Appearance"
-      />
-    </div>
+    <Section title="Appearance">
+      <Card>
+        <div className="flex items-center gap-2" style={{ minHeight: 36, padding: '0 12px' }}>
+          <span className="flex-1 text-[13px] leading-4" style={{ color: 'var(--label)' }}>
+            Theme
+          </span>
+          <PopUpButton
+            options={APPEARANCE_OPTIONS}
+            value={appearance}
+            onChange={onChange}
+            aria-label="Appearance"
+          />
+        </div>
+      </Card>
+    </Section>
   );
 }
 
@@ -1734,6 +1455,8 @@ export function Settings({
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saved' | 'error'>('idle');
   const [search, setSearch] = useState('');
   const [showDiff, setShowDiff] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
+  const overflow = useMenuAnchor();
   const [screen, setScreen] = useState<Screen>(() => {
     const section = new URLSearchParams(window.location.search).get('section');
     if (section && CONFIG_SCHEMA.some((s) => s.key === section)) {
@@ -1812,296 +1535,243 @@ export function Settings({
     );
   };
 
-  /* Not connected */
-  if (!connected && !loading) {
+  /* The toolbar owns the pane and always renders, so the daemon-down and
+     loading states sit INSIDE the surface rather than replacing it. */
+  if (!settings) {
     return (
-      <>
-        <AppearanceCard appearance={appearance} onChange={onAppearanceChange} />
-        <div className="flex flex-col items-center justify-center flex-1 gap-2">
-          <div className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
-            Daemon not reachable
-          </div>
-          <button
-            type="button"
-            onClick={() => restartDaemon()}
-            disabled={restarting}
-            className="text-[11px] px-4 py-1.5 rounded-lg font-medium transition-all"
-            style={{
-              background: 'var(--fill-control)',
-              backdropFilter: 'blur(12px)',
-              WebkitBackdropFilter: 'blur(12px)',
-              color: 'var(--accent)',
-              border: '0.5px solid var(--border)',
-              boxShadow: 'var(--shadow-control)',
-              cursor: restarting ? 'default' : 'pointer',
-              opacity: restarting ? 0.6 : 1,
-            }}
-          >
-            {restarting ? 'Starting…' : 'Restart Daemon'}
-          </button>
-        </div>
-      </>
-    );
-  }
-
-  if (loading || !settings) {
-    return (
-      <>
-        <AppearanceCard appearance={appearance} onChange={onAppearanceChange} />
-        <p
-          style={{
-            fontSize: 13,
-            textAlign: 'center',
-            padding: 32,
-            color: 'var(--text-tertiary)',
-            margin: 0,
-          }}
+      <div className="flex flex-col h-full min-h-0">
+        <div
+          className="flex items-center px-4 shrink-0 glass"
+          style={{ height: 52, borderBottom: '0.5px solid transparent' }}
         >
-          Loading…
-        </p>
-      </>
+          <h2
+            className="text-[17px] leading-[22px] font-semibold"
+            style={{ color: 'var(--label)', letterSpacing: '-0.01em' }}
+          >
+            Settings
+          </h2>
+        </div>
+        <div className="flex-1 overflow-auto flex flex-col">
+          <div className="px-4 pt-4 mx-auto w-full" style={{ maxWidth: 720 }}>
+            <AppearanceCard appearance={appearance} onChange={onAppearanceChange} />
+          </div>
+          <div className="flex-1 flex items-center justify-center">
+          {/* A finished fetch that produced nothing is not still loading. The
+              old code showed "Loading…" forever whenever the daemon answered
+              once and then stopped, which is exactly what a flapping daemon
+              does. */}
+          {loading ? (
+            <span
+              className="text-[13px] leading-4"
+              style={{ color: 'var(--label-secondary)' }}
+              role="status"
+            >
+              Loading settings…
+            </span>
+          ) : (
+            <EmptyState
+              icon="settings"
+              title={connected ? "Couldn't read the settings" : 'Daemon not reachable'}
+              subtitle={
+                connected
+                  ? "The daemon is running but didn't return its configuration. Restarting it usually clears this."
+                  : "Settings live in the daemon's config file, so they can't be read until it is running."
+              }
+              action={
+                <Button variant="prominent" disabled={restarting} onClick={() => restartDaemon()}>
+                  {restarting ? 'Starting…' : connected ? 'Restart daemon' : 'Start daemon'}
+                </Button>
+              }
+            />
+          )}
+          </div>
+        </div>
+      </div>
     );
   }
 
   const { daemon } = settings;
   const filtered = CONFIG_SCHEMA.filter(matchSection);
+  const activeSection =
+    screen.type === 'section'
+      ? CONFIG_SCHEMA.find((s) => s.key === screen.key)
+      : screen.type === 'picker'
+        ? CONFIG_SCHEMA.find((s) => s.key === screen.sectionKey)
+        : undefined;
 
-  const bottomBar = (
-    <BottomBar
-      dirty={dirty}
-      saving={saving}
-      hasErrors={hasErrors}
-      diffCount={diffs.length}
-      showDiff={showDiff}
-      onToggleDiff={() => setShowDiff(!showDiff)}
-      onSave={save}
-      onDiscard={discard}
-      saveStatus={saveStatus}
-    />
-  );
+  const title =
+    screen.type === 'list'
+      ? 'Settings'
+      : screen.type === 'projects'
+        ? 'Per-project overrides'
+        : screen.type === 'picker'
+          ? screen.picker.field.label
+          : (activeSection?.label ?? 'Settings');
 
-  /* ── Picker screen ── */
-  if (screen.type === 'picker') {
-    const sec = CONFIG_SCHEMA.find((s) => s.key === screen.sectionKey);
-    return (
-      <div style={{ paddingBottom: 52 }}>
-        <PickerScreen
-          picker={screen.picker}
-          sectionLabel={sec?.label ?? 'Back'}
-          onBack={() => setScreen({ type: 'section', key: screen.sectionKey })}
-        />
-        {bottomBar}
-      </div>
-    );
-  }
+  const back =
+    screen.type === 'list'
+      ? undefined
+      : screen.type === 'picker'
+        ? () => setScreen({ type: 'section', key: screen.sectionKey })
+        : () => setScreen({ type: 'list' });
 
-  /* ── Projects screen ── */
-  if (screen.type === 'projects') {
-    return (
-      <div style={{ paddingBottom: 52 }}>
-        <ProjectsScreen
-          config={config}
-          onUpdate={updateFull}
-          onBack={() => setScreen({ type: 'list' })}
-        />
-        {bottomBar}
-      </div>
-    );
-  }
+  const copyDaemonDetails = () => {
+    const text = `trace-mcp daemon · PID ${daemon.pid} · port ${daemon.port} · up ${formatUptime(daemon.uptime)} · config ${settings.path}`;
+    void navigator.clipboard?.writeText(text);
+  };
 
-  /* ── Section detail screen ── */
-  if (screen.type === 'section') {
-    const sec = CONFIG_SCHEMA.find((s) => s.key === screen.key);
-    if (!sec) {
-      setScreen({ type: 'list' });
-      return null;
-    }
-    return (
-      <div style={{ paddingBottom: 52 }}>
-        <SectionDetail
-          section={sec}
-          data={sd(config, sec)}
-          onUpdate={update}
-          onBack={() => setScreen({ type: 'list' })}
-          onOpenPicker={(p) => setScreen({ type: 'picker', sectionKey: screen.key, picker: p })}
-        />
-        {showDiff && <DiffPanel entries={diffs} onClose={() => setShowDiff(false)} />}
-        {bottomBar}
-      </div>
-    );
-  }
-
-  /* ── Main list screen ── */
   return (
-    <div style={{ paddingBottom: 52 }}>
-      {/* Daemon card */}
+    <div className="flex flex-col h-full min-h-0">
+      {/* ── Toolbar ──────────────────────────────────────────────────── */}
       <div
+        className="flex items-center gap-3 px-4 shrink-0 glass"
         style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 10,
-          padding: '10px 12px',
-          background: 'var(--bg-grouped)',
-          borderRadius: 10,
-          boxShadow: 'var(--shadow-grouped)',
-          marginBottom: 16,
+          height: 52,
+          borderBottom: '0.5px solid transparent',
+          borderBottomColor: scrolled ? 'var(--separator)' : 'transparent',
+          transition: 'border-bottom-color var(--dur-standard) var(--ease-out)',
         }}
       >
-        <StatusDot tone="green" pulse />
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>Daemon</div>
-          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 1 }}>
-            PID {daemon.pid} &middot; Port {daemon.port} &middot; {formatUptime(daemon.uptime)}
-          </div>
-        </div>
-        <button
-          type="button"
-          onClick={() => {
-            const api = window.electronAPI;
-            if (api?.openInEditor) api.openInEditor(settings.path);
-          }}
-          style={{
-            fontSize: 13,
-            fontWeight: 500,
-            color: '#fff',
-            background: 'var(--accent)',
-            border: 'none',
-            borderRadius: 6,
-            padding: '5px 14px',
-            cursor: 'pointer',
-          }}
-        >
-          Edit JSON
-        </button>
-      </div>
-
-      {/* Search */}
-      <div style={{ position: 'relative', marginBottom: 16 }}>
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          style={{
-            position: 'absolute',
-            left: 9,
-            top: '50%',
-            transform: 'translateY(-50%)',
-            color: 'var(--text-tertiary)',
-            pointerEvents: 'none',
-          }}
-        >
-          <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" />
-          <path d="M16 16L20 20" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-        </svg>
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search"
-          style={{
-            fontSize: 13,
-            fontFamily: 'inherit',
-            width: '100%',
-            height: 28,
-            padding: '0 28px 0 30px',
-            borderRadius: 7,
-            border: '1px solid var(--border)',
-            background: 'var(--fill-control)',
-            color: 'var(--text-primary)',
-            boxShadow: 'var(--shadow-control)',
-          }}
-        />
-        {search && (
-          <button
-            type="button"
-            onClick={() => setSearch('')}
-            style={{
-              position: 'absolute',
-              right: 6,
-              top: '50%',
-              transform: 'translateY(-50%)',
-              width: 18,
-              height: 18,
-              borderRadius: 9,
-              border: 'none',
-              cursor: 'pointer',
-              background: 'var(--bg-inset)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: 13,
-              lineHeight: 1,
-              color: 'var(--text-tertiary)',
-            }}
-          >
-            ×
-          </button>
+        {back && (
+          <Button
+            variant="icon"
+            icon="chevron_left"
+            onClick={back}
+            aria-label="Back"
+            title="Back"
+          />
         )}
+        <h2
+          className="flex-1 min-w-0 text-[17px] leading-[22px] font-semibold truncate"
+          style={{ color: 'var(--label)', letterSpacing: '-0.01em' }}
+        >
+          {title}
+        </h2>
+        {screen.type === 'list' && (
+          <SearchField
+            value={search}
+            onChange={setSearch}
+            placeholder="Search settings"
+            aria-label="Search settings"
+          />
+        )}
+        <Button
+          ref={overflow.ref}
+          variant="icon"
+          icon="more_horiz"
+          onClick={() => (overflow.at ? overflow.close() : overflow.open())}
+          aria-haspopup="menu"
+          aria-expanded={overflow.at !== null}
+          aria-label="More actions"
+          title="More actions"
+        />
       </div>
 
-      {(!q || 'appearance'.includes(q) || 'theme'.includes(q)) && (
-        <AppearanceCard appearance={appearance} onChange={onAppearanceChange} />
-      )}
-
-      {/* Section list */}
-      <SectionList
-        sections={filtered}
-        config={config}
-        onOpen={(key) => setScreen({ type: 'section', key })}
-        search={search}
-      />
-
-      {/* Per-project row */}
-      {(!q || 'project override'.includes(q)) && (
-        <div
-          style={{
-            background: 'var(--bg-grouped)',
-            borderRadius: 10,
-            boxShadow: 'var(--shadow-grouped)',
-            overflow: 'hidden',
-          }}
-        >
-          <button
-            type="button"
-            onClick={() => setScreen({ type: 'projects' })}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 10,
-              width: '100%',
-              padding: '8px 12px',
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              textAlign: 'left',
+      {overflow.at && (
+        <Menu x={overflow.at.x} y={overflow.at.y} align="end" onClose={overflow.close}>
+          <MenuItem
+            icon="content_copy"
+            onClick={() => {
+              copyDaemonDetails();
+              overflow.close();
             }}
           >
-            <span style={{ flex: 1, fontSize: 13, color: 'var(--text-primary)' }}>
-              Per-project Overrides
-            </span>
-            {Object.keys((config.projects ?? {}) as object).length > 0 && (
-              <span
-                style={{
-                  width: 7,
-                  height: 7,
-                  borderRadius: 4,
-                  background: 'var(--accent)',
-                  flexShrink: 0,
-                }}
-              />
-            )}
-            <ChevronRight />
-          </button>
-        </div>
+            Copy daemon details
+          </MenuItem>
+          <MenuSeparator />
+          {/* The raw-config escape hatch. It used to be the most prominent
+              control on the screen; a hatch belongs behind a menu. */}
+          <MenuItem
+            icon="code"
+            onClick={() => {
+              window.electronAPI?.openInEditor?.(settings.path);
+              overflow.close();
+            }}
+          >
+            Edit config file…
+          </MenuItem>
+        </Menu>
       )}
 
-      {showDiff && (
-        <div style={{ marginTop: 16 }}>
-          <DiffPanel entries={diffs} onClose={() => setShowDiff(false)} />
+      {/* ── Content ──────────────────────────────────────────────────── */}
+      <div
+        className="flex-1 overflow-auto"
+        onScroll={(e) => setScrolled((e.target as HTMLElement).scrollTop > 0)}
+      >
+        <div className="flex flex-col gap-6 px-4 py-4 mx-auto w-full" style={{ maxWidth: 720 }}>
+          {screen.type === 'list' && (
+            <>
+              {/* Daemon card — the STATE leads. The PID is diagnostic detail
+                  and lives behind "Copy daemon details" in the overflow menu. */}
+              <Card>
+                <div className="flex items-center gap-2.5 px-3" style={{ minHeight: 44 }}>
+                  <StatusDot tone="green" pulse title="Running" />
+                  <div className="flex-1 min-w-0">
+                    <div className="text-[13px] leading-4" style={{ color: 'var(--label)' }}>
+                      Daemon
+                    </div>
+                    <div
+                      className="text-[11px] leading-[13px] truncate"
+                      style={{ color: 'var(--label-secondary)' }}
+                    >
+                      Running · port <span className="tabular-nums">{daemon.port}</span> · up{' '}
+                      <span className="tabular-nums">{formatUptime(daemon.uptime)}</span>
+                    </div>
+                  </div>
+                </div>
+              </Card>
+
+              {(!q || 'appearance'.includes(q) || 'theme'.includes(q)) && (
+                <AppearanceCard appearance={appearance} onChange={onAppearanceChange} />
+              )}
+
+              <SectionList
+                sections={filtered}
+                config={config}
+                onOpen={(key) => setScreen({ type: 'section', key })}
+                onOpenProjects={() => setScreen({ type: 'projects' })}
+                projectOverrides={Object.keys((config.projects ?? {}) as object).length}
+                search={q}
+              />
+            </>
+          )}
+
+          {screen.type === 'section' &&
+            (activeSection ? (
+              <SectionDetail
+                section={activeSection}
+                data={sd(config, activeSection)}
+                onUpdate={update}
+                onOpenPicker={(p) =>
+                  setScreen({ type: 'picker', sectionKey: screen.key, picker: p })
+                }
+              />
+            ) : null)}
+
+          {screen.type === 'picker' && (
+            <PickerScreen
+              picker={screen.picker}
+              onBack={() => setScreen({ type: 'section', key: screen.sectionKey })}
+            />
+          )}
+
+          {screen.type === 'projects' && <ProjectsScreen config={config} onUpdate={updateFull} />}
+
+          {showDiff && <DiffPanel entries={diffs} onClose={() => setShowDiff(false)} />}
         </div>
-      )}
-      {bottomBar}
+      </div>
+
+      <BottomBar
+        dirty={dirty}
+        saving={saving}
+        hasErrors={hasErrors}
+        diffCount={diffs.length}
+        showDiff={showDiff}
+        onToggleDiff={() => setShowDiff(!showDiff)}
+        onSave={save}
+        onDiscard={discard}
+        saveStatus={saveStatus}
+      />
     </div>
   );
 }
@@ -2118,40 +1788,37 @@ export function Settings({
  * window manually.
  */
 function ActivityLink() {
-  const [hover, setHover] = useState(false);
+  /* The click's only effect is off-screen and in another window, so without
+     this the button looked broken: pressed, nothing happened. */
+  const [armed, setArmed] = useState(false);
   const onClick = useCallback(() => {
     try {
       localStorage.setItem('activity.subtab', 'ai');
+      setArmed(true);
     } catch {
       /* ignore quota / disabled storage */
     }
   }, []);
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      style={{
-        marginTop: 16,
-        width: '100%',
-        textAlign: 'left',
-        padding: '10px 12px',
-        background: hover ? 'var(--bg-hover)' : 'var(--fill-control)',
-        border: '0.5px solid var(--border)',
-        borderRadius: 10,
-        cursor: 'pointer',
-        color: 'var(--text-primary)',
-        transition: 'background 120ms ease',
-      }}
-    >
-      <div style={{ fontSize: 12, fontWeight: 500, marginBottom: 4 }}>
-        View AI activity
+    <Card>
+      <div className="flex items-center gap-3 px-3" style={{ minHeight: 44 }}>
+        <div className="flex-1 min-w-0">
+          <div className="text-[13px] leading-4" style={{ color: 'var(--label)' }}>
+            AI activity
+          </div>
+          <div
+            className="text-[11px] leading-[13px] mt-0.5"
+            style={{ color: armed ? 'var(--status-green)' : 'var(--label-secondary)' }}
+          >
+            {armed
+              ? 'The next project window you open will land on Activity → AI calls.'
+              : 'Recent embed, LLM and rerank requests live in a project window, under Activity.'}
+          </div>
+        </div>
+        <Button disabled={armed} onClick={onClick}>
+          {armed ? 'Ready' : 'Open there next'}
+        </Button>
       </div>
-      <div style={{ fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.4 }}>
-        Recent embed / LLM / rerank requests live in the Activity tab → AI calls.
-        Open a project window → Activity tab to view.
-      </div>
-    </button>
+    </Card>
   );
 }

--- a/packages/app/src/renderer/tabs/__tests__/Clients.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/Clients.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+/**
+ * Clients — the design invariants the TRA-295 rebuild has to keep.
+ *
+ * These assert the things that were wrong on the running app, not the
+ * implementation: a wall of accent-filled Connect buttons, a right-aligned
+ * grey word "Manual" as the only affordance, and a raw session id where the
+ * project name belongs.
+ */
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { Clients } from '../Clients';
+
+const STATUSES = [
+  { client: 'claude-code', configPath: '/Users/x/.claude.json', status: 'up_to_date' },
+  { client: 'cursor', configPath: null, status: 'missing' },
+  { client: 'warp', configPath: null, status: 'unmanageable' },
+  {
+    client: 'windsurf',
+    configPath: '/Users/x/.codeium/mcp.json',
+    status: 'stale',
+    staleReason: 'alwaysLoad',
+  },
+];
+
+const CLIENTS = [
+  {
+    id: '401b97c5aaaa',
+    name: 'claude-code',
+    transport: 'http',
+    project: '/Users/x/projects/workdir',
+    connectedAt: new Date().toISOString(),
+    lastSeen: new Date().toISOString(),
+  },
+];
+
+vi.mock('../../hooks/useDaemon', () => ({
+  useDaemon: () => ({
+    clients: CLIENTS,
+    loading: false,
+    connected: true,
+    restarting: false,
+    restartDaemon: vi.fn(),
+    fetchClients: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    getMcpClientStatuses: vi.fn().mockResolvedValue({ ok: true, statuses: STATUSES }),
+    detectMcpClients: vi.fn().mockResolvedValue([]),
+    configureMcpClient: vi.fn().mockResolvedValue({ ok: true }),
+  };
+});
+
+afterEach(() => {
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  vi.restoreAllMocks();
+});
+
+it('renders one toolbar with a title and a labelled refresh button', async () => {
+  render(<Clients />);
+  expect(await screen.findByRole('heading', { name: 'MCP clients', level: 2 })).toBeTruthy();
+  // Icon-only, so it needs both an accessible name and a tooltip.
+  const refresh = screen.getByRole('button', { name: 'Refresh clients' });
+  expect(refresh.getAttribute('title')).toBe('Refresh clients');
+});
+
+/* The screen shipped ten accent-filled Connect buttons stacked vertically —
+   far past the ~5% accent budget, and HIG reserves prominence for one action
+   per region. Nothing on this screen is prominent now. */
+it('has no prominent (accent-filled) control anywhere', async () => {
+  const { container } = render(<Clients />);
+  await screen.findAllByRole('button', { name: 'Connect' });
+  expect(container.querySelectorAll('.v-prominent').length).toBe(0);
+  for (const b of screen.getAllByRole('button', { name: 'Connect' })) {
+    expect(b.className).toContain('v-bordered');
+  }
+});
+
+/* "Manual" was a right-aligned grey word — an undocumented convention with no
+   affordance. It is a button that discloses the actual steps. */
+it('offers manual clients a real button that discloses the steps', async () => {
+  render(<Clients />);
+  // JetBrains AI Assistant and Warp, in declaration order.
+  const buttons = await screen.findAllByRole('button', { name: 'Set up manually…' });
+  expect(buttons).toHaveLength(2);
+  const btn = buttons[1];
+  expect(btn.getAttribute('aria-expanded')).toBe('false');
+  expect(screen.queryByText(/Settings → Agents/)).toBeNull();
+
+  fireEvent.click(btn);
+  expect(btn.getAttribute('aria-expanded')).toBe('true');
+  expect(screen.getByText(/Settings → Agents/)).toBeTruthy();
+});
+
+/* Connection state was a grey dot that looked identical for every supported
+   client. State is now a word; colour never carries it alone. */
+it('states connection with a word, not only a colour', async () => {
+  render(<Clients />);
+  expect(await screen.findByText('Connected')).toBeTruthy();
+  expect(screen.getByText('Update available')).toBeTruthy();
+});
+
+/* `401b97c5 http` was the session row's primary label: a raw id where the name
+   goes. The project leads; the id is a monospace caption. */
+it('leads a session row with the project, not the session id', async () => {
+  render(<Clients />);
+  const title = await screen.findByText('workdir');
+  expect(title.className).toContain('text-[13px]');
+
+  const caption = screen.getByText(/401b97c5/);
+  expect(caption.textContent).toContain('http');
+  expect(caption.getAttribute('style')).toContain('--font-mono');
+});
+
+it('titles its sections in sentence case', async () => {
+  render(<Clients />);
+  await waitFor(() => expect(screen.getByText('Supported clients')).toBeTruthy());
+  expect(screen.getByText('Active sessions')).toBeTruthy();
+  expect(screen.queryByText('Supported Clients')).toBeNull();
+  expect(screen.queryByText('Active Sessions')).toBeNull();
+});
+
+/* The Claude family takes an enforcement level, which used to be a hand-rolled
+   popover. It is the shared Menu, opened from the row's own button. */
+it('opens the enforcement-level menu from the Claude row', async () => {
+  render(<Clients />);
+  const connects = await screen.findAllByRole('button', { name: 'Connect' });
+  const claude = connects.find((b) => b.getAttribute('aria-haspopup') === 'menu');
+  expect(claude).toBeTruthy();
+
+  fireEvent.click(claude as HTMLElement);
+  const menu = await screen.findByRole('menu');
+  expect(within(menu).getByRole('menuitem', { name: 'Max' })).toBeTruthy();
+});

--- a/packages/app/src/renderer/tabs/__tests__/Settings.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/Settings.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+/**
+ * Settings — the design invariants the TRA-295 rebuild has to keep, plus the
+ * two data bugs the rebuild exposed.
+ *
+ * What was wrong on the running app: seven unlabelled groups, `Edit JSON` as
+ * the single most prominent control, a 7px blue dot as the only "differs from
+ * defaults" signal, Title Case section names, `PID 64806 · Port 3741 · 22s` as
+ * the daemon card's headline, and an `lsp` section that existed in the schema
+ * but rendered nowhere because it belonged to no group.
+ */
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, expect, it, vi } from 'vitest';
+import { CONFIG_SCHEMA, countModifiedFields, type SectionDef } from '../configSchema';
+import { Settings } from '../Settings';
+
+const SETTINGS = {
+  path: '/Users/x/.trace-mcp/.config.json',
+  daemon: { port: 3741, host: '127.0.0.1', log_path: '/x/daemon.log', uptime: 74, pid: 64806 },
+  settings: {
+    logLevel: 'info',
+    ai: { enabled: true, provider: 'ollama' },
+    projects: {},
+  },
+};
+
+vi.mock('../../hooks/useDaemon', () => ({
+  useDaemon: () => ({
+    settings: SETTINGS,
+    loading: false,
+    connected: true,
+    restarting: false,
+    restartDaemon: vi.fn(),
+    updateSettings: vi.fn(),
+  }),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+it('gives every group a title', () => {
+  render(<Settings />);
+  for (const title of [
+    'General',
+    'Intelligence',
+    'Quality and security',
+    'Infrastructure',
+    'Development',
+    'Monitoring',
+    'Advanced',
+  ]) {
+    expect(screen.getAllByText(title).length).toBeGreaterThan(0);
+  }
+});
+
+/* `lsp` was in the schema and in no group, and groups are what the list
+   renders — so a whole settings section was unreachable. */
+it('renders every schema section, including LSP enrichment', () => {
+  render(<Settings />);
+  for (const section of CONFIG_SCHEMA) {
+    const literal = section.label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    expect(screen.getByRole('button', { name: new RegExp(`^${literal}`) })).toBeTruthy();
+  }
+  expect(screen.getByRole('button', { name: /^LSP enrichment/ })).toBeTruthy();
+});
+
+/* An accent-filled button for a raw-config escape hatch was the loudest thing
+   on the screen. It is a menu item now, and the list has no prominent control
+   at all. */
+it('keeps the raw-config escape hatch out of the toolbar', async () => {
+  const { container } = render(<Settings />);
+  expect(screen.queryByRole('button', { name: 'Edit JSON' })).toBeNull();
+  expect(container.querySelectorAll('.v-prominent').length).toBe(0);
+
+  fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+  const menu = await screen.findByRole('menu');
+  expect(within(menu).getByRole('menuitem', { name: 'Edit config file…' })).toBeTruthy();
+});
+
+/* The dot had no legend anywhere in the app, so its colour was the whole
+   message. The word is the message now. */
+it('names the modified state instead of signalling it with colour alone', () => {
+  const { container } = render(<Settings />);
+  expect(screen.getAllByText('Modified').length).toBeGreaterThan(0);
+  // No bare accent-filled dot spans left in the rows.
+  const dots = [...container.querySelectorAll('span')].filter(
+    (s) => (s.getAttribute('style') ?? '').includes('var(--accent)') && !s.textContent,
+  );
+  expect(dots).toHaveLength(0);
+});
+
+/* PID is diagnostic detail, not a headline. */
+it('leads the daemon card with its state and hides the PID behind a copy action', async () => {
+  render(<Settings />);
+  expect(screen.getByText(/Running · port/)).toBeTruthy();
+  expect(screen.queryByText(/PID/)).toBeNull();
+
+  fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+  const menu = await screen.findByRole('menu');
+  expect(within(menu).getByRole('menuitem', { name: 'Copy daemon details' })).toBeTruthy();
+});
+
+it('titles the screen and its sections in sentence case', () => {
+  render(<Settings />);
+  expect(screen.getByRole('heading', { name: 'Settings', level: 2 })).toBeTruthy();
+  for (const wrong of [
+    'Quality Gates',
+    'Ignore Rules',
+    'Tool Exposure',
+    'Per-project Overrides',
+    'Cross-repo Topology',
+    'AI / Embeddings',
+  ]) {
+    expect(screen.queryByText(wrong)).toBeNull();
+  }
+});
+
+it('searches from the toolbar with the SearchField primitive', async () => {
+  const { container } = render(<Settings />);
+  const search = screen.getByRole('textbox', { name: 'Search settings' });
+  expect(search.closest('.lx-search')).not.toBeNull();
+
+  fireEvent.change(search, { target: { value: 'ollama' } });
+  await waitFor(() =>
+    expect(container.querySelectorAll('[class*="text-[13px]"]').length).toBeGreaterThan(0),
+  );
+  expect(screen.queryByRole('button', { name: /^File watcher/ })).toBeNull();
+});
+
+it('navigates into a section and back from the toolbar', async () => {
+  render(<Settings />);
+  fireEvent.click(screen.getByRole('button', { name: /^AI and embeddings/ }));
+  expect(screen.getByRole('heading', { name: 'AI and embeddings', level: 2 })).toBeTruthy();
+
+  fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+  expect(screen.getByRole('heading', { name: 'Settings', level: 2 })).toBeTruthy();
+});
+
+/* An absent key IS the default — the daemon applies the default when the key
+   is missing. Counting it as "modified" marked almost every section, which was
+   survivable while the signal was an unexplained dot and is not once the row
+   says the word. */
+it('does not count a never-set field as modified', () => {
+  const section: SectionDef = {
+    key: 'demo',
+    label: 'Demo',
+    fields: [
+      { key: 'a', label: 'A', type: 'boolean', defaultValue: true },
+      { key: 'b', label: 'B', type: 'number', defaultValue: 10 },
+    ],
+  };
+  expect(countModifiedFields(section, {})).toBe(0);
+  expect(countModifiedFields(section, { a: true, b: 10 })).toBe(0);
+  expect(countModifiedFields(section, { b: 42 })).toBe(1);
+});
+
+/* Emoji are banned as UI icons, and this field was never read by anything. */
+it('carries no emoji icon on any schema section', () => {
+  for (const section of CONFIG_SCHEMA) {
+    expect('icon' in section).toBe(false);
+  }
+});

--- a/packages/app/src/renderer/tabs/configSchema.ts
+++ b/packages/app/src/renderer/tabs/configSchema.ts
@@ -40,7 +40,6 @@ export interface FieldDef {
 export interface SectionDef {
   key: string;
   label: string;
-  icon: string;
   description?: string;
   fields: FieldDef[];
 }
@@ -176,10 +175,12 @@ export function countModifiedFields(section: SectionDef, data: Record<string, un
       } else if (JSON.stringify(value) !== JSON.stringify(def)) {
         count++;
       }
-    } else if (def !== undefined && def !== null && def !== '' && def !== false) {
-      // Default exists but value is empty = also modified (cleared)
-      count++;
     }
+    /* An absent key is NOT "cleared" — the daemon applies the default when the
+       key is missing, so undefined IS the default and counting it as modified
+       marked almost every section. That was survivable while the signal was an
+       unexplained 7px dot; the row now says the word "Modified", and the word
+       has to be true (TRA-295). */
   }
   return count;
 }
@@ -248,7 +249,6 @@ export const CONFIG_SCHEMA: SectionDef[] = [
   {
     key: '_root',
     label: 'General',
-    icon: '⚡',
     description: 'Auto-update and top-level settings',
     fields: [
       { key: 'auto_update', label: 'Auto-update', type: 'boolean', defaultValue: true },
@@ -272,8 +272,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
   },
   {
     key: 'ai',
-    label: 'AI / Embeddings',
-    icon: '🧠',
+    label: 'AI and embeddings',
     description: 'AI provider for semantic search, summaries, and intent classification',
     fields: [
       { key: 'enabled', label: 'Enabled', type: 'boolean', defaultValue: false },
@@ -365,7 +364,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
       },
       {
         key: 'api_key',
-        label: 'API Key',
+        label: 'API key',
         type: 'string',
         placeholder: 'sk-...',
         sensitive: true,
@@ -375,7 +374,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
       // ── Connection: Anthropic ──
       {
         key: 'api_key',
-        label: 'API Key',
+        label: 'API key',
         type: 'string',
         placeholder: 'sk-ant-...',
         sensitive: true,
@@ -386,7 +385,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
       // ── Connection: Gemini (Google Generative Language API — consumer endpoint) ──
       {
         key: 'api_key',
-        label: 'API Key',
+        label: 'API key',
         type: 'string',
         placeholder: 'AIza...',
         sensitive: true,
@@ -397,7 +396,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
       // ── Connection: Vertex AI (Google Cloud) ──
       {
         key: 'api_key',
-        label: 'Access Token',
+        label: 'Access token',
         type: 'string',
         placeholder: 'ya29....',
         sensitive: true,
@@ -407,7 +406,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
       },
       {
         key: 'vertex_project',
-        label: 'GCP Project',
+        label: 'GCP project',
         type: 'string',
         placeholder: 'my-gcp-project',
         showIf: 'provider=vertex',
@@ -416,7 +415,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
       },
       {
         key: 'vertex_location',
-        label: 'GCP Location',
+        label: 'GCP location',
         type: 'string',
         placeholder: 'us-central1',
         defaultValue: 'us-central1',
@@ -435,7 +434,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
       },
       {
         key: 'api_key',
-        label: 'API Key',
+        label: 'API key',
         type: 'string',
         placeholder: 'pa-...',
         sensitive: true,
@@ -454,7 +453,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
       },
       {
         key: 'api_key',
-        label: 'API Key',
+        label: 'API key',
         type: 'string',
         placeholder: 'sk-...',
         sensitive: true,
@@ -472,7 +471,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
       },
       {
         key: 'api_key',
-        label: 'API Key',
+        label: 'API key',
         type: 'string',
         placeholder: 'gsk_...',
         sensitive: true,
@@ -490,7 +489,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
       },
       {
         key: 'api_key',
-        label: 'API Key',
+        label: 'API key',
         type: 'string',
         placeholder: 'sk-...',
         sensitive: true,
@@ -508,7 +507,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
       },
       {
         key: 'api_key',
-        label: 'API Key',
+        label: 'API key',
         type: 'string',
         placeholder: 'sk-...',
         sensitive: true,
@@ -527,7 +526,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
       },
       {
         key: 'api_key',
-        label: 'API Key',
+        label: 'API key',
         type: 'string',
         placeholder: 'xai-...',
         sensitive: true,
@@ -939,7 +938,6 @@ export const CONFIG_SCHEMA: SectionDef[] = [
   {
     key: 'security',
     label: 'Security',
-    icon: '🔒',
     description: 'Secret detection and file limits',
     fields: [
       {
@@ -968,8 +966,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
   },
   {
     key: 'predictive',
-    label: 'Predictive Analysis',
-    icon: '📊',
+    label: 'Predictive analysis',
     description: 'Bug prediction, tech debt scoring, change risk',
     fields: [
       { key: 'enabled', label: 'Enabled', type: 'boolean', defaultValue: true },
@@ -1012,8 +1009,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
   },
   {
     key: 'intent',
-    label: 'Intent / Domains',
-    icon: '🏷️',
+    label: 'Intent and domains',
     description: 'Domain classification and auto-tagging',
     fields: [
       { key: 'enabled', label: 'Enabled', type: 'boolean', defaultValue: false },
@@ -1051,8 +1047,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
   },
   {
     key: 'runtime',
-    label: 'Runtime Tracing (OTLP)',
-    icon: '📡',
+    label: 'Runtime tracing (OTLP)',
     description: 'OpenTelemetry span ingestion and trace analysis',
     fields: [
       { key: 'enabled', label: 'Enabled', type: 'boolean', defaultValue: false },
@@ -1136,8 +1131,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
   },
   {
     key: 'topology',
-    label: 'Cross-repo Topology',
-    icon: '🔗',
+    label: 'Cross-repo topology',
     description: 'Subprojects and cross-service dependency tracking',
     fields: [
       { key: 'enabled', label: 'Enabled', type: 'boolean', defaultValue: true },
@@ -1173,8 +1167,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
   },
   {
     key: 'lsp',
-    label: 'LSP Enrichment',
-    icon: '🔬',
+    label: 'LSP enrichment',
     description: 'Compiler-grade call graph resolution via Language Server Protocol',
     fields: [
       {
@@ -1237,8 +1230,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
   },
   {
     key: 'quality_gates',
-    label: 'Quality Gates',
-    icon: '✅',
+    label: 'Quality gates',
     description: 'Automated quality checks on commits and PRs',
     fields: [
       { key: 'enabled', label: 'Enabled', type: 'boolean', defaultValue: true },
@@ -1261,8 +1253,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
   },
   {
     key: 'tools',
-    label: 'Tool Exposure',
-    icon: '🔧',
+    label: 'Tool exposure',
     description: 'Control which MCP tools are exposed and how',
     fields: [
       {
@@ -1307,8 +1298,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
   },
   {
     key: 'ignore',
-    label: 'Ignore Rules',
-    icon: '🚫',
+    label: 'Ignore rules',
     description: 'Extra directories and patterns to skip during indexing',
     fields: [
       {
@@ -1323,7 +1313,6 @@ export const CONFIG_SCHEMA: SectionDef[] = [
   {
     key: 'frameworks',
     label: 'Frameworks',
-    icon: '⚙️',
     description: 'Framework-specific settings (Laravel, etc.)',
     fields: [
       {
@@ -1337,7 +1326,6 @@ export const CONFIG_SCHEMA: SectionDef[] = [
   {
     key: 'logging',
     label: 'Logging',
-    icon: '📝',
     description: 'File logging and rotation',
     fields: [
       { key: 'file', label: 'Enable file logging', type: 'boolean', defaultValue: false },
@@ -1369,8 +1357,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
   },
   {
     key: 'watch',
-    label: 'File Watcher',
-    icon: '👁️',
+    label: 'File watcher',
     description: 'Auto-reindex on file changes',
     fields: [
       { key: 'enabled', label: 'Enabled', type: 'boolean', defaultValue: true },


### PR DESCRIPTION
Stage 3 of the macOS 26 revision (TRA-284). Three surfaces migrated whole, every claim measured on the running renderer before and after.

Closes TRA-295.

## MCP clients

| | Before | After |
|---|---|---|
| Row actions | 10 accent-filled `Connect` buttons stacked vertically | bordered 24px capsules; **zero** prominent controls on the screen |
| Rows | on the bare frame: grey dot, 12px name, ~1000px dead width, button | 44px rows of one inset grouped list, 720px measure |
| Leading dot | grey for every supported client, no legend | gone; state is a green dot **plus** the word "Connected" |
| Manual clients | the grey word `Manual`, right-aligned | "Set up manually…" button that discloses the steps |
| Session label | `401b97c5 http` | project name leads, `401b97c5 · http` is a monospace caption, `Active · 8s ago` |
| Chrome | no toolbar, no title, two unlabelled 18px refresh glyphs | 52px glass toolbar, title, one labelled refresh button |
| Level picker | hand-rolled popover | the shared `Menu` |

## Settings

| | Before | After |
|---|---|---|
| Groups | 7, all unlabelled | titled: General · Intelligence · Quality and security · Infrastructure · Development · Monitoring · Advanced |
| `lsp` section | **never rendered** — it belonged to no group, and groups are what the list renders | in Infrastructure |
| `Edit JSON` | the most prominent control on the screen | an overflow menu item; the list has no prominent control |
| "differs from defaults" | a 7px blue dot with no legend anywhere | the word "Modified" |
| Daemon card | `PID 64806 · Port 3741 · 22s` | `Running · port 3741 · up 1m`; PID behind "Copy daemon details" |
| Section names | `Quality Gates`, `Ignore Rules`, `Tool Exposure`, `AI / Embeddings`, … | sentence case, in the schema itself |
| Search | 928 × 28px, 7px radius, full-width grey rectangle | the `SearchField` primitive, 24px capsule, in the toolbar |
| Rows | 32–33px, ad-hoc | 36px |
| Unsaved-changes bar | `position: fixed` across the **whole window**, incl. under the sidebar | scoped to the pane, glass, one prominent action |
| Field help | a 14px non-focusable `?` span | an 11px caption |
| Field labels | `features.Use embeddings` — the nested key inline at label size | `Use embeddings` |
| Section icons | 14 emoji in the schema | deleted — nothing ever read that field |

### Two data bugs the rebuild exposed

`countModifiedFields` counted a **never-set** key as "cleared", so almost every section reported as modified. An absent key *is* the default — the daemon applies the default when the key is missing. Survivable while the signal was an unexplained dot; not once the row says the word. Same fix at field level, which is why `Reset` no longer sits on nine rows out of thirteen.

## Onboarding

Was a plain dark rectangle with a hard focus ring, no backdrop dim, no sheet geometry and no title bar. Now a macOS sheet: attached to the window's top edge (square top corners, 12px bottom), slides out of it, dimmed scrim, floating-panel shadow only, Esc and backdrop dismissal, **Tab trapped inside**.

`user-select: none` is set globally on `body`, so `npm install -g trace-mcp` — the one thing the dialog existed to communicate — could not be selected, let alone copied. It is a selectable monospace field with a copy button. Verified by actually copying it on the running renderer (the button flips to "Copied" only after `clipboard.writeText` resolves) and by a unit test asserting the exact string.

All six states designed and screenshotted: cli-missing · cli-stale · install-prompt · installing · installed · skipped.

## Also

- **OllamaPanel** migrated with the surface it renders inside: Lattice buttons, 0.5px hairlines, 44px rows, sentence-case captions instead of 10px ALL CAPS, and a `ConfirmPopover` instead of a blocking `window.confirm()` for deleting a model.
- **Focus ring**: the primitives still used `outline: 2px solid var(--accent); outline-offset: 2px`, which drew blue-on-blue with a dark gap on a prominent button — the same defect TRA-295 flagged, relocated from `app.css` to `controls.css` by TRA-290. It is the house `--focus-ring` now, like every other focusable element in the app.

## Verification

- `pnpm run typecheck`, `pnpm run test` (163 pass, 17 files — 17 new tests across `Clients.test.tsx`, `Settings.test.tsx`, `GuardOnboarding.test.tsx`), `pnpm run build` — all green.
- `scripts/design-tokens.mjs` clean; the raw-value baselines for `Clients.tsx`, `Settings.tsx`, `GuardOnboarding.tsx` and `OllamaPanel.tsx` are **removed**, not raised — those files are at zero.
- Runtime assertions on the running renderer: no prominent control on either list, every `.lx-btn` at 24px, font sizes on the Settings list are exactly {11, 13, 17}, rows 36px, search 24px capsule.
- Both appearances screenshotted, plus Reduce Transparency and Increase Contrast, the daemon-down and loading states, and the window at 620×520.
- Tabbed both screens end to end: DOM order, focus visible on every control, ring follows the card radius.

## Not in this PR

⌘, for Settings needs the app-menu sub-issue and is not wired here.
