### PR TITLE
feat(app): one toolbar per surface for Activity and Memory (TRA-294)

### DIFF
--- a/packages/app/scripts/token-guard.baseline.json
+++ b/packages/app/scripts/token-guard.baseline.json
@@ -7,11 +7,8 @@
   "src/renderer/components/ProjectStatsModal.tsx": 7,
   "src/renderer/lattice/icons.tsx": 1,
   "src/renderer/lattice/ui/Badge.tsx": 2,
-  "src/renderer/styles/island.css": 83,
-  "src/renderer/tabs/AIActivity.tsx": 6,
+  "src/renderer/styles/island.css": 36,
   "src/renderer/tabs/AskTab.tsx": 5,
   "src/renderer/tabs/GraphExplorerGPU.tsx": 51,
-  "src/renderer/tabs/MemoryExplorer.tsx": 37,
-  "src/renderer/tabs/Notebook.tsx": 1,
-  "src/renderer/tabs/ToolActivity.tsx": 33
+  "src/renderer/tabs/Notebook.tsx": 1
 }

--- a/packages/app/src/main/preload.ts
+++ b/packages/app/src/main/preload.ts
@@ -79,6 +79,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   restartApp: (): Promise<void> => ipcRenderer.invoke('restart-app'),
   openSettings: (section?: string): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('open-settings', section),
+  /* Client setup lives in the menu window; the Activity feed that tells you
+     nothing is connected lives in a project window. Without this verb its
+     empty state had no action to offer (TRA-294). */
+  openClients: (): Promise<{ ok: boolean }> => ipcRenderer.invoke('open-clients'),
   // Tab management (Windows custom tab bar)
   getPlatform: (): Promise<string> => ipcRenderer.invoke('get-platform'),
   focusTab: (tabId: string): Promise<{ ok: boolean }> => ipcRenderer.invoke('focus-tab', tabId),

--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -257,6 +257,12 @@ ipcMain.handle('open-settings', (_event: Electron.IpcMainInvokeEvent, section?: 
   return { ok: true };
 });
 
+// IPC: open the menu window on the MCP clients tab
+ipcMain.handle('open-clients', () => {
+  showMenuWindow('clients');
+  return { ok: true };
+});
+
 // IPC: get current platform (renderer needs this to decide whether to show custom tabs)
 ipcMain.handle('get-platform', () => process.platform);
 

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -808,9 +808,9 @@ export function App() {
      own 52px toolbar and its own 16px gutters since TRA-292, so the pane's
      `p-4` was doubling every inset on it — the KPI row started at x=32 and the
      first card at y=76 (TRA-306). MCP clients and Settings drew their own
-     toolbars in TRA-295 and joined them. */
+     toolbars in TRA-295 and joined them; Activity and Memory in TRA-294. */
   const ownsToolbar = isProject
-    ? projectTab === 'overview'
+    ? projectTab === 'overview' || projectTab === 'activity' || projectTab === 'memory'
     : globalTab === 'workspace' || globalTab === 'clients' || globalTab === 'settings';
   const isGraphGpu = isGraph; // alias — the Graph tab *is* the GPU graph now
 

--- a/packages/app/src/renderer/electron.d.ts
+++ b/packages/app/src/renderer/electron.d.ts
@@ -50,6 +50,7 @@ declare global {
       }>;
       restartApp: () => Promise<void>;
       openSettings: (section?: string) => Promise<{ ok: boolean }>;
+      openClients: () => Promise<{ ok: boolean }>;
       // Tab management (Windows custom tab bar)
       getPlatform: () => Promise<string>;
       focusTab: (tabId: string) => Promise<{ ok: boolean }>;

--- a/packages/app/src/renderer/lattice/ui/Badge.tsx
+++ b/packages/app/src/renderer/lattice/ui/Badge.tsx
@@ -10,6 +10,7 @@
    no gain. */
 
 import type { ReactNode } from 'react';
+import { Icon } from '../icons';
 
 export type Tone = 'neutral' | 'accent' | 'green' | 'orange' | 'red' | 'blue' | 'purple';
 
@@ -18,6 +19,9 @@ const LEGACY_TONE: Record<string, Tone> = { gold: 'orange', pink: 'purple' };
 
 export interface BadgeProps {
   tone?: Tone | 'gold' | 'pink';
+  /** Leading 11px glyph. A tone is a colour; pairing it with a glyph is what
+      keeps a status badge readable without colour vision. */
+  icon?: string;
   className?: string;
   title?: string;
   'aria-label'?: string;
@@ -26,6 +30,7 @@ export interface BadgeProps {
 
 export function Badge({
   tone = 'neutral',
+  icon,
   className,
   title,
   'aria-label': ariaLabel,
@@ -35,6 +40,7 @@ export function Badge({
   const cls = ['lx-badge', `t-${t}`, className ?? ''].filter(Boolean).join(' ');
   return (
     <span className={cls} title={title} aria-label={ariaLabel}>
+      {icon ? <Icon name={icon} size={11} /> : null}
       {children}
     </span>
   );

--- a/packages/app/src/renderer/lattice/ui/SearchField.tsx
+++ b/packages/app/src/renderer/lattice/ui/SearchField.tsx
@@ -5,7 +5,7 @@
    centred-placeholder-that-slides-left animation, which animated `left` (a
    layout property) over 0.42s and matched nothing on the platform. */
 
-import { useRef, type ReactNode } from 'react';
+import { useRef, type ReactNode, type RefObject } from 'react';
 import { Icon } from '../icons';
 
 export interface SearchFieldProps {
@@ -17,6 +17,8 @@ export interface SearchFieldProps {
   autoFocus?: boolean;
   className?: string;
   'aria-label'?: string;
+  /** Escape hatch for surfaces that focus the field from a keyboard shortcut. */
+  inputRef?: RefObject<HTMLInputElement | null>;
 }
 
 export function SearchField({
@@ -27,8 +29,10 @@ export function SearchField({
   autoFocus = false,
   className,
   'aria-label': ariaLabel,
+  inputRef: externalRef,
 }: SearchFieldProps): ReactNode {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const localRef = useRef<HTMLInputElement>(null);
+  const inputRef = externalRef ?? localRef;
   const cls = ['lx-search', grow ? 'grow' : '', className ?? ''].filter(Boolean).join(' ');
 
   return (

--- a/packages/app/src/renderer/lattice/ui/Surface.tsx
+++ b/packages/app/src/renderer/lattice/ui/Surface.tsx
@@ -1,0 +1,186 @@
+/* Surface.tsx — the skeleton every content surface is built from (TRA-294).
+
+   Extracted from ProjectOverview (TRA-293), which proved the shapes; Activity
+   and Memory are the second and third callers, so they move here rather than
+   being copied twice more.
+
+     <Toolbar>          52px glass row, one per surface, scroll-edge hairline
+     <Section title>    11/600 header + whitespace grouping, no rules
+     <Card>             CONTENT: opaque --surface, 12px radius, hairline,
+                        no shadow and no backdrop-filter. Ever.
+     <ListRow>          32px label/value row of a grouped list
+     <SkeletonRows>     loading at the real geometry, so nothing shifts
+     <SectionError>     "couldn't measure this" + the one action that helps
+*/
+
+import type { CSSProperties, ReactNode } from 'react';
+import { Icon } from '../icons';
+import { Skeleton } from '../../workspace/components/Skeleton';
+import { Button } from './Button';
+
+/** 52px glass toolbar. ONE per surface — a second control row is a bug.
+    `scrolled` fades in the hairline instead of a permanent hard border. */
+export function Toolbar({
+  scrolled = false,
+  className,
+  children,
+}: {
+  scrolled?: boolean;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      role="toolbar"
+      className={`flex items-center gap-2 px-4 shrink-0 glass relative${className ? ` ${className}` : ''}`}
+      style={{
+        height: 52,
+        borderBottom: '0.5px solid transparent',
+        borderBottomColor: scrolled ? 'var(--separator)' : 'transparent',
+        transition: 'border-bottom-color var(--dur-standard) var(--ease-out)',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Vertical rule between toolbar clusters. 16px, hairline, decoration. */
+export function ToolbarDivider() {
+  return (
+    <span
+      aria-hidden="true"
+      className="shrink-0"
+      style={{ width: 1, height: 16, background: 'var(--separator)' }}
+    />
+  );
+}
+
+export function Section({
+  title,
+  count,
+  trailing,
+  children,
+}: {
+  title: string;
+  count?: number;
+  trailing?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2 px-1 min-h-6">
+        <h3
+          className="flex items-baseline gap-1.5 text-[11px] leading-[13px] font-semibold"
+          style={{ color: 'var(--label-secondary)' }}
+        >
+          {title}
+          {count !== undefined && count > 0 && (
+            <span className="tabular-nums" style={{ color: 'var(--label-secondary)' }}>
+              {count.toLocaleString()}
+            </span>
+          )}
+        </h3>
+        {trailing}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+/** Inset grouped-list container. Content, so: opaque, hairline, no shadow. */
+export function Card({
+  children,
+  className,
+  style,
+}: {
+  children: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <div
+      className={`overflow-hidden${className ? ` ${className}` : ''}`}
+      style={{
+        background: 'var(--surface)',
+        borderRadius: 12,
+        border: '0.5px solid var(--separator)',
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** One label/value row of a grouped list. 32px, 13px both sides. */
+export function ListRow({
+  label,
+  value,
+  last = false,
+}: {
+  label: ReactNode;
+  value: ReactNode;
+  last?: boolean;
+}) {
+  return (
+    <div
+      className="flex items-center justify-between gap-3 px-3"
+      style={{
+        minHeight: 32,
+        borderBottom: last ? 'none' : '0.5px solid var(--separator)',
+      }}
+    >
+      <span className="text-[13px] leading-4" style={{ color: 'var(--label)' }}>
+        {label}
+      </span>
+      <span
+        className="text-[13px] leading-4 tabular-nums truncate"
+        style={{ color: 'var(--label-secondary)' }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+/** Rows at the real 32px geometry so nothing moves when the data lands. */
+export function SkeletonRows({ rows }: { rows: number }) {
+  return (
+    <div role="status" aria-label="Loading">
+      {Array.from({ length: rows }, (_, i) => (
+        <div
+          key={i}
+          className="flex items-center justify-between px-3"
+          style={{
+            minHeight: 32,
+            borderBottom: i === rows - 1 ? 'none' : '0.5px solid var(--separator)',
+          }}
+        >
+          <Skeleton width={92 + ((i * 29) % 40)} height={11} />
+          <Skeleton width={48 + ((i * 17) % 32)} height={11} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Inline "we couldn't measure this" panel with the one action that helps. */
+export function SectionError({ what, onRetry }: { what: string; onRetry: () => void }) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2.5">
+      <Icon name="warning" size={14} />
+      <span className="text-[13px] leading-4 flex-1" style={{ color: 'var(--label-secondary)' }}>
+        Couldn&apos;t load {what}. The daemon may still be indexing.
+      </span>
+      <Button size="small" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  );
+}
+
+/* Re-exported rather than moved: Skeleton is a general primitive with two
+   existing importers, and a re-export gives every surface the one import path
+   at the cost of a single line. */
+export { Skeleton };

--- a/packages/app/src/renderer/lattice/ui/index.ts
+++ b/packages/app/src/renderer/lattice/ui/index.ts
@@ -39,3 +39,14 @@ export type { EmptyStateProps } from './EmptyState';
 
 export { Menu, MenuItem, MenuSection, MenuSeparator, ConfirmPopover, useMenuAnchor } from './Menu';
 export type { MenuProps, MenuItemProps, ConfirmPopoverProps } from './Menu';
+
+export {
+  Card,
+  ListRow,
+  Section,
+  SectionError,
+  Skeleton,
+  SkeletonRows,
+  Toolbar,
+  ToolbarDivider,
+} from './Surface';

--- a/packages/app/src/renderer/styles/island.css
+++ b/packages/app/src/renderer/styles/island.css
@@ -605,196 +605,23 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
   --glass-line: rgba(0, 0, 0, 0.06);
 }
 
-/* shared toolbars */
-.ws-view-bar {
-  flex: none; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; row-gap: 8px;
-  padding: 11px 16px; border-bottom: 0.5px solid var(--sep); min-height: 42px;
-}
-.ws-view-subbar {
-  flex: none; display: flex; align-items: center; gap: 10px; min-width: 0; flex-wrap: wrap; row-gap: 8px;
-  padding: 10px 16px; border-bottom: 0.5px solid var(--sep);
-}
-.ws-view-subbar.flush { border-bottom: 0; padding: 0; }
-.ws-view-bar .grow, .ws-view-subbar .grow { flex: 1; }
-.ws-tdiv { width: 0.5px; align-self: stretch; margin: 4px 2px; background: var(--sep); flex: none; }
-
-/* Segmented control, chip/text buttons and the small search field moved to
+/* Segmented control, chip/text buttons and the small search field live in
    controls.css (.lx-seg / .lx-btn / .lx-search) — capsules on the 20/24/28
-   height scale (TRA-290). */
+   height scale (TRA-290). The unified search field is SearchField.tsx. */
 
 .lx-btn kbd {
   font-family: inherit; font-size: 11px; padding: 1px 4px; border-radius: var(--radius-row);
   background: var(--row-hover); color: var(--text-2);
 }
 
-/* The unified search field is SearchField.tsx + .lx-search in controls.css.
-   The old `.ws-sbar` centred-placeholder-that-slides-left treatment is gone:
-   it animated `left` (a layout property) over 0.42s and matched nothing on
-   the platform (TRA-290). */
-
-/* inline-label filter field */
-.ws-ff {
-  flex: 1 1 0; min-width: 0; display: inline-flex; align-items: center; gap: 8px;
-  height: 32px; padding: 0 12px; border-radius: var(--radius-popover); border: 0.5px solid var(--sep);
-  background: var(--row-hover); color: var(--text-3); transition: border-color .12s, background .12s;
-}
-.ws-ff:focus-within { border-color: var(--accent); background: var(--island); }
-.ws-ff .ff-lab {
-  flex: none; font-size: 10px; font-weight: 700; letter-spacing: 0.07em; text-transform: uppercase;
-  color: var(--text-3); padding-right: 9px; border-right: 0.5px solid var(--sep);
-}
-.ws-ff input { flex: 1; min-width: 0; border: 0; background: none; outline: 0; color: var(--text-1); font-family: inherit; font-size: 13px; }
-
-/* depth control group */
-.ws-depth { display: inline-flex; align-items: center; gap: 8px; flex: none; }
-.ws-depth .lab { font-size: 10px; font-weight: 700; letter-spacing: 0.07em; text-transform: uppercase; color: var(--text-3); }
-.ws-stepper { display: inline-flex; align-items: center; border: 0.5px solid var(--sep); border-radius: var(--radius-popover); overflow: hidden; }
-.ws-stepper button { width: 28px; height: 30px; border: 0; background: transparent; color: var(--text-2); cursor: default; display: flex; align-items: center; justify-content: center; }
-.ws-stepper button:hover { background: var(--row-hover); color: var(--text-1); }
-.ws-stepper span { min-width: 26px; text-align: center; font-size: 13px; color: var(--text-1); font-variant-numeric: tabular-nums; }
-
-/* live + zoom */
-.ws-live { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-1); font-weight: 500; }
-.ws-live .dot { width: 7px; height: 7px; border-radius: 50%; background: #2f9e6e; box-shadow: 0 0 0 3px color-mix(in srgb, #2f9e6e 22%, transparent); animation: ws-pulse 2.4s ease-in-out infinite; }
-@keyframes ws-pulse { 0%, 100% { box-shadow: 0 0 0 2px color-mix(in srgb, #2f9e6e 26%, transparent); } 50% { box-shadow: 0 0 0 5px color-mix(in srgb, #2f9e6e 8%, transparent); } }
-
-/* The prominent button is .lx-btn.v-prominent in controls.css (TRA-290). */
-
-/* ---- ACTIVITY --------------------------------------------------------- */
-.ws-av-cards {
-  flex: none; display: grid; grid-template-columns: repeat(auto-fit, minmax(168px, 1fr)); gap: 12px;
-  padding: 16px; border-bottom: 0.5px solid var(--sep);
-}
-.ws-statcard { min-width: 0; }
-.ws-statcard {
-  display: flex; flex-direction: column; gap: 8px; padding: 13px 15px; border-radius: var(--radius-card);
-  border: 0.5px solid var(--glass-line); background: var(--glass);
-  -webkit-backdrop-filter: blur(12px) saturate(1.4); backdrop-filter: blur(12px) saturate(1.4);
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 4px 14px rgba(0, 0, 0, 0.10);
-}
-.ws-statcard .sc-top { display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-wrap: wrap; row-gap: 6px; }
-.ws-statcard .sc-lab { font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--text-3); }
-.ws-statcard .sc-val { font-size: 30px; font-weight: 700; line-height: 1; color: var(--text-1); font-variant-numeric: tabular-nums; display: flex; align-items: baseline; gap: 6px; }
-.ws-statcard .sc-val.warn { color: #e0735c; }
-.ws-statcard .sc-unit { font-size: 12px; font-weight: 500; color: var(--text-3); letter-spacing: 0; }
-.ws-statcard .sc-sub { font-size: 11px; color: var(--text-3); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ws-statcard .sc-spark { display: flex; align-items: flex-end; gap: 3px; height: 22px; }
-.ws-statcard .sc-spark span { flex: 1; background: color-mix(in srgb, var(--accent) 55%, transparent); border-radius: 2px 2px 0 0; min-height: 3px; }
-.ws-statcard .sc-spark span:last-child { background: var(--accent); }
-.ws-statcard .sc-meter { height: 6px; border-radius: var(--radius-row); background: var(--row-hover); overflow: hidden; }
-.ws-statcard .sc-meter span { display: block; height: 100%; border-radius: var(--radius-row); background: var(--accent); }
-.ws-statcard .sc-meter span.warn { background: #e0735c; }
-.ws-statcard .sc-pills { display: flex; gap: 8px; }
-.ws-statcard .sc-pills span { font-size: 12px; padding: 3px 9px; border-radius: var(--radius-capsule); background: var(--row-hover); color: var(--text-3); }
-.ws-statcard .sc-pills .ok { color: #43b07f; background: color-mix(in srgb, #2f9e6e 14%, transparent); }
-.ws-statcard .sc-pills b { font-weight: 700; margin-right: 3px; }
-
-.ws-av-head {
-  flex: none; display: grid; grid-template-columns: 10px minmax(130px, 1fr) minmax(0, 1.6fr) 100px 122px 60px; align-items: center; gap: 14px;
-  padding: 9px 18px; border-bottom: 0.5px solid var(--sep);
-  font-size: 10px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-3);
-}
-.ws-av-head .r { text-align: right; }
-.ws-av-head span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ws-av-list { padding: 2px 0; }
-.ws-av-row {
-  display: grid; grid-template-columns: 10px minmax(130px, 1fr) minmax(0, 1.6fr) 100px 122px 60px; align-items: center; gap: 14px;
-  padding: 9px 18px; font-size: 13px; border-bottom: 0.5px solid var(--sep);
-}
-.ws-av-row:hover { background: var(--row-hover); }
-.ws-av-row.err { background: color-mix(in srgb, #e0563a 7%, transparent); }
-.ws-av-row .st { width: 8px; height: 8px; border-radius: 50%; }
-.ws-av-row .st.ok { background: #2f9e6e; }
-.ws-av-row .st.bad { background: #e0563a; box-shadow: 0 0 0 3px color-mix(in srgb, #e0563a 18%, transparent); }
-.ws-av-row .tool { font-family: var(--font-mono); font-size: 12px; color: var(--text-1); font-weight: 600; overflow: hidden; text-overflow: ellipsis; }
-.ws-av-row .params { color: var(--text-2); font-family: var(--font-mono); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ws-av-row .sess { font-size: 11px; color: var(--text-2); padding: 2px 9px; border-radius: var(--radius-capsule); background: var(--row-hover); justify-self: start; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ws-av-row .durcell { display: flex; align-items: center; gap: 9px; justify-content: flex-end; }
-.ws-av-row .durcell .bar { width: 64px; height: 5px; border-radius: 3px; background: var(--row-hover); overflow: hidden; }
-.ws-av-row .durcell .bar span { display: block; height: 100%; border-radius: 3px; }
-.ws-av-row .durcell .bar span.fast { background: #2f9e6e; }
-.ws-av-row .durcell .bar span.mid { background: #c9962f; }
-.ws-av-row .durcell .bar span.slow { background: #e0563a; }
-.ws-av-row .dur { font-variant-numeric: tabular-nums; font-size: 12px; font-weight: 600; min-width: 46px; text-align: right; }
-.ws-av-row .dur.fast { color: #43b07f; }
-.ws-av-row .dur.mid { color: #cda23f; }
-.ws-av-row .dur.slow { color: #e0735c; }
-.ws-av-row .time { font-size: 11px; color: var(--text-3); font-variant-numeric: tabular-nums; text-align: right; }
-
-/* ---- MEMORY ----------------------------------------------------------- */
-.ws-mv-body { padding: 16px 18px; display: flex; flex-direction: column; gap: 16px; overflow-y: auto; overflow-x: hidden; }
-.ws-mv-top { display: flex; gap: 12px; align-items: stretch; flex-wrap: wrap; }
-.ws-mv-top .ws-statcard.wide { flex: 1 1 200px; }
-.ws-mv-top .ws-statcard.grow2 { flex: 3 1 320px; min-width: 0; }
-
-.ws-mv-dist { display: flex; height: 12px; border-radius: var(--radius-row); overflow: hidden; gap: 2px; }
-.ws-mv-dist .seg { height: 100%; border-radius: 3px; opacity: 0.95; }
-.ws-mv-dist .seg.blue { background: #5b8df5; } .ws-mv-dist .seg.red { background: #e0735c; }
-.ws-mv-dist .seg.pink { background: #d96cb0; } .ws-mv-dist .seg.gray { background: var(--text-3); }
-.ws-mv-dist .seg.gold { background: #cda23f; } .ws-mv-dist .seg.green { background: #43b07f; }
-.ws-mv-cats { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 2px; }
-.mv-cat {
-  display: inline-flex; align-items: center; gap: 7px; border: 0.5px solid var(--sep); cursor: default; white-space: nowrap;
-  font-family: inherit; font-size: 12px; font-weight: 550; color: var(--text-2);
-  padding: 4px 11px 4px 8px; border-radius: var(--radius-capsule); background: transparent; transition: background .12s, border-color .12s, color .12s;
-}
-.mv-cat:hover { background: var(--row-hover); color: var(--text-1); }
-.mv-cat .swatch { width: 8px; height: 8px; border-radius: 50%; }
-.mv-cat.blue .swatch { background: #5b8df5; } .mv-cat.red .swatch { background: #e0735c; }
-.mv-cat.pink .swatch { background: #d96cb0; } .mv-cat.gray .swatch { background: var(--text-3); }
-.mv-cat.gold .swatch { background: #cda23f; } .mv-cat.green .swatch { background: #43b07f; }
-.mv-cat b { font-weight: 700; color: var(--text-1); }
-.mv-cat.is-active { background: var(--accent-fill); border-color: transparent; color: var(--on-accent); }
-.mv-cat.is-active b { color: #fff; } .mv-cat.is-active .swatch { box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.5); }
-
-.mv-badge { font-size: 10px; font-weight: 700; letter-spacing: 0.05em; padding: 2px 7px; border-radius: var(--radius-row); white-space: nowrap; }
-.mv-badge.outline { background: transparent; border: 1px solid color-mix(in srgb, var(--accent) 50%, transparent); color: var(--accent); }
-.mv-badge.blue { background: color-mix(in srgb, #3574f0 16%, transparent); color: #6f9bf6; }
-.mv-badge.red { background: color-mix(in srgb, #e0563a 16%, transparent); color: #e0735c; }
-.mv-badge.pink { background: color-mix(in srgb, #d6469b 16%, transparent); color: #d96cb0; }
-.mv-badge.gray { background: var(--row-hover); color: var(--text-2); }
-.mv-badge.gold { background: color-mix(in srgb, #c9962f 18%, transparent); color: #cda23f; }
-.mv-badge.green { background: color-mix(in srgb, #2f9e6e 16%, transparent); color: #43b07f; }
-
-.ws-mv-listhead { display: flex; align-items: baseline; justify-content: space-between; }
-.ws-mv-listhead span { font-size: 13px; font-weight: 600; color: var(--text-1); }
-.ws-mv-listhead .found { font-size: 12px; font-weight: 400; color: var(--text-3); }
-.ws-mv-list { display: flex; flex-direction: column; gap: 8px; }
-.ws-mv-row {
-  display: flex; align-items: stretch; gap: 12px; padding: 13px 14px 13px 0;
-  border: 0.5px solid var(--sep); border-radius: var(--radius-card); background: var(--island);
-  transition: border-color .12s, transform .08s;
-}
-.ws-mv-row:hover { border-color: color-mix(in srgb, var(--text-3) 40%, transparent); }
-.ws-mv-row .accent { width: 3px; border-radius: 3px; flex: none; margin: 2px 0; }
-.ws-mv-row.blue .accent { background: #5b8df5; } .ws-mv-row.red .accent { background: #e0735c; }
-.ws-mv-row.pink .accent { background: #d96cb0; } .ws-mv-row.gray .accent { background: var(--text-3); }
-.ws-mv-row.gold .accent { background: #cda23f; } .ws-mv-row.green .accent { background: #43b07f; }
-.ws-mv-row .body { flex: 1; min-width: 0; }
-.ws-mv-row .line1 { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
-.ws-mv-row .line1 .t { font-size: 13px; color: var(--text-1); font-weight: 500; }
-.ws-mv-row .date { display: inline-flex; align-items: center; gap: 5px; font-size: 12px; color: var(--text-3); margin-top: 6px; }
-.ws-mv-row .acts { display: flex; align-items: center; gap: 8px; flex: none; }
-.ws-mv-row .acts button { border: 0.5px solid var(--sep); background: transparent; cursor: default; font-family: inherit; font-size: 12px; padding: 5px 11px; border-radius: var(--radius-row); }
-.ws-mv-row .acts .edit { color: var(--text-1); }
-.ws-mv-row .acts .edit:hover { background: var(--row-hover); }
-.ws-mv-row .acts .inval { color: #e0563a; border-color: color-mix(in srgb, #e0563a 35%, transparent); }
-.ws-mv-row .acts .inval:hover { background: color-mix(in srgb, #e0563a 12%, transparent); }
-.ws-mv-row .acts .chev { color: var(--text-3); display: flex; }
-
-/* ---- container-query responsiveness (responds to PANE width) ---------- */
-@container (max-width: 660px) {
-  .ws-av-head, .ws-av-row { grid-template-columns: 10px minmax(120px, 1fr) minmax(0, 1.4fr) 92px 60px 56px; gap: 12px; }
-  .ws-av-row .durcell .bar { display: none; }
-}
-@container (max-width: 520px) {
-  .ws-av-head, .ws-av-row { grid-template-columns: 10px minmax(110px, 1fr) minmax(0, 1.5fr) 56px; gap: 12px; }
-  .ws-av-row .sess, .ws-av-head .sess-h, .ws-av-row .time, .ws-av-head .time-h { display: none; }
-  .ws-view-bar .ws-textbtn, .ws-view-bar .ws-tdiv { display: none; }
-}
-@container (max-width: 400px) {
-  .ws-av-cards { grid-template-columns: 1fr 1fr; }
-}
+/* TRA-294 deleted ~190 lines of unreferenced rules from the ported design
+   bundle here: .ws-view-bar/.ws-view-subbar/.ws-tdiv, .ws-ff/.ff-lab,
+   .ws-depth/.ws-stepper, .ws-live, and the whole .ws-av-* / .ws-mv-* /
+   .ws-statcard Activity + Memory kit. No TSX ever referenced them — they were
+   a second, divergent design for two surfaces that render from inline styles,
+   and they carried 60+ of this file's raw hex values, glass on cards, 30px/700
+   stat values and colour-only status dots. Activity and Memory now build from
+   lattice/ui (Toolbar/Card/Section/Badge/Chip/EmptyState). */
 
 /* ============================================================================
    MENU & POPOVER — Liquid Glass · macOS 26  (floating overlays)
@@ -861,11 +688,42 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
   font-size: 12px;
 }
 .ws-ctx-item:hover:not(:disabled) .ws-ctx-sc { color: rgba(255, 255, 255, 0.85); }
-/* Section header inside a menu (grouped menu). */
+/* Leading check column for a toggle item (role=menuitemcheckbox). Reserved on
+   EVERY item of a menu that has one, so labels stay on one left edge whether
+   or not their row is checked — macOS never reflows a menu on toggle.
+   Menu.tsx shipped `checked`/`showCheckSlot` with no rule behind them; the
+   slot rendered as a zero-width span and the checkmark landed on the label
+   (TRA-294). */
+.ws-ctx-item .ws-ctx-check {
+  width: 14px;
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+}
+.ws-ctx-item:hover:not(:disabled) .ws-ctx-check { color: var(--on-accent); }
+/* Destructive item. Red LABEL on the flat menu, white on the accent hover —
+   never a red fill, which reads as "selected" rather than "dangerous". */
+.ws-ctx-item.danger { color: var(--status-red); }
+.ws-ctx-item.danger .ws-ctx-ico { color: var(--status-red); }
+.ws-ctx-item.danger:hover:not(:disabled) {
+  background: var(--danger-fill);
+  color: var(--on-accent);
+}
+.ws-ctx-item.danger:hover:not(:disabled) .ws-ctx-ico { color: var(--on-accent); }
+/* Group divider — a hairline with 5px of air, inset to the menu's padding. */
+.ws-ctx-sep {
+  height: 0.5px;
+  margin: 5px 8px;
+  background: var(--sep);
+}
+/* Section header inside a menu (grouped menu). 10px/500 caps is the one legal
+   ALL-CAPS case in the house style; 700 + 0.06em was a shout. */
 .ws-ctx-section {
   padding: 8px 9px 3px;
   font-size: 10px;
-  font-weight: 700;
+  font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--text-3);

--- a/packages/app/src/renderer/tabs/AIActivity.tsx
+++ b/packages/app/src/renderer/tabs/AIActivity.tsx
@@ -1,6 +1,28 @@
-import { useCallback, useEffect, useState } from 'react';
-
-/* ═══ AI Activity panel ════════════════════════════════════════════ */
+/**
+ * AI Activity — embed / LLM / rerank requests the daemon has made.
+ *
+ * Rebuilt on the macOS 26 layer (TRA-294). What it replaces, measured on the
+ * running surface: three glass "stat pills" (`backdrop-filter: blur(12px)` on
+ * what is content, not chrome) with 10px ALL-CAPS labels; a `MATCH`-style
+ * type badge rendered `meta.label.toUpperCase()` at 9px/700; a status dot that
+ * carried ok / error / pending in colour alone; a 320px-tall scroll box and a
+ * 20px top margin inside a pane that is already full height.
+ */
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { Icon } from '../lattice/icons';
+import {
+  Badge,
+  Button,
+  Card,
+  EmptyState,
+  ListRow,
+  SearchField,
+  SectionError,
+  StatusDot,
+  Toolbar,
+  ToolbarDivider,
+  type Tone,
+} from '../lattice/ui';
 
 interface AIEntry {
   id: number;
@@ -25,16 +47,32 @@ interface AIStats {
 
 /* ── Helpers ── */
 
-const TYPE_META: Record<string, { label: string; icon: string; color: string }> = {
-  embed: { label: 'Embed', icon: 'E', color: '#5856d6' },
-  embed_batch: { label: 'Batch', icon: 'B', color: '#af52de' },
-  generate: { label: 'LLM', icon: 'G', color: '#007aff' },
-  generate_stream: { label: 'Stream', icon: 'S', color: '#32ade6' },
-  rerank: { label: 'Rerank', icon: 'R', color: '#ff9500' },
+/* Tones come from the shared status palette, so every series in this surface
+   is contrast-checked once, in tokens.css, instead of six times in hex here. */
+const TYPE_META: Record<string, { label: string; tone: Tone }> = {
+  embed: { label: 'Embed', tone: 'purple' },
+  embed_batch: { label: 'Batch', tone: 'purple' },
+  generate: { label: 'Generate', tone: 'blue' },
+  generate_stream: { label: 'Stream', tone: 'accent' },
+  rerank: { label: 'Rerank', tone: 'orange' },
 };
-const typeMeta = (t: string) =>
-  TYPE_META[t] ?? { label: t, icon: '?', color: 'var(--text-tertiary)' };
-const fmtMs = (ms: number) => (ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`);
+const typeMeta = (t: string): { label: string; tone: Tone } =>
+  TYPE_META[t] ?? { label: t.replace(/_/g, ' '), tone: 'neutral' };
+
+const TYPE_VAR: Record<Tone, string> = {
+  /* A meter segment is decoration, not text, so the neutral series takes the
+     tertiary grey. At --label-secondary it out-weighed the purple/blue/red
+     series beside it and read as a disabled bar (TRA-294). */
+  neutral: 'var(--label-tertiary)',
+  accent: 'var(--accent)',
+  green: 'var(--status-green)',
+  orange: 'var(--status-orange)',
+  red: 'var(--status-red)',
+  blue: 'var(--status-blue)',
+  purple: 'var(--status-purple)',
+};
+
+const fmtMs = (ms: number) => (ms < 1000 ? `${Math.round(ms)} ms` : `${(ms / 1000).toFixed(1)} s`);
 const fmtTime = (iso: string) => {
   try {
     return new Date(iso).toLocaleTimeString([], {
@@ -54,8 +92,15 @@ const fmtAgo = (iso: string) => {
   return `${Math.floor(s / 3600)}h ago`;
 };
 
-/* ── Stat card (glass pill) ── */
-function StatPill({
+/** ok / error / pending, said in a word as well as a tone. */
+const STATUS_META: Record<AIEntry['status'], { tone: Tone; label: string; icon?: string }> = {
+  ok: { tone: 'green', label: 'OK' },
+  error: { tone: 'red', label: 'Error', icon: 'warning' },
+  pending: { tone: 'orange', label: 'Running', icon: 'schedule' },
+};
+
+/* ── Metric card — content anatomy: label → value → footnote. No glass. ── */
+function MetricCard({
   label,
   value,
   sub,
@@ -63,75 +108,98 @@ function StatPill({
 }: {
   label: string;
   value: string;
-  sub?: string;
+  sub?: ReactNode;
   color?: string;
 }) {
   return (
-    <div
-      style={{
-        flex: 1,
-        minWidth: 0,
-        padding: '8px 10px',
-        background: 'var(--fill-control)',
-        borderRadius: 10,
-        backdropFilter: 'blur(12px)',
-        WebkitBackdropFilter: 'blur(12px)',
-        border: '0.5px solid var(--border)',
-        boxShadow: 'var(--shadow-control)',
-      }}
-    >
-      <div
-        className="text-[10px] font-medium uppercase tracking-wider"
-        style={{ color: 'var(--text-tertiary)', marginBottom: 2 }}
-      >
-        {label}
-      </div>
-      <div
-        className="text-[15px] font-bold tabular-nums"
-        style={{ color: color ?? 'var(--text-primary)', lineHeight: 1.1 }}
-      >
-        {value}
-      </div>
-      {sub && (
-        <div
-          className="text-[10px] tabular-nums"
-          style={{ color: 'var(--text-tertiary)', marginTop: 1 }}
-        >
-          {sub}
+    <Card className="flex-1 min-w-0">
+      <div className="px-3 py-2.5 flex flex-col gap-1">
+        <div className="text-[11px] leading-[13px]" style={{ color: 'var(--label-secondary)' }}>
+          {label}
         </div>
-      )}
-    </div>
+        <div
+          className="text-[26px] leading-8 font-semibold tabular-nums"
+          style={{ color: color ?? 'var(--label)', letterSpacing: '-0.01em' }}
+        >
+          {value}
+        </div>
+        {sub != null && (
+          <div
+            className="text-[11px] leading-[13px] tabular-nums"
+            style={{ color: 'var(--label-secondary)' }}
+          >
+            {sub}
+          </div>
+        )}
+      </div>
+    </Card>
   );
 }
 
-/* ── Type breakdown mini-bar ── */
-function TypeBar({ stats }: { stats: AIStats }) {
+/** Share-of-requests bar plus its legend — and the legend IS the filter, so
+    the four request types are named once instead of twice (a legend above the
+    list and a chip row below it, saying the same thing). */
+function TypeBar({
+  stats,
+  filter,
+  onFilter,
+}: {
+  stats: AIStats;
+  filter: string | null;
+  onFilter: (next: string | null) => void;
+}) {
   const types = Object.entries(stats.by_type);
   const total = stats.total_requests || 1;
   return (
-    <div
-      style={{
-        display: 'flex',
-        gap: 1,
-        height: 4,
-        borderRadius: 2,
-        overflow: 'hidden',
-        background: 'var(--bg-inset)',
-      }}
-    >
-      {types.map(([type, s]) => (
-        <div
-          key={type}
-          title={`${typeMeta(type).label}: ${s.count}`}
-          style={{
-            width: `${(s.count / total) * 100}%`,
-            background: typeMeta(type).color,
-            minWidth: 2,
-            borderRadius: 1,
-            transition: 'width .3s ease',
-          }}
-        />
-      ))}
+    <div className="flex flex-col gap-2">
+      <div
+        className="flex overflow-hidden"
+        style={{ gap: 1, height: 6, borderRadius: 3, background: 'var(--fill-quaternary)' }}
+      >
+        {types.map(([type, s]) => (
+          <div
+            key={type}
+            title={`${typeMeta(type).label}: ${s.count}`}
+            style={{
+              width: `${(s.count / total) * 100}%`,
+              background: TYPE_VAR[typeMeta(type).tone],
+              minWidth: 2,
+              borderRadius: 2,
+              opacity: filter === null || filter === type ? 1 : 0.3,
+              transition:
+                'width var(--dur-large) var(--ease-out), opacity var(--dur-micro) var(--ease-out)',
+            }}
+          />
+        ))}
+      </div>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <button
+          type="button"
+          className={`lx-chip single${filter === null ? ' is-on' : ''}`}
+          aria-pressed={filter === null}
+          onClick={() => onFilter(null)}
+        >
+          All {stats.total_requests.toLocaleString()}
+        </button>
+        {types.map(([type, s]) => {
+          const meta = typeMeta(type);
+          const active = filter === type;
+          return (
+            <button
+              key={type}
+              type="button"
+              className={`lx-chip single${active ? ' is-on' : ''}`}
+              aria-pressed={active}
+              onClick={() => onFilter(active ? null : type)}
+              title={`Show only ${meta.label.toLowerCase()} requests`}
+            >
+              <StatusDot tone={meta.tone} size={6} />
+              {meta.label}
+              <span className="tabular-nums">{s.count}</span>
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -140,149 +208,112 @@ function TypeBar({ stats }: { stats: AIStats }) {
 function RequestRow({ entry, isLast }: { entry: AIEntry; isLast: boolean }) {
   const [showDetail, setShowDetail] = useState(false);
   const meta = typeMeta(entry.type);
+  const status = STATUS_META[entry.status];
   const isPending = entry.status === 'pending';
+  const slow = entry.duration_ms > 5000;
 
   return (
-    <div style={{ borderBottom: isLast ? 'none' : '1px solid var(--border-row)' }}>
+    <div style={{ borderBottom: isLast ? 'none' : '0.5px solid var(--separator)' }}>
       <button
         type="button"
         onClick={() => setShowDetail(!showDetail)}
+        aria-expanded={showDetail}
+        className="flex items-center gap-2 w-full text-left px-3"
         style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 8,
-          width: '100%',
+          minHeight: 36,
           padding: '7px 12px',
           background: 'none',
           border: 'none',
           cursor: 'pointer',
-          textAlign: 'left',
-          transition: 'background .1s',
+          transition: 'background var(--dur-micro) var(--ease-out)',
         }}
         onMouseEnter={(e) => {
-          e.currentTarget.style.background = 'var(--bg-active)';
+          e.currentTarget.style.background = 'var(--fill-quaternary)';
         }}
         onMouseLeave={(e) => {
           e.currentTarget.style.background = 'none';
         }}
       >
-        {/* Status indicator */}
-        <span
-          style={{
-            width: 7,
-            height: 7,
-            borderRadius: 4,
-            flexShrink: 0,
-            background:
-              entry.status === 'ok'
-                ? 'var(--success)'
-                : entry.status === 'error'
-                  ? 'var(--destructive)'
-                  : 'var(--warning)',
-            boxShadow: isPending
-              ? '0 0 6px var(--warning)'
-              : entry.status === 'ok'
-                ? '0 0 4px var(--success)'
-                : undefined,
-            animation: isPending ? 'pulse 1.5s ease-in-out infinite' : undefined,
-          }}
+        <StatusDot
+          tone={status.tone}
+          pulse={isPending}
+          title={status.label}
+          className="shrink-0"
         />
+        <Badge tone={meta.tone}>{meta.label}</Badge>
 
-        {/* Type badge */}
         <span
-          style={{
-            fontSize: 9,
-            fontWeight: 700,
-            letterSpacing: '0.03em',
-            padding: '1px 5px',
-            borderRadius: 4,
-            background: `${meta.color}1a`,
-            color: meta.color,
-            flexShrink: 0,
-            fontFamily: 'SF Mono, Menlo, monospace',
-          }}
-        >
-          {meta.label.toUpperCase()}
-        </span>
-
-        {/* Provider + model */}
-        <span
-          className="flex-1 min-w-0 truncate"
-          style={{ fontSize: 12, color: 'var(--text-primary)', fontWeight: 500 }}
+          className="flex-1 min-w-0 truncate text-[13px] leading-4"
+          style={{ color: 'var(--label)', fontWeight: 500 }}
         >
           {entry.provider}
-          <span style={{ color: 'var(--text-tertiary)', fontWeight: 400 }}> {entry.model}</span>
+          <span style={{ color: 'var(--label-secondary)', fontWeight: 400 }}> {entry.model}</span>
         </span>
 
-        {/* Duration or pending */}
+        {entry.status === 'error' && (
+          <Badge tone="red" icon="warning">
+            Error
+          </Badge>
+        )}
+
         <span
-          className="tabular-nums"
+          className="tabular-nums shrink-0 text-[11px] leading-[13px]"
           style={{
-            fontSize: 11,
-            flexShrink: 0,
-            fontFamily: 'SF Mono, Menlo, monospace',
-            color: isPending
-              ? 'var(--warning)'
-              : entry.duration_ms > 5000
-                ? 'var(--destructive)'
-                : entry.duration_ms > 1000
-                  ? 'var(--warning)'
-                  : 'var(--text-secondary)',
+            fontFamily: 'var(--font-mono)',
+            color: slow ? 'var(--status-orange)' : 'var(--label-secondary)',
           }}
+          title={slow ? 'Over 5 seconds' : undefined}
         >
-          {isPending ? '...' : fmtMs(entry.duration_ms)}
+          {isPending ? 'running…' : fmtMs(entry.duration_ms)}
         </span>
 
-        {/* Time ago */}
         <span
-          className="tabular-nums"
-          style={{
-            fontSize: 10,
-            color: 'var(--text-tertiary)',
-            flexShrink: 0,
-            width: 52,
-            textAlign: 'right',
-          }}
+          className="tabular-nums shrink-0 text-[11px] leading-[13px] text-right"
+          style={{ color: 'var(--label-secondary)', width: 56 }}
         >
           {fmtAgo(entry.timestamp)}
         </span>
       </button>
 
-      {/* Expanded detail */}
       {showDetail && (
         <div
           style={{
-            padding: '4px 12px 8px 32px',
-            fontSize: 11,
-            fontFamily: 'SF Mono, Menlo, monospace',
+            padding: '4px 12px 10px 32px',
+            fontSize: 12,
+            lineHeight: '15px',
+            fontFamily: 'var(--font-mono)',
             display: 'grid',
             gridTemplateColumns: 'auto 1fr',
-            gap: '2px 10px',
-            color: 'var(--text-secondary)',
+            gap: '3px 12px',
+            color: 'var(--label)',
           }}
         >
-          <span style={{ color: 'var(--text-tertiary)' }}>Time</span>
+          <span style={{ color: 'var(--label-secondary)', fontFamily: 'var(--font-ui)' }}>Time</span>
           <span>{fmtTime(entry.timestamp)}</span>
-          <span style={{ color: 'var(--text-tertiary)' }}>URL</span>
+          <span style={{ color: 'var(--label-secondary)', fontFamily: 'var(--font-ui)' }}>URL</span>
           <span className="truncate">{entry.url}</span>
-          <span style={{ color: 'var(--text-tertiary)' }}>Input</span>
+          <span style={{ color: 'var(--label-secondary)', fontFamily: 'var(--font-ui)' }}>
+            Input
+          </span>
           <span>
             {entry.type.startsWith('embed')
-              ? `${entry.input_size} items`
+              ? `${entry.input_size.toLocaleString()} items`
               : `${entry.input_size.toLocaleString()} chars`}
           </span>
-          <span style={{ color: 'var(--text-tertiary)' }}>Output</span>
+          <span style={{ color: 'var(--label-secondary)', fontFamily: 'var(--font-ui)' }}>
+            Output
+          </span>
           <span>
             {entry.type.startsWith('embed')
-              ? `${entry.output_size} vectors`
+              ? `${entry.output_size.toLocaleString()} vectors`
               : `${entry.output_size.toLocaleString()} chars`}
           </span>
           {entry.error && (
             <>
-              <span style={{ color: 'var(--destructive)' }}>Error</span>
+              <span style={{ color: 'var(--status-red)', fontFamily: 'var(--font-ui)' }}>Error</span>
               <span
                 style={{
-                  color: 'var(--destructive)',
+                  color: 'var(--status-red)',
                   wordBreak: 'break-word',
                   whiteSpace: 'pre-wrap',
                 }}
@@ -311,13 +342,14 @@ function readPersistedFilter(): string | null {
   }
 }
 
-export function AIActivity() {
+export function AIActivity({ subTab }: { subTab?: ReactNode }) {
   const [entries, setEntries] = useState<AIEntry[]>([]);
   const [stats, setStats] = useState<AIStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<string | null>(readPersistedFilter);
   const [query, setQuery] = useState('');
+  const [scrolled, setScrolled] = useState(false);
 
   useEffect(() => {
     try {
@@ -367,204 +399,126 @@ export function AIActivity() {
       ? Math.round(stats.total_duration_ms / stats.total_requests)
       : 0;
 
+  const feedTone: Tone = error ? 'red' : hasPending ? 'orange' : 'green';
+  const feedLabel = error ? 'Offline' : hasPending ? 'Running' : 'Idle';
+
   return (
-    <div className="space-y-3" style={{ marginTop: 20 }}>
-      {/* ── Section header ── */}
-      <div className="flex items-center gap-2">
-        <div
-          className="text-[10px] font-semibold uppercase tracking-wider"
-          style={{ color: 'var(--text-tertiary)' }}
+    <div className="flex flex-col h-full overflow-hidden" style={{ color: 'var(--label)' }}>
+      <Toolbar scrolled={scrolled}>
+        {subTab}
+        <ToolbarDivider />
+        <span
+          className="flex items-center gap-1.5 shrink-0 text-[11px] leading-[13px]"
+          style={{ color: 'var(--label-secondary)' }}
         >
-          Activity Monitor
-        </div>
-        {hasPending && (
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: 3,
-              background: 'var(--success)',
-              boxShadow: '0 0 6px var(--success)',
-              animation: 'pulse 1.5s ease-in-out infinite',
-            }}
-          />
-        )}
-        {error && !loading && entries.length === 0 && (
-          <span className="text-[10px]" style={{ color: 'var(--destructive)' }}>
-            Offline
+          <StatusDot tone={feedTone} pulse={hasPending} />
+          <span style={{ color: 'var(--label)' }}>{feedLabel}</span>
+          <span className="tabular-nums">
+            · {entries.length.toLocaleString()} request{entries.length === 1 ? '' : 's'}
           </span>
-        )}
-        <div style={{ marginLeft: 'auto', position: 'relative', width: 180 }}>
-          <input
-            type="text"
-            value={query}
-            onChange={(ev) => setQuery(ev.target.value)}
-            placeholder="Search url, provider, model…"
-            style={{
-              width: '100%',
-              background: 'var(--fill-control)',
-              border: '0.5px solid var(--border)',
-              borderRadius: 6,
-              fontSize: 11,
-              padding: query ? '4px 22px 4px 8px' : '4px 8px',
-              color: 'var(--text-primary)',
-              outline: 'none',
-            }}
-          />
-          {query && (
-            <button
-              type="button"
-              aria-label="Clear search"
-              onClick={() => setQuery('')}
-              style={{
-                position: 'absolute',
-                right: 4,
-                top: '50%',
-                transform: 'translateY(-50%)',
-                background: 'transparent',
-                border: 'none',
-                color: 'var(--text-tertiary)',
-                cursor: 'pointer',
-                fontSize: 12,
-                lineHeight: 1,
-                padding: '2px 4px',
-              }}
-            >
-              ×
-            </button>
-          )}
-        </div>
-      </div>
+        </span>
 
-      {/* ── Stats pills ── */}
-      {stats && stats.total_requests > 0 && (
-        <>
-          <div className="flex gap-2">
-            <StatPill
-              label="Requests"
-              value={stats.total_requests.toLocaleString()}
-              sub={`${Object.keys(stats.by_type).length} type${Object.keys(stats.by_type).length !== 1 ? 's' : ''}`}
-            />
-            <StatPill
-              label="Avg latency"
-              value={fmtMs(avgMs)}
-              sub={`total ${fmtMs(stats.total_duration_ms)}`}
-              color={
-                avgMs > 3000 ? 'var(--destructive)' : avgMs > 1000 ? 'var(--warning)' : undefined
-              }
-            />
-            <StatPill
-              label="Errors"
-              value={stats.total_errors.toString()}
-              sub={errorRate > 0 ? `${errorRate}% rate` : 'none'}
-              color={stats.total_errors > 0 ? 'var(--destructive)' : 'var(--success)'}
-            />
-          </div>
-          <TypeBar stats={stats} />
-        </>
-      )}
+        <span className="flex-1" />
 
-      {/* ── Filter chips ── */}
-      {stats && Object.keys(stats.by_type).length > 1 && (
-        <div className="flex gap-1.5 flex-wrap">
-          <button
-            type="button"
+        {filter !== null && (
+          <Button
+            variant="bordered"
+            className="is-on shrink-0"
+            icon="close"
             onClick={() => setFilter(null)}
-            className="text-[10px] font-medium px-2.5 py-1 rounded-full transition-all"
-            style={{
-              background: !filter ? 'var(--accent)' : 'var(--fill-control)',
-              color: !filter ? '#fff' : 'var(--text-secondary)',
-              border: `0.5px solid ${!filter ? 'var(--accent)' : 'var(--border)'}`,
-              cursor: 'pointer',
-            }}
+            title="Show every request type"
           >
-            All
-          </button>
-          {Object.entries(stats.by_type).map(([type, s]) => {
-            const meta = typeMeta(type);
-            const active = filter === type;
-            return (
-              <button
-                key={type}
-                type="button"
-                onClick={() => setFilter(active ? null : type)}
-                className="text-[10px] font-medium px-2.5 py-1 rounded-full transition-all flex items-center gap-1"
-                style={{
-                  background: active ? `${meta.color}22` : 'var(--fill-control)',
-                  color: active ? meta.color : 'var(--text-secondary)',
-                  border: `0.5px solid ${active ? `${meta.color}44` : 'var(--border)'}`,
-                  cursor: 'pointer',
-                  backdropFilter: 'blur(8px)',
-                  WebkitBackdropFilter: 'blur(8px)',
-                }}
-              >
-                {meta.label}
-                <span className="tabular-nums" style={{ opacity: 0.7 }}>
-                  {s.count}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      )}
+            {typeMeta(filter).label}
+          </Button>
+        )}
 
-      {/* ── Request list ── */}
+        <SearchField
+          value={query}
+          onChange={setQuery}
+          placeholder="Search requests"
+          aria-label="Search requests"
+        />
+      </Toolbar>
+
       <div
-        style={{
-          background: 'var(--bg-grouped)',
-          borderRadius: 10,
-          boxShadow: 'var(--shadow-grouped)',
-          overflow: 'hidden',
-        }}
+        className="flex-1 min-h-0 overflow-y-auto"
+        onScroll={(e) => setScrolled((e.target as HTMLElement).scrollTop > 0)}
       >
-        <div
-          style={{
-            maxHeight: 320,
-            overflowY: 'auto',
-            scrollbarWidth: 'thin',
-            scrollbarColor: 'var(--text-tertiary) transparent',
-          }}
-        >
-          {loading && entries.length === 0 && (
-            <div className="text-center py-6 text-xs" style={{ color: 'var(--text-tertiary)' }}>
-              Connecting to daemon...
-            </div>
-          )}
-          {!loading && entries.length === 0 && !error && (
-            <div className="text-center py-8 px-4">
-              <div className="text-[13px] font-medium" style={{ color: 'var(--text-secondary)' }}>
-                No AI requests yet
+        <div className="flex flex-col gap-4 px-4 py-4">
+          {stats && stats.total_requests > 0 && (
+            <>
+              <div className="flex gap-3">
+                <MetricCard
+                  label="Requests"
+                  value={stats.total_requests.toLocaleString()}
+                  sub={`${Object.keys(stats.by_type).length} type${Object.keys(stats.by_type).length !== 1 ? 's' : ''}`}
+                />
+                <MetricCard
+                  label="Average latency"
+                  value={fmtMs(avgMs)}
+                  sub={`${fmtMs(stats.total_duration_ms)} total`}
+                  color={
+                    avgMs > 3000
+                      ? 'var(--status-red)'
+                      : avgMs > 1000
+                        ? 'var(--status-orange)'
+                        : undefined
+                  }
+                />
+                <MetricCard
+                  label="Errors"
+                  value={stats.total_errors.toLocaleString()}
+                  sub={errorRate > 0 ? `${errorRate}% of requests` : 'None so far'}
+                  color={stats.total_errors > 0 ? 'var(--status-red)' : undefined}
+                />
               </div>
-              <div className="text-[11px] mt-1" style={{ color: 'var(--text-tertiary)' }}>
-                Requests appear here during indexing and semantic search
-              </div>
-            </div>
+              <TypeBar stats={stats} filter={filter} onFilter={setFilter} />
+            </>
           )}
-          {error && entries.length === 0 && (
-            <div className="text-center py-6 px-4">
-              <div className="text-[11px] font-medium" style={{ color: 'var(--destructive)' }}>
-                Cannot reach daemon
-              </div>
-              <div className="text-[10px] mt-1" style={{ color: 'var(--text-tertiary)' }}>
-                {error}
-              </div>
-            </div>
-          )}
-          {filtered.map((e, i) => (
-            <RequestRow key={e.id} entry={e} isLast={i === filtered.length - 1} />
-          ))}
-          {(filter || normalizedQuery) && filtered.length === 0 && entries.length > 0 && (
-            <div className="text-center py-4 text-[11px]" style={{ color: 'var(--text-tertiary)' }}>
-              {normalizedQuery
-                ? `No requests match "${query}"`
-                : `No ${typeMeta(filter!).label.toLowerCase()} requests`}
-            </div>
-          )}
+
+          <Card>
+            {loading && entries.length === 0 && (
+              <EmptyState compact icon="schedule" title="Connecting to the daemon…" />
+            )}
+            {error && entries.length === 0 && !loading && (
+              <SectionError what="AI request history" onRetry={() => void fetchActivity()} />
+            )}
+            {!loading && !error && entries.length === 0 && (
+              <EmptyState
+                compact
+                icon="neurology"
+                title="No AI requests yet"
+                subtitle="Embedding, generation and rerank calls show up here while a project indexes or a semantic search runs."
+              />
+            )}
+            {filtered.map((e, i) => (
+              <RequestRow key={e.id} entry={e} isLast={i === filtered.length - 1} />
+            ))}
+            {(filter !== null || normalizedQuery !== '') &&
+              filtered.length === 0 &&
+              entries.length > 0 && (
+                <EmptyState
+                  compact
+                  icon="search"
+                  title="No matching requests"
+                  subtitle={`${entries.length.toLocaleString()} request${entries.length === 1 ? '' : 's'} are hidden by the current search and filter.`}
+                  action={
+                    <Button
+                      icon="close"
+                      onClick={() => {
+                        setFilter(null);
+                        setQuery('');
+                      }}
+                    >
+                      Clear filters and search
+                    </Button>
+                  }
+                />
+              )}
+          </Card>
+
         </div>
       </div>
-
-      {/* Pulse animation */}
-      <style>{`@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }`}</style>
     </div>
   );
 }

--- a/packages/app/src/renderer/tabs/Activity.tsx
+++ b/packages/app/src/renderer/tabs/Activity.tsx
@@ -4,6 +4,12 @@
  *   - "AI calls":   embed / LLM / rerank requests (AIActivity, project-agnostic)
  *
  * Active sub-tab persists in localStorage under key 'activity.subtab'.
+ *
+ * This container owns the sub-tab STATE but not a row of its own: it hands the
+ * switcher down and each surface renders it on the leading edge of its single
+ * toolbar. Before TRA-294 the switcher sat in a bar of its own above whatever
+ * the child stacked underneath, which is how the screen ended up with three
+ * control rows and no toolbar.
  */
 import { useEffect, useState } from 'react';
 import { ToolActivity } from './ToolActivity';
@@ -34,30 +40,22 @@ export function Activity({
     try { localStorage.setItem(STORAGE_KEY, sub); } catch { /* ignore quota */ }
   }, [sub]);
 
-  return (
-    <div className="flex flex-col h-full" style={{ color: 'var(--text-primary)' }}>
-      <div
-        className="shrink-0 flex items-center px-3 pt-3 pb-2"
-        style={{ borderBottom: '0.5px solid var(--border-row)' }}
-      >
-        <SegmentedControl
-          options={[
-            { value: 'tool', label: 'Tool calls' },
-            { value: 'ai', label: 'AI calls' },
-          ]}
-          value={sub}
-          onChange={setSub}
-          aria-label="Activity source"
-        />
-      </div>
+  const switcher = (
+    <SegmentedControl
+      className="shrink-0"
+      options={[
+        { value: 'tool', label: 'Tool calls' },
+        { value: 'ai', label: 'AI calls' },
+      ]}
+      value={sub}
+      onChange={setSub}
+      aria-label="Activity source"
+    />
+  );
 
-      <div className="flex-1 min-h-0 overflow-hidden">
-        {sub === 'tool' ? (
-          <ToolActivity root={root} onOpenFileInGraph={onOpenFileInGraph} />
-        ) : (
-          <AIActivity />
-        )}
-      </div>
-    </div>
+  return sub === 'tool' ? (
+    <ToolActivity root={root} subTab={switcher} onOpenFileInGraph={onOpenFileInGraph} />
+  ) : (
+    <AIActivity subTab={switcher} />
   );
 }

--- a/packages/app/src/renderer/tabs/MemoryExplorer.tsx
+++ b/packages/app/src/renderer/tabs/MemoryExplorer.tsx
@@ -1,6 +1,33 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { EMPTY_FILTER_VALUE, FilterBar, type FilterValue, matchesFilter } from '../components/FilterBar';
-import { SegmentedControl } from '../lattice/ui';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
+import { matchesFilter } from '../components/FilterBar';
+import { Icon } from '../lattice/icons';
+import {
+  Badge,
+  Button,
+  Card,
+  ConfirmPopover,
+  EmptyState,
+  Menu,
+  MenuItem,
+  MenuSeparator,
+  SearchField,
+  Section,
+  SectionError,
+  SegmentedControl,
+  SkeletonRows,
+  StatusDot,
+  Toolbar,
+  ToolbarDivider,
+  useMenuAnchor,
+  type Tone,
+} from '../lattice/ui';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -104,119 +131,183 @@ function parseTags(raw: string | null): string[] {
   }
 }
 
-function typeBadgeColors(type: string): { bg: string; text: string } {
-  const map: Record<string, { bg: string; text: string }> = {
-    architecture_decision: { bg: 'rgba(99,102,241,0.15)', text: '#818cf8' },
-    tech_choice: { bg: 'rgba(59,130,246,0.15)', text: '#60a5fa' },
-    bug_root_cause: { bg: 'rgba(239,68,68,0.15)', text: '#f87171' },
-    preference: { bg: 'rgba(16,185,129,0.15)', text: '#34d399' },
-    tradeoff: { bg: 'rgba(234,179,8,0.15)', text: '#fbbf24' },
-    discovery: { bg: 'rgba(236,72,153,0.15)', text: '#f472b6' },
-    convention: { bg: 'rgba(107,114,128,0.15)', text: '#9ca3af' },
-  };
-  return map[type] ?? { bg: 'rgba(107,114,128,0.15)', text: '#9ca3af' };
+/* Decision categories. A tone is one channel; `label` is the other, so the
+   colour never has to be read on its own. Tones come from the shared status
+   palette — the old map was seven hand-picked hex pairs at 9px/700 ALL CAPS. */
+const TYPE_META: Record<string, { label: string; tone: Tone }> = {
+  architecture_decision: { label: 'Architecture', tone: 'purple' },
+  tech_choice: { label: 'Tech choice', tone: 'blue' },
+  bug_root_cause: { label: 'Bug root cause', tone: 'red' },
+  preference: { label: 'Preference', tone: 'green' },
+  tradeoff: { label: 'Trade-off', tone: 'orange' },
+  discovery: { label: 'Discovery', tone: 'accent' },
+  convention: { label: 'Convention', tone: 'neutral' },
+};
+
+function typeMeta(type: string): { label: string; tone: Tone } {
+  return TYPE_META[type] ?? { label: type.replace(/_/g, ' '), tone: 'neutral' };
 }
 
+/** Tone → the CSS variable it paints with, for the one place that needs the
+    raw colour (a 6px meter segment, where a Badge does not fit). */
+const TONE_VAR: Record<Tone, string> = {
+  /* A meter segment is decoration, not text, so the neutral series takes the
+     tertiary grey. At --label-secondary it out-weighed the purple/blue/red
+     series beside it and read as a disabled bar (TRA-294). */
+  neutral: 'var(--label-tertiary)',
+  accent: 'var(--accent)',
+  green: 'var(--status-green)',
+  orange: 'var(--status-orange)',
+  red: 'var(--status-red)',
+  blue: 'var(--status-blue)',
+  purple: 'var(--status-purple)',
+};
+
+/** ↑↓ walks a list of rows. Roving DOM focus rather than a selection index:
+    the focus ring, the Enter handler and the scroll-into-view are already
+    correct on a focused row, so there is no second notion of "current" to keep
+    in sync. Anything the arrows land on is a row — the per-row ••• is a real
+    <button>, so it stays out of the walk and on the Tab path. */
+function rovingArrowKeys(e: KeyboardEvent<HTMLDivElement>) {
+  if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+  const rows = [...e.currentTarget.querySelectorAll<HTMLElement>('[role="button"][tabindex="0"]')];
+  if (rows.length === 0) return;
+  e.preventDefault();
+  const at = rows.indexOf(document.activeElement as HTMLElement);
+  const next =
+    at === -1
+      ? 0
+      : e.key === 'ArrowDown'
+        ? Math.min(at + 1, rows.length - 1)
+        : Math.max(at - 1, 0);
+  rows[next]?.focus();
+}
+
+const SOURCE_LABEL: Record<string, string> = {
+  manual: 'Added by hand',
+  mined: 'Mined from a session',
+  auto: 'Recorded automatically',
+};
+
 function TypeBadge({ type }: { type: string }) {
-  const { bg, text } = typeBadgeColors(type);
-  const label = type.replace(/_/g, ' ');
-  return (
-    <span
-      className="text-[9px] px-1.5 py-0.5 rounded font-medium uppercase shrink-0"
-      style={{ background: bg, color: text, letterSpacing: '0.03em' }}
-    >
-      {label}
-    </span>
-  );
+  const { label, tone } = typeMeta(type);
+  return <Badge tone={tone}>{label}</Badge>;
 }
 
 function SourceBadge({ source }: { source: string }) {
-  const colors: Record<string, string> = {
-    manual: '#34d399',
-    mined: '#60a5fa',
-    auto: '#fbbf24',
-  };
   return (
-    <span
-      className="text-[9px] px-1.5 py-0.5 rounded font-medium uppercase shrink-0"
-      style={{
-        background: 'rgba(255,255,255,0.06)',
-        color: colors[source] ?? '#9ca3af',
-        border: `0.5px solid ${colors[source] ?? '#9ca3af'}40`,
-      }}
-    >
-      {source}
-    </span>
+    <Badge tone="neutral" title={SOURCE_LABEL[source] ?? source}>
+      {SOURCE_LABEL[source] ?? source}
+    </Badge>
+  );
+}
+
+/** The one toolbar + one scroll container each Memory sub-view is built on.
+    The sub-tab switcher rides on the toolbar's leading edge rather than in a
+    row of its own — the old surface stacked the tab pills, a stat card, a lone
+    accent button and a filter card before any content appeared (TRA-294). */
+function ViewShell({
+  subTab,
+  status,
+  actions,
+  children,
+}: {
+  subTab?: ReactNode;
+  status?: ReactNode;
+  actions?: ReactNode;
+  children: ReactNode;
+}) {
+  const [scrolled, setScrolled] = useState(false);
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <Toolbar scrolled={scrolled}>
+        {subTab}
+        {status != null && (
+          <>
+            <ToolbarDivider />
+            <span
+              className="shrink-0 text-[11px] leading-[13px] tabular-nums"
+              style={{ color: 'var(--label-secondary)' }}
+            >
+              {status}
+            </span>
+          </>
+        )}
+        <span className="flex-1" />
+        {actions}
+      </Toolbar>
+      <div
+        className="flex-1 min-h-0 overflow-y-auto"
+        onScroll={(e) => setScrolled((e.target as HTMLElement).scrollTop > 0)}
+      >
+        <div className="flex flex-col gap-4 px-4 py-4">{children}</div>
+      </div>
+    </div>
   );
 }
 
 // ── Sub-views ─────────────────────────────────────────────────────────────────
 
-function StatsPanel({ stats }: { stats: DecisionStats }) {
-  const typeEntries = Object.entries(stats.by_type).sort((a, b) => b[1] - a[1]);
-  return (
-    <div
-      className="px-3 py-2.5 space-y-2"
-      style={{
-        background: 'var(--bg-grouped)',
-        borderRadius: 10,
-        boxShadow: 'var(--shadow-grouped)',
-      }}
-    >
-      {/* Totals row */}
-      <div className="flex items-center gap-4">
-        <div className="flex flex-col items-center">
-          <span
-            className="text-[20px] font-semibold tabular-nums leading-none"
-            style={{ color: 'var(--text-primary)' }}
-          >
-            {stats.total}
-          </span>
-          <span className="text-[10px] mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
-            total
-          </span>
-        </div>
-        <div className="flex flex-col items-center">
-          <span
-            className="text-[20px] font-semibold tabular-nums leading-none"
-            style={{ color: 'var(--green, #22c55e)' }}
-          >
-            {stats.active}
-          </span>
-          <span className="text-[10px] mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
-            active
-          </span>
-        </div>
-        <div className="flex flex-col items-center">
-          <span
-            className="text-[20px] font-semibold tabular-nums leading-none"
-            style={{ color: 'var(--text-secondary)' }}
-          >
-            {stats.total - stats.active}
-          </span>
-          <span className="text-[10px] mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
-            expired
-          </span>
-        </div>
-      </div>
+/** The decision mix, as one row of the surface rather than a 70px card that
+    was 96% whitespace around three numbers with 2.21:1 labels. The counts live
+    in the toolbar now; this is only the per-type breakdown, and each segment is
+    named in the legend under it. */
+function TypeMix({
+  stats,
+  activeType,
+  onTypeClick,
+}: {
+  stats: DecisionStats;
+  activeType: string;
+  onTypeClick: (type: string) => void;
+}) {
+  const entries = Object.entries(stats.by_type)
+    .filter(([, n]) => n > 0)
+    .sort((a, b) => b[1] - a[1]);
+  if (entries.length === 0) return null;
+  const total = entries.reduce((sum, [, n]) => sum + n, 0) || 1;
 
-      {/* Type breakdown */}
-      {typeEntries.length > 0 && (
-        <div className="flex flex-wrap gap-1 pt-1" style={{ borderTop: '0.5px solid var(--border-row)' }}>
-          {typeEntries.map(([type, count]) => {
-            const { bg, text } = typeBadgeColors(type);
-            return (
-              <span
-                key={type}
-                className="text-[10px] px-1.5 py-0.5 rounded font-medium"
-                style={{ background: bg, color: text }}
-              >
-                {type.replace(/_/g, ' ')} · {count}
-              </span>
-            );
-          })}
-        </div>
-      )}
+  return (
+    <div className="flex flex-col gap-2">
+      <div
+        className="flex overflow-hidden"
+        style={{ gap: 1, height: 6, borderRadius: 3, background: 'var(--fill-quaternary)' }}
+      >
+        {entries.map(([type, n]) => (
+          <div
+            key={type}
+            title={`${typeMeta(type).label}: ${n}`}
+            style={{
+              width: `${(n / total) * 100}%`,
+              minWidth: 2,
+              borderRadius: 2,
+              background: TONE_VAR[typeMeta(type).tone],
+              opacity: activeType === '' || activeType === type ? 1 : 0.3,
+              transition: 'opacity var(--dur-micro) var(--ease-out)',
+            }}
+          />
+        ))}
+      </div>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {entries.map(([type, n]) => {
+          const meta = typeMeta(type);
+          const active = activeType === type;
+          return (
+            <button
+              key={type}
+              type="button"
+              className={`lx-chip single${active ? ' is-on' : ''}`}
+              aria-pressed={active}
+              onClick={() => onTypeClick(type)}
+              title={`Show only ${meta.label.toLowerCase()} decisions`}
+            >
+              <StatusDot tone={meta.tone} size={6} />
+              {meta.label}
+              <span className="tabular-nums">{n}</span>
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -278,12 +369,15 @@ function DecisionForm({
   };
 
   const inputStyle: React.CSSProperties = {
-    background: 'var(--bg-inset)',
-    border: '0.5px solid var(--border-row)',
-    borderRadius: 6,
-    color: 'var(--text-primary)',
-    fontSize: 12,
-    padding: '4px 8px',
+    background: 'var(--fill-quaternary)',
+    boxShadow: 'inset 0 0 0 0.5px var(--separator)',
+    border: 0,
+    borderRadius: 'var(--radius-input)',
+    color: 'var(--label)',
+    fontSize: 13,
+    lineHeight: '16px',
+    fontFamily: 'inherit',
+    padding: '5px 8px',
     width: '100%',
     outline: 'none',
   };
@@ -291,13 +385,17 @@ function DecisionForm({
   return (
     <form
       onSubmit={(e) => { void handleSubmit(e); }}
-      className="space-y-2 px-3 py-3"
-      style={{ background: 'var(--bg-grouped)', borderRadius: 10 }}
+      className="flex flex-col gap-3 px-3 py-3"
+      style={{
+        background: 'var(--surface)',
+        borderRadius: 12,
+        border: '0.5px solid var(--separator)',
+      }}
       // Prevent click-through to parent toggles
       onClick={(e) => e.stopPropagation()}
     >
       <div className="space-y-1.5">
-        <label className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
+        <label className="text-[11px] leading-[13px]" style={{ color: 'var(--label-secondary)' }}>
           Title *
         </label>
         <input
@@ -311,7 +409,7 @@ function DecisionForm({
       </div>
 
       <div className="space-y-1.5">
-        <label className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
+        <label className="text-[11px] leading-[13px]" style={{ color: 'var(--label-secondary)' }}>
           Content *
         </label>
         <textarea
@@ -326,7 +424,7 @@ function DecisionForm({
 
       <div className="grid grid-cols-2 gap-2">
         <div className="space-y-1.5">
-          <label className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
+          <label className="text-[11px] leading-[13px]" style={{ color: 'var(--label-secondary)' }}>
             Type
           </label>
           <select
@@ -344,7 +442,7 @@ function DecisionForm({
         </div>
 
         <div className="space-y-1.5">
-          <label className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
+          <label className="text-[11px] leading-[13px]" style={{ color: 'var(--label-secondary)' }}>
             Tags (comma-separated)
           </label>
           <input
@@ -360,7 +458,7 @@ function DecisionForm({
 
       <div className="grid grid-cols-2 gap-2">
         <div className="space-y-1.5">
-          <label className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
+          <label className="text-[11px] leading-[13px]" style={{ color: 'var(--label-secondary)' }}>
             File path (optional)
           </label>
           <input
@@ -374,7 +472,7 @@ function DecisionForm({
         </div>
 
         <div className="space-y-1.5">
-          <label className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
+          <label className="text-[11px] leading-[13px]" style={{ color: 'var(--label-secondary)' }}>
             Symbol ID (optional)
           </label>
           <input
@@ -389,39 +487,24 @@ function DecisionForm({
       </div>
 
       {error && (
-        <div className="text-[11px]" style={{ color: '#f87171' }}>
+        <div
+          role="alert"
+          className="flex items-center gap-1.5 text-[13px] leading-4"
+          style={{ color: 'var(--status-red)' }}
+        >
+          <Icon name="warning" size={14} />
           {error}
         </div>
       )}
 
-      <div className="flex gap-2 pt-1">
-        <button
-          type="submit"
-          disabled={pending}
-          className="text-[12px] font-medium px-3 py-1 rounded"
-          style={{
-            background: 'var(--accent)',
-            color: '#fff',
-            cursor: pending ? 'not-allowed' : 'pointer',
-            opacity: pending ? 0.6 : 1,
-          }}
-        >
-          {pending ? 'Saving…' : submitLabel}
-        </button>
-        <button
-          type="button"
-          onClick={onCancel}
-          disabled={pending}
-          className="text-[12px] px-3 py-1 rounded"
-          style={{
-            background: 'var(--bg-inset)',
-            color: 'var(--text-secondary)',
-            border: '0.5px solid var(--border-row)',
-            cursor: 'pointer',
-          }}
-        >
+      {/* macOS puts the confirming action last, on the trailing edge. */}
+      <div className="flex justify-end gap-2 pt-1">
+        <Button type="button" onClick={onCancel} disabled={pending}>
           Cancel
-        </button>
+        </Button>
+        <Button type="submit" variant="prominent" disabled={pending}>
+          {pending ? 'Saving…' : submitLabel}
+        </Button>
       </div>
 
       {/* Suppress unused variable warning — root used in parent for POST URL */}
@@ -450,8 +533,12 @@ function DecisionCard({
   const tags = parseTags(decision.tags);
   const isActive = decision.valid_until === null;
   const [editing, setEditing] = useState(false);
-  const [confirmInvalidate, setConfirmInvalidate] = useState(false);
   const [actionPending, setActionPending] = useState(false);
+  /* Invalidate is destructive and used rarely, so it lives behind the row's
+     ••• menu with a named confirmation — not as a red bordered button sitting
+     in every row, one stray click from expiring a decision (TRA-294). */
+  const rowMenu = useMenuAnchor();
+  const confirm = useMenuAnchor();
 
   const handleEdit = async (values: DecisionFormValues) => {
     const res = await fetch(`${BASE}/api/projects/decisions/${decision.id}`, {
@@ -500,12 +587,12 @@ function DecisionCard({
       onInvalidated(decision.id);
     } finally {
       setActionPending(false);
-      setConfirmInvalidate(false);
+      confirm.close();
     }
   };
 
   return (
-    <div style={{ opacity: isActive ? 1 : 0.5 }}>
+    <div>
       {/* Edit form replaces the entire card when active */}
       {editing ? (
         <DecisionForm
@@ -523,166 +610,154 @@ function DecisionCard({
           onCancel={() => setEditing(false)}
         />
       ) : (
-        <button
-          type="button"
-          onClick={onToggle}
-          className="w-full text-left"
-          style={{ cursor: 'pointer' }}
-        >
-          {/* Collapsed header */}
-          <div className="px-3 py-2.5 flex items-start gap-2">
-            {/* Active indicator dot */}
-            <div
-              className="mt-1 shrink-0 w-1.5 h-1.5 rounded-full"
-              style={{ background: isActive ? 'var(--green, #22c55e)' : 'var(--text-tertiary)' }}
-              title={isActive ? 'Active' : 'Expired'}
-            />
+        <>
+          {/* A div with role=button, not a <button>: this row contains its own
+              buttons, and a nested <button> is invalid HTML that Chromium
+              reparents out of the row, desyncing React's refs. */}
+          <div
+            role="button"
+            tabIndex={0}
+            aria-expanded={expanded}
+            onClick={onToggle}
+            onKeyDown={(e) => {
+              if (e.key !== 'Enter' && e.key !== ' ') return;
+              e.preventDefault();
+              onToggle();
+            }}
+            className="w-full text-left px-3 py-2.5 flex items-start gap-2"
+            style={{ cursor: 'pointer' }}
+          >
+            {/* Expired is said in a badge as well as shown by the dot — the
+                old card carried it as a 50% opacity wash and nothing else. */}
+            <span className="mt-1 shrink-0">
+              <StatusDot
+                tone={isActive ? 'green' : 'neutral'}
+                size={6}
+                title={isActive ? 'Active' : 'Expired'}
+              />
+            </span>
 
-            <div className="flex-1 min-w-0 space-y-1">
-              {/* Title + badges row */}
+            <div className="flex-1 min-w-0 flex flex-col gap-1">
               <div className="flex items-center gap-1.5 flex-wrap">
                 <span
-                  className="text-[13px] font-medium leading-tight"
-                  style={{ color: 'var(--text-primary)' }}
+                  className="text-[13px] leading-4 font-medium"
+                  style={{ color: 'var(--label)' }}
                 >
                   {decision.title}
                 </span>
                 <TypeBadge type={decision.type} />
                 <SourceBadge source={decision.source} />
+                {!isActive && <Badge tone="neutral">Expired</Badge>}
               </div>
 
-              {/* Meta row */}
-              <div className="flex items-center gap-2 flex-wrap">
+              <div
+                className="flex items-center gap-2 flex-wrap text-[11px] leading-[13px]"
+                style={{ color: 'var(--label-secondary)' }}
+              >
                 {decision.file_path && (
                   <span
-                    className="text-[10px] truncate max-w-[180px]"
-                    style={{ color: 'var(--text-tertiary)', fontFamily: 'SF Mono, Menlo, monospace' }}
+                    className="truncate max-w-[220px]"
+                    style={{ fontFamily: 'var(--font-mono)' }}
                     title={decision.file_path}
                   >
                     {decision.file_path}
                   </span>
                 )}
-                <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-                  {formatDate(decision.created_at)}
-                </span>
+                <span className="tabular-nums">{formatDate(decision.created_at)}</span>
               </div>
             </div>
 
-            {/* Action buttons — visible in header, stop toggle propagation */}
-            {isActive && (
-              <div
-                className="flex items-center gap-1 shrink-0"
-                onClick={(e) => e.stopPropagation()}
-                onKeyDown={(e) => e.stopPropagation()}
-              >
-                <button
-                  type="button"
-                  onClick={() => { setEditing(true); }}
-                  className="text-[10px] px-1.5 py-0.5 rounded font-medium"
-                  style={{
-                    background: 'var(--bg-inset)',
-                    color: 'var(--text-secondary)',
-                    border: '0.5px solid var(--border-row)',
-                    cursor: 'pointer',
-                  }}
-                  title="Edit decision"
-                >
-                  Edit
-                </button>
-                {confirmInvalidate ? (
-                  <>
-                    <button
-                      type="button"
-                      onClick={() => { void handleInvalidate(); }}
-                      disabled={actionPending}
-                      className="text-[10px] px-1.5 py-0.5 rounded font-medium"
-                      style={{
-                        background: 'rgba(239,68,68,0.15)',
-                        color: '#f87171',
-                        cursor: actionPending ? 'not-allowed' : 'pointer',
-                        opacity: actionPending ? 0.6 : 1,
-                      }}
-                    >
-                      {actionPending ? '…' : 'Confirm'}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setConfirmInvalidate(false)}
-                      className="text-[10px] px-1.5 py-0.5 rounded"
-                      style={{
-                        background: 'var(--bg-inset)',
-                        color: 'var(--text-tertiary)',
-                        cursor: 'pointer',
-                      }}
-                    >
-                      ✕
-                    </button>
-                  </>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => setConfirmInvalidate(true)}
-                    className="text-[10px] px-1.5 py-0.5 rounded font-medium"
-                    style={{
-                      background: 'rgba(239,68,68,0.08)',
-                      color: '#f87171',
-                      border: '0.5px solid rgba(239,68,68,0.2)',
-                      cursor: 'pointer',
-                    }}
-                    title="Invalidate decision"
-                  >
-                    Invalidate
-                  </button>
-                )}
-              </div>
-            )}
-
-            {/* Chevron */}
-            <svg
-              width="10"
-              height="10"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="shrink-0 mt-1 transition-transform"
-              style={{
-                color: 'var(--text-tertiary)',
-                transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
-              }}
+            <div
+              className="flex items-center gap-1 shrink-0"
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
+              role="presentation"
             >
-              <polyline points="9 18 15 12 9 6" />
-            </svg>
+              <Button
+                ref={rowMenu.ref}
+                variant="icon"
+                icon="more_horiz"
+                onClick={() => (rowMenu.at ? rowMenu.close() : rowMenu.open())}
+                aria-haspopup="menu"
+                aria-expanded={rowMenu.at !== null}
+                aria-label={`Actions for ${decision.title}`}
+                title="Actions"
+              />
+            </div>
+
+            <span className="shrink-0 mt-0.5 flex" style={{ color: 'var(--label-secondary)' }}>
+              <Icon name={expanded ? 'expand_more' : 'chevron_right'} size={16} />
+            </span>
           </div>
+
+          {rowMenu.at && (
+            <Menu x={rowMenu.at.x} y={rowMenu.at.y} align="end" onClose={rowMenu.close}>
+              <MenuItem
+                icon="edit"
+                onClick={() => {
+                  rowMenu.close();
+                  setEditing(true);
+                }}
+              >
+                Edit decision…
+              </MenuItem>
+              {isActive && (
+                <>
+                  <MenuSeparator />
+                  <MenuItem
+                    danger
+                    icon="archive"
+                    disabled={actionPending}
+                    onClick={() => {
+                      const at = rowMenu.at;
+                      rowMenu.close();
+                      if (at) confirm.openAt(at);
+                    }}
+                  >
+                    Invalidate decision…
+                  </MenuItem>
+                </>
+              )}
+            </Menu>
+          )}
+
+          {confirm.at && (
+            <ConfirmPopover
+              x={confirm.at.x}
+              y={confirm.at.y}
+              align="end"
+              danger
+              title={`Invalidate ${decision.title}?`}
+              body="It stops being read back to assistants from now on. The record itself is kept, with today as its end date."
+              confirmLabel={actionPending ? 'Invalidating…' : 'Invalidate'}
+              onConfirm={() => void handleInvalidate()}
+              onCancel={confirm.close}
+            />
+          )}
 
           {/* Expanded body */}
           {expanded && (
             <div
-              className="px-3 pb-3 space-y-2"
-              style={{ borderTop: '0.5px solid var(--border-row)' }}
-              onClick={(e) => e.stopPropagation()}
-              onKeyDown={(e) => e.stopPropagation()}
+              className="px-3 pb-3 flex flex-col gap-2"
+              style={{ borderTop: '0.5px solid var(--separator)' }}
             >
-              {/* Content */}
               <div
-                className="text-[12px] leading-relaxed whitespace-pre-wrap mt-2"
-                style={{ color: 'var(--text-secondary)' }}
+                className="text-[13px] leading-[18px] whitespace-pre-wrap mt-2"
+                style={{ color: 'var(--label)' }}
               >
                 {decision.content}
               </div>
 
-              {/* Details grid */}
-              <div className="grid grid-cols-2 gap-x-4 gap-y-1 pt-1" style={{ borderTop: '0.5px solid var(--border-row)' }}>
+              <div
+                className="grid grid-cols-2 gap-x-4 gap-y-1 pt-2 text-[11px] leading-[13px]"
+                style={{ borderTop: '0.5px solid var(--separator)' }}
+              >
                 {decision.symbol_id && (
                   <>
-                    <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-                      Symbol
-                    </span>
+                    <span style={{ color: 'var(--label-secondary)' }}>Symbol</span>
                     <span
-                      className="text-[10px] truncate"
-                      style={{ color: 'var(--text-secondary)', fontFamily: 'SF Mono, Menlo, monospace' }}
+                      className="truncate"
+                      style={{ color: 'var(--label)', fontFamily: 'var(--font-mono)' }}
                       title={decision.symbol_id}
                     >
                       {decision.symbol_id}
@@ -691,84 +766,85 @@ function DecisionCard({
                 )}
                 {decision.file_path && (
                   <>
-                    <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-                      File
-                    </span>
+                    <span style={{ color: 'var(--label-secondary)' }}>File</span>
                     <span
-                      className="text-[10px] truncate"
-                      style={{ color: 'var(--text-secondary)', fontFamily: 'SF Mono, Menlo, monospace' }}
+                      className="truncate"
+                      style={{ color: 'var(--label)', fontFamily: 'var(--font-mono)' }}
                       title={decision.file_path}
                     >
                       {decision.file_path}
                     </span>
                   </>
                 )}
-                <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-                  Valid from
-                </span>
-                <span className="text-[10px]" style={{ color: 'var(--text-secondary)' }}>
+                <span style={{ color: 'var(--label-secondary)' }}>Valid from</span>
+                <span className="tabular-nums" style={{ color: 'var(--label)' }}>
                   {formatDate(decision.valid_from)}
                 </span>
                 {decision.valid_until && (
                   <>
-                    <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-                      Expired
-                    </span>
-                    <span className="text-[10px]" style={{ color: 'var(--text-secondary)' }}>
+                    <span style={{ color: 'var(--label-secondary)' }}>Expired</span>
+                    <span className="tabular-nums" style={{ color: 'var(--label)' }}>
                       {formatDate(decision.valid_until)}
                     </span>
                   </>
                 )}
                 {decision.confidence < 1 && (
                   <>
-                    <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-                      Confidence
-                    </span>
-                    <span className="text-[10px] tabular-nums" style={{ color: 'var(--text-secondary)' }}>
+                    <span style={{ color: 'var(--label-secondary)' }}>Confidence</span>
+                    <span className="tabular-nums" style={{ color: 'var(--label)' }}>
                       {Math.round(decision.confidence * 100)}%
                     </span>
                   </>
                 )}
               </div>
 
-              {/* Tags */}
               {tags.length > 0 && (
                 <div className="flex flex-wrap gap-1 pt-1">
                   {tags.map((tag) => (
-                    <span
-                      key={tag}
-                      className="text-[10px] px-1.5 py-0.5 rounded"
-                      style={{
-                        background: 'var(--bg-inset)',
-                        color: 'var(--text-secondary)',
-                        border: '0.5px solid var(--border-row)',
-                      }}
-                    >
+                    <Badge key={tag} tone="neutral">
                       {tag}
-                    </span>
+                    </Badge>
                   ))}
                 </div>
               )}
             </div>
           )}
-        </button>
+        </>
       )}
     </div>
   );
 }
 
-function DecisionsView({ root }: { root: string }) {
+function DecisionsView({ root, subTab }: { root: string; subTab?: ReactNode }) {
   const [decisions, setDecisions] = useState<DecisionRow[]>([]);
   const [stats, setStats] = useState<DecisionStats | null>(null);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
-  // Filter state — match feeds the FTS `q` parameter, exclude is applied
-  // client-side over the returned rows. Depth is intentionally disabled for
-  // this view: decisions are a flat list with no hierarchical depth concept.
-  const [filter, setFilter] = useState<FilterValue>(EMPTY_FILTER_VALUE);
+  /* A swallowed fetch failure used to fall through to "No decisions yet",
+     inviting you to re-add decisions you already have. Failure is its own
+     state (TRA-294). */
+  const [failed, setFailed] = useState(false);
+  /* One search field feeds the FTS `q` parameter; one optional exclude field
+     hides rows client-side. Both take plain text or /regex/i. This replaces the
+     shared FilterBar, whose MATCH / EXCLUDE labels were 10.5px/700 ALL-CAPS
+     jargon bolted to two inputs inside a bordered card (TRA-294). FilterBar
+     itself stays — the Graph surface still uses it. */
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [exclude, setExclude] = useState('');
+  const [showExclude, setShowExclude] = useState(false);
   const [activeType, setActiveType] = useState('');
   const [expandedId, setExpandedId] = useState<number | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
+  const overflow = useMenuAnchor();
+
+  /* FilterBar used to own the debounce; typing straight into a fetch would
+     issue one request per keystroke. */
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedQuery(query), 200);
+    return () => clearTimeout(id);
+  }, [query]);
 
   const fetchDecisions = useCallback(
     async (search: string, type: string) => {
@@ -781,13 +857,13 @@ function DecisionsView({ root }: { root: string }) {
         if (search && !search.startsWith('/')) params.set('q', search);
         if (type) params.set('type', type);
         const res = await fetch(`${BASE}/api/projects/decisions?${params}`);
-        if (res.ok) {
-          const data = (await res.json()) as { decisions: DecisionRow[]; total: number };
-          setDecisions(data.decisions);
-          setTotal(data.total);
-        }
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as { decisions: DecisionRow[]; total: number };
+        setDecisions(data.decisions);
+        setTotal(data.total);
+        setFailed(false);
       } catch {
-        /* optional */
+        setFailed(true);
       }
       setLoading(false);
     },
@@ -809,27 +885,25 @@ function DecisionsView({ root }: { root: string }) {
     fetchStats();
   }, [fetchStats]);
 
-  // Refetch whenever match or active type changes. FilterBar already
-  // debounces so we can react synchronously here.
   useEffect(() => {
-    void fetchDecisions(filter.match, activeType);
-  }, [fetchDecisions, filter.match, activeType]);
+    void fetchDecisions(debouncedQuery, activeType);
+  }, [fetchDecisions, debouncedQuery, activeType]);
 
-  // Client-side filter pass: applies `match` (when regex), and `exclude`
+  // Client-side filter pass: applies `query` (when regex), and `exclude`
   // against title + content + type + file_path so the user can quickly
   // narrow noisy result sets without a server round-trip.
   const visibleDecisions = useMemo(() => {
-    if (!filter.match && !filter.exclude) return decisions;
+    if (!debouncedQuery && !exclude) return decisions;
     return decisions.filter((d) => {
       const haystack = `${d.title}\n${d.content}\n${d.type}\n${d.file_path ?? ''}`;
       // For regex matches the server returned everything (we couldn't push
       // the regex down) so we still need the include check here. For plain
       // text the server already filtered, so matchesFilter is a no-op pass.
-      if (filter.match && !matchesFilter(haystack, filter.match)) return false;
-      if (filter.exclude && matchesFilter(haystack, filter.exclude)) return false;
+      if (debouncedQuery && !matchesFilter(haystack, debouncedQuery)) return false;
+      if (exclude && matchesFilter(haystack, exclude)) return false;
       return true;
     });
-  }, [decisions, filter.match, filter.exclude]);
+  }, [decisions, debouncedQuery, exclude]);
 
   const handleTypeFilter = (type: string) => {
     const next = activeType === type ? '' : type;
@@ -857,7 +931,7 @@ function DecisionsView({ root }: { root: string }) {
     }
     setShowAddForm(false);
     // Refetch to get accurate totals and server-generated id
-    await fetchDecisions(filter.match, activeType);
+    await fetchDecisions(debouncedQuery, activeType);
     await fetchStats();
   };
 
@@ -874,145 +948,224 @@ function DecisionsView({ root }: { root: string }) {
     void fetchStats();
   };
 
-  return (
-    <div className="space-y-3">
-      {/* Stats panel */}
-      {stats && <StatsPanel stats={stats} />}
+  const hasFilters = debouncedQuery !== '' || exclude !== '' || activeType !== '';
 
-      {/* Add decision button / form */}
-      {showAddForm ? (
-        <DecisionForm
-          root={root}
-          submitLabel="Add decision"
-          onSubmit={handleAdd}
-          onCancel={() => setShowAddForm(false)}
-        />
-      ) : (
-        <button
-          type="button"
-          onClick={() => setShowAddForm(true)}
-          className="text-[12px] font-medium px-3 py-1.5 rounded-md"
-          style={{
-            background: 'var(--accent)',
-            color: '#fff',
-            cursor: 'pointer',
-          }}
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* ── Toolbar ───────────────────────────────────────────────────
+          ONE row. It replaces four stacked ones: the tab pills, a 70px stat
+          card holding three numbers, a 40px accent "+ Add decision" button
+          alone on its own line, and a bordered MATCH / EXCLUDE card. */}
+      <Toolbar scrolled={scrolled}>
+        {subTab}
+        <ToolbarDivider />
+        <span
+          className="flex items-center gap-1 shrink-0 text-[11px] leading-[13px] tabular-nums"
+          style={{ color: 'var(--label-secondary)' }}
         >
-          + Add decision
-        </button>
+          <span style={{ color: 'var(--label)' }}>
+            {stats == null
+              ? '—'
+              : `${stats.total.toLocaleString()} decision${stats.total === 1 ? '' : 's'}`}
+          </span>
+          {stats != null && stats.total > stats.active && (
+            <span>· {(stats.total - stats.active).toLocaleString()} expired</span>
+          )}
+        </span>
+
+        <span className="flex-1" />
+
+        {showExclude || exclude !== '' ? (
+          <SearchField
+            value={exclude}
+            onChange={setExclude}
+            placeholder="Exclude"
+            aria-label="Exclude decisions containing"
+            className="shrink-0"
+          />
+        ) : null}
+
+        <SearchField
+          value={query}
+          onChange={setQuery}
+          placeholder="Search decisions"
+          aria-label="Search decisions"
+        />
+
+        <Button
+          variant="prominent"
+          icon="add"
+          onClick={() => setShowAddForm(true)}
+          disabled={showAddForm}
+        >
+          Add decision
+        </Button>
+
+        <Button
+          ref={overflow.ref}
+          variant="icon"
+          icon="more_horiz"
+          onClick={() => (overflow.at ? overflow.close() : overflow.open())}
+          aria-haspopup="menu"
+          aria-expanded={overflow.at !== null}
+          aria-label="More actions"
+          title="More actions"
+        />
+      </Toolbar>
+
+      {overflow.at && (
+        <Menu x={overflow.at.x} y={overflow.at.y} align="end" onClose={overflow.close}>
+          <MenuItem
+            showCheckSlot
+            checked={showExclude || exclude !== ''}
+            onClick={() => {
+              if (showExclude || exclude !== '') {
+                setExclude('');
+                setShowExclude(false);
+              } else {
+                setShowExclude(true);
+              }
+            }}
+          >
+            Exclude field
+          </MenuItem>
+          {hasFilters && (
+            <>
+              <MenuSeparator />
+              <MenuItem
+                icon="close"
+                onClick={() => {
+                  setQuery('');
+                  setExclude('');
+                  setActiveType('');
+                  overflow.close();
+                }}
+              >
+                Clear search and filters
+              </MenuItem>
+            </>
+          )}
+        </Menu>
       )}
 
-      {/* Filter bar — match feeds FTS, exclude is client-side */}
       <div
-        className="px-3 py-2"
-        style={{
-          background: 'var(--bg-grouped)',
-          border: '0.5px solid var(--border-row)',
-          borderRadius: 8,
-          boxShadow: 'var(--shadow-grouped)',
-        }}
+        className="flex-1 min-h-0 overflow-y-auto"
+        onScroll={(e) => setScrolled((e.target as HTMLElement).scrollTop > 0)}
       >
-        <FilterBar
-          value={filter}
-          onChange={setFilter}
-          depthEnabled={false}
-          storageKey="filter:decisions"
-          placeholder={{
-            match: 'Search decisions…',
-            exclude: 'hide rows containing…',
-          }}
-        />
-      </div>
-
-      {/* Type filter chips */}
-      <div className="flex flex-wrap gap-1">
-        {DECISION_TYPES.map((t) => {
-          const active = activeType === t;
-          const { bg, text } = typeBadgeColors(t);
-          return (
-            <button
-              type="button"
-              key={t}
-              onClick={() => handleTypeFilter(t)}
-              className="text-[10px] px-2 py-0.5 rounded font-medium uppercase transition-all"
-              style={{
-                background: active ? bg : 'var(--bg-inset)',
-                color: active ? text : 'var(--text-tertiary)',
-                border: active ? `0.5px solid ${text}40` : '0.5px solid transparent',
-                cursor: 'pointer',
-              }}
-            >
-              {t.replace(/_/g, ' ')}
-            </button>
-          );
-        })}
-      </div>
-
-      {/* Results */}
-      <div>
-        <div className="flex items-baseline justify-between mb-1.5 px-3">
-          <span className="text-[11px]" style={{ color: 'var(--text-secondary)', letterSpacing: '-0.01em' }}>
-            Decisions
-          </span>
-          {!loading && (
-            <span className="text-[11px] tabular-nums" style={{ color: 'var(--text-tertiary)' }}>
-              {total} found
-            </span>
-          )}
-        </div>
-
-        <div
-          style={{
-            background: 'var(--bg-grouped)',
-            borderRadius: 10,
-            boxShadow: 'var(--shadow-grouped)',
-            overflow: 'hidden',
-          }}
-        >
-          {loading && (
-            <div className="px-3 py-4 text-[12px] text-center" style={{ color: 'var(--text-tertiary)' }}>
-              Loading…
-            </div>
+        <div className="flex flex-col gap-4 px-4 py-4">
+          {showAddForm && (
+            <DecisionForm
+              root={root}
+              submitLabel="Add decision"
+              onSubmit={handleAdd}
+              onCancel={() => setShowAddForm(false)}
+            />
           )}
 
-          {!loading && visibleDecisions.length === 0 && (
-            <div className="px-3 py-4 text-[12px] text-center" style={{ color: 'var(--text-tertiary)' }}>
-              {filter.match || filter.exclude || activeType
-                ? 'No matching decisions.'
-                : 'No decisions stored yet.'}
-            </div>
+          {/* The mix doubles as the type filter: colour is the meter, the
+              chip next to it is the name and the count. */}
+          {stats != null && stats.total > 0 && (
+            <TypeMix stats={stats} activeType={activeType} onTypeClick={handleTypeFilter} />
           )}
 
-          {!loading &&
-            visibleDecisions.map((d, i) => {
-              const isLast = i === visibleDecisions.length - 1;
-              return (
-                <div
-                  key={d.id}
-                  style={{ borderBottom: isLast ? 'none' : '0.5px solid var(--border-row)' }}
+          <Section
+            title="Decisions"
+            trailing={
+              loading || failed ? undefined : (
+                <span
+                  className="text-[11px] leading-[13px] tabular-nums"
+                  style={{ color: 'var(--label-secondary)' }}
                 >
-                  <DecisionCard
-                    decision={d}
-                    root={root}
-                    expanded={expandedId === d.id}
-                    onToggle={() => setExpandedId(expandedId === d.id ? null : d.id)}
-                    onUpdated={handleUpdated}
-                    onInvalidated={handleInvalidated}
-                  />
-                </div>
-              );
-            })}
+                  {visibleDecisions.length === total
+                    ? `${total.toLocaleString()} found`
+                    : `${visibleDecisions.length.toLocaleString()} of ${total.toLocaleString()}`}
+                </span>
+              )
+            }
+          >
+            <Card>
+              {loading && <SkeletonRows rows={4} />}
 
-          {!loading && total > visibleDecisions.length && (
-            <div
-              className="px-3 py-1.5 text-[10px] text-center"
-              style={{ color: 'var(--text-tertiary)', borderTop: '0.5px solid var(--border-row)' }}
-            >
-              {filter.exclude
-                ? `Showing ${visibleDecisions.length} of ${total} (${decisions.length - visibleDecisions.length} hidden by exclude)`
-                : `Showing ${visibleDecisions.length} of ${total} — refine your search to narrow results`}
-            </div>
-          )}
+              {!loading && failed && (
+                <SectionError
+                  what="the decisions for this project"
+                  onRetry={() => fetchDecisions(debouncedQuery, activeType)}
+                />
+              )}
+
+              {!loading && !failed && visibleDecisions.length === 0 && (
+                hasFilters ? (
+                  <EmptyState
+                    compact
+                    icon="search"
+                    title="No matching decisions"
+                    subtitle="Nothing stored for this project matches the current search and filters."
+                    action={
+                      <Button
+                        icon="close"
+                        onClick={() => {
+                          setQuery('');
+                          setExclude('');
+                          setActiveType('');
+                        }}
+                      >
+                        Clear search and filters
+                      </Button>
+                    }
+                  />
+                ) : (
+                  <EmptyState
+                    compact
+                    icon="neurology"
+                    title="No decisions yet"
+                    subtitle="A decision is a note about why this codebase is the way it is — a trade-off, a convention, the root cause of a bug. Assistants read them back before they change your code."
+                    action={
+                      <Button variant="prominent" icon="add" onClick={() => setShowAddForm(true)}>
+                        Add the first decision
+                      </Button>
+                    }
+                  />
+                )
+              )}
+
+              {!loading && visibleDecisions.length > 0 && (
+                <div onKeyDown={rovingArrowKeys}>
+                  {visibleDecisions.map((d, i) => {
+                    const isLast = i === visibleDecisions.length - 1;
+                    return (
+                      <div
+                        key={d.id}
+                        style={{ borderBottom: isLast ? 'none' : '0.5px solid var(--separator)' }}
+                      >
+                        <DecisionCard
+                          decision={d}
+                          root={root}
+                          expanded={expandedId === d.id}
+                          onToggle={() => setExpandedId(expandedId === d.id ? null : d.id)}
+                          onUpdated={handleUpdated}
+                          onInvalidated={handleInvalidated}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              {!loading && visibleDecisions.length > 0 && total > visibleDecisions.length && (
+                <div
+                  className="px-3 py-2 text-[11px] leading-[13px] text-center"
+                  style={{
+                    color: 'var(--label-secondary)',
+                    borderTop: '0.5px solid var(--separator)',
+                  }}
+                >
+                  {exclude
+                    ? `${(decisions.length - visibleDecisions.length).toLocaleString()} more hidden by the exclude filter`
+                    : 'Narrow the search to see the rest'}
+                </div>
+              )}
+            </Card>
+          </Section>
         </div>
       </div>
     </div>
@@ -1068,28 +1221,36 @@ function CorpusQueryModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center"
-      style={{ background: 'rgba(0,0,0,0.6)' }}
+      className="fixed inset-0 z-50 flex items-start justify-center"
+      style={{ background: 'rgb(0 0 0 / 0.35)', paddingTop: '10vh' }}
       onClick={onClose}
+      role="presentation"
     >
+      {/* A sheet, not a centred web modal: 12px radius, panel shadow, Esc and
+          a backdrop press both dismiss. */}
       <div
-        className="w-full max-w-lg mx-4 rounded-xl shadow-2xl space-y-3 p-4"
-        style={{ background: 'var(--bg-primary)', maxHeight: '80vh', overflowY: 'auto' }}
+        className="w-full max-w-lg mx-4 flex flex-col gap-3 p-4"
+        style={{
+          background: 'var(--surface-raised)',
+          border: '0.5px solid var(--separator)',
+          borderRadius: 'var(--radius-panel)',
+          boxShadow: 'var(--shadow-panel)',
+          maxHeight: '70vh',
+          overflowY: 'auto',
+        }}
+        role="dialog"
+        aria-label={`Query corpus ${corpusName}`}
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') onClose();
+        }}
       >
-        <div className="flex items-center justify-between">
-          <span className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>
-            Query corpus:{' '}
-            <span style={{ fontFamily: 'SF Mono, Menlo, monospace' }}>{corpusName}</span>
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-[17px] leading-[22px] font-semibold" style={{ color: 'var(--label)' }}>
+            Query{' '}
+            <span style={{ fontFamily: 'var(--font-mono)' }}>{corpusName}</span>
           </span>
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-[13px] px-2 py-0.5 rounded"
-            style={{ color: 'var(--text-tertiary)', cursor: 'pointer' }}
-          >
-            ✕
-          </button>
+          <Button variant="icon" icon="close" onClick={onClose} aria-label="Close" title="Close" />
         </div>
 
         <form onSubmit={(e) => { void handleQuery(e); }} className="flex gap-2">
@@ -1099,66 +1260,63 @@ function CorpusQueryModal({
             onChange={(e) => setQuery(e.target.value)}
             placeholder="What do you want to know from this corpus?"
             autoFocus
-            className="flex-1 text-[12px] outline-none px-2.5"
+            aria-label="Corpus query"
+            className="flex-1 outline-none px-2.5 text-[13px]"
             style={{
-              background: 'var(--bg-grouped)',
-              border: '0.5px solid var(--border-row)',
-              borderRadius: 6,
-              height: 30,
-              color: 'var(--text-primary)',
+              background: 'var(--fill-quaternary)',
+              boxShadow: 'inset 0 0 0 0.5px var(--separator)',
+              border: 0,
+              borderRadius: 'var(--radius-input)',
+              height: 28,
+              color: 'var(--label)',
+              fontFamily: 'inherit',
             }}
             disabled={pending}
           />
-          <button
+          <Button
             type="submit"
+            size="large"
+            variant="prominent"
             disabled={pending || !query.trim()}
-            className="text-[12px] font-medium px-3 py-1 rounded"
-            style={{
-              background: 'var(--accent)',
-              color: '#fff',
-              cursor: pending || !query.trim() ? 'not-allowed' : 'pointer',
-              opacity: pending || !query.trim() ? 0.6 : 1,
-            }}
           >
-            {pending ? '…' : 'Search'}
-          </button>
+            {pending ? 'Searching…' : 'Search'}
+          </Button>
         </form>
 
         {error && (
-          <div className="text-[11px]" style={{ color: '#f87171' }}>
+          <div
+            role="alert"
+            className="flex items-center gap-1.5 text-[13px] leading-4"
+            style={{ color: 'var(--status-red)' }}
+          >
+            <Icon name="warning" size={14} />
             {error}
           </div>
         )}
 
         {result && (
-          <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-                ~{result.tokens_used} tokens
-              </span>
-              <button
-                type="button"
-                onClick={handleCopy}
-                className="text-[10px] px-2 py-0.5 rounded font-medium"
-                style={{
-                  background: 'var(--bg-inset)',
-                  color: copied ? '#34d399' : 'var(--text-secondary)',
-                  border: '0.5px solid var(--border-row)',
-                  cursor: 'pointer',
-                }}
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between gap-2">
+              <span
+                className="text-[11px] leading-[13px] tabular-nums"
+                style={{ color: 'var(--label-secondary)' }}
               >
-                {copied ? 'Copied!' : 'Copy'}
-              </button>
+                ~{result.tokens_used.toLocaleString()} tokens
+              </span>
+              <Button size="small" icon={copied ? 'check' : 'content_copy'} onClick={handleCopy}>
+                {copied ? 'Copied' : 'Copy'}
+              </Button>
             </div>
             <pre
-              className="text-[11px] leading-relaxed whitespace-pre-wrap overflow-auto"
+              className="text-[12px] leading-[16px] whitespace-pre-wrap overflow-auto"
               style={{
-                background: 'var(--bg-inset)',
-                borderRadius: 6,
+                background: 'var(--fill-quaternary)',
+                borderRadius: 'var(--radius-input)',
                 padding: '8px 10px',
-                color: 'var(--text-secondary)',
+                color: 'var(--label)',
                 maxHeight: 320,
-                border: '0.5px solid var(--border-row)',
+                boxShadow: 'inset 0 0 0 0.5px var(--separator)',
+                fontFamily: 'var(--font-mono)',
               }}
             >
               {result.excerpt}
@@ -1170,7 +1328,7 @@ function CorpusQueryModal({
   );
 }
 
-function CorporaView({ root }: { root: string }) {
+function CorporaView({ root, subTab }: { root: string; subTab?: ReactNode }) {
   const [corpora, setCorpora] = useState<CorpusItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [queryCorpus, setQueryCorpus] = useState<string | null>(null);
@@ -1214,7 +1372,14 @@ function CorporaView({ root }: { root: string }) {
   };
 
   return (
-    <div className="space-y-3">
+    <ViewShell
+      subTab={subTab}
+      status={
+        loading
+          ? 'Loading…'
+          : `${corpora.length.toLocaleString()} corpus${corpora.length === 1 ? '' : 'es'}`
+      }
+    >
       {queryCorpus && (
         <CorpusQueryModal
           corpusName={queryCorpus}
@@ -1223,170 +1388,140 @@ function CorporaView({ root }: { root: string }) {
         />
       )}
 
-      <div className="flex items-baseline justify-between mb-1.5 px-3">
-        <span className="text-[11px]" style={{ color: 'var(--text-secondary)', letterSpacing: '-0.01em' }}>
-          Corpora
-        </span>
-        {!loading && (
-          <span className="text-[11px] tabular-nums" style={{ color: 'var(--text-tertiary)' }}>
-            {corpora.length}
-          </span>
-        )}
-      </div>
+      <Section title="Corpora">
+        <Card>
+          {loading && <SkeletonRows rows={3} />}
 
-      <div
-        style={{
-          background: 'var(--bg-grouped)',
-          borderRadius: 10,
-          boxShadow: 'var(--shadow-grouped)',
-          overflow: 'hidden',
-        }}
-      >
-        {loading && (
-          <div className="px-3 py-4 text-[12px] text-center" style={{ color: 'var(--text-tertiary)' }}>
-            Loading…
-          </div>
-        )}
+          {!loading && corpora.length === 0 && (
+            <EmptyState
+              compact
+              icon="database"
+              title="No corpora yet"
+              subtitle="A corpus is a saved slice of this codebase an assistant can pull in one call. Build one with the build_corpus tool."
+            />
+          )}
 
-        {!loading && corpora.length === 0 && (
-          <div className="px-3 py-4 text-[12px] text-center" style={{ color: 'var(--text-tertiary)' }}>
-            No corpora for this project.
-          </div>
-        )}
-
-        {!loading &&
-          corpora.map((c, i) => {
-            const isLast = i === corpora.length - 1;
-            const isDeleting = deletePending === c.name;
-            const isConfirming = confirmDelete === c.name;
-            return (
-              <div
-                key={c.name}
-                className="px-3 py-2.5"
-                style={{ borderBottom: isLast ? 'none' : '0.5px solid var(--border-row)' }}
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <div className="flex-1 min-w-0 space-y-1">
-                    <div className="flex items-center gap-1.5">
-                      <span
-                        className="text-[13px] font-medium"
-                        style={{ color: 'var(--text-primary)', fontFamily: 'SF Mono, Menlo, monospace' }}
-                      >
-                        {c.name}
-                      </span>
-                      <span
-                        className="text-[10px] px-1.5 py-0.5 rounded font-medium uppercase"
-                        style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
-                      >
-                        {c.scope}
-                      </span>
-                    </div>
-
-                    {c.description && (
-                      <div className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>
-                        {c.description}
-                      </div>
-                    )}
-
-                    {(c.featureQuery || c.modulePath) && (
-                      <div
-                        className="text-[10px] truncate"
-                        style={{ color: 'var(--text-tertiary)', fontFamily: 'SF Mono, Menlo, monospace' }}
-                        title={c.featureQuery ?? c.modulePath}
-                      >
-                        {c.featureQuery ?? c.modulePath}
-                      </div>
-                    )}
-
-                    <div className="flex items-center gap-3 flex-wrap">
-                      <span className="text-[10px] tabular-nums" style={{ color: 'var(--text-tertiary)' }}>
-                        {c.symbolCount} symbols · {c.fileCount} files
-                      </span>
-                      <span className="text-[10px] tabular-nums" style={{ color: 'var(--text-tertiary)' }}>
-                        ~{(c.tokenBudget / 1000).toFixed(0)}K budget
-                      </span>
-                      {c.sizeKB !== null && (
-                        <span className="text-[10px] tabular-nums" style={{ color: 'var(--text-tertiary)' }}>
-                          {c.sizeKB} KB
+          {!loading &&
+            corpora.map((c, i) => {
+              const isLast = i === corpora.length - 1;
+              return (
+                <div
+                  key={c.name}
+                  className="px-3 py-2.5"
+                  style={{ borderBottom: isLast ? 'none' : '0.5px solid var(--separator)' }}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex-1 min-w-0 flex flex-col gap-1">
+                      <div className="flex items-center gap-1.5 flex-wrap">
+                        <span
+                          className="text-[13px] leading-4 font-medium"
+                          style={{ color: 'var(--label)', fontFamily: 'var(--font-mono)' }}
+                        >
+                          {c.name}
                         </span>
+                        <Badge tone="neutral">{c.scope}</Badge>
+                      </div>
+
+                      {c.description && (
+                        <div
+                          className="text-[13px] leading-4"
+                          style={{ color: 'var(--label-secondary)' }}
+                        >
+                          {c.description}
+                        </div>
                       )}
-                      <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-                        {formatDate(c.createdAt)}
-                      </span>
-                    </div>
-                  </div>
 
-                  {/* Action buttons */}
-                  <div className="flex items-center gap-1 shrink-0">
-                    <button
-                      type="button"
-                      onClick={() => setQueryCorpus(c.name)}
-                      className="text-[11px] font-medium px-2 py-1 rounded"
-                      style={{
-                        background: 'var(--accent)',
-                        color: '#fff',
-                        cursor: 'pointer',
-                      }}
-                    >
-                      Query
-                    </button>
+                      {(c.featureQuery || c.modulePath) && (
+                        <div
+                          className="text-[11px] leading-[13px] truncate"
+                          style={{
+                            color: 'var(--label-secondary)',
+                            fontFamily: 'var(--font-mono)',
+                          }}
+                          title={c.featureQuery ?? c.modulePath}
+                        >
+                          {c.featureQuery ?? c.modulePath}
+                        </div>
+                      )}
 
-                    {isConfirming ? (
-                      <>
-                        <button
-                          type="button"
-                          onClick={() => { void handleDelete(c.name); }}
-                          disabled={isDeleting}
-                          className="text-[11px] font-medium px-2 py-1 rounded"
-                          style={{
-                            background: 'rgba(239,68,68,0.15)',
-                            color: '#f87171',
-                            cursor: isDeleting ? 'not-allowed' : 'pointer',
-                            opacity: isDeleting ? 0.6 : 1,
-                          }}
-                        >
-                          {isDeleting ? '…' : 'Confirm'}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => setConfirmDelete(null)}
-                          className="text-[11px] px-1.5 py-1 rounded"
-                          style={{
-                            background: 'var(--bg-inset)',
-                            color: 'var(--text-tertiary)',
-                            border: '0.5px solid var(--border-row)',
-                            cursor: 'pointer',
-                          }}
-                        >
-                          ✕
-                        </button>
-                      </>
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={() => setConfirmDelete(c.name)}
-                        className="text-[11px] font-medium px-2 py-1 rounded"
-                        style={{
-                          background: 'var(--bg-inset)',
-                          color: 'var(--text-secondary)',
-                          border: '0.5px solid var(--border-row)',
-                          cursor: 'pointer',
-                        }}
+                      <div
+                        className="flex items-center gap-3 flex-wrap text-[11px] leading-[13px] tabular-nums"
+                        style={{ color: 'var(--label-secondary)' }}
                       >
-                        Delete
-                      </button>
-                    )}
+                        <span>
+                          {c.symbolCount.toLocaleString()} symbols · {c.fileCount.toLocaleString()}{' '}
+                          files
+                        </span>
+                        <span>~{(c.tokenBudget / 1000).toFixed(0)}K token budget</span>
+                        {c.sizeKB !== null && <span>{c.sizeKB} KB</span>}
+                        <span>{formatDate(c.createdAt)}</span>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      <Button variant="prominent" onClick={() => setQueryCorpus(c.name)}>
+                        Query
+                      </Button>
+                      <CorpusDeleteButton
+                        name={c.name}
+                        pending={deletePending === c.name}
+                        onDelete={() => void handleDelete(c.name)}
+                      />
+                    </div>
                   </div>
                 </div>
-              </div>
-            );
-          })}
-      </div>
-    </div>
+              );
+            })}
+        </Card>
+      </Section>
+    </ViewShell>
   );
 }
 
-function SessionsView({ root }: { root: string }) {
+/** Delete, behind a named confirmation popover. The old row put "Delete" and
+    an inline "Confirm ✕" pair straight in the row at 11px. */
+function CorpusDeleteButton({
+  name,
+  pending,
+  onDelete,
+}: {
+  name: string;
+  pending: boolean;
+  onDelete: () => void;
+}) {
+  const confirm = useMenuAnchor();
+  return (
+    <>
+      <Button
+        ref={confirm.ref}
+        variant="icon"
+        icon="trash"
+        disabled={pending}
+        onClick={() => (confirm.at ? confirm.close() : confirm.open())}
+        aria-label={`Delete corpus ${name}`}
+        title={`Delete corpus ${name}`}
+      />
+      {confirm.at && (
+        <ConfirmPopover
+          x={confirm.at.x}
+          y={confirm.at.y}
+          align="end"
+          danger
+          title={`Delete corpus ${name}?`}
+          body="The saved slice is removed. The code it points at is untouched, and you can rebuild it."
+          confirmLabel={pending ? 'Deleting…' : 'Delete corpus'}
+          onConfirm={() => {
+            onDelete();
+            confirm.close();
+          }}
+          onCancel={confirm.close}
+        />
+      )}
+    </>
+  );
+}
+
+function SessionsView({ root, subTab }: { root: string; subTab?: ReactNode }) {
   const [sessions, setSessions] = useState<MinedSession[]>([]);
   const [loading, setLoading] = useState(false);
 
@@ -1404,84 +1539,64 @@ function SessionsView({ root }: { root: string }) {
   }, [root]);
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-baseline justify-between mb-1.5 px-3">
-        <span
-          className="text-[11px]"
-          style={{ color: 'var(--text-secondary)', letterSpacing: '-0.01em' }}
-        >
-          Mined sessions
-        </span>
-        {!loading && (
-          <span className="text-[11px] tabular-nums" style={{ color: 'var(--text-tertiary)' }}>
-            {sessions.length}
-          </span>
-        )}
-      </div>
+    <ViewShell
+      subTab={subTab}
+      status={
+        loading
+          ? 'Loading…'
+          : `${sessions.length.toLocaleString()} session${sessions.length === 1 ? '' : 's'}`
+      }
+    >
+      <Section title="Mined sessions">
+        <Card>
+          {loading && <SkeletonRows rows={4} />}
 
-      <div
-        style={{
-          background: 'var(--bg-grouped)',
-          borderRadius: 10,
-          boxShadow: 'var(--shadow-grouped)',
-          overflow: 'hidden',
-        }}
-      >
-        {loading && (
-          <div className="px-3 py-4 text-[12px] text-center" style={{ color: 'var(--text-tertiary)' }}>
-            Loading…
-          </div>
-        )}
+          {!loading && sessions.length === 0 && (
+            <EmptyState
+              compact
+              icon="history"
+              title="No sessions mined yet"
+              subtitle="Mining reads past assistant transcripts for decisions worth keeping. Run the mine_sessions tool to fill this list."
+            />
+          )}
 
-        {!loading && sessions.length === 0 && (
-          <div className="px-3 py-4 text-[12px] text-center" style={{ color: 'var(--text-tertiary)' }}>
-            No mined sessions yet.
-          </div>
-        )}
-
-        {!loading &&
-          sessions.map((s, i) => {
-            const isLast = i === sessions.length - 1;
-            return (
-              <div
-                key={s.session_path}
-                className="px-3 py-2.5"
-                style={{ borderBottom: isLast ? 'none' : '0.5px solid var(--border-row)' }}
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <div className="flex-1 min-w-0 space-y-0.5">
-                    <div
-                      className="text-[11px] truncate"
-                      style={{
-                        color: 'var(--text-primary)',
-                        fontFamily: 'SF Mono, Menlo, monospace',
-                      }}
-                      title={s.session_path}
-                    >
-                      {shortPath(s.session_path)}
+          {!loading &&
+            sessions.map((s, i) => {
+              const isLast = i === sessions.length - 1;
+              return (
+                <div
+                  key={s.session_path}
+                  className="px-3 py-2.5"
+                  style={{ borderBottom: isLast ? 'none' : '0.5px solid var(--separator)' }}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+                      <div
+                        className="text-[13px] leading-4 truncate"
+                        style={{ color: 'var(--label)', fontFamily: 'var(--font-mono)' }}
+                        title={s.session_path}
+                      >
+                        {shortPath(s.session_path)}
+                      </div>
+                      <div
+                        className="text-[11px] leading-[13px] tabular-nums"
+                        style={{ color: 'var(--label-secondary)' }}
+                      >
+                        {formatDate(s.mined_at)}
+                      </div>
                     </div>
-                    <div className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-                      {formatDate(s.mined_at)}
-                    </div>
+                    {/* A count is the signal, so it is a number and a noun —
+                        not a green-vs-grey colour swap on the same string. */}
+                    <Badge tone={s.decisions_found > 0 ? 'green' : 'neutral'}>
+                      {s.decisions_found} decision{s.decisions_found === 1 ? '' : 's'}
+                    </Badge>
                   </div>
-                  <span
-                    className="shrink-0 text-[11px] tabular-nums font-medium"
-                    style={{
-                      color:
-                        s.decisions_found > 0
-                          ? 'var(--green, #22c55e)'
-                          : 'var(--text-tertiary)',
-                    }}
-                    title={`${s.decisions_found} decision${s.decisions_found === 1 ? '' : 's'} found`}
-                  >
-                    {s.decisions_found} found
-                  </span>
                 </div>
-              </div>
-            );
-          })}
-      </div>
-    </div>
+              );
+            })}
+        </Card>
+      </Section>
+    </ViewShell>
   );
 }
 
@@ -1524,167 +1639,113 @@ function ReviewCard({
     }
   };
 
+  const confidenceTone: Tone =
+    confidencePct >= 75 ? 'green' : confidencePct >= 50 ? 'orange' : 'red';
+
   return (
-    <div className="px-3 py-2.5 space-y-2">
-      {/* Header: title + type/source badges */}
-      <div className="flex items-start gap-2">
-        <div className="flex-1 min-w-0 space-y-1">
-          <div className="flex items-center gap-1.5 flex-wrap">
-            <span
-              className="text-[13px] font-medium leading-tight"
-              style={{ color: 'var(--text-primary)' }}
-            >
-              {decision.title}
-            </span>
-            <TypeBadge type={decision.type} />
-            <SourceBadge source={decision.source} />
-            <span
-              className="text-[9px] px-1.5 py-0.5 rounded font-medium uppercase shrink-0"
-              style={{
-                background: 'rgba(234,179,8,0.15)',
-                color: '#fbbf24',
-                letterSpacing: '0.03em',
-              }}
-            >
-              pending review
-            </span>
-          </div>
-        </div>
+    <div className="px-3 py-2.5 flex flex-col gap-2">
+      <div className="flex items-center gap-1.5 flex-wrap">
+        <span className="text-[13px] leading-4 font-medium" style={{ color: 'var(--label)' }}>
+          {decision.title}
+        </span>
+        <TypeBadge type={decision.type} />
+        <SourceBadge source={decision.source} />
+        <Badge tone="orange" icon="schedule">
+          Awaiting review
+        </Badge>
       </div>
 
-      {/* Content excerpt */}
       <div
-        className="text-[12px] leading-relaxed whitespace-pre-wrap"
-        style={{ color: 'var(--text-secondary)' }}
+        className="text-[13px] leading-[18px] whitespace-pre-wrap"
+        style={{ color: 'var(--label-secondary)' }}
       >
         {decision.content}
       </div>
 
-      {/* Confidence bar + numeric */}
+      {/* Confidence: a meter AND the number, so the tone is never the only
+          thing carrying "how sure was the miner". */}
       <div className="flex items-center gap-2">
-        <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-          confidence
+        <span
+          className="text-[11px] leading-[13px] shrink-0"
+          style={{ color: 'var(--label-secondary)' }}
+        >
+          Confidence
         </span>
         <div
-          className="flex-1 h-1.5 rounded overflow-hidden"
-          style={{ background: 'var(--bg-inset)', maxWidth: 200 }}
+          className="flex-1 overflow-hidden"
+          style={{ height: 6, borderRadius: 3, background: 'var(--fill-quaternary)', maxWidth: 200 }}
         >
           <div
             style={{
               width: `${confidencePct}%`,
               height: '100%',
-              background:
-                confidencePct >= 75
-                  ? 'var(--green, #22c55e)'
-                  : confidencePct >= 50
-                  ? '#fbbf24'
-                  : '#f87171',
+              borderRadius: 3,
+              background: TONE_VAR[confidenceTone],
             }}
           />
         </div>
         <span
-          className="text-[10px] tabular-nums"
-          style={{ color: 'var(--text-secondary)' }}
+          className="text-[11px] leading-[13px] tabular-nums"
+          style={{ color: 'var(--label)' }}
         >
           {confidencePct}%
         </span>
       </div>
 
-      {/* Meta row: session, file, branch */}
-      <div className="flex items-center gap-3 flex-wrap">
+      <div
+        className="flex items-center gap-3 flex-wrap text-[11px] leading-[13px]"
+        style={{ color: 'var(--label-secondary)', fontFamily: 'var(--font-mono)' }}
+      >
         {decision.session_id && (
-          <a
-            href={`#session:${decision.session_id}`}
-            className="text-[10px] truncate max-w-[180px] hover:underline"
-            style={{
-              color: 'var(--accent, #818cf8)',
-              fontFamily: 'SF Mono, Menlo, monospace',
-            }}
-            title={`Session ${decision.session_id}`}
-          >
+          <span className="truncate max-w-[180px]" title={`Session ${decision.session_id}`}>
             {decision.session_id.slice(0, 14)}…
-          </a>
+          </span>
         )}
         {decision.file_path && (
-          <span
-            className="text-[10px] truncate max-w-[200px]"
-            style={{
-              color: 'var(--text-tertiary)',
-              fontFamily: 'SF Mono, Menlo, monospace',
-            }}
-            title={decision.file_path}
-          >
+          <span className="truncate max-w-[220px]" title={decision.file_path}>
             {decision.file_path}
           </span>
         )}
         {decision.git_branch && (
-          <span
-            className="text-[10px] px-1.5 py-0.5 rounded"
-            style={{
-              background: 'var(--bg-inset)',
-              color: 'var(--text-secondary)',
-              border: '0.5px solid var(--border-row)',
-              fontFamily: 'SF Mono, Menlo, monospace',
-            }}
-            title={`Captured on branch ${decision.git_branch}`}
-          >
+          <Badge tone="neutral" title={`Captured on branch ${decision.git_branch}`}>
             {decision.git_branch}
-          </span>
+          </Badge>
         )}
       </div>
 
-      {/* Tags */}
       {tags.length > 0 && (
         <div className="flex flex-wrap gap-1">
           {tags.map((tag) => (
-            <span
-              key={tag}
-              className="text-[10px] px-1.5 py-0.5 rounded"
-              style={{
-                background: 'var(--bg-inset)',
-                color: 'var(--text-secondary)',
-                border: '0.5px solid var(--border-row)',
-              }}
-            >
+            <Badge key={tag} tone="neutral">
               {tag}
-            </span>
+            </Badge>
           ))}
         </div>
       )}
 
-      {/* Action buttons */}
-      <div className="flex gap-2 pt-1">
-        <button
-          type="button"
-          onClick={() => { void handle('approve')(); }}
+      <div className="flex items-center gap-2 pt-1">
+        <Button
+          variant="prominent"
+          icon="check"
           disabled={pending !== null}
-          className="text-[12px] font-medium px-3 py-1.5 rounded"
-          style={{
-            background: 'var(--green, #22c55e)',
-            color: '#fff',
-            cursor: pending ? 'not-allowed' : 'pointer',
-            opacity: pending ? 0.6 : 1,
-          }}
+          onClick={() => { void handle('approve')(); }}
         >
           {pending === 'approve' ? 'Approving…' : 'Approve'}
-        </button>
-        <button
-          type="button"
-          onClick={() => { void handle('reject')(); }}
+        </Button>
+        <Button
+          icon="close"
           disabled={pending !== null}
-          className="text-[12px] font-medium px-3 py-1.5 rounded"
-          style={{
-            background: 'rgba(239,68,68,0.15)',
-            color: '#f87171',
-            border: '0.5px solid rgba(239,68,68,0.4)',
-            cursor: pending ? 'not-allowed' : 'pointer',
-            opacity: pending ? 0.6 : 1,
-          }}
+          onClick={() => { void handle('reject')(); }}
         >
           {pending === 'reject' ? 'Rejecting…' : 'Reject'}
-        </button>
+        </Button>
         {error && (
-          <span className="text-[11px] self-center" style={{ color: '#f87171' }}>
+          <span
+            role="alert"
+            className="text-[11px] leading-[13px] flex items-center gap-1"
+            style={{ color: 'var(--status-red)' }}
+          >
+            <Icon name="warning" size={12} />
             {error}
           </span>
         )}
@@ -1700,9 +1761,11 @@ interface ToastState {
 
 function ReviewView({
   root,
+  subTab,
   onPendingCountChange,
 }: {
   root: string;
+  subTab?: ReactNode;
   onPendingCountChange?: (count: number) => void;
 }) {
   const [decisions, setDecisions] = useState<DecisionRow[]>([]);
@@ -1776,76 +1839,64 @@ function ReviewView({
   };
 
   return (
-    <div className="space-y-3">
-      {/* Toast */}
+    <ViewShell
+      subTab={subTab}
+      status={
+        loading
+          ? 'Loading…'
+          : `${decisions.length.toLocaleString()} awaiting review`
+      }
+    >
       {toast && (
         <div
-          className="px-3 py-2 text-[12px] rounded-md"
+          role="status"
+          className="flex items-center gap-2 px-3 py-2 text-[13px] leading-4"
           style={{
+            borderRadius: 10,
             background:
               toast.kind === 'error'
-                ? 'rgba(239,68,68,0.15)'
-                : 'rgba(34,197,94,0.15)',
-            color: toast.kind === 'error' ? '#f87171' : '#22c55e',
-            border: `0.5px solid ${toast.kind === 'error' ? '#f8717140' : '#22c55e40'}`,
+                ? 'color-mix(in oklab, var(--status-red) 12%, transparent)'
+                : 'color-mix(in oklab, var(--status-green) 12%, transparent)',
+            color: toast.kind === 'error' ? 'var(--status-red)' : 'var(--status-green)',
           }}
         >
+          <Icon name={toast.kind === 'error' ? 'warning' : 'check'} size={14} />
           {toast.message}
         </div>
       )}
 
-      <div className="flex items-baseline justify-between mb-1.5 px-3">
-        <span
-          className="text-[11px]"
-          style={{ color: 'var(--text-secondary)', letterSpacing: '-0.01em' }}
-        >
-          Review queue
-        </span>
-        {!loading && (
-          <span className="text-[11px] tabular-nums" style={{ color: 'var(--text-tertiary)' }}>
-            {decisions.length}
-          </span>
-        )}
-      </div>
+      <Section title="Review queue">
+        <Card>
+          {loading && <SkeletonRows rows={3} />}
 
-      <div
-        style={{
-          background: 'var(--bg-grouped)',
-          borderRadius: 10,
-          boxShadow: 'var(--shadow-grouped)',
-          overflow: 'hidden',
-        }}
-      >
-        {loading && (
-          <div className="px-3 py-4 text-[12px] text-center" style={{ color: 'var(--text-tertiary)' }}>
-            Loading…
-          </div>
-        )}
+          {!loading && decisions.length === 0 && (
+            <EmptyState
+              compact
+              icon="done_all"
+              title="Nothing to review"
+              subtitle="Decisions mined from past sessions land here first, so you can approve or reject them before assistants read them back."
+            />
+          )}
 
-        {!loading && decisions.length === 0 && (
-          <div className="px-3 py-4 text-[12px] text-center" style={{ color: 'var(--text-tertiary)' }}>
-            Nothing to review — the queue is empty.
-          </div>
-        )}
-
-        {!loading &&
-          decisions.map((d, i) => {
-            const isLast = i === decisions.length - 1;
-            return (
-              <div
-                key={d.id}
-                style={{ borderBottom: isLast ? 'none' : '0.5px solid var(--border-row)' }}
-              >
-                <ReviewCard
-                  decision={d}
-                  onApprove={(id) => handleAction(id, 'approved')}
-                  onReject={(id) => handleAction(id, 'rejected')}
-                />
-              </div>
-            );
-          })}
-      </div>
-    </div>
+          {!loading &&
+            decisions.map((d, i) => {
+              const isLast = i === decisions.length - 1;
+              return (
+                <div
+                  key={d.id}
+                  style={{ borderBottom: isLast ? 'none' : '0.5px solid var(--separator)' }}
+                >
+                  <ReviewCard
+                    decision={d}
+                    onApprove={(id) => handleAction(id, 'approved')}
+                    onReject={(id) => handleAction(id, 'rejected')}
+                  />
+                </div>
+              );
+            })}
+        </Card>
+      </Section>
+    </ViewShell>
   );
 }
 
@@ -1883,25 +1934,24 @@ export function MemoryExplorer({ root }: { root: string }) {
     { key: 'sessions', label: 'Sessions' },
   ];
 
-  return (
-    <div className="space-y-4 pb-4">
-      {/* Tab bar */}
-      <div className="flex">
-        <SegmentedControl
-          options={tabs.map((t) => ({ value: t.key, label: t.label }))}
-          value={activeTab}
-          onChange={setActiveTab}
-          aria-label="Memory section"
-        />
-      </div>
+  const switcher = (
+    <SegmentedControl
+      className="shrink-0"
+      options={tabs.map((t) => ({ value: t.key, label: t.label }))}
+      value={activeTab}
+      onChange={setActiveTab}
+      aria-label="Memory section"
+    />
+  );
 
-      {/* Content */}
-      {activeTab === 'decisions' && <DecisionsView root={root} />}
+  return (
+    <>
+      {activeTab === 'decisions' && <DecisionsView root={root} subTab={switcher} />}
       {activeTab === 'review' && (
-        <ReviewView root={root} onPendingCountChange={setPendingCount} />
+        <ReviewView root={root} subTab={switcher} onPendingCountChange={setPendingCount} />
       )}
-      {activeTab === 'corpora' && <CorporaView root={root} />}
-      {activeTab === 'sessions' && <SessionsView root={root} />}
-    </div>
+      {activeTab === 'corpora' && <CorporaView root={root} subTab={switcher} />}
+      {activeTab === 'sessions' && <SessionsView root={root} subTab={switcher} />}
+    </>
   );
 }

--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -26,21 +26,23 @@ import { Icon } from '../lattice/icons';
 import {
   Badge,
   Button,
+  Card,
   ConfirmPopover,
   EmptyState,
+  ListRow,
   Menu,
   MenuItem,
   MenuSeparator,
+  Section,
+  SectionError,
   SegmentedControl,
+  Skeleton,
+  SkeletonRows,
   StatusDot,
+  Toolbar,
   useMenuAnchor,
   type Tone,
 } from '../lattice/ui';
-// ponytail: Skeleton lives next to the workspace surface that introduced it.
-// It is a general primitive and wants to move to lattice/ui, but that means
-// editing four freshly-merged files for no visual change — do it when a third
-// surface needs it.
-import { Skeleton } from '../workspace/components/Skeleton';
 
 interface ProjectStats {
   files: number;
@@ -207,124 +209,6 @@ function buildIssueUrl(gap: CoverageGap | UnknownPackage): string {
     : `## Catalog review\n\n**Package:** \`${gap.name}\` (${gap.version})\n**Ecosystem:** ${(gap as UnknownPackage).ecosystem}\n**Assessment:** ${(gap as UnknownPackage).needs_plugin} — ${(gap as UnknownPackage).reason}\n\nThis dependency is not in the known-packages catalog.\n\n### Expected\nAdd to catalog with appropriate category/priority, or create a plugin if it has framework-level semantics.\n`;
   const labels = isGap ? 'enhancement,plugin-request' : 'enhancement,catalog-review';
   return `https://github.com/${GITHUB_REPO}/issues/new?${new URLSearchParams({ title, body, labels })}`;
-}
-
-// ── Section scaffolding ─────────────────────────────────────────────────────
-
-/** A titled group. Grouping is whitespace + a caption, never a rule. */
-function Section({
-  title,
-  count,
-  trailing,
-  children,
-}: {
-  title: string;
-  count?: number;
-  trailing?: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <section className="flex flex-col gap-2">
-      <div className="flex items-center justify-between gap-2 px-1 min-h-6">
-        <h3
-          className="flex items-baseline gap-1.5 text-[11px] leading-[13px] font-semibold"
-          style={{ color: 'var(--label-secondary)' }}
-        >
-          {title}
-          {count !== undefined && count > 0 && (
-            <span className="tabular-nums" style={{ color: 'var(--label-secondary)' }}>
-              {count.toLocaleString()}
-            </span>
-          )}
-        </h3>
-        {trailing}
-      </div>
-      {children}
-    </section>
-  );
-}
-
-/** Inset grouped-list container. Content, so: opaque, hairline, no shadow. */
-function Card({ children, className }: { children: React.ReactNode; className?: string }) {
-  return (
-    <div
-      className={`overflow-hidden${className ? ` ${className}` : ''}`}
-      style={{
-        background: 'var(--surface)',
-        borderRadius: 12,
-        border: '0.5px solid var(--separator)',
-      }}
-    >
-      {children}
-    </div>
-  );
-}
-
-/** One label/value row of a grouped list. 32px, 13px both sides. */
-function ListRow({
-  label,
-  value,
-  last = false,
-}: {
-  label: string;
-  value: React.ReactNode;
-  last?: boolean;
-}) {
-  return (
-    <div
-      className="flex items-center justify-between gap-3 px-3"
-      style={{
-        minHeight: 32,
-        borderBottom: last ? 'none' : '0.5px solid var(--separator)',
-      }}
-    >
-      <span className="text-[13px] leading-4" style={{ color: 'var(--label)' }}>
-        {label}
-      </span>
-      <span
-        className="text-[13px] leading-4 tabular-nums truncate"
-        style={{ color: 'var(--label-secondary)' }}
-      >
-        {value}
-      </span>
-    </div>
-  );
-}
-
-/** Rows at the real 32px geometry so nothing moves when the data lands. */
-function SkeletonRows({ rows }: { rows: number }) {
-  return (
-    <div role="status" aria-label="Loading">
-      {Array.from({ length: rows }, (_, i) => (
-        <div
-          key={i}
-          className="flex items-center justify-between px-3"
-          style={{
-            minHeight: 32,
-            borderBottom: i === rows - 1 ? 'none' : '0.5px solid var(--separator)',
-          }}
-        >
-          <Skeleton width={92 + ((i * 29) % 40)} height={11} />
-          <Skeleton width={48 + ((i * 17) % 32)} height={11} />
-        </div>
-      ))}
-    </div>
-  );
-}
-
-/** Inline "we couldn't measure this" panel with the one action that helps. */
-function SectionError({ what, onRetry }: { what: string; onRetry: () => void }) {
-  return (
-    <div className="flex items-center gap-2 px-3 py-2">
-      <Icon name="warning" size={14} />
-      <span className="text-[13px] leading-4 flex-1" style={{ color: 'var(--label-secondary)' }}>
-        Couldn't load {what}. The daemon may still be indexing.
-      </span>
-      <Button size="small" onClick={onRetry}>
-        Retry
-      </Button>
-    </div>
-  );
 }
 
 // ── Surface ─────────────────────────────────────────────────────────────────
@@ -543,15 +427,7 @@ export function ProjectOverview({
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* ── Toolbar ──────────────────────────────────────────────────── */}
-      <div
-        className="flex items-center gap-2 px-4 shrink-0 glass relative"
-        style={{
-          height: 52,
-          borderBottom: '0.5px solid transparent',
-          borderBottomColor: scrolled ? 'var(--separator)' : 'transparent',
-          transition: 'border-bottom-color var(--dur-standard) var(--ease-out)',
-        }}
-      >
+      <Toolbar scrolled={scrolled} className="gap-3">
         <StatusDot tone={statusTone} pulse={status === 'indexing'} />
         <div className="min-w-0 flex-1">
           <h2
@@ -631,7 +507,7 @@ export function ProjectOverview({
             />
           </div>
         )}
-      </div>
+      </Toolbar>
 
       {overflowMenu.at && (
         <Menu x={overflowMenu.at.x} y={overflowMenu.at.y} align="end" onClose={overflowMenu.close}>

--- a/packages/app/src/renderer/tabs/ToolActivity.tsx
+++ b/packages/app/src/renderer/tabs/ToolActivity.tsx
@@ -28,6 +28,23 @@ import {
   useRef,
   useState,
 } from 'react';
+import { Icon } from '../lattice/icons';
+import {
+  Badge,
+  Button,
+  Card,
+  EmptyState,
+  Menu,
+  MenuItem,
+  MenuSection,
+  MenuSeparator,
+  SearchField,
+  SegmentedControl,
+  StatusDot,
+  Toolbar,
+  ToolbarDivider,
+  useMenuAnchor,
+} from '../lattice/ui';
 
 const BASE = 'http://127.0.0.1:3741';
 const MAX_ENTRIES = 1000;
@@ -157,7 +174,7 @@ function highlightMatch(text: string, q: string): ReactNode {
   const idx = lower.indexOf(needle);
   if (idx === -1) return text;
   const markStyle: CSSProperties = {
-    background: 'var(--accent-soft, rgba(0,122,255,0.18))',
+    background: 'color-mix(in oklab, var(--accent) 22%, transparent)',
     color: 'inherit',
     padding: 0,
     borderRadius: 2,
@@ -392,16 +409,21 @@ function DeltaBadge({
   unit: string;
 }) {
   const delta = computeDelta(cur, prev);
-  let color = 'var(--text-tertiary)';
+  let color = 'var(--label-secondary)';
   if (higherIsBad && delta.direction !== 'flat') {
-    color = delta.direction === 'up' ? 'var(--red, #ef4444)' : 'var(--success, #22c55e)';
+    color = delta.direction === 'up' ? 'var(--status-red)' : 'var(--status-green)';
   }
-  const glyph = delta.direction === 'up' ? '▲' : delta.direction === 'down' ? '▼' : '';
+  /* The arrow is not decoration: it is the second channel that carries
+     "better / worse" for anyone who cannot separate the red from the green. */
+  const glyph = delta.direction === 'up' ? '↑' : delta.direction === 'down' ? '↓' : '';
   const title = `vs previous ${windowLabel(windowMs)}: ${prevLabel} → ${curLabel}${unit ? ` ${unit}` : ''}`;
+  /* "184 calls 0%" reads as a broken number. No change is not a delta — the
+     comparison lives in the tooltip and the badge stays out of the way. */
+  if (delta.direction === 'flat') return null;
   return (
     <span
-      className="tabular-nums"
-      style={{ fontSize: 9, color, marginLeft: 3, whiteSpace: 'nowrap' }}
+      className="tabular-nums text-[11px] leading-[13px]"
+      style={{ color, marginLeft: 3, whiteSpace: 'nowrap' }}
       title={title}
     >
       {glyph}
@@ -412,43 +434,17 @@ function DeltaBadge({
 
 // ── Sub-components ────────────────────────────────────────────────────────
 
+/** The tool identifier, as a monospace badge. Identifiers are not prose, so
+    this is the one place sentence case does not apply — `get_outline` is its
+    own name. Tone carries the same signal the row's Error badge spells out. */
 function ToolBadge({ tool, isError }: { tool: string; isError: boolean }) {
-  const bg = isError ? 'rgba(239,68,68,0.15)' : 'rgba(0,122,255,0.1)';
-  const color = isError ? 'var(--red, #ef4444)' : 'var(--accent, #007aff)';
   return (
     <span
-      className="shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded whitespace-nowrap"
-      style={{ background: bg, color }}
+      className={`lx-badge ${isError ? 't-red' : 't-accent'} shrink-0`}
+      style={{ fontFamily: 'var(--font-mono)' }}
     >
       {tool}
     </span>
-  );
-}
-
-function FilterChip({
-  label,
-  active,
-  onClick,
-}: {
-  label: string;
-  active: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="text-[11px] px-2.5 py-1 rounded-full transition-all shrink-0"
-      style={{
-        background: active ? 'var(--accent)' : 'var(--bg-inset)',
-        color: active ? '#fff' : 'var(--text-secondary)',
-        fontWeight: active ? 600 : 400,
-        cursor: 'pointer',
-        border: 'none',
-      }}
-    >
-      {label}
-    </button>
   );
 }
 
@@ -489,7 +485,9 @@ function EntryRow({
     };
   }, []);
 
-  const rowBg = entry.is_error ? 'rgba(239,68,68,0.06)' : 'transparent';
+  const rowBg = entry.is_error
+    ? 'color-mix(in oklab, var(--status-red) 7%, transparent)'
+    : 'transparent';
   const absoluteTime = new Date(entry.ts).toLocaleTimeString([], {
     hour: '2-digit',
     minute: '2-digit',
@@ -532,8 +530,8 @@ function EntryRow({
     <div
       data-entry-idx={entryIdx}
       style={{
-        borderBottom: '0.5px solid var(--border-row)',
-        background: isSelected ? 'var(--bg-active)' : rowBg,
+        borderBottom: '0.5px solid var(--separator)',
+        background: isSelected ? 'var(--fill-tertiary)' : rowBg,
         paddingLeft: indent,
         borderLeft: isSelected ? '2px solid var(--accent)' : '2px solid transparent',
       }}
@@ -553,16 +551,16 @@ function EntryRow({
             onToggleExpand?.();
           }
         }}
-        className="flex items-start gap-2.5 px-3 py-2 w-full text-left"
+        className="flex items-start gap-2 px-3 py-2 w-full text-left"
         style={{
           background: 'none',
           border: 'none',
           cursor: 'pointer',
           minHeight: 36,
-          transition: 'background .1s',
+          transition: 'background var(--dur-micro) var(--ease-out)',
         }}
         onMouseEnter={(e) => {
-          e.currentTarget.style.background = 'var(--bg-active)';
+          e.currentTarget.style.background = 'var(--fill-quaternary)';
         }}
         onMouseLeave={(e) => {
           e.currentTarget.style.background = 'none';
@@ -570,22 +568,34 @@ function EntryRow({
       >
         {/* Relative time */}
         <span
-          className="shrink-0 text-[10px] tabular-nums mt-0.5 w-14 text-right"
-          style={{ color: 'var(--text-tertiary)', fontFamily: 'SF Mono, Menlo, monospace' }}
+          className="shrink-0 text-[11px] leading-[13px] tabular-nums mt-1 w-14 text-right"
+          style={{ color: 'var(--label-secondary)', fontFamily: 'var(--font-mono)' }}
         >
           {relativeTime(entry.ts)}
         </span>
 
         {/* Tool badge */}
-        <ToolBadge tool={entry.tool} isError={entry.is_error} />
+        <span className="shrink-0 mt-0.5">
+          <ToolBadge tool={entry.tool} isError={entry.is_error} />
+        </span>
+
+        {/* Error is stated, not tinted. Red text and a red row wash are the
+            same channel twice; the badge is what a monochrome reader sees. */}
+        {entry.is_error && (
+          <span className="shrink-0 mt-0.5">
+            <Badge tone="red" icon="warning">
+              Error
+            </Badge>
+          </span>
+        )}
 
         {/* Params summary */}
         <div className="flex-1 min-w-0">
           <div
-            className="text-[12px] truncate leading-snug"
+            className="text-[13px] leading-4 truncate"
             style={{
-              color: entry.is_error ? 'var(--red, #ef4444)' : 'var(--text-primary)',
-              fontFamily: 'SF Mono, Menlo, monospace',
+              color: 'var(--label)',
+              fontFamily: 'var(--font-mono)',
             }}
           >
             {tokenizeParams(
@@ -596,11 +606,10 @@ function EntryRow({
             )}
             {recentlyCopied !== null && (
               <span
-                className="ml-2 text-[10px]"
+                className="ml-2 text-[11px] leading-[13px]"
                 style={{
-                  color: 'var(--success, #22c55e)',
-                  fontFamily: 'inherit',
-                  transition: 'opacity .3s',
+                  color: 'var(--status-green)',
+                  fontFamily: 'var(--font-ui)',
                 }}
                 title={recentlyCopied}
               >
@@ -608,21 +617,22 @@ function EntryRow({
               </span>
             )}
           </div>
-          <div className="flex items-center gap-2 mt-0.5">
-            <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
+          <div
+            className="flex items-center gap-2 mt-0.5 text-[11px] leading-[13px] tabular-nums"
+            style={{ color: 'var(--label-secondary)' }}
+          >
+            <span>
               {entry.result_count} result{entry.result_count === 1 ? '' : 's'}
             </span>
             {entry.latency_ms !== undefined && (
-              <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
+              <span>
                 {entry.latency_ms < 1000
-                  ? `${entry.latency_ms}ms`
-                  : `${(entry.latency_ms / 1000).toFixed(1)}s`}
+                  ? `${entry.latency_ms} ms`
+                  : `${(entry.latency_ms / 1000).toFixed(1)} s`}
               </span>
             )}
             {entry.result_tokens !== undefined && (
-              <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-                ~{entry.result_tokens} tok
-              </span>
+              <span>~{entry.result_tokens.toLocaleString()} tokens</span>
             )}
           </div>
         </div>
@@ -632,69 +642,74 @@ function EntryRow({
       {expanded && (
         <div
           style={{
-            padding: '4px 12px 8px 76px',
-            fontSize: 11,
-            fontFamily: 'SF Mono, Menlo, monospace',
+            padding: '4px 12px 10px 76px',
+            fontSize: 12,
+            lineHeight: '15px',
+            fontFamily: 'var(--font-mono)',
             display: 'grid',
             gridTemplateColumns: 'auto 1fr',
-            gap: '2px 10px',
-            color: 'var(--text-secondary)',
+            gap: '3px 12px',
+            color: 'var(--label)',
           }}
         >
-          <span style={{ color: 'var(--text-tertiary)' }}>Time</span>
+          <span style={{ color: 'var(--label-secondary)', fontFamily: 'var(--font-ui)' }}>Time</span>
           <span>{absoluteTime}</span>
 
-          <span style={{ color: 'var(--text-tertiary)' }}>Session</span>
+          <span style={{ color: 'var(--label-secondary)', fontFamily: 'var(--font-ui)' }}>
+            Session
+          </span>
           <span style={{ wordBreak: 'break-all' }}>{entry.session_id}</span>
 
-          <span style={{ color: 'var(--text-tertiary)' }}>Tool</span>
+          <span style={{ color: 'var(--label-secondary)', fontFamily: 'var(--font-ui)' }}>Tool</span>
           <span style={{ wordBreak: 'break-all' }}>{entry.tool}</span>
 
-          <span style={{ color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span
+            style={{
+              color: 'var(--label-secondary)',
+              fontFamily: 'var(--font-ui)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+            }}
+          >
             Params
-            <button
-              type="button"
-              onClick={handleCopyParams}
-              style={{
-                fontSize: 9,
-                padding: '1px 5px',
-                borderRadius: 3,
-                background: 'var(--bg-inset)',
-                color: 'var(--text-secondary)',
-                border: '0.5px solid var(--border-row)',
-                cursor: 'pointer',
-                fontFamily: 'inherit',
-              }}
-              title="Copy full params to clipboard"
-            >
+            <Button size="small" onClick={handleCopyParams} title="Copy full params to clipboard">
               Copy
-            </button>
+            </Button>
           </span>
           <span style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
             {entry.params_summary}
           </span>
 
-          <span style={{ color: 'var(--text-tertiary)' }}>Results</span>
+          <span style={{ color: 'var(--label-secondary)', fontFamily: 'var(--font-ui)' }}>
+            Results
+          </span>
           <span>{entry.result_count}</span>
 
           {entry.latency_ms !== undefined && (
             <>
-              <span style={{ color: 'var(--text-tertiary)' }}>Latency</span>
-              <span>{entry.latency_ms}ms</span>
+              <span style={{ color: 'var(--label-secondary)', fontFamily: 'var(--font-ui)' }}>
+                Latency
+              </span>
+              <span>{entry.latency_ms} ms</span>
             </>
           )}
 
           {entry.result_tokens !== undefined && (
             <>
-              <span style={{ color: 'var(--text-tertiary)' }}>Tokens</span>
-              <span>{entry.result_tokens}</span>
+              <span style={{ color: 'var(--label-secondary)', fontFamily: 'var(--font-ui)' }}>
+                Tokens
+              </span>
+              <span>{entry.result_tokens.toLocaleString()}</span>
             </>
           )}
 
           {entry.is_error && (
             <>
-              <span style={{ color: 'var(--red, #ef4444)' }}>Error</span>
-              <span style={{ color: 'var(--red, #ef4444)' }}>This call returned an error.</span>
+              <span style={{ color: 'var(--status-red)', fontFamily: 'var(--font-ui)' }}>Error</span>
+              <span style={{ color: 'var(--status-red)', fontFamily: 'var(--font-ui)' }}>
+                This call returned an error.
+              </span>
             </>
           )}
         </div>
@@ -729,10 +744,10 @@ function StatsSummaryBar({
   const curP95Ms = p95Ms(stats.latency_buckets);
   const errorColor =
     stats.error_rate > 0.1
-      ? 'var(--red, #ef4444)'
+      ? 'var(--status-red)'
       : stats.error_rate > 0.02
-        ? 'var(--orange, #f97316)'
-        : 'var(--text-secondary)';
+        ? 'var(--status-orange)'
+        : 'var(--label)';
 
   // Stops the picker click/key event from bubbling to the bar's expand/collapse handler.
   const stopBubble = (e: { stopPropagation: () => void }) => {
@@ -750,55 +765,38 @@ function StatsSummaryBar({
       }}
       role="button"
       tabIndex={0}
-      className="w-full flex items-center gap-3 px-3 py-1.5 text-left"
+      aria-expanded={expanded}
+      aria-label="Statistics"
+      className="w-full flex items-center gap-3 px-4 py-1.5 text-left"
       style={{
-        background: 'var(--bg-inset)',
+        background: 'var(--surface)',
         border: 'none',
-        borderBottom: '0.5px solid var(--border-row)',
+        borderBottom: '0.5px solid var(--separator)',
         cursor: 'pointer',
       }}
     >
-      <span className="text-[10px] font-semibold" style={{ color: 'var(--text-tertiary)', letterSpacing: '0.05em', textTransform: 'uppercase' }}>
+      <span
+        className="text-[11px] leading-[13px] font-semibold"
+        style={{ color: 'var(--label-secondary)' }}
+      >
         Stats
       </span>
       {/* Window picker — segmented control, click does not toggle the bar */}
-      <div
-        className="flex items-center gap-0.5"
-        onClick={stopBubble}
-        onKeyDown={stopBubble}
-        role="group"
-        aria-label="Stats window"
-      >
-        {WINDOW_OPTIONS.map((opt) => {
-          const isActive = windowMs === opt.value;
-          return (
-            <button
-              key={opt.value}
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                onWindowChange(opt.value);
-              }}
-              className="text-[10px] tabular-nums"
-              style={{
-                padding: '2px 6px',
-                borderRadius: 999,
-                border: isActive ? '0.5px solid var(--accent, #007aff)' : '0.5px solid var(--border-row)',
-                background: isActive ? 'var(--accent, #007aff)' : 'var(--fill-control, transparent)',
-                color: isActive ? 'white' : 'var(--text-secondary)',
-                cursor: 'pointer',
-                fontWeight: isActive ? 600 : 400,
-              }}
-              title={`Show stats for the last ${opt.label}`}
-            >
-              {opt.label}
-            </button>
-          );
-        })}
+      <div onClick={stopBubble} onKeyDown={stopBubble} className="shrink-0">
+        <SegmentedControl
+          size="small"
+          options={WINDOW_OPTIONS.map((o) => ({ value: String(o.value), label: o.label }))}
+          value={String(windowMs)}
+          onChange={(v) => onWindowChange(Number(v))}
+          aria-label="Stats window"
+        />
       </div>
-      <span className="flex items-center gap-1 text-[11px]" style={{ color: 'var(--text-primary)' }}>
+      <span
+        className="flex items-center gap-1 text-[13px] leading-4"
+        style={{ color: 'var(--label)' }}
+      >
         <span className="font-semibold tabular-nums">{stats.total_calls.toLocaleString()}</span>
-        <span style={{ color: 'var(--text-tertiary)' }}>calls</span>
+        <span style={{ color: 'var(--label-secondary)' }}>calls</span>
         {prevStats !== null && (
           <DeltaBadge
             cur={stats.total_calls}
@@ -811,9 +809,12 @@ function StatsSummaryBar({
           />
         )}
       </span>
-      <span className="flex items-center gap-1 text-[11px]" style={{ color: errorColor }}>
+      <span
+        className="flex items-center gap-1 text-[13px] leading-4"
+        style={{ color: errorColor }}
+      >
         <span className="font-semibold tabular-nums">{errorPct}%</span>
-        <span style={{ color: 'var(--text-tertiary)' }}>err</span>
+        <span style={{ color: 'var(--label-secondary)' }}>errors</span>
         {prevStats !== null && (
           <DeltaBadge
             cur={stats.error_rate}
@@ -826,9 +827,12 @@ function StatsSummaryBar({
           />
         )}
       </span>
-      <span className="flex items-center gap-1 text-[11px]" style={{ color: 'var(--text-primary)' }}>
+      <span
+        className="flex items-center gap-1 text-[13px] leading-4"
+        style={{ color: 'var(--label)' }}
+      >
         <span className="font-semibold tabular-nums">{p95}</span>
-        <span style={{ color: 'var(--text-tertiary)' }}>p95</span>
+        <span style={{ color: 'var(--label-secondary)' }}>p95</span>
         {prevStats !== null && (
           <DeltaBadge
             cur={curP95Ms}
@@ -841,9 +845,22 @@ function StatsSummaryBar({
           />
         )}
       </span>
-      <span className="ml-auto text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-        {expanded ? '▲' : '▼'}
+      <span className="ml-auto flex" style={{ color: 'var(--label-secondary)' }}>
+        <Icon name={expanded ? 'expand_less' : 'expand_more'} size={16} />
       </span>
+    </div>
+  );
+}
+
+/** Chart / group caption. 11px/600 sentence case — the house scale has no
+    10.5px, and ALL-CAPS is reserved for 10px table headers. */
+function ChartTitle({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="text-[11px] leading-[13px] font-semibold mb-1.5"
+      style={{ color: 'var(--label-secondary)' }}
+    >
+      {children}
     </div>
   );
 }
@@ -864,9 +881,7 @@ function HotToolsChart({
   const maxCount = tools[0].count;
   return (
     <div>
-      <div className="text-[10px] font-semibold mb-1.5" style={{ color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-        Hot Tools
-      </div>
+      <ChartTitle>Most-used tools</ChartTitle>
       <div className="flex flex-col gap-1">
         {tools.map((t) => {
           const pct = maxCount > 0 ? (t.count / maxCount) * 100 : 0;
@@ -882,29 +897,45 @@ function HotToolsChart({
               title={`avg ${t.avg_latency_ms}ms · ${t.error_count} errors`}
             >
               <span
-                className="shrink-0 text-[10px] tabular-nums w-24 truncate"
+                className="shrink-0 text-[11px] leading-[13px] tabular-nums w-36 truncate"
                 style={{
-                  color: isActive ? 'var(--accent)' : 'var(--text-primary)',
+                  color: isActive ? 'var(--accent)' : 'var(--label)',
                   fontWeight: isActive ? 600 : 400,
-                  fontFamily: 'SF Mono, Menlo, monospace',
+                  fontFamily: 'var(--font-mono)',
                 }}
               >
                 {t.tool}
               </span>
-              <div className="flex-1 relative h-3 rounded-sm overflow-hidden" style={{ background: 'var(--bg-grouped)' }}>
+              <div
+                className="flex-1 relative h-2 overflow-hidden"
+                style={{ background: 'var(--fill-quaternary)', borderRadius: 2 }}
+              >
                 <div
-                  className="absolute inset-y-0 left-0 rounded-sm"
+                  className="absolute inset-y-0 left-0"
                   style={{
                     width: `${pct}%`,
-                    background: hasErrors
-                      ? 'linear-gradient(90deg, var(--accent, #007aff), var(--red, #ef4444))'
-                      : 'var(--accent, #007aff)',
-                    opacity: isActive ? 1 : 0.6,
-                    transition: 'width 0.3s ease',
+                    borderRadius: 2,
+                    background: 'var(--accent)',
+                    opacity: isActive ? 1 : 0.75,
+                    transition: 'width var(--dur-large) var(--ease-out)',
                   }}
                 />
               </div>
-              <span className="shrink-0 text-[10px] tabular-nums w-7 text-right" style={{ color: 'var(--text-tertiary)' }}>
+              {/* The bar's tone says "this tool errors"; the count says how
+                  many, so the signal survives without colour. */}
+              {hasErrors && (
+                <span
+                  className="shrink-0 text-[11px] leading-[13px] tabular-nums"
+                  style={{ color: 'var(--status-red)' }}
+                  title={`${t.error_count} errors`}
+                >
+                  ⚠ {t.error_count}
+                </span>
+              )}
+              <span
+                className="shrink-0 text-[11px] leading-[13px] tabular-nums w-8 text-right"
+                style={{ color: 'var(--label-secondary)' }}
+              >
                 {t.count}
               </span>
             </button>
@@ -924,12 +955,7 @@ function HotFilesList({ files }: { files: HotFile[] }) {
   const maxCount = files[0].count;
   return (
     <div>
-      <div
-        className="text-[10px] font-semibold mb-1.5"
-        style={{ color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}
-      >
-        Hot Files
-      </div>
+      <ChartTitle>Most-read files</ChartTitle>
       <div className="flex flex-col gap-1">
         {files.map((f) => {
           const pct = maxCount > 0 ? (f.count / maxCount) * 100 : 0;
@@ -944,31 +970,29 @@ function HotFilesList({ files }: { files: HotFile[] }) {
               title={f.file}
             >
               <span
-                className="shrink-0 text-[10px] tabular-nums w-32 truncate"
-                style={{
-                  color: 'var(--text-primary)',
-                  fontFamily: 'SF Mono, Menlo, monospace',
-                }}
+                className="shrink-0 text-[11px] leading-[13px] tabular-nums w-32 truncate"
+                style={{ color: 'var(--label)', fontFamily: 'var(--font-mono)' }}
               >
                 {displayPath}
               </span>
               <div
-                className="flex-1 relative h-3 rounded-sm overflow-hidden"
-                style={{ background: 'var(--bg-grouped)' }}
+                className="flex-1 relative h-2 overflow-hidden"
+                style={{ background: 'var(--fill-quaternary)', borderRadius: 2 }}
               >
                 <div
-                  className="absolute inset-y-0 left-0 rounded-sm"
+                  className="absolute inset-y-0 left-0"
                   style={{
                     width: `${pct}%`,
-                    background: 'var(--accent, #007aff)',
-                    opacity: 0.6,
-                    transition: 'width 0.3s ease',
+                    borderRadius: 2,
+                    background: 'var(--accent)',
+                    opacity: 0.75,
+                    transition: 'width var(--dur-large) var(--ease-out)',
                   }}
                 />
               </div>
               <span
-                className="shrink-0 text-[10px] tabular-nums w-7 text-right"
-                style={{ color: 'var(--text-tertiary)' }}
+                className="shrink-0 text-[11px] leading-[13px] tabular-nums w-8 text-right"
+                style={{ color: 'var(--label-secondary)' }}
               >
                 {f.count}
               </span>
@@ -987,40 +1011,41 @@ function LatencyHistogram({ buckets }: { buckets: LatencyBucket[] }) {
   const maxCount = Math.max(...buckets.map((b) => b.count), 1);
   return (
     <div>
-      <div className="text-[10px] font-semibold mb-1.5" style={{ color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-        Latency
-      </div>
-      <div className="flex items-end gap-0.5" style={{ height: 40 }}>
+      <ChartTitle>Latency</ChartTitle>
+      {/* One label per bar was 8px and unreadable at any width the panel gets.
+          A histogram's x-axis only has to name its ends; the rest is the
+          shape, and each bar keeps its own bucket in the tooltip. */}
+      <div className="flex items-end gap-0.5" style={{ height: 32 }}>
         {buckets.map((b) => {
           const heightPct = (b.count / maxCount) * 100;
           const label = formatLatencyBucket(b.bucket_ms);
           return (
             <div
               key={b.bucket_ms}
-              className="flex flex-col items-center flex-1"
-              title={`${label}: ${b.count}`}
+              className="flex-1 flex items-end h-full"
+              title={`${label}: ${b.count} call${b.count === 1 ? '' : 's'}`}
             >
-              <div className="w-full flex items-end" style={{ height: 32 }}>
-                <div
-                  className="w-full rounded-t-sm"
-                  style={{
-                    height: `${heightPct}%`,
-                    minHeight: b.count > 0 ? 2 : 0,
-                    background: 'var(--accent, #007aff)',
-                    opacity: 0.7,
-                    transition: 'height 0.3s ease',
-                  }}
-                />
-              </div>
-              <span
-                className="text-[8px] tabular-nums mt-0.5 truncate w-full text-center"
-                style={{ color: 'var(--text-tertiary)' }}
-              >
-                {label}
-              </span>
+              <div
+                className="w-full"
+                style={{
+                  height: `${heightPct}%`,
+                  minHeight: b.count > 0 ? 2 : 0,
+                  borderRadius: '2px 2px 0 0',
+                  background: 'var(--accent)',
+                  opacity: 0.75,
+                  transition: 'height var(--dur-large) var(--ease-out)',
+                }}
+              />
             </div>
           );
         })}
+      </div>
+      <div
+        className="flex items-center justify-between mt-1 pt-1 text-[11px] leading-[13px] tabular-nums"
+        style={{ color: 'var(--label-secondary)', borderTop: '0.5px solid var(--separator)' }}
+      >
+        <span>{formatLatencyBucket(buckets[0]?.bucket_ms ?? 0)}</span>
+        <span>{formatLatencyBucket(buckets[buckets.length - 1]?.bucket_ms ?? -1)}</span>
       </div>
     </div>
   );
@@ -1046,9 +1071,7 @@ function ErrorGroupsList({
 
   return (
     <div>
-      <div className="text-[10px] font-semibold mb-1.5" style={{ color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-        Error Groups
-      </div>
+      <ChartTitle>Errors by tool</ChartTitle>
       <div className="flex flex-col gap-0.5">
         {groups.map((g) => {
           const isExpanded = expandedTool === g.tool;
@@ -1058,42 +1081,41 @@ function ErrorGroupsList({
               <div className="flex items-center gap-2">
                 <button
                   type="button"
+                  className="lx-btn v-icon sz-small shrink-0"
                   onClick={() => setExpandedTool(isExpanded ? null : g.tool)}
-                  className="text-[9px] shrink-0"
-                  style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-tertiary)', padding: '0 2px' }}
+                  aria-expanded={isExpanded}
+                  aria-label={`${isExpanded ? 'Hide' : 'Show'} a sample error for ${g.tool}`}
+                  title={isExpanded ? 'Hide sample' : 'Show sample'}
                 >
-                  {isExpanded ? '▼' : '▶'}
+                  <Icon name={isExpanded ? 'expand_more' : 'chevron_right'} size={14} />
                 </button>
                 <button
                   type="button"
                   onClick={() => onGroupClick(g.tool)}
-                  className="flex-1 text-left text-[10px] truncate"
+                  className="flex-1 text-left text-[11px] leading-[13px] truncate"
                   style={{
                     background: 'none',
                     border: 'none',
                     cursor: 'pointer',
-                    color: isActive ? 'var(--red, #ef4444)' : 'var(--text-primary)',
+                    color: isActive ? 'var(--status-red)' : 'var(--label)',
                     fontWeight: isActive ? 600 : 400,
-                    fontFamily: 'SF Mono, Menlo, monospace',
+                    fontFamily: 'var(--font-mono)',
                     padding: 0,
                   }}
+                  title={`Show only ${g.tool} errors`}
                 >
                   {g.tool}
                 </button>
-                <span
-                  className="shrink-0 text-[9px] font-semibold tabular-nums px-1.5 py-0.5 rounded-full"
-                  style={{ background: 'rgba(239,68,68,0.15)', color: 'var(--red, #ef4444)' }}
-                >
-                  {g.count}
-                </span>
+                <Badge tone="red">{g.count}</Badge>
               </div>
               {isExpanded && (
                 <div
-                  className="mt-0.5 ml-5 text-[9px] truncate rounded px-1.5 py-1"
+                  className="mt-0.5 ml-5 text-[11px] leading-[13px] truncate px-1.5 py-1"
                   style={{
-                    background: 'rgba(239,68,68,0.06)',
-                    color: 'var(--text-secondary)',
-                    fontFamily: 'SF Mono, Menlo, monospace',
+                    background: 'color-mix(in oklab, var(--status-red) 7%, transparent)',
+                    borderRadius: 6,
+                    color: 'var(--label-secondary)',
+                    fontFamily: 'var(--font-mono)',
                   }}
                   title={g.sample_summary}
                 >
@@ -1211,25 +1233,17 @@ function Sparkline({
 
   return (
     <div>
-      <div className="text-[10px] font-semibold mb-1.5 flex items-center gap-1" style={{ color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-        <span>Last {windowLabel(windowMs)}</span>
+      <div className="flex items-center gap-1 mb-1.5">
+        <ChartTitle>Last {windowLabel(windowMs)}</ChartTitle>
         {activeRange !== null && (
           <button
             type="button"
             onClick={() => onSelectRange(null)}
             title="Clear time-range filter"
-            style={{
-              background: 'none',
-              border: 'none',
-              padding: 0,
-              cursor: 'pointer',
-              color: 'var(--accent, #007aff)',
-              fontSize: 9,
-              lineHeight: 1,
-              textTransform: 'none',
-            }}
+            aria-label="Clear time-range filter"
+            className="lx-btn v-plain sz-small -mt-1.5"
           >
-            clear ✕
+            Clear
           </button>
         )}
       </div>
@@ -1256,11 +1270,9 @@ function Sparkline({
               style={{
                 height: `${heightPct}%`,
                 minHeight: m.count > 0 ? 2 : 0,
-                background: hasErrors
-                  ? 'var(--red, #ef4444)'
-                  : 'var(--accent, #007aff)',
-                opacity: activeRange !== null ? (inRange ? 0.9 : 0.3) : 0.65,
-                transition: 'height 0.3s ease, opacity 0.15s ease',
+                background: hasErrors ? 'var(--status-red)' : 'var(--accent)',
+                opacity: activeRange !== null ? (inRange ? 1 : 0.3) : 0.75,
+                transition: 'height var(--dur-large) var(--ease-out), opacity var(--dur-micro) var(--ease-out)',
               }}
             />
           );
@@ -1274,7 +1286,7 @@ function Sparkline({
               bottom: 0,
               left: `${(dragRange.lo / byMinute.length) * 100}%`,
               width: `${((dragRange.hi - dragRange.lo + 1) / byMinute.length) * 100}%`,
-              background: 'var(--accent, #007aff)',
+              background: 'var(--accent)',
               opacity: 0.15,
               borderRadius: 2,
               pointerEvents: 'none',
@@ -1310,10 +1322,10 @@ function StatsPanel({
 }) {
   return (
     <div
-      className="shrink-0 px-3 py-2.5 flex flex-col gap-3"
+      className="shrink-0 px-4 py-3 flex flex-col gap-4"
       style={{
-        borderBottom: '0.5px solid var(--border-row)',
-        background: 'var(--bg-grouped)',
+        borderBottom: '0.5px solid var(--separator)',
+        background: 'var(--surface)',
       }}
     >
       {/* Row 1: hot tools + latency histogram side by side */}
@@ -1349,7 +1361,10 @@ function StatsPanel({
               errorsOnly={errorsOnly}
             />
           ) : (
-            <div className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
+            <div
+              className="text-[11px] leading-[13px]"
+              style={{ color: 'var(--label-secondary)' }}
+            >
               No errors in this window.
             </div>
           )}
@@ -1472,37 +1487,33 @@ function SessionGroupHeader({
       onClick={onToggle}
       title={group.session_id}
       className="w-full flex items-center gap-2 px-3 text-left"
+      aria-expanded={!collapsed}
       style={{
-        background: 'var(--bg-inset)',
+        background: 'var(--fill-quaternary)',
         border: 'none',
-        borderBottom: '0.5px solid var(--border-row)',
+        borderBottom: '0.5px solid var(--separator)',
         cursor: 'pointer',
-        height: 24,
+        height: 28,
         fontSize: 11,
-        color: 'var(--text-secondary)',
-        fontFamily: 'SF Mono, Menlo, monospace',
+        lineHeight: '13px',
+        color: 'var(--label-secondary)',
       }}
     >
-      <span style={{ width: 10, color: 'var(--text-tertiary)' }}>
-        {collapsed ? '▶' : '▼'}
+      <span className="flex shrink-0" style={{ color: 'var(--label-secondary)' }}>
+        <Icon name={collapsed ? 'chevron_right' : 'expand_more'} size={14} />
       </span>
-      <span style={{ color: 'var(--text-primary)' }}>{shortId}</span>
-      <span style={{ color: 'var(--text-tertiary)' }}>
+      <span style={{ color: 'var(--label)', fontFamily: 'var(--font-mono)' }}>{shortId}</span>
+      <span className="tabular-nums">
         {group.entries.length} call{group.entries.length === 1 ? '' : 's'}
       </span>
-      <span style={{ color: 'var(--text-tertiary)' }}>
-        from {fromTime} to {toTime}
+      <span className="tabular-nums">
+        {fromTime} – {toTime}
       </span>
       {group.error_count > 0 && (
-        <span
-          className="ml-auto text-[10px] font-semibold px-1.5 py-0.5 rounded-full"
-          style={{
-            background: 'rgba(239,68,68,0.15)',
-            color: 'var(--red, #ef4444)',
-            fontFamily: 'inherit',
-          }}
-        >
-          {group.error_count} error{group.error_count === 1 ? '' : 's'}
+        <span className="ml-auto">
+          <Badge tone="red" icon="warning">
+            {group.error_count} error{group.error_count === 1 ? '' : 's'}
+          </Badge>
         </span>
       )}
     </button>
@@ -1513,26 +1524,14 @@ function SessionGroupHeader({
 
 const SHORTCUTS: { keys: string; desc: string }[] = [
   { keys: '/', desc: 'Focus search' },
-  { keys: 'j', desc: 'Next entry' },
-  { keys: 'k', desc: 'Previous entry' },
-  { keys: 'Enter', desc: 'Expand / collapse selected' },
-  { keys: 'Esc', desc: 'Blur search · clear search · clear filters · deselect' },
-  { keys: '?', desc: 'Toggle this help' },
+  { keys: '↓ / j', desc: 'Next call' },
+  { keys: '↑ / k', desc: 'Previous call' },
+  { keys: '⏎', desc: 'Expand or collapse the selected call' },
+  { keys: 'Esc', desc: 'Clear the search, then the filters, then the selection' },
+  { keys: '?', desc: 'Show or hide this list' },
 ];
 
 function ShortcutsHelp({ onClose }: { onClose: () => void }) {
-  const chipStyle: CSSProperties = {
-    display: 'inline-block',
-    minWidth: 18,
-    textAlign: 'center',
-    padding: '1px 6px',
-    borderRadius: 5,
-    background: 'var(--bg-inset)',
-    border: '0.5px solid var(--border-row)',
-    fontFamily: 'SF Mono, Menlo, monospace',
-    fontSize: 11,
-    color: 'var(--text-primary)',
-  };
   return (
     <div
       onClick={onClose}
@@ -1540,7 +1539,7 @@ function ShortcutsHelp({ onClose }: { onClose: () => void }) {
       style={{
         position: 'absolute',
         inset: 0,
-        background: 'rgba(0,0,0,0.35)',
+        background: 'rgb(0 0 0 / 0.35)',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
@@ -1552,39 +1551,55 @@ function ShortcutsHelp({ onClose }: { onClose: () => void }) {
         role="dialog"
         aria-label="Keyboard shortcuts"
         style={{
-          background: 'var(--bg-grouped)',
-          border: '0.5px solid var(--border-row)',
-          borderRadius: 12,
-          padding: '14px 18px',
+          background: 'var(--surface-raised)',
+          border: '0.5px solid var(--separator)',
+          borderRadius: 'var(--radius-panel)',
+          padding: '16px 20px',
           minWidth: 320,
           maxWidth: 420,
-          boxShadow: '0 8px 32px rgba(0,0,0,0.25)',
+          boxShadow: 'var(--shadow-panel)',
         }}
       >
         <div
-          className="text-[11px] font-semibold mb-2.5"
-          style={{ color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}
+          className="text-[17px] leading-[22px] font-semibold mb-3"
+          style={{ color: 'var(--label)' }}
         >
-          Keyboard Shortcuts
+          Keyboard shortcuts
         </div>
         <div
           style={{
             display: 'grid',
             gridTemplateColumns: 'auto 1fr',
-            gap: '6px 12px',
+            gap: '8px 12px',
             alignItems: 'center',
-            fontSize: 12,
-            color: 'var(--text-secondary)',
+            fontSize: 13,
+            lineHeight: '16px',
+            color: 'var(--label)',
           }}
         >
           {SHORTCUTS.map((s) => (
             <div key={s.keys} style={{ display: 'contents' }}>
-              <span style={chipStyle}>{s.keys}</span>
-              <span>{s.desc}</span>
+              <kbd
+                style={{
+                  display: 'inline-block',
+                  minWidth: 24,
+                  textAlign: 'center',
+                  padding: '2px 6px',
+                  borderRadius: 6,
+                  background: 'var(--fill-quaternary)',
+                  boxShadow: 'inset 0 0 0 0.5px var(--separator)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 12,
+                  color: 'var(--label)',
+                }}
+              >
+                {s.keys}
+              </kbd>
+              <span style={{ color: 'var(--label-secondary)' }}>{s.desc}</span>
             </div>
           ))}
         </div>
-        <div className="text-[10px] mt-3" style={{ color: 'var(--text-tertiary)' }}>
+        <div className="text-[11px] leading-[13px] mt-4" style={{ color: 'var(--label-secondary)' }}>
           Press Esc or ? to close.
         </div>
       </div>
@@ -1594,9 +1609,14 @@ function ShortcutsHelp({ onClose }: { onClose: () => void }) {
 
 export function ToolActivity({
   root,
+  subTab,
   onOpenFileInGraph,
 }: {
   root: string;
+  /** The Tool calls | AI calls switcher. Rendered INTO this surface's toolbar
+      rather than above it — two stacked control rows is what TRA-294 exists to
+      remove, and the switcher belongs on the leading edge of the one bar. */
+  subTab?: ReactNode;
   onOpenFileInGraph?: (filePath: string) => void;
 }) {
   const [entries, setEntries] = useState<JournalEntry[]>([]);
@@ -1625,6 +1645,12 @@ export function ToolActivity({
   const [showHelp, setShowHelp] = useState(false);
   // Ref to the search input so "/" can focus it and Escape can blur it.
   const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Toolbar scroll-edge hairline — content scrolls UNDER the bar, so the rule
+  // appears on scroll instead of being painted permanently.
+  const [scrolled, setScrolled] = useState(false);
+  const [historyFailed, setHistoryFailed] = useState(false);
+  const overflow = useMenuAnchor();
 
   // ── Pause / clear / export local controls ────────────────────────────
   const [paused, setPaused] = useState(false);
@@ -1773,7 +1799,8 @@ export function ToolActivity({
     try {
       const params = new URLSearchParams({ project: root, limit: '200' });
       const res = await fetch(`${BASE}/api/projects/journal?${params}`);
-      if (res.ok) {
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      {
         const data = (await res.json()) as JournalEntry[];
         // Snapshot is newest-first already (server sorts that way)
         setEntries((prev) => {
@@ -1791,8 +1818,12 @@ export function ToolActivity({
           return deduped.slice(0, MAX_ENTRIES);
         });
       }
+      setHistoryFailed(false);
     } catch {
-      /* history is optional — live SSE is the primary source */
+      /* Live SSE is the primary source, so a failed history fetch is not fatal
+         — but it must not read as "no calls yet". That sent you off to connect
+         a client that was already connected (TRA-294). */
+      setHistoryFailed(true);
     }
   }, [root]);
 
@@ -1892,6 +1923,9 @@ export function ToolActivity({
     if (!el) return;
     // If user scrolled more than 60px from top, mark as "scrolled away"
     userScrolledRef.current = el.scrollTop > 60;
+    // Separate threshold: the toolbar's hairline fades in the moment content
+    // slides under it, which is at the first pixel, not at 60.
+    setScrolled(el.scrollTop > 0);
   }, []);
 
   // ── Filter callbacks wired to stats panel ─────────────────────────────
@@ -2029,6 +2063,29 @@ export function ToolActivity({
             e.tool.toLowerCase().includes(queryLower),
         );
 
+  // ── Toolbar-derived state ────────────────────────────────────────────
+  // "Filters" are what the ••• menu and the sparkline set; the free-text query
+  // is not one of them (it has its own field with its own clear button).
+  const activeFilterCount =
+    (errorsOnly ? 1 : 0) + toolFilter.size + (timeRange !== null ? 1 : 0);
+
+  const clearFilters = useCallback(() => {
+    setErrorsOnly(false);
+    setToolFilter(new Set());
+    setTimeRange(null);
+  }, []);
+
+  /** How many calls the filters are holding back — the number the empty state
+      needs to say "clear them" honestly. */
+  const filteredOutCount = entries.length - filtered.length;
+
+  const feedTone = paused ? 'orange' : connected ? 'green' : 'neutral';
+  const feedLabel = paused
+    ? `Paused (${pausedBufferRef.current.length})`
+    : connected
+      ? 'Live'
+      : 'Offline';
+
   // Keep the selected index within bounds as the visible list shrinks/grows.
   // (e.g. a new filter trims the list below the previously-selected index.)
   useEffect(() => {
@@ -2092,12 +2149,15 @@ export function ToolActivity({
           e.preventDefault();
           searchInputRef.current?.focus();
           break;
+        // ↑↓ is what a Mac list responds to; j/k stay for the vim hands.
+        case 'ArrowDown':
         case 'j':
           e.preventDefault();
           setSelectedIdx((i) =>
             filtered.length === 0 ? -1 : Math.min(i + 1, filtered.length - 1),
           );
           break;
+        case 'ArrowUp':
         case 'k':
           e.preventDefault();
           setSelectedIdx((i) => (filtered.length === 0 ? -1 : Math.max(i - 1, 0)));
@@ -2133,269 +2193,159 @@ export function ToolActivity({
 
   return (
     <div
-      className="flex flex-col h-full"
-      style={{ color: 'var(--text-primary)', position: 'relative' }}
+      className="flex flex-col h-full overflow-hidden"
+      style={{ color: 'var(--label)', position: 'relative' }}
     >
-      {/* ── Header ── */}
-      <div
-        className="shrink-0 px-3 pt-3 pb-2"
-        style={{ borderBottom: '0.5px solid var(--border-row)' }}
-      >
-        <div className="flex items-center justify-end gap-1.5 mb-2">
-          {paused ? (
-            <span
-              className="text-[10px] flex items-center gap-1"
-              style={{ color: 'var(--warning, #f97316)' }}
-            >
-              <span
-                className="inline-block w-1.5 h-1.5 rounded-full"
-                style={{ background: 'var(--warning, #f97316)' }}
-              />
-              Paused ({pausedBufferRef.current.length})
-            </span>
-          ) : connected ? (
-            <span
-              className="text-[10px] flex items-center gap-1"
-              style={{ color: 'var(--success, #22c55e)' }}
-            >
-              <span
-                className="inline-block w-1.5 h-1.5 rounded-full"
-                style={{ background: 'var(--success, #22c55e)' }}
-              />
-              Live
-            </span>
-          ) : (
-            <span
-              className="text-[10px] flex items-center gap-1"
-              style={{ color: 'var(--text-tertiary)' }}
-            >
-              <span
-                className="inline-block w-1.5 h-1.5 rounded-full"
-                style={{ background: 'var(--text-tertiary)' }}
-              />
-              Offline
-            </span>
-          )}
-          <span
-            className="text-[10px] tabular-nums"
-            style={{ color: 'var(--text-tertiary)' }}
-          >
-            {entries.length.toLocaleString()} calls
-          </span>
-          {/* Pause / Clear / Export — local buffer controls */}
-          <div className="flex items-center gap-0.5 ml-1">
-            <button
-              type="button"
-              onClick={handleTogglePause}
-              title={paused ? 'Resume live feed' : 'Pause live feed'}
-              aria-label={paused ? 'Resume live feed' : 'Pause live feed'}
-              style={{
-                width: 22,
-                height: 22,
-                borderRadius: 999,
-                background: 'transparent',
-                border: 'none',
-                color: 'var(--text-tertiary)',
-                cursor: 'pointer',
-                display: 'inline-flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                fontSize: 11,
-                lineHeight: 1,
-                padding: 0,
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.color = 'var(--text-primary)';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.color = 'var(--text-tertiary)';
-              }}
-            >
-              {paused ? '▶' : '⏸'}
-            </button>
-            <button
-              type="button"
-              onClick={handleClear}
-              title="Clear local buffer"
-              aria-label="Clear local buffer"
-              style={{
-                width: 22,
-                height: 22,
-                borderRadius: 999,
-                background: 'transparent',
-                border: 'none',
-                color: 'var(--text-tertiary)',
-                cursor: 'pointer',
-                display: 'inline-flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                fontSize: 12,
-                lineHeight: 1,
-                padding: 0,
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.color = 'var(--text-primary)';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.color = 'var(--text-tertiary)';
-              }}
-            >
-              ⌫
-            </button>
-            <button
-              type="button"
-              onClick={handleExport}
-              title="Export filtered entries as JSONL"
-              aria-label="Export filtered entries as JSONL"
-              style={{
-                width: 22,
-                height: 22,
-                borderRadius: 999,
-                background: 'transparent',
-                border: 'none',
-                color: 'var(--text-tertiary)',
-                cursor: 'pointer',
-                display: 'inline-flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                fontSize: 12,
-                lineHeight: 1,
-                padding: 0,
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.color = 'var(--text-primary)';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.color = 'var(--text-tertiary)';
-              }}
-            >
-              ⤓
-            </button>
-          </div>
-        </div>
+      {/* ── Toolbar ───────────────────────────────────────────────────
+          ONE row. Before TRA-294 this surface stacked three: a right-aligned
+          floating cluster (● Live · N calls · ⏸ · ⌫ · ⤓) in bare whitespace,
+          then a "Group by session" pill beside a search box, then an
+          All | Errors chip row. Everything that is not the source switch, the
+          feed state or the search now lives behind the overflow menu. */}
+      <Toolbar scrolled={scrolled}>
+        {subTab}
 
-        {/* Search input — case-insensitive substring match across params + tool.
-            Group-by-session toggle lives on the same row, at the left edge. */}
-        <div className="flex items-center justify-between gap-2 mb-2">
-          <button
-            type="button"
+        <ToolbarDivider />
+
+        {/* Feed state. The dot is a tone; the word next to it is the state —
+            "Live" and "Paused" have to survive without colour. */}
+        <span
+          className="flex items-center gap-1.5 shrink-0 text-[11px] leading-[13px]"
+          style={{ color: 'var(--label-secondary)' }}
+        >
+          <StatusDot tone={feedTone} pulse={feedTone === 'green'} />
+          <span style={{ color: 'var(--label)' }}>{feedLabel}</span>
+          <span className="tabular-nums">
+            · {entries.length.toLocaleString()} call{entries.length === 1 ? '' : 's'}
+          </span>
+        </span>
+
+        <span className="flex-1" />
+
+        {/* Active filters read as removable tokens rather than a permanent
+            chip row that is empty most of the time. */}
+        {activeFilterCount > 0 && (
+          <Button
+            variant="bordered"
+            className="is-on shrink-0"
+            icon="close"
+            onClick={clearFilters}
+            title="Clear all filters"
+          >
+            {activeFilterCount} filter{activeFilterCount === 1 ? '' : 's'}
+          </Button>
+        )}
+
+        <SearchField
+          value={query}
+          onChange={setQuery}
+          placeholder="Search calls"
+          aria-label="Search calls"
+          inputRef={searchInputRef}
+        />
+
+        <Button
+          variant="icon"
+          icon={paused ? 'play_arrow' : 'pause'}
+          onClick={handleTogglePause}
+          aria-pressed={paused}
+          aria-label={paused ? 'Resume the live feed' : 'Pause the live feed'}
+          title={paused ? 'Resume the live feed' : 'Pause the live feed'}
+        />
+
+        <Button
+          ref={overflow.ref}
+          variant="icon"
+          icon="more_horiz"
+          onClick={() => (overflow.at ? overflow.close() : overflow.open())}
+          aria-haspopup="menu"
+          aria-expanded={overflow.at !== null}
+          aria-label="More actions"
+          title="More actions"
+        />
+      </Toolbar>
+
+      {overflow.at && (
+        <Menu x={overflow.at.x} y={overflow.at.y} align="end" onClose={overflow.close}>
+          <MenuItem
+            showCheckSlot
+            checked={errorsOnly}
+            onClick={() => setErrorsOnly((v) => !v)}
+          >
+            Errors only
+          </MenuItem>
+          <MenuItem
+            showCheckSlot
+            checked={groupBySession}
             onClick={() => setGroupBySession((v) => !v)}
-            title="Group entries by session_id"
-            aria-pressed={groupBySession}
-            className="text-[11px] px-2.5 py-1 rounded-full transition-all shrink-0"
-            style={{
-              background: groupBySession ? 'var(--accent)' : 'var(--bg-inset)',
-              color: groupBySession ? '#fff' : 'var(--text-secondary)',
-              fontWeight: groupBySession ? 600 : 400,
-              cursor: 'pointer',
-              border: 'none',
-            }}
           >
             Group by session
-          </button>
-          <div style={{ position: 'relative', width: 180 }}>
-            <input
-              ref={searchInputRef}
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search params, tool…"
-              aria-label="Search calls"
-              style={{
-                width: '100%',
-                fontSize: 11,
-                padding: query ? '4px 22px 4px 8px' : '4px 8px',
-                background: 'var(--fill-control, var(--bg-inset))',
-                color: 'var(--text-primary)',
-                border: '0.5px solid var(--border-row)',
-                borderRadius: 6,
-                outline: 'none',
-                fontFamily: 'inherit',
-                boxSizing: 'border-box',
-              }}
-            />
-            {query !== '' && (
-              <button
-                type="button"
-                onClick={() => setQuery('')}
-                aria-label="Clear search"
-                title="Clear search"
-                style={{
-                  position: 'absolute',
-                  right: 4,
-                  top: '50%',
-                  transform: 'translateY(-50%)',
-                  background: 'none',
-                  border: 'none',
-                  padding: '0 4px',
-                  cursor: 'pointer',
-                  color: 'var(--text-tertiary)',
-                  fontSize: 12,
-                  lineHeight: 1,
+          </MenuItem>
+          {top5.length > 0 && (
+            <>
+              <MenuSection>Tools</MenuSection>
+              {top5.map((tool) => (
+                <MenuItem
+                  key={tool}
+                  showCheckSlot
+                  checked={toolFilter.has(tool)}
+                  onClick={() => handleToolClick(tool)}
+                >
+                  {tool}
+                </MenuItem>
+              ))}
+            </>
+          )}
+          {activeFilterCount > 0 && (
+            <>
+              <MenuSeparator />
+              <MenuItem
+                icon="close"
+                onClick={() => {
+                  clearFilters();
+                  overflow.close();
                 }}
               >
-                ×
-              </button>
-            )}
-          </div>
-        </div>
-
-        {/* Filter chips — All clears the tool set, Errors toggles independently,
-            tool chips toggle membership in the multi-select set. */}
-        <div className="flex gap-1.5 overflow-x-auto pb-0.5" style={{ scrollbarWidth: 'none' }}>
-          <FilterChip
-            label="All"
-            active={toolFilter.size === 0}
-            onClick={() => {
-              if (toolFilter.size > 0) setToolFilter(new Set());
-            }}
-          />
-          <FilterChip
-            label="Errors"
-            active={errorsOnly}
-            onClick={() => setErrorsOnly((v) => !v)}
-          />
-          {top5.map((tool) => (
-            <FilterChip
-              key={tool}
-              label={tool}
-              active={toolFilter.has(tool)}
-              onClick={() => {
-                setToolFilter((prev) => {
-                  const next = new Set(prev);
-                  if (next.has(tool)) next.delete(tool);
-                  else next.add(tool);
-                  return next;
-                });
-              }}
-            />
-          ))}
-          {/* Time-range filter chip — present only while a sparkline range is
-              active. Styled like a filter chip but with an accent border to
-              mark it as a special (client-side) filter. ✕ clears the range. */}
-          {timeRange !== null && (
-            <button
-              type="button"
-              onClick={() => setTimeRange(null)}
-              title="Clear time range filter"
-              className="text-[11px] px-2.5 py-1 rounded-full transition-all shrink-0 flex items-center gap-1 tabular-nums"
-              style={{
-                background: 'var(--accent-soft, rgba(0,122,255,0.12))',
-                color: 'var(--accent, #007aff)',
-                border: '0.5px solid var(--accent, #007aff)',
-                fontWeight: 600,
-                cursor: 'pointer',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              🕒 {new Date(timeRange.start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-              –
-              {new Date(timeRange.end).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-              <span style={{ marginLeft: 2 }}>✕</span>
-            </button>
+                Clear filters
+              </MenuItem>
+            </>
           )}
-        </div>
-      </div>
+          <MenuSeparator />
+          <MenuItem
+            icon="download"
+            disabled={filtered.length === 0}
+            onClick={() => {
+              handleExport();
+              overflow.close();
+            }}
+          >
+            Export {filtered.length.toLocaleString()} call
+            {filtered.length === 1 ? '' : 's'} as JSONL
+          </MenuItem>
+          <MenuItem
+            danger
+            icon="trash"
+            disabled={entries.length === 0}
+            onClick={() => {
+              handleClear();
+              overflow.close();
+            }}
+          >
+            Clear the local feed
+          </MenuItem>
+          <MenuSeparator />
+          <MenuItem
+            icon="tune"
+            shortcut="?"
+            onClick={() => {
+              setShowHelp(true);
+              overflow.close();
+            }}
+          >
+            Keyboard shortcuts
+          </MenuItem>
+        </Menu>
+      )}
 
       {/* ── Stats panel (collapsible) ── */}
       {/* Stats summary bar — always visible when stats are loaded */}
@@ -2426,13 +2376,15 @@ export function ToolActivity({
       {/* ── Error banner ── */}
       {error && (
         <div
-          className="shrink-0 px-3 py-1.5 text-[11px]"
+          role="status"
+          className="shrink-0 flex items-center gap-2 px-4 py-2 text-[13px] leading-4"
           style={{
-            background: 'rgba(239,68,68,0.08)',
-            color: 'var(--red, #ef4444)',
-            borderBottom: '0.5px solid var(--border-row)',
+            background: 'color-mix(in oklab, var(--status-red) 8%, transparent)',
+            color: 'var(--status-red)',
+            borderBottom: '0.5px solid var(--separator)',
           }}
         >
+          <Icon name="warning" size={14} />
           {error}
         </div>
       )}
@@ -2441,25 +2393,57 @@ export function ToolActivity({
       <div
         ref={scrollRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto"
-        style={{ background: 'var(--bg-grouped)', borderRadius: '0 0 10px 10px' }}
+        className="flex-1 min-h-0 overflow-y-auto"
+        style={{ background: 'var(--surface)' }}
       >
         {filtered.length === 0 ? (
-          <div
-            className="flex flex-col items-center justify-center h-full text-center px-6 py-12"
-            style={{ color: 'var(--text-tertiary)' }}
-          >
-            <div className="text-[13px] mb-1">
-              {toolFilter.size === 0 && !errorsOnly && query === '' && timeRange === null
-                ? 'No tool calls yet'
-                : 'No matching entries'}
-            </div>
-            <div className="text-[11px]">
-              {toolFilter.size === 0 && !errorsOnly && query === '' && timeRange === null
-                ? 'Run a tool from Claude Code to see activity here.'
-                : 'Try a different filter or clear the search.'}
-            </div>
-          </div>
+          historyFailed && activeFilterCount === 0 && query === '' ? (
+            <EmptyState
+              icon="warning"
+              iconSize={32}
+              title="Can't reach the indexer"
+              subtitle="The trace-mcp daemon didn't answer, so this project's earlier calls couldn't be loaded. Anything new still arrives live."
+              action={<Button icon="refresh" onClick={() => void fetchHistory()}>Try again</Button>}
+            />
+          ) : activeFilterCount === 0 && query === '' ? (
+            <EmptyState
+              icon="monitoring"
+              iconSize={32}
+              title="No tool calls yet"
+              subtitle="Every trace-mcp call an assistant makes against this project lands here, live. Connect a client to start the feed."
+              action={
+                <Button
+                  variant="prominent"
+                  icon="plugins"
+                  onClick={() => void window.electronAPI?.openClients?.()}
+                >
+                  Connect a client
+                </Button>
+              }
+            />
+          ) : (
+            <EmptyState
+              icon="search"
+              iconSize={32}
+              title="No matching calls"
+              subtitle={
+                activeFilterCount > 0
+                  ? `${filteredOutCount.toLocaleString()} call${filteredOutCount === 1 ? '' : 's'} are hidden by the current filters.`
+                  : 'Nothing in the feed matches that search.'
+              }
+              action={
+                <Button
+                  icon="close"
+                  onClick={() => {
+                    clearFilters();
+                    setQuery('');
+                  }}
+                >
+                  Clear filters and search
+                </Button>
+              }
+            />
+          )
         ) : groupBySession ? (
           groupEntriesBySession(filtered).map((group) => {
             const collapsed = collapsedSessions.has(group.session_id);

--- a/packages/app/src/renderer/tabs/__tests__/activity-memory.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/activity-memory.test.tsx
@@ -1,0 +1,274 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * TRA-294. These assert the things the Activity + Memory rewrite exists to fix,
+ * so the surfaces fail loudly if they drift back:
+ *
+ *   - ONE toolbar per surface (Activity stacked three control rows; Memory four)
+ *   - every icon-only control has a name and a tooltip
+ *   - empty states are icon + line + sentence + an action, not two grey lines
+ *   - the destructive row action is behind a menu, not inline in every row
+ *   - no ALL-CAPS strings, no type below 11px, no glass on a card
+ */
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Activity } from '../Activity';
+import { MemoryExplorer } from '../MemoryExplorer';
+
+const ROOT = '/tmp/proj';
+const now = Date.now();
+
+const EMPTY_STATS = {
+  window_ms: 3_600_000,
+  total_calls: 0,
+  error_rate: 0,
+  hot_tools: [],
+  hot_files: [],
+  latency_buckets: [],
+  error_groups: [],
+  by_minute: [],
+};
+
+const DECISION = {
+  id: 1,
+  title: 'Index writes go through the queue',
+  content: 'Direct SQLite writes from the watcher raced the indexer.',
+  type: 'architecture_decision',
+  project_root: ROOT,
+  service_name: null,
+  symbol_id: null,
+  file_path: 'src/indexer/queue.ts',
+  tags: '["indexer"]',
+  valid_from: new Date(now).toISOString(),
+  valid_until: null,
+  session_id: null,
+  source: 'manual',
+  confidence: 1,
+  git_branch: null,
+  review_status: null,
+  created_at: new Date(now).toISOString(),
+  updated_at: null,
+};
+
+/** Route every endpoint these two surfaces touch; `decisions` is overridable. */
+function mockApi(decisions: unknown[] = []) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: RequestInfo | URL) => {
+      const u = String(input);
+      let body: unknown = {};
+      if (u.includes('/journal/stats')) body = EMPTY_STATS;
+      else if (u.includes('/journal')) body = [];
+      else if (u.includes('/decisions/stats')) {
+        body = { total: decisions.length, active: decisions.length, by_type: {}, by_source: {} };
+      } else if (u.includes('/decisions')) body = { decisions, total: decisions.length };
+      else if (u.includes('/ai/activity')) body = { entries: [], stats: null };
+      else if (u.includes('/corpora')) body = { corpora: [] };
+      else if (u.includes('/sessions')) body = { sessions: [] };
+      return Promise.resolve(
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    }),
+  );
+}
+
+beforeEach(() => {
+  const api = new Proxy(function () {} as object, {
+    get: () => () => Promise.resolve(undefined),
+    apply: () => Promise.resolve(undefined),
+  });
+  (window as unknown as { electronAPI: unknown }).electronAPI = api;
+  vi.stubGlobal(
+    'EventSource',
+    class {
+      close() {}
+    },
+  );
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Render and flush the mount fetches. */
+async function mount(node: React.ReactElement) {
+  let result!: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(node);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return result;
+}
+
+describe('Activity surface', () => {
+  it('collapses its three control rows into exactly one toolbar', async () => {
+    mockApi();
+    const { container } = await mount(<Activity root={ROOT} />);
+    expect(container.querySelectorAll('[role="toolbar"]')).toHaveLength(1);
+  });
+
+  it('puts the source switcher, the feed state and the search on that toolbar', async () => {
+    mockApi();
+    await mount(<Activity root={ROOT} />);
+    const toolbar = screen.getByRole('toolbar');
+    within(toolbar).getByRole('group', { name: 'Activity source' });
+    within(toolbar).getByRole('button', { name: 'Tool calls' });
+    /* The SSE stub never opens, so the feed reports Offline — the point is
+       that the state is a WORD next to the dot, not the dot alone. */
+    within(toolbar).getByText('Offline');
+    within(toolbar).getByRole('textbox', { name: 'Search calls' });
+  });
+
+  it('names its icon-only controls for both the pointer and the screen reader', async () => {
+    mockApi();
+    await mount(<Activity root={ROOT} />);
+    const toolbar = screen.getByRole('toolbar');
+    for (const button of within(toolbar).getAllByRole('button')) {
+      const hasText = (button.textContent ?? '').trim().length > 0;
+      if (hasText) continue;
+      expect(button.getAttribute('aria-label'), button.outerHTML).toBeTruthy();
+      expect(button.getAttribute('title'), button.outerHTML).toBeTruthy();
+    }
+  });
+
+  it('offers an action from the empty feed instead of two grey lines', async () => {
+    mockApi();
+    await mount(<Activity root={ROOT} />);
+    screen.getByText('No tool calls yet');
+    screen.getByRole('button', { name: 'Connect a client' });
+  });
+});
+
+describe('Memory surface', () => {
+  it('collapses tab pills, stat card, add button and filter card into one toolbar', async () => {
+    mockApi();
+    const { container } = await mount(<MemoryExplorer root={ROOT} />);
+    expect(container.querySelectorAll('[role="toolbar"]')).toHaveLength(1);
+  });
+
+  it('puts the one prominent action on that toolbar, at control height', async () => {
+    mockApi();
+    await mount(<MemoryExplorer root={ROOT} />);
+    const toolbar = screen.getByRole('toolbar');
+    const add = within(toolbar).getByRole('button', { name: 'Add decision' });
+    /* The old button was a 40px `rounded-md` accent block on a row of its own. */
+    expect(add.className).toContain('lx-btn');
+    expect(add.className).toContain('v-prominent');
+  });
+
+  it('replaces MATCH / EXCLUDE with one search field, exclude behind the menu', async () => {
+    mockApi();
+    await mount(<MemoryExplorer root={ROOT} />);
+    expect(screen.queryByText('Match')).toBeNull();
+    expect(screen.queryByText('Exclude')).toBeNull();
+    screen.getByRole('textbox', { name: 'Search decisions' });
+  });
+
+  it('gives the empty list the action it was missing', async () => {
+    mockApi();
+    await mount(<MemoryExplorer root={ROOT} />);
+    screen.getByText('No decisions yet');
+    screen.getByRole('button', { name: 'Add the first decision' });
+  });
+
+  it('walks the decision list with the arrow keys', async () => {
+    const second = { ...DECISION, id: 2, title: 'Embeddings are rebuilt on schema change' };
+    mockApi([DECISION, second]);
+    await mount(<MemoryExplorer root={ROOT} />);
+
+    /* The same selector the roving handler walks. */
+    const rows = [
+      ...document.querySelectorAll<HTMLElement>('[role="button"][tabindex="0"]'),
+    ].filter((el) => el.textContent?.startsWith(DECISION.title) || el.textContent?.startsWith(second.title));
+    expect(rows.length).toBe(2);
+
+    rows[0].focus();
+    await act(async () => {
+      fireEvent.keyDown(rows[0], { key: 'ArrowDown' });
+    });
+    expect(document.activeElement).toBe(rows[1]);
+
+    await act(async () => {
+      fireEvent.keyDown(rows[1], { key: 'ArrowUp' });
+    });
+    expect(document.activeElement).toBe(rows[0]);
+
+    /* ArrowUp at the top stays put rather than escaping the list. */
+    await act(async () => {
+      fireEvent.keyDown(rows[0], { key: 'ArrowUp' });
+    });
+    expect(document.activeElement).toBe(rows[0]);
+  });
+
+  it('keeps the destructive action out of the row and behind a named menu', async () => {
+    mockApi([DECISION]);
+    await mount(<MemoryExplorer root={ROOT} />);
+    /* "Invalidate" used to be a red bordered button in every row, one click
+       from expiring a decision with no confirmation. */
+    expect(screen.queryByRole('button', { name: /^Invalidate/ })).toBeNull();
+    screen.getByRole('button', { name: `Actions for ${DECISION.title}` });
+  });
+});
+
+/* A dead daemon must not read as "you have no data" — that sends you off to
+   connect a client that is already connected, or to re-add decisions you
+   already have. */
+describe('failure is its own state', () => {
+  function failApi() {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new TypeError('Failed to fetch'))));
+  }
+
+  it('Activity says the indexer is unreachable, not that there are no calls', async () => {
+    failApi();
+    await mount(<Activity root={ROOT} />);
+    screen.getByText("Can't reach the indexer");
+    expect(screen.queryByText('No tool calls yet')).toBeNull();
+    screen.getByRole('button', { name: 'Try again' });
+  });
+
+  it('Memory offers a retry instead of the add-your-first empty state', async () => {
+    failApi();
+    await mount(<MemoryExplorer root={ROOT} />);
+    screen.getByText(/Couldn.t load the decisions for this project/);
+    expect(screen.queryByText('No decisions yet')).toBeNull();
+    screen.getByRole('button', { name: 'Retry' });
+  });
+});
+
+/* ── Source-level guards ───────────────────────────────────────────────────
+   jsdom does not resolve Tailwind arbitrary values, so the type-scale and
+   material rules are checked where they are written. Same shape as
+   scripts/design-tokens.mjs: cheap, and it fails on the exact thing the
+   definition of done names. */
+describe('type scale and material', () => {
+  const files = ['Activity.tsx', 'ToolActivity.tsx', 'AIActivity.tsx', 'MemoryExplorer.tsx'];
+  /* vitest runs with cwd = packages/app; import.meta.url is a served URL. */
+  const read = (f: string) =>
+    readFileSync(join(process.cwd(), 'src/renderer/tabs', f), 'utf8')
+      /* Drop comments: they describe what was removed. */
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^\s*\/\/.*$/gm, '');
+
+  it.each(files)('%s has no type below 11px', (f) => {
+    const src = read(f);
+    const tw = [...src.matchAll(/text-\[(\d+(?:\.\d+)?)px\]/g)].map((m) => Number(m[1]));
+    const inline = [...src.matchAll(/fontSize:\s*(\d+(?:\.\d+)?)/g)].map((m) => Number(m[1]));
+    expect([...tw, ...inline].filter((n) => n < 11)).toEqual([]);
+  });
+
+  it.each(files)('%s ships no ALL-CAPS strings', (f) => {
+    const src = read(f);
+    expect(src).not.toMatch(/\btext-transform\b|textTransform|\buppercase\b|toUpperCase\(\)/);
+  });
+
+  it.each(files)('%s puts no glass on content', (f) => {
+    expect(read(f)).not.toMatch(/backdropFilter|backdrop-filter/);
+  });
+});


### PR DESCRIPTION
Stage 3 of the macOS 26 revision (TRA-294, parent TRA-284). Activity and Memory each get one 52px toolbar, opaque content cards, and the shared type scale.

## What was wrong

Activity stacked three control rows and Memory four before any content appeared. Beyond that: unlabelled icon-only controls, empty states that were two grey lines with no action, status carried by colour alone, five font sizes in one feed row, 10.5px/700 ALL-CAPS chart headers, and seven 9.5px ALL-CAPS category chips on Memory.

**One correction to the issue's premise.** It attributes these defects to the `.ws-av-*` / `.ws-mv-*` / `.ws-statcard` / `.ws-ff` rules in `island.css`. No TSX references any of them — they are dead CSS from a ported design bundle. The real problems were inline styles in the four components, which is where the fix landed. The dead rules are deleted (~190 lines).

## Shared skeleton first

`Toolbar` / `ToolbarDivider` / `Section` / `Card` / `ListRow` / `SkeletonRows` / `SectionError` move out of `ProjectOverview` into `lattice/ui/Surface.tsx`. Activity and Memory are the second and third callers; `ProjectOverview` drops its 116 local lines and imports them instead. `Badge` gains an optional leading glyph so a tone is never the only channel.

`Menu` shipped `checked` / `showCheckSlot` / `danger` / `MenuSeparator` with no CSS behind them; that is now written, and `.ws-ctx-section` drops from 700 to 500 weight (10px/500 caps is the one legal ALL-CAPS case).

## Activity

One toolbar: source switcher, feed state as a **word** beside its dot, search, pause, overflow. Errors-only, group-by-session, per-tool filters, export and clear move into that overflow menu.

Chart headers become 11/600 sentence case. Hot-tool bars are one accent colour with a separate red error count — they used to turn red for any tool with a single error, so three of five bars read as an error chart. A flat delta prints nothing instead of `0%`. The latency histogram drops its 8px per-bar labels for an 11px two-ended axis. `get_change_impact` no longer truncates.

Empty state gains an action (`Connect a client`, via a new `open-clients` IPC verb). A failed history fetch now says the indexer is unreachable with a retry, instead of claiming there are no calls and sending you off to connect a client that is already connected.

## Memory

Tab pills become a `SegmentedControl` on the same toolbar. The 70px stat card (96% whitespace around three numbers, 2.21:1 labels) and the bordered MATCH / EXCLUDE filter card are replaced by a type meter whose legend **is** the filter, plus one search field. Seven ALL-CAPS category chips become sentence-case `Badge`s; `manual` / `mined` / `auto` become "Added by hand" / "Mined from a session" / "Recorded automatically".

`Invalidate` leaves every row for a per-row menu behind a confirmation. An expired decision carries a badge rather than only a 50% opacity wash. Arrow keys walk the list (roving DOM focus, so the existing focus ring and Enter handler stay the single source of truth). A failed fetch offers Retry instead of the add-your-first empty state, and the surface stops printing counts it could not load.

## Verification

- `tsc --noEmit` clean for renderer and main; `pnpm test` 19 files / 188 tests; `pnpm build` green.
- `scripts/design-tokens.mjs` passes with the baseline lowered: `ToolActivity.tsx` 33 → 0, `MemoryExplorer.tsx` 37 → 0, `AIActivity.tsx` 6 → 0 (all three drop off the file), `island.css` 83 → 36. No contrast failures.
- New `tabs/__tests__/activity-memory.test.tsx` (24 tests) asserts exactly one `[role="toolbar"]` per surface, that every text-less toolbar button has both `aria-label` and `title`, that empty states carry an action, that the destructive row action is absent from the row and reachable via a named menu, that failure is its own state on both surfaces, plus source-level guards for **no type below 11px**, **no ALL-CAPS**, **no `backdrop-filter`** across all four files.
- Rendered and screenshotted both surfaces in light and dark, populated / empty / loading / error, plus Reduce Transparency and Increase Contrast. Tab order and focus ring verified on the live renderer (20 focusable elements on Memory, all with a visible ring, in reading order); ↑↓ and ⏎ verified against the running app, not just the test.

Four defects were found *only* by looking at the render and are fixed here: the flat `0%` delta, the red hot-tool bars, the truncated tool column, and a duplicated legend/chip pair on AI calls.

## Notes for review

`components/FilterBar.tsx` is deliberately left in place — the Graph surface still uses it. Rebased onto TRA-296 and TRA-306.

Closes TRA-294.
