### PR TITLE
fix(scan_security): kill the false positives whose guard sits above the sink

### DIFF
--- a/src/cli/scan-security.ts
+++ b/src/cli/scan-security.ts
@@ -30,6 +30,10 @@ export const scanSecurityCommand = new Command('scan-security')
   .option('--scope <path>', 'Directory to scan (default: whole project)')
   .option('--rules <rules>', 'Comma-separated rule list, or "all" (default: all)', 'all')
   .option('--severity-threshold <level>', 'Minimum severity to report: critical|high|medium|low')
+  .option(
+    '--include-low-confidence',
+    'Report weakly-grounded ("low" confidence) findings too (default: suppressed)',
+  )
   .option('--format <fmt>', 'Output format: json | sarif (default: json)', 'json')
   .option(
     '--fail-on <level>',
@@ -41,6 +45,7 @@ export const scanSecurityCommand = new Command('scan-security')
       scope?: string;
       rules: string;
       severityThreshold?: string;
+      includeLowConfidence?: boolean;
       format: string;
       failOn: string;
     }) => {
@@ -68,6 +73,7 @@ export const scanSecurityCommand = new Command('scan-security')
         scope: opts.scope,
         rules,
         severityThreshold: opts.severityThreshold as Severity | undefined,
+        includeLowConfidence: opts.includeLowConfidence,
       });
 
       db.close();

--- a/src/tools/analysis/visualize.ts
+++ b/src/tools/analysis/visualize.ts
@@ -1858,7 +1858,7 @@ canvas.addEventListener('mousemove', (e) => {
         + esc(n.type) + (n.language ? ' \u00b7 ' + esc(n.language) : '')
         + (n.framework_role ? ' \u00b7 ' + esc(n.framework_role) : '') + '<br>'
         + (dirKey ? '<span style="color:#76b7b2">' + esc(dirKey) + '</span> \u00b7 ' : '')
-        + 'Community ' + n.community + ' \u00b7 Importance ' + n.importance;
+        + 'Community ' + esc(n.community) + ' \u00b7 Importance ' + esc(n.importance);
     } else {
       tooltip.style.display = 'none';
     }

--- a/src/tools/quality/security-scan.ts
+++ b/src/tools/quality/security-scan.ts
@@ -53,6 +53,11 @@ export interface SecurityScanResult {
   files_scanned: number;
   findings: SecurityFinding[];
   summary: Record<Severity, number>;
+  /**
+   * Findings held back because their confidence was "low". Pass
+   * `includeLowConfidence: true` to get them in `findings` instead.
+   */
+  suppressed_low_confidence: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -382,21 +387,6 @@ const RULES: SecurityRule[] = [
 // ---------------------------------------------------------------------------
 
 /**
- * Extract identifier names referenced inside ${...} expressions of a template literal
- * (or a leading-backtick fragment) on `line`. Returns null if no interpolations found.
- * Only captures the head identifier — `${foo}` and `${foo.bar}` both yield "foo".
- */
-function extractInterpolatedIdents(line: string): string[] | null {
-  const idents: string[] = [];
-  const re = /\$\{\s*([A-Za-z_$][\w$]*)/g;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(line)) !== null) {
-    idents.push(m[1]);
-  }
-  return idents.length ? idents : null;
-}
-
-/**
  * Resolve an identifier in a file to a literal string by scanning upward
  * for a top-level `const X = '...'` / `let X = "..."` / `var X = \`...\``
  * binding. Only matches single-string RHS (no interpolation, no concat).
@@ -503,12 +493,39 @@ function classifyInterpolation(
   lines: string[],
   fromLine: number,
 ): 'constant' | 'non_constant' {
-  const idents = extractInterpolatedIdents(line);
-  if (!idents) return 'non_constant';
-  for (const id of idents) {
-    if (resolveStringBindingInFile(lines, id, fromLine) == null) return 'non_constant';
+  const exprs = extractInterpolatedExprs(line);
+  if (exprs.length === 0) return 'non_constant';
+  for (const expr of exprs) {
+    if (!isCompileTimeConstant(expr, lines, fromLine)) return 'non_constant';
   }
   return 'constant';
+}
+
+/** Module-location built-ins — fixed at build time, never attacker-controlled. */
+const BUILD_TIME_IDENT_RE = /^(?:__dirname|__filename|import\.meta\.(?:dirname|filename|url))$/;
+
+/**
+ * True when `expr` evaluates to a value fixed at build time: a string literal,
+ * `__dirname`/`__filename`, an identifier bound to a string literal, or a
+ * `path.join`/`path.resolve` over those.
+ */
+function isCompileTimeConstant(expr: string, lines: string[], fromLine: number): boolean {
+  const e = expr.trim();
+  if (STRING_LITERAL_RE.test(e)) return true;
+  if (BUILD_TIME_IDENT_RE.test(e)) return true;
+
+  const call = /^(?:path\.)?(?:join|resolve|normalize)\s*\((.*)\)$/s.exec(e);
+  if (call) {
+    const args = call[1].trim();
+    if (args === '') return true;
+    // Bail on nested calls — splitting their arguments needs a real parser.
+    if (/[A-Za-z_$][\w$.]*\s*\(/.test(args)) return false;
+    return args.split(',').every((a) => isCompileTimeConstant(a, lines, fromLine));
+  }
+
+  const head = /^([A-Za-z_$][\w$]*)$/.exec(e);
+  if (!head) return false;
+  return resolveStringBindingInFile(lines, head[1], fromLine) != null;
 }
 
 /**
@@ -561,7 +578,45 @@ function isWeakHashSecurityContext(
  * but we treat the outer backtick as a normal string scope, which is enough for
  * comment skipping. String contents are preserved verbatim so regex detectors
  * that target string literals (SQL, exec, fetch URLs) keep working.
+ *
+ * Regex literals are recognised and skipped whole. Without this a pattern such
+ * as /['"`]/ leaves the scanner stuck in "inside a string" state for the rest of
+ * the file, so every later comment survives stripping and can raise a finding.
  */
+
+/** Tokens after which a `/` starts a regex literal rather than a division. */
+const REGEX_PRECEDING_KEYWORD =
+  /(?:^|[^\w$.])(?:return|typeof|case|in|of|do|else|yield|await|new|delete|void|instanceof)\s*$/;
+
+/**
+ * Scan a regex literal starting at `source[start] === '/'`. Returns the index
+ * just past the closing delimiter and its flags, or -1 when the literal does not
+ * terminate on the same line (in which case the `/` was a division operator).
+ */
+function scanRegexLiteral(source: string, start: number): number {
+  let i = start + 1;
+  let inClass = false;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === '\n') return -1;
+    if (ch === '\\') {
+      i += 2;
+      continue;
+    }
+    if (inClass) {
+      if (ch === ']') inClass = false;
+    } else if (ch === '[') {
+      inClass = true;
+    } else if (ch === '/') {
+      i++;
+      while (i < source.length && /[a-z]/.test(source[i])) i++;
+      return i;
+    }
+    i++;
+  }
+  return -1;
+}
+
 function stripCommentsKeepStrings(source: string): string {
   const len = source.length;
   const out: string[] = new Array(len);
@@ -569,6 +624,9 @@ function stripCommentsKeepStrings(source: string): string {
   let inLine = false;
   let inBlock = false;
   let stringDelim: string | null = null;
+  /** Last non-whitespace character emitted outside comments/strings. */
+  let prev = '';
+  let prevIdx = -1;
   while (i < len) {
     const ch = source[i];
     const next = source[i + 1];
@@ -626,10 +684,35 @@ function stripCommentsKeepStrings(source: string): string {
     if (ch === '"' || ch === "'" || ch === '`') {
       stringDelim = ch;
       out[i] = ch;
+      prev = ch;
+      prevIdx = i;
       i++;
       continue;
     }
+    if (ch === '/') {
+      // Regex literal vs. division: a `/` can only start a regex where an
+      // expression may start — after an operator, an opening bracket, a
+      // statement separator, or one of the keywords above.
+      const isRegexStart =
+        prevIdx === -1 ||
+        '(,=:[!&|?{};+-*%~^<>'.includes(prev) ||
+        REGEX_PRECEDING_KEYWORD.test(source.slice(Math.max(0, prevIdx - 12), prevIdx + 1));
+      if (isRegexStart) {
+        const end = scanRegexLiteral(source, i);
+        if (end !== -1) {
+          for (let k = i; k < end; k++) out[k] = source[k];
+          prev = '/';
+          prevIdx = end - 1;
+          i = end;
+          continue;
+        }
+      }
+    }
     out[i] = ch;
+    if (!/\s/.test(ch)) {
+      prev = ch;
+      prevIdx = i;
+    }
     i++;
   }
   return out.join('');
@@ -666,19 +749,249 @@ const SSRF_BASE_IDENT_RE = /^(?:BASE|API|URL|BASE_URL|API_BASE|baseUrl|daemonUrl
 
 const LOCAL_URL_LITERAL_RE = /^https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?/i;
 
+// ---------------------------------------------------------------------------
+// Backward guard scan — a validator a few lines above the sink
+// ---------------------------------------------------------------------------
+
+/** How far above a sink to look for a guard before giving up. */
+const GUARD_WINDOW = 40;
+
+/**
+ * A line that opens a function/method body — the top of the block we scan.
+ * Control-flow braces (`if`, `try`, `for`, …) do NOT stop the walk: a guard
+ * normally sits above them, at the top of the enclosing function.
+ */
+const BLOCK_OPENER_RE =
+  /\bfunction\b|=>\s*\{|^\s*(?:(?:export|public|private|protected|static|async|readonly)\s+)*(?!if\b|for\b|while\b|switch\b|catch\b|do\b|return\b)[A-Za-z_$][\w$]*\s*\([^)]*\)\s*(?::[^={]*)?\{\s*$/;
+
+/** `assertFoo(x)` / `invariant(x)` — a validator that throws on bad input. */
+const ASSERT_CALL_RE = /\b(?:assert|invariant|ensure|require|validate|check)[A-Za-z_$]*\s*\(/;
+
+/** A conditional that exits the block — `if (...) return|throw|continue`. */
+const EXIT_RE = /\b(?:return|throw|continue|process\.exit)\b/;
+
+function escapeForRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Extract the full expression of each `${...}` interpolation on `line`.
+ * Only dotted identifier chains are returned (`this.table`, `pid`, `n.id`);
+ * anything else (a call, an operator expression) yields the raw trimmed text.
+ */
+function extractInterpolatedExprs(line: string): string[] {
+  const exprs: string[] = [];
+  for (let i = 0; i < line.length - 1; i++) {
+    if (line[i] !== '$' || line[i + 1] !== '{') continue;
+    let depth = 1;
+    let j = i + 2;
+    while (j < line.length && depth > 0) {
+      if (line[j] === '{') depth++;
+      else if (line[j] === '}') depth--;
+      if (depth === 0) break;
+      j++;
+    }
+    if (depth !== 0) break;
+    exprs.push(line.slice(i + 2, j).trim());
+    i = j;
+  }
+  return exprs;
+}
+
+/**
+ * Walk backwards from `fromLine` through the enclosing block looking for a
+ * validator applied to `expr`. Recognised shapes:
+ *   - `assertSafeX(expr)` / `validateX(expr)` — a throwing assertion,
+ *   - `if (... expr ...) return|throw|continue` — an early-exit guard.
+ *
+ * Heuristic by design: it proves a developer checked this value on this path,
+ * not that the check is sufficient. Used to suppress findings, never to raise
+ * severity.
+ */
+function hasGuardAbove(lines: string[], fromLine: number, expr: string): boolean {
+  if (!/^[A-Za-z_$][\w$]*(?:\.[\w$]+)*$/.test(expr)) return false;
+  const mention = new RegExp(`(?:^|[^\\w$.])${escapeForRegex(expr)}(?![\\w$])`);
+  const stop = Math.max(0, fromLine - GUARD_WINDOW);
+  for (let i = fromLine - 1; i >= stop; i--) {
+    const line = lines[i];
+    if (mention.test(line)) {
+      if (ASSERT_CALL_RE.test(line)) return true;
+      // `if (...)` whose body exits — on the same line or the next two.
+      if (/\bif\s*\(/.test(line)) {
+        const tail = lines.slice(i, Math.min(lines.length, i + 3)).join('\n');
+        if (EXIT_RE.test(tail)) return true;
+      }
+    }
+    if (BLOCK_OPENER_RE.test(line)) break;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Origin classification — config-derived values are not remote input
+// ---------------------------------------------------------------------------
+
+/** Roots that mean "the operator's own configuration", not remote input. */
+const CONFIG_ROOT_RE = /^(?:this\.|self\.)?(?:cfg|config|settings|options|opts|env|process)\b/;
+
+/** Tokens that mark a value as reaching the process from outside. */
+const UNTRUSTED_TOKEN_RE = /\b(?:req|request|body|params|query|argv|stdin|payload|incoming)\b/;
+
+/**
+ * True when `expr` is a call whose every argument is a string literal or a
+ * config-rooted member access — e.g. `modelUrl(this.cfg, this.model, 'x')`.
+ */
+function isConfigDerivedCall(expr: string): boolean {
+  const m = /^[A-Za-z_$][\w$]*(?:\.[\w$]+)*\s*\((.*)\)$/s.exec(expr);
+  if (!m) return false;
+  const args = m[1].trim();
+  if (args === '') return true;
+  if (args.includes('(') || args.includes(')')) return false; // nested calls — give up
+  return args.split(',').every((raw) => {
+    const arg = raw.trim();
+    if (/^(['"`]).*\1$/.test(arg)) return true;
+    if (UNTRUSTED_TOKEN_RE.test(arg)) return false;
+    return CONFIG_ROOT_RE.test(arg) || /^this\.[\w$.]+$/.test(arg);
+  });
+}
+
+/**
+ * True when `expr` is a `for (const expr of ARR)` loop variable whose array is
+ * declared locally in the same file and carries no untrusted-source token.
+ */
+function isLocalLoopVariable(lines: string[], fromLine: number, expr: string): boolean {
+  if (!/^[A-Za-z_$][\w$]*$/.test(expr)) return false;
+  const loopRe = new RegExp(
+    `for\\s*\\(\\s*(?:const|let|var)\\s+${escapeForRegex(expr)}\\s+of\\s+([A-Za-z_$][\\w$.]*)`,
+  );
+  const stop = Math.max(0, fromLine - GUARD_WINDOW);
+  for (let i = fromLine; i >= stop; i--) {
+    const m = loopRe.exec(lines[i]);
+    if (!m) continue;
+    const arr = m[1].split('.')[0];
+    if (UNTRUSTED_TOKEN_RE.test(m[1])) return false;
+    const declRe = new RegExp(`(?:const|let|var)\\s+${escapeForRegex(arr)}\\s*(?::[^=]+)?=(.*)$`);
+    for (let j = 0; j < lines.length; j++) {
+      const d = declRe.exec(lines[j]);
+      if (d) return !UNTRUSTED_TOKEN_RE.test(d[1]);
+    }
+    return false;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Escaper recognition
+// ---------------------------------------------------------------------------
+
+/**
+ * A whole-expression string literal. Each quote style is matched against its own
+ * delimiter, so `'<span style="x">'` — a single-quoted string carrying double
+ * quotes — still counts as a literal.
+ */
+const STRING_LITERAL_RE = /^(?:'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`$\\]|\\.)*`)$/;
+
+/** A call whose name marks it as an output escaper for its argument. */
+const ESCAPER_CALL_RE =
+  /^(?:[A-Za-z_$][\w$]*\.)*(?:esc|escape|escapeHtml|escapeHTML|htmlEscape|sanitize|sanitise|sanitizeHtml|DOMPurify|encodeURI|encodeURIComponent|htmlspecialchars)[A-Za-z_$]*\s*\(/;
+
+/**
+ * Split a JS expression on top-level `+`, ignoring `+` inside strings,
+ * parentheses, brackets, or template interpolations.
+ */
+function splitTopLevelConcat(expr: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let delim: string | null = null;
+  let start = 0;
+  for (let i = 0; i < expr.length; i++) {
+    const ch = expr[i];
+    if (delim) {
+      if (ch === '\\') i++;
+      else if (ch === delim) delim = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') delim = ch;
+    else if (ch === '(' || ch === '[' || ch === '{') depth++;
+    else if (ch === ')' || ch === ']' || ch === '}') depth--;
+    else if (ch === '+' && depth === 0) {
+      parts.push(expr.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  parts.push(expr.slice(start).trim());
+  return parts.filter((p) => p !== '');
+}
+
+/** True when every operand of a concatenation is a literal or an escaper call. */
+function isFullyEscapedConcat(expr: string): boolean {
+  const parts = splitTopLevelConcat(expr);
+  if (parts.length === 0) return false;
+  for (const part of parts) {
+    if (STRING_LITERAL_RE.test(part)) continue;
+    if (ESCAPER_CALL_RE.test(part)) continue;
+    // A parenthesised ternary whose branches are all safe — e.g.
+    // `(n.repo ? '<b>' + esc(n.repo) + '</b>' : '')`.
+    const ternary = /^\((.*)\)$/s.exec(part);
+    if (ternary) {
+      const q = ternary[1].indexOf('?');
+      if (q !== -1) {
+        const branches = ternary[1].slice(q + 1);
+        const colon = splitTernaryBranches(branches);
+        if (colon && colon.every((b) => isFullyEscapedConcat(b.trim()))) continue;
+      }
+    }
+    return false;
+  }
+  return true;
+}
+
+/** Split `a : b` of a ternary tail on the top-level `:`. */
+function splitTernaryBranches(tail: string): [string, string] | null {
+  let depth = 0;
+  let delim: string | null = null;
+  for (let i = 0; i < tail.length; i++) {
+    const ch = tail[i];
+    if (delim) {
+      if (ch === '\\') i++;
+      else if (ch === delim) delim = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') delim = ch;
+    else if (ch === '(' || ch === '[' || ch === '{') depth++;
+    else if (ch === ')' || ch === ']' || ch === '}') depth--;
+    else if (ch === ':' && depth === 0) return [tail.slice(0, i), tail.slice(i + 1)];
+  }
+  return null;
+}
+
 /** Identify XSS `innerHTML = ...` shapes that are safe by construction. */
 function classifyInnerHtmlAssignment(
   line: string,
+  lines?: string[],
+  fromLine?: number,
 ): { safe: true } | { safe: false; confidence: 'high' | 'medium' } {
-  // Extract the RHS after `innerHTML =`.
+  // Extract the RHS after `innerHTML =`, continuing across lines until the
+  // statement terminates — the assignment is commonly a multi-line concat.
   const m = /\.innerHTML\s*=\s*(.+?);?\s*$/.exec(line);
   if (!m) return { safe: false, confidence: 'high' };
-  const rhs = m[1].trim();
+  let rhs = m[1].trim();
+  if (lines && fromLine != null && !/;\s*$/.test(line)) {
+    for (let i = fromLine + 1; i < Math.min(lines.length, fromLine + 15); i++) {
+      const cont = lines[i];
+      rhs += ` ${cont.trim().replace(/;\s*$/, '')}`;
+      if (/;\s*$/.test(cont.trimEnd())) break;
+      if (cont.trim() === '' || /^\s*\}/.test(cont)) break;
+    }
+    rhs = rhs.trim();
+  }
+
+  // Every non-literal operand of the concatenation passes through an escaper.
+  if (isFullyEscapedConcat(rhs)) return { safe: true };
 
   // Literal-only string (no interpolation, no concat).
   // Examples: innerHTML = '', innerHTML = "<div></div>", innerHTML = `static`.
-  const literalOnly = /^(['"])([^'"\\]|\\.)*\1$/.exec(rhs) || /^`([^`$\\]|\\.)*`$/.exec(rhs);
-  if (literalOnly) return { safe: true };
+  if (STRING_LITERAL_RE.test(rhs)) return { safe: true };
 
   // Sanitizer call on the immediate RHS (covers `esc(x)`, `DOMPurify.sanitize(x)`,
   // `encodeURI(x)`, `encodeURIComponent(x)`).
@@ -718,15 +1031,56 @@ function classifySsrfTemplate(
   line: string,
   lines: string[],
   fromLine: number,
-): 'local' | 'downgrade' | null {
+): 'local' | 'fixed_authority' | 'config' | 'downgrade' | null {
+  if (hasFixedAuthority(line, lines, fromLine)) return 'fixed_authority';
+  const exprs = extractInterpolatedExprs(line);
   // Pull the first ${IDENT} in the line.
   const m = /\$\{\s*([A-Za-z_$][\w$]*)\s*\}/.exec(line);
-  if (!m) return null;
-  const ident = m[1];
-  const resolved = resolveStringBindingInFile(lines, ident, fromLine);
-  if (resolved && LOCAL_URL_LITERAL_RE.test(resolved)) return 'local';
-  if (SSRF_BASE_IDENT_RE.test(ident)) return 'downgrade';
+  if (m) {
+    const ident = m[1];
+    const resolved = resolveStringBindingInFile(lines, ident, fromLine);
+    if (resolved && LOCAL_URL_LITERAL_RE.test(resolved)) return 'local';
+    if (SSRF_BASE_IDENT_RE.test(ident)) return 'downgrade';
+  }
+  if (exprs.length > 0 && exprs.every((e) => isConfigDerivedCall(e) || CONFIG_ROOT_RE.test(e))) {
+    return 'config';
+  }
   return null;
+}
+
+/**
+ * True when the URL's authority (scheme + host + port) is fully determined
+ * before the first interpolation, so no interpolated value can redirect the
+ * request to another host. Two shapes qualify:
+ *
+ *   fetch(`https://api.example.com/v1/${id}`)   — literal host, `/` before ${
+ *   fetch(`${BASE_URL}/v1/${id}`)               — BASE_URL resolves to a URL
+ *                                                 literal and `/` follows `}`
+ *
+ * `fetch(\`https://\${host}/x\`)` and `fetch(\`\${BASE}.evil.com\`)` do NOT
+ * qualify — the interpolation reaches the authority.
+ */
+function hasFixedAuthority(line: string, lines: string[], fromLine: number): boolean {
+  const tick = /`([^`]*)`/.exec(line);
+  if (!tick) return false;
+  const tpl = tick[1];
+  const first = tpl.indexOf('${');
+  if (first === -1) return false;
+
+  // Case 1: the template starts with a literal scheme://host/ prefix.
+  if (/^https?:\/\/[^${\s/?#]+[/?#]/.test(tpl.slice(0, first + 2))) return true;
+
+  // Case 2: the template opens with ${IDENT} bound to a URL literal, and the
+  // character right after the closing brace closes the authority.
+  if (first !== 0) return false;
+  const close = tpl.indexOf('}');
+  if (close === -1) return false;
+  const ident = tpl.slice(2, close).trim();
+  if (!/^[A-Za-z_$][\w$]*$/.test(ident)) return false;
+  const resolved = resolveStringBindingInFile(lines, ident, fromLine);
+  if (!resolved || !/^https?:\/\/[^/]+/.test(resolved)) return false;
+  const after = tpl[close + 1] ?? '';
+  return resolved.endsWith('/') || after === '/' || after === '?' || after === '#' || after === '';
 }
 
 /**
@@ -833,6 +1187,8 @@ export function scanSecurity(
     scope?: string;
     rules: RuleName[];
     severityThreshold?: Severity;
+    /** Report findings whose confidence is "low" (default: false). */
+    includeLowConfidence?: boolean;
   },
 ): TraceMcpResult<SecurityScanResult> {
   const activeRules = resolveRules(opts.rules);
@@ -936,6 +1292,21 @@ export function scanSecurity(
             let interpolationSource: 'non_constant' | undefined;
             const usesTemplate = /\$\{/.test(line);
 
+            // Backward guard scan: drop when every interpolated value is
+            // validated by an assertion or an early-exit check above the sink.
+            if (
+              usesTemplate &&
+              (rule.key === 'sql_injection' ||
+                rule.key === 'path_traversal' ||
+                rule.key === 'command_injection' ||
+                rule.key === 'ssrf')
+            ) {
+              const exprs = extractInterpolatedExprs(line);
+              if (exprs.length > 0 && exprs.every((e) => hasGuardAbove(lines, lineIdx, e))) {
+                continue;
+              }
+            }
+
             if (
               usesTemplate &&
               (rule.key === 'command_injection' ||
@@ -987,8 +1358,18 @@ export function scanSecurity(
             let fixOverride: string | null = null;
 
             if (rule.key === 'xss' && /\.innerHTML\s*=/.test(line)) {
-              const cls = classifyInnerHtmlAssignment(line);
+              const cls = classifyInnerHtmlAssignment(line, lines, lineIdx);
               if (cls.safe) continue;
+            }
+
+            // SQL: value comes from a loop over a locally derived array — the
+            // origin is our own code, not remote input.
+            if (rule.key === 'sql_injection' && usesTemplate) {
+              const exprs = extractInterpolatedExprs(line);
+              if (exprs.length > 0 && exprs.every((e) => isLocalLoopVariable(lines, lineIdx, e))) {
+                confidence = 'low';
+                evidence = evidence ?? 'value iterated from a locally derived array';
+              }
             }
 
             if (rule.key === 'path_traversal' && /path\.(?:join|resolve)/.test(line)) {
@@ -1003,7 +1384,11 @@ export function scanSecurity(
 
             if (rule.key === 'ssrf' && usesTemplate) {
               const cls = classifySsrfTemplate(line, lines, lineIdx);
-              if (cls === 'local') continue;
+              if (cls === 'local' || cls === 'fixed_authority') continue;
+              if (cls === 'config') {
+                confidence = 'low';
+                evidence = evidence ?? 'request URL built from operator configuration';
+              }
               if (cls === 'downgrade') {
                 severity = downgradeSeverity(severity); // high -> medium
                 confidence = 'low';
@@ -1062,13 +1447,28 @@ export function scanSecurity(
     }
   }
 
+  // Low-confidence findings are weakly grounded by construction. Reporting them
+  // by default is what trains users to ignore the whole list, so they are opt-in
+  // and the suppressed count is surfaced instead of being silently dropped.
+  let suppressedLow = 0;
+  let reported = findings;
+  if (!opts.includeLowConfidence) {
+    reported = findings.filter((f) => f.confidence !== 'low');
+    suppressedLow = findings.length - reported.length;
+  }
+
   // Sort: critical first, then high, medium, low
-  findings.sort((a, b) => severityRank(b.severity) - severityRank(a.severity));
+  reported.sort((a, b) => severityRank(b.severity) - severityRank(a.severity));
 
   const summary: Record<Severity, number> = { critical: 0, high: 0, medium: 0, low: 0 };
-  for (const f of findings) {
+  for (const f of reported) {
     summary[f.severity]++;
   }
 
-  return ok({ files_scanned: scanned, findings, summary });
+  return ok({
+    files_scanned: scanned,
+    findings: reported,
+    summary,
+    suppressed_low_confidence: suppressedLow,
+  });
 }

--- a/src/tools/register/git.ts
+++ b/src/tools/register/git.ts
@@ -206,7 +206,7 @@ export function registerGitTools(server: McpServer, ctx: ServerContext): void {
 
   server.tool(
     'scan_security',
-    'Scan project files for OWASP Top-10 security vulnerabilities using pattern matching. Detects SQL injection (CWE-89), XSS (CWE-79), command injection (CWE-78), path traversal (CWE-22), hardcoded secrets (CWE-798), insecure crypto (CWE-327), open redirects (CWE-601), and SSRF (CWE-918). Skips test files. Use for pattern-based security audit. For data-flow-aware analysis use taint_analysis instead. Read-only. Returns JSON: { findings: [{ rule, severity, cwe, file, line, message }], total, summary }.',
+    'Scan project files for OWASP Top-10 security vulnerabilities using pattern matching. Detects SQL injection (CWE-89), XSS (CWE-79), command injection (CWE-78), path traversal (CWE-22), hardcoded secrets (CWE-798), insecure crypto (CWE-327), open redirects (CWE-601), and SSRF (CWE-918). Skips test files. Weakly-grounded ("low" confidence) findings are held back by default and counted in suppressed_low_confidence — pass include_low_confidence to see them. Use for pattern-based security audit. For data-flow-aware analysis use taint_analysis instead. Read-only. Returns JSON: { findings: [{ rule, severity, cwe, file, line, message }], total, summary, suppressed_low_confidence }.',
     {
       scope: optionalNonEmptyString(512).describe('Directory to scan (default: whole project)'),
       rules: z
@@ -229,6 +229,12 @@ export function registerGitTools(server: McpServer, ctx: ServerContext): void {
         .enum(['critical', 'high', 'medium', 'low'])
         .optional()
         .describe('Minimum severity to report (default: low)'),
+      include_low_confidence: z
+        .boolean()
+        .optional()
+        .describe(
+          'Report findings whose confidence is "low" (default: false). These are weakly grounded and are the main source of scanner noise.',
+        ),
       output_format: z
         .enum(['json', 'sarif'])
         .optional()
@@ -236,7 +242,7 @@ export function registerGitTools(server: McpServer, ctx: ServerContext): void {
           '"json" (default, native finding shape) or "sarif" (2.1.0 log) for GitHub/GitLab/Azure code-scanning ingestion.',
         ),
     },
-    async ({ scope, rules, severity_threshold, output_format }) => {
+    async ({ scope, rules, severity_threshold, include_low_confidence, output_format }) => {
       if (scope) {
         const blocked = guardPath(scope);
         if (blocked) return blocked;
@@ -245,6 +251,7 @@ export function registerGitTools(server: McpServer, ctx: ServerContext): void {
         scope,
         rules: rules as RuleName[],
         severityThreshold: severity_threshold as Severity | undefined,
+        includeLowConfidence: include_low_confidence,
       });
       if (result.isErr()) {
         return {

--- a/tests/tools/security-scan-precision.test.ts
+++ b/tests/tools/security-scan-precision.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Precision tests for scanSecurity — the false-positive shapes audited in TRA-340.
+ *
+ * Every "drops" test is paired with a "still detects" test on the same shape with
+ * the safety signal removed, so a precision fix cannot silently cost recall.
+ */
+import { execSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { beforeEach, describe, expect, test } from 'vitest';
+import type { Store } from '../../src/db/store.js';
+import { type RuleName, scanSecurity } from '../../src/tools/quality/security-scan.js';
+import { createTestStore } from '../test-utils.js';
+
+const TEST_DIR = path.join(tmpdir(), `trace-mcp-security-precision-${process.pid}`);
+
+function writeFile(store: Store, relPath: string, content: string, language: string): void {
+  const absPath = path.join(TEST_DIR, relPath);
+  mkdirSync(path.dirname(absPath), { recursive: true });
+  writeFileSync(absPath, content);
+  store.insertFile(relPath, language, `hash-${relPath}`, content.length);
+}
+
+describe('scanSecurity precision (TRA-340)', () => {
+  let store: Store;
+
+  beforeEach(() => {
+    store = createTestStore();
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  function scan(rules: RuleName[], opts: { includeLow?: boolean } = {}) {
+    const result = scanSecurity(store, TEST_DIR, {
+      rules,
+      includeLowConfidence: opts.includeLow,
+    });
+    expect(result.isOk()).toBe(true);
+    return result._unsafeUnwrap();
+  }
+
+  // -------------------------------------------------------------------
+  // 1. Backward guard scan
+  // -------------------------------------------------------------------
+
+  test('drops a SQL sink guarded by an assert* call above it', () => {
+    writeFile(
+      store,
+      'src/vec.ts',
+      `
+class Vec {
+  clear(): void {
+    assertSafeSqliteIdentifier(this.table);
+    this.db.exec(\`DROP TABLE IF EXISTS \${this.table}\`);
+  }
+}
+`,
+      'typescript',
+    );
+    expect(scan(['sql_injection']).findings).toHaveLength(0);
+  });
+
+  test('still detects the same SQL sink when the assert* guard is absent', () => {
+    writeFile(
+      store,
+      'src/vec.ts',
+      `
+class Vec {
+  clear(): void {
+    this.db.exec(\`DROP TABLE IF EXISTS \${this.table}\`);
+  }
+}
+`,
+      'typescript',
+    );
+    const findings = scan(['sql_injection']).findings;
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('critical');
+  });
+
+  test('drops a path sink guarded by an early-return type check above it', () => {
+    writeFile(
+      store,
+      'src/lifecycle.ts',
+      `
+export function captureProcessStartToken(pid: number): string | null {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  const stat = fs.readFileSync(\`/proc/\${pid}/stat\`, 'utf-8');
+  return stat;
+}
+`,
+      'typescript',
+    );
+    expect(scan(['path_traversal']).findings).toHaveLength(0);
+  });
+
+  test('still detects the same path sink when the early-return guard is absent', () => {
+    writeFile(
+      store,
+      'src/lifecycle.ts',
+      `
+export function captureProcessStartToken(pid: number): string | null {
+  const stat = fs.readFileSync(\`/proc/\${pid}/stat\`, 'utf-8');
+  return stat;
+}
+`,
+      'typescript',
+    );
+    expect(scan(['path_traversal']).findings).toHaveLength(1);
+  });
+
+  test('does not accept a guard on a different value as a guard on the sink', () => {
+    writeFile(
+      store,
+      'src/other.ts',
+      `
+export function read(pid: number, other: string): string {
+  if (!Number.isInteger(other)) throw new Error('bad');
+  return fs.readFileSync(\`/proc/\${pid}/stat\`, 'utf-8');
+}
+`,
+      'typescript',
+    );
+    expect(scan(['path_traversal']).findings).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------
+  // 2. Escaper recognition across a full concatenation
+  // -------------------------------------------------------------------
+
+  test('drops innerHTML whose every non-literal operand is escaped', () => {
+    writeFile(
+      store,
+      'src/tooltip.ts',
+      `
+function render(n) {
+  tooltip.innerHTML = '<strong>' + esc(n.label) + '</strong><br>'
+    + '<span>' + esc(n.id) + '</span><br>'
+    + esc(n.type);
+}
+`,
+      'typescript',
+    );
+    expect(scan(['xss']).findings).toHaveLength(0);
+  });
+
+  test('still detects innerHTML when one operand is unescaped', () => {
+    writeFile(
+      store,
+      'src/tooltip.ts',
+      `
+function render(n) {
+  tooltip.innerHTML = '<strong>' + esc(n.label) + '</strong><br>'
+    + '<span>' + n.id + '</span>';
+}
+`,
+      'typescript',
+    );
+    const findings = scan(['xss']).findings;
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('high');
+  });
+
+  // -------------------------------------------------------------------
+  // 3. SSRF: fixed authority, and config-derived origin
+  // -------------------------------------------------------------------
+
+  test('drops fetch whose host is a constant and only the path is interpolated', () => {
+    writeFile(
+      store,
+      'src/gemini.ts',
+      `
+const BASE_URL = 'https://generativelanguage.googleapis.com';
+async function listModels() {
+  const resp = await fetch(\`\${BASE_URL}/v1beta/models?key=\${this.config.apiKey}\`, {});
+  return resp;
+}
+`,
+      'typescript',
+    );
+    expect(scan(['ssrf']).findings).toHaveLength(0);
+  });
+
+  test('still detects fetch when the interpolation reaches the host', () => {
+    writeFile(
+      store,
+      'src/proxy.ts',
+      `
+async function call(target: string) {
+  const resp = await fetch(\`https://\${target}/v1/data\`, {});
+  return resp;
+}
+`,
+      'typescript',
+    );
+    expect(scan(['ssrf']).findings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('demotes a URL built from a config-derived helper to low confidence', () => {
+    writeFile(
+      store,
+      'src/vertex.ts',
+      `
+class Vertex {
+  async stream() {
+    const resp = await fetch(\`\${modelUrl(this.cfg, this.model, 'x')}?alt=sse\`, {});
+    return resp;
+  }
+}
+`,
+      'typescript',
+    );
+    expect(scan(['ssrf']).findings).toHaveLength(0);
+    const kept = scan(['ssrf'], { includeLow: true }).findings;
+    expect(kept).toHaveLength(1);
+    expect(kept[0].confidence).toBe('low');
+  });
+
+  // -------------------------------------------------------------------
+  // 4. SQL: loop variable over a locally derived array
+  // -------------------------------------------------------------------
+
+  test('demotes a SQL sink fed by a loop over a locally derived array', () => {
+    writeFile(
+      store,
+      'src/wipe.ts',
+      `
+function wipe(db) {
+  const rows = db.prepare('SELECT name FROM sqlite_master').all();
+  const targets = rows.map((r) => r.name).filter((name) => !PRESERVE.has(name));
+  for (const name of targets) {
+    db.exec(\`DELETE FROM "\${name}"\`);
+  }
+}
+`,
+      'typescript',
+    );
+    expect(scan(['sql_injection']).findings).toHaveLength(0);
+    const kept = scan(['sql_injection'], { includeLow: true }).findings;
+    expect(kept).toHaveLength(1);
+    expect(kept[0].confidence).toBe('low');
+  });
+
+  test('still detects a SQL sink fed by a loop over request data', () => {
+    writeFile(
+      store,
+      'src/wipe.ts',
+      `
+function wipe(db, req) {
+  const targets = req.body.tables;
+  for (const name of targets) {
+    db.exec(\`DELETE FROM "\${name}"\`);
+  }
+}
+`,
+      'typescript',
+    );
+    const findings = scan(['sql_injection']).findings;
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('critical');
+  });
+
+  // -------------------------------------------------------------------
+  // 5. Comment stripping survives regex literals containing quotes
+  // -------------------------------------------------------------------
+
+  test('strips a block comment that follows a regex literal containing quotes', () => {
+    writeFile(
+      store,
+      'src/patterns.ts',
+      `
+const RE = /\\buseSWR\\s*\\(\\s*['"\`](\\/[^'"\`$]*?)['"\`]/g;
+
+/**
+ * Template literal fetch patterns with interpolation.
+ * e.g., fetch(\`/api/users/\${id}\`) -> '/api/users/:param'
+ */
+export const OTHER = 1;
+`,
+      'typescript',
+    );
+    expect(scan(['ssrf']).findings).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------
+  // Recall: the one true positive this repo actually had (fixed in #489)
+  // -------------------------------------------------------------------
+
+  test('still detects execSync with an interpolated output path', () => {
+    writeFile(
+      store,
+      'src/cli/visualize.ts',
+      `
+export function openReport(outputPath: string): void {
+  execSync(\`trace-mcp visualize --output \${outputPath}\`);
+}
+`,
+      'typescript',
+    );
+    const findings = scan(['command_injection']).findings;
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule_id).toBe('CWE-78');
+    expect(findings[0].severity).toBe('critical');
+  });
+
+  // -------------------------------------------------------------------
+  // 6. Low-confidence findings are opt-in, and counted when suppressed
+  // -------------------------------------------------------------------
+
+  test('suppresses low-confidence findings by default and reports the count', () => {
+    writeFile(
+      store,
+      'src/move.ts',
+      `
+function move(params) {
+  const targetAbsPath = path.resolve(projectRoot, params.target_file);
+  return targetAbsPath;
+}
+`,
+      'typescript',
+    );
+    const def = scan(['path_traversal']);
+    expect(def.findings).toHaveLength(0);
+    expect(def.suppressed_low_confidence).toBe(1);
+
+    const all = scan(['path_traversal'], { includeLow: true });
+    expect(all.findings).toHaveLength(1);
+    expect(all.findings[0].confidence).toBe('low');
+    expect(all.suppressed_low_confidence).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Whole-repo precision baseline
+// ---------------------------------------------------------------------------
+
+/**
+ * TRA-340 audited every scan_security finding on this repo one by one: 16
+ * pattern hits, all false positives (the single true positive was fixed in
+ * PR #489). The default output must therefore be empty — but the scanner must
+ * still be live, which the suppressed-count assertion below proves.
+ *
+ * A failure here is not "loosen the test": it is either a real finding to fix
+ * or a new false-positive shape to teach the scanner.
+ *
+ * The file list comes from git rather than the index DB so this runs on a fresh
+ * clone (the repo-smoke test needs an indexed DB and is skipped in CI).
+ */
+describe('scanSecurity: whole-repo precision baseline (TRA-340)', () => {
+  const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+  test('reports nothing by default, and holds its low-confidence findings', () => {
+    const tracked = execSync('git ls-files "src/**" "packages/**"', {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      maxBuffer: 32 * 1024 * 1024,
+    })
+      .split('\n')
+      .filter((p) => /\.(ts|tsx|js|jsx|mjs|cjs)$/.test(p));
+    expect(tracked.length).toBeGreaterThan(100);
+
+    const store = createTestStore();
+    for (const rel of tracked) {
+      store.insertFile(rel, rel.endsWith('x') ? 'typescript' : 'typescript', `h-${rel}`, 1);
+    }
+
+    const def = scanSecurity(store, REPO_ROOT, { rules: ['all'] })._unsafeUnwrap();
+    const all = scanSecurity(store, REPO_ROOT, {
+      rules: ['all'],
+      includeLowConfidence: true,
+    })._unsafeUnwrap();
+
+    if (def.findings.length > 0) {
+      console.error(
+        'Unexpected scan_security findings:',
+        def.findings.map((f) => `${f.file}:${f.line} [${f.rule_id}] ${f.snippet.slice(0, 80)}`),
+      );
+    }
+    expect(def.findings).toHaveLength(0);
+    expect(all.findings.length).toBeGreaterThan(0);
+    expect(def.suppressed_low_confidence).toBe(all.findings.length);
+  });
+});


### PR DESCRIPTION
Fixes the precision problem in `scan_security` documented in TRA-340.

## The measurement

`scan_security` reported **16 findings on this repo, all 16 false positives** (the one true positive, `CWE-78` in `src/cli/visualize.ts`, was already fixed in #489). After this change: **0 by default, 11 reachable with `include_low_confidence`**.

```
before: files_scanned=912 total=16  critical=2 high=4 medium=7 low=3
after:  files_scanned=912 total=0   suppressed_low_confidence=11
```

## What was wrong, and what changed

**1. The guard was outside the rule's window.** Almost every FP had its validator a few lines above the sink. `hasGuardAbove` now walks back through the enclosing function for an `assert*`/`validate*` call or an `if (...) return|throw|continue` on the same value. Control-flow braces (`if`, `try`, `for`) no longer stop the walk — only a function/method opener does, which is what made the first attempt miss `lifecycle.ts:467` (its guard sits above an `if (process.platform === 'linux') {`).

Kills: `vec-extension.ts:134` (`assertSafeSqliteIdentifier`), `lifecycle.ts:467` (`Number.isInteger(pid)`).

**2. Escapers weren't recognised across a concatenation.** `classifyInnerHtmlAssignment` only looked at the head of the RHS and only at one line. It now reads the RHS across continuation lines and accepts the assignment when every non-literal operand is a literal or an escaper call (`esc`, `escapeHtml`, `sanitize*`, `encodeURI*`), recursing into ternary branches.

**3. Config origin is not attacker origin.**

- SSRF is dropped when the URL's **authority is fixed before the first interpolation** — ``fetch(`${BASE_URL}/v1/${id}`)`` where `BASE_URL` resolves to a URL literal, or a literal `https://host/` prefix. This is a stronger and more general rule than the host safelist it supersedes: an interpolation in the path cannot redirect the request. ``fetch(`https://${host}/x`)`` and ``fetch(`${BASE}.evil.com`)`` still flag.
- SSRF is demoted to low confidence when the URL comes from operator configuration (`modelUrl(this.cfg, ...)`).
- SQL is demoted when the value is iterated from a locally derived array (`project-manager.ts:829`), and rejected as local when the array touches `req`/`body`/`params`/`argv`.
- `path.join(__dirname, 'literal')` now resolves as a compile-time constant.

**4. A real bug in the comment stripper.** `stripCommentsKeepStrings` didn't know about regex literals, so a pattern containing quote characters left it stuck in "inside a string" state for the rest of the file — every later comment survived stripping and could raise a finding. That is what produced `data-fetching/index.ts:42`, a finding inside a JSDoc block. Regex literals are now scanned and skipped whole.

## Low-confidence findings are opt-in

A "low" confidence finding is weakly grounded by construction, and reporting it by default is what trains users to ignore the whole list. They are now held back and counted:

- MCP: `include_low_confidence: true`
- CLI: `--include-low-confidence`
- Result: `suppressed_low_confidence: <n>`

Additive to the tool contract — no signature or on-disk schema change. The default output does change (it gets quieter), which is the point of the issue.

## One real finding the noise was hiding

The issue's audit said every interpolation into `visualize.ts`'s tooltip `innerHTML` was wrapped in `esc()`. It wasn't: line 1861 concatenated `n.community` and `n.importance` raw. Now escaped.

## Test evidence

- `tests/tools/security-scan-precision.test.ts` — 16 tests. **Every precision test is paired with a recall test on the same shape**: guard removed, operand left unescaped, interpolation reaching the host, loop array coming from `req.body`. Includes a recall guard reproducing the true positive fixed in #489.
- Whole-repo baseline test asserts 0 default findings **and** that `include_low_confidence` still returns findings — so "0" means suppressed, not switched off. It builds its file list from `git ls-files` rather than the index DB, because the existing repo-smoke test needs an indexed DB and is skipped in CI.
- Full suite: **8838 passed, 9 skipped**. `tsc --noEmit` clean, `biome ci` clean, `pnpm run build` clean.

Refs TRA-340
