### PR TITLE
feat(app): migrate Notebook to the macOS 26 layer (TRA-310)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -126,7 +126,11 @@ Light accent is `#0069d9`, not Apple's `#007aff`: system blue measures 4.02:1 on
 
 ### Status and badges
 
-`--status-green|orange|red|blue|purple` are tuned to read **as text** on both surfaces.
+`--status-green|orange|red|blue|purple` are tuned to read **as text** on both surfaces
+— on `--surface` and `--surface-sunken`, and **nowhere else**. A status token on a tint
+of its own hue is a different, unmeasured pair: `--status-red` on a 10% red fill measured
+**4.31:1** in light and failed AA. Put status text on a plain surface with a glyph, or
+use the `--badge-*-fg` pair, which is the one tinted combination that was verified.
 The `--badge-*-fg` tokens are separate: each is that hue walked toward black (light) or
 white (dark) until the label clears 4.5:1 over the **18% tint of that same hue**, which
 is what `.lx-badge` paints. Badge foreground and status text are not interchangeable.
@@ -223,9 +227,11 @@ The two techniques in use, both worth copying:
 | `--radius-row` | 6px | rows, selection pills, square icon buttons |
 | `--radius-capsule` | 999px | every pill-shaped control |
 
-Controls are **capsules**, not rounded rectangles. The one square control is the
-icon-only button: 24×24 at 6px radius with a 16px glyph. There are no 4/5/9px control
-radii.
+Controls are **capsules**, not rounded rectangles. There are exactly two exceptions,
+both in the scale and both asserted by `primitives.test.tsx`: the icon-only button
+(24×24 at `--radius-row` 6px with a 16px glyph) and the text field (`--radius-input`
+8px — a capsule field sets its first character on a curve). There are no 4/5/9px
+control radii.
 
 When one rounded box sits inside another, the inner radius is the outer minus the
 inset, so the curves stay concentric. The sidebar's 8px bottom footer inset reads as
@@ -252,6 +258,7 @@ already exists here** — that is how the app ended up with four different pill 
 | `Chip` / `ChipGroup` | 24px. Multi-select "on" is a neutral filled state; accent fill is reserved for single-select, where exactly one chip is on. Groups carry a visible label. |
 | `Checkbox` | 16px visual in a 24×24 box. The CSS applies to every `input[type=checkbox]` in the renderer. |
 | `PopUpButton` | 24px bordered capsule. The native `<select>` menu is kept — that *is* the platform menu; only the chrome is ours. |
+| `.lx-input` | Text field. 24px, `--radius-input` (8px), hairline, house focus ring. Add `.mono` for a value that is an identifier or a path: `--font-mono` at 11px, because SF Mono runs optically larger than SF Pro at the same size. A raw `font-family: monospace` resolves to Courier and is a bug. |
 | `Badge` / `GradeBadge` | capsule, 11px/500, sentence case, tinted fill with the saturated hue as the label. 18px tall so it fits inside a 24px row. Never white-on-a-light-fill. |
 | `StatusDot` | tone dot. Pairs with a written label — never the only signal. |
 | `IslandHeader` / `MiniButton` | the canonical 38px island header row. |
@@ -515,6 +522,9 @@ new evidence.
 | A surface with extra columns collapses them with a **container query**, trailing column first | At the 640px window minimum the app sidebar already takes 220. Ask's chat rail + inspector left the conversation at zero width and painted the inspector over its own toolbar. The rules must be last in the file — a container query adds no specificity. |
 | A side inspector starts **closed** and persists the user's choice | 280px of "this appears after you send a message" is not worth the width. The toolbar toggle is how it is discovered. |
 | A failed send puts the question back in the composer | Losing what you typed is a worse cost than the error itself, and it makes "Send again" a single click instead of a retype. |
+| A status colour is never put on a tint of its own hue | `--status-red` is verified on `--surface`; on a 10% red fill it measured 4.31:1. An error reads as an error from its glyph, not from a coloured slab. |
+| Notebook's per-cell Run is `bordered`, not `prominent` | One accent capsule per cell put N prominent actions on one surface. The rule is one per region, and a notebook has no single default action. |
+| Optionality lives in a field's placeholder, not its label | "Kind (optional)" wrapped to two lines in the form's label column and broke the row baseline. `required` is what the code reads anyway. |
 | Migrate a screen **whole**, one screen per PR | A half-migrated screen looks worse than the un-migrated one; a big-bang redesign PR never lands. |
 | Tokens and primitives land before any surface | A surface migrated against a moving token layer gets migrated twice. |
 
@@ -522,13 +532,16 @@ new evidence.
 
 ## 12. Migration status
 
-On this system: the token layer, the control primitives, the window chrome, the
-sidebar and its footer, the workspace dashboard, Project Overview, Activity, Memory,
-MCP Clients, Settings, the onboarding sheet, Graph Explorer, Insights, and **Ask**.
+**Every surface is on this system**: the token layer, the control primitives, the
+window chrome, the sidebar and its footer, the workspace dashboard, Project Overview,
+Activity, Memory, MCP Clients, Settings, the onboarding sheet, Graph Explorer,
+Insights, Ask, and **Notebook** — the last one, migrated in TRA-310.
 
-Still to migrate: **Notebook**. Until it is, `styles/island.css` keeps a set of
+What is left is cleanup, not migration. `styles/island.css` still keeps a set of
 **legacy aliases** (`--text-1/2/3`, `--frame`, `--island`, `--row-hover`, `--sep`, …)
-that map onto the tokens above, plus per-domain styles that this document's "never"
-list already forbids — glass stat cards, ALL-CAPS labels, raw hex. **Those are being
+that map onto the tokens above, plus per-domain styles this document's "never" list
+already forbids — glass stat cards, ALL-CAPS labels, raw hex. The token guard still
+records raw colour in `island.css` and `GraphExplorerGPU.tsx`. **Those are being
 deleted, not copied.** If you are writing a new screen, use the tokens in §2 directly;
-if you are touching an old one, migrate it whole and delete the aliases it stops using.
+if you touch a file that still carries aliases, delete the ones it stops using and
+lower its baseline count.

--- a/packages/app/scripts/token-guard.baseline.json
+++ b/packages/app/scripts/token-guard.baseline.json
@@ -8,6 +8,5 @@
   "src/renderer/lattice/icons.tsx": 1,
   "src/renderer/lattice/ui/Badge.tsx": 2,
   "src/renderer/styles/island.css": 36,
-  "src/renderer/tabs/GraphExplorerGPU.tsx": 51,
-  "src/renderer/tabs/Notebook.tsx": 1
+  "src/renderer/tabs/GraphExplorerGPU.tsx": 51
 }

--- a/packages/app/src/renderer/lattice/ui/__tests__/primitives.test.tsx
+++ b/packages/app/src/renderer/lattice/ui/__tests__/primitives.test.tsx
@@ -139,6 +139,7 @@ describe('controls.css geometry', () => {
       '.lx-chip': '24px',
       '.lx-popup': '24px',
       '.lx-popup select': '24px',
+      '.lx-input': '24px',
       "input[type='checkbox']": '24px',
     };
     for (const [sel, want] of Object.entries(defaults)) {
@@ -161,7 +162,11 @@ describe('controls.css geometry', () => {
       // 9px is only legal on the checkbox: 5px inner + 4px transparent border
       // is concentric with the 16px visual.
       if (r === '9px' && !selector.includes('checkbox')) offenders.push(`${selector} → ${r}`);
-      else if (!ALLOWED.has(r)) offenders.push(`${selector} → ${r}`);
+      // The text field is the one non-capsule control in the scale (DESIGN.md
+      // §4) — a capsule field puts its first character on a curve.
+      else if (r === 'var(--radius-input)' && !selector.includes('lx-input'))
+        offenders.push(`${selector} → ${r}`);
+      else if (r !== 'var(--radius-input)' && !ALLOWED.has(r)) offenders.push(`${selector} → ${r}`);
     }
     expect(offenders).toEqual([]);
   });

--- a/packages/app/src/renderer/styles/controls.css
+++ b/packages/app/src/renderer/styles/controls.css
@@ -437,6 +437,54 @@ input[type='checkbox']:disabled {
 }
 
 /* ============================================================================
+   TEXT FIELD — .lx-input
+   The one control tier this file was missing. 24px like every other regular
+   control, but --radius-input (8px) rather than a capsule: the radius scale
+   makes text inputs the deliberate exception, because a capsule field puts its
+   first character on a curve.
+   `.mono` is for fields whose value is an identifier or a path — the house
+   --font-mono, never the raw `monospace` generic, which resolves to Courier.
+   ============================================================================ */
+.lx-input {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  height: 24px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: var(--radius-input);
+  background: var(--fill-quaternary);
+  box-shadow: inset 0 0 0 0.5px var(--separator);
+  font-family: var(--font-ui);
+  font-size: var(--text-body);
+  line-height: 1;
+  color: var(--label);
+  outline: 0;
+  transition: background var(--dur-micro) var(--ease-out);
+}
+.lx-input.mono {
+  font-family: var(--font-mono);
+  /* SF Mono runs optically larger than SF Pro at the same px, so a mono value
+     field sits one step down to keep the row's x-height even. */
+  font-size: var(--text-caption);
+}
+.lx-input::placeholder {
+  color: var(--label-tertiary);
+}
+.lx-input:hover {
+  background: var(--fill-tertiary);
+}
+.lx-input:focus-visible {
+  background: var(--surface);
+  box-shadow:
+    inset 0 0 0 0.5px var(--separator),
+    var(--focus-ring);
+}
+.lx-input:disabled {
+  opacity: 0.4;
+}
+
+/* ============================================================================
    POP-UP BUTTON — .lx-popup
    A macOS pop-up button: 24px bordered capsule, 13px label, chevron-up-down.
    The <select> keeps its native menu (that IS the platform menu) — only the
@@ -544,6 +592,7 @@ input[type='checkbox']:focus-visible {
   .lx-seg .lx-seg-item,
   .lx-search,
   .lx-chip,
+  .lx-input,
   .lx-popup select,
   input[type='checkbox'] {
     transition: none;

--- a/packages/app/src/renderer/tabs/Notebook.tsx
+++ b/packages/app/src/renderer/tabs/Notebook.tsx
@@ -5,11 +5,20 @@
  * the user can run; the JSON response is rendered inline. NOT a code-execution
  * sandbox — cells dispatch a fixed, allow-listed set of trace-mcp tools only.
  *
- * Visual style mirrors AskTab.tsx (sidebar header + flex content + accent
- * buttons + var(--*) theme tokens). Cells are local React state only; no
- * persistence in this slice — that's a follow-up.
+ * On the macOS 26 layer (TRA-310): one 52px Toolbar carrying the project this
+ * queries run against, content capped at 720px, and every control from
+ * lattice/ui. Cells are local React state only; no persistence in this slice.
  */
 import { useCallback, useState } from 'react';
+import { Icon } from '../lattice/icons';
+import {
+  Button,
+  Card,
+  PopUpButton,
+  Skeleton,
+  Toolbar,
+  ToolbarDivider,
+} from '../lattice/ui';
 import {
   NOTEBOOK_TOOLS,
   TOOL_BY_NAME,
@@ -22,6 +31,15 @@ import {
 // keep working unchanged.
 export { NOTEBOOK_TOOLS, defaultNotebookClient } from './notebook-runtime';
 export type { NotebookClient, ToolName } from './notebook-runtime';
+
+/** Content measure, same as Project Overview — a form is not a table. */
+const MEASURE = 720;
+
+/** Trailing-aligned label column, macOS form style. Wide enough that no label
+    in the tool catalog wraps to a second line and breaks its row's baseline. */
+const LABEL_COL = 88;
+
+const TOOL_OPTIONS = NOTEBOOK_TOOLS.map((t) => ({ value: t.name, label: t.label }));
 
 // ── Cell state ───────────────────────────────────────────────────────
 
@@ -44,6 +62,12 @@ function makeCell(): Cell {
   };
 }
 
+/** Head-truncated so the tail — the part that distinguishes siblings — stays. */
+function projectName(root: string): string {
+  const parts = root.split('/').filter(Boolean);
+  return parts[parts.length - 1] ?? root;
+}
+
 // ── Component ────────────────────────────────────────────────────────
 
 export function Notebook({
@@ -54,6 +78,7 @@ export function Notebook({
   client?: NotebookClient;
 }) {
   const [cells, setCells] = useState<Cell[]>(() => [makeCell()]);
+  const [scrolled, setScrolled] = useState(false);
 
   const addCell = useCallback(() => {
     setCells((prev) => [...prev, makeCell()]);
@@ -75,7 +100,12 @@ export function Notebook({
       // Validate required fields client-side so we don't ping the daemon for nothing.
       const missing = def.fields.find((f) => f.required && !cell.args[f.key]?.trim());
       if (missing) {
-        updateCell(id, { status: 'error', error: `Missing required field: ${missing.label}`, result: null });
+        updateCell(id, {
+          status: 'error',
+          // Says what to do next, not which form control failed validation.
+          error: `Enter a ${missing.label.toLowerCase()} to run this cell.`,
+          result: null,
+        });
         return;
       }
       updateCell(id, { status: 'running', error: undefined, result: null });
@@ -91,75 +121,62 @@ export function Notebook({
 
   return (
     <div
-      className="flex flex-col h-full"
-      style={{ WebkitAppRegion: 'no-drag', overflow: 'hidden' } as React.CSSProperties}
+      className="flex flex-col h-full overflow-hidden"
+      style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
     >
-      {/* Local keyframe — inline `@keyframes` is the renderer's standard
-          pattern for one-off spinner animations (see WorkspaceHeader). */}
-      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
-      {/* Header */}
-      <div
-        style={{
-          padding: '10px 14px 8px',
-          borderBottom: '0.5px solid var(--border)',
-          flexShrink: 0,
-        }}
-      >
-        <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>Notebook</div>
-        <div style={{ fontSize: 10, color: 'var(--text-tertiary)', marginTop: 2 }}>
-          Run ad-hoc trace-mcp queries. Read-only tools, no code execution.
-        </div>
-      </div>
-
-      {/* Cells */}
-      <div style={{ flex: 1, overflowY: 'auto', padding: '8px 12px 80px' }}>
-        {cells.map((cell, idx) => (
-          <CellView
-            key={cell.id}
-            index={idx + 1}
-            cell={cell}
-            onChange={(patch) => updateCell(cell.id, patch)}
-            onRun={() => runCell(cell.id)}
-            onRemove={cells.length === 1 ? undefined : () => removeCell(cell.id)}
-          />
-        ))}
-
-        <button
-          type="button"
-          onClick={addCell}
-          aria-label="Add cell"
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 6,
-            marginTop: 8,
-            padding: '7px 12px',
-            borderRadius: 8,
-            background: 'var(--fill-control)',
-            border: '0.5px dashed var(--border)',
-            boxShadow: 'var(--shadow-control)',
-            color: 'var(--text-secondary)',
-            fontSize: 12,
-            fontWeight: 500,
-            cursor: 'pointer',
-            fontFamily: 'inherit',
-          }}
-        >
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.8"
-            strokeLinecap="round"
-            aria-hidden="true"
+      {/* ── Toolbar ──────────────────────────────────────────────────────
+          The surface never said which project it queries. It does now. */}
+      <Toolbar scrolled={scrolled} className="gap-3">
+        <div className="min-w-0 flex-1">
+          <h2
+            className="text-[13px] leading-4 font-semibold truncate"
+            style={{ color: 'var(--label)' }}
           >
-            <line x1="6" y1="1" x2="6" y2="11" />
-            <line x1="1" y1="6" x2="11" y2="6" />
-          </svg>
-          Add cell
-        </button>
+            Notebook
+          </h2>
+          <p
+            className="text-[11px] leading-[13px] truncate"
+            style={{ color: 'var(--label-secondary)' }}
+            title={root}
+          >
+            {projectName(root)}
+          </p>
+        </div>
+        <ToolbarDivider />
+        <span
+          className="shrink-0 text-[11px] leading-[13px] tabular-nums"
+          style={{ color: 'var(--label-secondary)' }}
+        >
+          {cells.length === 1 ? '1 cell' : `${cells.length} cells`}
+        </span>
+      </Toolbar>
+
+      {/* ── Cells ────────────────────────────────────────────────────── */}
+      <div
+        className="flex-1 overflow-auto"
+        onScroll={(e) => setScrolled((e.target as HTMLElement).scrollTop > 0)}
+      >
+        <div
+          className="flex flex-col gap-3 px-4 py-4 mx-auto w-full"
+          style={{ maxWidth: MEASURE }}
+        >
+          {cells.map((cell, idx) => (
+            <CellView
+              key={cell.id}
+              index={idx + 1}
+              cell={cell}
+              onChange={(patch) => updateCell(cell.id, patch)}
+              onRun={() => runCell(cell.id)}
+              onRemove={cells.length === 1 ? undefined : () => removeCell(cell.id)}
+            />
+          ))}
+
+          <div className="flex">
+            <Button icon="add" onClick={addCell} aria-label="Add cell">
+              Add cell
+            </Button>
+          </div>
+        </div>
       </div>
     </div>
   );
@@ -184,136 +201,61 @@ function CellView({
   const running = cell.status === 'running';
 
   return (
-    <div
-      style={{
-        marginBottom: 10,
-        padding: '10px 12px',
-        borderRadius: 10,
-        background: 'var(--bg-grouped)',
-        border: '0.5px solid var(--border)',
-        boxShadow: 'var(--shadow-grouped)',
-      }}
-    >
-      {/* Cell header — index, tool picker, run, remove */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+    <Card>
+      {/* Cell header — index, tool picker, run, remove. Run is `bordered`:
+          one accent capsule per cell would put N prominent actions on one
+          surface, which is the rule this screen used to break hardest. */}
+      <div
+        className="flex items-center gap-2 px-3"
+        style={{ minHeight: 40, borderBottom: '0.5px solid var(--separator)' }}
+      >
         <span
-          style={{
-            fontSize: 9,
-            color: 'var(--text-tertiary)',
-            fontFamily: 'monospace',
-            minWidth: 24,
-          }}
+          className="shrink-0 text-[11px] leading-[13px] tabular-nums"
+          style={{ color: 'var(--label-secondary)', minWidth: 16 }}
         >
-          [{index}]
+          {index}
         </span>
-        <label htmlFor={`${cell.id}-tool`} style={{ position: 'absolute', left: -9999 }}>
-          Tool
-        </label>
-        <select
-          id={`${cell.id}-tool`}
-          aria-label="Tool"
+        <PopUpButton
+          options={TOOL_OPTIONS}
           value={cell.tool}
-          onChange={(e) => {
-            const next = e.target.value as ToolName;
+          aria-label="Tool"
+          onChange={(next) => {
             const nextDef = TOOL_BY_NAME[next];
             // Reset args when switching tool to avoid carrying stale keys.
             const args: Record<string, string> = {};
             for (const f of nextDef.fields) args[f.key] = '';
             onChange({ tool: next, args, status: 'idle', result: null, error: undefined });
           }}
-          style={{
-            fontSize: 11,
-            padding: '4px 8px',
-            borderRadius: 6,
-            background: 'var(--fill-control)',
-            color: 'var(--text-primary)',
-            border: '0.5px solid var(--border)',
-            outline: 'none',
-            fontFamily: 'monospace',
-          }}
-        >
-          {NOTEBOOK_TOOLS.map((t) => (
-            <option key={t.name} value={t.name}>
-              {t.label}
-            </option>
-          ))}
-        </select>
-        <span style={{ fontSize: 10, color: 'var(--text-tertiary)', flex: 1 }}>{def.description}</span>
-        <button
-          type="button"
-          onClick={onRun}
-          disabled={running}
-          style={{
-            padding: '5px 14px',
-            fontSize: 11,
-            fontWeight: 500,
-            borderRadius: 6,
-            background: running ? 'var(--fill-control)' : 'var(--accent)',
-            color: running ? 'var(--text-tertiary)' : '#fff',
-            border: 'none',
-            cursor: running ? 'default' : 'pointer',
-            boxShadow: 'var(--shadow-control)',
-            fontFamily: 'inherit',
-          }}
-        >
+        />
+        <span className="flex-1" />
+        <Button onClick={onRun} disabled={running} className={running ? 'is-status' : undefined}>
           {running ? 'Running…' : 'Run'}
-        </button>
+        </Button>
         {onRemove && (
-          <button
-            type="button"
+          <Button
+            variant="icon"
+            icon="close"
             onClick={onRemove}
+            aria-label={`Remove cell ${index}`}
             title="Remove cell"
-            aria-label="Remove cell"
-            style={{
-              width: 22,
-              height: 22,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              borderRadius: 5,
-              background: 'none',
-              border: 'none',
-              color: 'var(--text-tertiary)',
-              cursor: 'pointer',
-            }}
-          >
-            <svg
-              width="10"
-              height="10"
-              viewBox="0 0 10 10"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              aria-hidden="true"
-            >
-              <line x1="2" y1="2" x2="8" y2="8" />
-              <line x1="8" y1="2" x2="2" y2="8" />
-            </svg>
-          </button>
+          />
         )}
       </div>
 
-      {/* Fields */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {/* Fields — the human label from the tool catalog, at reading size, in
+          the UI face. The old rows showed the raw arg key in 10px monospace. */}
+      <div className="flex flex-col gap-2 px-3 py-3">
         {def.fields.map((f) => (
-          <label
-            key={f.key}
-            style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 11 }}
-          >
+          <label key={f.key} className="flex items-center gap-3">
             <span
-              style={{
-                color: 'var(--text-secondary)',
-                minWidth: 90,
-                textAlign: 'right',
-                fontFamily: 'monospace',
-                fontSize: 10,
-              }}
+              className="shrink-0 text-[13px] leading-4 text-right"
+              style={{ color: 'var(--label-secondary)', width: LABEL_COL }}
             >
-              {f.key}
+              {f.label}
             </span>
             <input
               type="text"
+              className="lx-input mono"
               value={cell.args[f.key] ?? ''}
               placeholder={f.placeholder}
               onChange={(e) => onChange({ args: { ...cell.args, [f.key]: e.target.value } })}
@@ -323,48 +265,65 @@ function CellView({
                   onRun();
                 }
               }}
-              style={{
-                flex: 1,
-                padding: '5px 9px',
-                fontSize: 11,
-                borderRadius: 6,
-                background: 'var(--fill-control)',
-                color: 'var(--text-primary)',
-                border: '0.5px solid var(--border)',
-                outline: 'none',
-                fontFamily: 'monospace',
-              }}
             />
           </label>
         ))}
       </div>
 
-      {/* Result area */}
-      {cell.status === 'error' && (
-        <div
-          role="alert"
-          style={{
-            marginTop: 8,
-            padding: '6px 10px',
-            borderRadius: 6,
-            fontSize: 11,
-            color: 'var(--destructive)',
-            background: 'rgba(255,59,48,0.06)',
-            border: '0.5px solid rgba(255,59,48,0.15)',
-          }}
-        >
-          {cell.error}
-        </div>
-      )}
-      {cell.status === 'running' && (
-        <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 6 }}>
-          <Spinner />
-          <span style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>Calling trace-mcp…</span>
-        </div>
-      )}
-      {cell.status === 'ok' && cell.result !== null && (
-        <ResultView result={cell.result} />
-      )}
+      {/* Result area. The idle state is a plain caption, NOT a well: rendered
+          as a sunken box it read as a third, oversized text field. */}
+      <div className="px-3 pb-3">
+        {cell.status === 'idle' && (
+          <p
+            className="text-[11px] leading-[13px]"
+            style={{ color: 'var(--label-secondary)', paddingLeft: LABEL_COL + 12 }}
+          >
+            {def.description}
+          </p>
+        )}
+        {cell.status === 'running' && (
+          <ResultBox>
+            <div role="status" aria-label="Running" className="flex flex-col gap-2">
+              <Skeleton width="62%" height={11} />
+              <Skeleton width="86%" height={11} />
+              <Skeleton width="44%" height={11} />
+            </div>
+          </ResultBox>
+        )}
+        {cell.status === 'error' && (
+          /* The same well as every other cell state, so the four states share
+             one geometry. NOT a red-tinted bar: --status-red on a tint of
+             itself measured 4.31:1 in light and failed AA, while the token is
+             verified at 4.94:1 on --surface-sunken. The glyph, not the fill,
+             is what makes this read as an error. */
+          <ResultBox>
+            <div role="alert" className="flex items-center gap-2" style={{ color: 'var(--status-red)' }}>
+              <Icon name="warning" size={14} />
+              {cell.error}
+            </div>
+          </ResultBox>
+        )}
+        {cell.status === 'ok' && cell.result !== null && <ResultView result={cell.result} />}
+      </div>
+    </Card>
+  );
+}
+
+/** The result well. Sunken, hairline, 8px — the same box in every cell state. */
+function ResultBox({ children, muted = false }: { children: React.ReactNode; muted?: boolean }) {
+  return (
+    <div
+      className="flex flex-col justify-center text-[13px] leading-4"
+      style={{
+        minHeight: 40,
+        padding: '10px 12px',
+        borderRadius: 'var(--radius-input)',
+        background: 'var(--surface-sunken)',
+        boxShadow: 'inset 0 0 0 0.5px var(--separator)',
+        color: muted ? 'var(--label-secondary)' : 'var(--label)',
+      }}
+    >
+      {children}
     </div>
   );
 }
@@ -377,19 +336,17 @@ function ResultView({ result }: { result: unknown }) {
   const body = truncated ? `${text.slice(0, MAX)}\n… (truncated, ${text.length - MAX} more chars)` : text;
   return (
     <pre
+      className="text-[11px] leading-4 overflow-auto"
       style={{
-        marginTop: 8,
-        padding: '8px 10px',
-        background: 'var(--bg-code, rgba(0,0,0,0.06))',
-        borderRadius: 6,
-        fontSize: 10,
-        lineHeight: '1.5',
-        fontFamily: 'monospace',
-        color: 'var(--text-primary)',
-        border: '0.5px solid var(--border)',
-        overflowX: 'auto',
+        margin: 0,
+        minHeight: 40,
+        padding: '10px 12px',
+        borderRadius: 'var(--radius-input)',
+        background: 'var(--surface-sunken)',
+        boxShadow: 'inset 0 0 0 0.5px var(--separator)',
+        fontFamily: 'var(--font-mono)',
+        color: 'var(--label)',
         maxHeight: 360,
-        overflowY: 'auto',
         whiteSpace: 'pre-wrap',
         wordBreak: 'break-word',
       }}
@@ -398,21 +355,3 @@ function ResultView({ result }: { result: unknown }) {
     </pre>
   );
 }
-
-function Spinner() {
-  return (
-    <span
-      style={{
-        width: 10,
-        height: 10,
-        borderRadius: '50%',
-        border: '1.5px solid var(--border)',
-        borderTopColor: 'var(--accent)',
-        animation: 'spin 0.8s linear infinite',
-        display: 'inline-block',
-      }}
-      aria-hidden="true"
-    />
-  );
-}
-

--- a/packages/app/src/renderer/tabs/__tests__/notebook.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/notebook.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+/**
+ * Notebook — the macOS 26 layer (TRA-310).
+ *
+ * These assert the rules the surface used to break, not its markup: it names
+ * the project it queries, every control comes from lattice/ui, the reading
+ * text is on the type scale, and there is no second accent capsule per cell.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Notebook } from '../Notebook';
+
+const root = '/Users/someone/code/my-project';
+
+function renderNotebook(callTool = vi.fn().mockResolvedValue({ items: [] })) {
+  const utils = render(<Notebook root={root} client={{ callTool }} />);
+  return { ...utils, callTool };
+}
+
+describe('Notebook', () => {
+  it('names the project the cells query', () => {
+    renderNotebook();
+    // The surface used to have no toolbar at all, so nothing on screen said
+    // which project a run would hit.
+    expect(screen.getByRole('toolbar')).toBeTruthy();
+    expect(screen.getByText('my-project')).toBeTruthy();
+  });
+
+  it('counts cells in the toolbar, in singular and plural', () => {
+    renderNotebook();
+    expect(screen.getByText('1 cell')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Add cell' }));
+    expect(screen.getByText('2 cells')).toBeTruthy();
+  });
+
+  it('uses lattice controls, not hand-rolled ones', () => {
+    const { container } = renderNotebook();
+    // Tool picker is a PopUpButton (a bare <select> was the old chrome).
+    expect(container.querySelector('.lx-popup select')).toBeTruthy();
+    // Every button is .lx-btn.
+    const buttons = [...container.querySelectorAll('button')];
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const b of buttons) expect(b.classList.contains('lx-btn')).toBe(true);
+    // Every text field is .lx-input.
+    const inputs = [...container.querySelectorAll('input[type="text"]')];
+    expect(inputs.length).toBeGreaterThan(0);
+    for (const i of inputs) expect(i.classList.contains('lx-input')).toBe(true);
+  });
+
+  it('keeps Run off the prominent variant so N cells are not N accent capsules', () => {
+    const { container } = renderNotebook();
+    fireEvent.click(screen.getByRole('button', { name: 'Add cell' }));
+    expect(container.querySelectorAll('.lx-btn.v-prominent').length).toBe(0);
+  });
+
+  it('gives the remove button both a label and a tooltip', () => {
+    renderNotebook();
+    fireEvent.click(screen.getByRole('button', { name: 'Add cell' }));
+    const remove = screen.getByRole('button', { name: 'Remove cell 1' });
+    expect(remove.getAttribute('title')).toBe('Remove cell');
+  });
+
+  it('labels fields with the human label, not the raw arg key', () => {
+    renderNotebook();
+    expect(screen.getByText('Query')).toBeTruthy();
+    expect(screen.queryByText('query')).toBeNull();
+  });
+
+  it('tells the user what to do instead of naming the failed field', () => {
+    renderNotebook();
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toBe('Enter a query to run this cell.');
+  });
+
+  it('shows a skeleton while a cell runs, never the word "Loading"', async () => {
+    let release: (v: unknown) => void = () => {};
+    const callTool = vi.fn(() => new Promise((r) => { release = r; }));
+    const { container } = renderNotebook(callTool);
+    fireEvent.change(screen.getByPlaceholderText('e.g. registerTool'), {
+      target: { value: 'registerTool' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    await waitFor(() => expect(screen.getByRole('status', { name: 'Running' })).toBeTruthy());
+    expect(container.querySelectorAll('.ws-skel').length).toBe(3);
+    expect(container.textContent).not.toMatch(/Loading/i);
+
+    release({ items: [] });
+    await waitFor(() => expect(screen.queryByRole('status', { name: 'Running' })).toBeNull());
+  });
+
+  it('runs the selected tool against the project root', async () => {
+    const { callTool } = renderNotebook();
+    fireEvent.change(screen.getByPlaceholderText('e.g. registerTool'), {
+      target: { value: 'registerTool' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    await waitFor(() =>
+      expect(callTool).toHaveBeenCalledWith('search', { query: 'registerTool' }, root),
+    );
+  });
+
+  it('resets args when the tool changes', () => {
+    renderNotebook();
+    fireEvent.change(screen.getByPlaceholderText('e.g. registerTool'), {
+      target: { value: 'stale' },
+    });
+    fireEvent.change(screen.getByLabelText('Tool'), { target: { value: 'get_outline' } });
+    expect(screen.getByPlaceholderText('src/server/server.ts')).toHaveProperty('value', '');
+    expect(screen.queryByPlaceholderText('e.g. registerTool')).toBeNull();
+  });
+});

--- a/packages/app/src/renderer/tabs/notebook-runtime.ts
+++ b/packages/app/src/renderer/tabs/notebook-runtime.ts
@@ -46,7 +46,10 @@ export const NOTEBOOK_TOOLS: ToolDef[] = [
     description: 'Search symbols by name across the project',
     fields: [
       { key: 'query', label: 'Query', placeholder: 'e.g. registerTool', required: true },
-      { key: 'kind', label: 'Kind (optional)', placeholder: 'function | class | method | …' },
+      // Optionality lives in the placeholder, not the label: "Kind (optional)"
+      // wrapped to two lines in the form's label column and broke the row's
+      // baseline. `required` is what the runtime actually reads.
+      { key: 'kind', label: 'Kind', placeholder: 'function | class | method — optional' },
     ],
   },
   {


### PR DESCRIPTION
Notebook was the last project surface that never went through the macOS 26 revision. `DESIGN.md` §12 listed it in neither the "done" nor the "being migrated" column, and the file was 419 lines of inline styles written against the legacy alias set.

Migrated whole, one surface, per the house rule.

## Measured on the running renderer, both appearances

| | before | after |
|---|---|---|
| type sizes on screen | 9 / 10 / 11 / 12 / 13px — five | 13 + 11 — two |
| control heights | 22 / 25 / 26 / 28 / 32px — four | 24px — one |
| control radii | 5 / 6 / 8px on capsule controls | capsule · 6px icon · 8px input |
| smallest hit target | remove-cell 22×22 | 24×24 |
| value font | raw `monospace` (resolves to Courier) | `--font-mono` |
| content measure | 1004px card in a 1060px pane | 720px, centred |
| prominent actions | one accent Run **per cell** | none — Run is `bordered` |
| controls from `lattice/ui` | 0 of 5 | 5 of 5 |
| token-guard violations | 1 | 0 (baseline entry dropped) |

The surface also had **no toolbar at all**, so nothing on screen said which project a run would hit — the one fact that matters with several windows open. It now draws the house 52px `Toolbar` with the project name and a cell count, like Activity and Project Overview.

## Two defects only the render showed

The measurements were all green before I caught these by looking:

- The idle tool description, drawn as a `--surface-sunken` well, read as **a third, oversized text field** stacked under Query and Kind. It is a plain caption now, no box.
- **"Kind (optional)" wrapped to two lines** in the 88px label column and broke its row's baseline. Optionality moved into the placeholder; `required` is what the runtime reads anyway.

## One AA failure introduced and fixed

The first pass put the error sentence in `--status-red` on a 10% tint of the same hue. Measured **4.31:1** in light — a fail. `--status-red` is verified against `--surface` / `--surface-sunken`, not against a tint of itself, and `--badge-red-fg` didn't rescue it either (4.41:1 — the browser's `color-mix(… in oklab)` isn't the sRGB alpha model the badge tokens were verified under).

The error is now the same well as every other cell state — **4.94:1 light / 5.41:1 dark**, exactly the token's verified value — and reads as an error from its warning glyph rather than from a coloured slab. That also gives the four cell states one shared geometry, which was the intent. `DESIGN.md` §2 and the decision log now say a status colour never goes on a tint of its own hue.

## New primitive

`controls.css` declared "one geometry for every control in the app" but had no text-field tier, so Notebook would have been a fourth hand-rolled input geometry. Added `.lx-input` (24px, `--radius-input`, hairline, house focus ring, `.mono` variant) and extended `primitives.test.tsx` to guard it. Worth noting the radius test **correctly failed** on the new value until the exception was named — 8px is legal on a text field and nowhere else, the same shape as the existing 9px-checkbox carve-out.

## Verification

- `typecheck`, `lint`, `format:check` clean; `pnpm test` 217/217 (10 new).
- `design-tokens.mjs` clean; Notebook's baseline entry removed, not lowered.
- Screenshots: light, dark, Increase Contrast, and the 640px minimum window — nothing overlaps, no double scroll.
- Tabbed the whole surface: 11 focusables, sane order, every one paints a ring, none under 24×24.
- All four states looked at, including a real `search` response and the running skeleton.

Closes TRA-310. Parent: TRA-284.
