### PR TITLE
fix(app): put the traffic lights on the top band's centre line (TRA-370)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -321,7 +321,7 @@ Every data surface owes four states, and each has a house form:
 ```
 ┌─ window: hiddenInset, 12px radius, min 640×420 ───────────────────┐
 │ ┌ sidebar (transparent → vibrancy) ┬ content pane (opaque) ─────┐ │
-│ │ 44px traffic-light strip [drag]  │ 44px header [drag]         │ │
+│ │ --top-band-h strip [drag]        │ --top-band-h header [drag] │ │
 │ ├──────────────────────────────────┼────────────────────────────┤ │
 │ │ scroll: 6px inset, 28px rows     │ 52px toolbar (glass)       │ │
 │ │                                  ├────────────────────────────┤ │
@@ -335,11 +335,16 @@ Every data surface owes four states, and each has a house form:
 - **Sidebar** — 220px default, 180–320px drag range, flush to the window edge: no
   radius, no shadow. The hairline separator and the material *are* the edge. Width and
   collapsed state persist and sync across windows (`renderer/sidebar-prefs.ts`).
-- **Traffic lights are native.** `trafficLightPosition: {x: 14, y: 18}` centres the 12px
-  lights on the 44px strip the sidebar reserves. When the sidebar is collapsed the
-  content header takes a `78px` left pad so the lights land on it instead.
-  **Never draw traffic lights in CSS** — the hand-drawn `.ws-lights` circles are gone
-  and must not come back.
+- **The traffic-light centre line is the app's top-band baseline.** Every control in a
+  top band — the sidebar toggle, the window's own controls, search, segmented controls,
+  primary actions — is centred on it. The band height and `trafficLightPosition` are two
+  views of ONE number and must be derived from a single source, never written twice.
+  That source is `packages/app/src/shared/chrome-metrics.ts`: `TOP_BAND_H` sizes every
+  band via `--top-band-h`, and `TRAFFIC_LIGHT_Y` is computed from it. See
+  "The top band" below.
+- **Traffic lights are native.** When the sidebar is collapsed the content header takes a
+  `78px` left pad so the lights land on it instead. **Never draw traffic lights in CSS** —
+  the hand-drawn `.ws-lights` circles are gone and must not come back.
 - **Drag regions**: exactly two — the sidebar's top 44px and the content pane's 44px
   header. `<main>` is not a drag region. Every interactive child inside a drag region
   needs `-webkit-app-region: no-drag`.
@@ -360,6 +365,37 @@ Every data surface owes four states, and each has a house form:
   permanent update strip, 70.5px of chrome under a column meant for navigation
   (TRA-305 → TRA-306 → TRA-363). The row is the product: its name, a chevron, and a
   pop-up. See "Where a global action lives" below.
+
+### The top band
+
+`--top-band-h` (44px) is the height of every top band, and `TOP_BAND_H` in
+`packages/app/src/shared/chrome-metrics.ts` is where that number lives. The main process
+derives `trafficLightPosition` from it; `tokens.css` declares `--top-band-h` from it;
+`.ws-sidebar-titlebar` and `.ws-content-head` read the token. Nothing writes a band
+height by hand.
+
+Why this is a rule and not a preference: it was written twice, and the two copies
+disagreed. `height: 44px` centres a control at 22; `trafficLightPosition.y = 18` put the
+lights' centre at 25 — and the comment above it asserted they were centred. Three pixels
+of misalignment on the most-looked-at row in the app, shipped, with a comment vouching
+for it (TRA-370).
+
+Two things to know before touching the offset:
+
+- **`trafficLightPosition.y` is not the circle's top edge.** The button's frame carries a
+  point above it, so the light renders one point lower than the offset asks for. The
+  centring offset is `(TOP_BAND_H − 12) / 2 − 1`, not `(TOP_BAND_H − 12) / 2`. Measured on
+  macOS 26 / Electron 41 by screen-capturing the real window and reading the red light's
+  row profile: y=18 → centre 25.0, y=15 → centre 22.0.
+- **Verify it by measuring, not by looking.** There are no traffic lights on the Vite dev
+  server, so a browser cannot show this at all. Launch the Electron window
+  (`node packages/app/scripts/electron-cdp.mjs launch`), capture the screen, and compare
+  the light's pixel centre against the toggle's `getBoundingClientRect()` centre. Both
+  appearances, sidebar expanded and collapsed.
+
+`packages/app/src/main/__tests__/chrome-metrics.test.ts` and the top-band block in
+`src/renderer/styles/__tests__/tokens.test.ts` fail if the constant, the token, the
+stylesheets and `tray.ts` ever drift apart again.
 
 ### Where a global action lives
 

--- a/packages/app/scripts/electron-cdp.mjs
+++ b/packages/app/scripts/electron-cdp.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * Drive the real Electron window over the Chrome DevTools Protocol.
+ *
+ * Design work has to be judged in the Electron window, not in `vite dev` in a
+ * browser: the window is `titleBarStyle: 'hiddenInset'` with real traffic
+ * lights and a native vibrancy view behind the sidebar, none of which a browser
+ * tab has. This script is the launch path for that.
+ *
+ *   node scripts/electron-cdp.mjs launch            # build + run with CDP on :9222
+ *   node scripts/electron-cdp.mjs shot out.png      # screenshot the current page
+ *   node scripts/electron-cdp.mjs shot out.png --view=project --tab=graph --dark
+ *
+ * `launch` uses its own --user-data-dir so it does not fight the installed
+ * trace-mcp.app for Electron's single-instance lock. Once it is up, an external
+ * CDP client can attach to http://127.0.0.1:9222 — including chrome-devtools
+ * MCP, which takes `--browser-url http://127.0.0.1:9222`.
+ */
+import { spawn } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const APP_DIR = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
+const PORT = Number(process.env.TRACE_MCP_CDP_PORT ?? 9222);
+const USER_DATA_DIR = process.env.TRACE_MCP_CDP_PROFILE ?? '/tmp/trace-mcp-cdp-profile';
+const ORIGIN = `http://127.0.0.1:${PORT}`;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function targets() {
+  const res = await fetch(`${ORIGIN}/json/list`);
+  return res.json();
+}
+
+/** First page target, retried — Electron opens its window a beat after boot. */
+async function waitForPage(timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const page = (await targets()).find((t) => t.type === 'page');
+      if (page) return page;
+    } catch {
+      // endpoint not up yet
+    }
+    if (Date.now() > deadline) throw new Error(`no page target on ${ORIGIN} after ${timeoutMs}ms`);
+    await sleep(500);
+  }
+}
+
+/** Minimal CDP session over the built-in WebSocket (Node >= 22). */
+async function connect(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  const pending = new Map();
+  let nextId = 1;
+  await new Promise((resolve, reject) => {
+    ws.addEventListener('open', resolve, { once: true });
+    ws.addEventListener('error', () => reject(new Error(`cannot connect to ${wsUrl}`)), {
+      once: true,
+    });
+  });
+  ws.addEventListener('message', (event) => {
+    const msg = JSON.parse(event.data);
+    const entry = pending.get(msg.id);
+    if (!entry) return;
+    pending.delete(msg.id);
+    if (msg.error) entry.reject(new Error(msg.error.message));
+    else entry.resolve(msg.result);
+  });
+  return {
+    send(method, params) {
+      const id = nextId++;
+      ws.send(JSON.stringify({ id, method, params: params ?? {} }));
+      return new Promise((resolve, reject) => pending.set(id, { resolve, reject }));
+    },
+    close: () => ws.close(),
+  };
+}
+
+function launch() {
+  mkdirSync(USER_DATA_DIR, { recursive: true });
+  const electron = path.join(APP_DIR, 'node_modules', '.bin', 'electron');
+  const env = { ...process.env, TRACE_MCP_DEV_ALWAYS_ON_TOP: '1' };
+  delete env.ELECTRON_RUN_AS_NODE;
+  const child = spawn(
+    electron,
+    ['.', `--remote-debugging-port=${PORT}`, `--user-data-dir=${USER_DATA_DIR}`],
+    { cwd: APP_DIR, env, stdio: 'inherit' },
+  );
+  child.on('exit', (code) => process.exit(code ?? 0));
+}
+
+async function shot(outFile, opts) {
+  const page = await waitForPage();
+  const cdp = await connect(page.webSocketDebuggerUrl);
+  if (opts.url) {
+    await cdp.send('Page.enable');
+    await cdp.send('Page.navigate', { url: opts.url });
+    await sleep(opts.settleMs);
+  }
+  /* Drive the app's OWN appearance control, not `Emulation.setEmulatedMedia`.
+     The sidebar is transparent over a native vibrancy view that follows
+     nativeTheme, and emulated media never reaches it — an "emulated dark" shot
+     is dark content behind a light sidebar, which is not a state the app has. */
+  if (opts.appearance) {
+    await cdp.send('Runtime.evaluate', {
+      expression: `localStorage.setItem('trace-mcp-theme', ${JSON.stringify(opts.appearance)});
+        location.reload();`,
+    });
+    await sleep(opts.settleMs);
+  }
+  /* Accessibility settings the material has to survive. */
+  if (opts.media?.length) {
+    await cdp.send('Emulation.setEmulatedMedia', { features: opts.media });
+    await sleep(400);
+  }
+  /* Which surface is on screen is React state, not a URL — so reach it the way
+     a user does, by clicking its sidebar row. */
+  if (opts.click) {
+    await cdp.send('Runtime.evaluate', {
+      expression: `[...document.querySelectorAll('.ws-sb-row')]
+        .find((r) => r.textContent.trim() === ${JSON.stringify(opts.click)})?.click()`,
+    });
+    await sleep(opts.settleMs);
+  }
+  mkdirSync(path.dirname(path.resolve(outFile)), { recursive: true });
+  /* Needs a visible window: an occluded one stops compositing, and the capture
+     then either hangs or hands back the last frame it painted. `launch` sets
+     TRACE_MCP_DEV_ALWAYS_ON_TOP for exactly this reason. */
+  const { data } = await cdp.send('Page.captureScreenshot', { format: 'png' });
+  writeFileSync(outFile, Buffer.from(data, 'base64'));
+  cdp.close();
+  console.log(`wrote ${outFile}`);
+}
+
+const [cmd, ...rest] = process.argv.slice(2);
+if (cmd === 'launch') {
+  launch();
+} else if (cmd === 'shot') {
+  const out = rest.find((a) => !a.startsWith('--'));
+  if (!out) throw new Error('usage: electron-cdp.mjs shot <out.png> [--url=…] [--dark|--light]');
+  const flag = (name) => rest.find((a) => a.startsWith(`--${name}=`))?.split('=').slice(1).join('=');
+  const media = [];
+  if (rest.includes('--reduce-transparency'))
+    media.push({ name: 'prefers-reduced-transparency', value: 'reduce' });
+  if (rest.includes('--increase-contrast')) media.push({ name: 'prefers-contrast', value: 'more' });
+  await shot(out, {
+    url: flag('url'),
+    appearance: rest.includes('--dark') ? 'dark' : rest.includes('--light') ? 'light' : undefined,
+    media,
+    settleMs: Number(flag('settle') ?? 1500),
+    click: flag('click'),
+  });
+} else {
+  console.error('usage: electron-cdp.mjs launch | shot <out.png> [--url=…] [--dark|--light]');
+  process.exit(1);
+}

--- a/packages/app/scripts/token-guard.baseline.json
+++ b/packages/app/scripts/token-guard.baseline.json
@@ -4,7 +4,7 @@
   "src/renderer/lattice/icons.tsx": 1,
   "src/renderer/lattice/ui/Badge.tsx": 2,
   "src/renderer/styles/controls.css": 1,
-  "src/renderer/styles/island.css": 71,
+  "src/renderer/styles/island.css": 70,
   "src/renderer/tabs/GraphExplorerGPU.tsx": 95,
   "src/renderer/tabs/MemoryExplorer.tsx": 1,
   "src/renderer/tabs/Settings.tsx": 2,

--- a/packages/app/src/main/__tests__/chrome-metrics.test.ts
+++ b/packages/app/src/main/__tests__/chrome-metrics.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  TOP_BAND_H,
+  TRAFFIC_LIGHT_D,
+  TRAFFIC_LIGHT_X,
+  TRAFFIC_LIGHT_Y,
+  trafficLightCentreY,
+} from '../../shared/chrome-metrics.js';
+
+/* TRA-370. Nikolai reported the sidebar toggle sitting off the traffic-light
+   centre line. It was arithmetic, not taste: `trafficLightPosition.y = 18` and
+   `height: 44px` were picked independently in two files, and nothing tied them
+   together. This test is the tie. */
+describe('traffic lights sit on the top band centre line', () => {
+  it('derives the offset from the band height', () => {
+    expect(trafficLightCentreY()).toBe(TOP_BAND_H / 2);
+    expect(TRAFFIC_LIGHT_Y).toBe((TOP_BAND_H - TRAFFIC_LIGHT_D) / 2 - 1);
+  });
+
+  it('reads the offset from the shared constant, never a literal', () => {
+    // `src/main` builds to CommonJS, where `import.meta` is a compile error —
+    // resolve from the vitest root instead, as install-path.test.ts does.
+    const tray = readFileSync(path.resolve(process.cwd(), 'src/main/tray.ts'), 'utf8');
+    expect(tray).toContain(
+      'opts.trafficLightPosition = { x: TRAFFIC_LIGHT_X, y: TRAFFIC_LIGHT_Y };',
+    );
+    expect(tray).not.toMatch(/trafficLightPosition\s*=\s*\{\s*x:\s*\d/);
+  });
+
+  it('keeps the lights clear of the window edge', () => {
+    expect(TRAFFIC_LIGHT_X).toBeGreaterThan(0);
+    expect(TRAFFIC_LIGHT_Y).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { app, BrowserWindow, ipcMain, Menu, nativeImage, nativeTheme, Tray } from 'electron';
+import { TRAFFIC_LIGHT_X, TRAFFIC_LIGHT_Y } from '../shared/chrome-metrics.js';
 import { DaemonClient } from './api-client';
 import { ensureDaemon, restartDaemon } from './daemon-lifecycle';
 
@@ -107,8 +108,10 @@ function createWindowOptions(
     // desaturates it when the window loses key, and macOS honours Reduce
     // Transparency for free — no CSS backdrop-filter fallback needed.
     opts.titleBarStyle = 'hiddenInset';
-    // y=18 centres the 12px lights on the 44px title strip the sidebar reserves.
-    opts.trafficLightPosition = { x: 14, y: 18 };
+    // Derived from the band height in src/shared/chrome-metrics.ts — the same
+    // number `--top-band-h` is generated from. Never write the offset by hand:
+    // that is what put the lights 3px below the sidebar toggle (TRA-370).
+    opts.trafficLightPosition = { x: TRAFFIC_LIGHT_X, y: TRAFFIC_LIGHT_Y };
     opts.vibrancy = 'sidebar';
     opts.visualEffectState = 'followWindow';
     opts.backgroundColor = '#00000000';

--- a/packages/app/src/renderer/styles/__tests__/tokens.test.ts
+++ b/packages/app/src/renderer/styles/__tests__/tokens.test.ts
@@ -1,6 +1,12 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import {
+  TOP_BAND_H,
+  TRAFFIC_LIGHT_D,
+  TRAFFIC_LIGHT_Y,
+  trafficLightCentreY,
+} from '../../../shared/chrome-metrics.js';
 // @ts-expect-error — plain .mjs helper, shared with the CLI check (TRA-289)
 import {
   contrast,
@@ -99,6 +105,58 @@ describe('design tokens', () => {
       }
     }
     expect(offenders).toEqual([]);
+  });
+
+  /* TRA-370. The traffic lights are positioned by the MAIN process and the band
+     they sit in is sized by CSS. When those were two literals in two files they
+     disagreed — a 44px strip centres at 22, `trafficLightPosition.y = 18` put
+     the lights' centre at 25, and the comment above it claimed they matched.
+     These four assertions are the guard: the token must equal the constant, the
+     offset must be derived from it and land the lights on the band's centre,
+     and no stylesheet may write a band height by hand again. */
+  describe('the top band (TRA-370)', () => {
+    it('generates --top-band-h from src/shared/chrome-metrics.ts', () => {
+      expect(tokensCss).toMatch(
+        new RegExp(`--top-band-h:\\s*${TOP_BAND_H}px`),
+      );
+    });
+
+    it('centres the traffic lights on the band, not 3px below it', () => {
+      expect(trafficLightCentreY()).toBe(TOP_BAND_H / 2);
+      // Measured on the real window: y=18 renders the light's centre at 25,
+      // y=15 at 22. Slope 1, so the offset that centres a 12px light in a 44px
+      // band is 15 — one less than naive (44-12)/2, because the button's frame
+      // carries a point above the circle.
+      expect(TRAFFIC_LIGHT_Y).toBe((TOP_BAND_H - TRAFFIC_LIGHT_D) / 2 - 1);
+    });
+
+    it('sizes every top band from the token instead of a literal', () => {
+      const sidebarCss = readFileSync(
+        fileURLToPath(new URL('../sidebar.css', import.meta.url)),
+        'utf8',
+      );
+      for (const selector of ['.ws-sidebar-titlebar', '.ws-content-head']) {
+        const body = new RegExp(`\\${selector}\\s*\\{([^}]*)\\}`).exec(sidebarCss)?.[1];
+        expect(body, `${selector} not found`).toBeDefined();
+        expect(body).toMatch(/height:\s*var\(--top-band-h\)/);
+      }
+    });
+
+    it('leaves no stylesheet writing a band height by hand', () => {
+      const dir = fileURLToPath(new URL('..', import.meta.url));
+      const offenders: string[] = [];
+      for (const name of readdirSync(dir).filter((f) => f.endsWith('.css'))) {
+        const css = readFileSync(`${dir}/${name}`, 'utf8');
+        for (const [, selector, body] of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+          if (!/-webkit-app-region:\s*drag/.test(body)) continue;
+          const height = /(?:^|[;{\s])height:\s*([^;]+)/.exec(body)?.[1]?.trim();
+          if (height && !height.includes('var(--top-band-h)')) {
+            offenders.push(`${name}: ${selector.trim().split('\n').pop()?.trim()} → ${height}`);
+          }
+        }
+      }
+      expect(offenders).toEqual([]);
+    });
   });
 
   /* TRA-297: `user-select: none` on body used to be the last word, so no path,

--- a/packages/app/src/renderer/styles/island.css
+++ b/packages/app/src/renderer/styles/island.css
@@ -195,51 +195,11 @@
   overflow: hidden;
 }
 
-/* ============================================================================
-   TOP BAR — project tabs (browser style)
-   ============================================================================ */
-.ws-topbar {
-  height: 42px;
-  flex: none;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 8px 0 14px;
-  background: linear-gradient(180deg, var(--surface-sunken), var(--surface-sunken));
-  -webkit-app-region: drag;
-}
-.ws-topbar > * { -webkit-app-region: no-drag; }
-/* NOTE: the hand-drawn `.ws-lights` / `.ws-light` circles that used to live
-   here are gone (TRA-291) — the window is `titleBarStyle: 'hiddenInset'` and
-   renders the REAL traffic lights. Never re-draw them in CSS. */
-
-.ws-ptabs { display: flex; align-items: center; gap: 3px; flex: 1; min-width: 0; overflow: hidden; }
-.ws-ptab {
-  display: flex; align-items: center; gap: 8px; height: 30px; padding: 0 7px 0 9px;
-  border-radius: var(--radius-input); font-size: 13px; color: var(--label-secondary); cursor: default;
-  max-width: 210px; transition: background .12s, color .12s;
-}
-.ws-ptab:hover { background: var(--fill-quaternary); }
-.ws-ptab.is-active { background: var(--surface); color: var(--label); box-shadow: var(--shadow); }
-.ws-ptab .ic {
-  width: 18px; height: 18px; border-radius: var(--radius-row); flex: none;
-  display: flex; align-items: center; justify-content: center;
-  color: #fff; font-size: 8px; font-weight: 800; letter-spacing: -0.02em;
-}
-.ws-ptab .nm { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ws-ptab .x {
-  width: 17px; height: 17px; border-radius: var(--radius-row); flex: none;
-  display: flex; align-items: center; justify-content: center; color: var(--label-secondary);
-  opacity: 0; transition: opacity .12s, background .12s;
-}
-.ws-ptab:hover .x, .ws-ptab.is-active .x { opacity: 0.8; }
-.ws-ptab .x:hover { background: var(--fill-quaternary); color: var(--label); }
-.ws-ptab-add {
-  width: 28px; height: 28px; flex: none; border-radius: var(--radius-row);
-  display: flex; align-items: center; justify-content: center; color: var(--label-secondary);
-  cursor: default; transition: background .12s, color .12s;
-}
-.ws-ptab-add:hover { background: var(--fill-quaternary); color: var(--label); }
+/* The browser-style project tab bar that used to live here is gone (TRA-370).
+   Nothing rendered `.ws-topbar` / `.ws-ptab*` — the app has one top band, and
+   this block's 42px height was a third, unreachable answer to how tall it is.
+   The window is `titleBarStyle: 'hiddenInset'` and renders the REAL traffic
+   lights; never re-draw them in CSS, and never write a band height here. */
 
 /* the agent avatar mark (Solar "black hole", see NOTICE) */
 .ws-ai-star { width: 18px; height: 18px; display: block; }

--- a/packages/app/src/renderer/styles/sidebar.css
+++ b/packages/app/src/renderer/styles/sidebar.css
@@ -43,10 +43,12 @@
   background: transparent;
 }
 
-/* 44px strip that the traffic lights sit in. Drag region — this and the
-   content pane's header are the ONLY draggable areas. */
+/* The strip the traffic lights sit in. Drag region — this and the content
+   pane's header are the ONLY draggable areas. Height comes from --top-band-h,
+   the same number `trafficLightPosition` is derived from (TRA-370): a literal
+   here is what put the lights 3px below the toggle. */
 .ws-sidebar-titlebar {
-  height: 44px;
+  height: var(--top-band-h);
   flex: none;
   display: flex;
   align-items: center;
@@ -348,11 +350,10 @@
   background: var(--surface-sunken, var(--surface));
 }
 
-/* Minimal 44px header: balances the sidebar title strip, carries the sidebar
-   toggle and owns the content pane's drag region. The full toolbar spec is a
-   separate issue — this is chrome, not a toolbar. */
+/* The content pane's half of the top band: same --top-band-h as the sidebar
+   strip, so the toggle it carries sits on the traffic-light centre line. */
 .ws-content-head {
-  height: 44px;
+  height: var(--top-band-h);
   flex: none;
   display: flex;
   align-items: center;

--- a/packages/app/src/renderer/styles/tokens.css
+++ b/packages/app/src/renderer/styles/tokens.css
@@ -114,6 +114,14 @@
   --space-40: 40px;
   --space-48: 48px;
 
+  /* ---- Window chrome — the top band (TRA-370)
+     The traffic-light centre line. EVERY top band in the app is this tall, and
+     every control in one is centred in it. The main process derives
+     `trafficLightPosition` from the same number, so the system's lights land on
+     the same line as the toggle we draw — src/shared/chrome-metrics.ts owns it,
+     and styles/__tests__/tokens.test.ts fails if these two drift apart. */
+  --top-band-h: 44px;
+
   /* ---- Motion */
   --dur-micro: 120ms;
   --dur-standard: 200ms;

--- a/packages/app/src/shared/chrome-metrics.ts
+++ b/packages/app/src/shared/chrome-metrics.ts
@@ -1,0 +1,37 @@
+/* The top band — the one horizontal line every window-chrome control sits on.
+   (TRA-370)
+
+   The macOS traffic lights are drawn by the system, positioned by the MAIN
+   process; the sidebar toggle and the surface toolbar are drawn by the
+   renderer, positioned by CSS. Before this file those were two independent
+   literals in two files, and they disagreed: the strip was 44px (centre 22)
+   while `trafficLightPosition.y = 18` put the lights' centre at 25. Three
+   pixels, permanently, with a comment claiming they were centred.
+
+   So the band height lives here once, `--top-band-h` is generated from it, and
+   the traffic-light offset is DERIVED from it. Change TOP_BAND_H and both
+   move together. `tokens.test.ts` fails if tokens.css drifts from this value. */
+
+/** Height of every top band in the app, in CSS px. Mirrored by `--top-band-h`. */
+export const TOP_BAND_H = 44;
+
+/** The macOS traffic lights are 12pt circles. */
+export const TRAFFIC_LIGHT_D = 12;
+
+/* `trafficLightPosition.y` is NOT the top edge of the circle — the button's
+   frame carries a point above it, so the circle renders one point lower than
+   the offset asks for. Measured on macOS 26 / Electron 41 by screen-capturing
+   the real window and reading the red light's row profile: y=18 centres it at
+   25.0, y=15 centres it at 22.0. Slope 1, intercept 7. If a future Electron
+   changes the button's frame, this is the constant that absorbs it. */
+const TRAFFIC_LIGHT_FRAME_INSET = 1;
+
+/** Offset that centres the lights in the band. Never write this number down. */
+export const TRAFFIC_LIGHT_Y = (TOP_BAND_H - TRAFFIC_LIGHT_D) / 2 - TRAFFIC_LIGHT_FRAME_INSET;
+
+/** Distance from the window's leading edge to the first light. */
+export const TRAFFIC_LIGHT_X = 14;
+
+/** Where the lights' centre lands, given TRAFFIC_LIGHT_Y — the band's centre. */
+export const trafficLightCentreY = (): number =>
+  TRAFFIC_LIGHT_Y + TRAFFIC_LIGHT_FRAME_INSET + TRAFFIC_LIGHT_D / 2;


### PR DESCRIPTION
Closes TRA-370.

## The miss, measured

The report was right that the sidebar toggle is off the traffic-light centre line. The gap is **3px, not 2** — and it is not something you can work out from the source, which is why the code comment claiming the lights were centred was wrong twice over.

`trafficLightPosition.y` is **not** the top edge of the circle. The button's frame carries a point above it, so the light renders one point lower than the offset asks for. Measured on the real Electron window by screen-capturing the frame against a DOM fiducial and reading the red light's row profile:

| `trafficLightPosition.y` | light centre, measured |
|---|---|
| 18 (master) | **25.00** |
| 15 (this PR) | **22.00** |

Slope 1, intercept 7. A 44px band centres its controls at 22, and the toggle's `getBoundingClientRect()` centre is 22.00 — so master was 3px out, not 2.

## Before / after, in the Electron window

Annotated before/after captures (magenta line = DOM y=22, the band's centre) are attached to TRA-370.

Measured in all four cases the issue lists — Workspace window and project window, light and dark, sidebar expanded and collapsed:

| | light centre before | after | toggle centre |
|---|---|---|---|
| Workspace, light | 25.00 | **22.00** | 22.00 |
| Workspace, dark | 25.00 | **22.00** | 22.00 |
| Project, light | 25.00 | **22.00** | 22.00 |
| Project, dark | 25.00 | **22.00** | 22.00 |
| Sidebar collapsed (both windows) | 25.00 | **22.00** | 22.00 |

## One number, in one place

`packages/app/src/shared/chrome-metrics.ts` owns it:

- `TOP_BAND_H = 44` → `--top-band-h` in `tokens.css` → `height: var(--top-band-h)` on `.ws-sidebar-titlebar` and `.ws-content-head`.
- `TRAFFIC_LIGHT_Y = (TOP_BAND_H - 12) / 2 - 1` → `tray.ts`.

Change `TOP_BAND_H` and both move together. The `-1` is the measured frame inset, documented with the numbers it came from, so a future Electron that changes the button's frame has one constant to absorb it.

## Guards, so it cannot drift again

`src/main/__tests__/chrome-metrics.test.ts` and a new top-band block in `styles/__tests__/tokens.test.ts` assert that the token equals the constant, that the derived offset lands the lights on the band centre, that both band rules read the token, and that **no stylesheet writes a band height by hand** — any `-webkit-app-region: drag` rule with a literal `height` fails the build.

Verified by mutation: setting the frame inset to 0 or putting `44px` back in `sidebar.css` fails 4 tests.

## The third band height was dead code

`.ws-topbar` (42px) in `island.css` was the third answer to "how tall is a top band". Nothing renders it — `.ws-topbar`, `.ws-ptab*` and `.ws-win` appear in no TSX in the repo. Removed the block (46 lines), which also drops `island.css` one below its token-guard baseline; lowered accordingly.

## Also checked

The "filled/selected-looking box" on the toggle glyph in the dark screenshot is **not** a stuck hover or active state — computed style on the live element is `background: rgba(0,0,0,0)`, no border, no box-shadow. It is the `dock_to_right` glyph's own artwork: a rounded rectangle with a filled right panel.

## The rule is written down

DESIGN.md §6 now states that the traffic-light centre line is the app's top-band baseline, that the band height and `trafficLightPosition` are two views of one number, that the offset is not the circle's top edge, and that this is only verifiable in the Electron window — there are no traffic lights on the Vite dev server.

## Notes for review

- `packages/app/scripts/electron-cdp.mjs` is the launch path for that verification, and DESIGN.md points at it. The same file is added by #518 (TRA-354) with identical content; whichever lands second resolves trivially.
- The Workspace toolbar's search / Filter / Table-Compact / + Add are on a **separate** 52px toolbar row on master, not in `.ws-content-head` — they cannot share the traffic-light line by construction here. #518 (TRA-354) is what merges them onto this band; once it lands they inherit `--top-band-h` and are centred by this change.
- In the light-appearance shot the sidebar material still reads dark. That is the native vibrancy following the system appearance rather than the app's — TRA-369, not this PR.

Agent: Design/UX Agent
