### PR TITLE
fix(app): close the last hit-target gaps found in the TRA-284 final walk

### DIFF
--- a/packages/app/src/renderer/styles/controls.css
+++ b/packages/app/src/renderer/styles/controls.css
@@ -586,6 +586,14 @@ input[type='checkbox']:focus-visible {
   position: absolute;
   inset: -2px 0;
 }
+.lx-seg.sz-small .lx-seg-item::after {
+  /* The SMALL track is 20px, so its segments are painted 16px and -2px only
+     reaches 20. Measured on the running app: Graph's Files/Symbols at 43x20
+     and 66x20, the workspace's Table/Compact at 48x20 and 68x20. -4px puts all
+     four on the 24px floor; the overflow is invisible and the track has room
+     for it inside a 52px toolbar. */
+  inset: -4px 0;
+}
 
 @media (prefers-reduced-motion: reduce) {
   .lx-btn,

--- a/packages/app/src/renderer/styles/sidebar.css
+++ b/packages/app/src/renderer/styles/sidebar.css
@@ -35,8 +35,8 @@
   min-height: 0;
   /* Opaque by default — only macOS has an NSVisualEffectView behind the
      window to show through. */
-  background: var(--surface, var(--surface));
-  border-right: 0.5px solid var(--separator, var(--separator));
+  background: var(--surface);
+  border-right: 0.5px solid var(--separator);
   -webkit-app-region: no-drag;
 }
 .ws-stage[data-platform="mac"] .ws-sidebar {
@@ -70,7 +70,7 @@
   letter-spacing: 0.01em;
   /* --label-secondary, not --label-tertiary: a group header is text a user
      reads, and tertiary is decoration-only (2.21:1 today). */
-  color: var(--label-secondary, var(--label-secondary));
+  color: var(--label-secondary);
 }
 .ws-sb-group:first-child {
   padding-top: 4px;
@@ -88,7 +88,7 @@
   border: 0;
   border-radius: 6px;
   background: transparent;
-  color: var(--label, var(--label));
+  color: var(--label);
   font-family: inherit;
   font-size: 13px;
   font-weight: 400;
@@ -99,7 +99,7 @@
   -webkit-app-region: no-drag;
 }
 .ws-sb-row:hover {
-  background: var(--fill-quaternary, var(--fill-quaternary));
+  background: var(--fill-quaternary);
 }
 .ws-sb-row .ws-sb-ico {
   flex: none;
@@ -108,7 +108,7 @@
   justify-content: center;
   width: 16px;
   height: 16px;
-  color: var(--label-secondary, var(--label-secondary));
+  color: var(--label-secondary);
 }
 .ws-sb-row .ws-sb-ico svg {
   width: 16px;
@@ -126,7 +126,7 @@
   flex: none;
   font-size: 11px;
   font-variant-numeric: tabular-nums;
-  color: var(--label-secondary, var(--label-secondary));
+  color: var(--label-secondary);
 }
 
 /* Selected: accent fill when the sidebar owns focus, neutral fill when not —
@@ -155,7 +155,7 @@
   border: 0;
   border-radius: var(--radius-row);
   background: transparent;
-  color: var(--label-secondary, var(--label-secondary));
+  color: var(--label-secondary);
   opacity: 0;
   transition: opacity 120ms ease, background 120ms ease;
 }
@@ -176,7 +176,7 @@
 .ws-sb-footer {
   flex: none;
   padding: 6px 6px 8px;
-  border-top: 0.5px solid var(--separator, var(--separator));
+  border-top: 0.5px solid var(--separator);
   -webkit-app-region: no-drag;
 }
 
@@ -197,7 +197,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--label-secondary, var(--label-secondary));
+  color: var(--label-secondary);
 }
 .ws-sb-path .name {
   flex: 0 1 auto;
@@ -216,14 +216,19 @@
   padding: 12px 8px;
   font-size: 13px;
   line-height: 17px;
-  color: var(--label-secondary, var(--label-secondary));
+  color: var(--label-secondary);
 }
 .ws-sb-empty .gi {
   width: 20px;
   height: 20px;
-  color: var(--label-secondary, var(--label-secondary));
+  color: var(--label-secondary);
 }
 .ws-sb-empty .act {
+  /* A text action is still a target: measured 100x17 against the 24px floor.
+     The box grows, the type does not. */
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
   border: 0;
   padding: 0;
   background: transparent;
@@ -241,7 +246,7 @@
   height: 28px;
   margin: 0 0 2px;
   border-radius: 6px;
-  background: var(--fill-quaternary, var(--fill-quaternary));
+  background: var(--fill-quaternary);
   animation: ws-sb-shimmer 1.4s ease-in-out infinite;
 }
 .ws-sb-skeleton:nth-child(2n) {
@@ -268,8 +273,19 @@
   cursor: default;
 }
 
-/* Resize handle — 6px hit strip straddling the separator, keyboard operable. */
+/* Resize handle — 6px strip straddling the separator, keyboard operable.
+   6px is the right LAYOUT width (it must not push the panes apart) but a thin
+   grab zone: measured 6x700 on the running app. The pseudo-element widens it
+   to the ~12px macOS split-view divider convention without moving a painted
+   pixel or changing the flex geometry.
+
+   Deliberately NOT the 24px control floor. A divider's position is essential —
+   it has to sit on the boundary it represents — and WCAG 2.5.8 exempts targets
+   whose size is essential. At 700px tall it is trivially hittable; going wider
+   would only steal clicks from the sidebar rows and the content pane on either
+   side. This is the one control in the app that is exempt on purpose. */
 .ws-sb-resize {
+  position: relative;
   flex: none;
   width: 6px;
   margin: 0 -3px;
@@ -277,6 +293,12 @@
   cursor: col-resize;
   background: transparent;
   -webkit-app-region: no-drag;
+}
+.ws-sb-resize::after {
+  content: '';
+  position: absolute;
+  inset: 0 -3px;
+  cursor: col-resize;
 }
 .ws-sb-resize:focus-visible {
   outline: 2px solid var(--accent);
@@ -331,13 +353,13 @@
   border: 0;
   border-radius: 6px;
   background: transparent;
-  color: var(--label-secondary, var(--label-secondary));
+  color: var(--label-secondary);
   cursor: default;
   transition: background 120ms ease, color 120ms ease;
 }
 .ws-chrome-toggle:hover {
-  background: var(--fill-quaternary, var(--fill-quaternary));
-  color: var(--label, var(--label));
+  background: var(--fill-quaternary);
+  color: var(--label);
 }
 
 /* ---- Accessibility ------------------------------------------------------ */
@@ -346,12 +368,12 @@
 @media (prefers-reduced-transparency: reduce) {
   /* Must out-specify `.ws-stage[data-platform="mac"] .ws-sidebar` above. */
   .ws-stage[data-platform="mac"] .ws-sidebar {
-    background: var(--surface, var(--surface));
+    background: var(--surface);
   }
 }
 @media (prefers-contrast: more) {
   .ws-stage .ws-sidebar {
-    border-right-color: var(--label-secondary, var(--label-secondary));
+    border-right-color: var(--label-secondary);
   }
   .ws-sb-row.is-selected {
     outline: 1px solid var(--accent);


### PR DESCRIPTION
Found by the TRA-284 final walk — the whole app driven in the real Electron window, light and dark, plus the Reduce Transparency path, with hit boxes, labels, contrast, type and radii measured off the running render.

Three geometry gaps survived the twelve surface migrations. All three are the same class: a control that reads correctly but is smaller than the floor it has to clear.

| | before | after |
|---|---|---|
| Graph `Files` / `Symbols` | 43×20, 66×20 | 24px |
| Workspace `Table` / `Compact` | 48×20, 68×20 | 24px |
| Sidebar `Open a project…` | 100×17 | 24px min-height |
| Sidebar resize handle | 6px grab strip | 12px (documented exception) |

The segmented case is a real gap in the TRA-293 rule, not a new offender: `.lx-seg.sz-small` is a 20px track, so its segments are painted 16px and the `-2px` overflow only reached 20. `-4px` puts them on 24 — invisible, and a 52px toolbar has the room.

**The divider is deliberately not 24px.** A split-view divider's position is essential — it has to sit on the boundary it represents — and WCAG 2.5.8 exempts targets whose size is essential. At 700px tall it is trivially hittable; widening it further would only steal clicks from the sidebar rows and the content pane on either side. 12px matches the macOS convention. It is the one control in the app that is exempt on purpose, and the stylesheet says so.

Also drops 18 `var(--x, var(--x))` self-fallbacks left in `sidebar.css` by the TRA-315 codemod. No behavioural change — a no-op `var()` fallback onto itself — but that file is the house reference and shouldn't carry dead rewrites.

## Verification

Measured on the running Electron window before and after, not read off the CSS. After: every focusable on the workspace, Overview and Graph clears 24×24 except the documented divider, and 0 unlabeled focusables across all nine surfaces.

Local: token guard exit 0 · typecheck clean · 26 files / 274 tests passed · build green.
