### PR TITLE
fix(daemon): auto-deregister stale one-shot agent-run workdirs (TRA-335)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3068,6 +3068,29 @@ program
           logger.warn({ err }, 'sweepMissingRoots failed (non-fatal)');
         }
 
+        // Soft GC (TRA-335): the sweep above only reaches workdirs that were
+        // *deleted*. Agent runtimes that leave their one-shot checkout on disk
+        // (Multica, and CI/sandbox workflows shaped like it) leave an entry
+        // `prune` will always classify as live, so the registry grew one row —
+        // and one permanently-reindexed project — per run, forever. Age since
+        // registration is the signal; see ProjectManager.sweepEphemeralProjects.
+        const ephemeralSweep = async () => {
+          try {
+            const removed = await projectManager.sweepEphemeralProjects();
+            if (removed.length > 0) {
+              logger.info(
+                { removedRoots: removed },
+                `Deregistered ${removed.length} stale one-shot workdir project(s)`,
+              );
+            }
+          } catch (err) {
+            logger.warn({ err }, 'sweepEphemeralProjects failed (non-fatal)');
+          }
+        };
+        await ephemeralSweep();
+        const ephemeralTimer = setInterval(() => void ephemeralSweep(), 60 * 60_000);
+        ephemeralTimer.unref();
+
         // If cwd is a project not yet registered, add it too.
         const cwd = process.cwd();
         if (!projectManager.getProject(cwd)) {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -584,8 +584,9 @@ function printRegistryReport(r: RegistryHealthReport): void {
     console.log(
       '  These look like one-shot Multica agent-run checkouts: the run that created them is ' +
         'long finished and nothing will ever query them again, but they still get permanently ' +
-        'reindexed. Unregister with `trace-mcp remove <path>`, then `trace-mcp prune --apply` ' +
-        'to reclaim their index DBs.',
+        'reindexed. A running daemon deregisters them by itself once they are 3 days old ' +
+        '(TRA-335); to reclaim them now, `trace-mcp doctor --fix`, or `trace-mcp remove <path>` ' +
+        'then `trace-mcp prune --apply`.',
     );
   }
   console.log('');

--- a/src/daemon/__tests__/project-manager-ephemeral-sweep.test.ts
+++ b/src/daemon/__tests__/project-manager-ephemeral-sweep.test.ts
@@ -1,0 +1,149 @@
+/**
+ * TRA-335: the registry accumulated one row per agent run forever — 135 of 147
+ * registered projects were one-shot Multica checkouts. Neither reclaim signal
+ * could see them: `prune` reads "root directory still exists" as liveness (the
+ * runtime doesn't delete finished checkouts), and `lastIndexed` stays fresh
+ * because this very daemon keeps reindexing them. `sweepEphemeralProjects`
+ * uses age since registration instead.
+ *
+ * Mocks IndexingPipeline + FileWatcher + createServer like
+ * project-manager-last-indexed.test.ts so only the sweep wiring is under test.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+vi.mock('../../indexer/pipeline.js', () => {
+  class FakeIndexingPipeline {
+    async indexAll() {
+      return { totalFiles: 0, indexed: 0, skipped: 0, errors: 0, durationMs: 0 };
+    }
+    async indexFiles() {
+      return { totalFiles: 0, indexed: 0, skipped: 0, errors: 0, durationMs: 0 };
+    }
+    deleteFiles() {}
+    async dispose() {}
+  }
+  return { IndexingPipeline: FakeIndexingPipeline };
+});
+
+vi.mock('../../indexer/watcher.js', () => {
+  class FakeWatcher {
+    async start() {}
+    async restartWithExcludes() {}
+    async stop() {}
+  }
+  return { FileWatcher: FakeWatcher };
+});
+
+vi.mock('../../server/server.js', async (orig) => {
+  const real = (await orig()) as Record<string, unknown>;
+  return {
+    ...real,
+    createServer: () => ({
+      server: { close: async () => undefined },
+      dispose: () => undefined,
+    }),
+  };
+});
+
+let tmpHome: string;
+let pmRef: { shutdown(): Promise<void> } | undefined;
+
+/** A directory shaped like a one-shot agent-run checkout. */
+function makeEphemeralWorkdir(runId: string): string {
+  const dir = join(tmpHome, 'multica_workspaces_example.com', 'ws-1', runId, 'workdir');
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** Backdate a registry entry's `addedAt` so it reads as past the TTL. */
+async function backdate(root: string, hours: number): Promise<void> {
+  const { REGISTRY_PATH } = await import('../../global.js');
+  const reg = JSON.parse(readFileSync(REGISTRY_PATH, 'utf-8'));
+  reg.projects[root].addedAt = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+  writeFileSync(REGISTRY_PATH, JSON.stringify(reg));
+}
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'trace-mcp-ephemeral-sweep-'));
+  vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+  vi.resetModules();
+  pmRef = undefined;
+});
+
+afterEach(async () => {
+  if (pmRef) {
+    try {
+      await pmRef.shutdown();
+    } catch {
+      /* half-initialized manager may throw on shutdown; only care resources release */
+    }
+    pmRef = undefined;
+  }
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  rmSync(tmpHome, { recursive: true, force: true });
+}, 30_000);
+
+describe('ProjectManager.sweepEphemeralProjects (TRA-335)', () => {
+  it('deregisters a one-shot workdir past the TTL even though its root still exists', async () => {
+    const { ProjectManager } = await import('../project-manager.js');
+    const { listProjects, registerProject } = await import('../../registry.js');
+
+    const stale = makeEphemeralWorkdir('run-old');
+    registerProject(stale);
+    await backdate(stale, 96);
+
+    const pm = new ProjectManager();
+    pmRef = pm;
+
+    expect(await pm.sweepEphemeralProjects(72)).toEqual([stale]);
+    expect(listProjects()).toEqual([]);
+  }, 30_000);
+
+  it('leaves a recent workdir and a normal project alone', async () => {
+    const { ProjectManager } = await import('../project-manager.js');
+    const { listProjects, registerProject } = await import('../../registry.js');
+
+    const fresh = makeEphemeralWorkdir('run-new');
+    registerProject(fresh);
+    await backdate(fresh, 2);
+
+    const normal = join(tmpHome, 'real-project');
+    mkdirSync(normal, { recursive: true });
+    registerProject(normal);
+    await backdate(normal, 1000);
+
+    const pm = new ProjectManager();
+    pmRef = pm;
+
+    expect(await pm.sweepEphemeralProjects(72)).toEqual([]);
+    expect(
+      listProjects()
+        .map((e) => e.root)
+        .sort(),
+    ).toEqual([fresh, normal].sort());
+  }, 30_000);
+
+  it('skips a workdir that a run is still holding open', async () => {
+    const { ProjectManager } = await import('../project-manager.js');
+    const { listProjects, registerProject } = await import('../../registry.js');
+
+    const busy = makeEphemeralWorkdir('run-busy');
+    registerProject(busy);
+    await backdate(busy, 96);
+
+    const pm = new ProjectManager();
+    pmRef = pm;
+    // Stand in for the resource pool's client tracking — the same signal
+    // unloadIdleProjects uses to leave a project with live clients alone.
+    (pm as unknown as { resourcePool: { getRefCount(root: string): number } }).resourcePool = {
+      getRefCount: (root: string) => (root === busy ? 1 : 0),
+    };
+
+    expect(await pm.sweepEphemeralProjects(72)).toEqual([]);
+    expect(listProjects().map((e) => e.root)).toEqual([busy]);
+  }, 30_000);
+});

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -34,6 +34,7 @@ import { isDangerousProjectRoot, setupProject } from '../project-setup.js';
 import {
   clearPendingReindex,
   descendantExcludeGlobs,
+  findEphemeralProjects,
   findOverlappingProjects,
   getProject,
   listProjects,
@@ -971,6 +972,43 @@ export class ProjectManager {
       'Project removed from daemon',
     );
     return artifacts;
+  }
+
+  /**
+   * Deregister one-shot agent-run checkouts whose run finished more than
+   * `ttlHours` ago, and reclaim their index DBs (TRA-335).
+   *
+   * `prune` can never reclaim these on its own: it reads "root directory still
+   * exists" as liveness, and the runtimes that create these workdirs don't
+   * delete them when a run ends. `lastIndexed` is no signal either — this
+   * daemon keeps reindexing them forever, so they look permanently fresh. Age
+   * since registration is the only honest clock for a directory whose whole
+   * purpose was one run, which is what `findEphemeralProjects` measures.
+   *
+   * Same liveness guards as `unloadIdleProjects` for the loaded ones (never
+   * touch a project mid-index or with connected clients), and `removeProject`
+   * keeps the index DB whenever a sibling checkout still points at it or holds
+   * it open. Unloaded candidates are removed directly — `stopProject` no-ops.
+   *
+   * ponytail: recognizing an ephemeral root is a path heuristic, so this only
+   * covers the workdir shapes `findEphemeralProjects` knows. A per-project
+   * last-*queried* timestamp would generalize to CI/worktrees/sandboxes; add
+   * it when one of those actually shows up, not before.
+   */
+  async sweepEphemeralProjects(ttlHours = 72): Promise<string[]> {
+    const removed: string[] = [];
+    for (const candidate of findEphemeralProjects(ttlHours)) {
+      const managed = this.projects.get(candidate.root);
+      if (managed && (managed.status === 'starting' || managed.status === 'indexing')) continue;
+      if ((this.resourcePool?.getRefCount(candidate.root) ?? 0) > 0) continue;
+      logger.info(
+        { projectRoot: candidate.root, ageHours: Math.round(candidate.ageHours) },
+        'Deregistering stale one-shot workdir project',
+      );
+      await this.removeProject(candidate.root);
+      removed.push(candidate.root);
+    }
+    return removed;
   }
 
   /** Get a managed project by root path. */


### PR DESCRIPTION
Closes TRA-335.

## Problem

The project registry grows one row per agent run and never shrinks. On the reporting machine: **135 of 147 registered projects** were one-shot Multica agent-run checkouts, holding **1.86 GB** of index DBs, growing several per hour, seven days a week.

Neither reclaim signal can identify them as dead:

1. **`prune` treats "directory still exists" as liveness.** Agent runtimes don't delete a checkout when the run ends, so every one of those 135 entries classified as `live` — `prune --apply` would never reclaim a byte, at any TTL.
2. **`lastIndexed` is not a staleness signal**, because the daemon writes it. 84 of these checkouts, from runs that finished days earlier, were reindexed within the last two days. The daemon keeps them permanently fresh.

`doctor` does warn ("stale one-shot workdir") and `doctor --fix` does act on it — but both need a human to run them, and nothing prevents the re-accumulation.

## Fix

Age since registration is the honest clock for a directory whose entire purpose was one run. `findEphemeralProjects` already measures exactly that (it's what powers the `doctor` warning); this wires it into the daemon's **existing hourly soft-GC**, next to `sweepMissingRoots`.

`ProjectManager.sweepEphemeralProjects(ttlHours = 72)` deregisters candidates past the TTL and reclaims their DBs. TTL is 3 days — well beyond any run's lifetime, and it caps the registry at ~3 days of runs instead of unbounded.

Safety reuses machinery that already exists rather than adding new:
- skip a project that is mid-index or has connected clients — same two guards as `unloadIdleProjects`;
- `removeProject` → `removeProjectArtifacts` already keeps the index DB whenever a TRA-38 sibling checkout still points at it, or a live holder (TRA-304) has it open.

**No registry schema change, no new flag, no change to `prune`'s contract, no cooperation required from the caller.**

## Why this option

The issue laid out three:

- **A. Ephemeral registration** — this PR, in its auto-detected form. Smallest surface; the detection already existed and was already trusted enough to drive a `doctor --fix` action.
- **B. Record last-*query* time and prune on it.** The genuinely general signal, but it means writing a timestamp on read paths and carefully excluding the daemon's own reindexing from counting as a query. Deferred as speculative generality: the measured problem is a known path shape, and B is the upgrade path when a real CI/worktree/sandbox report shows up (noted as a `ponytail:` comment at the sweep).
- **C. Fix it in the Multica runtime only.** Rejected — it leaves the identical trap for every other ephemeral-checkout workflow, and this class is growing.

The sub-question ("should `doctor --fix` act on the warning it prints?") was already answered in code — `fixRegistryIssues` handles `removedEphemeralProjects`. The `doctor` hint text is updated to mention the automatic sweep so a warning at 24h doesn't read as "nothing will ever clean this".

## Test evidence

New `src/daemon/__tests__/project-manager-ephemeral-sweep.test.ts` (3 tests):
- deregisters a one-shot workdir past the TTL **even though its root still exists** — the exact case `prune` can't reach;
- leaves a recent workdir and a normal long-lived project alone;
- skips a workdir a run is still holding open (refcount > 0).

Full suite: `803 files / 8810 tests passed`. The single failure in the first run was `tests/perf/benchmark.test.ts` (a timing threshold under parallel load) — passes on its own re-run at 1.10x vs. the 2x limit, unrelated to this change. `pnpm run build`, `tsc --noEmit`, and `biome ci` on the changed files are clean.

Agent: Lead Engineer (Multica), on behalf of Nikolai Vysotskyi. Measurement in TRA-335 by the Indexing & Registry Health autopilot.
