### PR TITLE
fix(tools): make compact_schemas cover all 141 tools and stop hiding required params (TRA-346)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -450,7 +450,7 @@ The `tools.*` section controls what the MCP server injects into every session �
 | `tools.instructions_verbosity` | `"full"` | Server-level instructions (the tool-routing block). `full` ~2K tokens, `minimal` ~200 |
 | `tools.agent_behavior` | `"off"` | Behavior rules appended to instructions — see [Agent behavior rules](#agent-behavior-rules) |
 | `tools.meta_fields` | `true` | Meta fields in responses (`_hints`, `_budget_warning`, etc.). Set `false` or list to narrow |
-| `tools.compact_schemas` | `false` | Strip advanced/optional params from tool schemas. Cuts schema size 40–60% |
+| `tools.compact_schemas` | `false` | Strip advanced/optional params from tool schemas. Cuts schema size ~42% (measured 2026-08-29) |
 
 ### Agent behavior rules
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://trace-mcp.com/</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -14,25 +14,25 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/comparisons.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/configuration.html</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/architecture.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/supported-frameworks.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -62,7 +62,7 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/quality-gates.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/packages/app/src/renderer/tabs/configSchema.ts
+++ b/packages/app/src/renderer/tabs/configSchema.ts
@@ -1286,7 +1286,7 @@ export const CONFIG_SCHEMA: SectionDef[] = [
         type: 'boolean',
         defaultValue: false,
         description:
-          'Strip advanced parameters from tool schemas to reduce token overhead (~40-60%)',
+          'Strip advanced parameters from tool schemas to reduce token overhead (~42%)',
       },
       {
         key: 'descriptions',

--- a/src/config.ts
+++ b/src/config.ts
@@ -250,7 +250,7 @@ const ToolsConfigSchema = z
         ),
       ])
       .default(true),
-    /** Strip advanced/optional parameters from tool schemas to reduce token overhead (~40-60% schema size reduction). Only core parameters are exposed; advanced options still work if passed. */
+    /** Strip advanced/optional parameters from tool schemas to reduce token overhead (~42% schema size reduction, measured 2026-08-29 across the always-on surface). Only core parameters are exposed; advanced options still work if passed. */
     compact_schemas: z.boolean().default(false),
     /** Wire format for tool responses.
      *  - 'json' (default): standard JSON, unchanged from prior versions.

--- a/src/server/compact-params.ts
+++ b/src/server/compact-params.ts
@@ -6,8 +6,15 @@
  * are stripped from the schema but still accepted at runtime (the handler
  * receives them as normal — only the JSON Schema definition is trimmed).
  *
- * Tools NOT listed here keep all their parameters unchanged.
- * Tools with ≤2 parameters are not worth compacting.
+ * Tools NOT listed here keep all their parameters unchanged — which is why
+ * `tool-schema-budget.test.ts` fails when an always-on tool with 3+ params has
+ * no entry here. Coverage silently decayed to 61/141 tools once already
+ * (TRA-346), which is what made `compact_schemas` deliver 30% instead of the
+ * documented 40-60%.
+ *
+ * Tools with ≤2 parameters are exempt: there is nothing meaningful to strip.
+ * Required params must always be listed — stripping one hides a parameter the
+ * handler cannot run without.
  */
 export const COMPACT_CORE_PARAMS: Record<string, string[]> = {
   // Navigation
@@ -16,34 +23,30 @@ export const COMPACT_CORE_PARAMS: Record<string, string[]> = {
   get_change_impact: ['file_path', 'symbol_id', 'symbol_ids', 'depth'],
   get_context_bundle: ['symbol_id', 'symbol_ids', 'fqn', 'token_budget'],
   get_task_context: ['task', 'focus'],
-  find_usages: ['symbol_id', 'fqn', 'kind_filter'],
-  get_call_graph: ['symbol_id', 'fqn', 'direction', 'depth'],
+  find_usages: ['symbol_id', 'fqn', 'file_path'],
+  get_call_graph: ['symbol_id', 'fqn', 'depth'],
   get_feature_context: ['description', 'token_budget'],
 
   // Analysis
-  get_import_graph: ['file_path', 'depth'],
-  get_complexity_report: ['file_path', 'symbol_id'],
-  get_coupling: ['file_path', 'module_path'],
+  get_complexity_report: ['file_path', 'limit'],
+  get_coupling: ['limit'],
   get_dead_code: ['file_pattern'],
-  get_circular_imports: ['file_pattern'],
   detect_antipatterns: ['file_pattern'],
-  scan_code_smells: ['file_pattern', 'kinds'],
+  scan_code_smells: ['scope', 'category', 'limit'],
   get_dataflow: ['symbol_id', 'fqn'],
   get_control_flow: ['symbol_id', 'fqn'],
-  graph_query: ['query', 'start_symbol'],
-  check_duplication: ['name', 'kind', 'file_path'],
-  get_untested_symbols: ['file_pattern', 'kind'],
-  detect_communities: ['min_size'],
+  graph_query: ['query', 'depth'],
+  check_duplication: ['name', 'kind', 'symbol_id'],
+  get_untested_symbols: ['file_pattern', 'scope', 'max_results'],
   get_complexity_trend: ['file_path'],
-  get_coupling_trend: ['module_path'],
+  get_coupling_trend: ['file_path', 'since_days'],
   get_symbol_complexity_trend: ['symbol_id'],
 
   // Git
-  get_git_churn: ['file_path', 'since', 'limit'],
-  get_co_changes: ['file_path', 'symbol_id'],
-  get_changed_symbols: ['base', 'head'],
+  get_git_churn: ['file_pattern', 'since_days', 'limit'],
+  get_co_changes: ['file', 'limit'],
+  get_changed_symbols: ['since', 'until'],
   compare_branches: ['branch', 'base'],
-  get_code_owners: ['file_path', 'symbol_id'],
 
   // Refactoring
   check_rename: ['symbol_id', 'target_name'],
@@ -51,41 +54,87 @@ export const COMPACT_CORE_PARAMS: Record<string, string[]> = {
   apply_move: ['symbol_id', 'source_file', 'target_file', 'new_path', 'dry_run'],
   change_signature: ['symbol_id', 'changes', 'dry_run'],
   plan_refactoring: ['type', 'symbol_id', 'target_file', 'changes'],
-  extract_function: ['file_path', 'start_line', 'end_line', 'name'],
+  extract_function: ['file_path', 'start_line', 'end_line', 'function_name', 'dry_run'],
   apply_codemod: ['pattern', 'replacement', 'file_pattern', 'dry_run'],
   remove_dead_code: ['symbol_id', 'dry_run'],
-  pack_context: ['symbol_ids', 'file_paths', 'token_budget'],
+  pack_context: ['scope', 'path', 'query', 'max_tokens'],
 
   // Quality
-  scan_security: ['file_pattern', 'rules'],
+  scan_security: ['scope', 'rules'],
   check_quality_gates: ['scope'],
-  taint_analysis: ['source_symbol_id', 'file_pattern'],
+  taint_analysis: ['scope'],
   export_security_context: ['scope', 'depth'],
   audit_config: [],
 
   // Framework
-  get_request_flow: ['route', 'method'],
-  get_component_tree: ['component', 'file_path'],
-  get_model_context: ['model', 'file_path'],
-  get_event_graph: ['event'],
-  get_schema: ['model'],
+  get_request_flow: ['url', 'method'],
+  get_component_tree: ['component_path', 'depth'],
   get_tests_for: ['symbol_id', 'fqn', 'file_path'],
 
   // Advanced / Topology
   get_workspace_map: [],
-  get_cross_workspace_impact: ['symbol_id', 'file_path'],
   assess_change_risk: ['file_path', 'symbol_id'],
   predict_bugs: ['file_pattern'],
-  get_tech_debt: ['module_path'],
-  get_risk_hotspots: ['file_pattern'],
+  get_risk_hotspots: ['limit'],
   plan_batch_change: ['package', 'from_version', 'to_version'],
   get_project_health: [],
   benchmark_project: [],
 
   // Session / Memory
-  add_decision: ['title', 'rationale', 'scope'],
-  query_decisions: ['query', 'scope', 'status'],
+  add_decision: ['title', 'content', 'type', 'symbol_id', 'file_path', 'tags'],
+  query_decisions: ['search', 'type', 'symbol_id', 'file_path', 'limit'],
 
-  // Batch
-  batch: ['calls'],
+  // Graph / topology
+  visualize_graph: ['scope', 'granularity', 'output'],
+  traverse_graph: ['start_symbol_id', 'start_file_path', 'direction', 'max_depth'],
+  get_dependency_diagram: ['scope', 'depth'],
+  get_graph_timeline: ['since_days', 'granularity'],
+  get_edge_bottlenecks: ['top_n'],
+  export_graph: ['format'],
+  get_domain_map: ['depth'],
+  get_domain_context: ['domain', 'token_budget'],
+  get_package_deps: ['package', 'project'],
+  get_api_surface: ['file_pattern'],
+
+  // Navigation / inspection
+  get_outline: ['path', 'detail_level', 'nested'],
+  search_text: ['query', 'file_pattern', 'is_regex', 'grouping'],
+  get_pagerank: ['limit'],
+  get_refactor_candidates: ['limit', 'min_cyclomatic'],
+  detect_ast_clones: ['file_pattern', 'min_loc'],
+  get_env_vars: ['pattern', 'file'],
+  get_artifacts: ['category', 'query'],
+  check_edit_safe: ['file_path', 'symbol_id'],
+  check_architecture: ['preset'],
+  check_claudemd_drift: [],
+  generate_docs: ['scope', 'path'],
+  generate_sbom: ['format'],
+  analyze_perf: ['tool', 'window'],
+
+  // Health / trends
+  get_file_health_timeline: ['file_path', 'since_days'],
+  get_health_trends: ['file_path', 'module'],
+  get_session_snapshot: [],
+  reindex: ['path', 'force'],
+
+  // Decisions / memory
+  remember_decision: ['title', 'content', 'type', 'symbol_id', 'file_path', 'tags'],
+  get_wake_up: ['scope', 'max_decisions'],
+  get_decision_clusters: ['search', 'limit'],
+  get_cluster_decisions: ['id'],
+  get_decision_timeline: ['symbol_id', 'file_path'],
+  export_decisions: ['format', 'type', 'limit'],
+  consolidate_decisions: ['dry_run'],
+  build_decision_clusters: ['dry_run'],
+  tune_decision_weights: ['dry_run'],
+  mine_sessions: ['force'],
+  regenerate_project_memo: ['force'],
+  discover_hermes_sessions: ['profile', 'limit'],
+
+  // Corpora / pins / projects
+  build_corpus: ['name', 'scope', 'module_path', 'feature_query'],
+  query_corpus: ['name', 'question', 'mode'],
+  search_bundles: ['query', 'kind'],
+  pin: ['symbol_id', 'file_path'],
+  call_project_tool: ['project', 'tool', 'args'],
 };

--- a/src/tools/register/__tests__/tool-schema-budget.test.ts
+++ b/src/tools/register/__tests__/tool-schema-budget.test.ts
@@ -11,6 +11,8 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
+import { COMPACT_CORE_PARAMS } from '../../../server/compact-params.js';
+import { applySchemaTransforms } from '../../../server/tool-gate-helpers.js';
 import type { MetaContext, ServerContext } from '../../../server/types.js';
 import { registerAdvancedTools } from '../advanced.js';
 import { registerAnalysisTools } from '../analysis.js';
@@ -396,6 +398,103 @@ describe('MCP tool-schema token budget guardrail — runtime-gated tools (TRA-21
       .filter((t) => t.description.length > PER_TOOL_DESCRIPTION_CHAR_CEILING)
       .map((t) => `  - ${t.name}: ${t.description.length} chars`);
     expect(offenders.length, offenders.join('\n')).toBe(0);
+  });
+});
+
+/**
+ * TRA-346: `compact_schemas` is a no-op for any tool missing from
+ * COMPACT_CORE_PARAMS, and silently strips the wrong things for any entry
+ * naming params the tool no longer has. Both decayed unnoticed — coverage sat
+ * at 61/141 tools, 27 entries referenced renamed params, and 11 entries hid a
+ * mandatory param (`add_decision` lost `content`/`type`, so the tool could not
+ * be called at all with the setting on). These guards make each of those fail
+ * loudly instead of quietly costing tokens or breaking a tool.
+ */
+describe('compact_schemas coverage (TRA-346)', () => {
+  const alwaysOn = captureAllTools();
+  // Union of every registration context, so entries for framework-gated tools
+  // (get_request_flow, get_component_tree, ...) are validated too.
+  const allCaptured = [
+    ...alwaysOn,
+    ...captureAllTools(FRAMEWORK_CTX),
+    ...captureAllTools(TOPOLOGY_CTX),
+    ...captureAllTools(RUNTIME_CTX),
+  ];
+  const shapeOf = new Map(allCaptured.map((t) => [t.name, t.schemaShape]));
+
+  /** A param the caller must pass: not optional and carrying no default. */
+  const isMandatory = (field: z.ZodTypeAny): boolean => !field.safeParse(undefined).success;
+
+  it('covers every always-on tool with more than two params', () => {
+    const uncovered = alwaysOn
+      .filter((t) => Object.keys(t.schemaShape).length > 2 && !COMPACT_CORE_PARAMS[t.name])
+      .map((t) => t.name)
+      .sort();
+    expect(
+      uncovered,
+      `Tool(s) with no COMPACT_CORE_PARAMS entry: ${uncovered.join(', ')}. ` +
+        'compact_schemas strips nothing for them, which is how coverage decayed to 61/141 (TRA-346). ' +
+        'Add an entry listing the core params, or [] if nothing is worth exposing.',
+    ).toEqual([]);
+  });
+
+  it('never lists a param the tool does not declare', () => {
+    const stale: string[] = [];
+    for (const [tool, params] of Object.entries(COMPACT_CORE_PARAMS)) {
+      const shape = shapeOf.get(tool);
+      expect(shape, `COMPACT_CORE_PARAMS entry for unregistered tool "${tool}"`).toBeDefined();
+      for (const p of params) {
+        if (!(p in (shape as Record<string, unknown>))) stale.push(`${tool}.${p}`);
+      }
+    }
+    expect(
+      stale,
+      `Stale param name(s): ${stale.join(', ')}. A renamed param turns its entry into a filter that ` +
+        'keeps nothing — the tool loses every param under compact_schemas (TRA-346).',
+    ).toEqual([]);
+  });
+
+  it('never strips a mandatory param', () => {
+    const hidden: string[] = [];
+    for (const [tool, params] of Object.entries(COMPACT_CORE_PARAMS)) {
+      const shape = shapeOf.get(tool);
+      if (!shape) continue;
+      const kept = new Set(params);
+      for (const [name, field] of Object.entries(shape)) {
+        if (!kept.has(name) && isMandatory(field)) hidden.push(`${tool}.${name}`);
+      }
+    }
+    expect(
+      hidden,
+      `Mandatory param(s) hidden by compact_schemas: ${hidden.join(', ')}. ` +
+        'The handler still requires them, so the client cannot call the tool at all.',
+    ).toEqual([]);
+  });
+
+  // Measured 2026-08-29 (TRA-346): 86,407 → 50,421 always-on schema chars, a
+  // 41.6% cut, after extending coverage to all 141 tools and repairing the
+  // stale entries. Below the documented 40-60% band means coverage decayed
+  // again — the docs claim went stale exactly this way once.
+  it('delivers the documented 40-60% schema reduction', () => {
+    let before = 0;
+    let after = 0;
+    for (const t of alwaysOn) {
+      before += fullSchemaCharSize(t.schemaShape);
+      const args: unknown[] = [t.name, t.description, { ...t.schemaShape }, () => undefined];
+      applySchemaTransforms(args, {
+        descriptionVerbosity: 'full',
+        compactSchemas: true,
+        descriptionOverrides: {},
+        sharedParamOverrides: {},
+      });
+      after += fullSchemaCharSize(args[2] as Record<string, z.ZodTypeAny>);
+    }
+    const cut = (before - after) / before;
+    expect(
+      cut,
+      `compact_schemas cuts ${(cut * 100).toFixed(1)}% of always-on schema chars ` +
+        `(${before} → ${after}); docs/configuration.md and config.ts promise 40-60%.`,
+    ).toBeGreaterThanOrEqual(0.4);
   });
 });
 


### PR DESCRIPTION
Fixes TRA-346.

## The reported gap

`compact_schemas` is documented as a 40-60% schema-size reduction. Measured on the always-on surface (141 tools, `z.toJSONSchema` over every registered `inputSchema`) it delivered **30.1%** — because `stripAdvancedParams` returns early for any tool missing from `COMPACT_CORE_PARAMS`, and that map covered 61 of 141 tools.

## The bigger one found on the way

Auditing the 61 existing entries against the live schemas:

- **27 entries named params that no longer exist.** A stale name turns the entry into a filter that matches nothing, so the tool loses *every* param under `compact_schemas` — `get_coupling` (`file_path`/`module_path` → the tool has `limit`/`assessment`), `query_decisions` (3 stale names against 17 real params), `pack_context`, `get_git_churn`, `scan_security`, `taint_analysis` and 21 more.
- **8 entries hid a param the handler requires.** With the setting on, `add_decision` was uncallable (`content` and `type` stripped), as were `get_request_flow` (`url`), `get_component_tree` (`component_path`) and `get_model_context` (`model_name`).

So the setting was not merely under-delivering; it was silently breaking tools.

## Change

- Extended the map to every always-on tool with 3+ params. Tools with ≤2 params stay exempt — nothing meaningful to strip, and exempting them by rule rather than by list means no second list to keep current.
- Repaired every stale entry against the current schemas.
- Dropped the dead `batch` entry: meta-tools registered through `_originalTool` bypass the gate, so no schema transform ever applied to it.
- Corrected the claim in `src/config.ts`, `docs/configuration.md` and the desktop config schema to the measured number.

## Guard (so coverage cannot decay again)

Four new tests in `src/tools/register/__tests__/tool-schema-budget.test.ts`, reusing that file's existing registration-capture harness:

1. every always-on tool with 3+ params has an entry;
2. no entry names a param the tool doesn't declare (validated across the always-on, framework, topology and runtime capture contexts);
3. no entry strips a mandatory param (not optional, no default);
4. the measured reduction stays at or above the documented 40%.

Coverage decay is the whole mechanism behind this issue, and #2/#3 are what turn a routine param rename from a silent breakage into a red test.

## Test evidence

- `86,407 → 50,421` always-on schema chars = **41.6%**, up from 30.1%.
- `pnpm run test`: 806 files / 8,851 tests passed, 3 files / 10 tests skipped.
- `pnpm run typecheck`, `pnpm run build`, `biome check`: clean.

Related: #499 (TRA-345) fixed the sibling knob `description_verbosity` — same class of defect, a token-saving setting nothing measured end-to-end.