### PR TITLE
feat(app): collapse the sidebar footer into one row that opens an app menu (TRA-363)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -355,6 +355,36 @@ Every data surface owes four states, and each has a house form:
 - **Scroll edges get a hairline.** A pinned footer or a sticky header that content
   slides under is a scroll edge; a sticky header must have an **opaque** backing, or
   rows show through the column labels.
+- **The sidebar footer is ONE row, and it opens the app menu.** It is not where
+  global actions accumulate — that is what it kept becoming, a row per action plus a
+  permanent update strip, 70.5px of chrome under a column meant for navigation
+  (TRA-305 → TRA-306 → TRA-363). The row is the product: its name, a chevron, and a
+  pop-up. See "Where a global action lives" below.
+
+### Where a global action lives
+
+An action that belongs to the app rather than to the surface in front of you —
+Settings, Check for updates, What's new, Get help — has exactly two homes, and
+**one definition**: `packages/app/src/shared/global-actions.ts`.
+
+- The **native application menu** (`main/menu.ts`) builds its items from that list.
+  On macOS the menu bar is these actions' native home and the place a Mac user
+  looks first.
+- The **app menu** in the sidebar footer renders the same list. Off macOS there is
+  no menu bar in the window, and on macOS it is still the discoverable path for
+  someone who has never opened the menu bar.
+
+Neither surface types a label or a key of its own: they read `label`, `accelerator`
+/ `shortcut` and `url` from the shared entry. Adding a global action means adding
+one object there — it appears in both places, named the same, on the same key.
+
+Two things deliberately stay out of that list. **Appearance** is a preference with
+three states, not a command, and lives in the app menu and in Settings only — a
+list with one member cannot drift. **Documentation** is native-menu-only for the
+same reason.
+
+The footer never grows a second row for any of this. If a new global action needs a
+home, it is a menu item.
 
 ### The window minimum is a size that has to work
 
@@ -588,7 +618,13 @@ new evidence.
 | `listPending` separates "daemon hasn't answered" from "never indexed" | `status ?? 'unknown'` blamed the project for the daemon's silence. |
 | Sidebar footer is `.ws-sb-row`, not its own geometry | One row system for the whole sidebar; the footer's labels started 26px left of every other label. |
 | Appearance is Auto / Light / Dark, with Auto clearing the key | The old `toggle` only ever wrote `light` or `dark`, so one click pinned the app forever and the system listener stopped mattering. |
-| Appearance lives in Settings, not the sidebar footer | A preference is not a navigation destination, and a second footer row cost 28px at the bottom of every window. It renders in Settings' daemon-down and loading states too — the theme is localStorage, not daemon config. |
+| Appearance lives in Settings, not the sidebar footer | A preference is not a navigation destination, and a second footer row cost 28px at the bottom of every window. It renders in Settings' daemon-down and loading states too — the theme is localStorage, not daemon config. (TRA-363 added it back as a checked group *inside* the app menu — a menu item costs no sidebar height, which is what the objection was about.) |
+| The sidebar footer is one row, and that row opens a menu | Every global action was costing 28px of a column meant for navigation: Settings, then Appearance, then a permanent "● Up to date · v3.1.1 ⟳" strip — 70.5px measured, of which the update row's entire message was "nothing is wrong". One row is 42.5px and the next global action costs a menu item instead of a row (TRA-363). |
+| A global action is defined once, in `src/shared/global-actions.ts` | The native menu and the app menu both offer Settings / What's new / Get help / Check for updates. Two hand-maintained lists drift — a relabelled item, a moved key, an action added to one and forgotten in the other. Neither surface types a label; both read the entry. |
+| "Up to date" belongs in the app menu's header, not in a sidebar row | It is the answer to a question you only ask when you go looking, and it belongs next to the action that re-asks it. A permanent strip pays 28px in every window, forever, to report the absence of news. The states you can *act* on — update available, restart pending, bundle stuck — still get a card in the sidebar. |
+| A menu anchors on the app, because there is no account to anchor on | The pattern this came from is an account menu, held together by an identity at the top. We have no users. The product is the identity: the trigger carries the name, the header carries the version and whether it is current. |
+| In a menu, focus IS the highlight — and the only one | Arrowing moves real DOM focus, so `:focus` has to paint the same accent fill `:hover` does. The house `*:focus-visible` ring on top of that fill drew a blue halo round an already-blue row, which reads as a button on a surface; macOS draws the fill and nothing else. |
+| A row that opens a menu takes the inactive-selection fill, keyed off `aria-expanded` | Accent fill means "this is the surface you are looking at". A menu is not a surface, and the footer row navigates nowhere — on `.is-selected` it lit up accent-blue the moment its own menu took focus. |
 | A surface that draws its own toolbar owns its whole pane | Wrapping it in the pane's `p-4` doubles every inset the surface already declares — the workspace KPI row started at x=32 with its first card at y=76. |
 | Paths truncate at the **head**, keeping the tail | The tail is the part that distinguishes siblings; tail-truncation hid the only useful segment. |
 | Sidebar file paths use a `dir`/`name` flex split, not `direction: rtl` | The rtl hack mangled any path containing `.` or `_` runs (`.idea/workspace.xml` → `idea/workspace.xml.`). |

--- a/packages/app/src/main/__tests__/menu.test.ts
+++ b/packages/app/src/main/__tests__/menu.test.ts
@@ -49,6 +49,7 @@ vi.mock('electron', () => ({
 
 vi.mock('../tray', () => ({ showMenuWindow: vi.fn() }));
 
+import { GLOBAL_ACTIONS } from '../../shared/global-actions.js';
 import { buildAppMenu, forgetWindowSections, setWindowSections } from '../menu';
 
 function menu(label: string): Item[] {
@@ -96,6 +97,24 @@ describe('application menu', () => {
     expect(keys.get('Close tab')).toBe('CmdOrCtrl+W');
     expect(keys.get('Close window')).toBe('CmdOrCtrl+Shift+W');
     expect(keys.get('Reload')).toBe('CmdOrCtrl+R');
+  });
+
+  /* TRA-363: the sidebar's app menu offers the same four actions. Both lists
+     are built from src/shared/global-actions.ts, and this is the half of that
+     promise the main process can check — that every shared action is actually
+     ON the native menu, under its own label. The renderer's half lives in
+     renderer/components/__tests__/AppMenu.test.tsx. */
+  it('carries every shared global action, by the shared label', () => {
+    const labels = template.flatMap((top) => (top.submenu ?? []).map((i) => i.label));
+    for (const action of GLOBAL_ACTIONS) {
+      expect(labels).toContain(action.label);
+    }
+  });
+
+  it('sends the shared list’s URL actions to the browser, not to a window', () => {
+    click(menu('Help'), 'Get help');
+    click(menu('Help'), "What's new");
+    expect(sent).toEqual([]); // neither is an app-command
   });
 
   it('keeps Edit on plain roles so text fields keep working', () => {

--- a/packages/app/src/main/menu.ts
+++ b/packages/app/src/main/menu.ts
@@ -26,12 +26,12 @@ import {
   shell,
   type MenuItemConstructorOptions,
 } from 'electron';
+import { type GlobalActionId, globalAction } from '../shared/global-actions.js';
 import { showMenuWindow } from './tray';
 
 const isMac = process.platform === 'darwin';
 
-const HELP_URL = 'https://github.com/nikolai-vysotskyi/trace-mcp#readme';
-const ISSUES_URL = 'https://github.com/nikolai-vysotskyi/trace-mcp/issues/new';
+const DOCS_URL = 'https://github.com/nikolai-vysotskyi/trace-mcp#readme';
 
 export interface WindowSection {
   id: string;
@@ -67,6 +67,17 @@ function closeWindowGroup(): void {
   }
 }
 
+/** One item of the shared global-action list (TRA-363). The sidebar's app menu
+    renders the SAME entry, so the label and the key are read here, never typed
+    here — that is the whole point of `src/shared/global-actions.ts`. */
+function actionItem(id: GlobalActionId): MenuItemConstructorOptions {
+  const action = globalAction(id);
+  const url = action.url;
+  return url
+    ? { label: action.label, click: () => void shell.openExternal(url) }
+    : { label: action.label, accelerator: action.accelerator, click: () => send(action.id) };
+}
+
 function sectionItems(): MenuItemConstructorOptions[] {
   const focused = BrowserWindow.getFocusedWindow();
   const sections = focused ? (sectionsByWebContents.get(focused.webContents.id) ?? []) : [];
@@ -84,9 +95,9 @@ export function buildAppMenu(): Menu {
     label: app.name,
     submenu: [
       { role: 'about' },
-      { label: 'Check for updates…', click: () => send('check-for-update') },
+      actionItem('check-for-update'),
       { type: 'separator' },
-      { label: 'Settings…', accelerator: 'CmdOrCtrl+,', click: () => send('settings') },
+      actionItem('settings'),
       { type: 'separator' },
       ...(isMac
         ? ([
@@ -120,7 +131,7 @@ export function buildAppMenu(): Menu {
         ? []
         : ([
             { type: 'separator' },
-            { label: 'Settings…', accelerator: 'CmdOrCtrl+,', click: () => send('settings') },
+            actionItem('settings'),
             { type: 'separator' },
             { role: 'quit' },
           ] as MenuItemConstructorOptions[])),
@@ -191,14 +202,18 @@ export function buildAppMenu(): Menu {
   const helpMenu: MenuItemConstructorOptions = {
     label: 'Help',
     submenu: [
-      { label: 'trace-mcp help', click: () => void shell.openExternal(HELP_URL) },
-      { label: 'Report an issue', click: () => void shell.openExternal(ISSUES_URL) },
+      // "Documentation", not the old "trace-mcp help": next to the shared
+      // "Get help" item, two things called help and pointing at different
+      // pages is a coin toss.
+      { label: 'Documentation', click: () => void shell.openExternal(DOCS_URL) },
+      actionItem('get-help'),
+      actionItem('whats-new'),
       // On macOS these live in the app menu; elsewhere Help is where they go.
       ...(isMac
         ? []
         : ([
             { type: 'separator' },
-            { label: 'Check for updates…', click: () => send('check-for-update') },
+            actionItem('check-for-update'),
             { role: 'about' },
           ] as MenuItemConstructorOptions[])),
     ],

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { AppMenu } from './components/AppMenu';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { GuardOnboarding, isOnboardingDone } from './components/GuardOnboarding';
 import { QuickOpen, type QuickOpenItem } from './components/QuickOpen';
+import { SidebarRow } from './components/SidebarRow';
 import { WindowTabBar } from './components/WindowTabBar';
 import { fileKind, FileTypeGlyph, Icon } from './lattice/icons';
 import { Menu, MenuItem, MenuSeparator, PopUpButton } from './lattice/ui';
+import { formatAgo, type UpdateCheck, useUpdateCheck } from './update-check.js';
 import {
   clampSidebarWidth,
   readSidebarCollapsed,
@@ -92,54 +95,6 @@ import {
 } from './recent-projects.js';
 
 export { removeRecentProject };
-
-/** One 28px sidebar row: 16px leading glyph, 13px label, optional trailing. */
-function SidebarRow({
-  icon,
-  glyph,
-  label,
-  selected = false,
-  onClick,
-  onKeyDown,
-  onContextMenu,
-  title,
-  count,
-  trailing,
-  rowRef,
-  ...aria
-}: {
-  icon?: string;
-  glyph?: React.ReactNode;
-  label: React.ReactNode;
-  selected?: boolean;
-  onClick: () => void;
-  onKeyDown?: (e: React.KeyboardEvent) => void;
-  onContextMenu?: (e: React.MouseEvent) => void;
-  title?: string;
-  count?: React.ReactNode;
-  trailing?: React.ReactNode;
-  rowRef?: React.Ref<HTMLButtonElement>;
-} & React.AriaAttributes & { role?: string; tabIndex?: number }) {
-  return (
-    <button
-      type="button"
-      ref={rowRef}
-      className={`ws-sb-row${selected ? ' is-selected' : ''}`}
-      onClick={onClick}
-      onKeyDown={onKeyDown}
-      onContextMenu={onContextMenu}
-      title={title}
-      {...aria}
-    >
-      <span className="ws-sb-ico" aria-hidden="true">
-        {glyph ?? (icon ? <Icon name={icon} size={16} /> : null)}
-      </span>
-      {typeof label === 'string' ? <span className="ws-sb-label">{label}</span> : label}
-      {count !== undefined && <span className="ws-sb-count">{count}</span>}
-      {trailing}
-    </button>
-  );
-}
 
 function RecentProjects() {
   const [recent, setRecent] = useState<string[]>(getRecentProjects);
@@ -440,176 +395,18 @@ function ProjectFileExplorer({
   );
 }
 
-// ── Sidebar footer ───────────────────────────────────────────
-// ONE row pinned below the scroll region, in the SAME row system as the nav
-// above it (.ws-sb-row: 28px, 16px leading glyph at x=14, 13px label at x=38).
-//
-// TRA-305 put the footer on that row system, which was right, but it also
-// parked Appearance in a second static row — 70.5px of footer under a 38px
-// update banner, and the bottom of the sidebar read as heavy (TRA-306).
-// Appearance is a preference, not a navigation destination, and no macOS app
-// pins an appearance switcher to its sidebar: it moved to the Settings screen,
-// where Auto / Light / Dark are still all three one click away. In project
-// windows, Settings opens the menu window via IPC instead of navigating.
-function SidebarFooter({
-  active,
-  onOpenSettingsInPlace,
-}: {
-  active: boolean;
-  onOpenSettingsInPlace?: () => void;
-}) {
-  const handleSettings = () => {
-    if (onOpenSettingsInPlace) {
-      onOpenSettingsInPlace();
-    } else {
-      const api = window.electronAPI;
-      api?.openSettings?.();
-    }
-  };
-  return (
-    <div className="ws-sb-footer">
-      <SidebarRow
-        icon="settings"
-        label="Settings"
-        selected={active}
-        aria-current={active ? 'page' : undefined}
-        onClick={handleSettings}
-      />
-    </div>
-  );
-}
-
-// ── Update banner ────────────────────────────────────────────
-// Always rendered at the bottom of the sidebar. Polls every 10min — the main
-// process checks the npm registry (no rate limit) with GitHub Releases as a
-// fallback. Surfaces three states: up-to-date (with last-checked timestamp),
-// update available, and update downloaded but pending restart.
 // Where the compiled bundles live — same repo the postinstall downloads from
 // (scripts/app-dist-repo.mjs). Used by the "manual install" card below.
 const RELEASES_URL = 'https://github.com/nikolai-vysotskyi/trace-mcp/releases/latest';
 
-type UpdateState = {
-  available: boolean;
-  current?: string;
-  latest?: string;
-  lastChecked?: number;
-  error?: string;
-  stuck?: boolean;
-  staleRoots?: { root: string; version: string }[];
-};
-
-/**
- * `npm install -g` only ever writes into the global root its own npm owns. On a
- * machine with several (nvm + Herd + a bundled runtime) the rest keep an old
- * version, and every other signal here still reads "Up to date" — so a client
- * wired to a stale root runs old code with nothing saying so (TRA-364). We
- * cannot safely write into a root the user never pointed us at, so we say it
- * out loud instead: the status row goes to the warning treatment and its
- * tooltip names each stale root and the command that fixes it.
- */
-function describeStaleRoots(staleRoots: { root: string; version: string }[]): {
-  label: string;
-  title: string;
-} {
-  const label =
-    staleRoots.length === 1
-      ? `Another npm install is on v${staleRoots[0].version}`
-      : `${staleRoots.length} other npm installs are out of date`;
-  const lines = staleRoots.map((r) => `v${r.version} — ${r.root}/trace-mcp`);
-  return {
-    label,
-    title: `${label}. This app updated the root it resolves to; these were not touched:\n${lines.join('\n')}\n\nFix each with its own npm: <root>/../../bin/npm install -g trace-mcp@latest`,
-  };
-}
-
-function formatAgo(ts?: number, now: number = Date.now()): string {
-  if (!ts) return 'never';
-  const s = Math.max(0, Math.floor((now - ts) / 1000));
-  if (s < 60) return `${s}s ago`;
-  if (s < 3600) return `${Math.floor(s / 60)}m ago`;
-  if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
-  return `${Math.floor(s / 86400)}d ago`;
-}
-
-export function UpdateBanner() {
-  const [state, setState] = useState<UpdateState>({ available: false });
-  const [updating, setUpdating] = useState(false);
-  const [checking, setChecking] = useState(false);
-  const [pendingVersion, setPendingVersion] = useState<string | null>(null);
-  const [now, setNow] = useState(Date.now());
-  const cancelledRef = useRef(false);
-
-  const runCheck = async () => {
-    const api = window.electronAPI;
-    if (!api?.checkForUpdate) return;
-    setChecking(true);
-    try {
-      const [upd, pend] = await Promise.all([
-        api.checkForUpdate(),
-        api.checkPendingUpdate
-          ? api.checkPendingUpdate()
-          : Promise.resolve<{ pending: boolean; version?: string }>({ pending: false }),
-      ]);
-      if (cancelledRef.current) return;
-      if (upd) setState(upd);
-      if (pend?.pending) setPendingVersion(pend.version || (upd?.latest ?? null));
-      else setPendingVersion(null);
-    } catch (err) {
-      if (!cancelledRef.current) setState((s) => ({ ...s, error: (err as Error).message }));
-    } finally {
-      if (!cancelledRef.current) setChecking(false);
-    }
-  };
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: runCheck is intentionally captured once on mount; adding it would tear down the polling interval on every state update inside runCheck (setState calls), defeating the 10-min cadence. The cancelledRef guards against state updates after unmount.
-  useEffect(() => {
-    cancelledRef.current = false;
-    runCheck();
-    const poll = setInterval(runCheck, 600_000);
-    const tick = setInterval(() => setNow(Date.now()), 15_000);
-    // "Check for updates…" in the application menu (TRA-297). App.tsx receives
-    // the IPC command and re-broadcasts it here so the banner stays the single
-    // owner of update state.
-    const onMenuCheck = () => runCheck();
-    window.addEventListener('trace-mcp:check-update', onMenuCheck);
-    return () => {
-      cancelledRef.current = true;
-      clearInterval(poll);
-      clearInterval(tick);
-      window.removeEventListener('trace-mcp:check-update', onMenuCheck);
-    };
-  }, []);
-
-  const handleUpdate = async () => {
-    const api = window.electronAPI;
-    if (!api) return;
-    setUpdating(true);
-    setState((s) => ({ ...s, error: undefined }));
-    try {
-      const result = await api.applyUpdate();
-      if (result?.ok && api.checkPendingUpdate) {
-        const pend = await api.checkPendingUpdate();
-        if (pend?.pending) setPendingVersion(pend.version || state.latest || null);
-      }
-      if (!result?.ok) {
-        setState((s) => ({ ...s, error: result?.error || 'update failed' }));
-      } else if (result.outcome === 'npm-only') {
-        // The npm package moved but the .app bundle stayed put. Re-run the
-        // availability check now — the main process just wrote the sticky
-        // marker, so this call returns { available: false, stuck: true } and
-        // the card switches to "needs a manual install" instead of looping the
-        // user through the same prompt on the next poll.
-        runCheck();
-      }
-    } finally {
-      setUpdating(false);
-    }
-  };
-
-  const handleRestart = () => {
-    const api = window.electronAPI;
-    api?.restartApp();
-  };
+// ── Update card ──────────────────────────────────────────────
+// Only the states you can DO something about: an update available, one
+// downloaded and waiting on a restart, and a bundle that could not replace
+// itself. "Up to date" used to be a permanent 28px strip above the footer whose
+// whole job was to say nothing was wrong; it says that in the app menu's
+// header now, next to Check for updates (TRA-363).
+export function UpdateCard({ update }: { update: UpdateCheck }) {
+  const { state, pendingVersion, updating } = update;
 
   // Pending swap takes precedence — the user's next click should restart, not redownload.
   if (pendingVersion) {
@@ -630,47 +427,12 @@ export function UpdateBanner() {
           v{pendingVersion} ready
         </div>
         <div className="subtitle">Restart to install · v{state.current}</div>
-        <button type="button" className="btn-prominent success" onClick={handleRestart}>
+        <button type="button" className="btn-prominent success" onClick={update.restart}>
           Restart to install
         </button>
       </div>
     );
   }
-
-  const refreshButton = (
-    <button
-      type="button"
-      className={`update-refresh${checking ? ' spinning' : ''}`}
-      onClick={runCheck}
-      disabled={checking}
-      title="Check for updates"
-      aria-label="Check for updates"
-    >
-      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-        <path
-          d="M10 2.5v2.6H7.4"
-          stroke="currentColor"
-          strokeWidth="1.3"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <path
-          d="M2 9.5V6.9h2.6"
-          stroke="currentColor"
-          strokeWidth="1.3"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <path
-          d="M9.3 5.1A3.7 3.7 0 003 4.6M2.7 6.9a3.7 3.7 0 006.3.5"
-          stroke="currentColor"
-          strokeWidth="1.3"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-    </button>
-  );
 
   // The CLI updated, the .app bundle did not, and clicking Update again would
   // repeat exactly that. Suppressing the "update available" card is correct;
@@ -685,10 +447,7 @@ export function UpdateBanner() {
         aria-live="polite"
         style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
-        <div className="title">
-          <span>v{state.latest} needs a manual install</span>
-          {refreshButton}
-        </div>
+        <div className="title">v{state.latest} needs a manual install</div>
         <div className="subtitle">
           The command line tool updated, but the app itself is still v{state.current} — it could not
           replace its own bundle. Download the release and drag it into Applications.
@@ -704,47 +463,28 @@ export function UpdateBanner() {
     );
   }
 
-  if (state.available) {
-    return (
-      <div className="update-card" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
-        <div className="title">
-          <span>v{state.latest} available</span>
-          {refreshButton}
-        </div>
-        <div className="subtitle">
-          Currently v{state.current} · checked {formatAgo(state.lastChecked, now)}
-        </div>
-        {state.error && (
-          <div className="subtitle error" title={state.error}>
-            {state.error}
-          </div>
-        )}
-        <button type="button" className="btn-prominent" onClick={handleUpdate} disabled={updating}>
-          {updating ? 'Updating…' : 'Update'}
-        </button>
-      </div>
-    );
-  }
+  if (!state.available) return null;
 
-  // Idle: minimal status row. No card chrome — stays out of the way.
-  const isError = !!state.error;
-  // A stale sibling root is not an error, but it must not read as healthy
-  // either — it borrows the same warning treatment when nothing worse is up.
-  const stale = !isError && state.staleRoots?.length ? describeStaleRoots(state.staleRoots) : null;
   return (
     <div
-      className={`update-idle${isError || stale ? ' error' : ''}`}
-      // The only place the app reports update health. It changes without the
-      // user asking, so assistive tech has to hear it (TRA-297).
+      className="update-card"
+      style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+      // It appears without the user asking, so assistive tech has to hear it.
       role="status"
       aria-live="polite"
-      style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
     >
-      <span className="dot" aria-hidden="true" />
-      <span className="label" title={isError ? state.error : (stale?.title ?? undefined)}>
-        {isError ? state.error : (stale?.label ?? `Up to date · v${state.current ?? '—'}`)}
-      </span>
-      {refreshButton}
+      <div className="title">v{state.latest} available</div>
+      <div className="subtitle">
+        Currently v{state.current} · checked {formatAgo(state.lastChecked)}
+      </div>
+      {state.error && (
+        <div className="subtitle error" title={state.error}>
+          {state.error}
+        </div>
+      )}
+      <button type="button" className="btn-prominent" onClick={update.apply} disabled={updating}>
+        {updating ? 'Updating…' : 'Update'}
+      </button>
     </div>
   );
 }
@@ -824,6 +564,10 @@ export function App() {
   const { view, tab, root } = getUrlParams();
   const isProject = view === 'project' && root !== null;
   const { theme, appearance, setAppearance } = useTheme();
+  /* One owner of update state for the whole window: the app menu's header
+     reports it, the card acts on it, and "Check for updates…" — from the
+     application menu or from the app menu — drives the same check (TRA-363). */
+  const update = useUpdateCheck();
 
   const [globalTab, setGlobalTab] = useState<GlobalTab>(normalizeGlobalTab(tab));
   const [projectTab, setProjectTab] = useState<ProjectTab>('overview');
@@ -1004,11 +748,11 @@ export function App() {
           void pickProject();
           break;
         case 'check-for-update':
-          window.dispatchEvent(new CustomEvent('trace-mcp:check-update'));
+          update.check();
           break;
       }
     });
-  }, [toggleSidebar, selectSection, focusSearch, openSettings, pickProject]);
+  }, [toggleSidebar, selectSection, focusSearch, openSettings, pickProject, update.check]);
 
   // ⌘P — the second quick-open key. Not in the menu (one accelerator per item).
   useEffect(() => {
@@ -1161,10 +905,14 @@ export function App() {
               )}
             </nav>
 
-            <UpdateBanner />
-            <SidebarFooter
-              active={!isProject && globalTab === 'settings'}
-              onOpenSettingsInPlace={isProject ? undefined : () => setGlobalTab('settings')}
+            <UpdateCard update={update} />
+            <AppMenu
+              update={update.state}
+              checking={update.checking}
+              onCheckForUpdate={update.check}
+              appearance={appearance}
+              onAppearanceChange={setAppearance}
+              onSettings={openSettings}
             />
           </aside>
         )}

--- a/packages/app/src/renderer/__tests__/app-commands.test.tsx
+++ b/packages/app/src/renderer/__tests__/app-commands.test.tsx
@@ -132,10 +132,17 @@ describe('application-menu commands', () => {
     expect(document.querySelector('.ws-sidebar')).not.toBeNull();
   });
 
+  /* The footer is a menu trigger now, not a Settings row (TRA-363). Settings
+     itself needs a live daemon to render, which this harness has no business
+     supplying — what is testable is that the menu window handles the command
+     in place (no IPC hand-off) and leaves no nav row selected, because
+     Settings stopped being a sidebar destination. */
   it('settings opens the Settings surface in the menu window', async () => {
     await renderApp('/?view=menu&tab=workspace');
+    expect(document.querySelector('.ws-sb-row.is-selected')?.textContent).toContain('Workspace');
     await act(async () => dispatch('settings'));
-    expect(document.querySelector('.ws-sb-footer .is-selected')).not.toBeNull();
+    expect(document.querySelector('.ws-sb-row.is-selected')).toBeNull();
+    expect(window.electronAPI?.openSettings).not.toHaveBeenCalled();
   });
 
   it('settings hands off to the menu window from a project window', async () => {

--- a/packages/app/src/renderer/__tests__/update-banner.test.tsx
+++ b/packages/app/src/renderer/__tests__/update-banner.test.tsx
@@ -2,11 +2,18 @@
 /* TRA-357: the updater's honest states. The bug that made this file necessary
    was not the suppression logic — clicking Update again really would do
    nothing — but its presentation: a bundle three majors behind rendered as a
-   green "Up to date". */
+   green "Up to date".
 
-import { render, screen, waitFor } from '@testing-library/react';
+   TRA-363 moved "up to date" out of the sidebar and into the app menu's
+   header, so the same promise now has two places to be broken and both are
+   checked here: the card must name the stuck state, and the header must never
+   call it current. */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { UpdateBanner } from '../App';
+import { UpdateCard } from '../App';
+import { AppMenu } from '../components/AppMenu';
+import { useUpdateCheck } from '../update-check';
 
 type CheckResult = {
   available: boolean;
@@ -14,6 +21,7 @@ type CheckResult = {
   latest?: string;
   stuck?: boolean;
   lastChecked?: number;
+  staleRoots?: { root: string; version: string }[];
 };
 
 function mockApi(check: CheckResult, openExternal = vi.fn()) {
@@ -27,16 +35,36 @@ function mockApi(check: CheckResult, openExternal = vi.fn()) {
   return openExternal;
 }
 
+/** The sidebar card, on the real hook — same wiring App uses. */
+function Card() {
+  return <UpdateCard update={useUpdateCheck()} />;
+}
+
+/** The app menu, on the same hook — the other reader of that state. */
+function Menu() {
+  const update = useUpdateCheck();
+  return (
+    <AppMenu
+      update={update.state}
+      checking={update.checking}
+      onCheckForUpdate={update.check}
+      appearance="auto"
+      onAppearanceChange={() => {}}
+      onSettings={() => {}}
+    />
+  );
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   (window as unknown as { electronAPI?: unknown }).electronAPI = undefined;
 });
 
-describe('UpdateBanner', () => {
+describe('update states', () => {
   it('never renders a stuck bundle as "Up to date"', async () => {
     mockApi({ available: false, current: '1.50.0', latest: '3.1.1', stuck: true });
 
-    render(<UpdateBanner />);
+    render(<Card />);
 
     await waitFor(() => expect(screen.getByRole('status')).toBeTruthy());
     expect(screen.queryByText(/Up to date/)).toBeNull();
@@ -54,7 +82,7 @@ describe('UpdateBanner', () => {
       stuck: true,
     });
 
-    render(<UpdateBanner />);
+    render(<Card />);
 
     const button = await screen.findByText(/Download v3\.1\.1/);
     button.click();
@@ -63,11 +91,53 @@ describe('UpdateBanner', () => {
     );
   });
 
-  it('still reports a genuinely current bundle as up to date', async () => {
-    mockApi({ available: false, current: '3.1.1', latest: '3.1.1' });
+  it('does not call a stuck bundle current in the app menu either', async () => {
+    mockApi({ available: false, current: '1.50.0', latest: '3.1.1', stuck: true });
 
-    render(<UpdateBanner />);
+    render(<Menu />);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /trace-mcp/ }).textContent).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /trace-mcp/ }));
+    const status = document.querySelector('.ws-ctx-header .status');
+    await waitFor(() => expect(status?.textContent).toContain('needs a manual install'));
+    expect(status?.className).toContain('is-warn');
+  });
 
-    await waitFor(() => expect(screen.getByText(/Up to date · v3\.1\.1/)).toBeTruthy());
+  /* TRA-364, re-homed by TRA-363: the stale-root warning used to live on the
+     sidebar status row. That row is gone, so the same signal has to reach the
+     menu header — otherwise a machine with an out-of-date sibling npm root
+     reads as fully current again, which is the bug TRA-364 fixed. */
+  it('reports another npm root left behind, with the roots in the tooltip', async () => {
+    mockApi({
+      available: false,
+      current: '3.1.1',
+      latest: '3.1.1',
+      staleRoots: [{ root: '/opt/homebrew/lib/node_modules', version: '2.9.0' }],
+    });
+
+    render(<Menu />);
+    fireEvent.click(screen.getByRole('button', { name: /trace-mcp/ }));
+    const status = document.querySelector('.ws-ctx-header .status');
+    await waitFor(() => expect(status?.textContent).toContain('Another npm install is on v2.9.0'));
+    expect(status?.className).toContain('is-warn');
+    expect(status?.querySelector('.text')?.getAttribute('title')).toContain(
+      '/opt/homebrew/lib/node_modules/trace-mcp',
+    );
+  });
+
+  it('a genuinely current bundle says so in the menu, and nowhere else', async () => {
+    mockApi({ available: false, current: '3.1.1', latest: '3.1.1', lastChecked: Date.now() });
+
+    const { container } = render(<Card />);
+    render(<Menu />);
+
+    fireEvent.click(screen.getByRole('button', { name: /trace-mcp/ }));
+    await waitFor(() =>
+      expect(document.querySelector('.ws-ctx-header .name')?.textContent).toBe('Version 3.1.1'),
+    );
+    expect(document.querySelector('.ws-ctx-header .status')?.textContent).toContain('Up to date');
+    // No card in the sidebar when there is nothing to do about it.
+    expect(container.querySelector('.update-card')).toBeNull();
   });
 });

--- a/packages/app/src/renderer/app.css
+++ b/packages/app/src/renderer/app.css
@@ -131,91 +131,15 @@ body {
   background: color-mix(in oklab, var(--status-green) 88%, black);
 }
 
-/* ── Update banner: idle row vs notification card ───────────────── */
-/* Idle: minimal sub-caption with status dot. No card, no border — */
-/* must not compete with sidebar content when nothing is happening. */
-.update-idle {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  /* Same box as a sidebar row: 28px tall, 8px horizontal padding, so the
-     status dot lands on the rows' 14px glyph column and the sidebar's bottom
-     stack is three aligned 28px strips instead of 6/8 asymmetric ad-hoc
-     padding (TRA-306). */
-  height: 28px;
-  padding: 0 8px;
-  margin: 0 6px;
-  font-size: 11px;
-  color: var(--label-secondary);
-  letter-spacing: -0.005em;
-}
-.update-idle .dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--status-green);
-  box-shadow: 0 0 0 0.5px color-mix(in srgb, var(--status-green) 60%, black 40%);
-  flex-shrink: 0;
-}
-.update-idle.error .dot {
-  background: var(--status-orange);
-  box-shadow: 0 0 0 0.5px color-mix(in srgb, var(--status-orange) 60%, black 40%);
-}
-.update-idle .label {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  flex: 1;
-  min-width: 0;
-}
-
-/* Inline refresh icon — sits on the right of the status row / card title. */
-.update-refresh {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  margin-left: auto;
-  padding: 0;
-  background: transparent;
-  border: 0;
-  border-radius: var(--radius-row);
-  color: var(--label-secondary);
-  cursor: pointer;
-  flex-shrink: 0;
-  transition:
-    background 120ms ease,
-    color 120ms ease;
-}
-.update-refresh:hover {
-  background: var(--fill-tertiary);
-  color: var(--label);
-}
-.update-refresh:active {
-  background: var(--fill-quaternary);
-}
-.update-refresh:disabled {
-  cursor: default;
-  opacity: 0.7;
-}
-.update-refresh.spinning svg {
-  animation: update-refresh-spin 800ms linear infinite;
-}
+/* ── Update card ─────────────────────────────────────────────────── */
+/* The idle "● Up to date · v3.1.1 ⟳" row and its inline refresh button are
+   gone (TRA-363): a permanent 28px strip whose only message was "nothing is
+   wrong" is the most expensive way to say it. The state moved into the app
+   menu's header, where "Check for updates" sits beside it. What is left here
+   is the card — and a card only appears when there is something to do. */
 @media (prefers-reduced-motion: reduce) {
-  .update-refresh.spinning svg {
-    animation: none;
-  }
   .update-card {
     animation: none;
-  }
-}
-@keyframes update-refresh-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
   }
 }
 

--- a/packages/app/src/renderer/components/AppMenu.tsx
+++ b/packages/app/src/renderer/components/AppMenu.tsx
@@ -1,0 +1,169 @@
+/* AppMenu.tsx — the sidebar footer, as one row that opens a menu (TRA-363).
+
+   The footer used to grow a row per global action: Settings, then Appearance,
+   then a permanent "● Up to date · v3.1.1 ⟳" strip. Two of those were removed
+   again for the space they cost (TRA-306); the pattern was the problem, not the
+   individual rows. One row that opens a menu ends it, and gives the next global
+   action somewhere to go that isn't 28px off the bottom of every window.
+
+   The anchor is the app itself. There are no accounts here, so the identity a
+   menu like this normally hangs on is the product: the trigger says its name,
+   the header says its version and whether that version is current. The update
+   state had a whole sidebar row to say "nothing is wrong"; it now says it in
+   the one place you go to act on it, next to "Check for updates…".
+
+   The actions are read from src/shared/global-actions.ts — the same list the
+   native application menu builds from, so the two cannot drift apart.
+   Appearance is not in that list: it is a preference with three states, it also
+   lives in Settings, and it exists on no other surface to drift against. */
+
+import { Icon } from '../lattice/icons';
+import { Menu, MenuItem, MenuSection, MenuSeparator, useMenuAnchor } from '../lattice/ui';
+import { GLOBAL_ACTIONS, type GlobalAction } from '../../shared/global-actions.js';
+import { APPEARANCE_OPTIONS, type Appearance } from '../theme.js';
+import { describeStaleRoots, formatAgo, type UpdateState } from '../update-check.js';
+import { SidebarRow } from './SidebarRow';
+
+export interface AppMenuProps {
+  update: UpdateState;
+  checking: boolean;
+  onCheckForUpdate: () => void;
+  appearance: Appearance;
+  onAppearanceChange: (next: Appearance) => void;
+  /** Menu window: switch to the Settings surface. Project window: hand off. */
+  onSettings: () => void;
+}
+
+interface Summary {
+  text: string;
+  tone: string;
+  /** Long-form detail for the cases where one line cannot carry it. */
+  title?: string;
+}
+
+/** The header's second line: what we know about this version right now. */
+function updateSummary(update: UpdateState, checking: boolean): Summary {
+  if (checking) return { text: 'Checking…', tone: 'is-busy' };
+  if (update.error) return { text: update.error, tone: 'is-warn', title: update.error };
+  if (update.available) return { text: `Version ${update.latest} available`, tone: 'is-info' };
+  /* `stuck` is available: false — the CLI moved and the bundle did not. Calling
+     that "Up to date" is the failure TRA-357 fixed on the card, and this header
+     is a second place it could be told. */
+  if (update.stuck && update.latest) {
+    return { text: `Version ${update.latest} needs a manual install`, tone: 'is-warn' };
+  }
+  /* Same shape of lie, different cause: this root is current, another npm root
+     on the machine is not (TRA-364). Not an error, but not healthy either. */
+  if (update.staleRoots?.length) {
+    const stale = describeStaleRoots(update.staleRoots);
+    return { text: stale.label, tone: 'is-warn', title: stale.title };
+  }
+  return { text: `Up to date · checked ${formatAgo(update.lastChecked)}`, tone: 'is-ok' };
+}
+
+export function AppMenu({
+  update,
+  checking,
+  onCheckForUpdate,
+  appearance,
+  onAppearanceChange,
+  onSettings,
+}: AppMenuProps) {
+  const menu = useMenuAnchor();
+  const open = menu.at !== null;
+  const summary = updateSummary(update, checking);
+
+  const toggle = (): void => {
+    if (open) {
+      menu.close();
+      return;
+    }
+    const r = menu.ref.current?.getBoundingClientRect();
+    // Anchor on the row's TOP edge, not its bottom: the footer is the last
+    // thing in the window, so FloatingLayer flips the menu above the anchor and
+    // it lands 4px clear of the trigger instead of covering it.
+    menu.openAt(r ? { x: r.left, y: r.top - 4 } : { x: 8, y: 8 });
+  };
+
+  const run = (action: () => void) => () => {
+    action();
+    menu.close();
+  };
+
+  const runAction = (action: GlobalAction): (() => void) => {
+    if (action.url) {
+      const url = action.url;
+      return run(() => void window.electronAPI?.openExternal?.(url));
+    }
+    if (action.id === 'settings') return run(onSettings);
+    return run(onCheckForUpdate);
+  };
+
+  const item = (action: GlobalAction) => (
+    <MenuItem
+      key={action.id}
+      icon={action.icon}
+      shortcut={action.shortcut}
+      disabled={action.id === 'check-for-update' && checking}
+      onClick={runAction(action)}
+    >
+      {action.label}
+    </MenuItem>
+  );
+
+  /* Settings sits alone above Appearance, the way it does in the app menu on
+     macOS; the rest follow the group. Split by id rather than by index so a
+     reordered shared list cannot silently move an item into the wrong group. */
+  const settings = GLOBAL_ACTIONS.find((a) => a.id === 'settings');
+  const rest = GLOBAL_ACTIONS.filter((a) => a.id !== 'settings');
+
+  return (
+    <div className="ws-sb-footer">
+      <SidebarRow
+        rowRef={menu.ref}
+        icon="compass"
+        label="trace-mcp"
+        onClick={toggle}
+        title="App menu"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        trailing={
+          <span className="ws-sb-chevron" aria-hidden="true">
+            <Icon name="expand_more" size={14} />
+          </span>
+        }
+      />
+      {menu.at && (
+        <Menu x={menu.at.x} y={menu.at.y} onClose={menu.close}>
+          {/* Not a menu item: it is what the menu is about. Version first —
+              the trigger already carries the name. */}
+          <div className="ws-ctx-header">
+            <div className="name">Version {update.current ?? '—'}</div>
+            <div className={`status ${summary.tone}`}>
+              <span className="dot" aria-hidden="true" />
+              <span className="text" title={summary.title}>
+                {summary.text}
+              </span>
+            </div>
+          </div>
+          <MenuSeparator />
+          {settings && item(settings)}
+          <MenuSeparator />
+          <MenuSection>Appearance</MenuSection>
+          {APPEARANCE_OPTIONS.map((option) => (
+            <MenuItem
+              key={option.value}
+              showCheckSlot
+              checked={appearance === option.value}
+              onClick={run(() => onAppearanceChange(option.value))}
+            >
+              {option.label}
+            </MenuItem>
+          ))}
+          <MenuSeparator />
+          {rest.map(item)}
+        </Menu>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/renderer/components/SidebarRow.tsx
+++ b/packages/app/src/renderer/components/SidebarRow.tsx
@@ -1,0 +1,56 @@
+/* SidebarRow.tsx — the sidebar's one row (TRA-305, extracted in TRA-363).
+
+   28px tall, 16px leading glyph, 13px label; `.ws-sb-row` in styles/sidebar.css
+   carries the geometry. It lived in App.tsx while App.tsx was its only caller;
+   the sidebar's app menu is a second one, and the alternative was importing
+   from App.tsx, which imports the menu — a cycle. */
+
+import type React from 'react';
+import { Icon } from '../lattice/icons';
+
+export function SidebarRow({
+  icon,
+  glyph,
+  label,
+  selected = false,
+  onClick,
+  onKeyDown,
+  onContextMenu,
+  title,
+  count,
+  trailing,
+  rowRef,
+  ...aria
+}: {
+  icon?: string;
+  glyph?: React.ReactNode;
+  label: React.ReactNode;
+  selected?: boolean;
+  onClick: () => void;
+  onKeyDown?: (e: React.KeyboardEvent) => void;
+  onContextMenu?: (e: React.MouseEvent) => void;
+  title?: string;
+  count?: React.ReactNode;
+  trailing?: React.ReactNode;
+  rowRef?: React.Ref<HTMLButtonElement>;
+} & React.AriaAttributes & { role?: string; tabIndex?: number }) {
+  return (
+    <button
+      type="button"
+      ref={rowRef}
+      className={`ws-sb-row${selected ? ' is-selected' : ''}`}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      onContextMenu={onContextMenu}
+      title={title}
+      {...aria}
+    >
+      <span className="ws-sb-ico" aria-hidden="true">
+        {glyph ?? (icon ? <Icon name={icon} size={16} /> : null)}
+      </span>
+      {typeof label === 'string' ? <span className="ws-sb-label">{label}</span> : label}
+      {count !== undefined && <span className="ws-sb-count">{count}</span>}
+      {trailing}
+    </button>
+  );
+}

--- a/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+/* TRA-363. Three promises worth pinning:
+
+   - the footer is ONE row, and that row is a menu trigger. The whole point was
+     to stop the bottom of the sidebar growing a row per global action.
+   - the menu's actions come from src/shared/global-actions.ts, the same list
+     the native application menu builds from. A label typed here instead of
+     read from there is the drift this design was supposed to make impossible.
+   - it behaves like a menu on the keyboard: arrows move, Escape closes, and
+     focus comes back to the trigger instead of landing on <body>. */
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GLOBAL_ACTIONS } from '../../../shared/global-actions.js';
+import type { UpdateState } from '../../update-check.js';
+import { AppMenu, type AppMenuProps } from '../AppMenu';
+
+const openExternal = vi.fn();
+
+function renderMenu(props: Partial<AppMenuProps> = {}) {
+  const onAppearanceChange = vi.fn();
+  const onCheckForUpdate = vi.fn();
+  const onSettings = vi.fn();
+  const update: UpdateState = { available: false, current: '3.1.1', lastChecked: Date.now() };
+  render(
+    <AppMenu
+      update={update}
+      checking={false}
+      onCheckForUpdate={onCheckForUpdate}
+      appearance="auto"
+      onAppearanceChange={onAppearanceChange}
+      onSettings={onSettings}
+      {...props}
+    />,
+  );
+  const trigger = screen.getByRole('button', { name: /trace-mcp/ });
+  return { trigger, onAppearanceChange, onCheckForUpdate, onSettings };
+}
+
+function openMenu(trigger: HTMLElement): HTMLElement {
+  fireEvent.click(trigger);
+  return screen.getByRole('menu');
+}
+
+beforeEach(() => {
+  openExternal.mockReset();
+  (window as unknown as { electronAPI: unknown }).electronAPI = { openExternal };
+});
+
+describe('sidebar app menu', () => {
+  it('is one row, and that row says it opens a menu', () => {
+    const { trigger } = renderMenu();
+    const footer = document.querySelector('.ws-sb-footer');
+    expect(footer?.querySelectorAll('.ws-sb-row')).toHaveLength(1);
+    expect(trigger.getAttribute('aria-haspopup')).toBe('menu');
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+
+  it('opens on click and flips aria-expanded', () => {
+    const { trigger } = renderMenu();
+    openMenu(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    fireEvent.click(trigger);
+    expect(screen.queryByRole('menu')).toBeNull();
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  /* The anti-drift test. If someone adds an action to the native menu and
+     forgets this one — or relabels one of them — this fails. */
+  it('renders every shared global action, with its own label and shortcut', () => {
+    const { trigger } = renderMenu();
+    const menu = openMenu(trigger);
+    for (const action of GLOBAL_ACTIONS) {
+      const item = within(menu).getByRole('menuitem', { name: new RegExp(action.label) });
+      if (action.shortcut) expect(item.textContent).toContain(action.shortcut);
+    }
+  });
+
+  it('anchors the menu on the app, not on an account it does not have', () => {
+    const { trigger } = renderMenu();
+    const menu = openMenu(trigger);
+    const header = menu.querySelector('.ws-ctx-header');
+    expect(header?.querySelector('.name')?.textContent).toBe('Version 3.1.1');
+    expect(header?.querySelector('.status')?.textContent).toContain('Up to date');
+    expect(header?.querySelector('.status')?.className).toContain('is-ok');
+  });
+
+  it('reports an available update in the header instead of a sidebar row', () => {
+    const { trigger } = renderMenu({
+      update: { available: true, current: '3.1.1', latest: '3.2.0' },
+    });
+    const header = openMenu(trigger).querySelector('.ws-ctx-header');
+    expect(header?.querySelector('.status')?.textContent).toContain('Version 3.2.0 available');
+    expect(header?.querySelector('.status')?.className).toContain('is-info');
+  });
+
+  it('offers Appearance as a checked group and reports the pick', () => {
+    const { trigger, onAppearanceChange } = renderMenu({ appearance: 'light' });
+    const menu = openMenu(trigger);
+    const options = within(menu).getAllByRole('menuitemcheckbox');
+    expect(options.map((o) => o.textContent)).toEqual(['Auto', 'Light', 'Dark']);
+    expect(options.map((o) => o.getAttribute('aria-checked'))).toEqual(['false', 'true', 'false']);
+    fireEvent.click(options[2]);
+    expect(onAppearanceChange).toHaveBeenCalledWith('dark');
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+
+  it('runs the commands and opens the links', () => {
+    const { trigger, onSettings, onCheckForUpdate } = renderMenu();
+    fireEvent.click(within(openMenu(trigger)).getByRole('menuitem', { name: /Settings/ }));
+    expect(onSettings).toHaveBeenCalled();
+
+    fireEvent.click(within(openMenu(trigger)).getByRole('menuitem', { name: /Get help/ }));
+    expect(openExternal).toHaveBeenCalledWith(
+      'https://github.com/nikolai-vysotskyi/trace-mcp/issues',
+    );
+
+    fireEvent.click(within(openMenu(trigger)).getByRole('menuitem', { name: /Check for updates/ }));
+    expect(onCheckForUpdate).toHaveBeenCalled();
+  });
+
+  it('arrows through the items and wraps', () => {
+    const { trigger } = renderMenu();
+    const menu = openMenu(trigger);
+    const all = Array.from(menu.querySelectorAll<HTMLElement>('[role^="menuitem"]'));
+    expect(all.length).toBe(GLOBAL_ACTIONS.length + 3); // + Auto / Light / Dark
+
+    // Nothing is highlighted until the first arrow — a macOS menu does not
+    // preselect its first item.
+    expect(document.activeElement).not.toBe(all[0]);
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(all[0]);
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(all[1]);
+    fireEvent.keyDown(document, { key: 'ArrowUp' });
+    fireEvent.keyDown(document, { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(all[all.length - 1]);
+    fireEvent.keyDown(document, { key: 'End' });
+    expect(document.activeElement).toBe(all[all.length - 1]);
+    fireEvent.keyDown(document, { key: 'Home' });
+    expect(document.activeElement).toBe(all[0]);
+  });
+
+  it('closes on Escape and gives focus back to the trigger', () => {
+    const { trigger } = renderMenu();
+    trigger.focus();
+    openMenu(trigger);
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    expect(document.activeElement).not.toBe(trigger);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('menu')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+});

--- a/packages/app/src/renderer/lattice/ui/Menu.tsx
+++ b/packages/app/src/renderer/lattice/ui/Menu.tsx
@@ -61,6 +61,12 @@ export function Menu({ x, y, align = 'start', onClose, className, children }: Me
      Note these listeners attach AFTER the event that opened the menu has
      already passed document capture, so the opening click/contextmenu can
      never instantly dismiss it. */
+  /* Whatever had focus when the menu opened — normally the trigger button,
+     since a click focuses it. A menu that closes and drops focus on <body>
+     strands the keyboard: Tab restarts at the top of the document. */
+  const returnFocusRef = useRef<Element | null>(null);
+  if (returnFocusRef.current === null) returnFocusRef.current = document.activeElement;
+
   useEffect(() => {
     const onPress = (e: MouseEvent): void => {
       const layer = layerRef.current;
@@ -69,13 +75,48 @@ export function Menu({ x, y, align = 'start', onClose, className, children }: Me
       if (layer && e.target instanceof Node && layer.contains(e.target)) return;
       onCloseRef.current();
     };
+    /* Every enabled item, in DOM order. Read per keypress rather than cached:
+       a menu's items can be conditional (an item that only exists while an
+       update is pending), and a stale list arrows onto a node that is gone. */
+    const items = (): HTMLElement[] =>
+      Array.from(
+        layerRef.current?.querySelectorAll<HTMLElement>(
+          '[role^="menuitem"]:not([disabled]):not([aria-disabled="true"])',
+        ) ?? [],
+      );
     const onKeyDown = (e: KeyboardEvent): void => {
-      if (e.key !== 'Escape') return;
-      // Consume Escape: the menu is the topmost layer, an enclosing surface
-      // (panel / dialog) must not ALSO close from the same keypress.
+      if (e.key === 'Escape') {
+        // Consume Escape: the menu is the topmost layer, an enclosing surface
+        // (panel / dialog) must not ALSO close from the same keypress.
+        e.preventDefault();
+        e.stopPropagation();
+        onCloseRef.current();
+        return;
+      }
+      if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp' && e.key !== 'Home' && e.key !== 'End') {
+        return;
+      }
+      /* Roving focus, macOS-style: nothing is highlighted until the first
+         arrow, and then the list wraps. Focus IS the highlight here — the real
+         one, so Enter and Space activate through the native button. */
+      const list = items();
+      if (list.length === 0) return;
       e.preventDefault();
       e.stopPropagation();
-      onCloseRef.current();
+      const from = list.indexOf(document.activeElement as HTMLElement);
+      const next =
+        e.key === 'Home'
+          ? 0
+          : e.key === 'End'
+            ? list.length - 1
+            : e.key === 'ArrowDown'
+              ? from < 0
+                ? 0
+                : (from + 1) % list.length
+              : from < 0
+                ? list.length - 1
+                : (from - 1 + list.length) % list.length;
+      list[next].focus();
     };
     // App/window switch (Cmd-Tab, native dialog opening) — never leave a
     // zombie menu floating over a window the user has left.
@@ -90,6 +131,15 @@ export function Menu({ x, y, align = 'start', onClose, className, children }: Me
       document.removeEventListener('contextmenu', onPress, true);
       document.removeEventListener('keydown', onKeyDown, true);
       window.removeEventListener('blur', onWindowBlur);
+      // Only take focus back if the menu still has it: an outside press has
+      // already given it to whatever was clicked, and stealing it back would
+      // undo that click.
+      const back = returnFocusRef.current;
+      const active = document.activeElement;
+      const inMenu = active instanceof Node && layerRef.current?.contains(active);
+      if ((inMenu || active === document.body) && back instanceof HTMLElement && back.isConnected) {
+        back.focus();
+      }
     };
   }, []);
 

--- a/packages/app/src/renderer/styles/island.css
+++ b/packages/app/src/renderer/styles/island.css
@@ -623,7 +623,23 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
   white-space: nowrap;
   cursor: default;
 }
-.ws-ctx-item:hover:not(:disabled) { background: var(--accent-fill); color: var(--on-accent); }
+/* Focus IS the highlight in a menu: arrowing down moves real DOM focus, so the
+   keyboard path has to paint the same selection the pointer does (TRA-363).
+   `:focus`, not `:focus-visible` — Chromium's heuristic for a programmatic
+   focus() is not reliable, and a menu item is never focused by any other
+   means (the menu closes on the click that would have done it). */
+.ws-ctx-item:hover:not(:disabled),
+.ws-ctx-item:focus:not(:disabled) {
+  background: var(--accent-fill);
+  color: var(--on-accent);
+  outline: none;
+}
+/* …and it is the ONLY indicator: the house `*:focus-visible` ring drew a blue
+   halo around an already-blue row, which reads as a button on a surface, not a
+   highlighted menu item. macOS draws the fill and nothing else. */
+.ws-ctx-item:focus-visible {
+  box-shadow: none;
+}
 .ws-ctx-item:disabled { color: var(--label-secondary); cursor: default; }
 /* Leading icon column — muted, white on accent hover (macOS idiom). */
 .ws-ctx-item .ws-ctx-ico {
@@ -635,7 +651,8 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
   justify-content: center;
   color: var(--label-secondary);
 }
-.ws-ctx-item:hover:not(:disabled) .ws-ctx-ico { color: rgba(255, 255, 255, 0.85); }
+.ws-ctx-item:hover:not(:disabled) .ws-ctx-ico,
+.ws-ctx-item:focus:not(:disabled) .ws-ctx-ico { color: rgba(255, 255, 255, 0.85); }
 /* Trailing shortcut hint (⌘C etc.) — tertiary, dims to white on hover. */
 .ws-ctx-item .ws-ctx-sc {
   margin-left: auto;
@@ -643,7 +660,8 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
   color: var(--label-secondary);
   font-size: 12px;
 }
-.ws-ctx-item:hover:not(:disabled) .ws-ctx-sc { color: rgba(255, 255, 255, 0.85); }
+.ws-ctx-item:hover:not(:disabled) .ws-ctx-sc,
+.ws-ctx-item:focus:not(:disabled) .ws-ctx-sc { color: rgba(255, 255, 255, 0.85); }
 /* Leading check column for a toggle item (role=menuitemcheckbox). Reserved on
    EVERY item of a menu that has one, so labels stay on one left edge whether
    or not their row is checked — macOS never reflows a menu on toggle.
@@ -651,23 +669,29 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
    slot rendered as a zero-width span and the checkmark landed on the label
    (TRA-294). */
 .ws-ctx-item .ws-ctx-check {
-  width: 14px;
+  /* 16px, matching .ws-ctx-ico: one menu can hold both kinds of item (the app
+     menu has icon commands and a checkable Appearance group), and at 14 the
+     two gutters put their labels 2px apart. */
+  width: 16px;
   flex: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   color: var(--accent);
 }
-.ws-ctx-item:hover:not(:disabled) .ws-ctx-check { color: var(--on-accent); }
+.ws-ctx-item:hover:not(:disabled) .ws-ctx-check,
+.ws-ctx-item:focus:not(:disabled) .ws-ctx-check { color: var(--on-accent); }
 /* Destructive item. Red LABEL on the flat menu, white on the accent hover —
    never a red fill, which reads as "selected" rather than "dangerous". */
 .ws-ctx-item.danger { color: var(--status-red); }
 .ws-ctx-item.danger .ws-ctx-ico { color: var(--status-red); }
-.ws-ctx-item.danger:hover:not(:disabled) {
+.ws-ctx-item.danger:hover:not(:disabled),
+.ws-ctx-item.danger:focus:not(:disabled) {
   background: var(--danger-fill);
   color: var(--on-accent);
 }
-.ws-ctx-item.danger:hover:not(:disabled) .ws-ctx-ico { color: var(--on-accent); }
+.ws-ctx-item.danger:hover:not(:disabled) .ws-ctx-ico,
+.ws-ctx-item.danger:focus:not(:disabled) .ws-ctx-ico { color: var(--on-accent); }
 /* Group divider — a hairline with 5px of air, inset to the menu's padding. */
 .ws-ctx-sep {
   height: 0.5px;
@@ -686,6 +710,58 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
   user-select: none;
 }
 .ws-ctx-section:first-child { padding-top: 4px; }
+
+/* Menu header (TRA-363) — what the menu is ABOUT, not something you can pick.
+   The app menu has no account to hang on, so the anchor is the product: the
+   trigger carries the name, this carries the version and whether it is current.
+   Same 9px left inset as .ws-ctx-section, so header, group headers and item
+   labels sit on one edge. */
+.ws-ctx-header {
+  padding: 4px 9px 7px;
+  user-select: none;
+}
+.ws-ctx-header .name {
+  font-size: 13px;
+  font-weight: 590;
+  letter-spacing: -0.01em;
+  color: var(--label);
+}
+.ws-ctx-header .status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 1px;
+  font-size: 11px;
+  color: var(--label-secondary);
+}
+.ws-ctx-header .status .text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* Never colour alone: the dot repeats what the sentence beside it already
+   says, it does not replace it. */
+.ws-ctx-header .dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--label-secondary);
+  box-shadow: 0 0 0 0.5px color-mix(in srgb, var(--label-secondary) 60%, black 40%);
+}
+.ws-ctx-header .status.is-ok .dot {
+  background: var(--status-green);
+  box-shadow: 0 0 0 0.5px color-mix(in srgb, var(--status-green) 60%, black 40%);
+}
+.ws-ctx-header .status.is-info .dot {
+  background: var(--accent);
+  box-shadow: 0 0 0 0.5px color-mix(in srgb, var(--accent) 60%, black 40%);
+}
+.ws-ctx-header .status.is-warn .dot {
+  background: var(--status-orange);
+  box-shadow: 0 0 0 0.5px color-mix(in srgb, var(--status-orange) 60%, black 40%);
+}
 
 /* ── Confirmation popover (.mac-popover) — paired with the context menu ──── */
 .ws-popover {

--- a/packages/app/src/renderer/styles/sidebar.css
+++ b/packages/app/src/renderer/styles/sidebar.css
@@ -177,6 +177,27 @@
   background: var(--fill-tertiary);
 }
 
+/* A row that OPENS a menu, not one that navigates (the app menu, TRA-363).
+   While its menu is up it takes the inactive-selection fill, never the accent
+   one: accent means "this is the surface you are looking at", and a menu is not
+   a surface. Keyed off aria-expanded so the state has exactly one source. */
+.ws-sb-row[aria-expanded='true'] {
+  background: var(--fill-tertiary);
+}
+
+/* Pop-up affordance on a row that opens a menu. Unlike .ws-sb-trailing this is
+   always visible — it is not an action revealed on hover, it is the row saying
+   what kind of control it is. */
+.ws-sb-row .ws-sb-chevron {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  color: var(--label-secondary);
+}
+
 /* ---- Sidebar footer ----------------------------------------------------- */
 /* Pinned below .ws-sidebar-scroll, so the rows above slide under it — that is
    a scroll edge, and a scroll edge gets the hairline. Same 6px inset as the

--- a/packages/app/src/renderer/update-check.ts
+++ b/packages/app/src/renderer/update-check.ts
@@ -1,0 +1,154 @@
+/* update-check.ts — the app's one owner of update state (TRA-363).
+
+   It used to live inside the sidebar's UpdateBanner, which was fine while the
+   banner was the only thing that showed it. It is not: the sidebar's app menu
+   reports "Up to date · v3.1.1" in its header and offers "Check for updates…",
+   and a second poller would be a second answer to the same question.
+
+   So App calls this once and hands the result to both. The main process does
+   the actual work — it checks the npm registry (no rate limit) with GitHub
+   Releases as a fallback; this is state plus a 10-minute cadence.
+
+   Three states worth distinguishing: up to date (with when we last looked),
+   an update available, and an update downloaded but pending a restart. */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type UpdateState = {
+  available: boolean;
+  current?: string;
+  latest?: string;
+  lastChecked?: number;
+  error?: string;
+  stuck?: boolean;
+  staleRoots?: { root: string; version: string }[];
+};
+
+/**
+ * `npm install -g` only ever writes into the global root its own npm owns. On a
+ * machine with several (nvm + Herd + a bundled runtime) the rest keep an old
+ * version, and every other signal here still reads "Up to date" — so a client
+ * wired to a stale root runs old code with nothing saying so (TRA-364). We
+ * cannot safely write into a root the user never pointed us at, so we say it
+ * out loud instead: the app menu's status line goes to the warning treatment
+ * and its tooltip names each stale root and the command that fixes it.
+ */
+export function describeStaleRoots(staleRoots: { root: string; version: string }[]): {
+  label: string;
+  title: string;
+} {
+  const label =
+    staleRoots.length === 1
+      ? `Another npm install is on v${staleRoots[0].version}`
+      : `${staleRoots.length} other npm installs are out of date`;
+  const lines = staleRoots.map((r) => `v${r.version} — ${r.root}/trace-mcp`);
+  return {
+    label,
+    title: `${label}. This app updated the root it resolves to; these were not touched:\n${lines.join('\n')}\n\nFix each with its own npm: <root>/../../bin/npm install -g trace-mcp@latest`,
+  };
+}
+
+export function formatAgo(ts?: number, now: number = Date.now()): string {
+  if (!ts) return 'never';
+  const s = Math.max(0, Math.floor((now - ts) / 1000));
+  if (s < 60) return `${s}s ago`;
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+  return `${Math.floor(s / 86400)}d ago`;
+}
+
+export interface UpdateCheck {
+  state: UpdateState;
+  /** Set once a new version is on disk and only a restart is left. */
+  pendingVersion: string | null;
+  checking: boolean;
+  updating: boolean;
+  check: () => void;
+  apply: () => void;
+  restart: () => void;
+}
+
+export function useUpdateCheck(): UpdateCheck {
+  const [state, setState] = useState<UpdateState>({ available: false });
+  const [updating, setUpdating] = useState(false);
+  const [checking, setChecking] = useState(false);
+  const [pendingVersion, setPendingVersion] = useState<string | null>(null);
+  const cancelledRef = useRef(false);
+
+  const check = useCallback(async () => {
+    const api = window.electronAPI;
+    if (!api?.checkForUpdate) return;
+    setChecking(true);
+    try {
+      const [upd, pend] = await Promise.all([
+        api.checkForUpdate(),
+        api.checkPendingUpdate
+          ? api.checkPendingUpdate()
+          : Promise.resolve<{ pending: boolean; version?: string }>({ pending: false }),
+      ]);
+      if (cancelledRef.current) return;
+      if (upd) setState(upd);
+      if (pend?.pending) setPendingVersion(pend.version || (upd?.latest ?? null));
+      else setPendingVersion(null);
+    } catch (err) {
+      if (!cancelledRef.current) setState((s) => ({ ...s, error: (err as Error).message }));
+    } finally {
+      if (!cancelledRef.current) setChecking(false);
+    }
+  }, []);
+
+  const checkRef = useRef(check);
+  checkRef.current = check;
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    void checkRef.current();
+    const poll = setInterval(() => void checkRef.current(), 600_000);
+    return () => {
+      cancelledRef.current = true;
+      clearInterval(poll);
+    };
+  }, []);
+
+  const apply = useCallback(async () => {
+    const api = window.electronAPI;
+    if (!api) return;
+    setUpdating(true);
+    setState((s) => ({ ...s, error: undefined }));
+    try {
+      const result = await api.applyUpdate();
+      if (result?.ok && api.checkPendingUpdate) {
+        const pend = await api.checkPendingUpdate();
+        if (pend?.pending) setPendingVersion(pend.version || stateRef.current.latest || null);
+      }
+      if (!result?.ok) {
+        setState((s) => ({ ...s, error: result?.error || 'update failed' }));
+      } else if (result.outcome === 'npm-only') {
+        // The npm package moved but the .app bundle stayed put. Re-run the
+        // availability check now — the main process just wrote the sticky
+        // marker, so this call returns { available: false, stuck: true } and
+        // the card switches to "needs a manual install" instead of looping the
+        // user through the same prompt on the next poll.
+        void checkRef.current();
+      }
+    } finally {
+      setUpdating(false);
+    }
+  }, []);
+
+  const restart = useCallback(() => {
+    void window.electronAPI?.restartApp();
+  }, []);
+
+  return {
+    state,
+    pendingVersion,
+    checking,
+    updating,
+    check: useCallback(() => void checkRef.current(), []),
+    apply: useCallback(() => void apply(), [apply]),
+    restart,
+  };
+}

--- a/packages/app/src/shared/global-actions.ts
+++ b/packages/app/src/shared/global-actions.ts
@@ -1,0 +1,74 @@
+/* global-actions.ts — the app's global actions, defined ONCE (TRA-363).
+
+   These four reach the user from two places: the native application menu
+   (main/menu.ts, TRA-297) and the sidebar's app menu (renderer AppMenu). That
+   is the normal cross-platform arrangement — the menu bar is their native home
+   on macOS, and a Windows or Linux user finds them where the app's own chrome
+   puts them — but two hand-maintained lists drift: a relabelled item, a moved
+   shortcut, an action added to one surface and forgotten in the other.
+
+   So neither surface owns a label or a key. This file does, and both read it.
+   The main process turns each entry into a MenuItemConstructorOptions; the
+   renderer turns it into a MenuItem. Only presentation differs: the native menu
+   draws no icons and needs an Electron accelerator string, the in-app menu
+   draws a Lattice glyph and a ⌘-hint.
+
+   It deliberately lives outside both `main/` and `renderer/` — the process that
+   imports it is not allowed to matter, so it holds data and nothing else. No
+   `electron` import, no DOM, no React.
+
+   Appearance is NOT here. It is a preference with three states, not a command,
+   and it exists only in the in-app menu and Settings — a list with one member
+   cannot drift. */
+
+export type GlobalActionId = 'settings' | 'check-for-update' | 'whats-new' | 'get-help';
+
+export interface GlobalAction {
+  /** Also the `app-command` name the native menu sends to the focused window. */
+  id: GlobalActionId;
+  label: string;
+  /** Electron accelerator for the application menu. */
+  accelerator?: string;
+  /** The same key drawn as a macOS glyph, for the in-app menu's hint column. */
+  shortcut?: string;
+  /** Present when the action opens a page instead of dispatching a command. */
+  url?: string;
+  /** Lattice glyph name. The native menu ignores it. */
+  icon: string;
+}
+
+/** Order here is the order the in-app menu renders them in. */
+export const GLOBAL_ACTIONS: readonly GlobalAction[] = [
+  {
+    id: 'settings',
+    label: 'Settings…',
+    accelerator: 'CmdOrCtrl+,',
+    shortcut: '⌘,',
+    icon: 'settings',
+  },
+  {
+    id: 'whats-new',
+    label: "What's new",
+    url: 'https://github.com/nikolai-vysotskyi/trace-mcp/releases',
+    icon: 'auto_awesome',
+  },
+  {
+    id: 'get-help',
+    label: 'Get help',
+    url: 'https://github.com/nikolai-vysotskyi/trace-mcp/issues',
+    icon: 'forum',
+  },
+  {
+    id: 'check-for-update',
+    label: 'Check for updates…',
+    icon: 'refresh',
+  },
+];
+
+export function globalAction(id: GlobalActionId): GlobalAction {
+  const found = GLOBAL_ACTIONS.find((a) => a.id === id);
+  // Unreachable through the type, but a silently missing menu item is exactly
+  // the failure this file exists to prevent — say so instead of rendering less.
+  if (!found) throw new Error(`no global action "${id}"`);
+  return found;
+}

--- a/packages/app/tsconfig.main.json
+++ b/packages/app/tsconfig.main.json
@@ -6,10 +6,13 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "outDir": "dist/main",
-    "rootDir": "src/main",
+    "outDir": "dist",
+    "rootDir": "src",
     "lib": ["ES2022"],
     "types": ["node"]
   },
-  "include": ["src/main/**/*"]
+  // `src/shared` holds definitions both processes read (TRA-363). rootDir has
+  // to be their common parent for tsc to emit it, which keeps main's output at
+  // dist/main/index.js — the path package.json#main already points at.
+  "include": ["src/main/**/*", "src/shared/**/*"]
 }


### PR DESCRIPTION
Closes TRA-363.

## Before → after

The footer was two rows again — a permanent `● Up to date · v3.1.1 ⟳` strip above `⚙ Settings`, **70.5px** measured at the bottom of a column meant for navigation. That is the creep TRA-306 was about: every global action costs another row. One row that opens a menu ends it, and gives the next global action somewhere to go.

Measured on the running Electron window (not Chrome — TRA-354's rule):

| | before | after |
|---|---|---|
| footer height | 70.5px (2 rows) | **42.5px** (1 row) |
| global action costs | 28px of sidebar | one menu item |

## The anchor

The pattern this comes from is an *account* menu, held together by an identity at the top. We have no users. So the anchor is the app itself: the trigger carries the name, the header carries the version and whether that version is current. That gives the update state a home worth its space — beside `Check for updates…` — instead of a strip whose entire message was "nothing is wrong".

The states you can actually *act* on still get a card in the sidebar: update available, restart pending, and the stuck bundle from TRA-357. `updateSummary()` also refuses to call a `stuck` bundle "Up to date" in the header, which is the same failure TRA-357 fixed on the card — the menu header was a second place to tell that lie.

## One definition, not two lists

`Settings…`, `What's new`, `Get help` and `Check for updates…` are offered by the native application menu (TRA-297) **and** by this one. Two hand-maintained lists drift, so neither surface owns a label or a key: both build from `packages/app/src/shared/global-actions.ts`.

- `main/menu.ts` turns each entry into a `MenuItemConstructorOptions`.
- `renderer/components/AppMenu.tsx` turns the same entry into a `MenuItem`.
- Two tests guard it: `menu.test.ts` asserts every shared action is on the native template under its shared label; `AppMenu.test.tsx` asserts the same for the in-app menu, shortcut hints included.

`tsconfig.main.json` moves `rootDir` to `src` so `tsc` can emit the shared module; `dist/main/index.js` — the path `package.json#main` points at — is unchanged, and `dist/shared/` ships under the existing `files: dist/**`.

Appearance is deliberately **not** in that list: a preference with three states, not a command, and it exists only in this menu and in Settings — a list with one member cannot drift. `Documentation` is native-menu-only for the same reason. (The old `trace-mcp help` was relabelled to `Documentation`, because "Documentation" and "Get help" pointing at different pages is a coin toss otherwise.)

**Language is left out**, as the issue asked: there is no i18n in the app, and a picker with one entry is a dead control.

## Keyboard

The shared `Menu` primitive grew what a menu owes — so every menu in the app gets it, not just this one:

- ↑ / ↓ move a **real** DOM focus, wrapping; nothing is preselected until the first arrow (macOS does not preselect either). Home / End jump.
- Escape closes and consumes the key.
- Focus returns to the trigger on close, unless an outside press already gave it to something else.
- `aria-haspopup="menu"` + `aria-expanded` on the trigger; Appearance items are `menuitemcheckbox` with `aria-checked`.

Focus paints the same accent fill hover does — and only that. The house `*:focus-visible` ring on top of that fill drew a blue halo around an already-blue row, which reads as a button on a surface; macOS draws the fill and nothing else.

The trigger takes the *inactive* selection fill while its menu is open, keyed off `aria-expanded`, not `.is-selected`: accent fill means "this is the surface you are looking at", and a menu is not a surface.

## Verified

Screenshots taken from the real Electron window in both appearances, plus Reduce Transparency, Increase Contrast, and over the native vibrancy layer — attached to the issue.

Measured on the running renderer:

- one `.ws-sb-row` in the footer; `aria-haspopup=menu`, `aria-expanded` flips
- seven menu items, all 30px, **every label on one 47px left edge** (the check gutter went 14→16px to match the icon gutter, so the icon commands and the checkable Appearance group align)
- menu 220px wide, 4.5px clear above the trigger, flipped above the anchor by `FloatingLayer`
- contrast on the menu surface: header 12.37:1, status line 5.43:1, shortcut hint 5.43:1

Local: `pnpm run typecheck`, `pnpm run test` (334 passed), `pnpm run build` all green.

## DESIGN.md

New §6 subsection "Where a global action lives" (the two homes, the one definition, what stays out), a footer bullet, and six decision-log rows.


## Rebased onto TRA-357 / TRA-360 / TRA-364

Two things had landed on the row this PR deletes, and both were re-homed rather than dropped:

- **TRA-357** — the stuck bundle still gets its own card, and `updateSummary()` refuses to call it "Up to date" in the menu header either. The header was a second place to tell the same lie.
- **TRA-364** — the stale-sibling-npm-root warning lived on the status row. It is now the menu header's warning state, tooltip and all (`describeStaleRoots` moved into `update-check.ts` with the rest of the update state). Confirmed on the running app, which really does have a stale root: `● Another npm install is on v3.0.0`, in orange.

Both are covered by `update-banner.test.tsx`, rewired from `UpdateBanner` to the card + menu pair.
