### PR TITLE
fix(app): stop the shared toolbar clipping its controls off-window

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -370,6 +370,15 @@ you undo them:
 - **A toolbar wraps; it never clips.** Give it `min-height: 52px` and `flex-wrap`,
   not `height: 52px`. A fixed non-wrapping row inside `overflow-x: hidden` ran 51px
   past a 420px pane and put + Add's chevron and the overflow menu outside the window.
+  This lives in the shared `Toolbar` primitive (`lattice/ui/Surface.tsx`), so every
+  surface built on it inherits the behaviour — do not re-declare a height on top.
+- **A control that can shrink declares a length `flex-basis`, not `auto`.** A wrapping
+  flex line is laid out from each item's *hypothetical* size, so `flex-basis: auto`
+  advertises a control's full content width and breaks the row before it has spent
+  the slack it has. `.lx-search` is `flex: 1 1 140px` (its own `min-width`) capped at
+  `max-width: max-content`: identical rendered width wherever there is room, 42px of
+  give before the toolbar goes to two rows. With `auto` it wrapped Memory's toolbar
+  at the *default* 960px window, not just at the minimum.
 
 **Respond to the pane, not to the window.** The sidebar is resizable 180–320px and
 collapsible, so window width says almost nothing about the room a surface has. Watch
@@ -593,6 +602,8 @@ new evidence.
 | Optionality lives in a field's placeholder, not its label | "Kind (optional)" wrapped to two lines in the form's label column and broke the row baseline. `required` is what the code reads anyway. |
 | The toolbar sits **above** the KPI strip, not below it | Chrome above content. With the strip first, 357px of tiles pushed the toolbar's bottom 33px past a 420px window and nothing on the surface could scroll it back. |
 | A toolbar has `min-height: 52px` and wraps, never a fixed `height` | A non-wrapping 52px row inside `overflow-x: hidden` ran 51px past a 420px pane and put + Add's chevron and the overflow menu outside the window. |
+| The wrap rule belongs to the shared `Toolbar`, not to each surface | Fixed on the Workspace header in TRA-292 and nowhere else, so four surfaces built on the primitive still clipped: at 640×420 Memory overflowed 333px with its search, its prominent "Add decision" and its overflow menu at zero visible pixels and no scrollable ancestor. |
+| A shrinkable control declares a length `flex-basis`, never `auto` | A wrapping flex line breaks on hypothetical sizes, so `flex-basis: auto` spends none of the control's slack first. `.lx-search` on `auto` wrapped Memory's toolbar at the default 960px window; on `1 1 140px` capped at `max-content` it renders identically and holds one row to a 740px pane. |
 | Breakpoints are read off the **pane**, and computed rather than picked | The sidebar is resizable 180–320px, so window width is not a proxy for room. `kpiStripHeight()` reproduces the measured 357px; a guessed number drifts the first time a tile changes. |
 | Narrow gives up the comparison, then the table, never the value | The number and the project name are the screen; the footnote and the metric columns are elaboration. Compact already renders a legible row at 420px. |
 | A view toggle with one usable option is hidden, not disabled | A disabled segment is a control with nothing to choose. The stored preference is untouched and returns with the width. |

--- a/packages/app/src/renderer/lattice/ui/Surface.tsx
+++ b/packages/app/src/renderer/lattice/ui/Surface.tsx
@@ -19,7 +19,18 @@ import { Skeleton } from '../../workspace/components/Skeleton';
 import { Button } from './Button';
 
 /** 52px glass toolbar. ONE per surface — a second control row is a bug.
-    `scrolled` fades in the hairline instead of a permanent hard border. */
+    `scrolled` fades in the hairline instead of a permanent hard border.
+
+    `min-height` and `flex-wrap`, never a fixed `height` (TRA-347). The pane is
+    420px wide at the 640px window minimum, and a non-wrapping fixed-height row
+    inside the pane's `overflow-x: hidden` does not shrink, does not scroll and
+    does not clip — it just runs off the edge. Measured at 640x420 before this:
+    Memory's row was 703px of content in 420px, which put its search field, its
+    prominent "Add decision" and its overflow menu wholly outside the window
+    with zero visible pixels and no scrollable ancestor to bring them back;
+    Activity's was 506px, losing "Pause the live feed" and its overflow menu.
+    The workspace toolbar had already been given this treatment on its own
+    (TRA-292) — the rule just never reached the shared primitive. */
 export function Toolbar({
   scrolled = false,
   className,
@@ -32,9 +43,9 @@ export function Toolbar({
   return (
     <div
       role="toolbar"
-      className={`flex items-center gap-2 px-4 shrink-0 glass relative${className ? ` ${className}` : ''}`}
+      className={`flex flex-wrap items-center gap-x-2 gap-y-1 px-4 py-2 shrink-0 glass relative${className ? ` ${className}` : ''}`}
       style={{
-        height: 52,
+        minHeight: 52,
         borderBottom: '0.5px solid transparent',
         borderBottomColor: scrolled ? 'var(--separator)' : 'transparent',
         transition: 'border-bottom-color var(--dur-standard) var(--ease-out)',

--- a/packages/app/src/renderer/lattice/ui/__tests__/primitives.test.tsx
+++ b/packages/app/src/renderer/lattice/ui/__tests__/primitives.test.tsx
@@ -20,6 +20,7 @@ import { resolve } from 'node:path';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { Gallery } from '../Gallery';
+import { Toolbar } from '../Surface';
 
 // jsdom rewrites import.meta.url to an http: URL, so resolve off the vitest
 // root (packages/app) instead.
@@ -201,6 +202,44 @@ describe('badge contrast', () => {
         expect(token(`badge-${tone}-fg`, scope).toLowerCase()).not.toBe('#ffffff');
       }
     }
+  });
+});
+
+/* TRA-347. At the 640x420 window minimum the content pane is 420px wide and
+   clips with `overflow-x: hidden` — a fixed-height, non-wrapping toolbar there
+   does not shrink, scroll or clip, it just runs off the edge. Memory's row was
+   703px of content in 420px, which left its search field, its prominent "Add
+   decision" and its overflow menu at zero visible pixels with no scrollable
+   ancestor. DESIGN.md has required `min-height` + `flex-wrap` since TRA-292;
+   the rule reached the Workspace header but never the shared primitive.
+
+   Both halves are asserted, because either one alone regresses: without the
+   wrap the row clips, and without a length flex-basis on the search field the
+   row wraps ~180px earlier than it must (a wrapping flex line is laid out from
+   each item's hypothetical size, and `flex-basis: auto` advertises the field's
+   full content width), which put Memory on two rows at the default window. */
+describe('a toolbar wraps; it never clips', () => {
+  it('gives Toolbar a min-height and a wrap, never a fixed height', () => {
+    const { container } = render(<Toolbar>{null}</Toolbar>);
+    const bar = container.querySelector('[role="toolbar"]') as HTMLElement;
+    expect(bar).toBeTruthy();
+    expect(bar.style.minHeight).toBe('52px');
+    expect(bar.style.height, 'a fixed height cannot wrap — use min-height').toBe('');
+    expect(bar.className).toMatch(/\bflex-wrap\b/);
+  });
+
+  it('bases the search field on its own min-width so it shrinks before the row wraps', () => {
+    const search = rules().find((x) => x.selector === '.lx-search')!;
+    const min = decl(search.body, 'min-width');
+    const basis = decl(search.body, 'flex')?.split(/\s+/)[2];
+    expect(min).toBe('140px');
+    expect(basis, 'flex-basis: auto wraps the toolbar early — use the min-width').toBe(min);
+    // Capped at the content width, so where there is room it renders unchanged.
+    expect(decl(search.body, 'max-width')).toBe('max-content');
+    // ...and the grow variant still fills, so the cap must not leak into it.
+    expect(decl(rules().find((x) => x.selector === '.lx-search.grow')!.body, 'max-width')).toBe(
+      'none',
+    );
   });
 });
 

--- a/packages/app/src/renderer/styles/controls.css
+++ b/packages/app/src/renderer/styles/controls.css
@@ -233,9 +233,19 @@
   background: var(--fill-tertiary);
   color: var(--label-tertiary);
   transition: background 120ms ease;
+  /* Spend the field's slack before the toolbar breaks to a second row (TRA-347).
+     A wrapping flex line is laid out from each item's *hypothetical* size, so
+     `flex-basis: auto` advertises this field's full content width and wraps the
+     row ~180px earlier than it has to — Memory's toolbar went to two rows at the
+     default 960px window. Basing it on its own `min-width` and capping growth at
+     its content width renders identically wherever there is room, and gives the
+     row 42px of give first. */
+  flex: 1 1 140px;
+  max-width: max-content;
 }
 .lx-search.grow {
-  flex: 1 1 auto;
+  flex: 1 1 140px;
+  max-width: none;
 }
 .lx-search:hover {
   background: var(--fill-quaternary);


### PR DESCRIPTION
## The problem

`main/tray.ts` sets `minWidth: 640, minHeight: 420`, and DESIGN.md requires every
surface to be *usable* there. At that size the content pane is 420px wide and clips
with `overflow-x: hidden`.

The shared `Toolbar` primitive (`lattice/ui/Surface.tsx`) declared `height: 52px` with
the default `flex-wrap: nowrap`. A fixed-height non-wrapping row inside a clipping
parent cannot shrink, cannot scroll and does not clip — it just runs off the edge.
Measured on the running renderer at 640×420:

| Surface | Overflow | Controls at **zero** visible pixels |
|---|---|---|
| Memory | 333px | `Search decisions`, `Add decision` (the surface's *prominent* action), `More actions` |
| Activity | 86px | `Pause the live feed`, `More actions` |

Each of those reported `horizontallyScrollableAncestor: null` — unreachable by pointer,
not merely off-screen.

DESIGN.md has required `min-height` + `flex-wrap` since TRA-292, but that fix landed on
the Workspace header alone and never reached the primitive the other surfaces are built
from.

## The fix

Two parts, because wrapping alone regresses the common case.

1. **`Toolbar`**: `min-height: 52px` with `flex-wrap`, `gap-x-2 gap-y-1`, `py-2`.
2. **`.lx-search`**: `flex: 1 1 140px` (its own `min-width`) capped at
   `max-width: max-content`.

A wrapping flex line is laid out from each item's *hypothetical* size, so
`flex-basis: auto` advertises the search field's full content width and breaks the row
~180px earlier than it has to — with part 1 alone, Memory went to two rows at the
**default 960px window**. Basing the field on its own minimum and capping growth at its
content width renders it identically wherever there is room and spends its 42px of give
first. `.lx-search.grow` overrides the cap so it still fills.

## Verified

Measured on the running renderer, not read off the diff. Memory, across pane widths:

| Pane | Before | After |
|---|---|---|
| 1220 | 52px, 1 row, search 182px | 52px, 1 row, search 182px — unchanged |
| 900 | 52px, 1 row, search 182px | 52px, 1 row, search 182px — unchanged |
| 740 (default window) | 52px, 1 row | 52px, 1 row, search 150px |
| 620 | 52px, overflow 105px | 69px, 2 rows, overflow 0 |
| 420 (window minimum) | 52px, **overflow 333px** | 69px, 2 rows, **overflow 0, nothing hidden** |

At 640×420 every toolbar surface now reports `overflow 0` with no fully-hidden control:
Overview, Ask, Activity, Memory, Notebook, Settings. At 960×700 all six are a single
52px row. The Workspace header (52px, wrap, overflow 0, all five controls visible) is
unchanged at both sizes.

This change is purely geometric — flex basis, wrap, min-height — and touches no colour
token, so it renders identically in both appearances.

## Guards

Both halves are locked down in `primitives.test.tsx`, next to the existing geometry
rules. Confirmed non-vacuous: reverting `min-height` → `height` and `140px` → `auto`
fails both.

`298/298` app tests, typecheck, build and `design-tokens.mjs` all pass.

Refs TRA-347. DESIGN.md updated in the same PR (the 640×420 rules and the decision log).
