### PR TITLE
test(update): prove the .app bundle actually moves on npm install (TRA-359)

### DIFF
--- a/scripts/postinstall-app.mjs
+++ b/scripts/postinstall-app.mjs
@@ -47,6 +47,15 @@ let PENDING_CHECKSUM = '';
 // scripts/app-dist-repo.mjs. Overridable via env.
 const GITHUB_REPO = getAppDistRepo();
 
+// Test seams. All three default to production values and are only ever set by
+// tests/scripts/postinstall-app.test.ts, which needs to point the release
+// lookup at a local HTTP server, make "is the app running" deterministic (the
+// real pgrep answers differently depending on whether the developer happens to
+// have trace-mcp.app open), and avoid bouncing the developer's real daemon.
+const API_BASE = process.env.TRACE_MCP_UPDATE_API_BASE || 'https://api.github.com';
+const PGREP_BIN = process.env.TRACE_MCP_PGREP_BIN || '/usr/bin/pgrep';
+const LAUNCHCTL_BIN = process.env.TRACE_MCP_LAUNCHCTL_BIN || '/bin/launchctl';
+
 if (process.env.TRACE_MCP_NO_AUTO_UPDATE === '1') process.exit(0);
 
 /**
@@ -64,7 +73,7 @@ if (process.env.TRACE_MCP_NO_AUTO_UPDATE === '1') process.exit(0);
 function stopRunningDaemon() {
   try {
     if (process.platform === 'darwin') {
-      execFileSync('/bin/launchctl', ['stop', 'com.trace-mcp.server'], { stdio: 'ignore' });
+      execFileSync(LAUNCHCTL_BIN, ['stop', 'com.trace-mcp.server'], { stdio: 'ignore' });
       return;
     }
     const pidFile = path.join(os.homedir(), '.trace-mcp', 'daemon.pid');
@@ -111,7 +120,7 @@ PENDING_CHECKSUM = path.join(INSTALL_DIR, '.trace-mcp-pending.sha256');
 function appIsRunning() {
   try {
     // pgrep -f matches the full command line; the main binary path is unique enough.
-    const out = execFileSync('/usr/bin/pgrep', ['-f', `${APP_NAME}/Contents/MacOS/`], {
+    const out = execFileSync(PGREP_BIN, ['-f', `${APP_NAME}/Contents/MacOS/`], {
       stdio: ['ignore', 'pipe', 'ignore'],
     });
     return out.toString().trim().length > 0;
@@ -243,7 +252,7 @@ async function main() {
     ? /^trace-mcp-.*-arm64-mac\.zip$/i
     : /^trace-mcp-(?!.*-arm64-).*-mac\.zip$/i;
 
-  const body = await httpGet(`https://api.github.com/repos/${GITHUB_REPO}/releases/latest`);
+  const body = await httpGet(`${API_BASE}/repos/${GITHUB_REPO}/releases/latest`);
   const release = JSON.parse(body);
   if (!release.tag_name || !Array.isArray(release.assets)) return;
 

--- a/tests/scripts/postinstall-app.test.ts
+++ b/tests/scripts/postinstall-app.test.ts
@@ -1,0 +1,277 @@
+import { execFileSync, spawn } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SCRIPT_PATH = path.join(REPO_ROOT, 'scripts', 'postinstall-app.mjs');
+
+const BUNDLE_ID = 'com.trace-mcp.app';
+const DIST_REPO = 'trace-mcp-test/dist';
+
+/**
+ * End-to-end coverage for `npm install -g trace-mcp` → the installed `.app`
+ * actually moving to the new version.
+ *
+ * This is deliberately not a unit test of the helpers. The incident that
+ * motivated it (TRA-357: bundle stuck on 1.50.0 for five consecutive updates
+ * while npm walked to 3.1.1) was invisible to code review — every helper read
+ * correctly. Only running the real script against a real bundle on disk and
+ * then reading the version back out of `Info.plist` catches it.
+ *
+ * The release API and the zip come from a local HTTP server, so the test is
+ * hermetic and fast; everything else — unzip, the rename swap, the pending
+ * staging, the checksum gate — is the production code path.
+ *
+ * macOS only: the script exits early on other platforms by design.
+ */
+
+interface Fixture {
+  home: string;
+  installDir: string;
+  appPath: string;
+  server: http.Server;
+  baseUrl: string;
+  /** Asset name → body served under /dl/<name>. */
+  assets: Map<string, Buffer>;
+  releaseBody: unknown;
+}
+
+function writeBundle(appPath: string, version: string): void {
+  const contents = path.join(appPath, 'Contents');
+  fs.mkdirSync(path.join(contents, 'MacOS'), { recursive: true });
+  fs.writeFileSync(
+    path.join(contents, 'Info.plist'),
+    `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>${BUNDLE_ID}</string>
+  <key>CFBundleShortVersionString</key>
+  <string>${version}</string>
+</dict>
+</plist>
+`,
+  );
+  fs.writeFileSync(path.join(contents, 'MacOS', 'trace-mcp'), '#!/bin/sh\nexit 0\n', {
+    mode: 0o755,
+  });
+}
+
+function readBundleVersion(appPath: string): string {
+  const plist = fs.readFileSync(path.join(appPath, 'Contents', 'Info.plist'), 'utf-8');
+  return (
+    plist.match(/<key>CFBundleShortVersionString<\/key>\s*<string>([^<]+)<\/string>/)?.[1] ?? ''
+  );
+}
+
+/** Zip a bundle the way the release CI does: `trace-mcp.app` at the zip root. */
+function zipBundle(appPath: string, outZip: string): Buffer {
+  execFileSync('/usr/bin/zip', ['-qry', outZip, path.basename(appPath)], {
+    cwd: path.dirname(appPath),
+  });
+  return fs.readFileSync(outZip);
+}
+
+/** A stub standing in for `/usr/bin/pgrep`, forcing the running/not-running branch. */
+function writePgrepStub(dir: string, running: boolean): string {
+  const stub = path.join(dir, 'pgrep-stub.sh');
+  // pgrep exits 1 with no output when nothing matches — mirror that exactly.
+  fs.writeFileSync(stub, running ? '#!/bin/sh\necho 4242\n' : '#!/bin/sh\nexit 1\n', {
+    mode: 0o755,
+  });
+  return stub;
+}
+
+describe.skipIf(process.platform !== 'darwin')('postinstall-app.mjs bundle swap', () => {
+  let fx: Fixture;
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-postinstall-'));
+    const home = path.join(tmp, 'home');
+    const installDir = path.join(home, 'Applications');
+    fs.mkdirSync(path.join(home, '.trace-mcp'), { recursive: true });
+    fs.mkdirSync(installDir, { recursive: true });
+
+    const assets = new Map<string, Buffer>();
+    const server = http.createServer((req, res) => {
+      const url = req.url ?? '';
+      if (url === `/repos/${DIST_REPO}/releases/latest`) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(fx.releaseBody));
+        return;
+      }
+      const name = decodeURIComponent(url.replace(/^\/dl\//, ''));
+      const body = assets.get(name);
+      if (!body) {
+        res.writeHead(404).end();
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/octet-stream' }).end(body);
+    });
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+    const { port } = server.address() as AddressInfo;
+
+    fx = {
+      home,
+      installDir,
+      appPath: path.join(installDir, 'trace-mcp.app'),
+      server,
+      baseUrl: `http://127.0.0.1:${port}`,
+      assets,
+      releaseBody: {},
+    };
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((r) => fx.server.close(() => r()));
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  /**
+   * Publish a fake release whose macOS zip contains a bundle at `newVersion`.
+   * `corruptChecksum` serves a digest that will not match the zip;
+   * `omitChecksum` drops the `.sha256` sibling entirely.
+   */
+  function publishRelease(
+    newVersion: string,
+    opts: { corruptChecksum?: boolean; omitChecksum?: boolean } = {},
+  ): void {
+    const staging = path.join(tmp, `staging-${newVersion}`);
+    fs.mkdirSync(staging, { recursive: true });
+    const newBundle = path.join(staging, 'trace-mcp.app');
+    writeBundle(newBundle, newVersion);
+
+    // Both arch names so the test runs on Intel and Apple silicon alike; only
+    // the one matching process.arch is picked up by the script.
+    const zipName =
+      process.arch === 'arm64'
+        ? `trace-mcp-${newVersion}-arm64-mac.zip`
+        : `trace-mcp-${newVersion}-mac.zip`;
+    const zipBytes = zipBundle(newBundle, path.join(tmp, zipName));
+    fx.assets.set(zipName, zipBytes);
+
+    const assets: Array<{ name: string; browser_download_url: string }> = [
+      { name: zipName, browser_download_url: `${fx.baseUrl}/dl/${zipName}` },
+    ];
+    if (!opts.omitChecksum) {
+      const digest = opts.corruptChecksum
+        ? 'f'.repeat(64)
+        : crypto.createHash('sha256').update(zipBytes).digest('hex');
+      fx.assets.set(`${zipName}.sha256`, Buffer.from(`${digest}  ${zipName}\n`));
+      assets.push({
+        name: `${zipName}.sha256`,
+        browser_download_url: `${fx.baseUrl}/dl/${zipName}.sha256`,
+      });
+    }
+    fx.releaseBody = { tag_name: `v${newVersion}`, assets };
+  }
+
+  /** Install a bundle at `version` and point the location marker at it. */
+  function installBundle(version: string): void {
+    writeBundle(fx.appPath, version);
+    fs.writeFileSync(
+      path.join(fx.home, '.trace-mcp', 'app-location.json'),
+      JSON.stringify({ appPath: fx.appPath, bundleId: BUNDLE_ID, version, writtenAt: Date.now() }),
+    );
+  }
+
+  /**
+   * Must be async: the fake release server lives in this process, so a
+   * synchronous execFileSync would block the event loop and deadlock against
+   * the child's own HTTP request.
+   */
+  function runPostinstall(opts: { appRunning?: boolean } = {}): Promise<string> {
+    const child = spawn(process.execPath, [SCRIPT_PATH], {
+      env: {
+        ...process.env,
+        HOME: fx.home,
+        TRACE_MCP_APP_DIST_REPO: DIST_REPO,
+        TRACE_MCP_UPDATE_API_BASE: fx.baseUrl,
+        TRACE_MCP_PGREP_BIN: writePgrepStub(tmp, opts.appRunning ?? false),
+        // Never bounce the developer's real launchd daemon from a test run.
+        TRACE_MCP_LAUNCHCTL_BIN: '/usr/bin/true',
+        TRACE_MCP_NO_AUTO_UPDATE: '',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    child.stdout.setEncoding('utf-8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    return new Promise((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', () => resolve(stdout));
+    });
+  }
+
+  it('replaces a bundle that is several majors behind', async () => {
+    // The exact shape of the incident: installed 1.50.0, released 3.1.1.
+    installBundle('1.50.0');
+    publishRelease('3.1.1');
+
+    const stdout = await runPostinstall();
+
+    expect(readBundleVersion(fx.appPath)).toBe('3.1.1');
+    expect(stdout).toContain('updated to v3.1.1');
+    expect(fs.readFileSync(path.join(fx.installDir, '.trace-mcp-version'), 'utf-8')).toBe('v3.1.1');
+    // No half-finished swap left behind.
+    expect(fs.readdirSync(fx.installDir).filter((f) => f.includes('.bak-'))).toEqual([]);
+  });
+
+  it('stages a pending zip instead of swapping while the app is running', async () => {
+    installBundle('1.50.0');
+    publishRelease('3.1.1');
+
+    await runPostinstall({ appRunning: true });
+
+    // Bundle untouched — replacing a running .app breaks its code signature.
+    expect(readBundleVersion(fx.appPath)).toBe('1.50.0');
+    expect(fs.existsSync(path.join(fx.installDir, '.trace-mcp-pending.zip'))).toBe(true);
+    expect(fs.readFileSync(path.join(fx.installDir, '.trace-mcp-pending-version'), 'utf-8')).toBe(
+      '3.1.1',
+    );
+    expect(fs.existsSync(path.join(fx.installDir, '.trace-mcp-pending.partial'))).toBe(false);
+  });
+
+  it('leaves the install alone when the checksum does not match', async () => {
+    installBundle('1.50.0');
+    publishRelease('3.1.1', { corruptChecksum: true });
+
+    await runPostinstall();
+
+    expect(readBundleVersion(fx.appPath)).toBe('1.50.0');
+    expect(fs.existsSync(path.join(fx.installDir, '.trace-mcp-version'))).toBe(false);
+  });
+
+  it('leaves the install alone when the release ships no .sha256 asset', async () => {
+    installBundle('1.50.0');
+    publishRelease('3.1.1', { omitChecksum: true });
+
+    await runPostinstall();
+
+    expect(readBundleVersion(fx.appPath)).toBe('1.50.0');
+  });
+
+  it('is a no-op once the installed version marker matches the release', async () => {
+    installBundle('3.1.1');
+    publishRelease('3.1.1');
+    fs.writeFileSync(path.join(fx.installDir, '.trace-mcp-version'), 'v3.1.1');
+
+    const before = fs.statSync(fx.appPath).mtimeMs;
+    const stdout = await runPostinstall();
+
+    expect(fs.statSync(fx.appPath).mtimeMs).toBe(before);
+    expect(stdout).not.toContain('updated to');
+  });
+});


### PR DESCRIPTION
## Why

TRA-357: the installed `.app` sat on **v1.50.0** through five consecutive updates while npm walked 1.48 → 3.1.1, every one logging `outcome: npm-only`. That class of failure produces no complaints — the user sees a green "Up to date" — so it has to be caught by a test, not by a report.

Code review did not catch it and could not have: every helper in the update path reads correctly in isolation, and `scripts/locate-app.mjs` already had 9 tests. The gap was that **nothing ever ran `scripts/postinstall-app.mjs` against a bundle on disk and checked the version afterwards**.

TRA-357 owns the marker-poisoning and "green Up to date" defects themselves. This PR is only the missing regression floor under them.

## What

`tests/scripts/postinstall-app.test.ts` — end-to-end, hermetic, ~1.2s. A local HTTP server plays the GitHub Releases API and serves a real zip; `unzip`, the rename swap, the pending-zip staging and the checksum gate are all the production code path. The assertion is `CFBundleShortVersionString` read back out of `Info.plist`.

Scenarios:
- several-majors-behind upgrade, 1.50.0 → 3.1.1 (the exact shape of the incident)
- pending zip staged, bundle untouched, while the app is running
- checksum mismatch → install left alone
- release ships no `.sha256` sibling → install left alone
- already at the released version → no-op

Mutation-checked: stubbing out the swap fails the upgrade test and nothing else.

Three env seams in `postinstall-app.mjs`, all defaulting to today's production values — `TRACE_MCP_UPDATE_API_BASE`, `TRACE_MCP_PGREP_BIN` (the real pgrep answers differently depending on whether the developer has the app open), `TRACE_MCP_LAUNCHCTL_BIN` (so a test run does not bounce the real daemon).

macOS-only, matching the script's own platform gate.

## Test evidence

```
pnpm run build   → success
pnpm run lint    → clean (tsc --noEmit)
biome ci         → clean
pnpm run test    → 8900 passed | 8 skipped (813 files)
```

No MCP tool-contract or DB/graph-schema change.