### PR TITLE
feat(app): update Windows through electron-updater instead of the macOS zip path (TRA-360)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,6 +267,20 @@ jobs:
         working-directory: packages/app
         run: pnpm exec electron-builder --win --x64 --publish never
 
+      # electron-updater is the Windows update mechanism (TRA-360) and it is
+      # driven entirely by latest.yml. A build that ships the installer without
+      # it is silently un-updatable — every existing install would keep polling
+      # a 404 forever — so treat a missing latest.yml as a failed release, not
+      # as a warning.
+      - name: Assert latest.yml was generated
+        shell: bash
+        run: |
+          if [ ! -f packages/app/release/latest.yml ]; then
+            echo "::error::packages/app/release/latest.yml missing — electron-updater metadata was not generated; check the win.publish block in packages/app/electron-builder.yml"
+            exit 1
+          fi
+          cat packages/app/release/latest.yml
+
       - name: Generate SHA-256 checksums
         shell: bash
         run: node scripts/generate-shasums.mjs packages/app/release .exe .zip
@@ -293,4 +307,5 @@ jobs:
           gh release upload "${{ needs.release-please.outputs.tag_name }}" \
             "${FILES[@]}" \
             "${SUMS[@]}" \
+            packages/app/release/latest.yml \
             --clobber

--- a/docs/development.md
+++ b/docs/development.md
@@ -120,6 +120,29 @@ tests/
 
 ---
 
+## Desktop app update channels
+
+The Electron app updates itself differently per platform, and the split is
+deliberate. `packages/app/src/main/update-channel.ts` is the single place that
+decides which one a platform gets; no platform ever runs both.
+
+| Platform | Mechanism | Why |
+| --- | --- | --- |
+| macOS | Staged zip (`scripts/postinstall-app.mjs` + `scripts/apply-pending-update.mjs`) | Squirrel.Mac, which electron-updater uses on macOS, validates the replacement bundle's code signature. We ship ad-hoc signed (`Signature=adhoc`, `TeamIdentifier=not set`), so it would need a paid Apple Developer ID — ruled out. The npm postinstall drops a verified zip next to the `.app` and a detached helper swaps the bundle on exit. |
+| Windows | `electron-updater` + NSIS | Windows imposes no signature requirement on the swap, so the standard mechanism works unsigned. Driven by `latest.yml`, generated from the `win.publish` block in `packages/app/electron-builder.yml` and uploaded to the GitHub release by `.github/workflows/release.yml`. A missing `latest.yml` fails the release. |
+| Linux | none | No packaged target today (`linux.target: []`). |
+
+Consequences worth knowing before touching this:
+
+- `publish` lives under `win:`, not at the top level. Hoisting it would make
+  electron-builder emit `latest-mac.yml` and point macOS installs at an update
+  path that cannot succeed.
+- `electron-updater` is the app's only production `dependency`. Everything the
+  renderer imports is bundled by Vite and therefore belongs in
+  `devDependencies` — that is what keeps the packaged `node_modules` small.
+
+---
+
 ## Adding a new integration plugin
 
 1. Create a directory under the appropriate category in `src/indexer/plugins/integration/`:

--- a/packages/app/electron-builder.yml
+++ b/packages/app/electron-builder.yml
@@ -8,11 +8,15 @@ files:
   - package.json
   - assets/**
   - build/icon.png
-  # The main process imports nothing but Node builtins and `electron`, and Vite
-  # already bundles every renderer dependency into dist/renderer. Without this,
-  # electron-builder auto-includes the production node_modules tree anyway —
-  # 27.5 MB of @luma.gl/@cosmos.gl/micromark that nothing ever loads (TRA-257).
-  - '!node_modules/**'
+  # The renderer's dependencies are all bundled into dist/renderer by Vite, so
+  # they live in devDependencies — electron-builder only packages production
+  # `dependencies`, which keeps the 27.5 MB of @luma.gl/@cosmos.gl/micromark
+  # that nothing ever loads out of the bundle (TRA-257). The one production
+  # dependency left is electron-updater, which the main process needs at
+  # runtime on Windows, so node_modules is no longer excluded wholesale.
+  # (`files` is an allow-list once it contains any inclusion pattern, so
+  # node_modules has to be named explicitly to be packaged at all.)
+  - node_modules/**
   - '!dist/main/__tests__/**'
 extraResources:
   - from: ../../scripts/apply-pending-update.mjs
@@ -29,6 +33,15 @@ mac:
 
 win:
   icon: build/icon.ico
+  # Windows-only on purpose. This block is what makes electron-builder emit
+  # `latest.yml` next to the installer, which is the file electron-updater
+  # reads. It must NOT be hoisted to the top level: macOS ships ad-hoc signed
+  # and Squirrel.Mac would reject the swap, so macOS stays on the staged-zip
+  # path and must never get a latest-mac.yml on the release.
+  publish:
+    - provider: github
+      owner: nikolai-vysotskyi
+      repo: trace-mcp
   target:
     - target: nsis
       arch:

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,9 +20,7 @@
   },
   "packageManager": "pnpm@10.33.0",
   "dependencies": {
-    "@cosmos.gl/graph": "3.4.1",
-    "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.0"
+    "electron-updater": "^6.6.2"
   },
   "overrides": {
     "@luma.gl/core": "9.2.6",
@@ -52,6 +50,7 @@
     }
   },
   "devDependencies": {
+    "@cosmos.gl/graph": "3.4.1",
     "@tailwindcss/vite": "^4.3.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
@@ -65,6 +64,8 @@
     "jsdom": "^30.0.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.0",
     "sharp": "^0.35.3",
     "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2",

--- a/packages/app/pnpm-lock.yaml
+++ b/packages/app/pnpm-lock.yaml
@@ -22,16 +22,13 @@ importers:
 
   .:
     dependencies:
+      electron-updater:
+        specifier: ^6.6.2
+        version: 6.8.9
+    devDependencies:
       '@cosmos.gl/graph':
         specifier: 3.4.1
         version: 3.4.1
-      react-markdown:
-        specifier: ^10.1.0
-        version: 10.1.0(@types/react@19.2.18)(react@19.2.8)
-      remark-gfm:
-        specifier: ^4.0.0
-        version: 4.0.1
-    devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0))
@@ -71,6 +68,12 @@ importers:
       react-dom:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.18)(react@19.2.8)
+      remark-gfm:
+        specifier: ^4.0.0
+        version: 4.0.1
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@26.2.0)
@@ -1602,6 +1605,9 @@ packages:
   electron-to-chromium@1.5.404:
     resolution: {integrity: sha512-3WJtd7/lVq2Jnuz6wed1l9+1ZD2u2Tet1/1NBc4Iedkmgbu+I7YuAqdAQ8T+VZtnwysMsAf3IqSq9D1gyZjA2g==}
 
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
+
   electron-winstaller@5.4.0:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
@@ -2049,6 +2055,13 @@ packages:
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -2646,6 +2659,9 @@ packages:
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4336,6 +4352,19 @@ snapshots:
 
   electron-to-chromium@1.5.404: {}
 
+  electron-updater@6.8.9:
+    dependencies:
+      builder-util-runtime: 9.7.0
+      fs-extra: 10.1.0
+      js-yaml: 4.3.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron-winstaller@5.4.0:
     dependencies:
       '@electron/asar': 3.4.1
@@ -4817,6 +4846,10 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash@4.18.1: {}
 
@@ -5683,6 +5716,8 @@ snapshots:
   tiny-async-pool@1.3.0:
     dependencies:
       semver: 5.7.2
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 

--- a/packages/app/src/main/__tests__/apply-pending-helper.test.ts
+++ b/packages/app/src/main/__tests__/apply-pending-helper.test.ts
@@ -40,7 +40,11 @@ describe('apply-pending-helper', () => {
 
   it('does not spawn the helper when there is no pending update', () => {
     fs.writeFileSync(applyHelper, '// noop');
-    const spawned = trySpawnApplyHelper({ pendingZip, pendingVersion, applyHelper }, 4242);
+    const spawned = trySpawnApplyHelper(
+      { pendingZip, pendingVersion, applyHelper },
+      4242,
+      'zip-staged',
+    );
     expect(spawned).toBe(false);
     expect(spawn).not.toHaveBeenCalled();
   });
@@ -51,6 +55,7 @@ describe('apply-pending-helper', () => {
     const spawned = trySpawnApplyHelper(
       { pendingZip, pendingVersion, applyHelper: path.join(dir, 'missing.mjs') },
       4242,
+      'zip-staged',
     );
     expect(spawned).toBe(false);
     expect(spawn).not.toHaveBeenCalled();
@@ -65,7 +70,11 @@ describe('apply-pending-helper', () => {
       pid: 555,
     } as unknown as ReturnType<typeof spawn>);
 
-    const spawned = trySpawnApplyHelper({ pendingZip, pendingVersion, applyHelper }, 4242);
+    const spawned = trySpawnApplyHelper(
+      { pendingZip, pendingVersion, applyHelper },
+      4242,
+      'zip-staged',
+    );
 
     expect(spawned).toBe(true);
     expect(spawn).toHaveBeenCalledTimes(1);
@@ -84,8 +93,10 @@ describe('apply-pending-helper', () => {
     });
 
     expect(() =>
-      trySpawnApplyHelper({ pendingZip, pendingVersion, applyHelper }, 4242),
+      trySpawnApplyHelper({ pendingZip, pendingVersion, applyHelper }, 4242, 'zip-staged'),
     ).not.toThrow();
-    expect(trySpawnApplyHelper({ pendingZip, pendingVersion, applyHelper }, 4242)).toBe(false);
+    expect(
+      trySpawnApplyHelper({ pendingZip, pendingVersion, applyHelper }, 4242, 'zip-staged'),
+    ).toBe(false);
   });
 });

--- a/packages/app/src/main/__tests__/update-channel.test.ts
+++ b/packages/app/src/main/__tests__/update-channel.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { updateChannelFor } from '../update-channel';
+import { trySpawnApplyHelper } from '../apply-pending-helper';
+
+describe('updateChannelFor', () => {
+  it('gives macOS the zip-staged path and Windows electron-updater', () => {
+    expect(updateChannelFor('darwin')).toBe('zip-staged');
+    expect(updateChannelFor('win32')).toBe('electron-updater');
+  });
+
+  it('leaves every other platform without an update mechanism', () => {
+    for (const p of ['linux', 'freebsd', 'aix'] as NodeJS.Platform[]) {
+      expect(updateChannelFor(p)).toBe('none');
+    }
+  });
+
+  // The whole point of the split: no platform may ever run both mechanisms.
+  it('never returns more than one mechanism for a platform', () => {
+    const platforms: NodeJS.Platform[] = ['darwin', 'win32', 'linux', 'freebsd', 'openbsd'];
+    for (const p of platforms) {
+      const channel = updateChannelFor(p);
+      expect(
+        [channel === 'zip-staged', channel === 'electron-updater'].filter(Boolean).length,
+      ).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe('trySpawnApplyHelper channel guard', () => {
+  // Paths deliberately point at nothing: if the channel guard is ever removed,
+  // this still returns false, so assert the guard rejects before touching fs by
+  // passing a channel that is not zip-staged and one that is.
+  const paths = {
+    pendingZip: __filename,
+    pendingVersion: __filename,
+    applyHelper: __filename,
+  };
+
+  it('refuses to stage a macOS zip swap on the electron-updater channel', () => {
+    expect(trySpawnApplyHelper(paths, process.pid, 'electron-updater')).toBe(false);
+  });
+
+  it('refuses on platforms with no update channel', () => {
+    expect(trySpawnApplyHelper(paths, process.pid, 'none')).toBe(false);
+  });
+});

--- a/packages/app/src/main/apply-pending-helper.ts
+++ b/packages/app/src/main/apply-pending-helper.ts
@@ -4,6 +4,7 @@
 
 import { spawn } from 'child_process';
 import fs from 'fs';
+import type { UpdateChannel } from './update-channel';
 
 export interface PendingUpdatePaths {
   pendingZip: string;
@@ -28,8 +29,17 @@ export function hasPendingUpdate(paths: PendingUpdatePaths): boolean {
  * then relaunches the new app. Returns true if the helper was spawned —
  * callers must not fall through to a plain relaunch/quit in that case, since
  * the helper now owns finishing the exit.
+ *
+ * `channel` is the hard interlock against the Windows electron-updater path:
+ * only `zip-staged` may swap a bundle this way, so the two mechanisms can
+ * never both fire on one platform.
  */
-export function trySpawnApplyHelper(paths: ApplyHelperPaths, pid: number): boolean {
+export function trySpawnApplyHelper(
+  paths: ApplyHelperPaths,
+  pid: number,
+  channel: UpdateChannel,
+): boolean {
+  if (channel !== 'zip-staged') return false;
   if (!hasPendingUpdate(paths) || !fs.existsSync(paths.applyHelper)) return false;
   try {
     const child = spawn(process.execPath, [paths.applyHelper, String(pid)], {

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -9,6 +9,12 @@ import {
   hasPendingUpdate as hasPendingUpdateImpl,
   trySpawnApplyHelper as trySpawnApplyHelperImpl,
 } from './apply-pending-helper';
+import { updateChannelFor } from './update-channel';
+
+// Exactly one update mechanism per platform — see update-channel.ts for why
+// macOS cannot use electron-updater and Windows can. Every update code path
+// below branches on this constant and nothing else.
+const UPDATE_CHANNEL = updateChannelFor(process.platform);
 
 // SharedArrayBuffer needed for cosmos.gl workers. GPU compositing + Skia
 // renderer are kept ON — disabling them forces a per-frame CPU readback of
@@ -590,6 +596,27 @@ function fetchLatestRelease(): Promise<{
   });
 }
 
+// --- Windows: electron-updater ---------------------------------------------
+//
+// NSIS + `latest.yml` on the GitHub release. Loaded lazily and only on the
+// electron-updater channel so macOS never pulls the module in at all — the
+// two mechanisms must never both be live in one process.
+let winUpdateDownloaded = false;
+
+async function getAutoUpdater() {
+  if (UPDATE_CHANNEL !== 'electron-updater') {
+    throw new Error(`electron-updater is not the update channel on ${process.platform}`);
+  }
+  const { autoUpdater } = await import('electron-updater');
+  // Download only when the user asks: the renderer's Update button drives the
+  // whole flow, so a silent background download would fight the UI's state.
+  autoUpdater.autoDownload = false;
+  // A downloaded update still installs if the user quits instead of pressing
+  // Restart — same self-healing property the macOS before-quit hook gives us.
+  autoUpdater.autoInstallOnAppQuit = true;
+  return autoUpdater;
+}
+
 ipcMain.handle('check-for-update', async () => {
   const result = await checkForUpdate();
   // Divergence between global roots exists independently of whether an update
@@ -604,6 +631,23 @@ ipcMain.handle('check-for-update', async () => {
 async function checkForUpdate() {
   const now = Date.now();
   const current = app.getVersion().replace(/^v/, '');
+
+  if (UPDATE_CHANNEL === 'electron-updater') {
+    try {
+      const updater = await getAutoUpdater();
+      const result = await updater.checkForUpdates();
+      const latest = result?.updateInfo?.version?.replace(/^v/, '');
+      if (!latest) return { available: false, current, lastChecked: now };
+      return { available: cmpSemver(latest, current) > 0, current, latest, lastChecked: now };
+    } catch (err) {
+      appendUpdateLog({
+        event: 'check-for-update:electron-updater-failed',
+        error: (err as Error)?.message ?? String(err),
+      });
+      return { available: false, current, lastChecked: now, error: toUpdateErrorMessage(err) };
+    }
+  }
+
   // Read the persisted "I tried npm-only" marker once. If the user already
   // clicked Update for exactly this (bundle, latest) pair and nothing on
   // disk has moved, we suppress the banner — clicking Update again will
@@ -1165,6 +1209,25 @@ async function repairStaleBundle(reason: string, roots?: {
 }
 
 ipcMain.handle('apply-update', async () => {
+  if (UPDATE_CHANNEL === 'electron-updater') {
+    // No npm involvement at all on Windows: electron-updater downloads the
+    // NSIS installer described by latest.yml and runs it on quit/restart.
+    try {
+      const updater = await getAutoUpdater();
+      // downloadUpdate() requires a check in this same process first.
+      const check = await updater.checkForUpdates();
+      const version = check?.updateInfo?.version?.replace(/^v/, '');
+      await updater.downloadUpdate();
+      winUpdateDownloaded = true;
+      appendUpdateLog({ event: 'apply-update:electron-updater-downloaded', version });
+      return { ok: true, pending: true, outcome: 'bundle-pending' as UpdateOutcome, version };
+    } catch (err) {
+      const summary = (err as Error)?.message ?? String(err);
+      appendUpdateLog({ event: 'apply-update:electron-updater-failed', summary });
+      return { ok: false, error: `${summary}\n\nFull log: ${UPDATE_LOG}` };
+    }
+  }
+
   // `install --force` is the robust swap: it replaces the package directory
   // wholesale rather than relying on `update`'s rename dance, which breaks when
   // the prior install left trace-mcp in a partially-extracted state.
@@ -1350,6 +1413,7 @@ const APPLY_HELPER = app.isPackaged
   : path.join(__dirname, '..', '..', '..', '..', 'scripts', 'apply-pending-update.mjs');
 
 function hasPendingUpdate(): boolean {
+  if (UPDATE_CHANNEL !== 'zip-staged') return false;
   return hasPendingUpdateImpl({ pendingZip: PENDING_ZIP, pendingVersion: PENDING_VERSION });
 }
 
@@ -1364,6 +1428,10 @@ function clearPendingFiles(): void {
 }
 
 ipcMain.handle('check-pending-update', () => {
+  // Windows: the pending state is whatever electron-updater has downloaded.
+  if (UPDATE_CHANNEL === 'electron-updater') {
+    return { pending: winUpdateDownloaded };
+  }
   // Only the zip-staged path can actually swap the Electron bundle on
   // restart. The previous "npm-install path" branch claimed pending=true
   // whenever the on-disk package was ahead of the running process, but
@@ -1391,12 +1459,20 @@ function trySpawnApplyHelper(): boolean {
   return trySpawnApplyHelperImpl(
     { pendingZip: PENDING_ZIP, pendingVersion: PENDING_VERSION, applyHelper: APPLY_HELPER },
     process.pid,
+    UPDATE_CHANNEL,
   );
 }
 
 // IPC: restart the app. If a staged update is waiting, apply it; otherwise
 // just relaunch.
-ipcMain.handle('restart-app', () => {
+ipcMain.handle('restart-app', async () => {
+  // Windows: hand the exit to electron-updater, which runs the downloaded
+  // NSIS installer and relaunches the new build itself.
+  if (UPDATE_CHANNEL === 'electron-updater' && winUpdateDownloaded) {
+    const updater = await getAutoUpdater();
+    updater.quitAndInstall();
+    return;
+  }
   if (trySpawnApplyHelper()) {
     app.exit(0);
     return;

--- a/packages/app/src/main/update-channel.ts
+++ b/packages/app/src/main/update-channel.ts
@@ -1,0 +1,26 @@
+/**
+ * Which self-update mechanism this platform is allowed to use.
+ *
+ * The two mechanisms are mutually exclusive by construction — exactly one
+ * channel per platform, decided here and nowhere else:
+ *
+ *   - `zip-staged` (macOS): npm postinstall (`scripts/postinstall-app.mjs`)
+ *     drops a verified zip next to the .app and a detached helper swaps the
+ *     bundle on exit. macOS cannot use electron-updater: Squirrel.Mac
+ *     validates the replacement bundle's code signature and we ship ad-hoc
+ *     signed (`Signature=adhoc`, `TeamIdentifier=not set`), which would
+ *     require a paid Apple Developer ID.
+ *   - `electron-updater` (Windows): NSIS + `latest.yml` published on the
+ *     GitHub release. Windows has no signature requirement for the swap, so
+ *     the real thing works unsigned.
+ *   - `none` (Linux and anything else): no packaged target exists today.
+ *
+ * See docs/development.md § "Desktop app update channels".
+ */
+export type UpdateChannel = 'zip-staged' | 'electron-updater' | 'none';
+
+export function updateChannelFor(platform: NodeJS.Platform): UpdateChannel {
+  if (platform === 'darwin') return 'zip-staged';
+  if (platform === 'win32') return 'electron-updater';
+  return 'none';
+}


### PR DESCRIPTION
Closes TRA-360.

## What changed

Windows was riding macOS's staged-zip update mechanism, which cannot work there — `apply-update` on Windows ran `npm install -g` through a resolver whose every candidate path is POSIX, so it returned "Could not locate `npm`" and the app never updated itself.

- **`packages/app/src/main/update-channel.ts`** (new) — maps platform to exactly one mechanism: `darwin` → `zip-staged`, `win32` → `electron-updater`, everything else → `none`.
- **Interlock.** `trySpawnApplyHelper` now takes the channel and refuses to swap a bundle unless it is `zip-staged`; the `electron-updater` module is loaded lazily behind the same check, so macOS never pulls it into the process. `check-for-update`, `apply-update`, `check-pending-update` and `restart-app` each branch on that one constant.
- **`electron-builder.yml`** — `publish` under `win:` only (hoisting it would emit `latest-mac.yml` and point macOS at a swap Squirrel.Mac would reject, since we ship ad-hoc signed).
- **Packaging.** `electron-updater` is a runtime import, so the bundle needs `node_modules`. Instead of re-admitting the 27.5 MB TRA-257's blanket `!node_modules/**` kept out, the renderer's deps moved to `devDependencies` alongside react/react-dom — Vite bundles all of them into `dist/renderer`, none is a runtime dependency.
- **`release.yml`** — asserts `latest.yml` exists after the Windows package step and uploads it. A missing one fails the release: an installer published without it leaves every install polling a 404 forever.
- **`docs/development.md`** — "Desktop app update channels" records the macOS/Windows/Linux split and why.

## Test evidence

- `pnpm run test` (packages/app): **303 passed / 29 files**, including the new `update-channel.test.ts` (exclusivity of the mapping + the helper's channel guard).
- `pnpm run typecheck` (packages/app), `pnpm run build` (packages/app and root), `pnpm run lint`, `pnpm run biome:ci`, `pnpm run format:check` — all clean.
- Packaged asar of a `--dir` build lists 16 packages under `node_modules` (electron-updater and its tree, 301 files) and nothing from @luma.gl/@cosmos.gl.
- macOS unchanged: a `--mac --arm64` zip build before and after this change produces the same two artifacts (`.zip` + `.blockmap`) and **no** `latest-mac.yml`.
- Confirmed in `app-builder-lib`'s `PublishManager` that update-info files are written independently of `isPublish`, so `--publish never` still emits `latest.yml` for the NSIS target.

## Not verified here

The end-to-end update of a real Windows install one version behind. Cross-building NSIS on the macOS host fails in `makensis` before an installer exists, and the flow needs a published release carrying `latest.yml` to run against. The CI guard covers the metadata; the install itself needs checking on the first release that ships this.

Agent: Implementation Engineer