### PR TITLE
fix(app): make the workspace survive the 640x420 minimum window

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -356,6 +356,42 @@ Every data surface owes four states, and each has a house form:
   slides under is a scroll edge; a sticky header must have an **opaque** backing, or
   rows show through the column labels.
 
+### The window minimum is a size that has to work
+
+`main/tray.ts` sets `minWidth: 640, minHeight: 420`. Every surface must be usable
+there, not merely render there. Two rules fall out, and the Workspace breaks both if
+you undo them:
+
+- **Chrome above content, always.** The toolbar is the top of the pane. Content —
+  including a KPI strip — goes *below* it. With the strip first, six 99px tiles
+  wrapped to 357px and pushed the toolbar's bottom edge 33px past a 420px window;
+  since nothing on this surface scrolls, search, Filter, + Add and the whole project
+  list became unreachable rather than merely off-screen.
+- **A toolbar wraps; it never clips.** Give it `min-height: 52px` and `flex-wrap`,
+  not `height: 52px`. A fixed non-wrapping row inside `overflow-x: hidden` ran 51px
+  past a 420px pane and put + Add's chevron and the overflow menu outside the window.
+
+**Respond to the pane, not to the window.** The sidebar is resizable 180–320px and
+collapsible, so window width says almost nothing about the room a surface has. Watch
+the pane with one `ResizeObserver` and derive from it. `Workspace.tsx` is the pattern:
+`TABLE_MIN_PANE_W` is *computed* from the table's own frozen columns plus a minimum
+scroll window, and `isDensePane()` compares the pane's height against
+`kpiStripHeight(paneW)` rather than against a guessed breakpoint — which is why it
+reproduces the measured 357px exactly instead of drifting from it.
+
+**What gives way, in order.** Never the identity of the screen; always the
+elaboration.
+
+1. **A comparison before a value.** A dense `KpiTile` drops the footnote/delta line
+   and lays out label ↔ value on one 36px line. The number never goes; the sentence
+   an em dash needs moves to the tile's `title`.
+2. **A table before a list.** Below `TABLE_MIN_PANE_W` the Workspace renders
+   `WorkspaceCompactView` instead of scrolling a 1025px table through a 15px slot.
+   The stored preference is **not** rewritten — widening the window brings the user's
+   own choice back.
+3. **A toggle whose alternatives are unusable is hidden, not disabled.** A disabled
+   segment is a control with nothing to choose; it returns with the width.
+
 ---
 
 ## 7. Accessibility
@@ -481,6 +517,9 @@ code correctness and visual correctness are different claims.
 - [ ] Tab through it: visible focus ring everywhere, tables are one tab stop, no keyboard trap.
 - [ ] No action reachable only on hover; right-click offers what the row buttons offer.
 - [ ] Screenshots in light **and** dark, plus Reduce Transparency and Increase Contrast wherever material is involved.
+- [ ] Resized to **640×420**, the window minimum: no control has a bounding box outside
+      the viewport without a scrollable ancestor, and the surface's own content is
+      reachable. Walk it — `getBoundingClientRect()` over every focusable, not a glance.
 
 ---
 
@@ -525,6 +564,11 @@ new evidence.
 | A status colour is never put on a tint of its own hue | `--status-red` is verified on `--surface`; on a 10% red fill it measured 4.31:1. An error reads as an error from its glyph, not from a coloured slab. |
 | Notebook's per-cell Run is `bordered`, not `prominent` | One accent capsule per cell put N prominent actions on one surface. The rule is one per region, and a notebook has no single default action. |
 | Optionality lives in a field's placeholder, not its label | "Kind (optional)" wrapped to two lines in the form's label column and broke the row baseline. `required` is what the code reads anyway. |
+| The toolbar sits **above** the KPI strip, not below it | Chrome above content. With the strip first, 357px of tiles pushed the toolbar's bottom 33px past a 420px window and nothing on the surface could scroll it back. |
+| A toolbar has `min-height: 52px` and wraps, never a fixed `height` | A non-wrapping 52px row inside `overflow-x: hidden` ran 51px past a 420px pane and put + Add's chevron and the overflow menu outside the window. |
+| Breakpoints are read off the **pane**, and computed rather than picked | The sidebar is resizable 180–320px, so window width is not a proxy for room. `kpiStripHeight()` reproduces the measured 357px; a guessed number drifts the first time a tile changes. |
+| Narrow gives up the comparison, then the table, never the value | The number and the project name are the screen; the footnote and the metric columns are elaboration. Compact already renders a legible row at 420px. |
+| A view toggle with one usable option is hidden, not disabled | A disabled segment is a control with nothing to choose. The stored preference is untouched and returns with the width. |
 | Migrate a screen **whole**, one screen per PR | A half-migrated screen looks worse than the un-migrated one; a big-bang redesign PR never lands. |
 | Tokens and primitives land before any surface | A surface migrated against a moving token layer gets migrated twice. |
 

--- a/packages/app/src/renderer/workspace/Workspace.tsx
+++ b/packages/app/src/renderer/workspace/Workspace.tsx
@@ -14,8 +14,13 @@
  * Every state keeps the chrome: a failed request never collapses the screen to
  * two centred lines. The KPI strip and the toolbar stay where they were, and
  * the pane below explains what happened next to the one action that fixes it.
+ *
+ * The surface also has to survive the smallest window the app allows
+ * (640×420 — `main/tray.ts`). It watches its own pane rather than the window,
+ * because the sidebar is resizable: below `TABLE_MIN_PANE_W` the table gives
+ * way to Compact, and below `DENSE_PANE_H` the KPI tiles collapse to one line.
  */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, EmptyState } from '../lattice/ui';
 import { addRecentProject, removeRecentProject } from '../recent-projects';
 import { AddProjectControl } from './AddProjectControl';
@@ -63,6 +68,63 @@ function loadFilter(): WorkspaceFilter {
     // Corrupted JSON — fall back to defaults
   }
   return EMPTY_FILTER;
+}
+
+// ── Responding to the pane, not to the window ─────────────────────────────
+//
+// The sidebar is user-resizable (180–320px) and collapsible, so window width
+// tells you very little about how much room this surface actually has. Both
+// thresholds are read off the pane itself.
+
+// Pane and strip geometry, all read off the rendered surface rather than guessed.
+const TILE_MIN_W = 132; // KpiTile's flex basis
+const TILE_GAP = 16; // gap-4
+const TILE_H = 99; // a full-height tile: 16 + 13 + 4 + 32 + 4 + 13 + 16 + hairlines
+const STRIP_PAD = 28; // pt-4 + pb-3
+const TOOLBAR_H = 52;
+const PANE_PAD = 32; // px-4, both sides
+const KPI_COUNT = 6;
+
+/** Table columns that are pinned and never scroll: checkbox, Project, Actions. */
+const FROZEN_COLS_W = 32 + 240 + 100;
+/** Narrower than this and the scroll window shows less than one whole column. */
+const MIN_SCROLL_WINDOW = 160;
+
+/**
+ * Below this pane width the table has nowhere to live. Its frozen columns never
+ * scroll, so what is left is the entire window onto 1025px of table. At a 420px
+ * pane that window is 15px wide and the pinned Actions cell paints over the
+ * Status dot, leaving status as half a coloured dot with no word.
+ */
+export const TABLE_MIN_PANE_W = PANE_PAD + FROZEN_COLS_W + MIN_SCROLL_WINDOW;
+
+/**
+ * How tall the full-height KPI strip would be in a pane this wide. The tiles
+ * flex-wrap, so width decides how many rows of 99px there are — at the app's
+ * 640px minimum window this returns 357, which is what the strip measured.
+ */
+export function kpiStripHeight(paneW: number): number {
+  const inner = Math.max(0, paneW - PANE_PAD);
+  const perRow = Math.max(1, Math.floor((inner + TILE_GAP) / (TILE_MIN_W + TILE_GAP)));
+  const rows = Math.ceil(KPI_COUNT / perRow);
+  return rows * TILE_H + (rows - 1) * TILE_GAP + STRIP_PAD;
+}
+
+/** A pane too narrow for the table. `0` means "not measured yet" — assume wide. */
+export function isNarrowPane(width: number): boolean {
+  return width > 0 && width < TABLE_MIN_PANE_W;
+}
+
+/**
+ * True when full-height tiles would leave less than two project rows. The strip
+ * is the only part of this surface that can give height back, and it has to,
+ * because nothing here scrolls: at 640×420 the strip was 357px of a 376px pane,
+ * which put the toolbar 33px past the window bottom and the list at 1px tall
+ * with no scroll container anywhere to recover either (TRA-325).
+ */
+export function isDensePane(width: number, height: number): boolean {
+  if (width <= 0 || height <= 0) return false;
+  return height - TOOLBAR_H - kpiStripHeight(width) < 2 * ROW_H;
 }
 
 // ── Open handler (cross-window IPC) ───────────────────────────────────────
@@ -162,6 +224,29 @@ export function Workspace() {
 
   const handleScroll = useCallback((top: number) => setScrolled(top > 0), []);
 
+  // ── Pane size ────────────────────────────────────────────────────────
+  const paneRef = useRef<HTMLDivElement>(null);
+  const [pane, setPane] = useState({ w: 0, h: 0 });
+  useEffect(() => {
+    const el = paneRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver((entries) => {
+      const box = entries[0]?.contentRect;
+      if (!box) return;
+      const w = Math.round(box.width);
+      const h = Math.round(box.height);
+      setPane((prev) => (prev.w === w && prev.h === h ? prev : { w, h }));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const narrow = isNarrowPane(pane.w);
+  const dense = isDensePane(pane.w, pane.h);
+  // The stored preference is never rewritten: widening the window has to bring
+  // the user's own choice back, not whatever the narrow layout fell back to.
+  const effectiveView: ViewMode = narrow ? 'compact' : view;
+
   // ── Render ───────────────────────────────────────────────────────────
   // The live feed being down does not mean there is nothing to show: the
   // metrics cache usually still has every project. Only take over the pane
@@ -205,7 +290,7 @@ export function Workspace() {
   };
 
   return (
-    <div className="flex flex-col h-full overflow-hidden relative">
+    <div ref={paneRef} className="flex flex-col h-full overflow-hidden relative">
       <WorkspaceHeader
         kpis={kpis}
         metricsLoading={data.metricsLoading && data.error === null}
@@ -219,6 +304,8 @@ export function Workspace() {
         onRefresh={() => void data.refresh()}
         refreshing={data.refreshing}
         scrolled={scrolled}
+        dense={dense}
+        hideViewToggle={narrow}
         rightExtra={<AddProjectControl onAdd={(root) => data.addProject(root)} />}
       />
 
@@ -278,7 +365,7 @@ export function Workspace() {
               </Button>
             }
           />
-        ) : view === 'compact' ? (
+        ) : effectiveView === 'compact' ? (
           <WorkspaceCompactView {...viewProps} />
         ) : (
           <WorkspaceTableView

--- a/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
@@ -1,13 +1,17 @@
 /**
  * WorkspaceHeader — dashboard strip + toolbar of the unified Workspace tab.
  *
- * Layout:
+ * Layout, top to bottom — chrome first, then content (DESIGN.md §6):
+ *  Toolbar  — glass row, 52px on one line, holding search, one Filter pop-up,
+ *             the view toggle, the single prominent action (+ Add) and an
+ *             overflow menu. Everything else lives in that menu: the ceiling is
+ *             four actions plus search, not thirteen controls in a row. It
+ *             wraps rather than clipping — at a 420px pane the trailing group
+ *             used to run 51px past the window with nothing to scroll, which
+ *             put + Add's chevron and the overflow menu out of reach entirely.
  *  KPI grid — six content cards, each in card anatomy (label → value →
- *             comparison). Opaque, hairline, no shadow, no glass.
- *  Toolbar  — 52px glass row holding search, one Filter pop-up, the view
- *             toggle, the single prominent action (+ Add) and an overflow
- *             menu. Everything else lives in that menu: the ceiling is four
- *             actions plus search, not thirteen controls in a wrap-around row.
+ *             comparison). Opaque, hairline, no shadow, no glass. `dense`
+ *             collapses each to a 36px line when the pane cannot afford 99px.
  *
  * Receives all data + state via props; does not call useWorkspaceProjects.
  */
@@ -64,6 +68,10 @@ export interface WorkspaceHeaderProps {
   refreshing: boolean;
   /** True once the content pane is scrolled — fades in the scroll-edge hairline. */
   scrolled?: boolean;
+  /** Collapse the KPI tiles to one line each — see {@link KpiTileProps.dense}. */
+  dense?: boolean;
+  /** The pane is too narrow for the table, so Compact is the only view. */
+  hideViewToggle?: boolean;
   /** Slot rendered at the end of the toolbar row (typically AddProjectControl). */
   rightExtra?: ReactNode;
 }
@@ -130,6 +138,8 @@ export function WorkspaceHeader({
   onRefresh,
   refreshing,
   scrolled = false,
+  dense = false,
+  hideViewToggle = false,
   rightExtra,
 }: WorkspaceHeaderProps) {
   // Locally-debounced search so typing doesn't spam upstream re-renders.
@@ -172,87 +182,16 @@ export function WorkspaceHeader({
 
   return (
     <div className="flex flex-col shrink-0">
-      {/* ── KPI grid ───────────────────────────────────────────────── */}
-      <div className="flex items-stretch gap-4 px-4 pt-4 pb-3 flex-wrap">
-        <KpiTile
-          label="Projects"
-          value={kpis.totalProjects}
-          pending={listLoading}
-          unavailable={listFailed}
-          delta={delta((k) => k.totalProjects)}
-          deltaCaption={deltaCaption}
-          footnote="tracking from today"
-          active={isDefaultFilter(filter)}
-          onClick={() => onFilterChange(EMPTY_FILTER)}
-        />
-        <KpiTile
-          label="Files"
-          value={kpis.totalFiles}
-          compact
-          pending={metricsLoading}
-          unavailable={metricsFailed}
-          delta={delta((k) => k.totalFiles)}
-          deltaCaption={deltaCaption}
-          footnote={
-            kpis.totalProjects > 0
-              ? `${Math.round(kpis.totalFiles / kpis.totalProjects).toLocaleString()} per project`
-              : 'no projects yet'
-          }
-        />
-        <KpiTile
-          label="Symbols"
-          value={kpis.totalSymbols}
-          compact
-          pending={metricsLoading}
-          unavailable={metricsFailed}
-          delta={delta((k) => k.totalSymbols)}
-          deltaCaption={deltaCaption}
-          footnote={
-            kpis.totalFiles > 0
-              ? `${Math.round(kpis.totalSymbols / kpis.totalFiles).toLocaleString()} per file`
-              : 'nothing indexed yet'
-          }
-        />
-        <KpiTile
-          label="Healthy"
-          value={kpis.healthy}
-          tone="ok"
-          pending={metricsLoading}
-          unavailable={metricsFailed}
-          footnote={share(kpis.healthy, kpis.totalProjects)}
-          active={filter.preset === 'healthy'}
-          onClick={() => togglePreset('healthy')}
-        />
-        <KpiTile
-          label="Needs attention"
-          value={kpis.needsAttention}
-          tone="warn"
-          pending={metricsLoading}
-          unavailable={metricsFailed}
-          footnote={share(kpis.needsAttention, kpis.totalProjects)}
-          active={filter.preset === 'needs_attention'}
-          onClick={() => togglePreset('needs_attention')}
-        />
-        <KpiTile
-          label="Indexing"
-          value={kpis.indexing}
-          tone="busy"
-          pending={listLoading}
-          unavailable={listFailed}
-          footnote={
-            kpis.indexing === 0 ? 'nothing running' : share(kpis.indexing, kpis.totalProjects)
-          }
-          active={filter.preset === 'indexing'}
-          onClick={() => togglePreset('indexing')}
-        />
-      </div>
-
       {/* ── Toolbar ────────────────────────────────────────────────── */}
+      {/* Chrome sits above content (DESIGN.md §6). With the KPI strip first, a
+          357px block of cards pushed the toolbar past the bottom of a 420px
+          window and nothing could scroll it back (TRA-325). */}
       {/* Ceiling is search + 4 actions. Everything else is in the two menus. */}
       <div
-        className="flex items-center gap-2 px-4 shrink-0 glass"
+        className="flex items-center gap-2 px-4 shrink-0 glass flex-wrap"
         style={{
-          height: 52,
+          minHeight: 52,
+          paddingBlock: 8,
           // Scroll-edge effect: the hairline fades in only once content is
           // sliding under the toolbar. No permanent hard border.
           borderBottom: '0.5px solid transparent',
@@ -280,13 +219,18 @@ export function WorkspaceHeader({
         </Button>
 
         <span className="ml-auto flex items-center gap-2">
-          <SegmentedControl
-            aria-label="View mode"
-            size="small"
-            value={view === 'compact' ? 'compact' : 'table'}
-            onChange={(v) => onViewChange(v as ViewMode)}
-            options={VIEW_OPTIONS}
-          />
+          {/* Hidden, not disabled, while Table cannot fit: a toggle whose only
+              other option is unusable is a control with nothing to choose. The
+              stored preference is untouched and returns with the width. */}
+          {!hideViewToggle && (
+            <SegmentedControl
+              aria-label="View mode"
+              size="small"
+              value={view === 'compact' ? 'compact' : 'table'}
+              onChange={(v) => onViewChange(v as ViewMode)}
+              options={VIEW_OPTIONS}
+            />
+          )}
           {rightExtra}
           <Button
             ref={overflowMenu.ref}
@@ -299,6 +243,87 @@ export function WorkspaceHeader({
             title="More actions"
           />
         </span>
+      </div>
+
+      {/* ── KPI grid ───────────────────────────────────────────────── */}
+      <div className="flex items-stretch gap-4 px-4 pt-4 pb-3 flex-wrap">
+        <KpiTile
+          label="Projects"
+          value={kpis.totalProjects}
+          dense={dense}
+          pending={listLoading}
+          unavailable={listFailed}
+          delta={delta((k) => k.totalProjects)}
+          deltaCaption={deltaCaption}
+          footnote="tracking from today"
+          active={isDefaultFilter(filter)}
+          onClick={() => onFilterChange(EMPTY_FILTER)}
+        />
+        <KpiTile
+          label="Files"
+          value={kpis.totalFiles}
+          compact
+          dense={dense}
+          pending={metricsLoading}
+          unavailable={metricsFailed}
+          delta={delta((k) => k.totalFiles)}
+          deltaCaption={deltaCaption}
+          footnote={
+            kpis.totalProjects > 0
+              ? `${Math.round(kpis.totalFiles / kpis.totalProjects).toLocaleString()} per project`
+              : 'no projects yet'
+          }
+        />
+        <KpiTile
+          label="Symbols"
+          value={kpis.totalSymbols}
+          compact
+          dense={dense}
+          pending={metricsLoading}
+          unavailable={metricsFailed}
+          delta={delta((k) => k.totalSymbols)}
+          deltaCaption={deltaCaption}
+          footnote={
+            kpis.totalFiles > 0
+              ? `${Math.round(kpis.totalSymbols / kpis.totalFiles).toLocaleString()} per file`
+              : 'nothing indexed yet'
+          }
+        />
+        <KpiTile
+          label="Healthy"
+          value={kpis.healthy}
+          tone="ok"
+          dense={dense}
+          pending={metricsLoading}
+          unavailable={metricsFailed}
+          footnote={share(kpis.healthy, kpis.totalProjects)}
+          active={filter.preset === 'healthy'}
+          onClick={() => togglePreset('healthy')}
+        />
+        <KpiTile
+          label="Needs attention"
+          value={kpis.needsAttention}
+          tone="warn"
+          dense={dense}
+          pending={metricsLoading}
+          unavailable={metricsFailed}
+          footnote={share(kpis.needsAttention, kpis.totalProjects)}
+          active={filter.preset === 'needs_attention'}
+          onClick={() => togglePreset('needs_attention')}
+        />
+        <KpiTile
+          label="Indexing"
+          value={kpis.indexing}
+          tone="busy"
+          dense={dense}
+          pending={listLoading}
+          unavailable={listFailed}
+          footnote={
+            kpis.indexing === 0 ? 'nothing running' : share(kpis.indexing, kpis.totalProjects)
+          }
+          active={filter.preset === 'indexing'}
+          onClick={() => togglePreset('indexing')}
+        />
       </div>
 
       {filterMenu.at && (

--- a/packages/app/src/renderer/workspace/__tests__/Workspace.pane.test.ts
+++ b/packages/app/src/renderer/workspace/__tests__/Workspace.pane.test.ts
@@ -1,0 +1,107 @@
+/**
+ * TRA-325: the Workspace has to survive the smallest window the app allows —
+ * `minWidth: 640, minHeight: 420` in `main/tray.ts`. Measured on the running
+ * renderer at 640×420 before this landed: the KPI grid was 357px tall, the
+ * toolbar's top edge sat at y=401 with its bottom 33px past the window, and the
+ * project list was 1px tall at y=465. No ancestor was scrollable, so none of it
+ * could be reached.
+ *
+ * Both thresholds are read off the pane, not the window: the sidebar is
+ * resizable 180–320px and collapsible, so window width says little about how
+ * much room this surface actually has.
+ */
+import { describe, expect, it } from 'vitest';
+import { TABLE_MIN_PANE_W, isDensePane, isNarrowPane, kpiStripHeight } from '../Workspace';
+
+/** Pane geometry for a window, with the default 220px sidebar and 44px header. */
+const pane = (winW: number, winH: number) => ({ w: winW - 220, h: winH - 44 });
+
+describe('kpiStripHeight', () => {
+  it('reproduces the strip measured at the minimum window', () => {
+    // 640 − 220 = a 420px pane: two tiles per row, three rows of 99px.
+    expect(kpiStripHeight(420)).toBe(357);
+  });
+
+  it('is one row of tiles once the pane fits all six', () => {
+    expect(kpiStripHeight(1060)).toBe(99 + 28);
+  });
+
+  it('never divides by a zero-width pane', () => {
+    expect(kpiStripHeight(0)).toBe(6 * 99 + 5 * 16 + 28);
+  });
+});
+
+describe('isNarrowPane', () => {
+  it('treats an unmeasured pane as wide', () => {
+    // The first paint runs before ResizeObserver reports. Guessing "narrow"
+    // there would flash Compact on every launch of a full-size window.
+    expect(isNarrowPane(0)).toBe(false);
+  });
+
+  it('is narrow at the app minimum window', () => {
+    expect(isNarrowPane(pane(640, 420).w)).toBe(true);
+  });
+
+  it('leaves the table alone at ordinary window sizes', () => {
+    for (const w of [800, 960, 1280, 1680]) {
+      expect(isNarrowPane(pane(w, 700).w)).toBe(false);
+    }
+  });
+
+  it('follows the pane, not the window — a widened sidebar narrows it too', () => {
+    // 800px window with the sidebar dragged to its 320px maximum.
+    expect(isNarrowPane(800 - 320)).toBe(true);
+  });
+
+  it('switches exactly at the threshold', () => {
+    expect(isNarrowPane(TABLE_MIN_PANE_W - 1)).toBe(true);
+    expect(isNarrowPane(TABLE_MIN_PANE_W)).toBe(false);
+  });
+
+  it('leaves the table a scroll window worth scrolling when it does allow it', () => {
+    // checkbox 32 + Project 240 + Actions 100 are pinned and never scroll.
+    expect(TABLE_MIN_PANE_W - 32 - (32 + 240 + 100)).toBeGreaterThanOrEqual(160);
+  });
+});
+
+describe('isDensePane', () => {
+  it('is dense at the app minimum window', () => {
+    const p = pane(640, 420);
+    // 376 − 52 toolbar − 357 strip is negative: the list had nowhere to be.
+    expect(isDensePane(p.w, p.h)).toBe(true);
+  });
+
+  it('is dense on a pane too short for the strip however wide it is', () => {
+    expect(isDensePane(1200, 200)).toBe(true);
+  });
+
+  it('is not dense at the default 960×700 window', () => {
+    const p = pane(960, 700);
+    expect(isDensePane(p.w, p.h)).toBe(false);
+  });
+
+  it('is not dense at ordinary window sizes', () => {
+    for (const [w, h] of [
+      [800, 600],
+      [1280, 800],
+      [1680, 1050],
+    ] as const) {
+      const p = pane(w, h);
+      expect(isDensePane(p.w, p.h)).toBe(false);
+    }
+  });
+
+  it('treats an unmeasured pane as roomy', () => {
+    expect(isDensePane(0, 0)).toBe(false);
+  });
+
+  it('always leaves two project rows when it declines to collapse', () => {
+    for (let winW = 640; winW <= 1600; winW += 40) {
+      for (let winH = 420; winH <= 1200; winH += 40) {
+        const p = pane(winW, winH);
+        if (isDensePane(p.w, p.h)) continue;
+        expect(p.h - 52 - kpiStripHeight(p.w)).toBeGreaterThanOrEqual(92);
+      }
+    }
+  });
+});

--- a/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
@@ -19,7 +19,13 @@ let strip: HTMLElement;
 
 function renderHeader(
   metricsLoading: boolean,
-  extra: Partial<{ listLoading: boolean; metricsFailed: boolean; listFailed: boolean }> = {},
+  extra: Partial<{
+    listLoading: boolean;
+    metricsFailed: boolean;
+    listFailed: boolean;
+    dense: boolean;
+    hideViewToggle: boolean;
+  }> = {},
 ) {
   const { container } = render(
     <WorkspaceHeader
@@ -117,6 +123,64 @@ describe('WorkspaceHeader KPI strip', () => {
       expect(lines).toHaveLength(3);
       expect(lines[2]).not.toBe('');
     }
+  });
+});
+
+describe('WorkspaceHeader at a pane that cannot afford the full layout', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('puts the toolbar above the KPI strip so chrome is never pushed off-window', () => {
+    // Six full tiles are 357px. With them first, a 420px window — the app's own
+    // minimum (main/tray.ts) — left the toolbar and the whole list below the
+    // bottom edge with no scroll container to reach them (TRA-325).
+    renderHeader(false);
+    const root = strip.firstElementChild!;
+    const toolbar = strip.querySelector('input[aria-label="Search projects"]')!.closest('.glass')!;
+    const kpiStrip = kpiTile('Projects').parentElement!;
+    const order = [...root.children];
+    expect(order.indexOf(toolbar)).toBeLessThan(order.indexOf(kpiStrip));
+  });
+
+  it('lets the toolbar wrap instead of clipping its trailing controls', () => {
+    renderHeader(false);
+    const toolbar = strip.querySelector('input[aria-label="Search projects"]')!.closest('.glass')!;
+    // A fixed 52px non-wrapping row ran 51px past a 420px pane, putting the
+    // + Add chevron and the overflow menu outside the window entirely.
+    expect(toolbar.className).toContain('flex-wrap');
+    expect(toolbar.getAttribute('style')).toContain('min-height: 52px');
+    // A floor, not a fixed height — a wrapped second line has to grow the row.
+    expect((toolbar as HTMLElement).style.height).toBe('');
+  });
+
+  it('collapses each KPI tile to label + value when dense', () => {
+    renderHeader(false, { dense: true });
+    for (const label of ['Projects', 'Files', 'Healthy', 'Indexing']) {
+      const tile = kpiTile(label);
+      expect(tile).toHaveProperty('dataset.dense', '');
+      // Two children, not three: the comparison line is what buys the height.
+      expect(tile.children).toHaveLength(2);
+      expect(kpiValue(label)).not.toBe('');
+    }
+  });
+
+  it('keeps "couldn\'t be measured" reachable when dense drops the caption', () => {
+    renderHeader(true, { dense: true, metricsFailed: true });
+    const tile = kpiTile('Files');
+    expect(kpiValue('Files')).toBe('—');
+    expect(tile.getAttribute('title')).toBe("Couldn't be measured");
+  });
+
+  it('hides the view toggle when Compact is the only view that fits', () => {
+    renderHeader(false, { hideViewToggle: true });
+    expect(strip.querySelector('[aria-label="View mode"]')).toBeNull();
+    // The rest of the toolbar stays: the surface still searches and filters.
+    expect(strip.querySelector('input[aria-label="Search projects"]')).not.toBeNull();
+    expect(strip.querySelector('[aria-label="More actions"]')).not.toBeNull();
+  });
+
+  it('shows the view toggle at a normal pane', () => {
+    renderHeader(false);
+    expect(strip.querySelector('[aria-label="View mode"]')).not.toBeNull();
   });
 });
 

--- a/packages/app/src/renderer/workspace/components/KpiTile.tsx
+++ b/packages/app/src/renderer/workspace/components/KpiTile.tsx
@@ -25,6 +25,14 @@ export interface KpiTileProps {
   /** Comparison shown when there is no delta, e.g. "36% of 116 projects". */
   footnote?: string;
   tone?: KpiTone;
+  /**
+   * The pane is too short or too narrow to spend 99px per tile. Collapses the
+   * card to one 36px line — label at the leading edge, value at the trailing
+   * edge — and drops the comparison. Six full tiles are 357px tall, which at
+   * the app's 420px minimum window height leaves the toolbar and the whole
+   * project list below the window edge with nothing to scroll (TRA-325).
+   */
+  dense?: boolean;
   active?: boolean;
   onClick?: () => void;
   /** The number isn't known yet — render skeletons at the final geometry. */
@@ -87,6 +95,7 @@ export function KpiTile({
   deltaCaption,
   footnote,
   tone,
+  dense = false,
   active = false,
   onClick,
   pending = false,
@@ -101,12 +110,20 @@ export function KpiTile({
       disabled={!interactive}
       aria-pressed={interactive ? active : undefined}
       data-kpi={label}
+      data-dense={dense ? '' : undefined}
+      // Dense drops the comparison line, so the one sentence that explains an
+      // em dash has to survive somewhere the user can still reach it.
+      title={dense && unavailable ? "Couldn't be measured" : undefined}
       onClick={onClick}
-      className="flex flex-col items-start gap-1 text-left transition-colors"
+      className={
+        dense
+          ? 'flex flex-row items-baseline justify-between gap-2 text-left transition-colors'
+          : 'flex flex-col items-start gap-1 text-left transition-colors'
+      }
       style={{
         minWidth: 132,
         flex: '1 1 132px',
-        padding: 16,
+        padding: dense ? '8px 12px' : 16,
         borderRadius: 12,
         // A card is content: it stays opaque --surface in BOTH states. Tinting
         // the active tile pushed --label-secondary to 4.45:1 on its footnote —
@@ -132,14 +149,18 @@ export function KpiTile({
       {/* `unavailable` outranks `pending`: a fetch that finished and failed is
           not still loading, so the skeleton must not win when both are set. */}
       {pending && !unavailable ? (
-        <Skeleton width={72} height={26} radius={6} style={{ margin: '3px 0' }} />
+        dense ? (
+          <Skeleton width={48} height={15} radius={4} />
+        ) : (
+          <Skeleton width={72} height={26} radius={6} style={{ margin: '3px 0' }} />
+        )
       ) : (
         <span
           data-kpi-value=""
           className="tabular-nums"
           style={{
-            fontSize: 28,
-            lineHeight: '32px',
+            fontSize: dense ? 15 : 28,
+            lineHeight: dense ? '20px' : '32px',
             fontWeight: 600,
             letterSpacing: '-0.01em',
             color: valueColor,
@@ -155,9 +176,12 @@ export function KpiTile({
         </span>
       )}
 
-      {/* `unavailable` outranks `pending`: a fetch that finished and failed is
-          not still loading, so the skeleton must not win when both are set. */}
-      {pending && !unavailable ? (
+      {/* The comparison line is the first thing to go when the pane is short:
+          it is the tallest part of the tile and the only part a user can
+          reconstruct by widening the window. The value never goes. */}
+      {dense ? null : pending && !unavailable ? (
+        // `unavailable` outranks `pending`: a fetch that finished and failed is
+        // not still loading, so the skeleton must not win when both are set.
         <Skeleton width={92} height={11} />
       ) : (
         <span className="text-[11px] leading-[13px]" style={{ color: 'var(--label-secondary)' }}>


### PR DESCRIPTION
## The bug

`packages/app/src/main/tray.ts:82` sets `minWidth: 640, minHeight: 420`. At that size the Workspace showed six KPI cards and nothing else.

Measured on the running renderer at exactly 640×420 (light, Reduce Transparency, 6 fixture projects):

| Region | Geometry | Window is 420 tall |
|---|---|---|
| KPI grid | y 44 → 401, **357px** | on screen |
| Toolbar | y 401 → **453** | bottom 33px past the edge |
| Search field | y 415 → **439** | 19px past the edge |
| Project list | y 465, height **1px** | entirely off screen |

`document.scrollHeight === clientHeight === 420`, and walking every descendant found **zero** scrollable elements. Search, Filter, the view toggle, **+ Add** and the whole project list were unreachable, not merely cramped.

Separately, at any pane narrower than ~691px the toolbar's trailing group ran past the pane inside an `overflow-x: hidden` ancestor: `Add a project by path` (the + Add chevron, x 640–659) and `More actions` (the ••• menu holding Refresh metrics and Clear filters, x 667–691) both returned `null` from `elementFromPoint` at their own centre.

## The fix

1. **Toolbar above the KPI strip.** Chrome above content, the DESIGN.md §6 skeleton. A 357px block of tiles can no longer push the app's own controls off-window.
2. **The toolbar wraps.** `min-height: 52px` + `flex-wrap` instead of a fixed `height: 52px`.
3. **`KpiTile` gains `dense`** — label and value on one 36px line, no comparison line. Six tiles go from 357px to ~120px. The sentence an em dash needs moves to the tile's `title` so "Couldn't be measured" stays reachable.
4. **Below a pane width computed from the table's own frozen columns** (checkbox 32 + Project 240 + Actions 100, plus a 160px minimum scroll window and the pane's 32px padding = 564), the surface renders `WorkspaceCompactView` and hides the view toggle. The stored preference is **not** rewritten — widening the window brings the user's own choice back.

Thresholds come from one `ResizeObserver` on the pane rather than from the window, because the sidebar is resizable 180–320px and collapsible. They are computed, not picked: `kpiStripHeight(420)` returns 357, the value measured on the running renderer, and `isDensePane` compares the pane height against it rather than against a guessed breakpoint.

## Verification

Walked every focusable element (`getBoundingClientRect` vs the viewport, ignoring anything with a scrollable ancestor) at 640×420, 800×600, 960×700, 1280×800 and 1680×1050 — **no stranded controls at any size**, before-and-after. At 640×420 the toolbar now sits at y 44–96, the dense strip at 96–267, and three project rows are visible.

Nothing changes visually at 960×700 or above: `dense` is false, the table renders, the view toggle is present, tiles stay 99px. The only difference at ordinary sizes is the toolbar being at the top of the pane.

`packages/app`: 274 tests pass (13 new), typecheck clean, build clean, `node packages/app/scripts/design-tokens.mjs` clean with no baseline count raised.

DESIGN.md gains a "The window minimum is a size that has to work" section under §6, a 640×420 line in the §10 checklist, and five decision-log rows.

## Screenshots

Attached to [TRA-325](https://multica.ai): before at 640×420, after at 640×420 in light, dark and Increase Contrast, and after at 1280×800 in light and dark.

Closes TRA-325.
