### PR TITLE
fix(app): abort the Settings model-list fetch on unmount

### DIFF
--- a/packages/app/src/renderer/tabs/Settings.tsx
+++ b/packages/app/src/renderer/tabs/Settings.tsx
@@ -557,7 +557,7 @@ function useProviderModels(
           size: m.size ? `${(m.size / 1e9).toFixed(1)} GB` : undefined,
         }));
         list.sort((a, b) => a.name.localeCompare(b.name));
-        setModels(list);
+        if (!ctrl.signal.aborted) setModels(list);
       }
       // ── Anthropic: static list (no models API) ──
       else if (provider === 'anthropic') {
@@ -576,25 +576,34 @@ function useProviderModels(
           name: (m.name ?? '').replace(/^models\//, ''),
         }));
         list.sort((a, b) => a.name.localeCompare(b.name));
-        setModels(list);
+        if (!ctrl.signal.aborted) setModels(list);
       }
       // ── All OpenAI-compatible providers ──
       else if (OPENAI_COMPAT_PROVIDERS.has(provider)) {
         const url = baseUrl || defaults?.baseUrl || '';
-        setModels(
-          await fetchOpenAICompatModels(url.replace(/\/+$/, ''), key, label, ctrl.signal),
+        const list = await fetchOpenAICompatModels(
+          url.replace(/\/+$/, ''),
+          key,
+          label,
+          ctrl.signal,
         );
+        if (!ctrl.signal.aborted) setModels(list);
       }
     } catch (e) {
       const err = e as Error;
-      if (err.name !== 'AbortError') setError(err.message ?? 'Failed to fetch models');
+      if (err.name !== 'AbortError' && !ctrl.signal.aborted)
+        setError(err.message ?? 'Failed to fetch models');
     } finally {
-      setLoading(false);
+      // Aborted means either a newer fetch superseded this one or the component
+      // unmounted — either way this run owns no state any more. Without the
+      // guard the settle lands after teardown and React touches a gone `window`.
+      if (!ctrl.signal.aborted) setLoading(false);
     }
   }, [provider, baseUrl, apiKey]);
 
   useEffect(() => {
     fetchModels();
+    return () => abortRef.current?.abort();
   }, [fetchModels]);
 
   return { models, loading, error, refresh: fetchModels };

--- a/packages/app/src/renderer/tabs/__tests__/Settings.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/Settings.test.tsx
@@ -37,6 +37,7 @@ vi.mock('../../hooks/useDaemon', () => ({
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 it('gives every group a title', () => {
@@ -135,6 +136,26 @@ it('navigates into a section and back from the toolbar', async () => {
 
   fireEvent.click(screen.getByRole('button', { name: 'Back' }));
   expect(screen.getByRole('heading', { name: 'Settings', level: 2 })).toBeTruthy();
+});
+
+/* TRA-333: the model-list fetch outlived the component. Its `finally` ran
+   `setLoading(false)` after the test's jsdom was torn down, React reached for
+   `window`, and vitest failed the whole run on the unhandled error even though
+   every test passed. */
+it('aborts the in-flight model fetch when the settings tab unmounts', async () => {
+  let signal: AbortSignal | undefined;
+  const fetchMock = vi.fn((_url: unknown, init?: { signal?: AbortSignal }) => {
+    signal = init?.signal;
+    return new Promise<never>(() => {}); // never settles on its own
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { unmount } = render(<Settings />);
+  fireEvent.click(screen.getByRole('button', { name: /^AI and embeddings/ }));
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+  unmount();
+  expect(signal?.aborted).toBe(true);
 });
 
 /* An absent key IS the default — the daemon applies the default when the key

--- a/src/pipeline/__tests__/sqlite-task-cache.test.ts
+++ b/src/pipeline/__tests__/sqlite-task-cache.test.ts
@@ -33,7 +33,14 @@ afterEach(() => {
   } catch {
     // best effort — some tests close the db themselves
   }
-  rmSync(workDir, { recursive: true, force: true });
+  // Windows can still hold the sqlite file briefly after close, which turned
+  // this hook red once on CI. Bound the wait and let the OS reap a stray temp
+  // dir rather than fail a run over cleanup.
+  try {
+    rmSync(workDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  } catch {
+    // best effort
+  }
 });
 
 describe('SqliteTaskCache', () => {


### PR DESCRIPTION
Fixes the `app-typecheck` flake from TRA-333 that blocked release PR #476.

## The leak

`useProviderModels` in `packages/app/src/renderer/tabs/Settings.tsx` built an `AbortController` per fetch but nothing ever aborted it on unmount, and `finally { setLoading(false) }` ran unconditionally. When the request settled after the component was gone — in vitest, after jsdom teardown — React hit `window is not defined` in `resolveUpdatePriority`, and vitest fails a run on an unhandled error even with all tests passing. Whether CI went red depended purely on how long the pending fetch outlived teardown, which is why a plain re-run went green.

## The fix

- the effect aborts its controller on cleanup (`return () => abortRef.current?.abort()`);
- every `setModels` / `setError` / `setLoading` is gated on `ctrl.signal.aborted`, so a superseded or orphaned run owns no state.

Regression test `aborts the in-flight model fetch when the settings tab unmounts` stubs `fetch` with a promise that never settles, navigates to the AI section, unmounts, and asserts the signal is aborted. Verified failing without the cleanup:

```
× aborts the in-flight model fetch when the settings tab unmounts
AssertionError: expected false to be true
Tests  1 failed | 12 passed (13)
```

## Windows `afterEach` timeout (second half of the issue)

`src/pipeline/__tests__/sqlite-task-cache.test.ts` timed out once in `afterEach` on Windows. No mechanism reproduced — this is a bounded hardening, not a diagnosed fix: `rmSync` gets `maxRetries: 5, retryDelay: 50` and its throw is swallowed, so a handle still held past `db.close()` costs at most ~250ms and a stray temp dir instead of a red run.

`Workspace.tsx:98` from the same stack has no corresponding file in the tree (only a planned entry in `src/renderer/workspace/README.md`), so nothing to fix there.

## Test evidence

- `pnpm --dir packages/app run test` → 27 files / 288 tests passing, exit 0, no `window is not defined` on stderr (it printed on every run before this change).
- `pnpm --dir packages/app run typecheck` → clean.
- `pnpm run test sqlite-task-cache` → 2 files / 16 tests passing.
