### PR TITLE
fix(app): make quick open readable — paths and ⌘-hints were 1.88:1 (TRA-344)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -473,6 +473,13 @@ Not a pass at the end. These are floors.
 `lattice/ui/__tests__/primitives.test.tsx` asserts the height set, the ≥24px boxes, the
 radius set, and ≥4.5:1 contrast for all seven badge tones in both appearances.
 
+`styles/__tests__/tokens.test.ts` adds the **tertiary-as-text guard** (TRA-344): no rule
+under `renderer/**` may declare `color: var(--label-tertiary)` *and* a `font-size`. Sizing
+text is what distinguishes reading text from a glyph, so the pair is the machine-checkable
+form of §2's "decoration only". `::placeholder` is the one exempt selector. This closes the
+gap the contrast table cannot see — it measures the tokens, not which token a component
+reaches for, so quick open sat at 1.88:1 for six weeks with a green build.
+
 Run it locally:
 
 ```bash
@@ -535,7 +542,8 @@ new evidence.
 | Accent `#0069d9`, not Apple's `#007aff` (light) | System blue measures 4.02:1 on `--surface` and fails AA both as text and under a white label. |
 | `--label-secondary` at `.55`, not Apple's `.50` | At `.50` it measures 3.98:1 and fails AA for the body text it carries. |
 | `--accent` and `--accent-fill` split (same for `--status-red`/`--danger-fill`) | A hue readable *as text* on `--surface` and a hue readable *under a white label* are different colours in dark. |
-| `--label-tertiary` is decoration-only | It measures 1.88:1 light / 2.53:1 dark. The sites that read as "quietest text" carry real reading text and use `--label-secondary`; only genuine decoration asks for `--label-tertiary` by name. |
+| `--label-tertiary` is decoration-only, and CI now enforces it | It measures 1.88:1 light / 2.53:1 dark. The sites that read as "quietest text" carry real reading text and use `--label-secondary`; only genuine decoration asks for `--label-tertiary` by name. Written down was not enough — quick open shipped paths, ⌘-hints and group headers on it. A rule that sets `color: var(--label-tertiary)` alongside a `font-size` now fails the build (§9). |
+| A shortcut hint on a selected row is full `--on-accent`, not a mix of it | `color-mix(--on-accent 72%, transparent)` on `--accent-fill` measured 3.22:1. Dimming a label to signal "secondary" only works over a surface with headroom; on a filled accent row there is none. |
 | One token layer; the legacy aliases are **gone** (TRA-315) | Aliases let surfaces migrate one at a time; once every surface had landed they were inlined to the token they resolved to and deleted. `var(--text-secondary)` and friends no longer exist — there is exactly one name per colour. |
 | Baselined token guard (counts, not per-line suppressions) | Counts only ever move down; a line-level baseline churns on every reflow. |
 | Control heights fixed at 20/24/28 | Matches the macOS small/regular/large tiers; any fourth height is drift. |

--- a/packages/app/src/renderer/__tests__/app-commands.test.tsx
+++ b/packages/app/src/renderer/__tests__/app-commands.test.tsx
@@ -7,7 +7,12 @@
 import { act, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { App } from '../App';
-import { filterItems, matchesQuery, type QuickOpenItem } from '../components/QuickOpen';
+import {
+  filterItems,
+  matchesQuery,
+  QuickOpen,
+  type QuickOpenItem,
+} from '../components/QuickOpen';
 
 type Command = (command: string, arg?: unknown) => void;
 
@@ -178,5 +183,19 @@ describe('quick-open filtering', () => {
 
   it('an empty query keeps everything', () => {
     expect(filterItems(items, '   ')).toHaveLength(3);
+  });
+
+  /* TRA-344. aria-activedescendant is only honoured on a combobox, and a plain
+     <div> between a listbox and its options drops the group header out of the
+     accessibility tree — so arrowing the panel announced neither the active
+     result nor which group it was in. */
+  it('exposes the field as a combobox and the headers as named groups', () => {
+    render(<QuickOpen items={items} onClose={() => {}} />);
+    const field = screen.getByRole('combobox', { name: 'Quick open' });
+    expect(field.getAttribute('aria-expanded')).toBe('true');
+    expect(field.getAttribute('aria-activedescendant')).toBeTruthy();
+    expect(screen.getByRole('group', { name: 'Go to' })).toBeTruthy();
+    expect(screen.getByRole('group', { name: 'Files' })).toBeTruthy();
+    expect(screen.getAllByRole('option')).toHaveLength(3);
   });
 });

--- a/packages/app/src/renderer/app.css
+++ b/packages/app/src/renderer/app.css
@@ -462,12 +462,15 @@ body {
   overflow-y: auto;
   padding: 4px 0 6px;
 }
+/* Same treatment as the sidebar's `.ws-sb-group` — 11px/600 on
+   --label-secondary. These are the same words at the same size; painting one
+   of them tertiary gave the app two group-header systems (TRA-344). */
 .lx-qo-group {
   padding: 8px 12px 2px;
   font-size: var(--text-caption);
   font-weight: var(--weight-semibold);
   line-height: var(--leading-caption);
-  color: var(--label-tertiary);
+  color: var(--label-secondary);
 }
 .lx-qo-item {
   display: flex;
@@ -505,6 +508,10 @@ body {
   white-space: nowrap;
   text-overflow: ellipsis;
 }
+/* The detail line is read, not decoration: it is the only thing separating two
+   `index.ts`, or two folders both called `workdir`. --label-tertiary put it at
+   1.88:1 light / 2.53:1 dark and left it there under Increase Contrast, which
+   lifts --label-secondary and not tertiary (TRA-344). */
 .lx-qo-detail {
   flex: 1 1 auto;
   min-width: 0;
@@ -512,10 +519,11 @@ body {
   white-space: nowrap;
   text-overflow: ellipsis;
   font-size: var(--text-caption);
-  color: var(--label-tertiary);
+  color: var(--label-secondary);
 }
+/* Full --on-accent, not a 72% mix: the mix measured 3.22:1 on --accent-fill. */
 .lx-qo-item.is-active .lx-qo-detail {
-  color: color-mix(in oklab, var(--on-accent) 72%, transparent);
+  color: var(--on-accent);
 }
 .lx-qo-empty {
   padding: 16px 12px;

--- a/packages/app/src/renderer/components/QuickOpen.tsx
+++ b/packages/app/src/renderer/components/QuickOpen.tsx
@@ -59,6 +59,21 @@ export function QuickOpen({
   const listId = useId();
   const matches = useMemo(() => filterItems(items, query).slice(0, 60), [items, query]);
 
+  /* Runs of consecutive same-group matches, carrying each item's index in
+     `matches` so the highlight and aria-activedescendant keep using the flat
+     numbering. A plain <div> between the listbox and its options drops the
+     group header from the accessibility tree entirely — role="group" with the
+     name on it is the shape that survives (TRA-344). */
+  const groups = useMemo(() => {
+    const out: { group: string; items: { item: QuickOpenItem; i: number }[] }[] = [];
+    matches.forEach((item, i) => {
+      const last = out[out.length - 1];
+      if (last && last.group === item.group) last.items.push({ item, i });
+      else out.push({ group: item.group, items: [{ item, i }] });
+    });
+    return out;
+  }, [matches]);
+
   // A shrinking result list must never leave the highlight past its end.
   const index = Math.min(active, Math.max(0, matches.length - 1));
 
@@ -90,8 +105,6 @@ export function QuickOpen({
     }
   };
 
-  let lastGroup = '';
-
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: the scrim is a dismissal affordance, not a control — Escape on the field is the keyboard path.
     <div className="lx-sheet-scrim lx-qo-scrim" onClick={onClose}>
@@ -107,9 +120,16 @@ export function QuickOpen({
             <Icon name="search" size={16} />
           </span>
           {/* biome-ignore lint/a11y/noAutofocus: a quick-open the user must click into is not a quick-open. */}
+          {/* combobox, not a bare textbox: aria-activedescendant is only
+              honoured on a combobox, so without the role arrowing through the
+              results announced nothing at all (TRA-344). */}
           <input
             autoFocus
             type="text"
+            role="combobox"
+            aria-expanded="true"
+            aria-haspopup="listbox"
+            aria-autocomplete="list"
             value={query}
             placeholder="Go to section, project or file"
             aria-label="Quick open"
@@ -126,13 +146,14 @@ export function QuickOpen({
           {matches.length === 0 ? (
             <div className="lx-qo-empty">No matches</div>
           ) : (
-            matches.map((item, i) => {
-              const header = item.group !== lastGroup ? item.group : null;
-              lastGroup = item.group;
-              return (
-                <div key={item.id}>
-                  {header && <div className="lx-qo-group">{header}</div>}
+            groups.map((g) => (
+              <div key={g.group} role="group" aria-label={g.group}>
+                <div className="lx-qo-group" aria-hidden="true">
+                  {g.group}
+                </div>
+                {g.items.map(({ item, i }) => (
                   <button
+                    key={item.id}
                     type="button"
                     id={`${listId}-${i}`}
                     role="option"
@@ -150,9 +171,9 @@ export function QuickOpen({
                     <span className="lx-qo-label">{item.label}</span>
                     {item.detail && <span className="lx-qo-detail">{item.detail}</span>}
                   </button>
-                </div>
-              );
-            })
+                ))}
+              </div>
+            ))
           )}
         </div>
       </div>

--- a/packages/app/src/renderer/styles/__tests__/tokens.test.ts
+++ b/packages/app/src/renderer/styles/__tests__/tokens.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 // @ts-expect-error — plain .mjs helper, shared with the CLI check (TRA-289)
@@ -35,6 +35,32 @@ describe('design tokens', () => {
   it('adds no raw hex or Tailwind grey beyond the recorded baseline', () => {
     const { violations } = tokenGuard();
     expect(violations).toEqual([]);
+  });
+
+  /* TRA-344. --label-tertiary is decoration only (1.88:1 light / 2.53:1 dark,
+     and `prefers-contrast: more` lifts --label-secondary but not it). A rule
+     that paints text with it AND sizes that text is by definition styling
+     something a user reads — the exception is a placeholder, which DESIGN.md
+     §2 names as a legitimate tertiary use. Quick open's paths, ⌘-hints and
+     group headers were the last three in the app. */
+  it('never paints sized text with --label-tertiary', () => {
+    const dir = fileURLToPath(new URL('..', import.meta.url));
+    const sources: Array<[string, string]> = [
+      ['app.css', appCss],
+      ...readdirSync(dir)
+        .filter((f) => f.endsWith('.css'))
+        .map((f) => [f, readFileSync(`${dir}/${f}`, 'utf8')] as [string, string]),
+    ];
+    const offenders: string[] = [];
+    for (const [name, css] of sources) {
+      for (const [, selector, body] of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+        if (!/color:\s*var\(--label-tertiary\)/.test(body)) continue;
+        if (!/font-size:/.test(body)) continue;
+        if (/::placeholder/.test(selector)) continue;
+        offenders.push(`${name}: ${selector.trim().split('\n').pop()?.trim()}`);
+      }
+    }
+    expect(offenders).toEqual([]);
   });
 
   /* TRA-297: `user-select: none` on body used to be the last word, so no path,


### PR DESCRIPTION
Quick open (⌘P / ⌘⇧O) was built during the keyboard/a11y sweep (TRA-297) and never got a visual
review. It is the last surface in the app painting reading text with `--label-tertiary`, which
`DESIGN.md` §2 reserves for decoration.

## Measured on the running renderer

A contrast walk over every rendered text node, light and dark, daemon up. The whole app is clean
except this panel:

| Element | Before | After |
|---|---|---|
| `.lx-qo-detail` — project path, file directory, `⌘1…⌘9` | 1.88 / 2.53 | **4.76 / 5.91** |
| `.lx-qo-group` — "Go to", "Recent projects", "Files" | 1.88 / 2.53 | **4.76 / 5.91** |
| `.lx-qo-item.is-active .lx-qo-detail` | 3.22 / 3.45 | **5.22 / 4.77** |

The detail line is not decoration — it is the only thing separating two `index.ts`, or two folders
both called `workdir`; the workspace has six of those right now. It also did not recover under
Increase Contrast: `@media (prefers-contrast: more)` lifts `--label-secondary` and leaves
`--label-tertiary` alone.

The sidebar's `.ws-sb-group` ("Recent") was already `--label-secondary` at the same 11px/600, so
the app had two group-header treatments for the same thing. Now one.

## Accessibility

Two defects on the flow this component exists for:

- The field carried `aria-controls` and `aria-activedescendant` but no `role="combobox"`. Neither
  is honoured without it, so arrowing through results announced nothing. Chrome's tree went
  `textbox "Quick open"` → `combobox "Quick open" autocomplete="list" expanded haspopup="listbox"`.
- Group headers were plain `<div>`s inside `role="listbox"` and were dropped from the tree
  entirely — a screen-reader user got one undifferentiated list. They are `role="group"` with the
  name on them now, which also deletes the per-item wrapper `<div>`.

## Guard

`styles/__tests__/tokens.test.ts` now fails the build if any rule under `renderer/**` declares
`color: var(--label-tertiary)` alongside a `font-size` (`::placeholder` exempt). Sizing text is
what separates reading text from a glyph. The existing contrast table measures the *tokens*, not
which token a component reaches for — which is why this sat at 1.88:1 with a green build.
Verified the guard fails when the old value is put back.

`DESIGN.md` §9 and the decision log record both.

## Verification

- 289 tests pass, `tsc --noEmit` clean, renderer builds.
- Panel screenshotted before and after in both appearances (attached to TRA-344).
- Fits the 640×420 minimum window: panel at x 40 → 600, y 72 → 313 inside a 640×420 viewport.
- Placeholder left on `--label-tertiary` — `DESIGN.md` §2 names that as a legitimate use.

Closes TRA-344.
