### PR TITLE
docs: require the repo git identity for agent commits so license/cla resolves

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,10 @@ These workflows define which trace-mcp tools MUST be used at each stage. Follow 
 3. `detect_antipatterns` {} — performance antipattern scan
 4. `compare_branches` { branch: "current" } — symbol-level diff for PR description
 5. Fix any critical/high findings before committing
+6. Commit with the repo's configured git identity — never `git config user.email` to an
+   agent address. It resolves to no GitHub login, so `license/cla` hangs at `pending`
+   forever and the PR reads red. Attribute the agent with an `Agent:` message trailer
+   (see CONTRIBUTING.md).
 
 ### Bug fixing
 1. `predict_bugs` {} — prioritize which files to investigate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,25 @@ The full CLA text is available in [CLA.md](CLA.md). Key points:
 - You represent that the work is original and you have authority to contribute it.
 - All contributions remain subject to the [Ethical Use Addendum](LICENSE).
 
+### Commit identity for AI agents
+
+`license/cla` matches a commit's author against a **GitHub login**. An address like
+`some-agent@users.noreply.github.com` belongs to no account, resolves to no login, and the
+check sits at `pending` forever — the PR looks red even when every required check is green.
+
+So: **do not override the repository's git identity when committing.** Leave `user.name` /
+`user.email` as configured for the checkout and record which agent did the work as a message
+trailer instead:
+
+```
+fix(indexer): skip symlinked dirs during walk
+
+Agent: Design/UX Agent
+```
+
+Use a plain `Agent:` trailer, not `Co-authored-by:` — a co-author address that maps to no
+GitHub account re-creates the same unresolvable check.
+
 ## Review Model
 
 trace-mcp currently has a single maintainer with commit access. `master` is protected by required status checks (CodeQL, Semgrep, `impact-report`) — these run on every PR and must pass before merge. There is no required-approving-review count: with one collaborator, a "1 approval" rule can never be satisfied by anyone but the PR author, so it was dropped rather than kept as a check that always reads "satisfied" without anyone having looked. If a second maintainer joins, review requirements will be reinstated.


### PR DESCRIPTION
Fixes TRA-317.

## The problem

`license/cla` (CLA Assistant) matches a commit's author against a GitHub **login**. Agent-authored commits used addresses like `design-ux-agent@users.noreply.github.com`, which belong to no account and resolve to no login — so there is nobody to check against a signed CLA and the check stays `pending` forever. The PR reads red even when CodeQL, Semgrep and `impact-report` are all green, which trains every agent run to reach past a non-passing check.

## The call

Of the three options in the issue, this takes **(1) agents commit with the repo git identity**:

- **(2) allowlist agent addresses** doesn't actually work — there is no login to allowlist — and would need Nikolai's cla-assistant.io account.
- **(3) drop `license/cla`** also needs his account, and gives up the guard if the repo ever takes outside PRs.
- **(1)** matches what every already-merged PR looks like, needs zero CI config, and I can land it today.

Attribution moves from the author field to an `Agent:` message trailer. Deliberately *not* `Co-authored-by:` — a co-author address that maps to no account re-creates the same unresolvable check.

## Changes

- `CONTRIBUTING.md` — new "Commit identity for AI agents" subsection under the CLA section, with the trailer convention.
- `CLAUDE.md` — step 6 in the "Before PR / commit" checklist, where an agent actually reads it.

Docs only, no code. This PR's own commit follows the rule, so `license/cla` on it is the test.