### PR TITLE
fix(registry): stop the mtime cache serving a stale registry (TRA-326)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,19 @@ jobs:
             # a Windows-shaped hole because cross-platform-test only ran on
             # release PRs — nothing exercised these files on Windows until the
             # release was already cut.
+            # TRA-326: the registry/global/db-holder files do raw fs work
+            # (mtime caching, holder files, pid liveness) whose semantics differ
+            # on Windows — #477 broke master there while showing all-green here.
             platform:
               - 'src/dangerous-root.ts'
               - 'src/project-setup.ts'
               - 'src/topology/**'
+              - 'src/registry.ts'
+              - 'src/global.ts'
+              - 'src/db-holders.ts'
               - 'tests/project-setup/dangerous-root.test.ts'
               - 'tests/topology/**'
+              - 'tests/registry.test.ts'
             core:
               - 'src/**'
               - 'scripts/**'

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -87,19 +87,21 @@ const MTIME_GRANULARITY_MS = 50;
 let _registryCache: { mtimeMs: number; size: number; reg: Registry } | null = null;
 
 function loadRegistry(): Registry {
-  let mtimeMs: number;
-  let size: number;
+  // Stat and read through one descriptor: the metadata we key the cache on then
+  // describes exactly the bytes we parsed, even if the file is replaced midway.
+  let fd: number;
   try {
-    ({ mtimeMs, size } = fs.statSync(REGISTRY_PATH));
+    fd = fs.openSync(REGISTRY_PATH, 'r');
   } catch {
     return emptyRegistry(); // no registry file yet
   }
-  const settled = Date.now() - mtimeMs >= MTIME_GRANULARITY_MS;
-  if (settled && _registryCache?.mtimeMs === mtimeMs && _registryCache.size === size) {
-    return structuredClone(_registryCache.reg);
-  }
   try {
-    const raw = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf-8'));
+    const { mtimeMs, size } = fs.fstatSync(fd);
+    const settled = Date.now() - mtimeMs >= MTIME_GRANULARITY_MS;
+    if (settled && _registryCache?.mtimeMs === mtimeMs && _registryCache.size === size) {
+      return structuredClone(_registryCache.reg);
+    }
+    const raw = JSON.parse(fs.readFileSync(fd, 'utf-8'));
     if (raw.version === 1 && raw.projects) {
       _registryCache = { mtimeMs, size, reg: raw as Registry };
       return structuredClone(raw as Registry);
@@ -107,6 +109,8 @@ function loadRegistry(): Registry {
     return emptyRegistry();
   } catch {
     return emptyRegistry();
+  } finally {
+    fs.closeSync(fd);
   }
 }
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -79,25 +79,29 @@ function emptyRegistry(): Registry {
 // corrupting the cache.
 // ponytail: mtime is the cross-process invalidation signal (another daemon/CLI
 // writing the file bumps it); within-process writes drop the cache explicitly
-// in saveRegistry. Ceiling: sub-mtime-resolution double-writes from a *foreign*
-// process could serve one stale read — acceptable for a registry that changes
-// on register/unregister only.
-let _registryCache: { mtimeMs: number; reg: Registry } | null = null;
+// in saveRegistry. mtime alone is not enough: filesystem timestamp granularity
+// is coarse (~15ms on Windows), so two writes can share one mtime and hide the
+// second (TRA-326). Size is a cheap second signal, and any file younger than
+// one granularity tick is never trusted from cache at all.
+const MTIME_GRANULARITY_MS = 50;
+let _registryCache: { mtimeMs: number; size: number; reg: Registry } | null = null;
 
 function loadRegistry(): Registry {
   let mtimeMs: number;
+  let size: number;
   try {
-    mtimeMs = fs.statSync(REGISTRY_PATH).mtimeMs;
+    ({ mtimeMs, size } = fs.statSync(REGISTRY_PATH));
   } catch {
     return emptyRegistry(); // no registry file yet
   }
-  if (_registryCache && _registryCache.mtimeMs === mtimeMs) {
+  const settled = Date.now() - mtimeMs >= MTIME_GRANULARITY_MS;
+  if (settled && _registryCache?.mtimeMs === mtimeMs && _registryCache.size === size) {
     return structuredClone(_registryCache.reg);
   }
   try {
     const raw = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf-8'));
     if (raw.version === 1 && raw.projects) {
-      _registryCache = { mtimeMs, reg: raw as Registry };
+      _registryCache = { mtimeMs, size, reg: raw as Registry };
       return structuredClone(raw as Registry);
     }
     return emptyRegistry();

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -50,6 +50,26 @@ function setAddedAt(root: string, iso: string): void {
   fs.writeFileSync(REGISTRY_PATH, JSON.stringify(reg, null, 2));
 }
 
+describe('registry cache invalidation', () => {
+  // TRA-326: loadRegistry caches by mtime. Windows' filesystem timestamp
+  // granularity (~15ms) is coarse enough that two writes land on the same
+  // mtime, which made a test see the previous test's registry. utimesSync
+  // reproduces that collision deterministically on every platform.
+  it('does not serve a stale registry when a rewrite reuses the same mtime', () => {
+    const workdir = makeEphemeralWorkdir();
+    registerProject(workdir);
+    setAddedAt(workdir, new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString());
+    const sameTick = Math.floor(Date.now() / 1000) - 3600; // whole seconds: exact on every fs
+    fs.utimesSync(REGISTRY_PATH, sameTick, sameTick);
+    expect(findEphemeralProjects()).toHaveLength(1); // populates the cache
+
+    fs.writeFileSync(REGISTRY_PATH, JSON.stringify({ version: 1, projects: {} }, null, 2));
+    fs.utimesSync(REGISTRY_PATH, sameTick, sameTick);
+
+    expect(findEphemeralProjects()).toEqual([]);
+  });
+});
+
 describe('resolveRegisteredAncestor', () => {
   it('returns null when no registered project covers the path', () => {
     const dir = makeTmpRepo();


### PR DESCRIPTION
Fixes TRA-326. Master went red on `cross-platform-test (windows-latest)` after #477, blocking the 2.3.0 release PR (#476).

## Root cause

`loadRegistry()` caches the parsed registry keyed on `mtimeMs` alone. Filesystem timestamp granularity is coarse (~15ms on Windows), so two writes can land on the *same* mtime — the second one is then invisible and every reader keeps getting the earlier state.

`tests/registry.test.ts` resets the registry in `beforeEach` with a raw `fs.writeFileSync` (not `saveRegistry`, which drops the cache explicitly). When that reset shared an mtime with the previous test's last write, the previous test's fixture survived into the next test:

```
expect(findEphemeralProjects(24)).toEqual([]);
+ [ { name: "workdir", ageHours: 48.00000333, ... } ]   // <- previous test's -48h fixture
```

Not a bug in #477 itself — #477 changed *when* `registerProject` reaches `saveRegistry` (the early-return path now announces a holder first), which changed the write timing enough to hit a latent hole.

## Fix

- `size` as a second invalidation signal alongside `mtimeMs`.
- Never serve from cache a file younger than one granularity tick (`MTIME_GRANULARITY_MS = 50`) — a just-written file is always re-read. Normal reads (registry untouched for seconds+) still hit the cache, so the token/IO win the cache exists for is unchanged.

## Test evidence

New regression test reproduces the failure deterministically on **every** platform by forcing an mtime collision with `utimesSync`. Before the fix it fails with the exact CI symptom (`ageHours: 48.000000...`); after, it passes.

`pnpm run test`: **8808 passed | 9 skipped** (803 files). Build + biome clean.

## CI gap this exposed

`cross-platform-test` skipped #477 because the `platform` paths filter didn't list the registry files. Added `src/registry.ts`, `src/global.ts`, `src/db-holders.ts`, `tests/registry.test.ts` — these do raw fs work (mtime caching, holder files, pid liveness) whose semantics differ on Windows. This PR therefore runs the Windows job itself.

## Not fixed here

The second Windows failure — `src/pipeline/__tests__/sqlite-task-cache.test.ts` `afterEach` timing out at 15s — is a separate slow-runner flake class with no identified mechanism (the same job passed 8633 tests). Not guessing at a fix; the Windows job on this PR will show whether it recurs.
