### PR TITLE
feat(app): rebuild Ask on the macOS 26 layer (TRA-312)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -497,6 +497,9 @@ new evidence.
 | Sidebar file paths use a `dir`/`name` flex split, not `direction: rtl` | The rtl hack mangled any path containing `.` or `_` runs (`.idea/workspace.xml` → `idea/workspace.xml.`). |
 | Whitespace separates sidebar groups, not rules | Fewer lines, clearer grouping; matches the platform sidebar. |
 | Rows are windowed past 100 items | A thousand projects costs what a hundred does. |
+| A surface with extra columns collapses them with a **container query**, trailing column first | At the 640px window minimum the app sidebar already takes 220. Ask's chat rail + inspector left the conversation at zero width and painted the inspector over its own toolbar. The rules must be last in the file — a container query adds no specificity. |
+| A side inspector starts **closed** and persists the user's choice | 280px of "this appears after you send a message" is not worth the width. The toolbar toggle is how it is discovered. |
+| A failed send puts the question back in the composer | Losing what you typed is a worse cost than the error itself, and it makes "Send again" a single click instead of a retype. |
 | Migrate a screen **whole**, one screen per PR | A half-migrated screen looks worse than the un-migrated one; a big-bang redesign PR never lands. |
 | Tokens and primitives land before any surface | A surface migrated against a moving token layer gets migrated twice. |
 
@@ -504,11 +507,11 @@ new evidence.
 
 ## 12. Migration status
 
-The token layer, the control primitives, the window chrome, the sidebar and its
-footer, the workspace dashboard, and Project Overview are on this system.
+On this system: the token layer, the control primitives, the window chrome, the
+sidebar and its footer, the workspace dashboard, Project Overview, Activity, Memory,
+MCP Clients, Settings, the onboarding sheet, Graph Explorer, Insights, and **Ask**.
 
-Activity, Memory, MCP Clients, Settings, the onboarding dialog, Graph Explorer and
-Insights are still being migrated. Until they are, `styles/island.css` keeps a set of
+Still to migrate: **Notebook**. Until it is, `styles/island.css` keeps a set of
 **legacy aliases** (`--text-1/2/3`, `--frame`, `--island`, `--row-hover`, `--sep`, …)
 that map onto the tokens above, plus per-domain styles that this document's "never"
 list already forbids — glass stat cards, ALL-CAPS labels, raw hex. **Those are being

--- a/packages/app/scripts/token-guard.baseline.json
+++ b/packages/app/scripts/token-guard.baseline.json
@@ -8,7 +8,6 @@
   "src/renderer/lattice/icons.tsx": 1,
   "src/renderer/lattice/ui/Badge.tsx": 2,
   "src/renderer/styles/island.css": 36,
-  "src/renderer/tabs/AskTab.tsx": 5,
   "src/renderer/tabs/GraphExplorerGPU.tsx": 51,
   "src/renderer/tabs/Notebook.tsx": 1
 }

--- a/packages/app/src/renderer/app.css
+++ b/packages/app/src/renderer/app.css
@@ -10,6 +10,8 @@
 /* Control primitives (TRA-290) — capsules, 20/24/28 heights, ≥24px hit
    targets. Imported LAST so it wins over the legacy island rules it replaces. */
 @import "./styles/controls.css";
+/* Ask surface (TRA-312) — layout only; every value comes from tokens.css. */
+@import "./styles/ask.css";
 
 /* Legacy token names kept as ALIASES of tokens.css for one migration step.
    Each surface sub-issue deletes the aliases it no longer uses (TRA-284). */

--- a/packages/app/src/renderer/styles/ask.css
+++ b/packages/app/src/renderer/styles/ask.css
@@ -1,0 +1,539 @@
+/* ============================================================================
+   Ask — macOS 26 surface (TRA-312)
+
+   Ask was the last project surface still on its pre-revision inline styles:
+   nine distinct font sizes (9–15px, most of the reading text at 9–10px), ten
+   radii, `--accent` used as a bubble background, `backdrop-filter` on content,
+   two ALL-CAPS group headers, a hover-only delete affordance and a centred
+   three-dot spinner where a skeleton belongs. Everything it draws now comes
+   from tokens.css and lattice/ui; this file only lays the surface out.
+
+   Layout, left to right:
+
+     .ask-rail        220px chat list — CONTENT, opaque, hairline trailing edge
+     .ask-main        toolbar (glass) + thread (720px measure) + composer
+     .ask-inspector   280px context panel, closed by default
+
+   The rail and the inspector are opaque because they are content panes inside
+   the window, not window chrome. The one glass element on this surface is the
+   52px `<Toolbar>`.
+   ============================================================================ */
+
+.ask {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--surface-sunken);
+  container-type: inline-size;
+  color: var(--label);
+}
+
+
+/* ---- Sessions rail ------------------------------------------------------ */
+
+.ask-rail {
+  flex: none;
+  width: 220px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--surface);
+  border-right: 0.5px solid var(--separator);
+}
+.ask-rail-head {
+  flex: none;
+  padding: 8px 6px 4px;
+}
+/* Same 6px inset as the app sidebar's scroll region, so the chat rows land on
+   the same pill geometry as every other row in the app. */
+.ask-rail-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 6px 6px;
+}
+/* Rows slide under the footer — that is a scroll edge, and it gets a hairline. */
+.ask-rail-foot {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 14px;
+  border-top: 0.5px solid var(--separator);
+  font-size: var(--text-caption);
+  line-height: var(--leading-caption);
+  color: var(--label-secondary);
+}
+.ask-rail-foot .label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The rail owns focus in its own right, so its selected row takes the active
+   accent fill exactly like the app sidebar's does. */
+.ask-rail-list:focus-within .ws-sb-row.is-selected {
+  background: var(--accent-fill);
+  color: var(--on-accent);
+}
+.ask-rail-list:focus-within .ws-sb-row.is-selected .ws-sb-count,
+.ask-rail-list:focus-within .ws-sb-row.is-selected .ws-sb-trailing {
+  color: var(--on-accent);
+}
+
+/* ---- Conversation ------------------------------------------------------- */
+
+.ask-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.ask-toolbar-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+  font-weight: var(--weight-semibold);
+  color: var(--label);
+}
+.ask-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+/* One measure for the thread, the composer and the empty state, so nothing
+   shifts sideways as the conversation starts. */
+.ask-measure {
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 16px;
+}
+/* `margin-top: auto` sits a short conversation on the composer instead of
+   stranding two bubbles at the top of an empty pane. It still scrolls once the
+   thread outgrows the viewport. */
+.ask-thread {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: auto;
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+
+.ask-msg {
+  display: flex;
+}
+.ask-msg.is-user {
+  justify-content: flex-end;
+}
+.ask-bubble {
+  max-width: 88%;
+  padding: 8px 12px;
+  border-radius: var(--radius-card);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+  user-select: text;
+  -webkit-user-select: text;
+}
+/* --accent-fill, not --accent: a hue readable AS text on --surface is not the
+   same hue as one readable UNDER a white label (DESIGN.md §2). */
+.ask-msg.is-user .ask-bubble {
+  background: var(--accent-fill);
+  color: var(--on-accent);
+  white-space: pre-wrap;
+}
+.ask-msg.is-assistant .ask-bubble {
+  background: var(--surface);
+  border: 0.5px solid var(--separator);
+  color: var(--label);
+}
+
+/* Streaming caret. */
+.ask-caret {
+  display: inline-block;
+  width: 6px;
+  height: 14px;
+  margin-left: 2px;
+  border-radius: 2px;
+  background: var(--accent);
+  vertical-align: text-bottom;
+  animation: ask-caret-blink 1s steps(2, start) infinite;
+}
+@keyframes ask-caret-blink {
+  50% {
+    opacity: 0.2;
+  }
+}
+
+/* Typing indicator — three dots inside an assistant bubble, next to the word
+   for what is happening. Not a centred spinner standing in for a skeleton. */
+.ask-typing {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--text-callout);
+  line-height: var(--leading-callout);
+  color: var(--label-secondary);
+}
+.ask-dots {
+  display: flex;
+  gap: 4px;
+}
+.ask-dots span {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: ask-dot 1.2s ease-in-out infinite;
+}
+.ask-dots span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.ask-dots span:nth-child(3) {
+  animation-delay: 0.4s;
+}
+@keyframes ask-dot {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+/* Error — the chrome stays put and the retry sits with the sentence. */
+.ask-error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: var(--radius-card);
+  background: var(--surface);
+  border: 0.5px solid var(--separator);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+  color: var(--status-red);
+}
+.ask-error .msg {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ---- Empty state -------------------------------------------------------- */
+
+/* Hero, slash-command reference and starter questions centre as ONE group.
+   `.ws-center-empty` is `flex: 1` by default, which would push the hero to the
+   middle of the pane and strand the rest against the composer. */
+.ask-empty {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 16px;
+  padding-bottom: 16px;
+}
+.ask-empty > .ws-center-empty {
+  flex: none;
+  padding: 8px 24px 0;
+}
+.ask-slash-row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  min-height: 32px;
+  padding: 6px 12px;
+  border-bottom: 0.5px solid var(--separator);
+}
+.ask-slash-row:last-child {
+  border-bottom: 0;
+}
+.ask-slash-row code {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: var(--text-callout);
+  color: var(--accent);
+}
+.ask-slash-row span {
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+  color: var(--label-secondary);
+}
+.ask-suggest {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* ---- Composer ----------------------------------------------------------- */
+
+.ask-composer {
+  flex: none;
+  padding-top: 8px;
+  padding-bottom: 16px;
+  border-top: 0.5px solid var(--separator);
+  background: var(--surface-sunken);
+}
+.ask-composer-inner {
+  position: relative;
+}
+.ask-input {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 6px 6px 6px 12px;
+  background: var(--surface);
+  border: 0.5px solid var(--separator);
+  border-radius: var(--radius-card);
+}
+.ask-input:focus-within {
+  box-shadow: var(--focus-ring);
+}
+.ask-input textarea {
+  flex: 1;
+  min-width: 0;
+  min-height: 24px;
+  max-height: 140px;
+  padding: 4px 0;
+  background: transparent;
+  border: 0;
+  outline: none;
+  resize: none;
+  font-family: var(--font-ui);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+  color: var(--label);
+  user-select: text;
+  -webkit-user-select: text;
+}
+.ask-input textarea::placeholder {
+  color: var(--label-secondary);
+}
+
+/* Slash-command popover — a floating layer, so it is the one thing here that
+   gets a shadow. */
+.ask-slash-popover {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 100%;
+  z-index: 50;
+  margin-bottom: 6px;
+  overflow: hidden;
+  background: var(--surface-raised);
+  border: 0.5px solid var(--separator);
+  border-radius: var(--radius-popover);
+  box-shadow: var(--shadow-panel);
+}
+.ask-slash-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  height: 28px;
+  padding: 0 12px;
+  border: 0;
+  background: transparent;
+  font-family: inherit;
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+  color: var(--label);
+  text-align: left;
+  cursor: default;
+}
+.ask-slash-item:hover,
+.ask-slash-item.is-active {
+  background: var(--fill-quaternary);
+}
+.ask-slash-item code {
+  flex: none;
+  min-width: 76px;
+  font-family: var(--font-mono);
+  color: var(--accent);
+}
+.ask-slash-item .desc {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--label-secondary);
+}
+
+/* ---- Context inspector -------------------------------------------------- */
+
+.ask-inspector {
+  flex: none;
+  width: 280px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--surface);
+  border-left: 0.5px solid var(--separator);
+}
+.ask-inspector-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 8px 6px 16px;
+}
+/* A <Section> lays its children out with an 8px gap, which is the spacing
+   between the header and the group — not between rows inside it. */
+.ask-rows {
+  display: flex;
+  flex-direction: column;
+}
+/* A decision has no target to open, so its row must not offer a hover fill it
+   cannot act on. */
+.ws-sb-row.is-static:hover {
+  background: transparent;
+}
+
+/* ---- Markdown ----------------------------------------------------------- */
+/* Assistant answers are body text on --surface: three sizes total (13 body,
+   12 code/table, 11 table header) and no size below 11px. */
+
+.ask-md > :first-child {
+  margin-top: 0;
+}
+.ask-md > :last-child {
+  margin-bottom: 0;
+}
+.ask-md p {
+  margin: 8px 0;
+}
+.ask-md ul,
+.ask-md ol {
+  margin: 8px 0;
+  padding-left: 20px;
+  list-style: revert;
+}
+.ask-md li {
+  margin-bottom: 4px;
+}
+.ask-md h1,
+.ask-md h2,
+.ask-md h3 {
+  margin: 12px 0 4px;
+  font-weight: var(--weight-semibold);
+}
+.ask-md h1 {
+  font-size: var(--text-title-3);
+  line-height: var(--leading-title-3);
+}
+.ask-md h2,
+.ask-md h3 {
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+}
+.ask-md a {
+  color: var(--accent);
+}
+.ask-md strong {
+  font-weight: var(--weight-semibold);
+}
+.ask-md blockquote {
+  margin: 8px 0;
+  padding-left: 12px;
+  border-left: 2px solid var(--separator);
+  color: var(--label-secondary);
+}
+.ask-md :not(pre) > code {
+  padding: 0 4px;
+  border-radius: var(--radius-row);
+  background: var(--fill-quaternary);
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+}
+.ask-table-wrap {
+  margin: 8px 0;
+  overflow-x: auto;
+}
+.ask-md table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-callout);
+  line-height: var(--leading-callout);
+}
+.ask-md th {
+  padding: 4px 8px;
+  border-bottom: 0.5px solid var(--separator);
+  font-size: var(--text-caption);
+  font-weight: var(--weight-semibold);
+  color: var(--label-secondary);
+  text-align: left;
+}
+.ask-md td {
+  padding: 4px 8px;
+  border-bottom: 0.5px solid var(--separator);
+}
+
+/* Code block. The copy button is permanent — a copy action has no second home
+   to be revealed from, so it may not be hover-only. */
+.ask-code {
+  position: relative;
+  margin: 8px 0;
+}
+.ask-code pre {
+  margin: 0;
+  padding: 8px 40px 8px 12px;
+  overflow-x: auto;
+  background: var(--surface-sunken);
+  border: 0.5px solid var(--separator);
+  border-radius: var(--radius-input);
+}
+.ask-code code {
+  font-family: var(--font-mono);
+  font-size: var(--text-callout);
+  line-height: var(--leading-callout);
+}
+/* Opaque backing: the code scrolls horizontally UNDER this button, and a
+   transparent icon button over moving glyphs is unreadable. */
+.ask-code .ask-copy {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: var(--surface-sunken);
+  box-shadow: 0 0 0 4px var(--surface-sunken);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ask-caret,
+  .ask-dots span {
+    animation: none;
+  }
+}
+
+/* ---- Column collapse ---------------------------------------------------- */
+/* The way NavigationSplitView does it. At the window minimum (640px) the app
+   sidebar already takes 220, and three more columns do not fit in what is
+   left — without this the conversation collapses to zero width and the
+   inspector paints over the toolbar. Trailing columns drop first.
+
+   These rules must stay LAST in the file: a container query carries no extra
+   specificity, so `.ask-inspector { display: flex }` above would win on order
+   alone. */
+@container (max-width: 720px) {
+  .ask-inspector,
+  .ask-inspector-toggle {
+    display: none;
+  }
+}
+@container (max-width: 480px) {
+  .ask-rail {
+    display: none;
+  }
+}

--- a/packages/app/src/renderer/tabs/AskTab.tsx
+++ b/packages/app/src/renderer/tabs/AskTab.tsx
@@ -1,6 +1,27 @@
+/* Ask — chat over the project's index (TRA-312 macOS 26 migration).
+
+   The network layer (sessions, SSE streaming, slash commands) is unchanged;
+   what moved is the presentation. Everything this file draws now comes from
+   `lattice/ui` and `styles/ask.css`, which reads tokens.css. See DESIGN.md.
+
+   Layout: 220px chat rail · toolbar + thread + composer · 280px context
+   inspector (closed by default — it is empty until a message is sent). */
+
 import { useCallback, useEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { Icon } from '../lattice/icons';
+import {
+  Button,
+  Card,
+  EmptyState,
+  IslandHeader,
+  Section,
+  Skeleton,
+  StatusDot,
+  Toolbar,
+} from '../lattice/ui';
+import { splitPath } from '../sidebar-prefs.js';
 
 const BASE = 'http://127.0.0.1:3741';
 
@@ -46,6 +67,8 @@ const SLASH_COMMANDS: SlashCommand[] = [
   { name: 'scan', usage: '/scan', description: 'Run security scan (OWASP top findings)', needsArgs: false },
 ];
 
+const SUGGESTIONS = ['How does auth work?', 'Explain the plugin system', 'Where are API routes?'];
+
 /** Parse slash command from input. Returns null if not a slash command. */
 function parseSlash(input: string): { command: string; args: string } | null {
   if (!input.startsWith('/')) return null;
@@ -67,6 +90,7 @@ function matchSlash(input: string): SlashCommand[] {
 // ── LocalStorage helpers ─────────────────────────────────────────────
 
 const lastSessionKey = (root: string) => `trace-mcp:current-chat-session-${root}`;
+const PANEL_KEY = 'trace-mcp.ask.context-panel';
 
 function loadLastSessionId(root: string): string | null {
   try {
@@ -83,6 +107,16 @@ function saveLastSessionId(root: string, id: string | null): void {
   } catch {}
 }
 
+/** The inspector starts closed: it has nothing in it until a message is sent,
+    and 280px of "appears here after you send a message" is not worth it. */
+function loadPanelOpen(): boolean {
+  try {
+    return localStorage.getItem(PANEL_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
 // ── Component ────────────────────────────────────────────────────────
 
 export function AskTab({ root }: { root: string }) {
@@ -96,10 +130,13 @@ export function AskTab({ root }: { root: string }) {
   const [error, setError] = useState<string | null>(null);
   const [provider, setProvider] = useState<string | null>(null);
   const [providerReady, setProviderReady] = useState(false);
-  const [panelOpen, setPanelOpen] = useState(true);
+  const [panelOpen, setPanelOpen] = useState(loadPanelOpen);
   const [loadingSession, setLoadingSession] = useState(false);
   const [slashSuggestions, setSlashSuggestions] = useState<SlashCommand[]>([]);
   const [slashIndex, setSlashIndex] = useState(0);
+  /* Toolbar scroll-edge hairline — the thread scrolls UNDER the bar, so the
+     rule fades in on scroll instead of being painted permanently. */
+  const [scrolled, setScrolled] = useState(false);
 
   const abortRef = useRef<AbortController | null>(null);
   const endRef = useRef<HTMLDivElement>(null);
@@ -107,6 +144,15 @@ export function AskTab({ root }: { root: string }) {
 
   const ok = provider !== null;
   const busy = phase === 'retrieving' || phase === 'streaming';
+
+  const togglePanel = useCallback(() => {
+    setPanelOpen((v) => {
+      try {
+        localStorage.setItem(PANEL_KEY, v ? '0' : '1');
+      } catch {}
+      return !v;
+    });
+  }, []);
 
   // Provider detection
   useEffect(() => {
@@ -207,8 +253,7 @@ export function AskTab({ root }: { root: string }) {
 
   // Delete a session
   const deleteSession = useCallback(
-    async (id: string, e: React.MouseEvent) => {
-      e.stopPropagation();
+    async (id: string) => {
       try {
         await fetch(`${BASE}/api/ask/sessions/${encodeURIComponent(id)}`, { method: 'DELETE' });
         if (activeSessionId === id) {
@@ -239,6 +284,11 @@ export function AskTab({ root }: { root: string }) {
     } else {
       setSlashSuggestions([]);
     }
+  }, []);
+
+  const prefill = useCallback((value: string) => {
+    setInput(value);
+    taRef.current?.focus();
   }, []);
 
   // Send a slash command (POST to /slash endpoint, get JSON back)
@@ -311,12 +361,14 @@ export function AskTab({ root }: { root: string }) {
         await loadSessions();
       } catch (e) {
         setError((e as Error).message ?? 'Failed to create session');
+        setInput(q);
         return;
       }
     }
 
     if (!sessionId) {
       setError('Could not establish a chat session');
+      setInput(q);
       return;
     }
 
@@ -436,6 +488,9 @@ export function AskTab({ root }: { root: string }) {
       setPhase('error');
       setStreaming('');
       setStreamingEnvelope(null);
+      /* Put the question back in the composer: a failed send must not cost the
+         user what they typed, and it makes "Send again" a single click. */
+      setInput(q);
     } finally {
       abortRef.current = null;
     }
@@ -455,562 +510,265 @@ export function AskTab({ root }: { root: string }) {
   if (providerReady && !ok) {
     return (
       <div
-        className="flex flex-col items-center justify-center h-full"
-        style={{ WebkitAppRegion: 'no-drag', gap: 20 } as React.CSSProperties}
+        className="ask"
+        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
-        <div
-          style={{
-            width: 56,
-            height: 56,
-            borderRadius: 16,
-            background: 'var(--fill-control)',
-            backdropFilter: 'blur(20px)',
-            WebkitBackdropFilter: 'blur(20px)',
-            border: '0.5px solid var(--border)',
-            boxShadow: 'var(--shadow-grouped)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          <svg
-            width="26"
-            height="26"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="var(--text-tertiary)"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-          </svg>
-        </div>
-        <div style={{ textAlign: 'center' }}>
-          <div
-            style={{
-              fontSize: 15,
-              fontWeight: 600,
-              color: 'var(--text-primary)',
-              letterSpacing: '-0.2px',
-            }}
-          >
-            Connect an AI provider
-          </div>
-          <div
-            style={{ fontSize: 11, color: 'var(--text-secondary)', marginTop: 4, lineHeight: '1.5' }}
-          >
-            Required for Ask to work
-          </div>
-        </div>
-        <button
-          onClick={openSettings}
-          type="button"
-          style={{
-            fontSize: 13,
-            fontWeight: 500,
-            color: '#fff',
-            background: 'var(--accent)',
-            border: 'none',
-            borderRadius: 8,
-            padding: '8px 24px',
-            cursor: 'pointer',
-            boxShadow: 'var(--shadow-control)',
-            letterSpacing: '-0.1px',
-          }}
-        >
-          AI Settings...
-        </button>
+        <EmptyState
+          icon="forum"
+          title="Connect an AI provider"
+          subtitle="Ask answers questions about this project using a model you supply. Add one in Settings to turn it on."
+          action={
+            <Button variant="prominent" size="large" onClick={openSettings}>
+              Open AI settings
+            </Button>
+          }
+        />
       </div>
     );
   }
 
+  const activeSession = sessions.find((s) => s.id === activeSessionId) ?? null;
+  const title = activeSession?.title?.trim() || 'New chat';
+  const providerLabel = !providerReady ? 'Connecting…' : (provider ?? 'No provider');
+
   // ── Main layout ───────────────────────────────────────────────────
   return (
-    <div
-      className="flex h-full"
-      style={{ WebkitAppRegion: 'no-drag', overflow: 'hidden' } as React.CSSProperties}
-    >
-      {/* ── Sessions sidebar (240px) ─────────────────────────────── */}
-      <div
-        style={{
-          width: 240,
-          flexShrink: 0,
-          display: 'flex',
-          flexDirection: 'column',
-          borderRight: '0.5px solid var(--border)',
-          background: 'var(--bg-sidebar, var(--bg-grouped))',
-          overflow: 'hidden',
-        }}
-      >
-        {/* Sidebar header */}
-        <div
-          style={{
-            padding: '10px 10px 6px',
-            flexShrink: 0,
-          }}
-        >
-          <button
-            type="button"
-            onClick={createSession}
-            style={{
-              width: '100%',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              padding: '7px 10px',
-              borderRadius: 8,
-              background: 'var(--fill-control)',
-              border: '0.5px solid var(--border)',
-              boxShadow: 'var(--shadow-control)',
-              color: 'var(--text-primary)',
-              fontSize: 12,
-              fontWeight: 500,
-              cursor: 'pointer',
-              fontFamily: 'inherit',
-            }}
-          >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 12 12"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.8"
-              strokeLinecap="round"
-            >
-              <line x1="6" y1="1" x2="6" y2="11" />
-              <line x1="1" y1="6" x2="11" y2="6" />
-            </svg>
+    <div className="ask" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
+      {/* ── Chat rail ─────────────────────────────────────────────── */}
+      <aside className="ask-rail" aria-label="Chats">
+        <div className="ask-rail-head">
+          <Button icon="add" onClick={createSession} style={{ width: '100%' }}>
             New chat
-          </button>
+          </Button>
         </div>
 
-        {/* Session list */}
-        <div style={{ flex: 1, overflowY: 'auto', padding: '0 6px 8px' }}>
-          {sessions.length === 0 && (
-            <div
-              style={{
-                fontSize: 10,
-                color: 'var(--text-tertiary)',
-                textAlign: 'center',
-                padding: '20px 8px',
-              }}
-            >
-              No chats yet
-            </div>
+        <div className="ask-rail-list">
+          {sessions.length === 0 ? (
+            <div className="ws-sb-empty">No chats yet.</div>
+          ) : (
+            sessions.map((s) => (
+              <SessionRow
+                key={s.id}
+                session={s}
+                active={s.id === activeSessionId}
+                onSelect={() => selectSession(s.id)}
+                onDelete={() => deleteSession(s.id)}
+              />
+            ))
           )}
-          {sessions.map((s) => (
-            <SessionItem
-              key={s.id}
-              session={s}
-              active={s.id === activeSessionId}
-              onSelect={() => selectSession(s.id)}
-              onDelete={(e) => deleteSession(s.id, e)}
-            />
-          ))}
         </div>
 
-        {/* Provider status */}
-        <div
-          style={{
-            flexShrink: 0,
-            padding: '6px 10px',
-            borderTop: '0.5px solid var(--border)',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 5,
-          }}
-        >
-          <span
-            style={{
-              width: 5,
-              height: 5,
-              borderRadius: '50%',
-              background: ok ? 'var(--success)' : 'var(--text-tertiary)',
-              flexShrink: 0,
-            }}
+        {/* Provider state — a dot AND the word, never colour alone. */}
+        <div className="ask-rail-foot">
+          <StatusDot tone={ok ? 'green' : 'orange'} size={6} />
+          <span className="label">{providerLabel}</span>
+        </div>
+      </aside>
+
+      {/* ── Conversation ──────────────────────────────────────────── */}
+      <section className="ask-main">
+        <Toolbar scrolled={scrolled}>
+          <span className="ask-toolbar-title">{title}</span>
+          <span className="flex-1" />
+          <Button
+            className="ask-inspector-toggle"
+            variant="icon"
+            icon="dock_to_right"
+            active={panelOpen}
+            onClick={togglePanel}
+            aria-pressed={panelOpen}
+            aria-label={panelOpen ? 'Hide the context panel' : 'Show the context panel'}
+            title={panelOpen ? 'Hide context' : 'Show context'}
           />
-          <span
-            style={{
-              fontSize: 10,
-              color: 'var(--text-tertiary)',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {!providerReady ? 'Connecting...' : (provider ?? 'No provider')}
-          </span>
-        </div>
-      </div>
+        </Toolbar>
 
-      {/* ── Chat area (flex-1) ───────────────────────────────────── */}
-      <div
-        style={{
-          flex: 1,
-          minWidth: 0,
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
-        }}
-      >
-        {/* Messages */}
         <div
-          className="flex-1 min-h-0 overflow-y-auto"
-          style={{ padding: '0 2px' }}
+          className="ask-scroll"
+          onScroll={(e) => setScrolled(e.currentTarget.scrollTop > 0)}
         >
-          {/* Empty / no session state — shows slash-command hint card */}
-          {!activeSessionId && !loadingSession && (
-            <div className="flex flex-col items-center justify-center h-full" style={{ gap: 16 }}>
-              <div
-                style={{
-                  fontSize: 11,
-                  color: 'var(--text-tertiary)',
-                  textAlign: 'center',
-                  maxWidth: 240,
-                }}
-              >
-                Ask anything about this codebase
-              </div>
-              {/* Slash-command hint card */}
-              <div
-                style={{
-                  background: 'var(--fill-control)',
-                  border: '0.5px solid var(--border)',
-                  borderRadius: 10,
-                  padding: '10px 14px',
-                  maxWidth: 300,
-                  width: '100%',
-                }}
-              >
-                <div style={{ fontSize: 9, fontWeight: 600, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.5px', marginBottom: 8 }}>
-                  Slash commands
-                </div>
-                {SLASH_COMMANDS.map((cmd) => (
-                  <div
-                    key={cmd.name}
-                    style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 5 }}
-                  >
-                    <code
-                      style={{
-                        fontSize: 10,
-                        color: 'var(--accent)',
-                        background: 'rgba(0,122,255,0.08)',
-                        borderRadius: 4,
-                        padding: '1px 5px',
-                        flexShrink: 0,
-                        fontFamily: 'monospace',
-                      }}
-                    >
-                      {cmd.usage}
-                    </code>
-                    <span style={{ fontSize: 10, color: 'var(--text-secondary)' }}>
-                      {cmd.description}
-                    </span>
+          {loadingSession ? (
+            <div className="ask-measure ask-thread" role="status" aria-label="Loading chat">
+              {[0, 1, 2].map((i) => (
+                <div key={i} className={`ask-msg ${i % 2 ? 'is-user' : 'is-assistant'}`}>
+                  <div className="ask-bubble">
+                    <Skeleton width={180 + i * 40} height={13} />
                   </div>
-                ))}
-              </div>
-              <div
-                style={{
-                  display: 'flex',
-                  flexWrap: 'wrap',
-                  justifyContent: 'center',
-                  gap: 6,
-                  maxWidth: 340,
-                }}
-              >
-                {['How does auth work?', 'Explain the plugin system', 'Where are API routes?'].map(
-                  (q) => (
-                    <button
-                      type="button"
-                      key={q}
-                      onClick={() => {
-                        setInput(q);
-                        taRef.current?.focus();
-                      }}
-                      style={{
-                        fontSize: 10,
-                        padding: '5px 10px',
-                        borderRadius: 8,
-                        background: 'var(--fill-control)',
-                        backdropFilter: 'blur(12px)',
-                        WebkitBackdropFilter: 'blur(12px)',
-                        border: '0.5px solid var(--border)',
-                        boxShadow: 'var(--shadow-control)',
-                        color: 'var(--text-secondary)',
-                        cursor: 'pointer',
-                      }}
-                    >
-                      {q}
-                    </button>
-                  ),
-                )}
-              </div>
-            </div>
-          )}
-
-          {loadingSession && (
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                height: '100%',
-              }}
-            >
-              <Dots />
-            </div>
-          )}
-
-          {/* Bubbles */}
-          {messages.map((m) => (
-            <Bubble key={m.id} msg={m} />
-          ))}
-
-          {/* Streaming bubble */}
-          {streaming && (
-            <div style={{ display: 'flex', padding: '3px 2px' }}>
-              <div style={{ ...assistantStyle, maxWidth: '88%' }}>
-                <MarkdownBody content={streaming} />
-                <span
-                  style={{
-                    display: 'inline-block',
-                    width: 6,
-                    height: 14,
-                    marginLeft: 2,
-                    borderRadius: 2,
-                    background: 'var(--accent)',
-                    verticalAlign: 'text-bottom',
-                    animation: 'pulse 1s infinite',
-                  }}
-                />
-              </div>
-            </div>
-          )}
-
-          {/* Phase indicator */}
-          {busy && !streaming && (
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 4px' }}>
-              <Dots />
-              <span style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>
-                {phase === 'retrieving' ? 'Searching codebase...' : 'Thinking...'}
-              </span>
-            </div>
-          )}
-
-          {/* Error */}
-          {error && (
-            <div
-              style={{
-                margin: '4px 2px',
-                padding: '8px 12px',
-                borderRadius: 10,
-                fontSize: 11,
-                color: 'var(--destructive)',
-                background: 'rgba(255,59,48,0.06)',
-                border: '0.5px solid rgba(255,59,48,0.15)',
-              }}
-            >
-              {error}
-            </div>
-          )}
-          <div ref={endRef} />
-        </div>
-
-        {/* Input bar + slash popup */}
-        <div style={{ padding: '8px 2px 4px', flexShrink: 0, position: 'relative' }}>
-          {/* Slash command popup */}
-          {slashSuggestions.length > 0 && (
-            <div
-              style={{
-                position: 'absolute',
-                bottom: '100%',
-                left: 2,
-                right: 2,
-                marginBottom: 4,
-                background: 'var(--bg-grouped)',
-                border: '0.5px solid var(--border)',
-                borderRadius: 10,
-                boxShadow: 'var(--shadow-grouped)',
-                overflow: 'hidden',
-                zIndex: 50,
-              }}
-            >
-              {slashSuggestions.map((cmd, i) => (
-                <button
-                  type="button"
-                  key={cmd.name}
-                  onClick={() => {
-                    setInput(`/${cmd.name}${cmd.needsArgs ? ' ' : ''}`);
-                    setSlashSuggestions([]);
-                    taRef.current?.focus();
-                  }}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 10,
-                    width: '100%',
-                    padding: '7px 12px',
-                    background: i === slashIndex ? 'var(--accent-tint, rgba(0,122,255,0.08))' : 'none',
-                    border: 'none',
-                    cursor: 'pointer',
-                    textAlign: 'left',
-                    borderBottom: i < slashSuggestions.length - 1 ? '0.5px solid var(--border)' : 'none',
-                  }}
-                >
-                  <code
-                    style={{
-                      fontSize: 11,
-                      color: 'var(--accent)',
-                      fontFamily: 'monospace',
-                      minWidth: 80,
-                    }}
-                  >
-                    /{cmd.name}
-                  </code>
-                  <span style={{ fontSize: 10, color: 'var(--text-secondary)' }}>
-                    {cmd.description}
-                  </span>
-                  <span style={{ fontSize: 9, color: 'var(--text-tertiary)', marginLeft: 'auto', whiteSpace: 'nowrap' }}>
-                    {cmd.usage}
-                  </span>
-                </button>
+                </div>
               ))}
             </div>
-          )}
+          ) : messages.length === 0 && !streaming && !busy && !error ? (
+            <div className="ask-measure ask-empty">
+              <EmptyState
+                icon="forum"
+                title="Ask anything about this codebase"
+                subtitle="Answers are grounded in the indexed graph — the files, symbols and decisions this project already has."
+              />
+              <Section title="Slash commands">
+                <Card>
+                  {SLASH_COMMANDS.map((cmd) => (
+                    <div key={cmd.name} className="ask-slash-row">
+                      <code>{cmd.usage}</code>
+                      <span>{cmd.description}</span>
+                    </div>
+                  ))}
+                </Card>
+              </Section>
+              <div className="ask-suggest">
+                {SUGGESTIONS.map((q) => (
+                  <Button key={q} size="small" onClick={() => prefill(q)}>
+                    {q}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div
+              className="ask-measure ask-thread"
+              role="log"
+              aria-live="polite"
+              aria-label="Conversation"
+            >
+              {messages.map((m) => (
+                <Bubble key={m.id} msg={m} />
+              ))}
 
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'flex-end',
-              gap: 6,
-              padding: '8px 12px',
-              borderRadius: 12,
-              background: 'var(--fill-control)',
-              backdropFilter: 'blur(20px)',
-              WebkitBackdropFilter: 'blur(20px)',
-              border: '0.5px solid var(--border)',
-              boxShadow: 'var(--shadow-control)',
-            }}
-          >
-            <textarea
-              ref={taRef}
-              value={input}
-              onChange={(e) => {
-                setInput(e.target.value);
-                grow();
-                updateSlash(e.target.value);
-              }}
-              onKeyDown={(e) => {
-                // Arrow keys navigate slash popup
-                if (slashSuggestions.length > 0) {
-                  if (e.key === 'ArrowDown') {
-                    e.preventDefault();
-                    setSlashIndex((i) => (i + 1) % slashSuggestions.length);
-                    return;
-                  }
-                  if (e.key === 'ArrowUp') {
-                    e.preventDefault();
-                    setSlashIndex((i) => (i - 1 + slashSuggestions.length) % slashSuggestions.length);
-                    return;
-                  }
-                  if (e.key === 'Tab' || e.key === 'Enter') {
-                    e.preventDefault();
-                    const chosen = slashSuggestions[slashIndex];
-                    if (chosen) {
-                      setInput(`/${chosen.name}${chosen.needsArgs ? ' ' : ''}`);
+              {streaming && (
+                <div className="ask-msg is-assistant">
+                  <div className="ask-bubble">
+                    <MarkdownBody content={streaming} />
+                    <span className="ask-caret" aria-hidden="true" />
+                  </div>
+                </div>
+              )}
+
+              {busy && !streaming && (
+                <div className="ask-msg is-assistant">
+                  <div className="ask-bubble ask-typing">
+                    <span className="ask-dots" aria-hidden="true">
+                      <span />
+                      <span />
+                      <span />
+                    </span>
+                    {phase === 'retrieving' ? 'Searching the codebase' : 'Thinking'}
+                  </div>
+                </div>
+              )}
+
+              {error && (
+                <div className="ask-error" role="alert">
+                  <Icon name="warning" size={14} />
+                  <span className="msg">{error}</span>
+                  <Button size="small" onClick={send} disabled={!input.trim() || busy}>
+                    Send again
+                  </Button>
+                </div>
+              )}
+              <div ref={endRef} />
+            </div>
+          )}
+        </div>
+
+        {/* ── Composer ────────────────────────────────────────────── */}
+        <div className="ask-composer">
+          <div className="ask-measure ask-composer-inner">
+            {slashSuggestions.length > 0 && (
+              <div className="ask-slash-popover" role="listbox" aria-label="Slash commands">
+                {slashSuggestions.map((cmd, i) => (
+                  <button
+                    type="button"
+                    key={cmd.name}
+                    role="option"
+                    aria-selected={i === slashIndex}
+                    className={`ask-slash-item${i === slashIndex ? ' is-active' : ''}`}
+                    onClick={() => {
+                      setInput(`/${cmd.name}${cmd.needsArgs ? ' ' : ''}`);
                       setSlashSuggestions([]);
-                    }
-                    return;
-                  }
-                  if (e.key === 'Escape') {
-                    setSlashSuggestions([]);
-                    return;
-                  }
-                }
-                if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-                  e.preventDefault();
-                  send();
-                }
-              }}
-              placeholder="Ask about your code... (⌘↵ to send, / for commands)"
-              rows={1}
-              disabled={!ok}
-              style={{
-                flex: 1,
-                background: 'transparent',
-                border: 'none',
-                outline: 'none',
-                resize: 'none',
-                fontSize: 12,
-                color: 'var(--text-primary)',
-                fontFamily: 'inherit',
-                minHeight: 20,
-                maxHeight: 140,
-                lineHeight: '1.5',
-              }}
-            />
-            {busy ? (
-              <button
-                type="button"
-                onClick={() => abortRef.current?.abort()}
-                title="Stop"
-                style={{
-                  ...btnBase,
-                  width: 28,
-                  height: 28,
-                  borderRadius: 8,
-                  background: 'rgba(255,59,48,0.1)',
-                  color: 'var(--destructive)',
-                }}
-              >
-                <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor">
-                  <rect width="10" height="10" rx="2" />
-                </svg>
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={send}
-                disabled={!input.trim() || !ok}
-                title="Send (⌘↵)"
-                style={{
-                  ...btnBase,
-                  width: 28,
-                  height: 28,
-                  borderRadius: 8,
-                  background: input.trim() && ok ? 'var(--accent)' : 'transparent',
-                  color: input.trim() && ok ? '#fff' : 'var(--text-tertiary)',
-                  cursor: input.trim() && ok ? 'pointer' : 'default',
-                  transition: 'all 0.15s',
-                }}
-              >
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <line x1="12" y1="19" x2="12" y2="5" />
-                  <polyline points="5 12 12 5 19 12" />
-                </svg>
-              </button>
+                      taRef.current?.focus();
+                    }}
+                  >
+                    <code>/{cmd.name}</code>
+                    <span className="desc">{cmd.description}</span>
+                  </button>
+                ))}
+              </div>
             )}
+
+            <div className="ask-input">
+              <textarea
+                ref={taRef}
+                value={input}
+                aria-label="Ask about this project"
+                onChange={(e) => {
+                  setInput(e.target.value);
+                  grow();
+                  updateSlash(e.target.value);
+                }}
+                onKeyDown={(e) => {
+                  // Arrow keys navigate slash popup
+                  if (slashSuggestions.length > 0) {
+                    if (e.key === 'ArrowDown') {
+                      e.preventDefault();
+                      setSlashIndex((i) => (i + 1) % slashSuggestions.length);
+                      return;
+                    }
+                    if (e.key === 'ArrowUp') {
+                      e.preventDefault();
+                      setSlashIndex((i) => (i - 1 + slashSuggestions.length) % slashSuggestions.length);
+                      return;
+                    }
+                    if (e.key === 'Tab' || e.key === 'Enter') {
+                      e.preventDefault();
+                      const chosen = slashSuggestions[slashIndex];
+                      if (chosen) {
+                        setInput(`/${chosen.name}${chosen.needsArgs ? ' ' : ''}`);
+                        setSlashSuggestions([]);
+                      }
+                      return;
+                    }
+                    if (e.key === 'Escape') {
+                      setSlashSuggestions([]);
+                      return;
+                    }
+                  }
+                  if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    send();
+                  }
+                }}
+                placeholder="Ask about this project, or type / for commands"
+                rows={1}
+                disabled={!ok}
+              />
+              {busy ? (
+                <Button
+                  variant="icon"
+                  icon="stop"
+                  onClick={() => abortRef.current?.abort()}
+                  aria-label="Stop generating"
+                  title="Stop generating"
+                />
+              ) : (
+                <Button
+                  variant="prominent"
+                  icon="arrow_upward"
+                  iconSize={16}
+                  onClick={send}
+                  disabled={!input.trim() || !ok}
+                  size="large"
+                  aria-label="Send message"
+                  title="Send (⌘↵)"
+                  style={{ width: 28, padding: 0 }}
+                />
+              )}
+            </div>
           </div>
         </div>
-      </div>
+      </section>
 
-      {/* ── Transparency panel (280px, collapsible) ──────────────── */}
-      <TransparencyPanel
-        envelope={lastAssistantEnvelope}
-        open={panelOpen}
-        onToggle={() => setPanelOpen((v) => !v)}
-      />
+      {/* ── Context inspector ─────────────────────────────────────── */}
+      {panelOpen && (
+        <ContextInspector envelope={lastAssistantEnvelope} onClose={togglePanel} />
+      )}
     </div>
   );
 }
@@ -1029,428 +787,167 @@ function CodeBlock({ children, className }: { children?: React.ReactNode; classN
   }, [code]);
 
   return (
-    <div style={{ position: 'relative' }} className="group">
-      <pre
-        style={{
-          background: 'var(--bg-code, rgba(0,0,0,0.06))',
-          borderRadius: 7,
-          padding: '8px 10px',
-          overflowX: 'auto',
-          fontSize: 11,
-          lineHeight: '1.5',
-          margin: '6px 0',
-          border: '0.5px solid var(--border)',
-        }}
-      >
-        <code className={className} style={{ fontFamily: 'monospace' }}>
-          {code}
-        </code>
+    <div className="ask-code">
+      <pre>
+        <code className={className}>{code}</code>
       </pre>
-      <button
-        type="button"
+      <Button
+        className="ask-copy"
+        variant="icon"
+        icon={copied ? 'check' : 'content_copy'}
         onClick={copy}
-        title="Copy code"
-        style={{
-          position: 'absolute',
-          top: 5,
-          right: 6,
-          fontSize: 9,
-          padding: '2px 7px',
-          borderRadius: 5,
-          background: copied ? 'var(--success, #34c759)' : 'var(--fill-control)',
-          border: '0.5px solid var(--border)',
-          color: copied ? '#fff' : 'var(--text-secondary)',
-          cursor: 'pointer',
-          transition: 'all 0.15s',
-          opacity: 0.85,
-        }}
-      >
-        {copied ? 'Copied!' : 'Copy'}
-      </button>
+        aria-label={copied ? 'Copied' : 'Copy code'}
+        title={copied ? 'Copied' : 'Copy code'}
+      />
     </div>
-  );
-}
-
-function InlineCode({ children }: { children?: React.ReactNode }) {
-  return (
-    <code
-      style={{
-        fontFamily: 'monospace',
-        fontSize: '0.9em',
-        background: 'var(--bg-code, rgba(0,0,0,0.06))',
-        borderRadius: 4,
-        padding: '1px 4px',
-        border: '0.5px solid var(--border)',
-      }}
-    >
-      {children}
-    </code>
   );
 }
 
 function MarkdownBody({ content }: { content: string }) {
   return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
-      components={{
-        // react-markdown v9: block code lives inside a <pre> node in the hast tree.
-        // The `pre` override receives the block code child; we render CodeBlock there.
-        // The `code` override is only reached for inline code (not wrapped in <pre>).
-        pre({ children }) {
-          // children is the <code> element from react-markdown — unwrap and render as CodeBlock.
-          // biome-ignore lint/suspicious/noExplicitAny: react-markdown child is untyped
-          const codeEl = children as any;
-          const className = codeEl?.props?.className ?? '';
-          const content = String(codeEl?.props?.children ?? '').replace(/\n$/, '');
-          return <CodeBlock className={className}>{content}</CodeBlock>;
-        },
-        // biome-ignore lint/suspicious/noExplicitAny: react-markdown passes untyped props
-        code({ className, children, ...props }: any) {
-          // Only reached for inline code (block code is intercepted by `pre` above).
-          return <InlineCode {...props}>{children}</InlineCode>;
-        },
-        p({ children }) {
-          return <p style={{ margin: '4px 0', lineHeight: '1.55' }}>{children}</p>;
-        },
-        ul({ children }) {
-          return <ul style={{ paddingLeft: 16, margin: '4px 0' }}>{children}</ul>;
-        },
-        ol({ children }) {
-          return <ol style={{ paddingLeft: 16, margin: '4px 0' }}>{children}</ol>;
-        },
-        li({ children }) {
-          return <li style={{ marginBottom: 2 }}>{children}</li>;
-        },
-        h1({ children }) {
-          return <h1 style={{ fontSize: 14, fontWeight: 700, margin: '8px 0 4px' }}>{children}</h1>;
-        },
-        h2({ children }) {
-          return <h2 style={{ fontSize: 13, fontWeight: 600, margin: '6px 0 3px' }}>{children}</h2>;
-        },
-        h3({ children }) {
-          return <h3 style={{ fontSize: 12, fontWeight: 600, margin: '4px 0 2px' }}>{children}</h3>;
-        },
-        table({ children }) {
-          return (
-            <div style={{ overflowX: 'auto', margin: '6px 0' }}>
-              <table style={{ borderCollapse: 'collapse', fontSize: 11, width: '100%' }}>{children}</table>
-            </div>
-          );
-        },
-        th({ children }) {
-          return (
-            <th
-              style={{
-                padding: '4px 8px',
-                borderBottom: '1px solid var(--border)',
-                textAlign: 'left',
-                fontWeight: 600,
-                fontSize: 10,
-                color: 'var(--text-secondary)',
-              }}
-            >
-              {children}
-            </th>
-          );
-        },
-        td({ children }) {
-          return (
-            <td
-              style={{
-                padding: '3px 8px',
-                borderBottom: '0.5px solid var(--border)',
-                fontSize: 10,
-              }}
-            >
-              {children}
-            </td>
-          );
-        },
-        blockquote({ children }) {
-          return (
-            <blockquote
-              style={{
-                borderLeft: '3px solid var(--accent)',
-                paddingLeft: 10,
-                margin: '4px 0',
-                color: 'var(--text-secondary)',
-                fontStyle: 'italic',
-              }}
-            >
-              {children}
-            </blockquote>
-          );
-        },
-        strong({ children }) {
-          return <strong style={{ fontWeight: 600 }}>{children}</strong>;
-        },
-        em({ children }) {
-          return <em style={{ fontStyle: 'italic' }}>{children}</em>;
-        },
-      }}
-    >
-      {content}
-    </ReactMarkdown>
+    <div className="ask-md">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          // react-markdown v9: block code lives inside a <pre> node in the hast tree.
+          // The `pre` override receives the block code child; we render CodeBlock there.
+          // The `code` override is only reached for inline code (not wrapped in <pre>).
+          pre({ children }) {
+            // children is the <code> element from react-markdown — unwrap and render as CodeBlock.
+            // biome-ignore lint/suspicious/noExplicitAny: react-markdown child is untyped
+            const codeEl = children as any;
+            const className = codeEl?.props?.className ?? '';
+            const content = String(codeEl?.props?.children ?? '').replace(/\n$/, '');
+            return <CodeBlock className={className}>{content}</CodeBlock>;
+          },
+          table({ children }) {
+            return (
+              <div className="ask-table-wrap">
+                <table>{children}</table>
+              </div>
+            );
+          },
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
   );
 }
 
-// ── Transparency panel ────────────────────────────────────────────────
+// ── Context inspector ────────────────────────────────────────────────
 
-function TransparencyPanel({
+function ContextInspector({
   envelope,
-  open,
-  onToggle,
+  onClose,
 }: {
   envelope: ContextEnvelope | null;
-  open: boolean;
-  onToggle: () => void;
+  onClose: () => void;
 }) {
   return (
-    <div
-      style={{
-        width: open ? 280 : 32,
-        flexShrink: 0,
-        display: 'flex',
-        flexDirection: 'column',
-        borderLeft: '0.5px solid var(--border)',
-        background: 'var(--bg-grouped)',
-        transition: 'width 0.2s ease',
-        overflow: 'hidden',
-      }}
-    >
-      {/* Toggle button */}
-      <button
-        type="button"
-        onClick={onToggle}
-        title={open ? 'Hide context panel' : 'Show context panel'}
-        style={{
-          ...btnBase,
-          flexShrink: 0,
-          width: '100%',
-          height: 36,
-          borderBottom: '0.5px solid var(--border)',
-          color: 'var(--text-tertiary)',
-          background: 'none',
-          cursor: 'pointer',
-          justifyContent: open ? 'flex-end' : 'center',
-          paddingRight: open ? 10 : 0,
-          gap: 6,
-        }}
-      >
-        {open && (
-          <span style={{ fontSize: 10, color: 'var(--text-tertiary)', whiteSpace: 'nowrap' }}>
-            Context
-          </span>
-        )}
-        <svg
-          width="12"
-          height="12"
-          viewBox="0 0 12 12"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          style={{ transform: open ? 'rotate(0deg)' : 'rotate(180deg)', transition: 'transform 0.2s' }}
-        >
-          <polyline points="8 2 4 6 8 10" />
-        </svg>
-      </button>
+    <aside className="ask-inspector" aria-label="Context">
+      <IslandHeader
+        title="Context"
+        actions={
+          <Button
+            variant="icon"
+            icon="close"
+            onClick={onClose}
+            aria-label="Hide the context panel"
+            title="Hide context"
+          />
+        }
+      />
+      <div className="ask-inspector-body">
+        {!envelope ? (
+          <EmptyState
+            compact
+            icon="description"
+            title="No context yet"
+            subtitle="The files, symbols and decisions the model read appear here after you send a message. Slash commands do not retrieve context."
+          />
+        ) : (
+          <>
+            <Section title="Files read" count={envelope.files.length}>
+              {envelope.files.length === 0 ? (
+                <EmptyState compact>No files were read.</EmptyState>
+              ) : (
+                <div className="ask-rows">
+                  {envelope.files.map((f) => (
+                    <PathRow
+                      key={f}
+                      path={f}
+                      onClick={() => window.electronAPI?.openInEditor?.(f)}
+                    />
+                  ))}
+                </div>
+              )}
+            </Section>
 
-      {/* Panel content */}
-      {open && (
-        <div style={{ flex: 1, overflowY: 'auto', padding: '8px 10px' }}>
-          {!envelope && (
-            <div
-              style={{
-                fontSize: 10,
-                color: 'var(--text-tertiary)',
-                textAlign: 'center',
-                padding: '24px 0',
-                lineHeight: 1.6,
-              }}
-            >
-              Context used by the LLM appears here after you send a message.
-              <br />
-              <span style={{ fontSize: 9, opacity: 0.7 }}>
-                Slash commands do not retrieve context.
-              </span>
-            </div>
-          )}
-
-          {envelope && (
-            <>
-              {/* Files — clickable, opens in editor */}
-              <EnvelopeSection
-                title="Files in context"
-                count={envelope.files.length}
-                empty="No files"
-              >
-                {envelope.files.map((f) => (
-                  <EnvelopeItem
-                    key={f}
-                    label={f.split('/').pop() ?? f}
-                    detail={f}
-                    onClick={() => {
-                      window.electronAPI?.openInEditor?.(f);
-                    }}
-                  />
-                ))}
-              </EnvelopeSection>
-
-              {/* Symbols — tooltip shows full symbol_id; console.log on click */}
-              {envelope.symbols.length > 0 && (
-                <EnvelopeSection
-                  title="Symbols read"
-                  count={envelope.symbols.length}
-                >
+            {envelope.symbols.length > 0 && (
+              <Section title="Symbols read" count={envelope.symbols.length}>
+                <div className="ask-rows">
                   {envelope.symbols.map((s) => (
-                    <EnvelopeItem
+                    <button
                       key={s.symbol_id}
-                      label={s.symbol_id.split(':').pop() ?? s.symbol_id}
-                      detail={s.symbol_id}
-                      onClick={() =>
-                        console.log('[trace-mcp] navigate to symbol:', s.symbol_id, s.file, s.line)
-                      }
-                    />
+                      type="button"
+                      className="ws-sb-row"
+                      title={s.symbol_id}
+                      onClick={() => window.electronAPI?.openInEditor?.(s.file)}
+                    >
+                      <span className="ws-sb-ico" aria-hidden="true">
+                        <Icon name="function" size={16} />
+                      </span>
+                      <span className="ws-sb-label">
+                        {s.symbol_id.split(':').pop() ?? s.symbol_id}
+                      </span>
+                    </button>
                   ))}
-                </EnvelopeSection>
-              )}
+                </div>
+              </Section>
+            )}
 
-              {/* Decisions */}
-              {envelope.decisions.length > 0 && (
-                <EnvelopeSection
-                  title="Decisions consulted"
-                  count={envelope.decisions.length}
-                >
+            {envelope.decisions.length > 0 && (
+              <Section title="Decisions consulted" count={envelope.decisions.length}>
+                <div className="ask-rows">
                   {envelope.decisions.map((d) => (
-                    <EnvelopeItem
-                      key={d.id}
-                      label={d.title}
-                      onClick={() => console.log('[trace-mcp] navigate to decision:', d.id)}
-                    />
+                    <div key={d.id} className="ws-sb-row is-static" title={d.title}>
+                      <span className="ws-sb-ico" aria-hidden="true">
+                        <Icon name="history" size={16} />
+                      </span>
+                      <span className="ws-sb-label">{d.title}</span>
+                    </div>
                   ))}
-                </EnvelopeSection>
-              )}
-            </>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function EnvelopeSection({
-  title,
-  count,
-  empty,
-  children,
-}: {
-  title: string;
-  count: number;
-  empty?: string;
-  children?: React.ReactNode;
-}) {
-  return (
-    <div style={{ marginBottom: 14 }}>
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          marginBottom: 4,
-        }}
-      >
-        <span style={{ fontSize: 9, fontWeight: 600, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-          {title}
-        </span>
-        <span
-          style={{
-            fontSize: 9,
-            color: 'var(--text-tertiary)',
-            background: 'var(--fill-control)',
-            borderRadius: 4,
-            padding: '1px 5px',
-          }}
-        >
-          {count}
-        </span>
+                </div>
+              </Section>
+            )}
+          </>
+        )}
       </div>
-      {count === 0 && empty && (
-        <div style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>{empty}</div>
-      )}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>{children}</div>
-    </div>
+    </aside>
   );
 }
 
-function EnvelopeItem({
-  label,
-  detail,
-  onClick,
-}: {
-  label: string;
-  detail?: string;
-  onClick: () => void;
-}) {
+/** One 28px row showing `<dir>/<name>`, where the directory truncates at the
+    head and the filename never does (DESIGN.md §4). */
+function PathRow({ path, onClick }: { path: string; onClick: () => void }) {
+  const { dir, name } = splitPath(path);
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={detail ?? label}
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-start',
-        width: '100%',
-        padding: '4px 6px',
-        borderRadius: 6,
-        background: 'none',
-        border: 'none',
-        cursor: 'pointer',
-        textAlign: 'left',
-        transition: 'background 0.1s',
-      }}
-      onMouseEnter={(e) => {
-        (e.currentTarget as HTMLButtonElement).style.background = 'var(--fill-control)';
-      }}
-      onMouseLeave={(e) => {
-        (e.currentTarget as HTMLButtonElement).style.background = 'none';
-      }}
-    >
-      <span
-        style={{
-          fontSize: 10,
-          color: 'var(--text-primary)',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-          width: '100%',
-        }}
-      >
-        {label}
+    <button type="button" className="ws-sb-row" title={path} onClick={onClick}>
+      <span className="ws-sb-ico" aria-hidden="true">
+        <Icon name="description" size={16} />
       </span>
-      {detail && (
-        <span
-          style={{
-            fontSize: 9,
-            color: 'var(--text-tertiary)',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-            width: '100%',
-          }}
-        >
-          {detail}
-        </span>
-      )}
+      <span className="ws-sb-path">
+        <span className="dir">{dir}</span>
+        <span className="name">{name}</span>
+      </span>
     </button>
   );
 }
 
-// ── Session sidebar item ───────────────────────────────────────────────
+// ── Chat rail row ─────────────────────────────────────────────────────
 
-function SessionItem({
+function SessionRow({
   session,
   active,
   onSelect,
@@ -1459,161 +956,57 @@ function SessionItem({
   session: Session;
   active: boolean;
   onSelect: () => void;
-  onDelete: (e: React.MouseEvent) => void;
+  onDelete: () => void;
 }) {
-  const [hovered, setHovered] = useState(false);
   return (
-    <div
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
+      className={`ws-sb-row${active ? ' is-selected' : ''}`}
+      aria-current={active ? 'true' : undefined}
+      title={session.title || 'Untitled'}
       onClick={onSelect}
-      onKeyDown={(e) => e.key === 'Enter' && onSelect()}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 6,
-        padding: '6px 8px',
-        borderRadius: 8,
-        cursor: 'pointer',
-        background: active
-          ? 'var(--accent-tint, rgba(0,122,255,0.12))'
-          : hovered
-            ? 'var(--fill-control)'
-            : 'transparent',
-        marginBottom: 1,
+      // Keyboard route for the delete affordance — the row is itself a button,
+      // so the ✕ inside it cannot be one (nested interactive content).
+      onKeyDown={(e) => {
+        if (e.key !== 'Delete' && e.key !== 'Backspace') return;
+        e.preventDefault();
+        onDelete();
       }}
     >
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div
-          style={{
-            fontSize: 11,
-            fontWeight: active ? 600 : 400,
-            color: active ? 'var(--accent)' : 'var(--text-primary)',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {session.title || 'Untitled'}
-        </div>
-        <div style={{ fontSize: 9, color: 'var(--text-tertiary)', marginTop: 1 }}>
-          {session.msg_count} msg{session.msg_count !== 1 ? 's' : ''} ·{' '}
-          {formatRelativeTime(session.last_msg_at)}
-        </div>
-      </div>
-      {hovered && (
-        <button
-          type="button"
-          onClick={onDelete}
-          title="Delete chat"
-          style={{
-            ...btnBase,
-            width: 18,
-            height: 18,
-            borderRadius: 4,
-            background: 'none',
-            color: 'var(--text-tertiary)',
-            flexShrink: 0,
-          }}
-        >
-          <svg
-            width="10"
-            height="10"
-            viewBox="0 0 10 10"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-          >
-            <line x1="2" y1="2" x2="8" y2="8" />
-            <line x1="8" y1="2" x2="2" y2="8" />
-          </svg>
-        </button>
-      )}
-    </div>
+      <span className="ws-sb-label">{session.title || 'Untitled'}</span>
+      <span className="ws-sb-count">{formatRelativeTime(session.last_msg_at)}</span>
+      <span
+        className="ws-sb-trailing"
+        aria-hidden="true"
+        title="Delete chat (⌫)"
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete();
+        }}
+      >
+        <Icon name="close" size={12} />
+      </span>
+    </button>
   );
 }
-
-// ── Styles ────────────────────────────────────────────────────────────
-
-const btnBase: React.CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  border: 'none',
-  padding: 0,
-  flexShrink: 0,
-};
-
-const assistantStyle: React.CSSProperties = {
-  padding: '10px 14px',
-  fontSize: 12,
-  lineHeight: '1.55',
-  color: 'var(--text-primary)',
-  background: 'var(--bg-grouped)',
-  boxShadow: 'var(--shadow-grouped)',
-  borderRadius: '14px 14px 14px 4px',
-};
 
 // ── Sub-components ───────────────────────────────────────────────────
 
 function Bubble({ msg }: { msg: ChatMessage }) {
-  const u = msg.role === 'user';
+  const user = msg.role === 'user';
   return (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: u ? 'flex-end' : 'flex-start',
-        padding: '3px 2px',
-      }}
-    >
-      <div
-        style={{
-          padding: '10px 14px',
-          fontSize: 12,
-          lineHeight: '1.55',
-          maxWidth: '88%',
-          ...(u
-            ? {
-                background: 'var(--accent)',
-                color: '#fff',
-                borderRadius: '14px 14px 4px 14px',
-                whiteSpace: 'pre-wrap',
-              }
-            : assistantStyle),
-        }}
-      >
-        {u ? msg.content : <MarkdownBody content={msg.content} />}
+    <div className={`ask-msg ${user ? 'is-user' : 'is-assistant'}`}>
+      <div className="ask-bubble">
+        {user ? msg.content : <MarkdownBody content={msg.content} />}
       </div>
-    </div>
-  );
-}
-
-function Dots() {
-  return (
-    <div style={{ display: 'flex', gap: 3 }}>
-      {[0, 1, 2].map((i) => (
-        <span
-          key={i}
-          style={{
-            width: 5,
-            height: 5,
-            borderRadius: '50%',
-            background: 'var(--accent)',
-            animation: `pulse 1.2s ease-in-out ${i * 0.2}s infinite`,
-          }}
-        />
-      ))}
     </div>
   );
 }
 
 function formatRelativeTime(ts: number): string {
   const diff = Date.now() - ts;
-  if (diff < 60_000) return 'just now';
-  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
-  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
-  return `${Math.floor(diff / 86_400_000)}d ago`;
+  if (diff < 60_000) return 'now';
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h`;
+  return `${Math.floor(diff / 86_400_000)}d`;
 }

--- a/packages/app/src/renderer/tabs/__tests__/AskTab.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/AskTab.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * TRA-312. These assert what the Ask migration exists to fix, so the surface
+ * fails loudly if it drifts back:
+ *
+ *   - a toolbar, where the surface previously drew no chrome at all
+ *   - four real states: empty, loading, error (with the question preserved)
+ *     and populated — the old error was a red strip with no way forward
+ *   - the delete affordance has a keyboard route, not hover only
+ *   - the context inspector is closed until the user asks for it
+ *   - no ALL-CAPS, no type below 11px, no glass on content, no `--accent`
+ *     used as a background
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AskTab } from '../AskTab';
+
+const ROOT = '/tmp/proj';
+const now = Date.now();
+
+const SESSIONS = [
+  { id: 's1', project_root: ROOT, title: 'Where does the indexer resolve imports?', created_at: now, last_msg_at: now - 120_000, msg_count: 6 },
+  { id: 's2', project_root: ROOT, title: 'Explain the plugin registry', created_at: now, last_msg_at: now - 7_200_000, msg_count: 2 },
+];
+
+const ENVELOPE = {
+  files: ['src/indexer/resolve.ts'],
+  symbols: [{ symbol_id: 'src/indexer/resolve.ts:resolveEdges', file: 'src/indexer/resolve.ts', line: 12 }],
+  decisions: [{ id: 'd1', title: 'Edges resolve in pass 2' }],
+};
+
+const MESSAGES = [
+  { id: 'm1', role: 'user', content: 'Where does the indexer resolve imports?', created_at: now - 120_000 },
+  { id: 'm2', role: 'assistant', content: 'In `resolveEdges()`, during pass 2.', created_at: now - 110_000, context_envelope: ENVELOPE },
+];
+
+/** Route every endpoint Ask touches. `opts.send` decides what a POST does. */
+function mockApi(opts: { provider?: string | null; messages?: unknown[]; sendFails?: boolean } = {}) {
+  const { provider = 'anthropic/claude-sonnet-5', messages = MESSAGES, sendFails = false } = opts;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: RequestInfo | URL) => {
+      const u = String(input);
+      if (sendFails && u.endsWith('/messages')) {
+        return Promise.resolve(new Response('The provider rejected the request.', { status: 502 }));
+      }
+      let body: unknown = {};
+      if (u.includes('/api/ask/provider')) body = { provider };
+      else if (/\/api\/ask\/sessions\/[^/?]+$/.test(u)) body = { messages };
+      else if (u.includes('/api/ask/sessions')) body = { sessions: SESSIONS };
+      return Promise.resolve(
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    }),
+  );
+}
+
+beforeEach(() => {
+  const api = new Proxy(function () {} as object, {
+    get: () => () => Promise.resolve(undefined),
+    apply: () => Promise.resolve(undefined),
+  });
+  (window as unknown as { electronAPI: unknown }).electronAPI = api;
+  localStorage.clear();
+  /* jsdom has no layout, so scrollIntoView is not implemented. */
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function mount() {
+  let result!: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(<AskTab root={ROOT} />);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return result;
+}
+
+describe('Ask chrome', () => {
+  it('draws exactly one toolbar, where it used to draw none', async () => {
+    mockApi();
+    const { container } = await mount();
+    expect(container.querySelectorAll('[role="toolbar"]')).toHaveLength(1);
+  });
+
+  it('names every icon-only control for the pointer and the screen reader', async () => {
+    mockApi();
+    const { container } = await mount();
+    for (const button of Array.from(container.querySelectorAll('button'))) {
+      if ((button.textContent ?? '').trim().length > 0) continue;
+      expect(button.getAttribute('aria-label'), button.outerHTML).toBeTruthy();
+      expect(button.getAttribute('title'), button.outerHTML).toBeTruthy();
+    }
+  });
+
+  it('reports the provider as a word, not as a coloured dot alone', async () => {
+    mockApi();
+    await mount();
+    screen.getByText('anthropic/claude-sonnet-5');
+  });
+
+  it('keeps the context inspector closed until it is asked for', async () => {
+    mockApi();
+    const { container } = await mount();
+    expect(container.querySelector('.ask-inspector')).toBeNull();
+
+    const toggle = screen.getByRole('button', { name: 'Show the context panel' });
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+    expect(container.querySelector('.ask-inspector')).not.toBeNull();
+    expect(localStorage.getItem('trace-mcp.ask.context-panel')).toBe('1');
+  });
+});
+
+describe('Ask states', () => {
+  it('offers a way forward when no provider is configured', async () => {
+    mockApi({ provider: null });
+    await mount();
+    screen.getByText('Connect an AI provider');
+    screen.getByRole('button', { name: 'Open AI settings' });
+  });
+
+  it('shows the slash-command reference and starter questions on an empty chat', async () => {
+    mockApi({ messages: [] });
+    await mount();
+    screen.getByText('Ask anything about this codebase');
+    screen.getByText('Slash commands');
+    screen.getByText('/find <query>');
+    screen.getByRole('button', { name: 'How does auth work?' });
+  });
+
+  it('renders the conversation once a session has messages', async () => {
+    mockApi();
+    localStorage.setItem(`trace-mcp:current-chat-session-${ROOT}`, 's1');
+    await mount();
+    const log = screen.getByRole('log', { name: 'Conversation' });
+    within(log).getByText('Where does the indexer resolve imports?');
+    expect(screen.queryByText('Ask anything about this codebase')).toBeNull();
+  });
+
+  it('keeps the failed question in the composer and offers to send it again', async () => {
+    mockApi({ sendFails: true });
+    localStorage.setItem(`trace-mcp:current-chat-session-${ROOT}`, 's1');
+    await mount();
+
+    const box = screen.getByRole('textbox', { name: 'Ask about this project' });
+    await act(async () => {
+      fireEvent.change(box, { target: { value: 'Why is vendor/ skipped?' } });
+    });
+    await act(async () => {
+      fireEvent.keyDown(box, { key: 'Enter', metaKey: true });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    screen.getByRole('alert');
+    screen.getByRole('button', { name: 'Send again' });
+    /* The question is not lost: a failed send must not cost what was typed. */
+    expect((box as HTMLTextAreaElement).value).toBe('Why is vendor/ skipped?');
+  });
+});
+
+describe('Ask chat list', () => {
+  it('gives the delete affordance a keyboard route rather than hover alone', async () => {
+    mockApi();
+    await mount();
+    const row = screen.getByRole('button', { name: /Where does the indexer resolve imports/ });
+    await act(async () => {
+      fireEvent.keyDown(row, { key: 'Backspace' });
+      await Promise.resolve();
+    });
+    const calls = (globalThis.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(
+      calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'DELETE'),
+    ).toBe(true);
+  });
+});
+
+/* ── Source-level guards ───────────────────────────────────────────────────
+   jsdom resolves no stylesheet, so the type-scale and material rules are
+   checked where they are written — same shape as the TRA-294 guards. */
+describe('type scale and material', () => {
+  const read = (rel: string) =>
+    readFileSync(join(process.cwd(), rel), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^\s*\/\/.*$/gm, '');
+
+  const tsx = () => read('src/renderer/tabs/AskTab.tsx');
+  const css = () => read('src/renderer/styles/ask.css');
+
+  it('has no type below 11px', () => {
+    const src = `${tsx()}\n${css()}`;
+    const sizes = [
+      ...[...src.matchAll(/text-\[(\d+(?:\.\d+)?)px\]/g)].map((m) => Number(m[1])),
+      ...[...src.matchAll(/fontSize:\s*(\d+(?:\.\d+)?)/g)].map((m) => Number(m[1])),
+      ...[...src.matchAll(/font-size:\s*(\d+(?:\.\d+)?)px/g)].map((m) => Number(m[1])),
+    ];
+    expect(sizes.filter((n) => n < 11)).toEqual([]);
+  });
+
+  it('ships no ALL-CAPS strings', () => {
+    expect(`${tsx()}\n${css()}`).not.toMatch(/text-transform|textTransform|uppercase|toUpperCase\(\)/);
+  });
+
+  it('puts no glass on content — the toolbar is the only translucent layer', () => {
+    expect(tsx()).not.toMatch(/backdropFilter|backdrop-filter/);
+    expect(css()).not.toMatch(/backdrop-filter/);
+  });
+
+  it('fills the user bubble with --accent-fill, not --accent', () => {
+    /* --accent is tuned to read AS text on --surface; white on it measures
+       3.65:1 in dark. A fill that carries a label uses --accent-fill.
+       DESIGN.md §2. (The 4px typing dots and the caret carry no label, so they
+       keep --accent — that is the same thing StatusDot does with a tone.) */
+    const bubble = /\.ask-msg\.is-user \.ask-bubble \{([^}]*)\}/.exec(css())?.[1] ?? '';
+    expect(bubble).toMatch(/background:\s*var\(--accent-fill\)/);
+    expect(bubble).toMatch(/color:\s*var\(--on-accent\)/);
+  });
+
+  it('uses no radius outside the scale', () => {
+    const bad = [...css().matchAll(/border-radius:\s*(\d+)px/g)]
+      .map((m) => Number(m[1]))
+      .filter((n) => ![2, 6, 8, 10, 12].includes(n));
+    expect(bad).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes TRA-312.

Ask was the last project surface still on its pre-revision inline styles — everything
around it moved to the macOS 26 layer during the TRA-284 revision, and Ask is the
second item in the project sidebar. The network layer (sessions, SSE streaming, slash
commands) is unchanged; only the presentation moved.

## What was measured on the running renderer, before

| What | Before | Rule (`DESIGN.md`) |
|---|---|---|
| Type sizes on screen | **9, 10, 11, 12, 14, 15px** — most reading text at 9–10px | §3 |
| ALL-CAPS group headers | 2, both at 9px | §8 rule 10 |
| Toolbar | **none** — no chrome, no title, no actions | §6 |
| User bubble | `--accent` as a background under a white label → 3.65:1 in dark | §2, §8 rule 3 |
| Glass | `backdrop-filter` on three content elements | §8 rule 4 |
| Radii | 4, 5, 6, 7, 8, 10, 12, 14, 16 and `14px 14px 14px 4px` | §4 |
| Delete a chat | row-hover only, no keyboard route | §8 rule 15 |
| Loading a chat | a centred three-dot spinner | §8 rule 12 |
| Error | red strip, no retry, and the typed question was gone | §5 |
| 640px window | conversation collapsed to **zero width**, context panel painted over the toolbar | §10 |

## What lands

- `styles/ask.css` owns the layout; every value reads from `tokens.css`. `AskTab.tsx`
  drops ~450 lines of inline style for the `lattice/ui` primitives.
- 52px glass `Toolbar` with the chat title and the inspector toggle; the thread scrolls
  under it behind a scroll-edge hairline.
- 220px chat rail on the app's own `.ws-sb-row` system — 28px rows, 6px pill, 13px
  label, relative time in tabular figures, a trailing ✕ **and** a ⌫ keyboard route.
- 280px context inspector, closed by default and persisted; it holds nothing until a
  message is sent. Paths use the `dir`/`name` head-truncating split.
- Four states, all designed: skeleton bubbles at the real bubble geometry while a chat
  loads; an empty state with the hero, the slash-command reference and three starter
  questions; an error that keeps the chrome, puts the failed question back in the
  composer and offers "Send again"; the conversation itself.
- Container-query column collapse, trailing column first: the inspector drops below a
  720px pane, the rail below 480px. These rules sit last in the file on purpose — a
  container query carries no extra specificity.
- `token-guard.baseline.json`: `AskTab.tsx` leaves the baseline entirely (5 → 0).
- `DESIGN.md` §12 updated, plus three decision-log rows for the rules this run settled.

## Verification

Computed styles on the live surface at 1120×760: font sizes **13 / 12 / 11 only**,
zero ALL-CAPS strings, zero focusable box under 24×24, control heights 20/24/28 only,
radii capsule + 6px only, and exactly one element carrying a `backdrop-filter` — the
toolbar. A Tab walk driven with real key events shows a focus ring on every stop.
Screenshotted light + dark, Reduce Transparency + Increase Contrast, at 640/900/1120.

`pnpm test` in `packages/app`: 221 passed (22 files), including 14 new ones that pin
the toolbar count, the four states, the keyboard delete route, the inspector default,
and source-level guards for type scale, ALL-CAPS, glass, the accent fill and the radius
set. `vite build`, `tsc -p tsconfig.main.json` and `scripts/design-tokens.mjs` are clean.

Notebook is now the only unmigrated surface; it gets its own issue.
