### PR TITLE
fix(app): put the Workspace toolbar's + Add on the row's type and icon scale (TRA-355)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -464,11 +464,19 @@ Not a pass at the end. These are floors.
 - **`contrastTable()` / `contrastFailures()`** — WCAG contrast for every text token
   against `--surface` and `--surface-sunken` in both appearances, plus `--on-accent` on
   `--accent-fill`. Any pair under 4.5:1 fails the build.
-- **`tokenGuard()`** — scans the renderer for raw hex and Tailwind greys. It is
-  **baselined** in `scripts/token-guard.baseline.json`: pre-existing violations are
-  recorded per file and only an **increase** fails. Every surface migration lowers a
-  number; nobody may raise one. If your change drops a file below its baseline, the
-  script tells you to lower it — do.
+- **`tokenGuard()`** — scans the renderer for raw hex, raw `rgb()`/`rgba()`, and Tailwind
+  greys. It is **baselined** in `scripts/token-guard.baseline.json`: pre-existing
+  violations are recorded per file and only an **increase** fails. Every surface migration
+  lowers a number; nobody may raise one. If your change drops a file below its baseline,
+  the script tells you to lower it — do.
+
+  `rgb()` was added in TRA-355. §8 rule 1 had named it since the revision, but the guard
+  only ever counted hex, so two thirds of the rule was enforced and one third was a
+  comment. The Workspace toolbar shipped an `inset 1px 0 0 rgb(255 255 255 / 0.25)`
+  divider with a green build, and the sidebar kept a `rgba(255, 255, 255, 0.85)` label on
+  `--accent-fill` that measured 4.22:1 light / 3.89:1 dark. When you want "this token at
+  some alpha", write `color-mix(in oklab, var(--token) N%, transparent)` — a numeric
+  channel is how a value escapes the contrast table.
 
 `lattice/ui/__tests__/primitives.test.tsx` asserts the height set, the ≥24px boxes, the
 radius set, and ≥4.5:1 contrast for all seven badge tones in both appearances.
@@ -587,6 +595,8 @@ new evidence.
 | A loading sentence goes in chrome that is **already** on screen, never a new layer over the content | Graph Explorer put "Building graph…" and a 45% scrim across the whole 1044×760 pane on every re-load, landing on top of the node labels underneath. The stats pill was already in the corner; it says it there, and the graph stays readable. Only a pane with nothing drawn in it yet gets an `EmptyState`. |
 | An error the user is meant to act on is never on a timer | Graph Explorer's red toast erased itself after 7s and left a blank pane with no account of what happened. An error persists until it is retried or resolved, and carries the glyph, the sentence and the Retry together. |
 | A primitive's verified contrast is verified against `--surface`, so re-check it on glass | `Badge tone="red"` clears AA over an opaque surface; over the graph overlay's `--viz-glass` its backdrop composites to 253, and the pair had to be re-measured on the running renderer (4.75:1) rather than assumed from the primitive's own test. |
+| A hand-rolled control still sits on the type and icon scale of the row it lives in | `+ Add` is a split capsule because `Button` has one radius, and that is fine — but it also inherited an 11px label and a `⌄` text character while every regular-tier control beside it labelled at 13px with real icons. The row's one prominent action was the quietest thing on it. Escaping a primitive's *shape* is not licence to escape its *scale*. |
+| A rule the enforcement cannot see is a comment | §8 rule 1 named `rgb()` from day one and `tokenGuard()` never counted it, so the ban held for hex and lapsed for `rgb()` — which is how a 3.89:1 label sat on the sidebar with a green build. When a rule goes into §8, check the script actually implements all of it. |
 | A row label never repeats its own control's verb | "Temporary pause" beside a "Pause for 10 minutes" button wrapped to two lines at the 640px minimum and added no meaning. The label names the subject ("Enforcement"), the control names the action. |
 
 ---
@@ -626,5 +636,21 @@ What still carries raw colour, and why:
 | `styles/island.css` | 36 | The file-tree / graph **domain palette** (`--folder-*`, `--db-*`, `--mod-text`, `--ignored-*`, glass tints). It has hand-picked light *and* dark branches, so it is a deliberate exception, not drift. |
 | `lattice/icons.tsx` | 1 | `AgentMark`'s brand purple — artwork, not chrome. |
 | `lattice/ui/Badge.tsx` | 2 | Two hex in a comment recording what the primitive replaced. |
+
+Counts in that table are what `tokenGuard()` reports, so `island.css` and
+`GraphExplorerGPU.tsx` roughly doubled in TRA-355 when the guard started counting `rgb()`
+as well as hex (§9). The files did not change; the guard's eyesight did.
+
+The same change made eight smaller sites visible, all of them **compositing values rather
+than palette** — a modal scrim (`app.css`, `ProjectStatsModal.tsx`, `MemoryExplorer.tsx`,
+`ToolActivity.tsx`), or the black at low alpha inside a shadow (`controls.css`,
+`Settings.tsx`). A scrim is not a colour a token names, so they are baselined where they
+are rather than tokenised for the sake of the count.
+
+Two were **not** compositing, and were fixed in the same pass:
+`workspace/AddProjectControl.tsx`'s split-button divider (raw white → `color-mix` over
+`--on-accent`) and `styles/sidebar.css` (a dimmed white on the selected row, plus two dead
+`var(--fill-tertiary, rgba(…))` fallbacks of the kind the decision log already calls a
+bug). Both files are now absent from the baseline entirely.
 
 Nothing else in the renderer paints a colour the contrast table cannot see.

--- a/packages/app/scripts/design-tokens.mjs
+++ b/packages/app/scripts/design-tokens.mjs
@@ -2,7 +2,7 @@
    Two independent checks, both usable from CI and from vitest:
 
      contrastTable()  — WCAG contrast of every text token in both appearances
-     tokenGuard()     — no NEW raw hex / text-gray-* / bg-slate-* in the renderer
+     tokenGuard()     — no NEW raw hex / rgb() / text-gray-* / bg-slate-* in the renderer
 
    tokenGuard is baselined (token-guard.baseline.json): the pre-existing
    violations are recorded per file, and only an INCREASE fails. Each surface
@@ -121,6 +121,11 @@ export function contrastFailures(rows = contrastTable()) {
 const SCAN_EXT = /\.(css|ts|tsx|js|jsx|html)$/;
 /* A hex colour anywhere outside tokens.css. */
 const RAW_HEX = /#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?\b/g;
+/* A literal rgb()/rgba(). DESIGN.md §8 rule 1 names it alongside hex, but the
+   guard only ever counted hex — so `rgb(255 255 255 / 0.25)` shipped to the
+   Workspace toolbar with a green build (TRA-355). `color-mix()` over a token is
+   the way to say "this token at some alpha"; a numeric channel is not. */
+const RAW_RGB = /\brgba?\(\s*[0-9]/g;
 /* Tailwind's own greys — the palette we are replacing. */
 const GREY_CLASS = /\b(?:text|bg|border|fill|stroke|ring|divide|from|to|via)-(?:gray|grey|slate|zinc|neutral|stone)-\d{2,3}\b/g;
 
@@ -142,7 +147,10 @@ export function tokenGuardCounts() {
     /* Tests assert ON colour values; they are not UI. */
     if (rel.includes('/__tests__/')) continue;
     const src = readFileSync(file, 'utf8');
-    const n = (src.match(RAW_HEX)?.length ?? 0) + (src.match(GREY_CLASS)?.length ?? 0);
+    const n =
+      (src.match(RAW_HEX)?.length ?? 0) +
+      (src.match(GREY_CLASS)?.length ?? 0) +
+      (src.match(RAW_RGB)?.length ?? 0);
     if (n > 0) counts[rel] = n;
   }
   return counts;

--- a/packages/app/scripts/token-guard.baseline.json
+++ b/packages/app/scripts/token-guard.baseline.json
@@ -1,6 +1,12 @@
 {
+  "src/renderer/app.css": 1,
+  "src/renderer/components/ProjectStatsModal.tsx": 2,
   "src/renderer/lattice/icons.tsx": 1,
   "src/renderer/lattice/ui/Badge.tsx": 2,
-  "src/renderer/styles/island.css": 36,
-  "src/renderer/tabs/GraphExplorerGPU.tsx": 46
+  "src/renderer/styles/controls.css": 1,
+  "src/renderer/styles/island.css": 71,
+  "src/renderer/tabs/GraphExplorerGPU.tsx": 95,
+  "src/renderer/tabs/MemoryExplorer.tsx": 1,
+  "src/renderer/tabs/Settings.tsx": 2,
+  "src/renderer/tabs/ToolActivity.tsx": 1
 }

--- a/packages/app/src/renderer/styles/__tests__/tokens.test.ts
+++ b/packages/app/src/renderer/styles/__tests__/tokens.test.ts
@@ -2,7 +2,13 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 // @ts-expect-error — plain .mjs helper, shared with the CLI check (TRA-289)
-import { contrast, contrastFailures, contrastTable, tokenGuard } from '../../../../scripts/design-tokens.mjs';
+import {
+  contrast,
+  contrastFailures,
+  contrastTable,
+  tokenGuard,
+  tokenGuardCounts,
+} from '../../../../scripts/design-tokens.mjs';
 
 const tokensCss = readFileSync(
   fileURLToPath(new URL('../tokens.css', import.meta.url)),
@@ -32,9 +38,35 @@ describe('design tokens', () => {
     expect(tokensCss).not.toContain('Inter');
   });
 
-  it('adds no raw hex or Tailwind grey beyond the recorded baseline', () => {
+  it('adds no raw hex, rgb() or Tailwind grey beyond the recorded baseline', () => {
     const { violations } = tokenGuard();
     expect(violations).toEqual([]);
+  });
+
+  /* TRA-355. DESIGN.md §8 rule 1 bans a raw `rgb()` by name, but the guard only
+     ever counted hex and Tailwind greys — so the Workspace toolbar shipped an
+     `inset 1px 0 0 rgb(255 255 255 / 0.25)` divider with a green build. These
+     two files were the renderer's only palette-carrying rgb() outside the three
+     exceptions recorded in DESIGN.md §12; if either reappears in the counts,
+     something painted a channel instead of asking for a token. */
+  it('counts a raw rgb() as a token violation, not just hex', () => {
+    const counts = tokenGuardCounts();
+    expect(counts['src/renderer/styles/sidebar.css']).toBeUndefined();
+    expect(counts['src/renderer/workspace/AddProjectControl.tsx']).toBeUndefined();
+  });
+
+  /* Dimming a label to signal "secondary" needs surface headroom, and a filled
+     accent row has none — the same call the decision log already made for the
+     shortcut hint. White at .85 on --accent-fill measured 4.22:1 light and
+     3.89:1 dark, and the count is a number the user reads. */
+  it('paints the selected sidebar row icon and count at full --on-accent', () => {
+    const sidebarCss = readFileSync(
+      fileURLToPath(new URL('../sidebar.css', import.meta.url)),
+      'utf8',
+    );
+    expect(sidebarCss).toMatch(
+      /\.ws-sidebar:focus-within[^{]*\.ws-sb-count\s*\{[^}]*color:\s*var\(--on-accent\)/,
+    );
   });
 
   /* TRA-344. --label-tertiary is decoration only (1.88:1 light / 2.53:1 dark,

--- a/packages/app/src/renderer/styles/sidebar.css
+++ b/packages/app/src/renderer/styles/sidebar.css
@@ -132,16 +132,20 @@
 /* Selected: accent fill when the sidebar owns focus, neutral fill when not —
    the standard macOS "active vs inactive selection" pair. */
 .ws-sb-row.is-selected {
-  background: var(--fill-tertiary, rgba(120, 120, 128, 0.24));
+  background: var(--fill-tertiary);
   font-weight: 500;
 }
 .ws-sidebar:focus-within .ws-sb-row.is-selected {
   background: var(--accent-fill);
   color: var(--on-accent);
 }
+/* Full --on-accent, not a dimmed white: on a filled accent row there is no
+   headroom to spend on dimming. White at .85 measured 4.22:1 light / 3.89:1
+   dark and failed AA for the count, which is a number the user reads; full
+   --on-accent is 5.22:1 / 4.77:1. Same decision as the shortcut hint. */
 .ws-sidebar:focus-within .ws-sb-row.is-selected .ws-sb-ico,
 .ws-sidebar:focus-within .ws-sb-row.is-selected .ws-sb-count {
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--on-accent);
 }
 
 /* Trailing affordance revealed on hover (remove-from-recents). */
@@ -164,7 +168,7 @@
   opacity: 1;
 }
 .ws-sb-row .ws-sb-trailing:hover {
-  background: var(--fill-tertiary, rgba(120, 120, 128, 0.24));
+  background: var(--fill-tertiary);
 }
 
 /* ---- Sidebar footer ----------------------------------------------------- */

--- a/packages/app/src/renderer/workspace/AddProjectControl.tsx
+++ b/packages/app/src/renderer/workspace/AddProjectControl.tsx
@@ -163,7 +163,11 @@ export function AddProjectControl({ onAdd, variant = 'compact' }: AddProjectCont
           type="button"
           disabled={adding}
           onClick={() => void handlePickFolder()}
-          className="h-6 px-2 text-[11px] font-medium transition-opacity disabled:opacity-40"
+          // 13px, not 11: this is a 24px control, and every other regular-tier
+          // control on this row (Filter, the search field) labels at 13px. The
+          // row's one prominent action was reading two steps quieter than the
+          // secondary button beside it.
+          className="h-6 px-2 text-[13px] font-medium transition-opacity disabled:opacity-40"
           style={{
             // --accent-fill, not --accent: a white label on --accent measures
             // 3.65:1 in dark. Split radii, so this cannot be a Button capsule.
@@ -181,16 +185,20 @@ export function AddProjectControl({ onAdd, variant = 'compact' }: AddProjectCont
           aria-label="Add a project by path"
           aria-expanded={showPathInput}
           onClick={() => setShowPathInput((v) => !v)}
-          className="h-6 w-6 inline-flex items-center justify-center text-[11px] transition-opacity disabled:opacity-40"
+          className="h-6 w-6 inline-flex items-center justify-center transition-opacity disabled:opacity-40"
           style={{
             background: 'var(--accent-fill)',
             color: 'var(--on-accent)',
             borderRadius: '0 999px 999px 0',
-            boxShadow: 'inset 1px 0 0 rgb(255 255 255 / 0.25)',
+            // The divider is the label colour at low alpha, not a raw white:
+            // on --accent-fill only --on-accent is a verified pair.
+            boxShadow: 'inset 1px 0 0 color-mix(in oklab, var(--on-accent) 25%, transparent)',
           }}
           title="Enter path manually"
         >
-          <span aria-hidden="true">⌄</span>
+          {/* An icon, not the text character ⌄ — a font glyph cannot hold a
+              1.5px stroke next to the real icons on this row. */}
+          <Icon name="expand_more" size={14} />
         </button>
         {showPathInput && (
           // A popover under the chevron — the toolbar row must not grow a


### PR DESCRIPTION
On the Workspace toolbar — the app's main screen — the primary action carried the smallest
label on the row. Measured on the running renderer, both appearances:

| Control | Before | After |
|---|---|---|
| Search field | 13px | 13px |
| `Filter` (`lx-btn sz-regular`) | 13px / 500 | 13px / 500 |
| `Table` / `Compact` | 12px | 12px |
| **`+ Add`** | **11px / 500** | **13px / 500** |
| chevron | `⌄` U+2304 text char @ 11px | `Icon name="expand_more"` @ 14px |

`+ Add` is a 24px control — the regular tier — and every other regular-tier control on that
row labels at 13px. 11px is the Caption step in `DESIGN.md` §3, not a control label. The
split radii are still why this isn't a `Button` capsule (that comment stays); escaping the
primitive's *shape* was never licence to escape its *scale*.

### Why CI didn't catch the raw colour in the same file

`DESIGN.md` §8 rule 1 has banned a raw `rgb()` by name since the revision, but
`tokenGuard()` counted `RAW_HEX` and `GREY_CLASS` only — two thirds of the rule enforced,
one third a comment. So this shipped green:

- `AddProjectControl.tsx` — `boxShadow: 'inset 1px 0 0 rgb(255 255 255 / 0.25)'`
- `sidebar.css` — `color: rgba(255, 255, 255, 0.85)` on the selected row's icon and count,
  over `--accent-fill`. **4.22:1 light / 3.89:1 dark — an AA failure for the count, which
  is a number the user reads.** Full `--on-accent` is 5.22:1 / 4.77:1. This is the same
  call the decision log already made for the shortcut hint ("dimming a label to signal
  secondary only works over a surface with headroom; on a filled accent row there is
  none"), just one selector over. Two dead `var(--fill-tertiary, rgba(…))` fallbacks —
  the pattern the log calls "a bug, not a safety net" — went with it.

The guard now counts `rgb()`/`rgba()` too. Re-baselining makes eight more sites visible;
every one is a modal scrim or the black inside a shadow — compositing values, not palette
— so they are baselined where they are rather than tokenised for the sake of the count.
`sidebar.css` and `AddProjectControl.tsx` leave the baseline entirely.

### Verification

Screenshots and computed styles off the running renderer, not off the diff:

- Light and dark, before and after.
- Increase Contrast and Reduce Transparency: label stays 13px `--on-accent` on
  `--accent-fill`.
- 640×420 window minimum: the chevron's right edge lands at x=592 of 640, bottom inside
  the window — the row still fits unclipped with the view toggle hidden.
- Sidebar selected row, focused, both appearances: icon now computes to
  `rgb(255, 255, 255)` (full `--on-accent`) instead of white at .85. The `.ws-sb-count`
  element isn't rendered in the states reachable here, but it shares the one declaration
  block with the icon and is covered by a CSS assertion in the test.

`node packages/app/scripts/design-tokens.mjs` exits 0; 298 tests, typecheck and build
green. Two regression tests added: the guard must report neither cleaned file in its
counts, and the selected sidebar row must resolve to full `--on-accent`.

`DESIGN.md` updated in the same PR — §9 (the guard now counts `rgb()`, and why),
§12 (the raw-colour table's counts moved because the guard's eyesight changed, not the
files), and two decision-log lines.

Closes TRA-355.
