### PR TITLE
feat(app): application menu, keyboard shortcuts and the text-selection fix (TRA-297)

### DIFF
--- a/packages/app/src/main/__tests__/menu.test.ts
+++ b/packages/app/src/main/__tests__/menu.test.ts
@@ -1,0 +1,150 @@
+/* The application menu is the app's keyboard contract (TRA-297): if an
+   accelerator silently disappears from this template, the shortcut it names
+   stops existing and nothing else in the suite notices. These tests pin the
+   accelerators, the per-window ⌘1…⌘9 section list, and the one thing that is
+   easy to get wrong — a menu that dispatches to a window that has gone away. */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+interface Item {
+  label?: string;
+  role?: string;
+  type?: string;
+  accelerator?: string;
+  click?: () => void;
+  submenu?: Item[];
+}
+
+const sent: { command: string; arg?: unknown }[] = [];
+let focusedId: number | null = 1;
+let template: Item[] = [];
+
+const focusedWindow = {
+  isDestroyed: () => false,
+  webContents: {
+    get id() {
+      return focusedId ?? 0;
+    },
+    isDestroyed: () => false,
+    send: (_channel: string, command: string, arg?: unknown) => sent.push({ command, arg }),
+  },
+};
+
+vi.mock('electron', () => ({
+  app: { name: 'trace-mcp', on: vi.fn() },
+  BrowserWindow: {
+    getFocusedWindow: () => (focusedId === null ? null : focusedWindow),
+    getAllWindows: () => [],
+  },
+  ipcMain: { on: vi.fn() },
+  Menu: {
+    buildFromTemplate: (t: Item[]) => {
+      template = t;
+      return t;
+    },
+    setApplicationMenu: vi.fn(),
+  },
+  shell: { openExternal: vi.fn() },
+}));
+
+vi.mock('../tray', () => ({ showMenuWindow: vi.fn() }));
+
+import { buildAppMenu, forgetWindowSections, setWindowSections } from '../menu';
+
+function menu(label: string): Item[] {
+  const found = template.find((m) => m.label === label);
+  if (!found?.submenu) throw new Error(`no "${label}" menu in the template`);
+  return found.submenu;
+}
+
+/** Every accelerator in the whole menu, flattened. */
+function accelerators(): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const top of template) {
+    for (const item of top.submenu ?? []) {
+      if (item.accelerator && item.label) out.set(item.label, item.accelerator);
+    }
+  }
+  return out;
+}
+
+function click(items: Item[], label: string): void {
+  const item = items.find((i) => i.label === label);
+  if (!item?.click) throw new Error(`"${label}" has no click handler`);
+  item.click();
+}
+
+beforeEach(() => {
+  sent.length = 0;
+  focusedId = 1;
+  forgetWindowSections(1);
+  buildAppMenu();
+});
+
+describe('application menu', () => {
+  it('carries the shortcuts the app promises', () => {
+    const keys = accelerators();
+    expect(keys.get('Settings…')).toBe('CmdOrCtrl+,');
+    expect(keys.get('Find')).toBe('CmdOrCtrl+F');
+    expect(keys.get('Toggle sidebar')).toBe('CmdOrCtrl+Alt+S');
+    expect(keys.get('Quick open…')).toBe('CmdOrCtrl+Shift+O');
+    expect(keys.get('Open project…')).toBe('CmdOrCtrl+O');
+    expect(keys.get('New window')).toBe('CmdOrCtrl+N');
+    expect(keys.get('Close tab')).toBe('CmdOrCtrl+W');
+    expect(keys.get('Close window')).toBe('CmdOrCtrl+Shift+W');
+    expect(keys.get('Reload')).toBe('CmdOrCtrl+R');
+  });
+
+  it('keeps Edit on plain roles so text fields keep working', () => {
+    const roles = menu('Edit')
+      .map((i) => i.role)
+      .filter(Boolean);
+    expect(roles).toEqual(
+      expect.arrayContaining(['undo', 'redo', 'cut', 'copy', 'paste', 'selectAll']),
+    );
+  });
+
+  it('dispatches app-specific items to the focused window', () => {
+    click(menu('View'), 'Toggle sidebar');
+    click(menu('Edit'), 'Find');
+    expect(sent).toEqual([{ command: 'toggle-sidebar' }, { command: 'find' }]);
+  });
+
+  it('numbers the focused window’s own sections ⌘1…⌘n', () => {
+    setWindowSections(1, [
+      { id: 'overview', label: 'Overview' },
+      { id: 'ask', label: 'Ask' },
+      { id: 'graph', label: 'Graph' },
+    ]);
+    buildAppMenu();
+    const view = menu('View');
+    expect(view.find((i) => i.label === 'Overview')?.accelerator).toBe('CmdOrCtrl+1');
+    expect(view.find((i) => i.label === 'Graph')?.accelerator).toBe('CmdOrCtrl+3');
+
+    click(view, 'Graph');
+    expect(sent).toEqual([{ command: 'select-section', arg: 3 }]);
+  });
+
+  it('caps the section list at the nine keys that exist', () => {
+    setWindowSections(
+      1,
+      Array.from({ length: 12 }, (_, i) => ({ id: `s${i}`, label: `Section ${i}` })),
+    );
+    buildAppMenu();
+    const numbered = menu('View').filter((i) => /^CmdOrCtrl\+\d$/.test(i.accelerator ?? ''));
+    expect(numbered).toHaveLength(9);
+  });
+
+  it('shows no section items for a window that never reported any', () => {
+    focusedId = 99;
+    buildAppMenu();
+    expect(menu('View').some((i) => /^CmdOrCtrl\+\d$/.test(i.accelerator ?? ''))).toBe(false);
+  });
+
+  it('drops the command instead of throwing when no window has focus', () => {
+    const items = menu('View');
+    focusedId = null;
+    expect(() => click(items, 'Toggle sidebar')).not.toThrow();
+    expect(sent).toEqual([]);
+  });
+});

--- a/packages/app/src/main/__tests__/menu.test.ts
+++ b/packages/app/src/main/__tests__/menu.test.ts
@@ -57,7 +57,10 @@ function menu(label: string): Item[] {
   return found.submenu;
 }
 
-/** Every accelerator in the whole menu, flattened. */
+/** Every accelerator in the whole menu, flattened. Deliberately not scoped to
+    one menu: Settings and Quit live in the app menu on macOS and at the bottom
+    of File everywhere else, and the promise being tested is that the KEY works,
+    not where the item sits. CI runs this on Linux and a dev runs it on macOS. */
 function accelerators(): Map<string, string> {
   const out = new Map<string, string>();
   for (const top of template) {
@@ -139,6 +142,29 @@ describe('application menu', () => {
     focusedId = 99;
     buildAppMenu();
     expect(menu('View').some((i) => /^CmdOrCtrl\+\d$/.test(i.accelerator ?? ''))).toBe(false);
+  });
+
+  /* CI caught this the hard way: the first version built the app menu only on
+     macOS, so on Windows and Linux — where the app also ships — Settings and
+     Quit had no home at all and ⌘, was dead. */
+  it('keeps Settings and Quit reachable on Windows and Linux', async () => {
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    try {
+      vi.resetModules();
+      // `.js` — the main tsconfig is on node16 resolution, which requires the
+      // extension on a dynamic import even though the static one above is fine.
+      const { buildAppMenu: buildForLinux } = await import('../menu.js');
+      buildForLinux();
+      expect(template[0].label).toBe('File'); // no app menu off macOS
+      const file = menu('File').map((i) => i.label ?? i.role);
+      expect(file).toContain('Settings…');
+      expect(file).toContain('quit');
+      expect(accelerators().get('Settings…')).toBe('CmdOrCtrl+,');
+    } finally {
+      if (platform) Object.defineProperty(process, 'platform', platform);
+      vi.resetModules();
+    }
   });
 
   it('drops the command instead of throwing when no window has focus', () => {

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -3,6 +3,7 @@ import { execFile, spawn } from 'child_process';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
+import { registerAppMenu } from './menu';
 import { createTray, showMenuWindow } from './tray';
 import {
   hasPendingUpdate as hasPendingUpdateImpl,
@@ -1150,6 +1151,9 @@ app.whenReady().then(() => {
   if (process.platform === 'darwin' && fs.existsSync(dockIconPath)) {
     app.dock?.setIcon(nativeImage.createFromPath(dockIconPath));
   }
+  // The application menu carries every accelerator the app answers to —
+  // install it before the first window so ⌘, / ⌘R / ⌘1 work on first paint.
+  registerAppMenu();
   createTray();
   // Open the main window straight away — the tray remains for background control.
   // Users who close the window still have the tray; users who quit via ⌘Q shut down.

--- a/packages/app/src/main/menu.ts
+++ b/packages/app/src/main/menu.ts
@@ -1,0 +1,212 @@
+/* menu.ts — the application menu (TRA-297).
+
+   Until now the app shipped Electron's default menu: no Settings item, no
+   app-specific commands, no accelerators. A Mac app is judged by its keyboard,
+   and every shortcut the user reaches for first (⌘, ⌘R ⌘F ⌘1…⌘9) lives here.
+
+   Two halves:
+
+   - Items the OS or Electron can service alone (Edit roles, zoom, window roles)
+     are plain `role` entries — they keep working inside text fields for free.
+   - Everything app-specific dispatches ONE IPC message, `app-command`, to the
+     focused window. The renderer owns what a command means on the surface the
+     user is looking at; the menu owns only the key that triggers it.
+
+   The View menu's section list is per-window: the menu window has Workspace /
+   MCP clients, a project window has Overview … Insights. The renderer reports
+   its own list over `window-sections` on mount, we cache it per webContents id,
+   and rebuild the menu whenever a window takes focus. That keeps the labels and
+   their ⌘1…⌘9 numbering in one place (App.tsx) instead of duplicated here. */
+
+import {
+  app,
+  BrowserWindow,
+  ipcMain,
+  Menu,
+  shell,
+  type MenuItemConstructorOptions,
+} from 'electron';
+import { showMenuWindow } from './tray';
+
+const isMac = process.platform === 'darwin';
+
+const HELP_URL = 'https://github.com/nikolai-vysotskyi/trace-mcp#readme';
+const ISSUES_URL = 'https://github.com/nikolai-vysotskyi/trace-mcp/issues/new';
+
+export interface WindowSection {
+  id: string;
+  label: string;
+}
+
+/** webContents.id → the sections that window's sidebar currently offers. */
+const sectionsByWebContents = new Map<number, WindowSection[]>();
+
+export function setWindowSections(webContentsId: number, sections: WindowSection[]): void {
+  sectionsByWebContents.set(webContentsId, sections.slice(0, 9));
+  // The focused window is the one whose sections the View menu shows, so a
+  // late report (renderer mounted after focus) has to redraw the menu.
+  if (BrowserWindow.getFocusedWindow()?.webContents.id === webContentsId) installAppMenu();
+}
+
+export function forgetWindowSections(webContentsId: number): void {
+  sectionsByWebContents.delete(webContentsId);
+}
+
+function send(command: string, arg?: unknown): void {
+  const win = BrowserWindow.getFocusedWindow();
+  if (!win || win.isDestroyed() || win.webContents.isDestroyed()) return;
+  win.webContents.send('app-command', command, arg);
+}
+
+/** ⌘⇧W: with native tabs, ⌘W closes the tab and ⌘⇧W closes the whole window.
+    Electron exposes no tab-group membership, and this app runs exactly one
+    group, so "every window" and "this window's tabs" are the same set. */
+function closeWindowGroup(): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) win.close();
+  }
+}
+
+function sectionItems(): MenuItemConstructorOptions[] {
+  const focused = BrowserWindow.getFocusedWindow();
+  const sections = focused ? (sectionsByWebContents.get(focused.webContents.id) ?? []) : [];
+  return sections.map((section, i) => ({
+    label: section.label,
+    accelerator: `CmdOrCtrl+${i + 1}`,
+    click: () => send('select-section', i + 1),
+  }));
+}
+
+export function buildAppMenu(): Menu {
+  const sections = sectionItems();
+
+  const appMenu: MenuItemConstructorOptions = {
+    label: app.name,
+    submenu: [
+      { role: 'about' },
+      { label: 'Check for updates…', click: () => send('check-for-update') },
+      { type: 'separator' },
+      { label: 'Settings…', accelerator: 'CmdOrCtrl+,', click: () => send('settings') },
+      { type: 'separator' },
+      ...(isMac
+        ? ([
+            { role: 'services' },
+            { type: 'separator' },
+            { role: 'hide' },
+            { role: 'hideOthers' },
+            { role: 'unhide' },
+            { type: 'separator' },
+          ] as MenuItemConstructorOptions[])
+        : []),
+      { role: 'quit' },
+    ],
+  };
+
+  const fileMenu: MenuItemConstructorOptions = {
+    label: 'File',
+    submenu: [
+      // The menu window IS this app's main window: ⌘N creates it when it has
+      // been closed, and brings it forward when it hasn't.
+      { label: 'New window', accelerator: 'CmdOrCtrl+N', click: () => showMenuWindow() },
+      { label: 'Open project…', accelerator: 'CmdOrCtrl+O', click: () => send('open-project') },
+      { label: 'Quick open…', accelerator: 'CmdOrCtrl+Shift+O', click: () => send('quick-open') },
+      { type: 'separator' },
+      { label: 'Close tab', accelerator: 'CmdOrCtrl+W', role: 'close' },
+      { label: 'Close window', accelerator: 'CmdOrCtrl+Shift+W', click: closeWindowGroup },
+    ],
+  };
+
+  // Plain roles, so undo/redo/cut/copy/paste keep working inside every text
+  // field — that is what they are here for, not decoration.
+  const editMenu: MenuItemConstructorOptions = {
+    label: 'Edit',
+    submenu: [
+      { role: 'undo' },
+      { role: 'redo' },
+      { type: 'separator' },
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      { role: 'selectAll' },
+      { type: 'separator' },
+      { label: 'Find', accelerator: 'CmdOrCtrl+F', click: () => send('find') },
+    ],
+  };
+
+  const viewMenu: MenuItemConstructorOptions = {
+    label: 'View',
+    submenu: [
+      {
+        label: 'Toggle sidebar',
+        accelerator: 'CmdOrCtrl+Alt+S',
+        click: () => send('toggle-sidebar'),
+      },
+      ...(sections.length > 0
+        ? ([{ type: 'separator' }, ...sections] as MenuItemConstructorOptions[])
+        : []),
+      { type: 'separator' },
+      { label: 'Reload', accelerator: 'CmdOrCtrl+R', role: 'reload' },
+      { type: 'separator' },
+      { role: 'resetZoom' },
+      { role: 'zoomIn' },
+      { role: 'zoomOut' },
+      { type: 'separator' },
+      { role: 'togglefullscreen' },
+    ],
+  };
+
+  const windowMenu: MenuItemConstructorOptions = {
+    label: 'Window',
+    role: 'window',
+    submenu: [
+      { role: 'minimize' },
+      { role: 'zoom' },
+      ...(isMac
+        ? ([
+            { type: 'separator' },
+            { role: 'selectNextTab' },
+            { role: 'selectPreviousTab' },
+            { role: 'toggleTabBar' },
+            { role: 'mergeAllWindows' },
+            { type: 'separator' },
+            { role: 'front' },
+          ] as MenuItemConstructorOptions[])
+        : []),
+    ],
+  };
+
+  // Plain label, no `role: 'help'`: AppKit recognises a menu titled "Help" and
+  // adds the system Help search to it itself.
+  const helpMenu: MenuItemConstructorOptions = {
+    label: 'Help',
+    submenu: [
+      { label: 'trace-mcp help', click: () => void shell.openExternal(HELP_URL) },
+      { label: 'Report an issue', click: () => void shell.openExternal(ISSUES_URL) },
+    ],
+  };
+
+  return Menu.buildFromTemplate([
+    ...(isMac ? [appMenu] : []),
+    fileMenu,
+    editMenu,
+    viewMenu,
+    windowMenu,
+    helpMenu,
+  ]);
+}
+
+export function installAppMenu(): void {
+  Menu.setApplicationMenu(buildAppMenu());
+}
+
+/** Call once from whenReady. Rebuilds on focus so ⌘1…⌘9 always name the
+    sections of the window the user is actually looking at. */
+export function registerAppMenu(): void {
+  ipcMain.on('window-sections', (event, sections: WindowSection[]) => {
+    if (!Array.isArray(sections)) return;
+    setWindowSections(event.sender.id, sections);
+    event.sender.once('destroyed', () => forgetWindowSections(event.sender.id));
+  });
+  installAppMenu();
+  app.on('browser-window-focus', () => installAppMenu());
+}

--- a/packages/app/src/main/menu.ts
+++ b/packages/app/src/main/menu.ts
@@ -102,6 +102,9 @@ export function buildAppMenu(): Menu {
     ],
   };
 
+  /* Off macOS there is no app menu, so Settings and Quit would have no home at
+     all — they go to the bottom of File, which is where Windows and Linux users
+     look for them anyway. Ctrl+, still works; the accelerator is the same. */
   const fileMenu: MenuItemConstructorOptions = {
     label: 'File',
     submenu: [
@@ -113,6 +116,14 @@ export function buildAppMenu(): Menu {
       { type: 'separator' },
       { label: 'Close tab', accelerator: 'CmdOrCtrl+W', role: 'close' },
       { label: 'Close window', accelerator: 'CmdOrCtrl+Shift+W', click: closeWindowGroup },
+      ...(isMac
+        ? []
+        : ([
+            { type: 'separator' },
+            { label: 'Settings…', accelerator: 'CmdOrCtrl+,', click: () => send('settings') },
+            { type: 'separator' },
+            { role: 'quit' },
+          ] as MenuItemConstructorOptions[])),
     ],
   };
 
@@ -182,6 +193,14 @@ export function buildAppMenu(): Menu {
     submenu: [
       { label: 'trace-mcp help', click: () => void shell.openExternal(HELP_URL) },
       { label: 'Report an issue', click: () => void shell.openExternal(ISSUES_URL) },
+      // On macOS these live in the app menu; elsewhere Help is where they go.
+      ...(isMac
+        ? []
+        : ([
+            { type: 'separator' },
+            { label: 'Check for updates…', click: () => send('check-for-update') },
+            { role: 'about' },
+          ] as MenuItemConstructorOptions[])),
     ],
   };
 

--- a/packages/app/src/main/preload.ts
+++ b/packages/app/src/main/preload.ts
@@ -83,6 +83,21 @@ contextBridge.exposeInMainWorld('electronAPI', {
      nothing is connected lives in a project window. Without this verb its
      empty state had no action to offer (TRA-294). */
   openClients: (): Promise<{ ok: boolean }> => ipcRenderer.invoke('open-clients'),
+  /* Application menu ↔ renderer (TRA-297). The menu owns the accelerator; the
+     renderer owns what the command means on the surface in front of the user.
+     `setWindowSections` reports this window's ⌘1…⌘9 destinations so the View
+     menu can name them instead of duplicating the list in the main process. */
+  setWindowSections: (sections: { id: string; label: string }[]): void => {
+    ipcRenderer.send('window-sections', sections);
+  },
+  onAppCommand: (callback: (command: string, arg?: unknown) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, command: string, arg?: unknown) =>
+      callback(command, arg);
+    ipcRenderer.on('app-command', handler);
+    return () => {
+      ipcRenderer.removeListener('app-command', handler);
+    };
+  },
   // Tab management (Windows custom tab bar)
   getPlatform: (): Promise<string> => ipcRenderer.invoke('get-platform'),
   focusTab: (tabId: string): Promise<{ ok: boolean }> => ipcRenderer.invoke('focus-tab', tabId),

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { GuardOnboarding, isOnboardingDone } from './components/GuardOnboarding';
+import { QuickOpen, type QuickOpenItem } from './components/QuickOpen';
 import { WindowTabBar } from './components/WindowTabBar';
 import { fileKind, FileTypeGlyph, Icon } from './lattice/icons';
-import { PopUpButton } from './lattice/ui';
+import { Menu, MenuItem, MenuSeparator, PopUpButton } from './lattice/ui';
 import {
   clampSidebarWidth,
   readSidebarCollapsed,
@@ -100,6 +101,7 @@ function SidebarRow({
   selected = false,
   onClick,
   onKeyDown,
+  onContextMenu,
   title,
   count,
   trailing,
@@ -112,6 +114,7 @@ function SidebarRow({
   selected?: boolean;
   onClick: () => void;
   onKeyDown?: (e: React.KeyboardEvent) => void;
+  onContextMenu?: (e: React.MouseEvent) => void;
   title?: string;
   count?: React.ReactNode;
   trailing?: React.ReactNode;
@@ -124,6 +127,7 @@ function SidebarRow({
       className={`ws-sb-row${selected ? ' is-selected' : ''}`}
       onClick={onClick}
       onKeyDown={onKeyDown}
+      onContextMenu={onContextMenu}
       title={title}
       {...aria}
     >
@@ -139,6 +143,9 @@ function SidebarRow({
 
 function RecentProjects() {
   const [recent, setRecent] = useState<string[]>(getRecentProjects);
+  // Right-click target — the same actions the row's click and ⌫ already offer,
+  // reachable the way a Mac user reaches for them (TRA-297).
+  const [ctx, setCtx] = useState<{ x: number; y: number; root: string } | null>(null);
 
   // Re-read on focus (other tab might have opened a project)
   useEffect(() => {
@@ -171,8 +178,47 @@ function RecentProjects() {
     );
   }
 
+  const forget = (root: string) => {
+    removeRecentProject(root);
+    setRecent(getRecentProjects());
+  };
+
   return (
     <>
+      {ctx && (
+        <Menu x={ctx.x} y={ctx.y} onClose={() => setCtx(null)}>
+          <MenuItem
+            icon="folder_open"
+            onClick={() => {
+              setCtx(null);
+              openProject(ctx.root);
+            }}
+          >
+            Open project
+          </MenuItem>
+          <MenuItem
+            icon="content_copy"
+            onClick={() => {
+              setCtx(null);
+              void navigator.clipboard?.writeText(ctx.root);
+            }}
+          >
+            Copy path
+          </MenuItem>
+          <MenuSeparator />
+          <MenuItem
+            danger
+            icon="close"
+            shortcut="⌫"
+            onClick={() => {
+              setCtx(null);
+              forget(ctx.root);
+            }}
+          >
+            Remove from recent
+          </MenuItem>
+        </Menu>
+      )}
       {recent.map((root) => (
         <SidebarRow
           key={root}
@@ -180,13 +226,16 @@ function RecentProjects() {
           label={root.split(/[/\\]/).filter(Boolean).pop() ?? root}
           title={root}
           onClick={() => openProject(root)}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setCtx({ x: e.clientX, y: e.clientY, root });
+          }}
           // Keyboard route for the remove affordance — the row is itself a
           // button, so the ✕ can't be one too (nested interactive content).
           onKeyDown={(e) => {
             if (e.key !== 'Delete' && e.key !== 'Backspace') return;
             e.preventDefault();
-            removeRecentProject(root);
-            setRecent(getRecentProjects());
+            forget(root);
           }}
           trailing={
             <span
@@ -195,8 +244,7 @@ function RecentProjects() {
               title="Remove from recent (⌫)"
               onClick={(e) => {
                 e.stopPropagation();
-                removeRecentProject(root);
-                setRecent(getRecentProjects());
+                forget(root);
               }}
             >
               <Icon name="close" size={12} />
@@ -238,6 +286,7 @@ function ProjectFileExplorer({
   const [files, setFiles] = useState<FileEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [selected, setSelected] = useState<string | null>(null);
+  const [ctx, setCtx] = useState<{ x: number; y: number; path: string } | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
   const LIMIT = 30;
 
@@ -295,6 +344,39 @@ function ProjectFileExplorer({
 
   return (
     <>
+      {ctx && (
+        <Menu x={ctx.x} y={ctx.y} onClose={() => setCtx(null)}>
+          <MenuItem
+            icon="hub"
+            onClick={() => {
+              setCtx(null);
+              setSelected(ctx.path);
+              onFileClick(ctx.path);
+            }}
+          >
+            Reveal in graph
+          </MenuItem>
+          <MenuItem
+            icon="edit"
+            onClick={() => {
+              setCtx(null);
+              void window.electronAPI?.openInEditor(ctx.path);
+            }}
+          >
+            Open in editor
+          </MenuItem>
+          <MenuSeparator />
+          <MenuItem
+            icon="content_copy"
+            onClick={() => {
+              setCtx(null);
+              void navigator.clipboard?.writeText(ctx.path);
+            }}
+          >
+            Copy path
+          </MenuItem>
+        </Menu>
+      )}
       <div className="ws-sb-group">Files</div>
       {/* Sort — the shared pop-up button primitive (TRA-290). */}
       <PopUpButton
@@ -342,6 +424,11 @@ function ProjectFileExplorer({
                 onClick={() => {
                   setSelected(f.path);
                   onFileClick(f.path);
+                }}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  setSelected(f.path);
+                  setCtx({ x: e.clientX, y: e.clientY, path: f.path });
                 }}
                 onKeyDown={(e) => onRowKeyDown(e, i)}
               />
@@ -451,10 +538,16 @@ function UpdateBanner() {
     runCheck();
     const poll = setInterval(runCheck, 600_000);
     const tick = setInterval(() => setNow(Date.now()), 15_000);
+    // "Check for updates…" in the application menu (TRA-297). App.tsx receives
+    // the IPC command and re-broadcasts it here so the banner stays the single
+    // owner of update state.
+    const onMenuCheck = () => runCheck();
+    window.addEventListener('trace-mcp:check-update', onMenuCheck);
     return () => {
       cancelledRef.current = true;
       clearInterval(poll);
       clearInterval(tick);
+      window.removeEventListener('trace-mcp:check-update', onMenuCheck);
     };
   }, []);
 
@@ -577,6 +670,10 @@ function UpdateBanner() {
   return (
     <div
       className={`update-idle${isError ? ' error' : ''}`}
+      // The only place the app reports update health. It changes without the
+      // user asking, so assistive tech has to hear it (TRA-297).
+      role="status"
+      aria-live="polite"
       style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
     >
       <span className="dot" aria-hidden="true" />
@@ -669,6 +766,8 @@ export function App() {
   const [sidebarWidth, setSidebarWidth] = useState(readSidebarWidth);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(readSidebarCollapsed);
   const [_isFullscreen, setIsFullscreen] = useState(false);
+  const [quickOpen, setQuickOpen] = useState(false);
+  const [quickFiles, setQuickFiles] = useState<string[]>([]);
   const dragging = useRef(false);
   const graphRef = useRef<GraphExplorerGPUHandle | null>(null);
   const [graphGpuSettings, setGraphGpuSettings] = useState<GraphGPUSettings>(
@@ -769,28 +868,152 @@ export function App() {
     return () => window.removeEventListener('storage', onStorage);
   }, []);
 
-  // ⌘⌥S toggles the sidebar; ⌘1…⌘9 select the nth primary section.
+  const sectionList = isProject ? PROJECT_TABS : GLOBAL_TABS;
+
+  /** ⌘1…⌘9 and quick-open both land here: n is 1-based, matching the menu. */
+  const selectSection = useCallback(
+    (n: number) => {
+      const section = sectionList[n - 1];
+      if (!section) return;
+      if (isProject) setProjectTab(section.id as ProjectTab);
+      else setGlobalTab(section.id as GlobalTab);
+    },
+    [isProject, sectionList],
+  );
+
+  /* ⌘F. Every surface's search is the same Lattice SearchField, so "the search
+     field of the surface in front of me" is literally the first one in the
+     content pane — no per-surface registry to keep in sync. */
+  const focusSearch = useCallback(() => {
+    const field = document.querySelector<HTMLInputElement>(
+      '.ws-content-body .lx-search input, .ws-content-body input[type="search"]',
+    );
+    if (!field) return;
+    field.focus();
+    field.select();
+  }, []);
+
+  const pickProject = useCallback(async () => {
+    const api = window.electronAPI;
+    const picked = await api?.selectFolder?.();
+    if (!picked) return;
+    addRecentProject(picked);
+    api?.openProjectTab(picked);
+  }, []);
+
+  const openSettings = useCallback(() => {
+    if (isProject) window.electronAPI?.openSettings?.();
+    else setGlobalTab('settings');
+  }, [isProject]);
+
+  /* The application menu owns every accelerator now (main/menu.ts) and sends
+     one `app-command` per item to the focused window. Keeping a duplicate
+     window-level keydown for the same keys would double-fire the toggles, so
+     this is the single renderer-side handler — ⌘P below is the one exception,
+     because Electron allows a menu item only one accelerator. */
   useEffect(() => {
-    const sections: string[] = isProject
-      ? PROJECT_TABS.map((t) => t.id)
-      : GLOBAL_TABS.map((t) => t.id);
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey)) return;
-      if (e.altKey && (e.key === 's' || e.key === 'S' || e.code === 'KeyS')) {
-        e.preventDefault();
-        toggleSidebar();
-        return;
+    const api = window.electronAPI;
+    api?.setWindowSections?.(sectionList.map((t) => ({ id: t.id, label: t.label })));
+  }, [sectionList]);
+
+  useEffect(() => {
+    const api = window.electronAPI;
+    if (!api?.onAppCommand) return;
+    return api.onAppCommand((command, arg) => {
+      switch (command) {
+        case 'toggle-sidebar':
+          toggleSidebar();
+          break;
+        case 'select-section':
+          selectSection(Number(arg));
+          break;
+        case 'find':
+          focusSearch();
+          break;
+        case 'quick-open':
+          setQuickOpen(true);
+          break;
+        case 'settings':
+          openSettings();
+          break;
+        case 'open-project':
+          void pickProject();
+          break;
+        case 'check-for-update':
+          window.dispatchEvent(new CustomEvent('trace-mcp:check-update'));
+          break;
       }
-      if (e.altKey || e.shiftKey) return;
-      const n = Number(e.key);
-      if (!Number.isInteger(n) || n < 1 || n > 9 || n > sections.length) return;
+    });
+  }, [toggleSidebar, selectSection, focusSearch, openSettings, pickProject]);
+
+  // ⌘P — the second quick-open key. Not in the menu (one accelerator per item).
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
+      if (e.key !== 'p' && e.key !== 'P') return;
       e.preventDefault();
-      if (isProject) setProjectTab(sections[n - 1] as ProjectTab);
-      else setGlobalTab(sections[n - 1] as GlobalTab);
+      setQuickOpen(true);
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [isProject, toggleSidebar]);
+  }, []);
+
+  /* Quick-open's file list. Fetched when the panel opens rather than on mount:
+     it is a bigger page than the sidebar's 30 rows and nobody pays for it
+     until they ask. Failures leave sections and projects, which still work. */
+  useEffect(() => {
+    if (!quickOpen || !isProject || !root || quickFiles.length > 0) return;
+    let cancelled = false;
+    const params = new URLSearchParams({ project: root, sort: 'symbols', limit: '400' });
+    fetch(`${BASE}/api/projects/files?${params}`)
+      .then((r) => (r.ok ? r.json() : Promise.reject()))
+      .then((data: { files?: { path: string }[] }) => {
+        if (!cancelled) setQuickFiles((data.files ?? []).map((f) => f.path));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [quickOpen, isProject, root, quickFiles.length]);
+
+  const quickOpenItems = useCallback((): QuickOpenItem[] => {
+    const items: QuickOpenItem[] = sectionList.map((section, i) => ({
+      id: `section:${section.id}`,
+      label: section.label,
+      detail: `⌘${i + 1}`,
+      group: 'Go to',
+      icon: section.icon,
+      run: () => selectSection(i + 1),
+    }));
+    for (const projectRoot of getRecentProjects()) {
+      items.push({
+        id: `project:${projectRoot}`,
+        label: projectRoot.split(/[/\\]/).filter(Boolean).pop() ?? projectRoot,
+        detail: projectRoot,
+        group: 'Recent projects',
+        icon: 'folder',
+        run: () => {
+          addRecentProject(projectRoot);
+          window.electronAPI?.openProjectTab(projectRoot);
+        },
+      });
+    }
+    for (const filePath of quickFiles) {
+      const display = root && filePath.startsWith(root)
+        ? filePath.slice(root.length).replace(/^[/\\]/, '')
+        : filePath;
+      const { dir, name } = splitPath(display);
+      items.push({
+        id: `file:${filePath}`,
+        label: name,
+        detail: dir,
+        group: 'Files',
+        icon: 'description',
+        run: () => openFileInGraph(filePath),
+      });
+    }
+    return items;
+  }, [sectionList, selectSection, quickFiles, root, openFileInGraph]);
 
   // Track fullscreen state
   useEffect(() => {
@@ -821,6 +1044,7 @@ export function App() {
       data-platform={isMacPlatform() ? 'mac' : 'other'}
     >
       {showOnboarding && <GuardOnboarding onClose={() => setShowOnboarding(false)} />}
+      {quickOpen && <QuickOpen items={quickOpenItems()} onClose={() => setQuickOpen(false)} />}
       {/* Windows custom tab bar (hidden on macOS — native tabs handle it) */}
       <WindowTabBar />
 

--- a/packages/app/src/renderer/__tests__/app-commands.test.tsx
+++ b/packages/app/src/renderer/__tests__/app-commands.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+/* The renderer half of TRA-297: the app menu owns the keys, this owns what
+   they mean. Both halves have to agree — a section list the View menu never
+   receives is nine dead shortcuts, and a command nobody handles is a menu item
+   that does nothing when clicked. */
+
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { App } from '../App';
+import { filterItems, matchesQuery, type QuickOpenItem } from '../components/QuickOpen';
+
+type Command = (command: string, arg?: unknown) => void;
+
+let commandHandlers: Command[] = [];
+let reportedSections: { id: string; label: string }[] | null = null;
+
+function dispatch(command: string, arg?: unknown): void {
+  for (const handler of commandHandlers) handler(command, arg);
+}
+
+beforeEach(() => {
+  commandHandlers = [];
+  reportedSections = null;
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    setWindowSections: (sections: { id: string; label: string }[]) => {
+      reportedSections = sections;
+    },
+    onAppCommand: (cb: Command) => {
+      commandHandlers.push(cb);
+      return () => {
+        commandHandlers = commandHandlers.filter((h) => h !== cb);
+      };
+    },
+    openProjectTab: vi.fn(),
+    openSettings: vi.fn(),
+    selectFolder: vi.fn(async () => null),
+    syncSidebarWidth: vi.fn(),
+    checkForUpdate: vi.fn(async () => ({ available: false })),
+    checkPendingUpdate: vi.fn(async () => ({ pending: false })),
+    openInEditor: vi.fn(),
+    guard: {
+      checkCliVersion: vi.fn(async () => ({
+        current: '2.1.0',
+        required: '2.1.0',
+        ok: true,
+        needsUpgrade: false,
+        notInstalled: false,
+      })),
+      installStatus: vi.fn(async () => ({ claudeDetected: false, installed: false })),
+    },
+  };
+  localStorage.clear();
+  // The onboarding sheet is modal and would swallow the keyboard; it is not
+  // what these tests are about.
+  localStorage.setItem('trace-mcp.onboarded.v1', '1');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(JSON.stringify({ projects: [], files: [] }), { status: 200 })),
+  );
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function renderApp(search: string): Promise<void> {
+  window.history.replaceState({}, '', search);
+  await act(async () => {
+    render(<App />);
+  });
+}
+
+describe('application-menu commands', () => {
+  it('reports the menu window’s sections so ⌘1…⌘9 can name them', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+    expect(reportedSections).toEqual([
+      { id: 'workspace', label: 'Workspace' },
+      { id: 'clients', label: 'MCP Clients' },
+    ]);
+  });
+
+  it('reports a project window’s seven sections instead', async () => {
+    await renderApp('/?view=project&root=/tmp/proj');
+    expect(reportedSections?.map((s) => s.id)).toEqual([
+      'overview',
+      'ask',
+      'graph',
+      'activity',
+      'memory',
+      'notebook',
+      'insights',
+    ]);
+  });
+
+  it('select-section switches the surface', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+    await act(async () => dispatch('select-section', 2));
+    // MCP Clients is ⌘2 in the menu window.
+    expect(document.querySelector('.ws-sb-row.is-selected')?.textContent).toContain('MCP Clients');
+  });
+
+  it('ignores a section index the window does not have', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+    await act(async () => dispatch('select-section', 7));
+    expect(document.querySelector('.ws-sb-row.is-selected')?.textContent).toContain('Workspace');
+  });
+
+  it('toggle-sidebar collapses and restores the sidebar', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+    expect(document.querySelector('.ws-sidebar')).not.toBeNull();
+    await act(async () => dispatch('toggle-sidebar'));
+    expect(document.querySelector('.ws-sidebar')).toBeNull();
+    await act(async () => dispatch('toggle-sidebar'));
+    expect(document.querySelector('.ws-sidebar')).not.toBeNull();
+  });
+
+  it('settings opens the Settings surface in the menu window', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+    await act(async () => dispatch('settings'));
+    expect(document.querySelector('.ws-sb-footer .is-selected')).not.toBeNull();
+  });
+
+  it('settings hands off to the menu window from a project window', async () => {
+    await renderApp('/?view=project&root=/tmp/proj');
+    await act(async () => dispatch('settings'));
+    expect(window.electronAPI?.openSettings).toHaveBeenCalled();
+  });
+
+  it('quick-open opens a dialog listing this window’s sections', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+    await act(async () => dispatch('quick-open'));
+    const dialog = screen.getByRole('dialog', { name: 'Quick open' });
+    expect(dialog.textContent).toContain('Workspace');
+    expect(dialog.textContent).toContain('MCP Clients');
+  });
+
+  it('an unknown command is ignored, not thrown', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+    expect(() => dispatch('no-such-command')).not.toThrow();
+  });
+});
+
+describe('quick-open filtering', () => {
+  const items: QuickOpenItem[] = [
+    { id: 'a', label: 'Workspace', group: 'Go to', icon: 'grid_view', run: () => {} },
+    { id: 'b', label: 'MCP Clients', group: 'Go to', icon: 'cable', run: () => {} },
+    {
+      id: 'c',
+      label: 'WorkspaceTableView.tsx',
+      detail: 'src/renderer/workspace',
+      group: 'Files',
+      icon: 'description',
+      run: () => {},
+    },
+  ];
+
+  it('matches a subsequence, not just a prefix', () => {
+    expect(matchesQuery('WorkspaceTableView.tsx', 'wtv')).toBe(true);
+    expect(matchesQuery('WorkspaceTableView.tsx', 'vtw')).toBe(false);
+  });
+
+  it('searches the detail line too, so a path finds its file', () => {
+    expect(filterItems(items, 'renderer/workspace').map((i) => i.id)).toEqual(['c']);
+  });
+
+  it('an empty query keeps everything', () => {
+    expect(filterItems(items, '   ')).toHaveLength(3);
+  });
+});

--- a/packages/app/src/renderer/app.css
+++ b/packages/app/src/renderer/app.css
@@ -56,9 +56,38 @@ body {
   background: transparent;
   margin: 0;
   padding: 0;
+  /* Chrome default. Content opts back in below — see "Text selection". */
   user-select: none;
   -webkit-app-region: no-drag;
   overflow: hidden;
+}
+
+/* ── Text selection (TRA-297) ────────────────────────────────────── */
+/* macOS chrome — sidebar, toolbars, menus, buttons — is not selectable; macOS
+   CONTENT always is. `user-select: none` on body was doing both, so nothing in
+   the app could be selected or copied: not a file path, not a session id, not
+   an error message, not a metric. Content opts back in here, and the controls
+   inside it opt out again, so drag-selecting a paragraph never picks up the
+   label of the button next to it. */
+.ws-content-body {
+  user-select: text;
+  -webkit-user-select: text;
+}
+.ws-content-body button,
+.ws-content-body a,
+.ws-content-body label,
+.ws-content-body summary,
+.ws-content-body [role='button'],
+.ws-content-body [role='tab'],
+.ws-content-body [role='menuitem'],
+.ws-content-body [role='menuitemcheckbox'],
+.ws-content-body [role='option'],
+.ws-content-body [role='columnheader'],
+.ws-content-body .ws-island-head,
+.ws-content-body .lx-seg,
+.ws-content-body canvas {
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 /* House focus ring — visible on every focusable element, keyboard only. */
@@ -386,4 +415,139 @@ body {
   justify-content: flex-end;
   gap: 8px;
   margin-top: 4px;
+}
+
+/* ── Quick open (TRA-297) ────────────────────────────────────────── */
+/* ⌘⇧O / ⌘P. A panel floating over content, pushed clear of the traffic
+   lights — not a full sheet, because it is a way to go somewhere, not a
+   decision to make. Escape cancels; ↑↓ + ⏎ pick. */
+.lx-qo-scrim {
+  align-items: flex-start;
+  padding-top: 72px;
+}
+.lx-qo {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: min(560px, calc(100vw - 64px));
+  max-height: min(420px, calc(100vh - 140px));
+  overflow: hidden;
+  background: var(--surface);
+  border: 0.5px solid var(--separator);
+  border-radius: var(--radius-panel);
+  box-shadow: var(--shadow-panel);
+  animation: lx-qo-in var(--dur-standard) var(--ease-spring);
+}
+@keyframes lx-qo-in {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.lx-qo-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  height: 44px;
+  padding: 0 12px;
+  border-bottom: 0.5px solid var(--separator);
+}
+.lx-qo-glyph {
+  display: flex;
+  color: var(--label-tertiary);
+}
+.lx-qo-field input {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  outline: none;
+  background: transparent;
+  font-family: var(--font-ui);
+  font-size: var(--text-title-3);
+  line-height: var(--leading-title-3);
+  color: var(--label);
+}
+.lx-qo-field input::placeholder {
+  color: var(--label-tertiary);
+}
+/* The one exception to the house focus ring. This field is the panel — it takes
+   focus the moment the panel opens and never gives it up, so a ring around it
+   is a box drawn around the whole top row for no information. The panel's own
+   shadow and scrim already say where focus is. */
+.lx-qo-field input:focus-visible {
+  box-shadow: none;
+}
+
+.lx-qo-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px 0 6px;
+}
+.lx-qo-group {
+  padding: 8px 12px 2px;
+  font-size: var(--text-caption);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-caption);
+  color: var(--label-tertiary);
+}
+.lx-qo-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: calc(100% - 12px);
+  height: 28px;
+  margin: 0 6px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: var(--radius-row);
+  background: transparent;
+  font-family: var(--font-ui);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+  color: var(--label);
+  text-align: left;
+  cursor: default;
+}
+.lx-qo-item.is-active {
+  background: var(--accent-fill);
+  color: var(--on-accent);
+}
+.lx-qo-ico {
+  display: flex;
+  flex: 0 0 auto;
+  color: var(--label-secondary);
+}
+.lx-qo-item.is-active .lx-qo-ico {
+  color: var(--on-accent);
+}
+.lx-qo-label {
+  flex: 0 1 auto;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.lx-qo-detail {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: var(--text-caption);
+  color: var(--label-tertiary);
+}
+.lx-qo-item.is-active .lx-qo-detail {
+  color: color-mix(in oklab, var(--on-accent) 72%, transparent);
+}
+.lx-qo-empty {
+  padding: 16px 12px;
+  font-size: var(--text-body);
+  color: var(--label-secondary);
+  text-align: center;
 }

--- a/packages/app/src/renderer/components/QuickOpen.tsx
+++ b/packages/app/src/renderer/components/QuickOpen.tsx
@@ -1,0 +1,161 @@
+/* QuickOpen.tsx — ⌘⇧O / ⌘P over the app's destinations (TRA-297).
+
+   One field, one list, ↑↓ + ⏎, Esc to cancel. Deliberately not a command
+   palette: it lists what the sidebar already offers — sections, recent
+   projects, and (in a project window) indexed files — so the keyboard reaches
+   the same places the mouse does, in one step instead of three.
+
+   Filtering is a plain subsequence match on the label + detail, which is what
+   makes "wtv" find "WorkspaceTableView" without a fuzzy-search dependency. */
+
+import { useEffect, useId, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Icon } from '../lattice/icons';
+
+export interface QuickOpenItem {
+  id: string;
+  /** Primary line — what the user is looking for. */
+  label: string;
+  /** Secondary line: a path, a group name. Also searched. */
+  detail?: string;
+  /** Group header this item sits under. */
+  group: string;
+  icon: string;
+  run: () => void;
+}
+
+/** Subsequence match, case-insensitive. Returns false when a query character
+    never appears in order — the cheapest thing that behaves like a fuzzy
+    matcher without pulling one in. */
+export function matchesQuery(haystack: string, query: string): boolean {
+  if (query === '') return true;
+  const h = haystack.toLowerCase();
+  const q = query.toLowerCase();
+  let i = 0;
+  for (const ch of q) {
+    if (ch === ' ') continue;
+    const next = h.indexOf(ch, i);
+    if (next === -1) return false;
+    i = next + 1;
+  }
+  return true;
+}
+
+export function filterItems(items: QuickOpenItem[], query: string): QuickOpenItem[] {
+  const trimmed = query.trim();
+  if (trimmed === '') return items;
+  return items.filter((item) => matchesQuery(`${item.label} ${item.detail ?? ''}`, trimmed));
+}
+
+export function QuickOpen({
+  items,
+  onClose,
+}: {
+  items: QuickOpenItem[];
+  onClose: () => void;
+}): ReactNode {
+  const [query, setQuery] = useState('');
+  const [active, setActive] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+  const listId = useId();
+  const matches = useMemo(() => filterItems(items, query).slice(0, 60), [items, query]);
+
+  // A shrinking result list must never leave the highlight past its end.
+  const index = Math.min(active, Math.max(0, matches.length - 1));
+
+  useEffect(() => {
+    // `?.` on the call too: scrollIntoView is absent in jsdom, and an effect
+    // that throws takes the whole panel down with it.
+    listRef.current
+      ?.querySelectorAll<HTMLElement>('.lx-qo-item')
+      [index]?.scrollIntoView?.({ block: 'nearest' });
+  }, [index]);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      onClose();
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActive(Math.min(index + 1, matches.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive(Math.max(index - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const item = matches[index];
+      if (!item) return;
+      onClose();
+      item.run();
+    }
+  };
+
+  let lastGroup = '';
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: the scrim is a dismissal affordance, not a control — Escape on the field is the keyboard path.
+    <div className="lx-sheet-scrim lx-qo-scrim" onClick={onClose}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Quick open"
+        className="lx-qo"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="lx-qo-field">
+          <span className="lx-qo-glyph" aria-hidden="true">
+            <Icon name="search" size={16} />
+          </span>
+          {/* biome-ignore lint/a11y/noAutofocus: a quick-open the user must click into is not a quick-open. */}
+          <input
+            autoFocus
+            type="text"
+            value={query}
+            placeholder="Go to section, project or file"
+            aria-label="Quick open"
+            aria-controls={listId}
+            aria-activedescendant={matches[index] ? `${listId}-${index}` : undefined}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setActive(0);
+            }}
+            onKeyDown={onKeyDown}
+          />
+        </div>
+        <div className="lx-qo-list" id={listId} role="listbox" aria-label="Results" ref={listRef}>
+          {matches.length === 0 ? (
+            <div className="lx-qo-empty">No matches</div>
+          ) : (
+            matches.map((item, i) => {
+              const header = item.group !== lastGroup ? item.group : null;
+              lastGroup = item.group;
+              return (
+                <div key={item.id}>
+                  {header && <div className="lx-qo-group">{header}</div>}
+                  <button
+                    type="button"
+                    id={`${listId}-${i}`}
+                    role="option"
+                    aria-selected={i === index}
+                    className={`lx-qo-item${i === index ? ' is-active' : ''}`}
+                    onMouseMove={() => setActive(i)}
+                    onClick={() => {
+                      onClose();
+                      item.run();
+                    }}
+                  >
+                    <span className="lx-qo-ico" aria-hidden="true">
+                      <Icon name={item.icon} size={16} />
+                    </span>
+                    <span className="lx-qo-label">{item.label}</span>
+                    {item.detail && <span className="lx-qo-detail">{item.detail}</span>}
+                  </button>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/renderer/electron.d.ts
+++ b/packages/app/src/renderer/electron.d.ts
@@ -51,6 +51,9 @@ declare global {
       restartApp: () => Promise<void>;
       openSettings: (section?: string) => Promise<{ ok: boolean }>;
       openClients: () => Promise<{ ok: boolean }>;
+      // Application menu ↔ renderer (TRA-297)
+      setWindowSections: (sections: { id: string; label: string }[]) => void;
+      onAppCommand: (callback: (command: string, arg?: unknown) => void) => () => void;
       // Tab management (Windows custom tab bar)
       getPlatform: () => Promise<string>;
       focusTab: (tabId: string) => Promise<{ ok: boolean }>;

--- a/packages/app/src/renderer/styles/__tests__/tokens.test.ts
+++ b/packages/app/src/renderer/styles/__tests__/tokens.test.ts
@@ -8,6 +8,7 @@ const tokensCss = readFileSync(
   fileURLToPath(new URL('../tokens.css', import.meta.url)),
   'utf8',
 );
+const appCss = readFileSync(fileURLToPath(new URL('../../app.css', import.meta.url)), 'utf8');
 
 describe('design tokens', () => {
   it('composites translucent labels before measuring contrast', () => {
@@ -34,5 +35,13 @@ describe('design tokens', () => {
   it('adds no raw hex or Tailwind grey beyond the recorded baseline', () => {
     const { violations } = tokenGuard();
     expect(violations).toEqual([]);
+  });
+
+  /* TRA-297: `user-select: none` on body used to be the last word, so no path,
+     id, metric or error message anywhere in the app could be selected — let
+     alone copied. Content opts back in; chrome inside it opts back out. */
+  it('lets content text be selected while chrome stays unselectable', () => {
+    expect(appCss).toMatch(/\.ws-content-body\s*\{[^}]*user-select:\s*text/);
+    expect(appCss).toMatch(/\.ws-content-body button[^{]*\{[^}]*user-select:\s*none/);
   });
 });


### PR DESCRIPTION
Closes TRA-297.

## What was actually missing

Re-verified the issue's premises against the current `master` first. Several had already been fixed by the earlier stages of this revision and are **not** in this PR: `⌘⌥S` and `⌘1…⌘9` existed in App.tsx, the resize handle is already `tabIndex={0}` with arrow/Home/End keys, the sidebar file list already has `role="tree"` / `treeitem` / `aria-selected`, `<nav>` already wraps the sidebar, `<main>` no longer carries `-webkit-app-region: drag`, and `prefers-reduced-motion` / `-reduced-transparency` / `prefers-contrast: more` all landed globally in `tokens.css` with TRA-289 (`animation-iteration-count: 1`, so no infinite animation survives Reduce Motion).

What was genuinely missing, and is what this PR does:

1. **There was no application menu at all.** `Menu.setApplicationMenu` appeared nowhere in `packages/app`; the app shipped Electron's default menu, which on macOS is App / File / Edit / View / Window with no Settings item and none of our commands.
2. **`body { user-select: none }` was the last word**, so nothing in the app could be selected or copied — not a file path, not a session id, not a metric, not an error message.
3. No `⌘F`, `⌘R`, `⌘,`, quick-open, or right-click menus in the sidebar.

## The menu

`packages/app/src/main/menu.ts`:

| Menu | Items |
|---|---|
| **trace-mcp** | About · Check for updates… · **Settings… ⌘,** · Services · Hide / Hide Others / Show All · Quit |
| **File** | New window ⌘N · Open project… ⌘O · Quick open… ⌘⇧O · Close tab ⌘W · Close window ⌘⇧W |
| **Edit** | Undo / Redo / Cut / Copy / Paste / Select All (plain roles) · Find ⌘F |
| **View** | Toggle sidebar ⌘⌥S · *the focused window's sections* ⌘1…⌘9 · Reload ⌘R · Actual size / Zoom in / Zoom out · Toggle full screen |
| **Window** | Minimize · Zoom · Select next/previous tab · Show all tabs · Merge all windows · Bring all to front |
| **Help** | trace-mcp help · Report an issue |

Two design points worth reviewing:

- **The section list is reported by the renderer, not duplicated in main.** `App.tsx` sends its own `GLOBAL_TABS` / `PROJECT_TABS` over `window-sections`; main caches them per `webContents.id` and rebuilds the menu on `browser-window-focus`. So the menu window's View menu reads *Workspace ⌘1 · MCP Clients ⌘2* and a project window's reads *Overview ⌘1 … Insights ⌘7*, with one source of truth for the labels and the numbering.
- **The renderer's duplicate keydown handlers for ⌘⌥S and ⌘1…⌘9 are removed.** Keeping both would double-fire the toggles. `⌘P` is the one key still handled in the renderer, because Electron allows a menu item only one accelerator.

Edit stays on plain roles deliberately — that is what makes undo/copy/paste work inside every text field.

## Text selection

`user-select: none` remains the chrome default on `body`. `.ws-content-body` opts content back in, and the interactive elements inside it (`button`, `a`, `label`, `[role=button|tab|menuitem|option|columnheader]`, island headers, segmented controls, canvas) opt out again — so a paragraph selects cleanly without dragging in the label of the button beside it.

## Quick open

`⌘⇧O` / `⌘P`. Sections, recent projects, and — in a project window — indexed files, fetched only when the panel opens. Subsequence match on label + detail (`wtv` → `WorkspaceTableView.tsx`), `↑↓` + `⏎`, Esc cancels. 560px panel, 12px radius, 44px field at 15px, 28px rows at 13px, accent capsule selection. No new dependency.

## What I verified on the running app

Not from reading the diff:

- **The real menu bar** of a dev build launched with its own profile: `trace-mcp · File · Edit · View · Window · Help`, with `View` listing `Workspace` and `MCP Clients` — i.e. the `window-sections` round-trip works at runtime, not just in the unit test.
  One correction worth recording: my first attempt at this screenshotted the *installed* trace-mcp.app, which was holding the single-instance lock and silently making the dev build exit. That menu bar had no Help and I briefly mistook it for a bug in this change. Running with `--user-data-dir` isolated the two.
- **`⌘F`** focuses `Search calls` on Activity, and is a no-op on Overview, which has no search field.
- **Selection**: a table path (`/Users/nikolai/PhpstormProjects/app-laravel`) selects and reads back; a sidebar row label computes `user-select: none`.
- **Both context menus** render (recent projects in light mode, file rows in a project window).
- **Quick open** in light and dark. I removed the house focus ring from its input after seeing it: the field *is* the panel, so a ring around the whole top row was a box drawn for no information.

## Tests

`src/main/__tests__/menu.test.ts` (7) pins the accelerators, the Edit roles, the per-window ⌘1…⌘9 numbering, the 9-key cap, and that a command with no focused window is dropped rather than thrown. `src/renderer/__tests__/app-commands.test.tsx` (12) covers the section reporting for both window types, every command, an unknown command, and quick-open filtering. `tokens.test.ts` pins the selection scoping.

227 tests pass, typecheck clean for renderer and main, `pnpm run build` clean.

## Not done, deliberately

- **Toggle inspector ⌘⌥I** — there is no inspector pane in the app. Adding a menu item for a surface that does not exist is worse than leaving the key free.
- **`⌘F` is not greyed out** on surfaces without a search field; it is a no-op. Disabling it correctly would need every surface to report its find capability, which is more machinery than the behaviour is worth right now.
