### PR TITLE
ci(release): do not publish to npm before the app artifacts exist (TRA-362)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,37 @@ jobs:
           )
           gh release edit "$TAG" --repo "${{ github.repository }}" --notes "${BODY}${FOOTER}"
 
+  # Gate between the app builds and npm. release-please marks the GitHub
+  # Release `latest` the moment it cuts the tag, but the zips land 2-5 minutes
+  # later from the matrix jobs below. scripts/postinstall-app.mjs resolves the
+  # update from /releases/latest and returns silently when the arch zip or its
+  # .sha256 is not there yet — so every `npm install -g trace-mcp` inside that
+  # window updates the CLI and quietly leaves the old `.app` behind, with no
+  # error anywhere. `publish` therefore waits for this job: npm never
+  # advertises a version whose artifacts are not already downloadable.
+  #
+  # `always()` so the workflow_dispatch republish path still runs it — there
+  # the build jobs are skipped and the assets are already on the tag.
+  verify-release-assets:
+    needs: [release-please, build-app-mac, build-app-win]
+    if: always() && (needs.release-please.outputs.release_created == 'true' || github.event.inputs.publish_tag != '')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Assert every updater artifact is on the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.publish_tag != '' && github.event.inputs.publish_tag || needs.release-please.outputs.tag_name }}
+        run: |
+          gh release view "$TAG" --repo "${{ github.repository }}" --json assets --jq '.assets' \
+            | node scripts/verify-release-assets.mjs "${TAG#v}"
+
   publish:
-    needs: release-please
+    needs: [release-please, verify-release-assets]
     if: needs.release-please.outputs.release_created == 'true' || github.event.inputs.publish_tag != ''
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/scripts/verify-release-assets.mjs
+++ b/scripts/verify-release-assets.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+/**
+ * verify-release-assets.mjs — assert a GitHub Release carries every artifact
+ * the updaters need, before npm advertises that version as `latest`.
+ *
+ * Why this gate exists: `scripts/postinstall-app.mjs` resolves the update from
+ * `/releases/latest` and returns silently when the arch zip or its `.sha256`
+ * sibling is absent (see its `if (!asset) return;` / `if (!checksumAsset) return;`
+ * paths). A release that ships without those files therefore does not fail an
+ * install — it produces an install that quietly keeps the old `.app`, which is
+ * exactly the invisible failure mode TRA-357 was reported for. The only place
+ * that can notice is the release itself, so it is checked here.
+ *
+ * Usage:
+ *   gh release view <tag> --json assets -q '.assets' |
+ *     node scripts/verify-release-assets.mjs <version>
+ *
+ * Exits non-zero (and names what is missing) when anything is absent or empty.
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Artifacts an updater resolves by name, plus the checksum each one requires. */
+export function expectedAssets(version) {
+  return [
+    `trace-mcp-${version}-arm64-mac.zip`, // macOS Apple silicon
+    `trace-mcp-${version}-mac.zip`, // macOS Intel
+    `trace-mcp-${version}-win.zip`, // Windows portable
+    `trace-mcp.Setup.${version}.exe`, // Windows NSIS installer
+  ].flatMap((name) => [name, `${name}.sha256`]);
+}
+
+/**
+ * @param {string} version
+ * @param {Array<{name: string, size?: number}>} assets  `gh release view --json assets`
+ * @returns {string[]} human-readable problems; empty means the release is complete
+ */
+export function auditReleaseAssets(version, assets) {
+  const bySize = new Map(assets.map((a) => [a.name, a.size ?? 0]));
+  const problems = [];
+  for (const name of expectedAssets(version)) {
+    if (!bySize.has(name)) {
+      problems.push(`missing: ${name}`);
+      continue;
+    }
+    // A truncated upload keeps the name and loses the content — postinstall
+    // would fetch it, fail the digest compare, and give up just as silently.
+    const min = name.endsWith('.sha256') ? 64 : 1;
+    if (bySize.get(name) < min) {
+      problems.push(`empty or truncated: ${name} (${bySize.get(name)} bytes)`);
+    }
+  }
+  return problems;
+}
+
+async function main() {
+  const version = process.argv[2];
+  if (!version) {
+    console.error('usage: node scripts/verify-release-assets.mjs <version> < assets.json');
+    process.exit(1);
+  }
+
+  let raw = '';
+  for await (const chunk of process.stdin) raw += chunk;
+  const assets = JSON.parse(raw);
+
+  const problems = auditReleaseAssets(version, assets);
+  if (problems.length > 0) {
+    console.error(`Release ${version} is incomplete — updates would silently no-op:`);
+    for (const p of problems) console.error(`  ${p}`);
+    process.exit(1);
+  }
+
+  console.log(`Release ${version}: all ${expectedAssets(version).length} assets present.`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tests/scripts/verify-release-assets.test.ts
+++ b/tests/scripts/verify-release-assets.test.ts
@@ -1,0 +1,84 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MODULE_PATH = path.join(__dirname, '..', '..', 'scripts', 'verify-release-assets.mjs');
+
+const { auditReleaseAssets, expectedAssets } = (await import(MODULE_PATH)) as {
+  auditReleaseAssets: (version: string, assets: { name: string; size?: number }[]) => string[];
+  expectedAssets: (version: string) => string[];
+};
+
+/** The shape `gh release view <tag> --json assets -q '.assets'` emits. */
+function completeRelease(version: string) {
+  return expectedAssets(version).map((name) => ({
+    name,
+    size: name.endsWith('.sha256') ? 65 : 110_897_057,
+  }));
+}
+
+describe('verify-release-assets', () => {
+  it('accepts a release carrying every artifact and checksum', () => {
+    expect(auditReleaseAssets('3.1.1', completeRelease('3.1.1'))).toEqual([]);
+  });
+
+  it('names the four zips/installers plus one .sha256 each', () => {
+    expect(expectedAssets('3.1.1')).toEqual([
+      'trace-mcp-3.1.1-arm64-mac.zip',
+      'trace-mcp-3.1.1-arm64-mac.zip.sha256',
+      'trace-mcp-3.1.1-mac.zip',
+      'trace-mcp-3.1.1-mac.zip.sha256',
+      'trace-mcp-3.1.1-win.zip',
+      'trace-mcp-3.1.1-win.zip.sha256',
+      'trace-mcp.Setup.3.1.1.exe',
+      'trace-mcp.Setup.3.1.1.exe.sha256',
+    ]);
+  });
+
+  // The failure this gate exists for: one matrix leg does not upload, npm
+  // publishes anyway, and every Intel Mac silently keeps the old bundle.
+  it('fails when a single arch is missing', () => {
+    const assets = completeRelease('3.1.1').filter(
+      (a) => !a.name.startsWith('trace-mcp-3.1.1-mac'),
+    );
+    expect(auditReleaseAssets('3.1.1', assets)).toEqual([
+      'missing: trace-mcp-3.1.1-mac.zip',
+      'missing: trace-mcp-3.1.1-mac.zip.sha256',
+    ]);
+  });
+
+  // postinstall aborts without a sibling checksum, leaving the old .app in place.
+  it('fails when a zip is present but its checksum is not', () => {
+    const assets = completeRelease('3.1.1').filter(
+      (a) => a.name !== 'trace-mcp-3.1.1-arm64-mac.zip.sha256',
+    );
+    expect(auditReleaseAssets('3.1.1', assets)).toEqual([
+      'missing: trace-mcp-3.1.1-arm64-mac.zip.sha256',
+    ]);
+  });
+
+  it('fails on a truncated upload that kept its name', () => {
+    const assets = completeRelease('3.1.1').map((a) =>
+      a.name === 'trace-mcp-3.1.1-win.zip' ? { ...a, size: 0 } : a,
+    );
+    expect(auditReleaseAssets('3.1.1', assets)).toEqual([
+      'empty or truncated: trace-mcp-3.1.1-win.zip (0 bytes)',
+    ]);
+  });
+
+  it('fails on a checksum file too short to hold a sha256 digest', () => {
+    const assets = completeRelease('3.1.1').map((a) =>
+      a.name === 'trace-mcp-3.1.1-win.zip.sha256' ? { ...a, size: 12 } : a,
+    );
+    expect(auditReleaseAssets('3.1.1', assets)).toEqual([
+      'empty or truncated: trace-mcp-3.1.1-win.zip.sha256 (12 bytes)',
+    ]);
+  });
+
+  // A release-please tag is `v3.1.1`; asset names use the bare version. Passing
+  // the tag through unstripped would report every asset as missing.
+  it('reports everything missing when handed a tag instead of a version', () => {
+    expect(auditReleaseAssets('v3.1.1', completeRelease('3.1.1'))).toHaveLength(8);
+  });
+});


### PR DESCRIPTION
## The hole

`release-please` marks the GitHub Release **`latest` the moment it cuts the tag**. The macOS and Windows zips are uploaded 2-5 minutes later by `build-app-mac` / `build-app-win`. Until this PR, `publish` (npm) had `needs: release-please` only — it did not wait for either build job.

That window is silent by construction. `scripts/postinstall-app.mjs` resolves the update from `/releases/latest` and gives up without a word when the arch zip or its checksum is not there yet:

```js
const asset = release.assets.find((a) => zipPattern.test(a.name));
if (!asset) return;                 // no arch zip yet -> silent no-op
...
if (!checksumAsset) return;         // no .sha256 yet -> silent no-op
```

So `npm install -g trace-mcp` inside that window updates the CLI, leaves the old `.app` untouched, and reports nothing. That is exactly the `outcome: npm-only` shape from TRA-357.

Job timings from the last three releases — the ordering was luck, not design:

| run | build-app-win done | publish done |
|---|---|---|
| v3.1.1 | 06:10:03 | 06:08:36 — **npm was 87s ahead of the Windows assets** |
| v3.1.0 | 05:06:53 | 05:06:27 |
| v3.0.0 | 04:26:21 | 04:25:28 |

The second failure mode is unbounded: if a matrix leg fails or uploads nothing, npm publishes anyway and every user on that platform silently keeps the old bundle forever, with a green release page.

## The fix

- New `verify-release-assets` job: `needs: [release-please, build-app-mac, build-app-win]`, asserts all four artifacts plus one non-empty `.sha256` each are actually on the release.
- `publish` now `needs: [release-please, verify-release-assets]` — npm cannot advertise a version whose artifacts are not downloadable.
- `always()` on the gate keeps the `workflow_dispatch` republish path working (build jobs skipped there; assets already on the tag).

Cost: npm publish lands ~2-4 min later. An incomplete release now fails loudly instead of shipping.

## Verification

Ran the gate against live release data, not fixtures:

```
$ gh release view v3.1.1 --json assets -q '.assets' | node scripts/verify-release-assets.mjs 3.1.1
Release 3.1.1: all 8 assets present.                                   exit=0

$ gh release view v1.46.2 --json assets -q '.assets' | node scripts/verify-release-assets.mjs 1.46.2
Release 1.46.2 is incomplete — updates would silently no-op:
  missing: trace-mcp-1.46.2-arm64-mac.zip
  ... (8 lines)                                                        exit=1
```

Also audited all 25 releases: every release from **v1.47.0** onward carries the full 8-asset set; **v1.46.0/1/2** carry none (they predate the app build jobs). No live release is currently broken — this closes the window before the next one is.

7 unit tests cover missing arch, zip-without-checksum, truncated upload, short checksum, and the tag-vs-version mistake. `pnpm run lint`, `pnpm run build`, `pnpm run test` all green (811 files / 8902 tests).

Scope note: deliberately does not touch `scripts/postinstall-app.mjs` — #511 (TRA-359) is in that file.

Closes TRA-362.

Agent: Implementation Engineer