### PR TITLE
ci: publish server.json to the official MCP Registry on release

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,67 @@
+name: Publish to MCP Registry
+
+# We are not in the official MCP Registry, and that is what makes the directory
+# listings wrong (TRA-352). PulseMCP is hand-maintaining a server.json for us
+# that still says "44+ tools" — its own submit page says the fix is to publish
+# to the official registry, and mcp.so / Smithery auto-discover from it too.
+# server.json is already release-please-versioned, so publishing is the only
+# missing step.
+#
+# GitHub OIDC needs no secret: the namespace io.github.nikolai-vysotskyi/*
+# matches this repo's owner, so the registry trusts the workflow's own token.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v3.1.1). Defaults to the latest release.'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write # OIDC authentication to the MCP Registry
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag != '' && inputs.tag || github.event.release.tag_name }}
+
+      # The registry rejects a server.json whose npm package it cannot find, and
+      # the release event fires while release.yml is still building and testing
+      # the npm publish. Wait for the version to land instead of failing the
+      # release on a race.
+      - name: Wait for the npm package to be published
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          for i in $(seq 1 60); do
+            if curl -fsS "https://registry.npmjs.org/trace-mcp/$VERSION" > /dev/null; then
+              echo "trace-mcp@$VERSION is on npm"
+              exit 0
+            fi
+            echo "waiting for trace-mcp@$VERSION on npm ($i/60)"
+            sleep 30
+          done
+          echo "trace-mcp@$VERSION never appeared on npm — is the publish job red?" >&2
+          exit 1
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.nikolai-vysotskyi/trace-mcp",
-  "description": "Framework-aware code intelligence: 80 languages, 87 framework integrations, 169 tools, up to 99% token reduction",
+  "description": "Framework-aware code intelligence: 80 languages, 87 frameworks, 169 tools, up to 99% fewer tokens",
   "repository": {
     "url": "https://github.com/nikolai-vysotskyi/trace-mcp",
     "source": "github"
@@ -10,6 +10,7 @@
   "packages": [
     {
       "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "trace-mcp",
       "version": "3.1.1",
       "transport": {


### PR DESCRIPTION
Fixes the root cause behind TRA-352: we were never published to the official MCP Registry, so every downstream directory guessed.

**What was wrong**
- PulseMCP (~616 est. ecosystem visitors/week, more than our 56 Google organic clicks/30d) is hand-maintaining a `server.json` for us that says *"Framework-aware code intelligence MCP server with 44+ tools"* — actual count is 169 (`docs/_data/counts.yml`). Their submit page says submissions are paused and the fix is to publish to the official registry.
- `mcp.so`, `smithery.ai`, `mcpmarket.com`: no listing. mcp.so and Smithery auto-discover from the official registry.
- `registry.modelcontextprotocol.io` search for `io.github.nikolai-vysotskyi/trace-mcp` returned 0 results.

**Changes**
- `.github/workflows/publish-mcp-registry.yml` — publishes `server.json` on `release: published` (plus `workflow_dispatch` for backfills) using GitHub OIDC. No secret needed: the `io.github.nikolai-vysotskyi/*` namespace matches the repo owner. It waits for the npm version to appear first, because the release event fires while `release.yml` is still building and the registry rejects a server whose npm package it can't find.
- `server.json` — description trimmed to the registry's 100-char cap, `registryBaseUrl` added.

**Test evidence**
`mcp-publisher validate` against the live registry rejected the old file:

```
422 ... {"message":"expected length <= 100","location":"body.description", ...}
```

after the change:

```
✅ server.json is valid
```

v3.1.1 was then published manually so the live listings are corrected today, not at the next release:

```
✓ Server io.github.nikolai-vysotskyi/trace-mcp version 3.1.1
```

Confirmed live via `GET /v0/servers?search=io.github.nikolai-vysotskyi/trace-mcp` — `isLatest: true`, description now carries the correct 169.

Refs TRA-352.

Agent: Lead Engineer