### PR TITLE
docs(seo): per-competitor /vs/ pages, visible dates, token-usage guide (TRA-351)

### DIFF
--- a/docs/_data/docs_nav.yml
+++ b/docs/_data/docs_nav.yml
@@ -5,6 +5,14 @@
   url: /tools-reference.html
 - title: Comparisons
   url: /comparisons.html
+- title: vs Repomix
+  url: /vs/repomix.html
+- title: vs Serena
+  url: /vs/serena.html
+- title: vs codebase-memory-mcp
+  url: /vs/codebase-memory-mcp.html
+- title: Cut Claude Code token usage
+  url: /reduce-claude-code-token-usage.html
 - title: Supported frameworks
   url: /supported-frameworks.html
 - title: Architecture

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -12,6 +12,7 @@
       .site-brand { font-weight: 600; font-size: 1.25em; margin-bottom: 1.5em; }
       .site-brand a { text-decoration: none; }
       .docs-nav { color: #57606a; font-size: 0.9em; }
+      .page-updated { color: #57606a; font-size: 0.9em; margin-top: 2em; }
     </style>
   </head>
   <body>
@@ -19,6 +20,16 @@
       <p class="site-brand"><a href="{{ '/' | relative_url }}">trace-mcp</a></p>
 
       {{ content }}
+
+      {%- comment -%}
+        Every page that outranks us for these queries shows a reader-visible
+        date; ours only had one inside the TechArticle JSON-LD, which a reader
+        never sees. `updated:` is stamped from git by `pnpm docs:sitemap`, so it
+        cannot drift from <lastmod> the way the hand-maintained dates did.
+      {%- endcomment -%}
+      {%- if page.updated %}
+      <p class="page-updated">Last updated: {{ page.updated | date: "%B %-d, %Y" }}</p>
+      {%- endif %}
 
       <hr>
       <p class="docs-nav">

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,6 +1,7 @@
 ---
 title: "Session Analytics & Coverage Intelligence — token savings, wasteful patterns"
 description: "trace-mcp's built-in analytics engine parses AI agent session logs, tracks token savings, detects wasteful patterns, and assesses technology coverage."
+updated: 2026-08-26
 ---
 
 # Session Analytics & Coverage Intelligence

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,7 +1,7 @@
 ---
 title: "Session Analytics & Coverage Intelligence — token savings, wasteful patterns"
 description: "trace-mcp's built-in analytics engine parses AI agent session logs, tracks token savings, detects wasteful patterns, and assesses technology coverage."
-updated: 2026-08-26
+updated: 2026-08-29
 ---
 
 # Session Analytics & Coverage Intelligence

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,7 @@
 ---
 title: "trace-mcp Architecture — indexing pipeline, storage, and MCP server internals"
 description: "How trace-mcp indexes a codebase into a queryable graph: tree-sitter parsing, SQLite + FTS5 storage, optional LSP enrichment, and the MCP server that serves it all."
+updated: 2026-08-28
 ---
 
 # Architecture

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 ---
 title: "trace-mcp Architecture — indexing pipeline, storage, and MCP server internals"
 description: "How trace-mcp indexes a codebase into a queryable graph: tree-sitter parsing, SQLite + FTS5 storage, optional LSP enrichment, and the MCP server that serves it all."
-updated: 2026-08-28
+updated: 2026-08-29
 ---
 
 # Architecture

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -1,6 +1,7 @@
 ---
 title: "Code Graph MCP Server Comparison: trace-mcp vs Repomix, Serena & 20+ alternatives"
 description: "Compare trace-mcp against Repomix, Serena, Kage, codebase-memory-mcp and 20+ MCP code-graph tools — capabilities, language support, GitHub stars. Last verified August 2026."
+updated: 2026-08-28
 ---
 
 # How trace-mcp compares
@@ -32,7 +33,15 @@ description: "Compare trace-mcp against Repomix, Serena, Kage, codebase-memory-m
 </script>
 trace-mcp is not just a code intelligence server — it combines **code graph navigation**, **cross-session memory**, and **real-time code understanding** in a single tool. Other projects solve one of these; trace-mcp unifies all three.
 
-_Last updated: August 28, 2026 (deep-dive pass on the two largest peers + star/feature re-verification). Based on public documentation and GitHub repos. If you maintain one of these projects and see an inaccuracy, [open an issue](https://github.com/nikolai-vysotskyi/trace-mcp/issues). This revision re-verifies star counts against the live GitHub API — several jumped by 3-4x since July (viral GitHub-trending spikes are common in this space and can reverse just as fast), so treat every count below as a snapshot, not a ranking. The two 60K+-star entrants flagged in a previous revision got their deep-dive: **Graphify** (110.6K stars, Python, deterministic AST-to-knowledge-graph skill/MCP server, no vector store) and **Headroom** (67.6K stars, Python, reversible tool-output/JSON/log compression layer — library, HTTP proxy, or MCP server). Neither closes a real gap for us: Graphify's edge provenance tagging (`EXTRACTED`/`INFERRED`/`AMBIGUOUS`) is a 3-tier scheme trace-mcp's existing 4-tier `resolution_tier` (`scip_resolved`/`lsp_resolved`/`ast_resolved`/`ast_inferred`/`text_matched`) already exceeds, and its Cypher/GraphML export is a feature trace-mcp already ships (`export_graph`). Headroom compresses arbitrary tool output generically (JSON/logs/RAG chunks) rather than understanding code structure — orthogonal to a code-graph server, not a lane worth chasing. See their rows/footnotes below. The "Honest assessment" section below was updated after six of seven identified gaps shipped and went through an adversarial deep-validation pass._
+## Head-to-head pages
+
+This page is the whole field. For the three peers people most often evaluate against trace-mcp, there is a dedicated page with a focused table, an honest "when to pick theirs" section, and an FAQ:
+
+- **[trace-mcp vs Repomix](/vs/repomix.html)** — packing a repository into one prompt vs indexing it into a queryable graph.
+- **[trace-mcp vs Serena](/vs/serena.html)** — a live LSP proxy vs a precomputed framework-aware graph.
+- **[trace-mcp vs codebase-memory-mcp](/vs/codebase-memory-mcp.html)** — the closest peer: same premise, opposite bets on breadth vs depth.
+
+_Last verification pass: August 28, 2026 — deep-dive on the two largest peers plus star/feature re-verification. Based on public documentation and GitHub repos. If you maintain one of these projects and see an inaccuracy, [open an issue](https://github.com/nikolai-vysotskyi/trace-mcp/issues). This revision re-verifies star counts against the live GitHub API — several jumped by 3-4x since July (viral GitHub-trending spikes are common in this space and can reverse just as fast), so treat every count below as a snapshot, not a ranking. The two 60K+-star entrants flagged in a previous revision got their deep-dive: **Graphify** (110.6K stars, Python, deterministic AST-to-knowledge-graph skill/MCP server, no vector store) and **Headroom** (67.6K stars, Python, reversible tool-output/JSON/log compression layer — library, HTTP proxy, or MCP server). Neither closes a real gap for us: Graphify's edge provenance tagging (`EXTRACTED`/`INFERRED`/`AMBIGUOUS`) is a 3-tier scheme trace-mcp's existing 4-tier `resolution_tier` (`scip_resolved`/`lsp_resolved`/`ast_resolved`/`ast_inferred`/`text_matched`) already exceeds, and its Cypher/GraphML export is a feature trace-mcp already ships (`export_graph`). Headroom compresses arbitrary tool output generically (JSON/logs/RAG chunks) rather than understanding code structure — orthogonal to a code-graph server, not a lane worth chasing. See their rows/footnotes below. The "Honest assessment" section below was updated after six of seven identified gaps shipped and went through an adversarial deep-validation pass._
 
 ## vs. token-efficient code exploration
 

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -1,7 +1,7 @@
 ---
 title: "Code Graph MCP Server Comparison: trace-mcp vs Repomix, Serena & 20+ alternatives"
 description: "Compare trace-mcp against Repomix, Serena, Kage, codebase-memory-mcp and 20+ MCP code-graph tools — capabilities, language support, GitHub stars. Last verified August 2026."
-updated: 2026-08-28
+updated: 2026-08-29
 ---
 
 # How trace-mcp compares

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,7 @@
 ---
 title: "trace-mcp Configuration Reference — all config options (works with none)"
 description: "Every trace-mcp config option in .trace-mcp.json — indexing, quality gates, LSP enrichment, TOON output, telemetry. Configuration is optional; trace-mcp works out of the box for standard projects."
+updated: 2026-08-28
 ---
 
 # Configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: "trace-mcp Configuration Reference — all config options (works with none)"
 description: "Every trace-mcp config option in .trace-mcp.json — indexing, quality gates, LSP enrichment, TOON output, telemetry. Configuration is optional; trace-mcp works out of the box for standard projects."
-updated: 2026-08-28
+updated: 2026-08-29
 ---
 
 # Configuration

--- a/docs/decision-memory.md
+++ b/docs/decision-memory.md
@@ -1,7 +1,7 @@
 ---
 title: "Decision Memory — a persistent knowledge graph for architectural decisions"
 description: "trace-mcp's decision knowledge graph captures architectural decisions, tech choices, bug root causes, preferences, and conventions — linked to the code they're about."
-updated: 2026-08-28
+updated: 2026-08-29
 ---
 
 # Decision memory

--- a/docs/decision-memory.md
+++ b/docs/decision-memory.md
@@ -1,6 +1,7 @@
 ---
 title: "Decision Memory — a persistent knowledge graph for architectural decisions"
 description: "trace-mcp's decision knowledge graph captures architectural decisions, tech choices, bug root causes, preferences, and conventions — linked to the code they're about."
+updated: 2026-08-28
 ---
 
 # Decision memory

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,7 +1,7 @@
 ---
 title: "Contributing to trace-mcp — local setup, build, and test"
 description: "How to set up trace-mcp for local development: install, build, run the test suite, and the conventions to follow before opening a PR."
-updated: 2026-08-26
+updated: 2026-08-29
 ---
 
 # Development

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,7 @@
 ---
 title: "Contributing to trace-mcp — local setup, build, and test"
 description: "How to set up trace-mcp for local development: install, build, run the test suite, and the conventions to follow before opening a PR."
+updated: 2026-08-26
 ---
 
 # Development

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -385,6 +385,52 @@ Priority for next deep-dive: **codebase-memory-mcp** (largest peer by stars — 
 
 ---
 
+# trace-mcp vs Repomix
+
+Repomix answers "put my repository into a prompt"; trace-mcp answers "let the agent look things up in my repository". Repomix is a packer — it concatenates files into one artifact, optionally stripping function bodies with tree-sitter (`--compress`, ~70% fewer bytes across ~20 languages), and ships an official MCP server via `--mcp`, including packing remote repos. trace-mcp is an index: tree-sitter parsing across {{ site.data.counts.languages }} languages into SQLite + FTS5, a cross-file dependency graph, {{ site.data.counts.frameworks }} framework integrations, refactoring tools, and incremental updates on file change.
+
+Pick Repomix for one-shot questions, repositories you do not own, small repos that fit in context, and workflows with no MCP client. Pick trace-mcp when the repo does not fit in context, the session runs many turns, the question is structural ("what breaks if I change this"), framework edges matter, or the agent needs to change code and not only read it.
+
+Honest caveat: a Repomix pack is a fixed cost re-paid on every refresh, while trace-mcp pays an up-front schema cost (~50K tokens on the shipped default surface, a tracked bug) and then small scoped per-query costs. On a short session against a small repo, Repomix can genuinely cost less.
+
+Full page: https://trace-mcp.com/vs/repomix.html
+
+---
+
+# trace-mcp vs Serena
+
+Serena is a live LSP proxy: it forwards questions to a real language server, so references and renames are compiler-grade across 40+ languages, and it ships ~55 MCP tools plus a live debugger. trace-mcp is a precomputed graph with LSP and offline SCIP ingestion as an *optional* precision upgrade rather than a hard dependency.
+
+Pick Serena when you work in one language with a first-class language server, want zero index state, or need runtime inspection. Pick trace-mcp for polyglot or unusual stacks, framework edges no language server models (route → handler, controller → template, model → table), graph impact analysis rather than plain references, and everything past navigation — security scanning with type-aware taint pruning, SARIF 2.1.0, quality gates, AST codemods, and code-linked decision memory that is verified non-stale at recall time.
+
+Honest caveats: trace-mcp's AST resolution is less precise than live LSP by default, we have not yet read Serena's source (it is the priority for our next competitor deep-dive), and Serena's ~55-tool surface is materially cheaper than our {{ site.data.counts.tools }}.
+
+Full page: https://trace-mcp.com/vs/serena.html
+
+---
+
+# trace-mcp vs codebase-memory-mcp
+
+DeusData's codebase-memory-mcp is the closest peer: same premise of a persistent tree-sitter knowledge graph served over MCP, with impact analysis (`detect_changes`), call-path tracing (`trace_call_path`), cross-service HTTP linking, IaC as graph nodes, MinHash near-clone and Louvain community detection, and a 3D web UI. It is written in C, covers 161 languages, and advertises 15 tools (~7K tokens) with `scout` (7) and `analysis` (11) profiles.
+
+Where it leads: advertised tool cost (~7K vs trace-mcp's ~50K on the shipped default path — the clearest place any competitor beats us), raw language count, a published benchmark preprint (arXiv 2603.27277: 83% answer quality, ~10× fewer tokens, 2.1× fewer tool calls across 31 repos, not independently reproduced by us), SLSA Level 3 supply-chain provenance, and `ingest_traces` for runtime-observed call edges.
+
+Where trace-mcp leads: {{ site.data.counts.frameworks }} framework integrations producing edges a language-agnostic parser cannot; a refactoring engine (rename, move, signature change, AST codemod, verified dead-code removal) against a read-only analyser; OWASP Top-10 and taint scanning with SARIF 2.1.0 output; configurable quality gates in CI; and decision memory bound to symbol IDs and staleness-verified rather than flat ADR markdown.
+
+Full page: https://trace-mcp.com/vs/codebase-memory-mcp.html
+
+---
+
+# How to reduce Claude Code token usage
+
+Seven tactics, ordered by measured impact. (1) Stop paying for exploration twice — name the file when you know it, ask for structure before content. (2) Read symbols, not files: outline → one symbol → edit, instead of 500 lines to change five. (3) Audit your MCP tool surface, including ours: every connected server injects its schemas at session start whether or not you call it — trace-mcp's default `tools/list` is {{ site.data.counts.tools }} tools and roughly 50K tokens, and its `minimal` (24 tools) / `standard` (59 tools) / `full` ({{ site.data.counts.tools }} tools) presets currently apply only with `TRACE_MCP_NO_DAEMON=1`. (4) Pick the output format per tool: measured with cl100k_base, TOON beat JSON by +31.4% on `query_decisions` and +28.8% on `get_outline`, and lost by −17.5% on `find_usages` and −25.5% on `search_text`. (5) Prefer one structural query over many reads. (6) Compact, don't clear — clearing forces re-derivation that costs more than the transcript. (7) Index once, query many times; packing pays its full cost on every refresh.
+
+The homepage's "~40–50% fewer tokens" is our own aggregate figure from our own usage, not a third-party benchmark, and it varies with repository size and session shape. The per-tool format numbers above are reproducible from `scripts/bench-toon.ts`.
+
+Full page: https://trace-mcp.com/reduce-claude-code-token-usage.html
+
+---
+
 # Configuration
 
 Configuration is optional — trace-mcp works out of the box for standard projects.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,6 +11,10 @@ layout: null
 
 - [Tools reference](https://trace-mcp.com/tools-reference.html): Full list of the {{ site.data.counts.tools }} MCP tools and 9 resources trace-mcp exposes, registered dynamically per detected framework.
 - [How trace-mcp compares](https://trace-mcp.com/comparisons.html): Feature-by-feature comparison against other code-graph and code-intelligence MCP servers.
+- [trace-mcp vs Repomix](https://trace-mcp.com/vs/repomix.html): Head-to-head against Repomix — packing a repository into one prompt vs indexing it into a queryable graph, and when Repomix is the better pick.
+- [trace-mcp vs Serena](https://trace-mcp.com/vs/serena.html): Head-to-head against Serena — a live LSP proxy vs a precomputed framework-aware graph.
+- [trace-mcp vs codebase-memory-mcp](https://trace-mcp.com/vs/codebase-memory-mcp.html): Head-to-head against the closest peer — same knowledge-graph premise, opposite bets on language breadth vs framework depth.
+- [How to reduce Claude Code token usage](https://trace-mcp.com/reduce-claude-code-token-usage.html): Seven measured tactics for cutting agent token cost, including the ones that have nothing to do with trace-mcp.
 - [Configuration](https://trace-mcp.com/configuration.html): All config file options; trace-mcp works out of the box without one.
 - [Architecture](https://trace-mcp.com/architecture.html): The two-pass indexing pipeline and how the dependency graph is built and stored.
 - [Supported frameworks & languages](https://trace-mcp.com/supported-frameworks.html): The {{ site.data.counts.languages }} supported languages and the frameworks each plugin understands.

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,6 +1,7 @@
 ---
 title: "Quality Gates Reference — complexity, security, and coverage thresholds"
 description: "How trace-mcp's quality_gates.rules in .trace-mcp.json override CLI defaults for cyclomatic complexity, security findings, and coverage — with this project's own thresholds as a worked example."
+updated: 2026-08-28
 ---
 
 # Quality gates — this project's thresholds

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,7 +1,7 @@
 ---
 title: "Quality Gates Reference — complexity, security, and coverage thresholds"
 description: "How trace-mcp's quality_gates.rules in .trace-mcp.json override CLI defaults for cyclomatic complexity, security findings, and coverage — with this project's own thresholds as a worked example."
-updated: 2026-08-28
+updated: 2026-08-29
 ---
 
 # Quality gates — this project's thresholds

--- a/docs/reduce-claude-code-token-usage.md
+++ b/docs/reduce-claude-code-token-usage.md
@@ -1,0 +1,177 @@
+---
+title: "How to Reduce Claude Code Token Usage — 7 measured tactics"
+description: "Seven ways to cut token usage in Claude Code, ordered by measured impact: stop full-file reads, trim your MCP tool surface, pick the right output format. With real numbers and honest caveats."
+updated: 2026-08-29
+---
+
+# How to reduce Claude Code token usage
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "TechArticle",
+      "headline": "How to reduce Claude Code token usage",
+      "description": "Seven measured tactics for cutting token usage in Claude Code and other MCP-based coding agents.",
+      "url": "https://trace-mcp.com/reduce-claude-code-token-usage.html",
+      "datePublished": "2026-08-29",
+      "dateModified": "2026-08-29",
+      "author": {
+        "@type": "Person",
+        "name": "Nikolai Vysotskyi",
+        "url": "https://github.com/nikolai-vysotskyi"
+      },
+      "publisher": {
+        "@type": "Person",
+        "name": "Nikolai Vysotskyi",
+        "url": "https://github.com/nikolai-vysotskyi"
+      },
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "https://trace-mcp.com/reduce-claude-code-token-usage.html"
+      }
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What actually uses the most tokens in Claude Code?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Three things, in this order: repeated full-file reads during exploration, the MCP tool schemas advertised at session start, and long transcripts that carry every earlier tool result forward. Exploration dominates on large repositories, because finding the right file costs many reads before any useful one happens."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Do MCP servers increase or decrease token usage?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Both. Every MCP server pays a fixed up-front cost — its tool schemas are injected into the context at session start — and then saves tokens per query if its answers are narrower than the file reads they replace. A server with a large advertised surface and few calls per session is a net loss. Check the cost: run tools/list and count the tokens before deciding."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Does asking for an outline instead of reading the file really help?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Substantially, when you only need structure. An outline returns signatures and line ranges without bodies, so a 500-line file becomes a short list. The pattern that pays is outline first, then read only the specific symbol or line range you need — rather than reading the whole file to edit five lines of it."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Does output format affect token cost?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Measurably, but only for the right payload shape. On trace-mcp's own measurements with the cl100k_base tokenizer, TOON encoding beat JSON by 31.4% on query_decisions and 28.8% on get_outline, where every row has the same scalar fields. On payloads with nested objects or inner arrays it lost — minus 17.5% on find_usages and minus 25.5% on search_text. Format is a per-tool decision, not a global switch."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Is clearing context the same as saving tokens?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "No, and it is often worse. Clearing throws away work the agent has to redo, and re-derivation usually costs more than the transcript did. Compacting or handing off a short written summary keeps the conclusions while dropping the raw tool output that made them."
+          }
+        }
+      ]
+    }
+  ]
+}
+</script>
+
+Token cost in Claude Code is not mostly the code you show it. It is the code it reads **looking for** the code it needs, plus everything it re-reads on later turns because the earlier result scrolled out of reach.
+
+Below are seven tactics ordered by how much they moved the number in our own measurements, with the numbers we actually have and honest gaps where we do not have any. Several of them have nothing to do with trace-mcp; those come first, because they are free.
+
+## 1. Stop paying for exploration twice
+
+The dominant cost on a repository too large to fit in context is *search*, not reading. An agent asked "where is rate limiting handled" will open a dozen candidate files before it finds the one that matters, and every one of those reads stays in the transcript for the rest of the session.
+
+Two cheap habits fix most of it:
+
+- **Name the file when you know it.** "Fix the retry backoff in `src/http/client.ts`" costs one read. "Fix the retry backoff" costs an exploration.
+- **Ask for structure before content.** Signatures and line ranges are a fraction of a file's tokens, and they are usually enough to pick the one symbol worth reading in full.
+
+## 2. Read symbols, not files
+
+Reading a 500-line file to change five lines pays for 495 lines you did not need — and pays again on the next turn if the result gets re-read. The pattern that works is outline → one symbol → edit.
+
+This is what trace-mcp's `get_outline` and `get_symbol` exist for: the first returns signatures with line numbers, the second returns exactly one function or class. Claude Code's native `Read` supports `offset`/`limit` and will do the same job once you know the range, which is precisely what the outline gives you.
+
+## 3. Audit your MCP tool surface — including ours
+
+This is the tactic most people never check, and it can dominate everything else.
+
+Every MCP server you connect injects its tool schemas into the context **at session start, before you ask anything**. Three servers with large surfaces can cost tens of thousands of tokens on every single session, whether or not you call any of them.
+
+Measured on our own server, August 2026: trace-mcp's default `tools/list` is {{ site.data.counts.tools }} tools and roughly 50K tokens, plus ~2.1K tokens of server instructions. That is genuinely expensive, and we say so on our own [comparisons page](/comparisons.html) — the leanest peers in this category advertise ~1.9K and ~7K tokens by shipping a small default surface with the rest opt-in.
+
+What to do about it:
+
+- Run `tools/list` against each server you have connected and count the tokens. Most people have never looked.
+- Disconnect servers you are not using in this project. A server connected "just in case" is a fixed tax.
+- Use a preset or allowlist where the server offers one. trace-mcp ships `minimal` (24 tools), `standard` (59 tools) and `full` ({{ site.data.counts.tools }} tools), plus `tools.include` / `tools.exclude` in config.
+- **Honest caveat:** those presets currently take effect only when the daemon is bypassed (`TRACE_MCP_NO_DAEMON=1`) — on the default daemon-backed path they are silently ignored and you get the full surface. That is a bug we track publicly, not a design decision. Until it lands, the env var is the workaround.
+
+## 4. Pick the output format per tool, not globally
+
+Encoding matters, but not uniformly. Our measurements (`scripts/bench-toon.ts`, `gpt-tokenizer` with the cl100k_base encoding, against a snapshot of this repo's own index — 1,501 files, 9,467 symbols):
+
+| Payload shape | Format change | Measured |
+|---|---|---:|
+| Flat, same scalar fields per row (`query_decisions`) | JSON → TOON | **+31.4%** |
+| Flat symbol records (`get_outline`) | JSON → TOON | **+28.8%** |
+| Flat item records (`search`) | JSON → TOON | **+16.4%** |
+| Nested object per row (`find_usages`) | JSON → TOON | **−17.5%** |
+| Inner array per row (`search_text`) | JSON → TOON | **−25.5%** |
+| Repeated long paths (`search_text`) | flat → grouped by file | **+20.8%** |
+
+The rule underneath: compact tabular encodings win when every row has the same scalar columns, and lose the moment a row contains a nested object or an inner array. Full method and the breakeven curve are on the [TOON savings page](/toon-savings.html).
+
+## 5. Prefer one structural query over many reads
+
+"What breaks if I change this function" answered by reading files is an open-ended crawl: find the definition, grep for the name, open each hit, follow each of those. Answered from a dependency graph it is one call that returns the affected symbols and the tests covering them.
+
+The same applies to "who calls this", "which tests cover this", and "what does this module import". These are graph traversals. If your tooling can compute them, the token cost is the answer's size rather than the search's size — and the search is the expensive part.
+
+## 6. Compact, don't clear
+
+Clearing the context feels like saving tokens and usually is not: the agent re-derives what it lost, and re-derivation costs more than the transcript did. Compaction — or simply writing a short summary of conclusions and starting fresh from it — keeps the findings while dropping the raw tool output that produced them.
+
+## 7. Index once, query many times
+
+The reason a code index pays off is amortisation. Building it costs something once; every query afterwards is cheap and scoped. A packing tool that concatenates your repository into a prompt pays its full cost on **every** refresh, which is fine for a one-shot question and expensive across a long session.
+
+That is the trade in one line: if your session is a single question about a small repository, pack it. If it is many turns against a repository too large to fit in context, index it. We wrote up the specifics against the main packing tool in [trace-mcp vs Repomix](/vs/repomix.html).
+
+## What we claim, and what we have measured
+
+Our homepage claims **~40–50% fewer tokens on average** across real agent workflows. That is our own aggregate figure from our own usage, not a third-party benchmark, and it varies enormously with repository size and session shape — on a small repo that fits in context it is roughly zero. The numbers on this page that come with a script and a tokenizer are the ones in section 4; those you can reproduce.
+
+We do not currently have a published, independently reproducible end-to-end benchmark, and at least one competitor does. We would rather write that here than quietly imply otherwise.
+
+## FAQ
+
+**What actually uses the most tokens in Claude Code?**
+Repeated full-file reads during exploration, the MCP tool schemas advertised at session start, and long transcripts carrying every earlier tool result forward — in that order on large repositories.
+
+**Do MCP servers increase or decrease token usage?**
+Both. Each pays a fixed up-front schema cost and then saves per query if its answers are narrower than the reads they replace. A large surface with few calls per session is a net loss. Measure it with `tools/list`.
+
+**Does asking for an outline instead of reading the file really help?**
+Yes, when you only need structure. Outline first, then read the specific symbol or line range — instead of reading 500 lines to edit five.
+
+**Does output format affect token cost?**
+Measurably, per payload shape. TOON beat JSON by 31.4% on `query_decisions` and 28.8% on `get_outline`, and lost by 17.5% and 25.5% on `find_usages` and `search_text`. It is a per-tool decision.
+
+**Is clearing context the same as saving tokens?**
+No — clearing forces re-derivation, which usually costs more. Compact, or hand off a short written summary.
+
+## Next steps
+
+- [Tools reference](/tools-reference.html) — every trace-mcp tool, including the outline/symbol/impact ones above.
+- [TOON savings](/toon-savings.html) — the full measurement method behind section 4.
+- [Configuration](/configuration.html) — presets and `tools.include` / `tools.exclude`.
+- [Get started](/#install) — no configuration required.

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -19,8 +19,32 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://trace-mcp.com/configuration.html</loc>
+    <loc>https://trace-mcp.com/vs/repomix.html</loc>
     <lastmod>2026-08-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://trace-mcp.com/vs/serena.html</loc>
+    <lastmod>2026-08-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://trace-mcp.com/vs/codebase-memory-mcp.html</loc>
+    <lastmod>2026-08-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://trace-mcp.com/reduce-claude-code-token-usage.html</loc>
+    <lastmod>2026-08-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://trace-mcp.com/configuration.html</loc>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -8,13 +8,13 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/tools-reference.html</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/comparisons.html</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -44,61 +44,61 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/configuration.html</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/architecture.html</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/supported-frameworks.html</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/analytics.html</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/toon-savings.html</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/decision-memory.html</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/telemetry.html</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/quality-gates.html</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/tweakcc.html</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/development.html</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/docs/supported-frameworks.md
+++ b/docs/supported-frameworks.md
@@ -1,6 +1,7 @@
 ---
 title: "Supported Languages & Frameworks — 80 languages, 87 framework integrations"
 description: "Full list of languages and frameworks trace-mcp understands out of the box — web frameworks, ORMs, UI libraries, and tooling, across 80 languages."
+updated: 2026-08-28
 ---
 
 # Supported frameworks & languages

--- a/docs/supported-frameworks.md
+++ b/docs/supported-frameworks.md
@@ -1,7 +1,7 @@
 ---
 title: "Supported Languages & Frameworks — 80 languages, 87 framework integrations"
 description: "Full list of languages and frameworks trace-mcp understands out of the box — web frameworks, ORMs, UI libraries, and tooling, across 80 languages."
-updated: 2026-08-28
+updated: 2026-08-29
 ---
 
 # Supported frameworks & languages

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,6 +1,7 @@
 ---
 title: "Telemetry & Observability — OpenTelemetry spans for every MCP tool call"
 description: "trace-mcp's pluggable observability bridge emits OpenTelemetry-compatible spans for every AI provider call and every MCP tool call."
+updated: 2026-08-26
 ---
 
 # Telemetry & Observability

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,7 +1,7 @@
 ---
 title: "Telemetry & Observability — OpenTelemetry spans for every MCP tool call"
 description: "trace-mcp's pluggable observability bridge emits OpenTelemetry-compatible spans for every AI provider call and every MCP tool call."
-updated: 2026-08-26
+updated: 2026-08-29
 ---
 
 # Telemetry & Observability

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -1,7 +1,7 @@
 ---
 title: "trace-mcp MCP Tools Reference — every code-intelligence tool, by framework"
 description: "Full reference for trace-mcp's MCP tools and 9 resources — navigation, refactoring, impact analysis, security, and framework-aware queries. Tools register dynamically based on what your repo uses."
-updated: 2026-08-28
+updated: 2026-08-29
 ---
 
 # Tools reference

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -1,6 +1,7 @@
 ---
 title: "trace-mcp MCP Tools Reference — every code-intelligence tool, by framework"
 description: "Full reference for trace-mcp's MCP tools and 9 resources — navigation, refactoring, impact analysis, security, and framework-aware queries. Tools register dynamically based on what your repo uses."
+updated: 2026-08-28
 ---
 
 # Tools reference

--- a/docs/toon-savings.md
+++ b/docs/toon-savings.md
@@ -1,7 +1,7 @@
 ---
 title: "TOON Output Format — Measured Token Savings on Real Tool Calls"
 description: "Real-world token measurements for trace-mcp's TOON (Token-Oriented Object Notation) output format across tabular MCP tool responses."
-updated: 2026-08-28
+updated: 2026-08-29
 ---
 
 # TOON Token Savings — Measured

--- a/docs/toon-savings.md
+++ b/docs/toon-savings.md
@@ -1,6 +1,7 @@
 ---
 title: "TOON Output Format — Measured Token Savings on Real Tool Calls"
 description: "Real-world token measurements for trace-mcp's TOON (Token-Oriented Object Notation) output format across tabular MCP tool responses."
+updated: 2026-08-28
 ---
 
 # TOON Token Savings — Measured

--- a/docs/tweakcc.md
+++ b/docs/tweakcc.md
@@ -1,7 +1,7 @@
 ---
 title: "System Prompt Routing via tweakcc — pairing trace-mcp with Claude Code"
 description: "How to pair trace-mcp with tweakcc to patch Claude Code's system prompts and route tool selection toward trace-mcp instead of native file reads."
-updated: 2026-08-26
+updated: 2026-08-29
 ---
 
 # System Prompt Routing via tweakcc

--- a/docs/tweakcc.md
+++ b/docs/tweakcc.md
@@ -1,6 +1,7 @@
 ---
 title: "System Prompt Routing via tweakcc — pairing trace-mcp with Claude Code"
 description: "How to pair trace-mcp with tweakcc to patch Claude Code's system prompts and route tool selection toward trace-mcp instead of native file reads."
+updated: 2026-08-26
 ---
 
 # System Prompt Routing via tweakcc

--- a/docs/vs/codebase-memory-mcp.md
+++ b/docs/vs/codebase-memory-mcp.md
@@ -1,0 +1,154 @@
+---
+title: "codebase-memory-mcp Alternative: trace-mcp vs codebase-memory-mcp"
+description: "Both build a persistent code knowledge graph for AI agents. Head-to-head on language coverage, advertised tool cost, framework awareness, refactoring and security — including the two places codebase-memory-mcp is clearly ahead."
+updated: 2026-08-29
+---
+
+# codebase-memory-mcp alternative: trace-mcp vs codebase-memory-mcp
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "TechArticle",
+      "headline": "codebase-memory-mcp alternative: trace-mcp vs codebase-memory-mcp",
+      "description": "Head-to-head comparison of trace-mcp and DeusData's codebase-memory-mcp as persistent code knowledge graphs for AI agents.",
+      "url": "https://trace-mcp.com/vs/codebase-memory-mcp.html",
+      "datePublished": "2026-08-29",
+      "dateModified": "2026-08-29",
+      "author": {
+        "@type": "Person",
+        "name": "Nikolai Vysotskyi",
+        "url": "https://github.com/nikolai-vysotskyi"
+      },
+      "publisher": {
+        "@type": "Person",
+        "name": "Nikolai Vysotskyi",
+        "url": "https://github.com/nikolai-vysotskyi"
+      },
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "https://trace-mcp.com/vs/codebase-memory-mcp.html"
+      }
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "How similar are trace-mcp and codebase-memory-mcp?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "They are the closest pair in this space. Both parse a repository with tree-sitter into a persistent knowledge graph, both do impact analysis and call-path tracing, both model infrastructure-as-code as graph nodes, and both expose it over MCP. The divergence is what sits on top: trace-mcp adds framework-aware edges, a refactoring engine, security scanning and code-linked decision memory; codebase-memory-mcp goes wider on raw language count and much leaner on advertised tool surface."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "codebase-memory-mcp supports 161 languages and trace-mcp supports {{ site.data.counts.languages }}. Does that matter?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Only if your repository contains a language in the gap, which for most teams it does not. trace-mcp's coverage is chosen to span the real-world long tail rather than to win a count. Where trace-mcp goes deeper is per-language and per-framework semantics: route-to-handler, controller-to-template, model-to-table edges that a broader-but-shallower parser does not produce."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Is codebase-memory-mcp cheaper in tokens?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "On advertised surface, yes, and by a wide margin. Its 15 tools cost roughly 7K tokens of schema, and its scout and analysis profiles trim that to 7 and 11 tools. trace-mcp advertises {{ site.data.counts.tools }} tools at roughly 50K tokens on the shipped default path. trace-mcp has an equivalent preset mechanism that is currently bypassed on that path — a tracked bug, and the single clearest place a competitor leads today."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Does codebase-memory-mcp have a published benchmark?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Its authors published a preprint (arXiv 2603.27277) reporting 83% answer quality, roughly 10 times fewer tokens and 2.1 times fewer tool calls versus file-by-file exploration across 31 repositories. We have not independently reproduced it, and it is a self-published preprint rather than peer-reviewed third-party work — but it is still more evidence than most peers, trace-mcp included, have put on the table."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Can either one refactor code, not just read it?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Only trace-mcp. It ships graph-aware rename across files, symbol and file moves with import rewriting, signature changes with call-site updates, AST-based codemods and verified dead-code removal. codebase-memory-mcp is read-only analysis: it will tell an agent what would break, but the agent still edits by hand."
+          }
+        }
+      ]
+    }
+  ]
+}
+</script>
+
+**TL;DR.** codebase-memory-mcp (DeusData) is the peer closest to trace-mcp's premise: parse a repository into a persistent knowledge graph and serve it to agents over MCP, instead of letting them re-read files. Both do impact analysis, call-path tracing, cross-service linking and infrastructure-as-code as graph nodes.
+
+The split is depth versus breadth, in both directions. codebase-memory-mcp is broader on languages (161 vs {{ site.data.counts.languages }}) and dramatically leaner on advertised tool cost. trace-mcp is deeper per repository: {{ site.data.counts.frameworks }} framework integrations produce edges a language-agnostic parser cannot, and it can act on the graph — rename, move, codemod, remove dead code, scan for vulnerabilities — rather than only describe it.
+
+## Head-to-head
+
+| Capability | trace-mcp | codebase-memory-mcp |
+|---|:---:|:---:|
+| **GitHub stars** | 100 | 41.0K |
+| Languages | {{ site.data.counts.languages }} | 161 |
+| Framework integrations | ✅ {{ site.data.counts.frameworks }} | ❌ (partial REST routes) |
+| Persistent knowledge graph | ✅ SQLite + FTS5 | ✅ |
+| Knowledge-graph queries | ✅ `graph_query` | ✅ Cypher-like |
+| Impact analysis | ✅ reverse dependency traversal + decorator filter | ✅ `detect_changes` |
+| Call graph | ✅ bidirectional | ✅ `trace_call_path` |
+| Cross-service / multi-repo | ✅ cross-repo API linking | ✅ cross-service HTTP linking |
+| IaC as graph nodes | ✅ K8s/Kustomize/HCL/Docker, cross-file resolved | ✅ K8s/Kustomize/HCL/Docker |
+| Clone / community detection | ✅ AST Type-2 subtree hashing, 11 antipatterns | ✅ MinHash near-clone, Louvain communities |
+| Refactoring tools | ✅ rename, move, signature, AST codemod, extract | ❌ |
+| Security scanning | ✅ OWASP Top-10, type-aware taint, SARIF 2.1.0 | ❌ |
+| Control-flow graph | ✅ basic blocks, loop back-edges, try/catch merges | ❌ |
+| Quality gates in CI | ✅ complexity / security / coverage thresholds | ❌ |
+| Code-linked decision memory | ✅ decisions bound to symbol IDs, staleness-verified | partial (`manage_adr` markdown documents) |
+| Runtime trace ingestion | ❌ | ✅ `ingest_traces` |
+| Graph visualization | ✅ desktop app | ✅ 3D web UI |
+| MCP tools advertised (default) | {{ site.data.counts.tools }} (~50K tok) | 15 (~7K tok); profiles: 11 / 7 |
+| Supply-chain posture | OpenSSF Scorecard, CodeQL, Semgrep | SLSA L3, VirusTotal, OpenSSF Scorecard |
+| Published benchmark | ❌ | ✅ preprint, not independently reproduced |
+| Written in | TypeScript | C |
+
+## When to pick codebase-memory-mcp
+
+This is the peer where the honest list is longest, so here it is in full:
+
+- **Your advertised tool budget is tight.** 15 tools at roughly 7K tokens — or 7 with `--tool-profile=scout` — against trace-mcp's ~50K on the shipped default path. If you run several MCP servers in one client and every one of them is competing for the same context window, that difference is decisive. This is currently the clearest place any competitor beats us, we track it publicly, and we are not going to pretend otherwise on our own comparison page.
+- **You need a language we do not parse.** 161 grammars against {{ site.data.counts.languages }}. If your repo has one in the gap, none of trace-mcp's depth helps you.
+- **You want evidence before adopting.** Its authors published a benchmark preprint (arXiv 2603.27277: 83% answer quality, ~10× fewer tokens, 2.1× fewer tool calls across 31 repositories). We have not reproduced it and it is not peer-reviewed — but trace-mcp has no comparable published number at all.
+- **Supply-chain requirements are strict.** SLSA Level 3 provenance plus VirusTotal-scanned reproducible release candidates is a stronger posture than ours, and in a regulated environment that can be the whole decision.
+- **You have runtime traces to fold in.** `ingest_traces` enriches the graph with observed caller/callee counts — dynamic edges static analysis cannot see. trace-mcp has no equivalent.
+
+## When to pick trace-mcp
+
+- **Framework semantics.** A graph that knows `UserController` exists but not that it renders `Users/Show.vue` via Inertia is missing the edges developers actually reason about. {{ site.data.counts.frameworks }} integrations produce route → handler, controller → template, model → table and component edges; a language-agnostic parser produces none of them.
+- **You want the agent to change code.** Rename across files with import rewriting, symbol and file moves, signature changes that update call sites, AST-based codemods with metavariable substitution, dead-code removal with orphan-import detection. codebase-memory-mcp is read-only.
+- **Security is part of the job.** OWASP Top-10 rules, taint analysis with type-aware pruning, and OASIS-schema-validated SARIF 2.1.0 for CI ingestion.
+- **Memory should be code-linked and verified.** `manage_adr` writes flat markdown documents. trace-mcp binds decisions to symbol IDs, checks at recall time that the linked code still resolves and is unchanged, and surfaces them inside `get_change_impact` — so a decision about code that was deleted stops being served.
+- **Gates, not just reports.** Quality gates with configurable complexity, security and coverage thresholds, plus SARIF output, make the graph a CI participant rather than a chat aid.
+
+## FAQ
+
+**How similar are trace-mcp and codebase-memory-mcp?**
+The closest pair in this space. Both parse with tree-sitter into a persistent knowledge graph, both do impact analysis and call-path tracing, both model IaC as nodes. The divergence is what sits on top: framework-aware edges, refactoring, security and code-linked memory for trace-mcp; raw language breadth and a much leaner advertised surface for codebase-memory-mcp.
+
+**It supports 161 languages and trace-mcp supports {{ site.data.counts.languages }}. Does that matter?**
+Only if your repository contains a language in the gap. trace-mcp's coverage targets the real-world long tail rather than a count; the depth goes into per-framework semantics instead.
+
+**Is codebase-memory-mcp cheaper in tokens?**
+On advertised surface, yes, by a wide margin — ~7K against our ~50K on the shipped default path. Our preset mechanism exists and is bypassed there; it is a tracked bug and the single clearest place a competitor leads.
+
+**Does it have a published benchmark?**
+A self-published preprint (arXiv 2603.27277), not independently reproduced and not peer-reviewed — but still more evidence than most peers, us included, have put on the table.
+
+**Can either one refactor code, not just read it?**
+Only trace-mcp. codebase-memory-mcp is read-only analysis.
+
+## Next steps
+
+- Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html)
+- [Decision memory](/decision-memory.html) — how code-linked decisions differ from a notes file.
+- [Get started](/#install) — no configuration required.

--- a/docs/vs/repomix.md
+++ b/docs/vs/repomix.md
@@ -1,0 +1,155 @@
+---
+title: "Repomix Alternative: trace-mcp vs Repomix for AI code context"
+description: "Repomix packs your repository into one prompt. trace-mcp indexes it into a queryable graph. Head-to-head on token cost, freshness, search, and refactoring — plus when Repomix is still the right pick."
+updated: 2026-08-29
+---
+
+# Repomix alternative: trace-mcp vs Repomix
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "TechArticle",
+      "headline": "Repomix alternative: trace-mcp vs Repomix",
+      "description": "Head-to-head comparison of trace-mcp and Repomix for feeding codebase context to AI coding agents.",
+      "url": "https://trace-mcp.com/vs/repomix.html",
+      "datePublished": "2026-08-29",
+      "dateModified": "2026-08-29",
+      "author": {
+        "@type": "Person",
+        "name": "Nikolai Vysotskyi",
+        "url": "https://github.com/nikolai-vysotskyi"
+      },
+      "publisher": {
+        "@type": "Person",
+        "name": "Nikolai Vysotskyi",
+        "url": "https://github.com/nikolai-vysotskyi"
+      },
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "https://trace-mcp.com/vs/repomix.html"
+      }
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Is trace-mcp a drop-in replacement for Repomix?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "No. Repomix produces one packed file you paste or attach; trace-mcp exposes MCP tools an agent calls during a session. If your workflow is 'paste my repo into a chat', Repomix is the closer fit. If your agent runs many turns against the same repo, trace-mcp replaces the pack entirely because the agent queries the index instead of re-reading a snapshot."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Does Repomix have an MCP server?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Repomix ships an official MCP server (run with --mcp) that exposes packing as a tool, including packing remote repositories. It is still packing, not indexing: the tools return file content, not a symbol graph."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Repomix has a --compress flag. Isn't that the same as a code graph?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "No. --compress uses tree-sitter to strip function bodies and keep signatures, which cuts roughly 70% of the bytes of a pack. It is lossy summarisation of files, per file. There is no cross-file dependency edge, no call graph, no impact analysis, and no way to ask 'who calls this'."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Which one is cheaper in tokens?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "It depends on session length. A Repomix pack is a fixed, up-front cost paid once per prompt and re-paid whenever the pack is refreshed. trace-mcp pays an up-front cost for its advertised tool schemas (~50K tokens on the current default surface, which is a known open gap) and then per-query costs that are small and scoped. On a one-shot question about a small repo, Repomix usually wins. Across a multi-turn session on a repo too large to fit in context, trace-mcp wins."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Can I use both?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes, and it is a reasonable setup. Use Repomix to hand a whole small repository or a remote third-party repository to a model in one shot, and trace-mcp for day-to-day navigation, impact analysis and refactoring inside the repo you actually work in."
+          }
+        }
+      ]
+    }
+  ]
+}
+</script>
+
+**TL;DR.** Repomix answers "put my repository into a prompt." trace-mcp answers "let the agent look things up in my repository." Repomix is a packer: it concatenates files into one artifact, optionally stripping function bodies with tree-sitter to save bytes. trace-mcp is an index: it parses the repo into a dependency graph with full-text search and serves it over MCP, so an agent asks for the outline of one file or the callers of one symbol instead of loading a snapshot of everything.
+
+If you are picking between them, the question is not "which is better" — it is **how many turns your agent spends in the same repo**.
+
+## Head-to-head
+
+| Capability | trace-mcp | Repomix |
+|---|:---:|:---:|
+| **GitHub stars** | 100 | 28.1K |
+| Model | live index (SQLite + FTS5) | one-shot pack |
+| Tree-sitter AST parsing | ✅ {{ site.data.counts.languages }} languages | ✅ `--compress` only (~20) |
+| Token-efficient symbol lookup | ✅ outlines, symbols, bundles | ❌ packs entire files |
+| Cross-file dependency graph | ✅ directed edge graph | ❌ |
+| Framework-aware edges | ✅ {{ site.data.counts.frameworks }} integrations | ❌ |
+| Call graph | ✅ bidirectional, graph-based | ❌ |
+| Impact analysis | ✅ reverse dependency traversal | ❌ |
+| Search | ✅ FTS5 + embeddings + graph | ❌ no search |
+| Refactoring tools | ✅ rename, move, signature, codemod, extract | ❌ |
+| Security scanning | ✅ OWASP Top-10, taint analysis | ✅ Secretlint (secrets only) |
+| Freshness | ✅ incremental, file-watcher, content hash | ❌ snapshot at pack time, full repack |
+| Remote repositories | ✅ multi-repo subprojects | ✅ packs remote repos directly |
+| Official MCP server | ✅ core product | ✅ `--mcp` |
+| Setup cost | index build, then instant queries | none, but re-pack on every change |
+| Works offline, no API keys | ✅ | ✅ |
+| Written in | TypeScript | TypeScript |
+
+## When to pick Repomix
+
+Honest version, and it is a real list:
+
+- **One-shot questions.** "Read this whole repo and tell me what it does" is exactly what a pack is for. No index build, no daemon, no config.
+- **Repositories you do not own.** `repomix --remote owner/name` gives you a third-party codebase in a prompt in seconds. trace-mcp can index other repos as subprojects, but that is a heavier setup for a one-time look.
+- **Small repositories that fit in context.** If the whole thing fits, a graph buys you nothing — the model already has every file.
+- **Zero-install-in-the-loop workflows.** Pasting a pack into a web chat needs no MCP client at all.
+- **Ecosystem.** Repomix is roughly 280× more popular by stars, with far more third-party recipes and integrations. That matters when you need an answer from a search engine at 2am.
+
+## When to pick trace-mcp
+
+- **The repo does not fit in context**, so a pack is either truncated or ruinously expensive.
+- **Multi-turn sessions.** A pack is a fixed cost re-paid every time it is regenerated; an index is a fixed cost paid once and amortised across every query in the session.
+- **The question is structural.** "What breaks if I change this function", "who calls this", "which route handler renders this component" — a pack contains the bytes that would answer this, but nothing that computes it. trace-mcp resolves it as one tool call over the graph.
+- **Framework semantics matter.** A graph that knows `UserController` exists but not that it renders `Users/Show.vue` via Inertia is missing the edges a developer actually reasons about. trace-mcp ships {{ site.data.counts.frameworks }} framework integrations for exactly those edges.
+- **You want the agent to change code, not just read it.** Rename across files, move a symbol, change a signature, apply an AST codemod, remove verified-dead code — Repomix has no write path.
+- **Freshness.** trace-mcp reindexes incrementally on file change. A pack is stale the moment you edit anything.
+
+## The honest caveat on token cost
+
+trace-mcp's per-query cost is small, but its *advertised* cost is not: on the current shipped default path, `tools/list` is {{ site.data.counts.tools }} tools and roughly 50K tokens, paid by every client that does not support deferred tool loading. The presets that fix this (`minimal`, `standard`, `full`) work, but are bypassed on the default daemon-backed path — that is a bug we track publicly, not a design choice. Until it lands, a short session on a small repo can genuinely cost less through Repomix. We would rather say that here than have you discover it yourself.
+
+## FAQ
+
+**Is trace-mcp a drop-in replacement for Repomix?**
+No. Repomix produces one packed file you paste or attach; trace-mcp exposes MCP tools an agent calls during a session. If your workflow is "paste my repo into a chat", Repomix is the closer fit. If your agent runs many turns against the same repo, trace-mcp replaces the pack entirely, because the agent queries the index instead of re-reading a snapshot.
+
+**Does Repomix have an MCP server?**
+Yes — an official one, via `--mcp`, including packing remote repositories. It is still packing rather than indexing: the tools return file content, not a symbol graph.
+
+**Repomix has a `--compress` flag. Isn't that the same as a code graph?**
+No. `--compress` uses tree-sitter to strip function bodies and keep signatures, cutting roughly 70% of a pack's bytes. That is lossy summarisation *per file*. There are no cross-file edges, no call graph, and no impact analysis.
+
+**Which one is cheaper in tokens?**
+It depends on session length. A pack is a fixed up-front cost, re-paid on every refresh. trace-mcp pays an up-front schema cost (see the caveat above) and then small scoped per-query costs. One-shot question on a small repo: Repomix. Multi-turn session on a repo that does not fit in context: trace-mcp.
+
+**Can I use both?**
+Yes, and it is a sensible setup — Repomix for handing a whole small or third-party repo to a model in one shot, trace-mcp for navigation, impact analysis and refactoring in the repo you work in daily.
+
+## Next steps
+
+- Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
+- The other head-to-heads: [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html)
+- [Cut Claude Code token usage](/reduce-claude-code-token-usage.html) — the measured tactics, including the ones that have nothing to do with us.
+- [Get started](/#install) — no configuration required.

--- a/docs/vs/serena.md
+++ b/docs/vs/serena.md
@@ -1,0 +1,158 @@
+---
+title: "Serena MCP Alternative: trace-mcp vs Serena for agent code navigation"
+description: "Serena drives a live language server; trace-mcp precomputes a framework-aware code graph. Head-to-head on precision, startup cost, refactoring, security and memory — plus where Serena is clearly ahead."
+updated: 2026-08-29
+---
+
+# Serena MCP alternative: trace-mcp vs Serena
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "TechArticle",
+      "headline": "Serena MCP alternative: trace-mcp vs Serena",
+      "description": "Head-to-head comparison of trace-mcp and Serena as code-navigation MCP servers for AI coding agents.",
+      "url": "https://trace-mcp.com/vs/serena.html",
+      "datePublished": "2026-08-29",
+      "dateModified": "2026-08-29",
+      "author": {
+        "@type": "Person",
+        "name": "Nikolai Vysotskyi",
+        "url": "https://github.com/nikolai-vysotskyi"
+      },
+      "publisher": {
+        "@type": "Person",
+        "name": "Nikolai Vysotskyi",
+        "url": "https://github.com/nikolai-vysotskyi"
+      },
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "https://trace-mcp.com/vs/serena.html"
+      }
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What is the core difference between Serena and trace-mcp?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Serena proxies a live language server (LSP) per request, so its answers are compiler-grade but only as broad as the language server exposes. trace-mcp precomputes a persistent graph from tree-sitter parsing, then optionally upgrades edges with LSP or offline SCIP indexes. Serena is precision-first and stateless; trace-mcp is breadth-first and persistent."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Is Serena more accurate than trace-mcp?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "For plain symbol references and renames in a language with a good language server, yes by default — LSP resolution is compiler-grade and trace-mcp's AST resolution is not. trace-mcp closes that gap only when you enable its opt-in LSP enrichment or ingest a SCIP index, which raises those edges to the lsp_resolved or scip_resolved tier. For cross-language and framework edges, no language server has the answer at all, and trace-mcp is ahead."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Does trace-mcp need a language server installed?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "No. trace-mcp works with tree-sitter alone across {{ site.data.counts.languages }} languages and needs no toolchain, no compile step and no language server. LSP enrichment is opt-in via lsp.enabled in config, and SCIP ingestion is fully offline. Serena's core premise is the opposite: no language server for your stack means no answers."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Can Serena do impact analysis or framework-aware navigation?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Not as a graph. A language server answers 'references to this symbol'; it has no notion that a controller renders a specific template via Inertia, that a route maps to a handler, or that an ORM model backs a table. trace-mcp models those as first-class edges across {{ site.data.counts.frameworks }} framework integrations and traverses them for reverse-dependency impact analysis."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Which has a lower startup cost?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Serena, on a cold repository: there is no index to build, though the language server itself still has to warm up, which on a large TypeScript or Java project is not free. trace-mcp pays a one-time index build and then serves queries from SQLite, so it is faster once warm and survives restarts."
+          }
+        }
+      ]
+    }
+  ]
+}
+</script>
+
+**TL;DR.** Serena and trace-mcp both give an agent structured code navigation instead of raw file reads, and they get there from opposite directions. Serena is a **live LSP proxy**: it asks a real language server your question, so its references and renames are compiler-grade, but its world is exactly what the language server knows. trace-mcp is a **precomputed graph**: tree-sitter parsing across {{ site.data.counts.languages }} languages into SQLite, with framework-aware edges, refactoring, security scanning and code-linked memory on top — and LSP or offline SCIP as an *optional* precision upgrade rather than a hard dependency.
+
+Pick Serena if precision on one well-supported language is the whole job. Pick trace-mcp if breadth, framework semantics, or anything beyond navigation is.
+
+## Head-to-head
+
+| Capability | trace-mcp | Serena |
+|---|:---:|:---:|
+| **GitHub stars** | 100 | ~28.5K |
+| Languages | {{ site.data.counts.languages }} (tree-sitter) | 40+ (via LSP) |
+| Requires a language server | ❌ optional enrichment | ✅ core premise |
+| Reference precision by default | AST-resolved (tiered) | compiler-grade (LSP) |
+| Compiler-grade path | ✅ opt-in LSP + offline SCIP ingestion | ✅ live LSP |
+| Framework integrations | ✅ {{ site.data.counts.frameworks }} | ❌ |
+| Cross-language edges | ✅ | ❌ |
+| Persistent graph across restarts | ✅ SQLite + FTS5 | ❌ per-session |
+| Impact analysis | ✅ reverse dependency traversal + decorator filter | ❌ |
+| Call graph | ✅ bidirectional, graph-based | partial (LSP call hierarchy) |
+| Refactoring tools | ✅ rename, move, signature, AST codemod, extract | ✅ rename, move, inline, safe-delete |
+| Live debugger | ❌ deliberately out of lane | ✅ breakpoints, variable inspection |
+| Session memory | ✅ code-linked decision graph | ✅ manual notes |
+| Security scanning | ✅ OWASP Top-10, type-aware taint | ❌ |
+| Control-flow / data-flow | ✅ CFG with basic blocks and loop back-edges | ❌ |
+| SARIF / CI output | ✅ 2.1.0, schema-validated | ❌ |
+| Multi-repo subprojects | ✅ cross-repo API linking | ❌ |
+| Graph visualization | ✅ desktop app | ❌ |
+| MCP tools advertised (default) | {{ site.data.counts.tools }} | ~55 |
+| Written in | TypeScript | Python |
+
+## When to pick Serena
+
+- **You work in one language with a first-class language server.** For Python or TypeScript, "find all references" and "rename symbol" from a real language server are correct in cases AST heuristics get wrong: overloads, re-exports, generics, dynamic dispatch through interfaces. That is a genuine precision lead, and it is on by default for Serena while it is opt-in for us.
+- **You want zero index state.** Nothing to build, nothing to invalidate, nothing on disk to go stale.
+- **You need runtime inspection.** Serena shipped a live debugger in v1.5.x — breakpoints and variable inspection driven by the agent. trace-mcp deliberately does not do this; a static graph is not the right tool for a running process, and we are not planning to chase it.
+- **Popularity.** Serena is roughly 285× larger by stars, with correspondingly more community answers and integrations.
+
+## When to pick trace-mcp
+
+- **Your stack is polyglot or unusual.** {{ site.data.counts.languages }} tree-sitter grammars beat 40+ language servers when part of your repo is Terraform, Kotlin, SQL, Dockerfiles, or a language whose LSP is a maintenance liability.
+- **The edges you care about are framework edges.** Route → handler, controller → template, model → table, component → component. No language server models these. trace-mcp ships {{ site.data.counts.frameworks }} integrations that do.
+- **You want impact analysis, not just references.** "Everything transitively affected by changing this function, filtered to route handlers" is a graph traversal; it is not an LSP request.
+- **The job goes past navigation.** Security scanning with type-aware taint pruning, quality gates, dead-code removal, AST codemods, SARIF output for CI, complexity and churn hotspots — Serena's scope stops well before these.
+- **Memory should survive the session and be tied to code.** Serena's memories are notes the agent writes. trace-mcp's decisions are linked to symbol IDs, verified as non-stale at recall time, and surface inside `get_change_impact`.
+
+## Where we are not being smug
+
+Two honest points.
+
+First, **we have not read Serena's source**. Serena is the largest peer we have never profiled beyond its README, and it is the current priority for our next competitor deep-dive. The table above is built from its public documentation. If you maintain Serena and something is wrong, [open an issue](https://github.com/nikolai-vysotskyi/trace-mcp/issues) and we will fix it.
+
+Second, **our default tool surface is expensive.** trace-mcp advertises {{ site.data.counts.tools }} tools, roughly 50K tokens, on the shipped default path; Serena's ~55 is materially cheaper to have sitting in a context window. Our preset mechanism (`minimal` / `standard` / `full`) exists and works, but is bypassed on the daemon-backed default — a tracked bug, not a design position.
+
+## FAQ
+
+**What is the core difference between Serena and trace-mcp?**
+Serena proxies a live language server per request: compiler-grade, but only as broad as the language server. trace-mcp precomputes a persistent graph from tree-sitter, then optionally upgrades edges with LSP or offline SCIP. Precision-first and stateless versus breadth-first and persistent.
+
+**Is Serena more accurate than trace-mcp?**
+For plain references and renames in a well-served language, yes by default. trace-mcp closes that gap only with opt-in LSP enrichment or a SCIP index, which raise edges to the `lsp_resolved` / `scip_resolved` tier. For cross-language and framework edges, no language server has the answer at all.
+
+**Does trace-mcp need a language server installed?**
+No. tree-sitter alone covers {{ site.data.counts.languages }} languages with no toolchain and no compile step. LSP is opt-in; SCIP ingestion is offline. Serena's premise is the opposite — no language server for your stack means no answers.
+
+**Can Serena do impact analysis or framework-aware navigation?**
+Not as a graph. "References to this symbol" is an LSP request; "this controller renders that template via Inertia" is not something a language server models.
+
+**Which has a lower startup cost?**
+Serena on a cold repo — no index build, though the language server still has to warm up, which on a large TypeScript or Java project is not free. trace-mcp pays a one-time index build, then serves from SQLite and survives restarts.
+
+## Next steps
+
+- Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html)
+- [Architecture](/architecture.html) — how the indexing pipeline, storage and LSP enrichment fit together.
+- [Get started](/#install) — no configuration required.

--- a/scripts/gen-sitemap.mjs
+++ b/scripts/gen-sitemap.mjs
@@ -29,8 +29,27 @@ export function gitDate(file) {
     cwd: join(DOCS, '..'),
     encoding: 'utf-8',
   }).trim();
-  if (!out) throw new Error(`no git history for docs/${file}`);
+  // A page added in the working tree has no commit yet — date it today rather
+  // than throwing, so `pnpm docs:sitemap` can be run before the first commit.
+  if (!out) return new Date().toISOString().slice(0, 10);
   return out;
+}
+
+/**
+ * Mirror the same date into the page's `updated:` front matter, which
+ * _layouts/default.html renders as a reader-visible "Last updated" line.
+ * Same source, one command, so the visible date can't drift from <lastmod>.
+ */
+export function stampUpdated(file, date) {
+  if (!file.endsWith('.md')) return;
+  const path = join(DOCS, file);
+  const raw = readFileSync(path, 'utf-8');
+  const fm = raw.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!fm) throw new Error(`docs/${file} has no front matter to stamp`);
+  const body = /^updated:.*$/m.test(fm[1])
+    ? fm[1].replace(/^updated:.*$/m, `updated: ${date}`)
+    : `${fm[1]}\nupdated: ${date}`;
+  writeFileSync(path, `---\n${body}\n---\n${raw.slice(fm[0].length)}`);
 }
 
 /** A shallow clone dates every file to the one fetched commit — gitDate is meaningless there. */
@@ -51,7 +70,16 @@ export function rewrite(xml) {
   );
 }
 
+/** Every source page referenced by the sitemap. */
+export function sitemapSources(xml) {
+  return [...xml.matchAll(/<loc>https:\/\/trace-mcp\.com([^<]*)<\/loc>/g)].map((m) =>
+    sourceFor(m[1]),
+  );
+}
+
 if (process.argv[1] === import.meta.filename) {
-  writeFileSync(SITEMAP, rewrite(readFileSync(SITEMAP, 'utf-8')));
-  console.log('docs/sitemap.xml lastmod refreshed from git');
+  const xml = readFileSync(SITEMAP, 'utf-8');
+  writeFileSync(SITEMAP, rewrite(xml));
+  for (const source of sitemapSources(xml)) stampUpdated(source, gitDate(source));
+  console.log('docs/sitemap.xml lastmod + page `updated:` front matter refreshed from git');
 }

--- a/tests/docs/page-dates.test.ts
+++ b/tests/docs/page-dates.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Reader-visible date guard (TRA-351).
+ *
+ * Every page that outranks trace-mcp.com for the queries we target shows a
+ * publication or update date to the reader. Ours carried one only inside the
+ * TechArticle JSON-LD, which nobody sees. The layout now renders `updated:`
+ * from front matter, and `pnpm docs:sitemap` stamps it from the same git date
+ * it writes into <lastmod> — this test fails if a page loses the key or the
+ * two dates drift apart, which is exactly how the hand-maintained <lastmod>
+ * values all went stale before TRA-262.
+ */
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const DOCS = join(REPO_ROOT, 'docs');
+
+function sitemapEntries(): Array<{ path: string; lastmod: string }> {
+  const xml = readFileSync(join(DOCS, 'sitemap.xml'), 'utf-8');
+  return [
+    ...xml.matchAll(/<loc>https:\/\/trace-mcp\.com([^<]*)<\/loc>\s*<lastmod>([^<]*)<\/lastmod>/g),
+  ].map(([, path, lastmod]) => ({ path, lastmod }));
+}
+
+function frontMatterUpdated(source: string): string | null {
+  const raw = readFileSync(join(DOCS, source), 'utf-8');
+  const fm = raw.match(/^---\n([\s\S]*?)\n---\n/);
+  return fm?.[1].match(/^updated:\s*(\S+)\s*$/m)?.[1] ?? null;
+}
+
+describe('docs pages show a reader-visible date', () => {
+  // docs/index.html is a hand-written static file with no front matter, so the
+  // layout never runs for it — it carries its own dates in its own <head>.
+  const markdownPages = sitemapEntries().filter((e) => e.path.endsWith('.html'));
+
+  it('every markdown page in the sitemap has an `updated:` front-matter key', () => {
+    const missing = markdownPages
+      .map((e) => e.path.replace(/^\//, '').replace(/\.html$/, '.md'))
+      .filter((source) => frontMatterUpdated(source) === null);
+    expect(
+      missing,
+      `pages with no \`updated:\` front matter — run \`pnpm docs:sitemap\`: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it("`updated:` matches the page's <lastmod> in sitemap.xml", () => {
+    const drifted = markdownPages
+      .map((e) => ({
+        source: e.path.replace(/^\//, '').replace(/\.html$/, '.md'),
+        lastmod: e.lastmod,
+      }))
+      .map((e) => ({ ...e, updated: frontMatterUpdated(e.source) }))
+      .filter((e) => e.updated !== null && e.updated !== e.lastmod);
+    expect(
+      drifted,
+      `visible date disagrees with sitemap <lastmod> — run \`pnpm docs:sitemap\`: ${drifted
+        .map((e) => `${e.source} (${e.updated} vs ${e.lastmod})`)
+        .join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('the layout renders the date from front matter', () => {
+    const layout = readFileSync(join(DOCS, '_layouts', 'default.html'), 'utf-8');
+    expect(layout).toMatch(/page\.updated/);
+  });
+});

--- a/tests/docs/preset-claims.test.ts
+++ b/tests/docs/preset-claims.test.ts
@@ -24,7 +24,12 @@ function servedCount(preset: string): number {
 // comparisons.md stated its own preset sizes (`minimal` 24, `standard` 55) and
 // drifted for exactly as long as it was outside this list (TRA-263). Its claims
 // were reworded into the `<preset>` (N tools) shape so they land in scope here.
-const DOCS = ['docs/configuration.md', 'docs/llms-full.txt', 'docs/comparisons.md'];
+const DOCS = [
+  'docs/configuration.md',
+  'docs/llms-full.txt',
+  'docs/comparisons.md',
+  'docs/reduce-claude-code-token-usage.md',
+];
 const PRESETS = ['standard', 'minimal', 'review', 'architecture'];
 
 describe('documented tool-preset sizes', () => {


### PR DESCRIPTION
Closes TRA-351.

## Problem

GSC (2026-07-30 → 2026-08-29, `sc-domain:trace-mcp.com`) returns 10 queries, all of them the brand, a misspelling of it, or a navigational query for a *different* product we accidentally intercept. Zero non-branded informational or commercial queries. All 56 clicks and 526 impressions land on `/`; all 12 docs pages sit at **0 impressions**.

Technical SEO is clean — this is a page-inventory problem. Every docs title is brand-first (`trace-mcp Configuration Reference…`), which nobody searches who hasn't heard of us, and the single non-branded page (`comparisons.html`) tries to cover 20+ competitors in 4,397 words.

## What this does

**1. Per-competitor `/vs/` pages** — the "X alternative" query class is a demonstrated SERP format (G2, AlternativeTo rank for it) and the closest-to-purchase query class in this niche. Three pages, built by *restructuring* content `comparisons.md` already owned rather than writing new research:

- `/vs/repomix.html` — "repomix alternative"
- `/vs/serena.html` — "serena mcp alternative"
- `/vs/codebase-memory-mcp.html` — "codebase memory mcp alternative"

Each: focused head-to-head table, an honest "when to pick theirs" section (reused from the existing *Honest assessment: where competitors lead*), a 5-question FAQ with `FAQPage` schema, `TechArticle` schema, and links both ways with the `comparisons.html` hub.

The honesty is not decorative — each page names where the competitor beats us, including our ~50K-token advertised tool surface against codebase-memory-mcp's ~7K, and that we have never read Serena's source.

**2. Reader-visible dates on every docs page.** The dates existed only inside the `TechArticle` JSON-LD, which a reader never sees; every page outranking us shows one. The layout now renders an `updated:` front-matter key, and `pnpm docs:sitemap` stamps it from the same git date it writes into `<lastmod>` — so the visible date can't drift from the sitemap the way the hand-maintained values did before TRA-262.

**3. One top-of-funnel page** — `/reduce-claude-code-token-usage.html`, targeting the query class where `claude.com/blog` and several tutorials rank and we are absent. Seven tactics ordered by measured impact; the reproducible numbers come from `scripts/bench-toon.ts`, and the homepage's "~40–50%" is explicitly labelled as our own aggregate rather than a benchmark.

`llms.txt` / `llms-full.txt` and `docs_nav.yml` / `sitemap.xml` updated to match.

## Test evidence

- `pnpm test` — 8894 passed, 9 skipped, 812 files. New: `tests/docs/page-dates.test.ts` (3 tests) guards the `updated:` key, its agreement with `<lastmod>`, and the layout hook. `tests/docs/preset-claims.test.ts` extended to cover the new page's `minimal` (24) / `standard` (59) preset numbers against the real tool filter.
- `pnpm run lint` (tsc --noEmit) clean; `biome check` clean.
- All JSON-LD blocks validated as parseable JSON after Liquid substitution.

## Caveat carried over from the issue

DataForSEO is not attached to this runtime, so there are **no keyword volume or difficulty numbers** behind these three `/vs/` targets — the ranking is derived from observed SERP structure and commercial intent. Items 1 and 2 are worth doing regardless since they restructure content we already have; item 3 is the only net-new writing.

Acceptance criteria (90 days: at least one non-branded query with impressions in GSC) will be reported on TRA-351.

Agent: Lead Engineer (Multica)
