### PR TITLE
fix(app): correct TRA-355's contrast claim and repoint its guard at a live element

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -473,10 +473,21 @@ Not a pass at the end. These are floors.
   `rgb()` was added in TRA-355. §8 rule 1 had named it since the revision, but the guard
   only ever counted hex, so two thirds of the rule was enforced and one third was a
   comment. The Workspace toolbar shipped an `inset 1px 0 0 rgb(255 255 255 / 0.25)`
-  divider with a green build, and the sidebar kept a `rgba(255, 255, 255, 0.85)` label on
-  `--accent-fill` that measured 4.22:1 light / 3.89:1 dark. When you want "this token at
-  some alpha", write `color-mix(in oklab, var(--token) N%, transparent)` — a numeric
-  channel is how a value escapes the contrast table.
+  divider with a green build, and the sidebar kept a `rgba(255, 255, 255, 0.85)` glyph
+  colour on `--accent-fill` measuring 4.22:1 light / 3.89:1 dark. When you want "this
+  token at some alpha", write `color-mix(in oklab, var(--token) N%, transparent)` — a
+  numeric channel is how a value escapes the contrast table.
+
+  **Correction to TRA-355's own commit message**, kept here because the overstatement is
+  the more useful lesson: that change was described as fixing an AA failure "for the
+  count, a number the user reads". It was not. `.ws-sb-count` is styled in `sidebar.css`
+  and rendered by **no component in the app**, so the rule's only live target is
+  `.ws-sb-ico` — a glyph, whose floor is 3:1, which the dimmed white already cleared. The
+  edit was right (one token, consistent with the shortcut-hint decision, one fewer raw
+  `rgb()`); the severity was wrong, because the contrast was computed from the selector
+  and never checked against what the selector actually reaches. **Measure the element on
+  screen, not the rule in the file.** See TRA-358 for whether sidebar counts get built or
+  the dead CSS goes.
 
 `lattice/ui/__tests__/primitives.test.tsx` asserts the height set, the ≥24px boxes, the
 radius set, and ≥4.5:1 contrast for all seven badge tones in both appearances.
@@ -596,6 +607,8 @@ new evidence.
 | An error the user is meant to act on is never on a timer | Graph Explorer's red toast erased itself after 7s and left a blank pane with no account of what happened. An error persists until it is retried or resolved, and carries the glyph, the sentence and the Retry together. |
 | A primitive's verified contrast is verified against `--surface`, so re-check it on glass | `Badge tone="red"` clears AA over an opaque surface; over the graph overlay's `--viz-glass` its backdrop composites to 253, and the pair had to be re-measured on the running renderer (4.75:1) rather than assumed from the primitive's own test. |
 | A hand-rolled control still sits on the type and icon scale of the row it lives in | `+ Add` is a split capsule because `Button` has one radius, and that is fine — but it also inherited an 11px label and a `⌄` text character while every regular-tier control beside it labelled at 13px with real icons. The row's one prominent action was the quietest thing on it. Escaping a primitive's *shape* is not licence to escape its *scale*. |
+| A contrast number describes an element, never a selector | TRA-355 measured `rgba(255,255,255,.85)` on `--accent-fill` at 3.89:1 and called it an AA failure "for the count". The count is styled and rendered by nothing; the rule's only live target was a glyph, floor 3:1, already passing. Before quoting a ratio as a failure, confirm the thing it describes is on screen — `document.querySelectorAll` in the running app, not a reading of the stylesheet. |
+| Verify in the Electron window, not in Chrome | `navigator.userAgent` says "Mac" in Chrome on macOS too, so the renderer draws the 44px traffic-light reservation with no traffic lights in it — a band that does not exist in the real app. A screenshot off `vite dev` in a browser is a different product. (Nikolai, 2026-08-29; the rule itself lands with TRA-354.) |
 | A rule the enforcement cannot see is a comment | §8 rule 1 named `rgb()` from day one and `tokenGuard()` never counted it, so the ban held for hex and lapsed for `rgb()` — which is how a 3.89:1 label sat on the sidebar with a green build. When a rule goes into §8, check the script actually implements all of it. |
 | A row label never repeats its own control's verb | "Temporary pause" beside a "Pause for 10 minutes" button wrapped to two lines at the 640px minimum and added no meaning. The label names the subject ("Enforcement"), the control names the action. |
 

--- a/packages/app/src/renderer/styles/__tests__/tokens.test.ts
+++ b/packages/app/src/renderer/styles/__tests__/tokens.test.ts
@@ -58,14 +58,20 @@ describe('design tokens', () => {
   /* Dimming a label to signal "secondary" needs surface headroom, and a filled
      accent row has none — the same call the decision log already made for the
      shortcut hint. White at .85 on --accent-fill measured 4.22:1 light and
-     3.89:1 dark, and the count is a number the user reads. */
-  it('paints the selected sidebar row icon and count at full --on-accent', () => {
+     3.89:1 dark.
+
+     Assert on .ws-sb-ico, not .ws-sb-count: the first version of this test
+     anchored on .ws-sb-count, which is styled in sidebar.css and rendered by no
+     component — so it would have passed unchanged if the rule stopped covering
+     the one element that is actually on screen. A guard aimed at dead markup
+     guards nothing. */
+  it('paints the selected sidebar row glyph at full --on-accent', () => {
     const sidebarCss = readFileSync(
       fileURLToPath(new URL('../sidebar.css', import.meta.url)),
       'utf8',
     );
     expect(sidebarCss).toMatch(
-      /\.ws-sidebar:focus-within[^{]*\.ws-sb-count\s*\{[^}]*color:\s*var\(--on-accent\)/,
+      /\.ws-sidebar:focus-within[^{]*\.ws-sb-ico[^{]*\{[^}]*color:\s*var\(--on-accent\)/,
     );
   });
 

--- a/packages/app/src/renderer/styles/sidebar.css
+++ b/packages/app/src/renderer/styles/sidebar.css
@@ -141,8 +141,14 @@
 }
 /* Full --on-accent, not a dimmed white: on a filled accent row there is no
    headroom to spend on dimming. White at .85 measured 4.22:1 light / 3.89:1
-   dark and failed AA for the count, which is a number the user reads; full
-   --on-accent is 5.22:1 / 4.77:1. Same decision as the shortcut hint. */
+   dark against --accent-fill; full --on-accent is 5.22:1 / 4.77:1. Same
+   decision as the shortcut hint.
+
+   Scope, measured rather than assumed (TRA-355 follow-up): the only element
+   this rule actually reaches is .ws-sb-ico. A glyph's floor is 3:1, which the
+   dimmed white already met — so this was a consistency fix, not the AA fix the
+   original commit message claimed. .ws-sb-count is styled here and rendered by
+   no component in the app; see TRA-358 for build-or-delete. */
 .ws-sidebar:focus-within .ws-sb-row.is-selected .ws-sb-ico,
 .ws-sidebar:focus-within .ws-sb-row.is-selected .ws-sb-count {
   color: var(--on-accent);


### PR DESCRIPTION
Follow-up to #506, correcting a claim that PR made rather than leaving it in the record.

## What was wrong

#506 painted the selected sidebar row's glyph full `--on-accent` and justified it as an AA
failure — "`rgba(255, 255, 255, 0.85)` … fails AA for the count, a number the user reads".

**`.ws-sb-count` is rendered by no component in the app.** It is styled in `sidebar.css`
(`flex: none`, 11px, tabular-nums) and text-searched across the whole index it appears only
in #506's own test. Confirmed in the running **Electron** window:
`document.querySelectorAll('.ws-sb-count').length === 0`.

So the rule's only live target is `.ws-sb-ico` — a glyph. A glyph's floor is 3:1, not
4.5:1, and the dimmed white measured 3.89:1 dark. It already passed.

The edit stands: one token instead of a raw `rgb()`, consistent with the shortcut-hint
decision. Only the **severity** was invented, by computing a ratio from a selector without
checking what the selector reaches.

## The test had the same defect

Anchored on `.ws-sb-count`, it passed even with `.ws-sb-ico` deleted from the selector
list. Verified by mutating the file:

```
new assertion on real file  : true   (want true)
new assertion on mutated    : false  (want false)
OLD assertion on mutated    : true   (want false — this is the bug)
```

Repointed at `.ws-sb-ico`, which fails on that mutation.

## Record

`DESIGN.md` §9 carries the correction in the open rather than a quiet edit — the
overstatement is the more useful lesson. Two decision-log lines added:

- **A contrast number describes an element, never a selector.** Confirm the thing is on
  screen — `querySelectorAll` in the running app, not a reading of the stylesheet.
- **Verify in the Electron window, not in Chrome.** `navigator.userAgent` says "Mac" in
  Chrome on macOS too, so the renderer draws the 44px traffic-light reservation with no
  traffic lights in it — a band that doesn't exist in the real app. From Nikolai's
  feedback, 2026-08-29; the layout rule itself lands with TRA-354.

Sidebar counts are specified in `DESIGN.md` §6, fully styled, and unrendered — filed as
**TRA-358** for build-or-delete rather than deleted here, per "deleting the last host of a
feature means re-homing the feature, in the same pass or in a filed issue".

## Verification

This time in the **real Electron app** (built renderer, `file://` load, `isElectron: true`),
not the Vite dev server in Chrome:

- `+ Add` 13px/500 vs `Filter` 13px/500 — #506's fix holds in the real window;
- chevron renders as an SVG;
- selected sidebar row focused: background `rgb(0, 105, 217)` (`--accent-fill`), label and
  glyph both `rgb(255, 255, 255)` (full `--on-accent`).

298 tests, `design-tokens.mjs` exit 0.
