### PR TITLE
fix(tools): actually strip param descriptions at minimal/none verbosity (TRA-345)

### DIFF
--- a/src/server/__tests__/tool-gate-verbosity.test.ts
+++ b/src/server/__tests__/tool-gate-verbosity.test.ts
@@ -1,0 +1,67 @@
+/**
+ * `tools.description_verbosity` is a token-saving switch, so it has to be
+ * verified against the JSON Schema the client actually receives — not against
+ * `field.description`. Zod v4 keeps descriptions in `z.globalRegistry`, so the
+ * original strip (deleting `_def.description`) cleared the accessor while
+ * `z.toJSONSchema` still emitted every word: ~38.7k chars of param prose that
+ * a user who explicitly asked for minimal descriptions kept paying for.
+ */
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { applySchemaTransforms, type SchemaTransformConfig } from '../tool-gate-helpers.js';
+
+const cfg = (verbosity: SchemaTransformConfig['descriptionVerbosity']): SchemaTransformConfig => ({
+  descriptionVerbosity: verbosity,
+  compactSchemas: false,
+  descriptionOverrides: {},
+  sharedParamOverrides: {},
+});
+
+const emitted = (shape: Record<string, z.ZodTypeAny>): string =>
+  JSON.stringify(z.toJSONSchema(z.object(shape)));
+
+function transformed(
+  shape: Record<string, z.ZodTypeAny>,
+  verbosity: SchemaTransformConfig['descriptionVerbosity'],
+): Record<string, z.ZodTypeAny> {
+  const args: unknown[] = ['demo_tool', 'First sentence. Second sentence.', shape, () => undefined];
+  applySchemaTransforms(args, cfg(verbosity));
+  return args[2] as Record<string, z.ZodTypeAny>;
+}
+
+describe('description_verbosity strips param prose from the emitted schema', () => {
+  for (const verbosity of ['minimal', 'none'] as const) {
+    it(`removes describe() text at verbosity=${verbosity}`, () => {
+      const shape = {
+        bare: z.string().describe('bare param prose'),
+        opt: z.number().describe('optional param prose').optional(),
+        dflt: z.enum(['a', 'b']).describe('defaulted param prose').default('a'),
+      };
+      const out = emitted(transformed({ ...shape }, verbosity));
+      expect(out).not.toContain('param prose');
+      expect(out).not.toContain('"description"');
+      // Structure survives — only the prose goes.
+      expect(out).toContain('"enum":["a","b"]');
+      expect(out).toContain('"default":"a"');
+    });
+  }
+
+  it('keeps param prose at verbosity=full', () => {
+    const out = emitted(transformed({ bare: z.string().describe('bare param prose') }, 'full'));
+    expect(out).toContain('bare param prose');
+  });
+
+  it('leaves a schema constant shared with other tools untouched', () => {
+    // The daemon registers many tools — and many sessions — from the same
+    // module-level schema objects, so stripping must not mutate them in place.
+    const shared = z.string().describe('shared param prose').optional();
+    transformed({ shared }, 'minimal');
+    expect(emitted({ shared })).toContain('shared param prose');
+  });
+
+  it('collapses the tool description to its first sentence at minimal', () => {
+    const args: unknown[] = ['demo_tool', 'First sentence. Second sentence.', {}, () => undefined];
+    applySchemaTransforms(args, cfg('minimal'));
+    expect(args[1]).toBe('First sentence.');
+  });
+});

--- a/src/server/tool-gate-helpers.ts
+++ b/src/server/tool-gate-helpers.ts
@@ -11,6 +11,7 @@
  * pure refactor. The functions take explicit context objects instead of
  * closing over `installToolGate`'s locals.
  */
+import { z } from 'zod';
 import type { TraceMcpConfig } from '../config.js';
 import type { SessionJournal } from '../session/journal.js';
 import type { SessionTracker } from '../session/tracker.js';
@@ -102,18 +103,35 @@ function applyDescriptionOverrides(args: unknown[], cfg: SchemaTransformConfig):
   }
 }
 
+/**
+ * Return a copy of `field` with its `describe()` text gone from the emitted
+ * JSON Schema. Zod v4 keeps descriptions in `z.globalRegistry`, keyed by the
+ * schema instance — deleting `_def.description` only clears the convenience
+ * accessor, so the old strip left every param description on the wire while
+ * looking like it worked. Cloning first keeps module-level schema constants
+ * shared across tools (and across daemon sessions with different verbosity)
+ * unmodified. Walks the `innerType` chain so `.describe().optional()` and
+ * `.describe().default(x)` are handled; nested object/array params don't carry
+ * their own describe() in this codebase, same shallow-is-enough reasoning as
+ * the schema-budget guard.
+ */
+function withoutDescription(field: unknown): unknown {
+  const def = (field as { _zod?: { def?: Record<string, unknown> } })?._zod?.def;
+  if (!def) return field;
+  const nextDef = { ...def };
+  if (nextDef.innerType) nextDef.innerType = withoutDescription(nextDef.innerType);
+  const clone = z.core.clone(field as z.ZodType, nextDef as never);
+  z.globalRegistry.remove(clone);
+  return clone;
+}
+
 /** Drop per-parameter `description` metadata for minimal/none verbosity. */
 function stripParamDescriptions(args: unknown[]): void {
   const schema = args[schemaIndexOf(args)];
   if (!schema || typeof schema !== 'object') return;
-  for (const val of Object.values(schema as Record<string, unknown>)) {
-    if (val && typeof val === 'object' && '_def' in val) {
-      const def = (val as { _def: Record<string, unknown> })._def;
-      // biome-ignore lint/performance/noDelete: Zod attaches `description` as a getter-only property; assigning undefined throws.
-      delete def.description;
-      // biome-ignore lint/performance/noDelete: same as above — Zod description is getter-only.
-      delete (val as Record<string, unknown>).description;
-    }
+  const shape = schema as Record<string, unknown>;
+  for (const [key, val] of Object.entries(shape)) {
+    if (val && typeof val === 'object') shape[key] = withoutDescription(val);
   }
 }
 


### PR DESCRIPTION
## Problem

`tools.description_verbosity: "minimal"` / `"none"` is documented as a token-saving switch that drops per-parameter `describe()` text. It doesn't. The strip deleted `_def.description`, a Zod v3 location. Zod v4 stores descriptions in `z.globalRegistry`, so the delete cleared the convenience accessor (`field.description === undefined`) while `z.toJSONSchema` kept emitting all of it.

Reproduced directly against zod 4.3.6:

```
before:            {"a":{"type":"string","description":"hello world"}}
after old strip:   {"a":{"type":"string","description":"hello world"}}   // field.description === undefined
after this fix:    {"a":{"type":"string"}}
```

There was no test for `description_verbosity` at all — and any test written against `field.description` would have passed.

## Impact

Measured on the always-on surface (141 tools), `verbosity=minimal`:

| | before | after |
|---|---|---|
| serialized inputSchema chars | 86,217 | **47,532** |
| total advertised payload (name+desc+schema) | 101,385 | **62,700** |
| ≈ tokens (chars/4) | 25.3k | **15.7k** |

~9.7k tokens per session, for every client without deferred tool loading, for a user who explicitly asked for smaller descriptions.

## Fix

`withoutDescription()` clones the field (walking the `innerType` chain so `.describe().optional()` and `.describe().default(x)` are covered) and removes the clone's `z.globalRegistry` entry. Cloning matters: the daemon registers many tools — and many sessions with different verbosity — from the same module-level schema constants, so an in-place mutation would leak across them. A test pins that.

Nested object/array params don't carry their own `describe()` in this codebase, so the walk stays shallow — same reasoning the schema-budget guard uses.

## Test evidence

- New `src/server/__tests__/tool-gate-verbosity.test.ts` (5 tests) — asserts against the **emitted JSON Schema**, not `field.description`.
- Full suite: 8840 passed, 6 skipped, 0 failed.
- `pnpm run typecheck` clean; `biome ci` clean on both touched files.
- No MCP tool signature or on-disk schema change — this only affects what an opted-in session advertises.

Refs TRA-345.
