### PR TITLE
feat!: raise the Node floor to 22 and re-ground the dependabot ignores (TRA-329)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,35 +20,20 @@ updates:
       prefix-development: chore(deps-dev)
       include: scope
     ignore:
-      # @types/node tracks the minimum supported runtime (Node 20), not the
-      # latest: a major bump would type-check against APIs that do not exist
-      # on the runtime floor declared in `engines.node`.
+      # @types/node tracks the minimum supported runtime, not the latest: a
+      # major bump would type-check against APIs that do not exist on the
+      # runtime floor declared in `engines.node` (now >=22). Move this major
+      # only when that floor moves, and move both together.
       - dependency-name: "@types/node"
         update-types:
           - version-update:semver-major
       # web-tree-sitter 0.24.7 -> 0.26.x changes the parser API and broke 589
-      # of 4546 tests across 82 test files (PR #89). Held until a dedicated
-      # migration updates the language plugins to the new API; until then a
-      # bump is a migration project, not a dependency bump.
+      # of 4546 tests across 82 test files (PR #89). This is a migration
+      # project, not a dependency bump — tracked as TRA-330. Delete this entry
+      # as part of that migration.
       - dependency-name: "web-tree-sitter"
         update-types:
           - version-update:semver-minor
-          - version-update:semver-major
-      # better-sqlite3 13.x declares `engines: node >=22`, but this project's
-      # support policy is `engines: node >=20` — merging would break installs
-      # on Node 20/21, same blocker as commander below. (The original reason
-      # for this entry was the TRA-51 N-API segfault on `new Database()`; that
-      # no longer reproduces on 13.0.3, so the Node floor is what holds it.)
-      # Revisit once the Node floor moves to 22.
-      - dependency-name: "better-sqlite3"
-        update-types:
-          - version-update:semver-major
-      # commander 15 is ESM-only and requires Node >=22.12, but this
-      # project's support policy is `engines: node >=20` — merging would
-      # silently break installs on Node 20/21 (decided on PR #197).
-      # Revisit once the Node floor moves to 22.
-      - dependency-name: "commander"
-        update-types:
           - version-update:semver-major
     groups:
       production-minor-patch:
@@ -86,7 +71,9 @@ updates:
       # Vite 8 switches the default bundler to Rolldown, which fails on
       # @cosmos.gl/graph's transitive `gl-bench` dep (stricter CJS default
       # import handling) — PR #95. @vitejs/plugin-react v6 requires Vite 7+
-      # (PR #91), so the two move together or not at all.
+      # (PR #91), so the two move together or not at all. Still live as of
+      # TRA-329: @cosmos.gl/graph is unchanged at 3.4.1. Lift only once an app
+      # build on Vite 8 has been verified green.
       - dependency-name: "vite"
         update-types:
           - version-update:semver-major
@@ -95,9 +82,11 @@ updates:
           - version-update:semver-major
       # Originally held because menubar@9.5.2 pinned `electron <35.0.0`.
       # menubar was dropped in the TRA-257 artifact-slimming work and the app
-      # is on Electron 41, so that blocker is gone — the entry stands only as
-      # "an Electron major needs a manual packaging/signing smoke pass, not an
-      # auto-merge". Re-evaluate whether to lift it (TRA-329).
+      # is on Electron 41, so that blocker is gone. Kept anyway (decided in
+      # TRA-329) on its own merit: an Electron major moves Chromium, Node and
+      # the packaging / signing / notarization surface at once and needs a
+      # manual build-and-sign pass per target platform, so it must never
+      # arrive as an auto-mergeable dependency PR. Bump it deliberately.
       - dependency-name: "electron"
         update-types:
           - version-update:semver-major

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "packageManager": "pnpm@10.33.0",
   "license": "MIT",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "engines": {
     "vscode": "^1.85.0",
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "categories": [
     "Other"

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -88,7 +88,7 @@ export default defineConfig({
   dts: true,
   sourcemap: true,
   clean: true,
-  target: process.env.TSUP_TARGET || 'node20',
+  target: process.env.TSUP_TARGET || 'node22',
   splitting: false,
   // Force-bundle all dependencies into the output. Natives matched by the
   // plugin below are rewritten to `createRequire(...)` shims; everything else


### PR DESCRIPTION
Closes the decisions raised in TRA-329. Node 20 went end-of-life on 2026-04-30 — four months ago — and `engines.node: ">=20.0.0"` was the single thing holding three of the six Dependabot ignores in place. This raises the floor to Node 22 (supported until 2027-04-30) and rewrites every remaining ignore reason so it states the reason that is actually still true.

## Node floor: 20 → 22

- `package.json` and `packages/vscode-extension/package.json`: `engines.node` → `>=22.0.0`
- `tsup.config.ts`: default build target → `node22`
- `.github/workflows/eval.yml`: `node-version: '20'` → `'22'` — this was the last workflow still running on the EOL runtime; every other job in `ci.yml` and `release.yml` was already on 22.

This is a breaking change for installs on Node 20/21, hence `feat!`.

## Dependabot ignores: 6 → 4

**Removed** — the Node floor was the only thing holding these:

- `better-sqlite3` major. The recorded reason ("13.x N-API prebuilds segfault on `new Database()`", TRA-51) no longer reproduces: a clean `better-sqlite3@13.0.3` install on Node v22.22.3 / darwin arm64 opens a database, creates a table, inserts and counts without incident. 13.x declares `engines: node >=22`, which is now satisfied.
- `commander` major. 15.x is ESM-only and needs Node >=22.12; this package has been `"type": "module"` all along, so with the floor at 22 the objection from PR #197 is gone.

Both are left to Dependabot to propose on its normal schedule rather than bundled here — that is what the cooldown and the grouping config exist for.

**Kept, with corrected reasons:**

- `@types/node` major — the previous entry had no comment at all. Types must track the *supported floor*, not the newest Node, otherwise code typechecks against APIs the oldest supported runtime cannot run. The comment now ties it explicitly to `engines.node`, so the next person moves both together.
- `web-tree-sitter` minor+major — also previously uncommented. This is not a version pin, it is a deferred migration: 0.26.x reworks the parser API and broke 589 of 4546 tests across 82 files. Now tracked as a real issue (TRA-330) and the comment says to delete the entry as part of that work.
- `vite` / `@vitejs/plugin-react` majors — reason re-verified, not just restated: Vite 8 defaults to Rolldown, which failed on the transitive `gl-bench` import inside `@cosmos.gl/graph`, and `@cosmos.gl/graph@3.4.1` is still a dependency of the app package. Still live.
- `electron` major — the recorded reason was dead (`menubar@9.5.2` capping electron at `<35`; menubar was dropped in TRA-257 and has zero occurrences in the lockfile). The ignore stays, but on its real justification: an Electron major moves Chromium, Node, and the packaging/signing/notarization surface at once and needs a manual build-and-sign pass per platform, so it must never arrive as an auto-mergeable dependency PR.

## Test evidence

```
pnpm run build      → Target: node22, build success
pnpm run typecheck  → clean
pnpm run test       → 803 files passed | 2 skipped, 8807 tests passed | 9 skipped
```

`.github/dependabot.yml` re-parsed after editing to confirm the YAML is still valid and the ignore list resolves to exactly `@types/node`, `web-tree-sitter` (root) and `vite`, `@vitejs/plugin-react`, `electron` (app).

## Note on the release train

release-please will retarget the pending release PR from 2.3.0 to 3.0.0. That is the correct semver for dropping an end-of-life runtime from `engines`, and it does not change anything about the fixes already queued for that release.
