### PR TITLE
docs: move language and framework counts into counts.yml (TRA-275)

### DIFF
--- a/docs/_data/counts.yml
+++ b/docs/_data/counts.yml
@@ -18,3 +18,13 @@
 # (TRA-259) checks those against the real tool filter, which is exact where a
 # hand-maintained number would only be a copy.
 tools: 169
+
+# TRA-275: `languages` and `frameworks` are derived — PluginRegistry
+# .createWithDefaults() knows them exactly — so readme-claims.test.ts asserts
+# these two match the registry EXACTLY, not within the ±tolerance the prose
+# surfaces get. A plugin add fails CI here with the number to write.
+#
+# README.md / CLAUDE.md / AGENTS.md / skills/ are not Jekyll-rendered, so they
+# keep prose numbers and stay on the ±tolerance guard.
+languages: 80
+frameworks: 87

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -218,7 +218,7 @@ src/
 │   └── service-detector.ts #   Subproject discovery (Docker Compose, flat/grouped workspace, monolith fallback)
 ├── indexer/
 │   ├── plugins/
-│   │   ├── language/       # 80 languages — PHP, TS, Vue, Python, Go, Java, Kotlin, Ruby, Rust,
+│   │   ├── language/       # {{ site.data.counts.languages }} languages — PHP, TS, Vue, Python, Go, Java, Kotlin, Ruby, Rust,
 │   │   │                   #   C/C++/C#, Swift, Dart, Scala, Zig, OCaml, Clojure, F#, Elm,
 │   │   │                   #   CUDA, COBOL, Verilog, GLSL, Svelte, MATLAB, Lean, Wolfram, …
 │   │   └── integration/    # 85 plugins organized by category:

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -41,10 +41,10 @@ Tools that help AI agents read code with fewer tokens — AST parsing, outlines,
 | Capability | trace-mcp | Repomix | Context Mode | code-review-graph | jCodeMunch | codebase-memory-mcp | cymbal |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **GitHub stars** | 100 | 28.1K | 8.8K | ~19K | 2.6K | 41.0K | 165 |
-| Tree-sitter AST parsing | ✅ 80 languages | ✅ compress only (~20) | ❌ no code parsing | ✅ 23 langs + Jupyter | ✅ 70+ languages | ✅ 161 languages | ✅ 22 languages |
+| Tree-sitter AST parsing | ✅ {{ site.data.counts.languages }} languages | ✅ compress only (~20) | ❌ no code parsing | ✅ 23 langs + Jupyter | ✅ 70+ languages | ✅ 161 languages | ✅ 22 languages |
 | Token-efficient symbol lookup | ✅ outlines, symbols, bundles | ❌ packs entire files | ✅ sandboxed output (98% reduction) | ✅ | ✅ core focus (~95% reduction) | ✅ | ✅ outline/show/context |
 | Cross-file dependency graph | ✅ directed edge graph | ❌ | ❌ | ✅ incremental knowledge graph | ✅ import graph | ✅ knowledge graph | ✅ refs/importers |
-| Framework-aware edges | ✅ 87 integrations | ❌ | ❌ | ❌ | ✅ 21 frameworks (route/middleware) | partial (REST routes) | ❌ |
+| Framework-aware edges | ✅ {{ site.data.counts.frameworks }} integrations | ❌ | ❌ | ❌ | ✅ 21 frameworks (route/middleware) | partial (REST routes) | ❌ |
 | Impact analysis | ✅ reverse dep traversal + decorator filter | ❌ | ❌ | ✅ blast-radius + Leiden communities | ✅ blast radius + decorator filter | ✅ detect_changes | ✅ impact command |
 | Call graph | ✅ bidirectional, graph-based | ❌ | ❌ | ✅ graph-based | ✅ AST-based, bidirectional | ✅ trace_call_path | ✅ refs/importers |
 | Refactoring tools | ✅ rename, extract, dead code, codemod | ❌ | ❌ | ❌ | ❌ (dead code detect only) | ❌ | ❌ |
@@ -108,8 +108,8 @@ _¹ mcp-local-rag and knowledge-rag are document RAG tools (PDF, DOCX, Markdown)
 | Capability | trace-mcp | Serena | code-review-graph | codebase-memory-mcp | SocratiCode | Narsil-MCP | Roam-Code |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **GitHub stars** | 100 | ~28.5K | ~19K | 41.0K | ~900 | ~100 | ~500 |
-| Languages | 80 | 40+ (via LSP) | 23 + Jupyter | 161 | 19 | 32 | 28 |
-| Framework integrations | 85 | ❌ | ❌ (Python entry points only) | ❌ | ❌ | ❌ | ~15 (ORM N+1 / API drift only) |
+| Languages | {{ site.data.counts.languages }} | 40+ (via LSP) | 23 + Jupyter | 161 | 19 | 32 | 28 |
+| Framework integrations | {{ site.data.counts.frameworks }} | ❌ | ❌ (Python entry points only) | ❌ | ❌ | ❌ | ~15 (ORM N+1 / API drift only) |
 | Cross-language edges | ✅ | ❌ | ❌ | ✅ cross-service HTTP | ✅ polyglot dep graph | ❌ | ✅ PHP↔TS API drift |
 | MCP tools advertised (default) | {{ site.data.counts.tools }} (~51K tok) | ~55 | ~28 | 15 all / 11 `analysis` / 7 `scout` (~7K tok) | 21 | 90 | 224 |
 | Session memory | ✅ | ✅ (manual notes) | ❌ | ✅ | ❌ | ❌ | ❌ |
@@ -169,7 +169,7 @@ No tool is uniformly ahead. trace-mcp is the only one combining framework-aware 
 - **Worst-case decision-verification latency.** The memoization fix above only helps when decisions cluster on a handful of files; a batch fully scattered across N distinct files is still O(N) git subprocess spawns. An async/batched redesign would be needed to bound the worst case.
 - **CFG is line-based, not AST-based**, and taint analysis remains lexical/regex, not a real dataflow engine — both are known architectural ceilings, not just untested edge cases; a full AST/dataflow rewrite of either is out of scope for now.
 
-**Deliberately NOT chasing (out of lane or vanity):** live runtime debugger (Serena — runtime, not static graph); counterfactual architecture simulation / multi-agent swarm (Roam-Code — unverified, speculative); the 161-language count race (codebase-memory-mcp — trace-mcp's 80 already covers the real-world long tail); the tool-count arms race for its own sake (Roam 224, Narsil 90 — quality of edges beats tool count; note this is a claim about which tools to *build*, not about how many to advertise by default, where we are currently behind — see above); verbatim chat storage and 20× "Endless Mode" (MemPalace / claude-mem — trace-mcp's extract-then-store model is deliberate, and Endless Mode adds 60–90s latency per tool).
+**Deliberately NOT chasing (out of lane or vanity):** live runtime debugger (Serena — runtime, not static graph); counterfactual architecture simulation / multi-agent swarm (Roam-Code — unverified, speculative); the 161-language count race (codebase-memory-mcp — trace-mcp's {{ site.data.counts.languages }} already covers the real-world long tail); the tool-count arms race for its own sake (Roam 224, Narsil 90 — quality of edges beats tool count; note this is a claim about which tools to *build*, not about how many to advertise by default, where we are currently behind — see above); verbatim chat storage and 20× "Endless Mode" (MemPalace / claude-mem — trace-mcp's extract-then-store model is deliberate, and Endless Mode adds 60–90s latency per tool).
 
 ## Profiling depth tracker
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,7 +75,7 @@ layout: null
     "@type": "SoftwareApplication",
     "name": "trace-mcp",
     "alternateName": "trace-mcp — Recomputation → Reuse for AI Systems",
-    "description": "AI agents recompute the same work every turn — re-reading files, re-traversing dependencies, re-inflating context. trace-mcp makes them reuse instead. 40–50% fewer tokens on average, up to 2× effective capacity, up to 99% less redundant processing. Framework-aware dependency graph via MCP, 80 languages, 87 integrations.",
+    "description": "AI agents recompute the same work every turn — re-reading files, re-traversing dependencies, re-inflating context. trace-mcp makes them reuse instead. 40–50% fewer tokens on average, up to 2× effective capacity, up to 99% less redundant processing. Framework-aware dependency graph via MCP, {{ site.data.counts.languages }} languages, {{ site.data.counts.frameworks }} integrations.",
     "url": "https://trace-mcp.com/",
     "image": "https://trace-mcp.com/og-image.png",
     "applicationCategory": "DeveloperApplication",
@@ -108,7 +108,7 @@ layout: null
       "40–50% fewer tokens on average across real agent workflows",
       "Up to 2× effective capacity at the same context budget",
       "Up to 99% less redundant processing in structured tasks (code navigation, dependency traversal)",
-      "Framework-aware dependency graph (87 integrations, 80 languages)",
+      "Framework-aware dependency graph ({{ site.data.counts.frameworks }} integrations, {{ site.data.counts.languages }} languages)",
       "{{ site.data.counts.tools }} MCP tools for navigation, impact analysis, refactoring",
       "Local-first: SQLite + bundled ONNX embeddings, zero API keys",
       "Native Model Context Protocol integration"
@@ -127,7 +127,7 @@ layout: null
         "name": "What is the best MCP server for giving Claude Code codebase context?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across 80 languages) and exposes {{ site.data.counts.tools }} MCP tools — outline, symbol lookup, call graph, impact analysis, dead code detection — so Claude Code queries precomputed structure instead of re-reading files every turn. It runs entirely locally with no API keys, works with 87 framework integrations, and typically cuts token usage 40–50% versus raw file reads while producing more consistent answers as the codebase grows. It's open source (MIT), installs with 'npm install -g trace-mcp', and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf."
+          "text": "trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across {{ site.data.counts.languages }} languages) and exposes {{ site.data.counts.tools }} MCP tools — outline, symbol lookup, call graph, impact analysis, dead code detection — so Claude Code queries precomputed structure instead of re-reading files every turn. It runs entirely locally with no API keys, works with {{ site.data.counts.frameworks }} framework integrations, and typically cuts token usage 40–50% versus raw file reads while producing more consistent answers as the codebase grows. It's open source (MIT), installs with 'npm install -g trace-mcp', and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf."
         }
       },
       {
@@ -175,7 +175,7 @@ layout: null
         "name": "What about my framework? Is it supported?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "80 languages and 87 framework integrations ship out of the box. For unsupported frameworks, the plugin API is open — write a custom plugin in TypeScript, register it via ~/.trace-mcp/plugins/. Most plugins are ~200–500 lines."
+          "text": "{{ site.data.counts.languages }} languages and {{ site.data.counts.frameworks }} framework integrations ship out of the box. For unsupported frameworks, the plugin API is open — write a custom plugin in TypeScript, register it via ~/.trace-mcp/plugins/. Most plugins are ~200–500 lines."
         }
       },
       {
@@ -2184,8 +2184,8 @@ layout: null
       <div class="definition reveal">
         <div class="def-text">
           <h3>This is how agents stop <span class="em">recomputing and start reusing.</span></h3>
-          <p><strong>Computed once</strong> &mdash; every symbol, every edge, across 80 languages in one directed graph. The agent queries it instead of rediscovering it each turn.</p>
-          <p><strong>Framework-aware</strong> &mdash; routes to controllers, Inertia to Vue, Eloquent to migrations. 87 integrations capture edges the agent would otherwise reconstruct from raw files.</p>
+          <p><strong>Computed once</strong> &mdash; every symbol, every edge, across {{ site.data.counts.languages }} languages in one directed graph. The agent queries it instead of rediscovering it each turn.</p>
+          <p><strong>Framework-aware</strong> &mdash; routes to controllers, Inertia to Vue, Eloquent to migrations. {{ site.data.counts.frameworks }} integrations capture edges the agent would otherwise reconstruct from raw files.</p>
           <p><strong>Compiler-grade where it matters</strong> &mdash; optional LSP enrichment with <code>tsserver</code>, <code>pyright</code>, <code>gopls</code> for call resolution that survives across calls.</p>
           <p><strong>Reused, not rebuilt</strong> &mdash; 300ms file-watcher debounce and content-hashed incremental reindex keep the graph fresh without redoing finished work.</p>
         </div>
@@ -2371,7 +2371,7 @@ layout: null
       <div class="diff-block reveal">
         <ul class="diff-list">
           <li><span class="num">/ 01</span><span><strong>Computed once, queried many times</strong> &mdash; a graph, not a text index that gets re-ranked every turn.</span></li>
-          <li><span class="num">/ 02</span><span><strong>Framework-aware edges</strong> across 87 integrations &mdash; routes, ORMs, views, DI captured up front, not rediscovered from raw files.</span></li>
+          <li><span class="num">/ 02</span><span><strong>Framework-aware edges</strong> across {{ site.data.counts.frameworks }} integrations &mdash; routes, ORMs, views, DI captured up front, not rediscovered from raw files.</span></li>
           <li><span class="num">/ 03</span><span><strong>Tools that return answers</strong>, not snippets to read &mdash; <code>get_change_impact</code>, <code>get_call_graph</code>, <code>find_usages</code> over a precomputed structure.</span></li>
           <li><span class="num">/ 04</span><span><strong>Reuse survives the session</strong> &mdash; incremental reindex, decision memory, agent-behavior rules keep cost from rebounding.</span></li>
         </ul>
@@ -2485,7 +2485,7 @@ layout: null
       <div class="section-meta">
         <div class="section-meta-tag"><span class="label">011 / Ecosystem</span></div>
         <div>
-          <h2 class="section-title">87 integrations. <span class="em">80 languages.</span></h2>
+          <h2 class="section-title">{{ site.data.counts.frameworks }} integrations. <span class="em">{{ site.data.counts.languages }} languages.</span></h2>
           <p class="section-lede">Each integration adds framework-specific edges &mdash; routes, components, migrations, queries &mdash; not just syntax parsing. Plugin API is open: write your own for a niche framework in under a day.</p>
         </div>
       </div>
@@ -2631,7 +2631,7 @@ layout: null
             <h3>What is the best MCP server for giving Claude Code codebase context?</h3>
             <span class="toggle">+</span>
           </summary>
-          <div class="answer">trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across 80 languages) and exposes {{ site.data.counts.tools }} MCP tools &mdash; outline, symbol lookup, call graph, impact analysis, dead code detection &mdash; so Claude Code queries precomputed structure instead of re-reading files every turn. It runs entirely locally with no API keys, works with 87 framework integrations, and typically cuts token usage 40&ndash;50% versus raw file reads while producing more consistent answers as the codebase grows. It's open source (MIT), installs with <code>npm install -g trace-mcp</code>, and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf.</div>
+          <div class="answer">trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across {{ site.data.counts.languages }} languages) and exposes {{ site.data.counts.tools }} MCP tools &mdash; outline, symbol lookup, call graph, impact analysis, dead code detection &mdash; so Claude Code queries precomputed structure instead of re-reading files every turn. It runs entirely locally with no API keys, works with {{ site.data.counts.frameworks }} framework integrations, and typically cuts token usage 40&ndash;50% versus raw file reads while producing more consistent answers as the codebase grows. It's open source (MIT), installs with <code>npm install -g trace-mcp</code>, and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf.</div>
         </details>
         <details class="faq">
           <summary>
@@ -2673,7 +2673,7 @@ layout: null
             <h3>What about my framework? Is it supported?</h3>
             <span class="toggle">+</span>
           </summary>
-          <div class="answer">80 languages and 87 framework integrations ship out of the box. For unsupported frameworks, the plugin API is open &mdash; write a custom plugin in TypeScript, register it via <code>~/.trace-mcp/plugins/</code>. Most plugins are ~200&ndash;500 lines.</div>
+          <div class="answer">{{ site.data.counts.languages }} languages and {{ site.data.counts.frameworks }} framework integrations ship out of the box. For unsupported frameworks, the plugin API is open &mdash; write a custom plugin in TypeScript, register it via <code>~/.trace-mcp/plugins/</code>. Most plugins are ~200&ndash;500 lines.</div>
         </details>
         <details class="faq">
           <summary>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -255,10 +255,10 @@ Tools that help AI agents read code with fewer tokens — AST parsing, outlines,
 | Capability | trace-mcp | Repomix | Context Mode | code-review-graph | jCodeMunch | codebase-memory-mcp | cymbal |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **GitHub stars** | 100 | 28.1K | 8.8K | ~19K | 2.6K | 40.7K | 165 |
-| Tree-sitter AST parsing | ✅ 80 languages | ✅ compress only (~20) | ❌ no code parsing | ✅ 23 langs + Jupyter | ✅ 70+ languages | ✅ 158 languages | ✅ 22 languages |
+| Tree-sitter AST parsing | ✅ {{ site.data.counts.languages }} languages | ✅ compress only (~20) | ❌ no code parsing | ✅ 23 langs + Jupyter | ✅ 70+ languages | ✅ 158 languages | ✅ 22 languages |
 | Token-efficient symbol lookup | ✅ outlines, symbols, bundles | ❌ packs entire files | ✅ sandboxed output (98% reduction) | ✅ | ✅ core focus (~95% reduction) | ✅ | ✅ outline/show/context |
 | Cross-file dependency graph | ✅ directed edge graph | ❌ | ❌ | ✅ incremental knowledge graph | ✅ import graph | ✅ knowledge graph | ✅ refs/importers |
-| Framework-aware edges | ✅ 87 integrations | ❌ | ❌ | ❌ | ✅ 21 frameworks (route/middleware) | partial (REST routes) | ❌ |
+| Framework-aware edges | ✅ {{ site.data.counts.frameworks }} integrations | ❌ | ❌ | ❌ | ✅ 21 frameworks (route/middleware) | partial (REST routes) | ❌ |
 | Impact analysis | ✅ reverse dep traversal + decorator filter | ❌ | ❌ | ✅ blast-radius + Leiden communities | ✅ blast radius + decorator filter | ✅ detect_changes | ✅ impact command |
 | Call graph | ✅ bidirectional, graph-based | ❌ | ❌ | ✅ graph-based | ✅ AST-based, bidirectional | ✅ trace_call_path | ✅ refs/importers |
 | Refactoring tools | ✅ rename, extract, dead code, codemod | ❌ | ❌ | ❌ | ❌ (dead code detect only) | ❌ | ❌ |
@@ -322,8 +322,8 @@ _¹ mcp-local-rag and knowledge-rag are document RAG tools (PDF, DOCX, Markdown)
 | Capability | trace-mcp | Serena | code-review-graph | codebase-memory-mcp | SocratiCode | Narsil-MCP | Roam-Code |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **GitHub stars** | 100 | ~28.5K | ~19K | 40.7K | ~900 | ~100 | ~500 |
-| Languages | 80 | 40+ (via LSP) | 23 + Jupyter | 158 | 19 | 32 | 28 |
-| Framework integrations | 85 | ❌ | ❌ (Python entry points only) | ❌ | ❌ | ❌ | ~15 (ORM N+1 / API drift only) |
+| Languages | {{ site.data.counts.languages }} | 40+ (via LSP) | 23 + Jupyter | 158 | 19 | 32 | 28 |
+| Framework integrations | {{ site.data.counts.frameworks }} | ❌ | ❌ (Python entry points only) | ❌ | ❌ | ❌ | ~15 (ORM N+1 / API drift only) |
 | Cross-language edges | ✅ | ❌ | ❌ | ✅ cross-service HTTP | ✅ polyglot dep graph | ❌ | ✅ PHP↔TS API drift |
 | MCP tools | {{ site.data.counts.tools }} | ~55 | ~28 | 14 | 21 | 90 | 224 |
 | Session memory | ✅ | ✅ (manual notes) | ❌ | ✅ | ❌ | ❌ | ❌ |
@@ -369,7 +369,7 @@ No tool is uniformly ahead. trace-mcp is the only one combining framework-aware 
 - **Worst-case decision-verification latency.** The memoization fix above only helps when decisions cluster on a handful of files; a batch fully scattered across N distinct files is still O(N) git subprocess spawns. An async/batched redesign would be needed to bound the worst case.
 - **CFG is line-based, not AST-based**, and taint analysis remains lexical/regex, not a real dataflow engine — both are known architectural ceilings, not just untested edge cases; a full AST/dataflow rewrite of either is out of scope for now.
 
-**Deliberately NOT chasing (out of lane or vanity):** live runtime debugger (Serena — runtime, not static graph); counterfactual architecture simulation / multi-agent swarm (Roam-Code — unverified, speculative); the 158-language count race (codebase-memory-mcp — trace-mcp's 80 already covers the real-world long tail); tool-count arms race (Roam 224, Narsil 90 — quality of edges beats tool count); verbatim chat storage and 20× "Endless Mode" (MemPalace / claude-mem — trace-mcp's extract-then-store model is deliberate, and Endless Mode adds 60–90s latency per tool).
+**Deliberately NOT chasing (out of lane or vanity):** live runtime debugger (Serena — runtime, not static graph); counterfactual architecture simulation / multi-agent swarm (Roam-Code — unverified, speculative); the 158-language count race (codebase-memory-mcp — trace-mcp's {{ site.data.counts.languages }} already covers the real-world long tail); tool-count arms race (Roam 224, Narsil 90 — quality of edges beats tool count); verbatim chat storage and 20× "Endless Mode" (MemPalace / claude-mem — trace-mcp's extract-then-store model is deliberate, and Endless Mode adds 60–90s latency per tool).
 
 ## Profiling depth tracker
 
@@ -1325,7 +1325,7 @@ src/
 │   └── service-detector.ts #   Subproject discovery (Docker Compose, flat/grouped workspace, monolith fallback)
 ├── indexer/
 │   ├── plugins/
-│   │   ├── language/       # 80 languages — PHP, TS, Vue, Python, Go, Java, Kotlin, Ruby, Rust,
+│   │   ├── language/       # {{ site.data.counts.languages }} languages — PHP, TS, Vue, Python, Go, Java, Kotlin, Ruby, Rust,
 │   │   │                   #   C/C++/C#, Swift, Dart, Scala, Zig, OCaml, Clojure, F#, Elm,
 │   │   │                   #   CUDA, COBOL, Verilog, GLSL, Svelte, MATLAB, Lean, Wolfram, …
 │   │   └── integration/    # 85 plugins organized by category:
@@ -1379,7 +1379,7 @@ src/
 
 # Supported frameworks & languages
 
-## Languages (80)
+## Languages ({{ site.data.counts.languages }})
 
 ### Tree-sitter (full AST parsing)
 
@@ -2499,7 +2499,7 @@ these after any large refactor round — don't treat them as permanent.
 ## max_cyclomatic_complexity: 130 (warning)
 
 The generic default of 30 fires on nearly every language/framework plugin in
-this repo — dispatch tables for 80 languages and 87 frameworks are
+this repo — dispatch tables for {{ site.data.counts.languages }} languages and {{ site.data.counts.frameworks }} frameworks are
 inherently branchy. After decomposing every class that was a genuine
 god-object (`DecisionStore` 262→96, `TopologyStore` 125→49,
 `IndexingPipeline` 137→115, plus tool-gate/api-routes/memory-tools splits),

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,7 +5,7 @@ layout: null
 ---
 # trace-mcp
 
-> trace-mcp is a framework-aware MCP server that serves precomputed code intelligence — a dependency graph, full-text search, impact analysis, and decision memory — to cut token usage for AI coding agents. It understands 87 frameworks across 80 languages and exposes {{ site.data.counts.tools }} MCP tools over stdio or HTTP.
+> trace-mcp is a framework-aware MCP server that serves precomputed code intelligence — a dependency graph, full-text search, impact analysis, and decision memory — to cut token usage for AI coding agents. It understands {{ site.data.counts.frameworks }} frameworks across {{ site.data.counts.languages }} languages and exposes {{ site.data.counts.tools }} MCP tools over stdio or HTTP.
 
 ## Docs
 
@@ -13,7 +13,7 @@ layout: null
 - [How trace-mcp compares](https://trace-mcp.com/comparisons.html): Feature-by-feature comparison against other code-graph and code-intelligence MCP servers.
 - [Configuration](https://trace-mcp.com/configuration.html): All config file options; trace-mcp works out of the box without one.
 - [Architecture](https://trace-mcp.com/architecture.html): The two-pass indexing pipeline and how the dependency graph is built and stored.
-- [Supported frameworks & languages](https://trace-mcp.com/supported-frameworks.html): The 80 supported languages and the frameworks each plugin understands.
+- [Supported frameworks & languages](https://trace-mcp.com/supported-frameworks.html): The {{ site.data.counts.languages }} supported languages and the frameworks each plugin understands.
 - [Session Analytics & Coverage Intelligence](https://trace-mcp.com/analytics.html): The built-in engine that parses agent session logs and tracks token savings and waste.
 - [TOON Token Savings — Measured](https://trace-mcp.com/toon-savings.html): Real-world token measurements for the TOON output format across trace-mcp tools.
 - [Decision memory](https://trace-mcp.com/decision-memory.html): The persistent decision knowledge graph linking architectural decisions and tradeoffs to code.

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -38,7 +38,7 @@ these after any large refactor round — don't treat them as permanent.
 ## max_cyclomatic_complexity: 130 (warning)
 
 The generic default of 30 fires on nearly every language/framework plugin in
-this repo — dispatch tables for 80 languages and 87 frameworks are
+this repo — dispatch tables for {{ site.data.counts.languages }} languages and {{ site.data.counts.frameworks }} frameworks are
 inherently branchy. After decomposing every class that was a genuine
 god-object (`DecisionStore` 262→96, `TopologyStore` 125→49,
 `IndexingPipeline` 137→115, plus tool-gate/api-routes/memory-tools splits),

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://trace-mcp.com/</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -14,7 +14,7 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/comparisons.html</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -26,13 +26,13 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/architecture.html</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/supported-frameworks.html</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -62,7 +62,7 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/quality-gates.html</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/docs/supported-frameworks.md
+++ b/docs/supported-frameworks.md
@@ -10,7 +10,7 @@ description: "Full list of languages and frameworks trace-mcp understands out of
   "@context": "https://schema.org",
   "@type": "TechArticle",
   "headline": "Supported frameworks & languages",
-  "description": "The 80 supported languages and the frameworks each plugin understands.",
+  "description": "The {{ site.data.counts.languages }} supported languages and the frameworks each plugin understands.",
   "url": "https://trace-mcp.com/supported-frameworks.html",
   "datePublished": "2026-04-05",
   "dateModified": "2026-04-05",
@@ -30,7 +30,7 @@ description: "Full list of languages and frameworks trace-mcp understands out of
   }
 }
 </script>
-## Languages (80)
+## Languages ({{ site.data.counts.languages }})
 
 ### Tree-sitter (full AST parsing)
 

--- a/tests/docs/readme-claims.test.ts
+++ b/tests/docs/readme-claims.test.ts
@@ -329,6 +329,70 @@ describe('docs site numeric claims (TRA-174)', () => {
     }
   });
 
+  it('docs/_data/counts.yml language and framework counts match the registry exactly (TRA-275)', () => {
+    // Exact, not ±tolerance: unlike the tool count these are derived, so the
+    // registry is an exact receipt (same reasoning as preset-claims.test.ts).
+    expect(
+      lookupCount('languages'),
+      'update `languages:` in docs/_data/counts.yml — a language plugin was added or removed',
+    ).toBe(langPlugins);
+    expect(
+      lookupCount('frameworks'),
+      'update `frameworks:` in docs/_data/counts.yml — a framework plugin was added or removed',
+    ).toBe(fwPlugins);
+  });
+
+  it('no docs page hardcodes its own language / framework count any more (TRA-275)', () => {
+    // TRA-272 had to sweep "85 framework integrations" -> "87" across 8 files
+    // (docs/index.html alone had 9 occurrences) and nothing failed in between,
+    // because ±5 tolerates a whole plugin batch. These pages read the tags now.
+    const pages: Array<{ path: string; keys: string[] }> = [
+      { path: 'docs/index.html', keys: ['languages', 'frameworks'] },
+      { path: 'docs/llms.txt', keys: ['languages', 'frameworks'] },
+      { path: 'docs/llms-full.txt', keys: ['languages', 'frameworks'] },
+      { path: 'docs/comparisons.md', keys: ['languages', 'frameworks'] },
+      { path: 'docs/supported-frameworks.md', keys: ['languages'] },
+      { path: 'docs/quality-gates.md', keys: ['languages', 'frameworks'] },
+      { path: 'docs/architecture.md', keys: ['languages'] },
+    ];
+    for (const { path, keys } of pages) {
+      const raw = readFileSync(join(REPO_ROOT, path), 'utf-8');
+      for (const key of keys) {
+        expect(
+          raw.includes(`site.data.counts.${key}`),
+          `${path} no longer reads {{ site.data.counts.${key} }} — keep the number in docs/_data/counts.yml.`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('front matter in docs/supported-frameworks.md still states the real counts (TRA-275)', () => {
+    // Jekyll does not render Liquid inside front matter, so the page title and
+    // meta description keep prose numbers. They are the only two left in docs/,
+    // and they are what search results show — check them exactly.
+    const frontMatter = readFileSync(
+      join(REPO_ROOT, 'docs/supported-frameworks.md'),
+      'utf-8',
+    ).split('---')[1];
+    for (const [unit, expected] of [
+      [/languages?/, langPlugins],
+      [/framework integrations?/, fwPlugins],
+    ] as const) {
+      const claims = findAllClaims(unit, frontMatter);
+      expect(
+        claims.length,
+        `no "X ${unit.source}" claim in supported-frameworks.md front matter`,
+      ).toBeGreaterThan(0);
+      for (const claim of claims) {
+        expect(
+          claim.count,
+          `docs/supported-frameworks.md front matter is stale — Liquid does not render there, ` +
+            `so update the prose by hand. Line: "${claim.rawLine}"`,
+        ).toBe(expected);
+      }
+    }
+  });
+
   it('every {{ site.data.counts.* }} tag in docs/ resolves to a number (TRA-263)', () => {
     // Jekyll renders an unknown key as the empty string rather than failing the
     // build, so a typo would ship as "trace-mcp exposes  MCP tools".


### PR DESCRIPTION
Closes TRA-275.

`docs/_data/counts.yml` has been the single source of truth for the MCP tool count since TRA-263, but the other two headline numbers — languages and framework integrations — were still prose on every surface, so they drifted the same way the tool count used to. TRA-272 had to sweep `85 framework integrations` → `87` across 8 files (`docs/index.html` alone had 9 occurrences), and nothing failed in between because the per-page guard tolerates ±5.

## What changed

- `docs/_data/counts.yml` gains `languages: 80` and `frameworks: 87`.
- Every trace-mcp claim in `docs/` now reads `{{ site.data.counts.* }}`: `index.html` (incl. JSON-LD + FAQ answers), `llms.txt`, `llms-full.txt`, `comparisons.md`, `supported-frameworks.md`, `quality-gates.md`, `architecture.md`. In the comparison tables only trace-mcp's own cells were touched — competitor numbers are untouched.
- New exact guard: `counts.yml` must equal `PluginRegistry.createWithDefaults()` exactly, **not** ±tolerance. Both values are derived, so the registry is an exact receipt — same reasoning as `tests/docs/preset-claims.test.ts`. A plugin add now fails CI with the number to write.
- The TRA-263 "no docs page hardcodes its own count any more" test is extended to the two new keys, per page.

## Two deliberate exceptions

- **Front matter.** Jekyll does not render Liquid inside front matter, so the `title:` and `description:` of `docs/supported-frameworks.md` keep prose numbers. Those two lines were previously unguarded entirely (the file isn't in the per-page scan list) — they now get their own exact check with a message saying they must be updated by hand.
- **Non-Jekyll surfaces.** `README.md`, `CLAUDE.md`, `AGENTS.md` and `skills/` are not rendered, so they keep prose and stay on the existing ±tolerance guard, as scoped in the issue.

## Why not a separate `docs/claims.json`

TRA-272 asked about a machine-readable "current claims" file for diffing against external listings. Decided against: `counts.yml` already is that artifact, and a second one is one more thing to drift. Detecting drift on a *third-party* page needs a network fetch of someone else's site, which doesn't belong in CI.

## Test evidence

- `pnpm run test` — **804 files / 8824 tests passed**, 3 files / 10 tests skipped.
- `tests/docs/` — 52 passed (43 in `readme-claims.test.ts`, up from 40: the 3 new checks).
- `pnpm run build` — ESM + DTS build success.
- `npx biome check docs tests/docs` — clean.

Agent: Lead Engineer
