### PR TITLE
feat(app): give the guard a UI on Project Overview (TRA-334)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -573,6 +573,10 @@ new evidence.
 | Tokens and primitives land before any surface | A surface migrated against a moving token layer gets migrated twice. |
 | A `var(--x, #hex)` fallback is a bug, not a safety net | `--red` and `--orange` were never defined, so four call sites quietly painted Tailwind `#ef4444` (3.76:1) and `#f97316` (2.8:1) on light. A fallback hides exactly the case the token guard exists to catch. |
 | A component nothing renders gets deleted, not migrated | `ProjectRow`, `ProjectDetail` and `GuardBadge` lost their host in the workspace rebuild and carried 10 of the guard's raw hex for three weeks. Rung one is always "does this need to exist". |
+| Deleting the last host of a feature means **re-homing the feature**, in the same pass or in a filed issue | `GuardBadge` was the guard's only surface *and* the only caller of `guard.initialize`. Deleting it left 670 lines of working main-process code with three of eight IPC channels reachable, and new projects silently skipping the coach grace period for weeks. A dead component is a rendering fact; the feature it carried is a separate question. |
+| Per-project state lives on **Project Overview**, not as another workspace-table column | The table is already at nine columns and drops trailing ones under a container query; a status the user needs is the worst candidate for "first to go". Overview is per-project by definition and has the measure for a mode control and a sentence. |
+| A control inside a 32px `ListRow` is the **24px tier**, never `small` | Measured on the running renderer: a `small` segment paints 16px inside a 20px hit box and a `small` button paints 20 in 20 — both under the 24×24 floor, and the row has the height for the regular tier anyway. `small` is for a dense toolbar, not for a list row. |
+| A row label never repeats its own control's verb | "Temporary pause" beside a "Pause for 10 minutes" button wrapped to two lines at the 640px minimum and added no meaning. The label names the subject ("Enforcement"), the control names the action. |
 
 ---
 
@@ -582,6 +586,11 @@ new evidence.
 window chrome, the sidebar and its footer, the workspace dashboard, Project Overview,
 Activity, Memory, MCP Clients, Settings, the onboarding sheet, Graph Explorer,
 Insights, Ask, and **Notebook** — the last one, migrated in TRA-310.
+
+Project Overview carries a fifth section as of TRA-334: **Guard** — health as a
+`Badge` (tone + glyph + word), mode as a `SegmentedControl`, the coach→strict
+date, and the bypass readout with its pause/resume control. It is also what calls
+`guard.initialize`, which nothing had called since `GuardBadge` was deleted.
 
 **The legacy alias layer is gone** (TRA-315). `app.css` no longer declares
 `--text-primary/secondary/tertiary`, `--bg-*`, `--border*`, `--success`, `--warning`

--- a/packages/app/src/renderer/components/GuardSection.tsx
+++ b/packages/app/src/renderer/components/GuardSection.tsx
@@ -1,0 +1,242 @@
+/* GuardSection.tsx — the per-project guard readout on Project Overview (TRA-334).
+
+   The guard was fully built in main/guard-control.ts and completely invisible:
+   of its eight IPC channels the renderer called three, all from the onboarding
+   sheet. The app walked you through installing the guard and then never
+   mentioned it again — no health, no mode, no bypass, and no way to pause it
+   short of hand-editing a sentinel file in the OS temp dir.
+
+   `GuardBadge` used to be that surface and died with `ProjectRow` in the
+   workspace rebuild. This is not a port of it. What that one got wrong and this
+   one does not: status was five hues on a 6px dot with only the *mode* written
+   out, so "down" and "ok" differed by colour alone; mode selection was three
+   bordered buttons in a hand-rolled radiogroup inside a hand-rolled popover;
+   reading text ran at 10px; five raw single-appearance hex; auto-promotion
+   arrived as a toast. Here every tone is a `Badge` (tone + glyph + word), mode
+   is a `SegmentedControl`, and promotion is state shown next to the mode.
+
+   `guard.initialize` was called on the old badge's mount, and nothing has
+   called it since — which is why this runs it before the first status read.
+   Without it a project never gets its `guard-mode` file, and `getGuardMode`
+   falls back to `strict`, so the 7-day coach grace period silently never
+   happened. */
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Badge,
+  Button,
+  Card,
+  ListRow,
+  Section,
+  SectionError,
+  SegmentedControl,
+  SkeletonRows,
+  type Tone,
+} from '../lattice/ui';
+
+type GuardMode = 'strict' | 'coach' | 'off';
+type GuardHealth = 'ok' | 'stalled' | 'down' | 'unknown';
+
+interface GuardState {
+  health: GuardHealth;
+  mode: GuardMode;
+  bypassUntil?: number;
+  reason?: string;
+  coachExpiresAt?: number;
+  autoPromoted?: boolean;
+}
+
+type Load = 'loading' | 'ready' | 'failed';
+
+/** Health is a tone AND a glyph AND a word — never the tone alone. */
+const HEALTH: Record<GuardHealth, { tone: Tone; icon: string; label: string }> = {
+  ok: { tone: 'green', icon: 'check', label: 'Active' },
+  stalled: { tone: 'orange', icon: 'schedule', label: 'Stalled' },
+  down: { tone: 'red', icon: 'warning', label: 'Not running' },
+  unknown: { tone: 'neutral', icon: 'remove', label: 'Unknown' },
+};
+
+const MODE_OPTIONS: ReadonlyArray<{ value: GuardMode; label: string; title: string }> = [
+  {
+    value: 'strict',
+    label: 'Strict',
+    title: 'Block Read, Grep and Glob when a trace-mcp tool answers the question',
+  },
+  { value: 'coach', label: 'Coach', title: 'Never block — suggest the trace-mcp tool instead' },
+  { value: 'off', label: 'Off', title: 'Leave Claude Code alone in this project' },
+];
+
+const POLL_MS = 15_000;
+const BYPASS_MINUTES = 10;
+
+/** "in 9 minutes" / "in 6 days". Future-tense sibling of `relativeTime`. */
+export function untilLabel(epochSec: number, now: number): string {
+  const s = Math.max(0, Math.round(epochSec - now / 1000)); // now is ms, epochSec is s
+  if (s < 60) return 'in under a minute';
+  const m = Math.round(s / 60);
+  if (m < 60) return `in ${m} minute${m === 1 ? '' : 's'}`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `in ${h} hour${h === 1 ? '' : 's'}`;
+  const d = Math.round(h / 24);
+  return `in ${d} day${d === 1 ? '' : 's'}`;
+}
+
+/** "in 6 days · Sep 4" — when it happens, and which day that is. */
+export function promotionLabel(epochSec: number, now: number): string {
+  const abs = new Date(epochSec * 1000).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+  return `${untilLabel(epochSec, now)} · ${abs}`;
+}
+
+export function GuardSection({ root }: { root: string }) {
+  const [state, setState] = useState<GuardState | null>(null);
+  const [load, setLoad] = useState<Load>('loading');
+  const [busy, setBusy] = useState(false);
+  const guard = window.electronAPI?.guard;
+
+  const refresh = useCallback(async () => {
+    if (!guard) return;
+    try {
+      const next = await guard.status(root);
+      setState(next);
+      setLoad('ready');
+    } catch {
+      setLoad((prev) => (prev === 'ready' ? prev : 'failed'));
+    }
+  }, [guard, root]);
+
+  useEffect(() => {
+    if (!guard) return;
+    let cancelled = false;
+    setLoad('loading');
+    setState(null);
+    (async () => {
+      /* Initialize first: on a project that has never been initialized this is
+         what writes `coach` + the install date, and the status read one line
+         below is what would otherwise report a `strict` that nobody chose. */
+      try {
+        await guard.initialize(root);
+      } catch {
+        /* An un-initializable project still has a readable status. */
+      }
+      if (!cancelled) await refresh();
+    })();
+    const timer = setInterval(refresh, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [guard, root, refresh]);
+
+  /* No bridge means no guard to report on — and inventing a reassuring row for
+     a channel we cannot reach would be worse than saying nothing. */
+  if (!guard) return null;
+
+  const now = Date.now();
+  const bypassUntil = state?.bypassUntil ?? 0;
+  const bypassActive = bypassUntil * 1000 > now;
+
+  const setMode = async (mode: GuardMode) => {
+    setBusy(true);
+    /* Optimistic: the segment moves on click, and the poll reconciles. */
+    setState((prev) => (prev ? { ...prev, mode, autoPromoted: false } : prev));
+    try {
+      await guard.setMode(root, mode);
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const setBypass = async (minutes: number) => {
+    setBusy(true);
+    try {
+      await guard.setBypass(root, minutes);
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const health = HEALTH[state?.health ?? 'unknown'];
+
+  return (
+    <Section title="Guard">
+      <Card>
+        {load === 'loading' && !state ? (
+          <SkeletonRows rows={3} />
+        ) : load === 'failed' && !state ? (
+          <SectionError what="the guard status" onRetry={refresh} />
+        ) : state ? (
+          <>
+            <ListRow
+              label="Status"
+              value={
+                <Badge tone={health.tone} icon={health.icon}>
+                  {health.label}
+                </Badge>
+              }
+            />
+            <ListRow
+              label="Mode"
+              value={
+                /* Regular (24px), not small: measured on the running renderer
+                   a small segment is a 16px paint in a 20px hit box, and the
+                   32px row has the height for the 24px tier. */
+                <SegmentedControl
+                  aria-label="Guard mode"
+                  options={MODE_OPTIONS.map((o) => ({ ...o, disabled: busy }))}
+                  value={state.mode}
+                  onChange={(m) => setMode(m)}
+                />
+              }
+            />
+            {state.mode === 'coach' && state.coachExpiresAt ? (
+              <ListRow
+                label="Switches to strict"
+                value={promotionLabel(state.coachExpiresAt, now)}
+              />
+            ) : null}
+            {state.autoPromoted ? (
+              /* State, not an event: it belongs next to the mode it changed,
+                 not in a toast that is gone before it is read. */
+              <ListRow label="Switched to strict" value="Coach period ended" />
+            ) : null}
+            <ListRow
+              last
+              /* "Enforcement", not "Temporary pause": the row already carries a
+                 Pause button, and label + button both saying "pause" wrapped to
+                 two lines at the 640px window minimum for no added meaning. */
+              label="Enforcement"
+              value={
+                bypassActive ? (
+                  <span className="inline-flex items-center gap-2">
+                    <span>Resumes {untilLabel(bypassUntil, now)}</span>
+                    <Button icon="play_arrow" disabled={busy} onClick={() => setBypass(0)}>
+                      Resume now
+                    </Button>
+                  </span>
+                ) : (
+                  <Button
+                    icon="pause"
+                    disabled={busy || state.mode === 'off'}
+                    onClick={() => setBypass(BYPASS_MINUTES)}
+                  >
+                    Pause for {BYPASS_MINUTES} minutes
+                  </Button>
+                )
+              }
+            />
+          </>
+        ) : null}
+      </Card>
+      {state?.reason && state.health !== 'ok' ? (
+        <p className="text-[11px] leading-[13px] px-1" style={{ color: 'var(--label-secondary)' }}>
+          {state.reason}
+        </p>
+      ) : null}
+    </Section>
+  );
+}

--- a/packages/app/src/renderer/components/__tests__/GuardSection.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/GuardSection.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, expect, it, vi } from 'vitest';
+import { GuardSection, promotionLabel, untilLabel } from '../GuardSection';
+
+const ROOT = '/tmp/project';
+
+interface StatusShape {
+  health: 'ok' | 'stalled' | 'down' | 'unknown';
+  mode: 'strict' | 'coach' | 'off';
+  bypassUntil?: number;
+  reason?: string;
+  coachExpiresAt?: number;
+  autoPromoted?: boolean;
+}
+
+function stubGuard(status: StatusShape, calls: string[] = []) {
+  const guard = {
+    initialize: vi.fn(async () => {
+      calls.push('initialize');
+      return { initialized: true, mode: status.mode };
+    }),
+    status: vi.fn(async () => {
+      calls.push('status');
+      return status;
+    }),
+    setMode: vi.fn(async () => ({ ok: true })),
+    setBypass: vi.fn(async () => ({ ok: true })),
+  };
+  (window as unknown as { electronAPI: unknown }).electronAPI = { guard };
+  return guard;
+}
+
+afterEach(() => {
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  vi.restoreAllMocks();
+});
+
+/* ── The functional half: nothing has called `initialize` since the workspace
+      rebuild, so a project never got its coach grace period. ─────────────── */
+
+it('initializes the project before reading its status', async () => {
+  const calls: string[] = [];
+  const guard = stubGuard({ health: 'ok', mode: 'coach' }, calls);
+  render(<GuardSection root={ROOT} />);
+
+  await waitFor(() => expect(guard.status).toHaveBeenCalled());
+  expect(guard.initialize).toHaveBeenCalledWith(ROOT);
+  expect(calls[0]).toBe('initialize');
+});
+
+it('still reports status when initialization throws', async () => {
+  const guard = stubGuard({ health: 'down', mode: 'strict', reason: 'server not running' });
+  guard.initialize.mockRejectedValueOnce(new Error('read-only volume'));
+  render(<GuardSection root={ROOT} />);
+
+  expect(await screen.findByText('Not running')).toBeTruthy();
+});
+
+/* ── Status is a tone AND a glyph AND a word ──────────────────────────────── */
+
+it.each([
+  ['ok', 'Active'],
+  ['stalled', 'Stalled'],
+  ['down', 'Not running'],
+  ['unknown', 'Unknown'],
+] as const)('spells %s out as "%s" with a glyph, not a colour alone', async (health, label) => {
+  stubGuard({ health, mode: 'strict' });
+  const { container } = render(<GuardSection root={ROOT} />);
+
+  const badge = await screen.findByText(label);
+  expect(badge.closest('.lx-badge')?.querySelector('svg')).toBeTruthy();
+  expect(container.querySelector('.lx-badge')).toBeTruthy();
+});
+
+it('shows the failure reason as reading text, not only as a tone', async () => {
+  stubGuard({ health: 'down', mode: 'strict', reason: 'Heartbeat stale (412s)' });
+  render(<GuardSection root={ROOT} />);
+
+  expect(await screen.findByText('Heartbeat stale (412s)')).toBeTruthy();
+});
+
+/* ── Mode ─────────────────────────────────────────────────────────────────── */
+
+it('offers the three modes as one segmented control and writes the chosen one', async () => {
+  const guard = stubGuard({ health: 'ok', mode: 'coach' });
+  render(<GuardSection root={ROOT} />);
+
+  const group = await screen.findByRole('group', { name: 'Guard mode' });
+  expect(group.className).toContain('lx-seg');
+  expect(screen.getByRole('button', { name: 'Coach' }).getAttribute('aria-pressed')).toBe('true');
+
+  fireEvent.click(screen.getByRole('button', { name: 'Off' }));
+  await waitFor(() => expect(guard.setMode).toHaveBeenCalledWith(ROOT, 'off'));
+});
+
+it('shows when coach auto-promotes instead of announcing it in a toast', async () => {
+  const in6Days = Math.floor(Date.now() / 1000) + 6 * 86_400;
+  stubGuard({ health: 'ok', mode: 'coach', coachExpiresAt: in6Days });
+  render(<GuardSection root={ROOT} />);
+
+  expect(await screen.findByText('Switches to strict')).toBeTruthy();
+  expect(screen.getByText(promotionLabel(in6Days, Date.now()))).toBeTruthy();
+});
+
+/* ── Bypass ───────────────────────────────────────────────────────────────── */
+
+it('offers a ten-minute pause when enforcement is running', async () => {
+  const guard = stubGuard({ health: 'ok', mode: 'strict' });
+  render(<GuardSection root={ROOT} />);
+
+  fireEvent.click(await screen.findByRole('button', { name: /Pause for 10 minutes/ }));
+  await waitFor(() => expect(guard.setBypass).toHaveBeenCalledWith(ROOT, 10));
+});
+
+it('reads out an active bypass with its end and a way back', async () => {
+  const in9Min = Math.floor(Date.now() / 1000) + 9 * 60;
+  const guard = stubGuard({ health: 'ok', mode: 'strict', bypassUntil: in9Min });
+  render(<GuardSection root={ROOT} />);
+
+  expect(await screen.findByText(/Resumes in 9 minutes/)).toBeTruthy();
+  fireEvent.click(screen.getByRole('button', { name: /Resume now/ }));
+  await waitFor(() => expect(guard.setBypass).toHaveBeenCalledWith(ROOT, 0));
+});
+
+it('renders nothing rather than a reassuring row when the bridge is missing', () => {
+  const { container } = render(<GuardSection root={ROOT} />);
+  expect(container.innerHTML).toBe('');
+});
+
+/* ── Time wording ─────────────────────────────────────────────────────────── */
+
+it('words a future instant in the future tense', () => {
+  const now = 1_700_000_000_000;
+  const s = now / 1000;
+  expect(untilLabel(s + 30, now)).toBe('in under a minute');
+  expect(untilLabel(s + 60, now)).toBe('in 1 minute');
+  expect(untilLabel(s + 9 * 60, now)).toBe('in 9 minutes');
+  expect(untilLabel(s + 3 * 3600, now)).toBe('in 3 hours');
+  expect(untilLabel(s + 6 * 86_400, now)).toBe('in 6 days');
+  // A bypass that has already lapsed reads as over, never as a negative.
+  expect(untilLabel(s - 500, now)).toBe('in under a minute');
+});

--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -8,7 +8,7 @@
  *              toolbar's bottom edge, not a full-bleed accent band across the
  *              content.
  *   Content  — inset grouped lists capped at a readable measure and centred:
- *              Index · Coverage · Quality · Services.
+ *              Index · Guard · Coverage · Quality · Services.
  *
  * What this replaces, measured on the running app before the rewrite:
  *   - "Re-index Project" as a 1640px-wide accent-filled bar spanning the whole
@@ -20,6 +20,7 @@
  *     (2.21:1), and row actions that only existed on hover.
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { GuardSection } from '../components/GuardSection';
 import { ProjectStatsModal } from '../components/ProjectStatsModal';
 import { useDaemon } from '../hooks/useDaemon';
 import { Icon } from '../lattice/icons';
@@ -605,6 +606,12 @@ export function ProjectOverview({
               )}
             </Card>
           </Section>
+
+          {/* ── Guard ─────────────────────────────────────────────────
+              Second, not last: it is live state about how agents read this
+              project, which is the same class of question as Index. Coverage,
+              Quality and Services are analysis of what was read. */}
+          <GuardSection root={root} />
 
           {/* ── Coverage ───────────────────────────────────────────── */}
           <Section


### PR DESCRIPTION
Closes TRA-334.

## The problem

`packages/app/src/main/guard-control.ts` is 670 lines wired through eight IPC channels. The renderer called **three** of them — `checkCliVersion`, `installStatus`, `install` — all from `GuardOnboarding.tsx`. So the app walked a new user through installing the guard and then never mentioned it again: no health, no mode, no bypass, and no way to pause enforcement short of hand-editing a sentinel file in the OS temp dir.

`GuardBadge` was the only surface, and it rendered inside `ProjectRow`, which the workspace rebuild (TRA-292) replaced. Nothing carried it across, so the chain went dead quietly — no error, no missing import.

**It was not only a missing screen.** `guard.initialize` was called on that badge's mount, and it is what writes `.trace-mcp/guard-mode` = `coach` plus the install date that arms the 7-day coach→strict promotion. With nothing calling it, `getGuardMode` falls back to `strict`, so every project registered since the rebuild skipped the coach grace period silently. Observed on disk rather than inferred: two projects registered in May carry a `guard-mode` file; a checkout created today has none.

## What this adds

A **Guard** section on Project Overview, between Index and Coverage:

| Row | What it answers |
|---|---|
| Status | Is the guard running — `Badge` with tone **and** glyph **and** word (Active / Stalled / Not running / Unknown), with `reason` as reading text below the card when it is not `ok` |
| Mode | `SegmentedControl` — Strict / Coach / Off, each with a tooltip saying what it does |
| Switches to strict | Only in coach: `in 6 days · Sep 4` |
| Enforcement | `Pause for 10 minutes`, or `Resumes in 9 minutes` + `Resume now` when a bypass is live |

It calls `guard.initialize(root)` before the first status read, and polls status every 15s so a guard that dies while you are looking at it stops reading "Active".

Where it lives was a decision, not a default: the workspace table is already at nine columns and drops trailing ones under a container query, which makes it the worst possible home for a status the user needs. Project Overview is per-project by definition and has the measure for a control plus a sentence.

## Not a port of `GuardBadge`

The old badge broke eight `DESIGN.md` rules and the issue explicitly said not to copy it. Status was five hues on a 6px dot with only the *mode* written out, so "down" and "ok" differed by colour alone; mode selection was three bordered buttons in a hand-rolled `radiogroup` inside a hand-rolled popover; reading text ran at 10px; it hardcoded `#30d158` (2.02:1 on light), `#ff9500`, `#ff3b30`, `#0a84ff`, `#8e8e93` and used them in both appearances; auto-promotion arrived as a toast. Here every colour is a token, every control comes from `lattice/ui`, and promotion is state shown next to the mode it changed.

## Measured on the running renderer

Not read off the stylesheet — `getBoundingClientRect` / `elementFromPoint` / canvas-composited contrast on the live page, in both appearances.

- Rows 32px; every focusable 24×24 or larger. First pass used `size="small"` and measured a 16px paint in a 20px hit box for segments and 20×20 for the button — both under the floor. The 24px tier is what a 32px list row takes, and it needs no pseudo-element growth.
- Contrast, light: badge 4.83:1, section header and footnote 4.61:1, everything else 13–15:1. Dark: badge 5.70:1, header/footnote 6.15:1, bypass readout 5.85:1, rest 14:1+.
- 640×420 window minimum: nothing overflows, no control lands outside the viewport. "Temporary pause" as the row label wrapped to two lines there against its own "Pause for 10 minutes" button, so the label is "Enforcement" — the label names the subject, the control names the action.
- Tabbed it: Strict → Coach → Off → the pause button, house focus ring visible on each.
- No material involved (the card is opaque content), so Reduce Transparency has nothing to change here; the section reads only tokens, so `prefers-contrast: more` is inherited.

## States

Loading is `SkeletonRows` at the final 32px geometry. A failed status read is `SectionError` with Retry. With no `electronAPI` bridge the section renders nothing rather than inventing a reassuring row for a channel it cannot reach.

## Checks

`pnpm test` in `packages/app` — 287 passed (27 files), 13 of them new. `typecheck`, `build`, `biome ci` clean. `design-tokens.mjs` clean, no baseline count raised — the section introduces no raw colour.

`DESIGN.md` gains the Guard section in §12 and five decisions in §11, including the one that cost this run a re-measure: deleting the last host of a feature means re-homing the feature, not just deleting a component.

Agent: Design/UX Agent
