### PR TITLE
docs: fix the framework/language counts on the install surfaces (TRA-361)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "trace-mcp",
       "source": "./.claude-plugin",
-      "description": "Framework-aware code intelligence: semantic search, refactoring, change-impact, security scanning, and decision memory across 60+ frameworks and 81 languages.",
+      "description": "Framework-aware code intelligence: semantic search, refactoring, change-impact, security scanning, and decision memory across 87 frameworks and 80 languages.",
       "version": "3.1.1",
       "author": {
         "name": "Nikolai Vysotskyi"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trace-mcp",
   "version": "3.1.1",
-  "description": "Framework-aware code intelligence MCP server. 60+ framework integrations, 81 languages, semantic search with Signal Fusion (BM25 + PageRank + embeddings + identity), refactoring tools (rename/move/extract/codemod), change-impact analysis, security scanning, and decision/session memory.",
+  "description": "Framework-aware code intelligence MCP server. 87 framework integrations, 80 languages, semantic search with Signal Fusion (BM25 + PageRank + embeddings + identity), refactoring tools (rename/move/extract/codemod), change-impact analysis, security scanning, and decision/session memory.",
   "author": {
     "name": "Nikolai Vysotskyi",
     "url": "https://github.com/nikolai-vysotskyi"

--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "trace-mcp",
       "source": "./.codex-plugin",
-      "description": "Framework-aware code intelligence: semantic search, refactoring, change-impact, security scanning, and decision memory across 60+ frameworks and 81 languages.",
+      "description": "Framework-aware code intelligence: semantic search, refactoring, change-impact, security scanning, and decision memory across 87 frameworks and 80 languages.",
       "version": "3.1.1",
       "author": {
         "name": "Nikolai Vysotskyi"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trace-mcp",
   "version": "3.1.1",
-  "description": "Framework-aware code intelligence MCP server. 60+ framework integrations, 81 languages, semantic search with Signal Fusion (BM25 + PageRank + embeddings + identity), refactoring tools (rename/move/extract/codemod), change-impact analysis, security scanning, and decision/session memory.",
+  "description": "Framework-aware code intelligence MCP server. 87 framework integrations, 80 languages, semantic search with Signal Fusion (BM25 + PageRank + embeddings + identity), refactoring tools (rename/move/extract/codemod), change-impact analysis, security scanning, and decision/session memory.",
   "author": {
     "name": "Nikolai Vysotskyi",
     "url": "https://github.com/nikolai-vysotskyi"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "trace-mcp",
   "version": "3.1.1",
   "mcpName": "io.github.nikolai-vysotskyi/trace-mcp",
-  "description": "Framework-aware code intelligence MCP server — 60 framework integrations, 81 languages, up to 99% token reduction",
+  "description": "Framework-aware code intelligence MCP server — 87 framework integrations, 80 languages, up to 99% token reduction",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/docs/readme-claims.test.ts
+++ b/tests/docs/readme-claims.test.ts
@@ -246,6 +246,16 @@ describe('docs site numeric claims (TRA-174)', () => {
     // integrations, 138 tools". docs/configuration.md was unguarded too.
     { path: 'server.json', tolerance: 5 },
     { path: 'docs/configuration.md', tolerance: 5, skipLine: /output_format|preset/ },
+    // TRA-361: the install surfaces — the npm page and the Claude Code / Codex
+    // plugin marketplaces — were the last unguarded copies, and every one of
+    // them still advertised "60(+) framework integrations, 81 languages" while
+    // server.json next to them said 87 / 80. Their `version` fields were
+    // guarded (tests/plugin/manifest-sync.test.ts), their prose was not.
+    { path: 'package.json', tolerance: 5 },
+    { path: '.claude-plugin/plugin.json', tolerance: 5 },
+    { path: '.claude-plugin/marketplace.json', tolerance: 5 },
+    { path: '.codex-plugin/plugin.json', tolerance: 5 },
+    { path: '.codex-plugin/marketplace.json', tolerance: 5 },
   ];
 
   for (const { path, tolerance, skipLine } of docs) {


### PR DESCRIPTION
`package.json` and both plugin marketplaces still advertised **"60(+) framework integrations, 81 languages"** while `server.json` sitting next to them said **87 / 80**. The npm page and the Claude Code / Codex plugin listings are the first copy a user reads, and they were the only surfaces the numeric-claims guard never scanned — the manifests' `version` fields are guarded (`tests/plugin/manifest-sync.test.ts`), their prose was not.

Registry truth (`PluginRegistry.createWithDefaults()`, same source `docs/_data/counts.yml` is asserted against): **87 frameworks, 80 languages**. The framework number was off by 27.

## Changes

- Corrected the description in `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json`, `.codex-plugin/marketplace.json`.
- Added those five files to the per-file scan in `tests/docs/readme-claims.test.ts` (the same loop that already guards `server.json` and `docs/configuration.md`), so the next plugin batch fails CI with the number to write instead of drifting for another release.

## Test evidence

- Mutation check: restoring `"60 framework integrations"` in `package.json` fails the new `package.json: every "frameworks/integrations" claim matches the registry` test. Reverting it passes.
- `pnpm vitest run tests/docs/ tests/plugin/manifest-sync.test.ts` → 85 passed (readme-claims grew 43 → 58 tests).
- `pnpm run lint` clean.

No tool/schema/DB-schema surface touched.
