### PR TITLE
fix(app): report global npm roots the update never touched (TRA-364)

### DIFF
--- a/packages/app/src/main/__tests__/update-state.test.ts
+++ b/packages/app/src/main/__tests__/update-state.test.ts
@@ -11,8 +11,11 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   type AppUpdateState,
   computeUpdateOutcome,
+  findStaleRoots,
+  type GlobalInstall,
   isStuckOnVersion,
   readAppUpdateState,
+  scanGlobalInstalls,
   shouldAttemptRepair,
   writeAppUpdateState,
 } from '../update-state';
@@ -99,5 +102,90 @@ describe('state persistence', () => {
     expect(readAppUpdateState(path.join(dir, 'nope.json'))).toEqual({});
     fs.writeFileSync(file, '{not json');
     expect(readAppUpdateState(file)).toEqual({});
+  });
+});
+
+describe('scanGlobalInstalls', () => {
+  let tmp: string;
+
+  const makeRoot = (name: string, version?: string): string => {
+    const root = path.join(tmp, name);
+    if (version === undefined) {
+      fs.mkdirSync(root, { recursive: true });
+      return root;
+    }
+    const pkgDir = path.join(root, 'trace-mcp');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ version }));
+    return root;
+  };
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-global-roots-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('reports the version in every root that has trace-mcp', () => {
+    const a = makeRoot('nvm', '3.1.1');
+    const b = makeRoot('hermes', '3.0.0');
+    expect(scanGlobalInstalls([a, b])).toEqual([
+      { root: a, version: '3.1.1' },
+      { root: b, version: '3.0.0' },
+    ]);
+  });
+
+  it('skips absent roots, roots without trace-mcp, and null entries', () => {
+    const withPkg = makeRoot('nvm', '3.1.1');
+    const empty = makeRoot('empty');
+    expect(scanGlobalInstalls([withPkg, empty, path.join(tmp, 'nope'), null, undefined])).toEqual([
+      { root: withPkg, version: '3.1.1' },
+    ]);
+  });
+
+  it('counts a symlinked duplicate of the same install once', () => {
+    const real = makeRoot('nvm', '3.1.1');
+    const link = path.join(tmp, 'linked');
+    fs.mkdirSync(link);
+    fs.symlinkSync(path.join(real, 'trace-mcp'), path.join(link, 'trace-mcp'), 'dir');
+    expect(scanGlobalInstalls([real, link])).toEqual([{ root: real, version: '3.1.1' }]);
+  });
+
+  it('skips a package whose package.json is unreadable or has no version', () => {
+    const broken = makeRoot('broken', '3.1.1');
+    fs.writeFileSync(path.join(broken, 'trace-mcp', 'package.json'), '{ not json');
+    const versionless = makeRoot('versionless', '3.1.1');
+    fs.writeFileSync(path.join(versionless, 'trace-mcp', 'package.json'), '{}');
+    expect(scanGlobalInstalls([broken, versionless])).toEqual([]);
+  });
+});
+
+describe('findStaleRoots', () => {
+  const install = (root: string, version: string): GlobalInstall => ({ root, version });
+
+  it('reports nothing for a single-root machine', () => {
+    expect(findStaleRoots([install('/a', '3.1.1')], cmpSemver)).toEqual([]);
+    expect(findStaleRoots([], cmpSemver)).toEqual([]);
+  });
+
+  it('reports nothing when every root agrees', () => {
+    expect(findStaleRoots([install('/a', '3.1.1'), install('/b', '3.1.1')], cmpSemver)).toEqual([]);
+  });
+
+  it('reports every root behind the newest — the TRA-364 three-root case', () => {
+    const stale = findStaleRoots(
+      [install('/herd', '3.1.1'), install('/nvm', '3.1.1'), install('/hermes', '3.0.0')],
+      cmpSemver,
+    );
+    expect(stale).toEqual([install('/hermes', '3.0.0')]);
+  });
+
+  it('measures against the newest root, not the first one seen', () => {
+    const stale = findStaleRoots(
+      [install('/old', '3.0.0'), install('/new', '3.1.1'), install('/older', '2.9.0')],
+      cmpSemver,
+    );
+    expect(stale.map((s) => s.root)).toEqual(['/old', '/older']);
   });
 });

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -160,8 +160,11 @@ import {
 } from './ollama-control';
 import {
   computeUpdateOutcome,
+  findStaleRoots,
+  type GlobalInstall,
   isStuckOnVersion,
   readAppUpdateState,
+  scanGlobalInstalls,
   shouldAttemptRepair,
   type UpdateOutcome,
   writeAppUpdateState,
@@ -588,6 +591,17 @@ function fetchLatestRelease(): Promise<{
 }
 
 ipcMain.handle('check-for-update', async () => {
+  const result = await checkForUpdate();
+  // Divergence between global roots exists independently of whether an update
+  // is available, so it rides along with every check rather than only after an
+  // install. Empty on the normal single-root machine. `npm root -g` is folded
+  // in because the user's own npm may own a root the static scan never guesses.
+  const { configRoot, binRoot } = await resolveNpmRoots();
+  const staleRoots = staleGlobalRoots(configRoot, binRoot);
+  return staleRoots.length > 0 ? { ...result, staleRoots } : result;
+});
+
+async function checkForUpdate() {
   const now = Date.now();
   const current = app.getVersion().replace(/^v/, '');
   // Read the persisted "I tried npm-only" marker once. If the user already
@@ -682,7 +696,7 @@ ipcMain.handle('check-for-update', async () => {
       error: toUpdateErrorMessage(err),
     };
   }
-});
+}
 
 // IPC: apply update (runs npm update -g trace-mcp, which triggers postinstall → app update)
 
@@ -693,8 +707,7 @@ ipcMain.handle('check-for-update', async () => {
 // without invoking a subshell (which would otherwise be needed to source
 // .zshrc / .bashrc).
 let cachedNpmBin: string | null | undefined;
-async function resolveNpmBin(): Promise<string | null> {
-  if (cachedNpmBin !== undefined) return cachedNpmBin;
+function npmBinCandidates(): string[] {
   const home = os.homedir();
   const guesses: string[] = [
     // Homebrew (Apple Silicon and Intel)
@@ -732,6 +745,47 @@ async function resolveNpmBin(): Promise<string | null> {
       /* dir absent — skip */
     }
   }
+  return guesses;
+}
+
+/**
+ * `<prefix>/lib/node_modules` for every global npm root we know how to find —
+ * not just the one the resolved npm binary owns.
+ *
+ * Most come from `npmBinCandidates()`, but a runtime can ship a global root
+ * whose npm binary we never look for (nothing resolves `npm` to it, so it was
+ * never a candidate) and still be the root some client's PATH lands on. Those
+ * are listed separately below.
+ */
+function globalRootCandidates(): string[] {
+  const home = os.homedir();
+  return [
+    ...npmBinCandidates().map((npm) =>
+      path.resolve(path.dirname(npm), '..', 'lib', 'node_modules'),
+    ),
+    // Bundled Node runtimes and prefix-style installs whose bin dir we do not
+    // scan for npm, but which still hold their own global node_modules.
+    path.join(home, '.hermes/node/lib/node_modules'),
+    path.join(home, '.local/lib/node_modules'),
+    '/usr/lib/node_modules',
+  ];
+}
+
+/**
+ * Global roots stuck on an older trace-mcp than the newest one on this machine.
+ * `extraRoots` lets callers fold in a root we learned about at runtime (e.g.
+ * `npm root -g`) that the static candidate scan would miss.
+ */
+function staleGlobalRoots(...extraRoots: (string | null | undefined)[]): GlobalInstall[] {
+  return findStaleRoots(
+    scanGlobalInstalls([...globalRootCandidates(), ...extraRoots]),
+    cmpSemver,
+  );
+}
+
+async function resolveNpmBin(): Promise<string | null> {
+  if (cachedNpmBin !== undefined) return cachedNpmBin;
+  const guesses = npmBinCandidates();
   // Prefer a node version that already has `trace-mcp` installed: when nvm
   // hosts multiple versions (e.g. v22 and v24) and only v22 has the global
   // package, picking the latest version's npm would install into a sibling
@@ -796,10 +850,17 @@ async function resolveNpmRoots(): Promise<{ configRoot: string | null; binRoot: 
   return { configRoot, binRoot };
 }
 
+// `npm root -g` is a subprocess, and the 10-minute update poll now asks for it
+// too. It is a fixed property of the resolved npm binary, so resolve it once.
+let cachedNpmRoot: string | null | undefined;
 async function resolveNpmRoot(): Promise<string | null> {
+  if (cachedNpmRoot !== undefined) return cachedNpmRoot;
   const npmBin = await resolveNpmBin();
-  if (!npmBin) return null;
-  return new Promise((resolve) => {
+  if (!npmBin) {
+    cachedNpmRoot = null;
+    return null;
+  }
+  cachedNpmRoot = await new Promise<string | null>((resolve) => {
     // execFile bypasses shell parsing — npmBin is a filesystem path that
     // could in theory contain a space or quote.
     execFile(
@@ -816,6 +877,7 @@ async function resolveNpmRoot(): Promise<string | null> {
       },
     );
   });
+  return cachedNpmRoot;
 }
 
 function forceRemove(p: string): boolean {
@@ -1246,14 +1308,26 @@ ipcMain.handle('apply-update', async () => {
     });
   }
 
+  // `npm install -g` writes into exactly one global root. On a machine with
+  // several (nvm + Herd + a bundled runtime), the rest keep whatever version
+  // they last received — and nothing else here would ever say so.
+  const staleRoots = staleGlobalRoots(npmRoot, npmRoots.binRoot);
+
   appendUpdateLog({
     event: 'apply-update:ok',
     outcome,
     pending,
     installedVersion: installedVersion ?? null,
     runningVersion: running,
+    staleRoots,
   });
-  return { ok: true, pending, outcome, version: pending ? installedVersion : undefined };
+  return {
+    ok: true,
+    pending,
+    outcome,
+    version: pending ? installedVersion : undefined,
+    ...(staleRoots.length > 0 ? { staleRoots } : {}),
+  };
 });
 
 // Pending update plumbing — postinstall stages a verified zip next to the

--- a/packages/app/src/main/preload.ts
+++ b/packages/app/src/main/preload.ts
@@ -65,6 +65,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     error?: string;
     /** True when the user already attempted this transition via npm-only and nothing on disk has moved since. */
     stuck?: boolean;
+    /** Global npm roots holding an older trace-mcp than the newest install on this machine. */
+    staleRoots?: { root: string; version: string }[];
   }> => ipcRenderer.invoke('check-for-update'),
   checkPendingUpdate: (): Promise<{ pending: boolean; version?: string }> =>
     ipcRenderer.invoke('check-pending-update'),
@@ -75,6 +77,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     /** "bundle-pending" — restart will swap the .app; "npm-only" — CLI moved but bundle is stuck; "already-current" — nothing to do. */
     outcome?: 'bundle-pending' | 'npm-only' | 'already-current';
     version?: string;
+    /** Global npm roots holding an older trace-mcp than the newest install on this machine. */
+    staleRoots?: { root: string; version: string }[];
   }> => ipcRenderer.invoke('apply-update'),
   restartApp: (): Promise<void> => ipcRenderer.invoke('restart-app'),
   openSettings: (section?: string): Promise<{ ok: boolean }> =>

--- a/packages/app/src/main/update-state.ts
+++ b/packages/app/src/main/update-state.ts
@@ -110,6 +110,70 @@ export function computeUpdateOutcome(
   return 'already-current';
 }
 
+/** A global npm root that currently holds a `trace-mcp` install. */
+export interface GlobalInstall {
+  /** The `.../lib/node_modules` directory. */
+  root: string;
+  /** Version read from `<root>/trace-mcp/package.json`. */
+  version: string;
+}
+
+/**
+ * Read the trace-mcp version out of each candidate global npm root.
+ *
+ * A developer machine routinely has several: nvm, a bundled runtime (Herd,
+ * Hermes), Homebrew node, a system node. `npm install -g` only ever writes
+ * into the root owned by the npm binary that ran it, so every other root
+ * freezes at whatever version it last received — silently, because the
+ * install that did happen reports success.
+ *
+ * Roots are deduplicated by the realpath of the package directory, so a
+ * symlink farm (`npm link`, a shared prefix behind two PATH entries) counts
+ * once. Unreadable or absent roots are skipped, not reported.
+ */
+export function scanGlobalInstalls(roots: readonly (string | null | undefined)[]): GlobalInstall[] {
+  const seen = new Set<string>();
+  const found: GlobalInstall[] = [];
+  for (const root of roots) {
+    if (!root) continue;
+    let pkgDir: string;
+    try {
+      pkgDir = fs.realpathSync(path.join(root, 'trace-mcp'));
+    } catch {
+      continue; // Root absent, or no trace-mcp in it.
+    }
+    if (seen.has(pkgDir)) continue;
+    seen.add(pkgDir);
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf-8')) as {
+        version?: unknown;
+      };
+      const version = String(pkg.version ?? '').replace(/^v/, '');
+      if (version) found.push({ root, version });
+    } catch {
+      /* half-extracted or unreadable package — not a version we can report on */
+    }
+  }
+  return found;
+}
+
+/**
+ * Roots left behind the newest install on this machine.
+ *
+ * We report rather than repair: writing into a global root the user never
+ * pointed us at is a meaningful escalation of what an update click may do.
+ * But an unfixable state must at least not look healthy — a consumer wired
+ * to a stale root runs old code while every other signal says "up to date".
+ */
+export function findStaleRoots(
+  installs: readonly GlobalInstall[],
+  cmpSemver: (a: string, b: string) => number,
+): GlobalInstall[] {
+  if (installs.length < 2) return [];
+  const newest = installs.reduce((a, b) => (cmpSemver(b.version, a.version) > 0 ? b : a));
+  return installs.filter((i) => cmpSemver(i.version, newest.version) < 0);
+}
+
 /**
  * Should we try to stage the bundle swap ourselves?
  *

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -495,7 +495,32 @@ type UpdateState = {
   lastChecked?: number;
   error?: string;
   stuck?: boolean;
+  staleRoots?: { root: string; version: string }[];
 };
+
+/**
+ * `npm install -g` only ever writes into the global root its own npm owns. On a
+ * machine with several (nvm + Herd + a bundled runtime) the rest keep an old
+ * version, and every other signal here still reads "Up to date" — so a client
+ * wired to a stale root runs old code with nothing saying so (TRA-364). We
+ * cannot safely write into a root the user never pointed us at, so we say it
+ * out loud instead: the status row goes to the warning treatment and its
+ * tooltip names each stale root and the command that fixes it.
+ */
+function describeStaleRoots(staleRoots: { root: string; version: string }[]): {
+  label: string;
+  title: string;
+} {
+  const label =
+    staleRoots.length === 1
+      ? `Another npm install is on v${staleRoots[0].version}`
+      : `${staleRoots.length} other npm installs are out of date`;
+  const lines = staleRoots.map((r) => `v${r.version} — ${r.root}/trace-mcp`);
+  return {
+    label,
+    title: `${label}. This app updated the root it resolves to; these were not touched:\n${lines.join('\n')}\n\nFix each with its own npm: <root>/../../bin/npm install -g trace-mcp@latest`,
+  };
+}
 
 function formatAgo(ts?: number, now: number = Date.now()): string {
   if (!ts) return 'never';
@@ -703,9 +728,12 @@ export function UpdateBanner() {
 
   // Idle: minimal status row. No card chrome — stays out of the way.
   const isError = !!state.error;
+  // A stale sibling root is not an error, but it must not read as healthy
+  // either — it borrows the same warning treatment when nothing worse is up.
+  const stale = !isError && state.staleRoots?.length ? describeStaleRoots(state.staleRoots) : null;
   return (
     <div
-      className={`update-idle${isError ? ' error' : ''}`}
+      className={`update-idle${isError || stale ? ' error' : ''}`}
       // The only place the app reports update health. It changes without the
       // user asking, so assistive tech has to hear it (TRA-297).
       role="status"
@@ -713,8 +741,8 @@ export function UpdateBanner() {
       style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
     >
       <span className="dot" aria-hidden="true" />
-      <span className="label" title={isError ? state.error : undefined}>
-        {isError ? state.error : `Up to date · v${state.current ?? '—'}`}
+      <span className="label" title={isError ? state.error : (stale?.title ?? undefined)}>
+        {isError ? state.error : (stale?.label ?? `Up to date · v${state.current ?? '—'}`)}
       </span>
       {refreshButton}
     </div>

--- a/packages/app/src/renderer/electron.d.ts
+++ b/packages/app/src/renderer/electron.d.ts
@@ -39,6 +39,8 @@ declare global {
         lastChecked?: number;
         error?: string;
         stuck?: boolean;
+        /** Global npm roots holding an older trace-mcp than the newest install on this machine. */
+        staleRoots?: { root: string; version: string }[];
       }>;
       checkPendingUpdate: () => Promise<{ pending: boolean; version?: string }>;
       applyUpdate: () => Promise<{
@@ -47,6 +49,8 @@ declare global {
         error?: string;
         outcome?: 'bundle-pending' | 'npm-only' | 'already-current';
         version?: string;
+        /** Global npm roots holding an older trace-mcp than the newest install on this machine. */
+        staleRoots?: { root: string; version: string }[];
       }>;
       restartApp: () => Promise<void>;
       openSettings: (section?: string) => Promise<{ ok: boolean }>;


### PR DESCRIPTION
Closes TRA-364.

## The defect

`npm install -g trace-mcp@latest` writes into exactly one global root — the one the resolved npm binary owns. On a machine with several (nvm + Herd + a bundled runtime, a normal developer setup), every other root keeps whatever version it last received, forever.

This was silent in the same way TRA-357's bundle-swap failure was silent: `apply-update:ok` gets logged, one root really did update, and the app keeps reading "Up to date". A tool config, shell alias, or MCP client wired to a stale root runs old code indefinitely while every visible signal says the update succeeded.

## The decision

Three options were on the table (update every root / detect and surface / document as a limitation). This takes **detect and surface**:

- Updating roots the user never pointed us at is a meaningful escalation of what an update click is allowed to do, and it does not fit "the smallest change that fully solves the issue".
- A state we cannot safely fix must at least not *look* healthy — that is the TRA-357 lesson, applied.

Documenting it alone was rejected: the whole failure mode is that nothing reports it, and a docs paragraph does not reach a user who never suspects there is a problem.

## The change

- `scanGlobalInstalls` / `findStaleRoots` in `update-state.ts` — pure and unit-tested, deduplicating by the realpath of the package dir so a symlinked duplicate (`npm link`, a shared prefix behind two PATH entries) counts once.
- Candidate roots come from the existing npm-bin scan, plus prefix-style roots whose npm binary is never a resolve candidate (`~/.hermes/node`, `~/.local`, `/usr/lib`) and whatever `npm root -g` reports. The `~/.hermes` root in the report is exactly the case the bin-derived list alone would have missed.
- `check-for-update` and `apply-update` both return `staleRoots`; `apply-update` also records them in `~/.trace-mcp/update.log`. Divergence is reported on every poll, not only after an install — it exists whether or not an update is available.
- The sidebar status row drops "Up to date" for the existing warning treatment, and its tooltip names each stale root, its version, and the command that fixes it.
- `resolveNpmRoot` is now cached, since the 10-minute poll asks for it too. It is a fixed property of the resolved npm binary.

No MCP tool signature, on-disk schema, or query-cost change — this is Electron-main and renderer only.

## Test evidence

New `packages/app/src/main/__tests__/update-state.test.ts`, 8 cases: per-root version reads, absent/empty/null roots skipped, symlinked duplicate counted once, unreadable and version-less `package.json` skipped, single-root and all-agree machines reporting nothing, the reported three-root case, and "newest root, not first seen" as the baseline.

```
pnpm --filter trace-mcp-app exec vitest run   -> 30 files, 311 tests passed
pnpm --filter trace-mcp-app run typecheck     -> clean
pnpm --filter trace-mcp-app run build:main    -> clean
pnpm run lint (tsc --noEmit, root)            -> clean
pnpm run biome:ci                             -> 1607 files, no fixes
```

Agent: Lead Engineer
