### PR TITLE
feat(app): Theme is one menu row with an inline switcher (TRA-363)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -422,6 +422,47 @@ same reason.
 The footer never grows a second row for any of this. If a new global action needs a
 home, it is a menu item.
 
+### A choice in a menu is one row, not a group of items
+
+A menu item is a **destination or a command**: you pick it, something happens, the
+menu closes. A **choice** is not that — it is a setting with two or three values
+that you may want to try, and it does not belong in the same shape.
+
+Appearance shipped as the wrong shape first: an `APPEARANCE` caps header plus three
+checked items, four rows for one three-state preference, in a menu whose whole
+premise was that the sidebar footer should stop spending a row per thing. A caps
+header over a single control is weight without information.
+
+**The rule.** A choice inside a menu is one row: its name on the left, the control
+inline on the right, on the same centre line as every item above and below it
+(`MenuChoiceRow` in `lattice/ui/Menu.tsx`, `.ws-ctx-row` in `styles/island.css`).
+Two to four short values → a segmented pill. More than four, or values that need
+words → a pop-up button on the same row shape. Never a section header plus one
+item per value.
+
+What the row has to get right, all of it enforced by
+`components/__tests__/AppMenu.test.tsx`:
+
+- **Geometry.** Same 30px box and 8px inset as `.ws-ctx-item`, so the label, the
+  control and the neighbouring items share one centre line and the control's right
+  edge lands in the same column as an item's shortcut. Measured: 214.5px for both.
+- **Roles.** `role="group"` + `aria-label` on the row, `role="menuitemradio"` +
+  `aria-checked` on each value. Not `radiogroup` / `radio` — a `radiogroup` is not
+  a legal child of `role="menu"`, and `aria-pressed` (what the shared
+  `SegmentedControl` uses) says "toggled", not "chosen".
+- **Two axes on the keyboard.** Up/Down keep moving between menu *rows*: the row is
+  a single stop, marked `data-menu-row`, and the stop resolves to whichever segment
+  is checked right now. Left/Right move *within* the control and change the value.
+  Roving `tabIndex` puts the one Tab stop on the current value.
+- **Icon-only segments carry their name in `aria-label` and in `title`.** The
+  visible glyph is not a label; screen readers and hover both need the word.
+- **Selection needs a second cue when the segments are icons.** The thumb alone is
+  1.19:1 (light) / 1.63:1 (dark) against the track — fine for word segments, which
+  stay readable regardless, but an icon has nothing else to fall back on, so an
+  unselected icon drops to `--label-secondary`.
+- **Picking a value does not close the menu.** The point of an inline switcher is
+  watching the app change under it. A command still closes; a choice does not.
+
 ### The window minimum is a size that has to work
 
 `main/tray.ts` sets `minWidth: 640, minHeight: 420`. Every surface must be usable
@@ -654,8 +695,11 @@ new evidence.
 | `listPending` separates "daemon hasn't answered" from "never indexed" | `status ?? 'unknown'` blamed the project for the daemon's silence. |
 | Sidebar footer is `.ws-sb-row`, not its own geometry | One row system for the whole sidebar; the footer's labels started 26px left of every other label. |
 | Appearance is Auto / Light / Dark, with Auto clearing the key | The old `toggle` only ever wrote `light` or `dark`, so one click pinned the app forever and the system listener stopped mattering. |
-| Appearance lives in Settings, not the sidebar footer | A preference is not a navigation destination, and a second footer row cost 28px at the bottom of every window. It renders in Settings' daemon-down and loading states too — the theme is localStorage, not daemon config. (TRA-363 added it back as a checked group *inside* the app menu — a menu item costs no sidebar height, which is what the objection was about.) |
+| Appearance lives in Settings, not the sidebar footer | A preference is not a navigation destination, and a second footer row cost 28px at the bottom of every window. It renders in Settings' daemon-down and loading states too — the theme is localStorage, not daemon config. (TRA-363 added it back *inside* the app menu, as one `Theme` row — a menu row costs no sidebar height, which is what the objection was about.) |
 | The sidebar footer is one row, and that row opens a menu | Every global action was costing 28px of a column meant for navigation: Settings, then Appearance, then a permanent "● Up to date · v3.1.1 ⟳" strip — 70.5px measured, of which the update row's entire message was "nothing is wrong". One row is 42.5px and the next global action costs a menu item instead of a row (TRA-363). |
+| A choice in a menu is one row with the control inline, not a header plus one item per value | Appearance first shipped as an `APPEARANCE` caps header over three checked items: four rows for one three-state preference, in the menu built to stop the footer spending a row per thing. A header over a single control is weight without information. One row, name left, pill right, on the shared centre line — and the rule is written for every future choice, not solved for Theme (TRA-363). |
+| A choice row is `group` + `menuitemradio`, one keyboard stop, and does not close the menu | `radiogroup` is not a legal child of `role="menu"`, and the shared `SegmentedControl`'s `aria-pressed` says "toggled" rather than "chosen". The row is one Up/Down stop resolved to the checked segment, Left/Right move inside it, and picking a value leaves the menu open — an inline switcher exists so you can watch the app change under it. |
+| Icon-only segments dim when unselected; word segments do not | The selected thumb is 1.19:1 light / 1.63:1 dark against the track. On a word that is enough because the word stays readable (TRA-292); an icon has no fallback, so the only cue would be a sub-3:1 fill. Unselected icons drop to `--label-secondary` (4.5:1 on the track). |
 | A global action is defined once, in `src/shared/global-actions.ts` | The native menu and the app menu both offer Settings / What's new / Get help / Check for updates. Two hand-maintained lists drift — a relabelled item, a moved key, an action added to one and forgotten in the other. Neither surface types a label; both read the entry. |
 | "Up to date" belongs in the app menu's header, not in a sidebar row | It is the answer to a question you only ask when you go looking, and it belongs next to the action that re-asks it. A permanent strip pays 28px in every window, forever, to report the absence of news. The states you can *act* on — update available, restart pending, bundle stuck — still get a card in the sidebar. |
 | A menu anchors on the app, because there is no account to anchor on | The pattern this came from is an account menu, held together by an identity at the top. We have no users. The product is the identity: the trigger carries the name, the header carries the version and whether it is current. |

--- a/packages/app/src/renderer/components/AppMenu.tsx
+++ b/packages/app/src/renderer/components/AppMenu.tsx
@@ -18,7 +18,7 @@
    lives in Settings, and it exists on no other surface to drift against. */
 
 import { Icon } from '../lattice/icons';
-import { Menu, MenuItem, MenuSection, MenuSeparator, useMenuAnchor } from '../lattice/ui';
+import { Menu, MenuChoiceRow, MenuItem, MenuSeparator, useMenuAnchor } from '../lattice/ui';
 import { GLOBAL_ACTIONS, type GlobalAction } from '../../shared/global-actions.js';
 import { APPEARANCE_OPTIONS, type Appearance } from '../theme.js';
 import { describeStaleRoots, formatAgo, type UpdateState } from '../update-check.js';
@@ -149,17 +149,15 @@ export function AppMenu({
           <MenuSeparator />
           {settings && item(settings)}
           <MenuSeparator />
-          <MenuSection>Appearance</MenuSection>
-          {APPEARANCE_OPTIONS.map((option) => (
-            <MenuItem
-              key={option.value}
-              showCheckSlot
-              checked={appearance === option.value}
-              onClick={run(() => onAppearanceChange(option.value))}
-            >
-              {option.label}
-            </MenuItem>
-          ))}
+          {/* One row, not a header plus three checked items. Changing it does
+              NOT close the menu: the whole point of an inline switcher is
+              seeing the app change under it. */}
+          <MenuChoiceRow
+            label="Theme"
+            options={APPEARANCE_OPTIONS}
+            value={appearance}
+            onChange={onAppearanceChange}
+          />
           <MenuSeparator />
           {rest.map(item)}
         </Menu>

--- a/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
@@ -95,15 +95,60 @@ describe('sidebar app menu', () => {
     expect(header?.querySelector('.status')?.className).toContain('is-info');
   });
 
-  it('offers Appearance as a checked group and reports the pick', () => {
+  /* Nikolai on the four-row APPEARANCE group: "это оч плохо во всплывашке".
+     One labelled row with the switcher inline — and the segments are icon-only,
+     so each one's accessible NAME is what has to carry Auto / Light / Dark. */
+  it('offers Theme as one labelled row with an inline switcher', () => {
     const { trigger, onAppearanceChange } = renderMenu({ appearance: 'light' });
     const menu = openMenu(trigger);
-    const options = within(menu).getAllByRole('menuitemcheckbox');
-    expect(options.map((o) => o.textContent)).toEqual(['Auto', 'Light', 'Dark']);
+
+    const row = within(menu).getByRole('group', { name: 'Theme' });
+    expect(row.textContent).toBe('Theme'); // the label, and no item text
+    const options = within(row).getAllByRole('menuitemradio');
+    expect(options.map((o) => o.getAttribute('aria-label'))).toEqual(['Auto', 'Light', 'Dark']);
+    expect(options.map((o) => o.getAttribute('title'))).toEqual(['Auto', 'Light', 'Dark']);
+    // Selected, not merely hovered: the state is on the element, not the fill.
     expect(options.map((o) => o.getAttribute('aria-checked'))).toEqual(['false', 'true', 'false']);
+    expect(options[1].className).toContain('is-active');
+
     fireEvent.click(options[2]);
     expect(onAppearanceChange).toHaveBeenCalledWith('dark');
-    expect(screen.queryByRole('menu')).toBeNull();
+    // Picking a theme does NOT close the menu — the point of an inline
+    // switcher is watching the app change under it.
+    expect(screen.queryByRole('menu')).not.toBeNull();
+  });
+
+  it('is one Tab stop, entered on the current value', () => {
+    const { trigger } = renderMenu({ appearance: 'dark' });
+    const row = within(openMenu(trigger)).getByRole('group', { name: 'Theme' });
+    const options = within(row).getAllByRole('menuitemradio');
+    expect(options.map((o) => o.tabIndex)).toEqual([-1, -1, 0]);
+  });
+
+  /* The hard part Lead Engineer called out: two axes in one menu. Up/down has
+     to keep moving between rows while left/right moves inside the switcher. */
+  it('moves within the switcher on left/right and out of it on up/down', () => {
+    const onAppearanceChange = vi.fn();
+    const { trigger } = renderMenu({ appearance: 'light', onAppearanceChange });
+    const menu = openMenu(trigger);
+    const row = within(menu).getByRole('group', { name: 'Theme' });
+    const checked = within(row).getByRole('menuitemradio', { name: 'Light' });
+
+    // Down from Settings lands on the row's CHECKED segment, once — not once
+    // per segment.
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(checked);
+
+    fireEvent.keyDown(checked, { key: 'ArrowRight' });
+    expect(onAppearanceChange).toHaveBeenLastCalledWith('dark');
+    fireEvent.keyDown(checked, { key: 'ArrowLeft' });
+    expect(onAppearanceChange).toHaveBeenLastCalledWith('auto');
+
+    // …and down again leaves the row entirely, rather than stepping to Dark.
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    expect(row.contains(document.activeElement)).toBe(false);
+    expect(document.activeElement?.textContent).toContain("What's new");
   });
 
   it('runs the commands and opens the links', () => {
@@ -121,10 +166,14 @@ describe('sidebar app menu', () => {
   });
 
   it('arrows through the items and wraps', () => {
-    const { trigger } = renderMenu();
+    const { trigger } = renderMenu({ appearance: 'auto' });
     const menu = openMenu(trigger);
-    const all = Array.from(menu.querySelectorAll<HTMLElement>('[role^="menuitem"]'));
-    expect(all.length).toBe(GLOBAL_ACTIONS.length + 3); // + Auto / Light / Dark
+    /* The stop list, not the element list: the Theme row contributes ONE stop
+       (its checked segment), so up/down sees actions + 1. */
+    const all = Array.from(
+      menu.querySelectorAll<HTMLElement>('[role^="menuitem"]'),
+    ).filter((el) => !el.closest('[data-menu-row]') || el.getAttribute('aria-checked') === 'true');
+    expect(all.length).toBe(GLOBAL_ACTIONS.length + 1); // + the Theme row
 
     // Nothing is highlighted until the first arrow — a macOS menu does not
     // preselect its first item.

--- a/packages/app/src/renderer/lattice/ui/Menu.tsx
+++ b/packages/app/src/renderer/lattice/ui/Menu.tsx
@@ -14,6 +14,7 @@
    control in one click. <ConfirmPopover> is the paired destructive-action
    confirmation; it deliberately KEEPS a click-eating scrim (see comment there). */
 
+import type React from 'react';
 import { useEffect, useRef, useState, type ButtonHTMLAttributes, type ReactNode } from 'react';
 import { FloatingLayer } from '../FloatingLayer';
 import { Icon } from '../icons';
@@ -77,13 +78,33 @@ export function Menu({ x, y, align = 'start', onClose, className, children }: Me
     };
     /* Every enabled item, in DOM order. Read per keypress rather than cached:
        a menu's items can be conditional (an item that only exists while an
-       update is pending), and a stale list arrows onto a node that is gone. */
-    const items = (): HTMLElement[] =>
-      Array.from(
-        layerRef.current?.querySelectorAll<HTMLElement>(
-          '[role^="menuitem"]:not([disabled]):not([aria-disabled="true"])',
-        ) ?? [],
-      );
+       update is pending), and a stale list arrows onto a node that is gone.
+
+       A MenuChoiceRow is ONE stop, not one per segment: up/down step over the
+       whole row and left/right move inside it, which is the only arrangement
+       that leaves both axes meaning something. Its stop is whichever segment is
+       currently checked, so arrowing back into the row lands on the live value
+       rather than on a fixed position. */
+    const ENABLED = '[role^="menuitem"]:not([disabled]):not([aria-disabled="true"])';
+    const items = (): HTMLElement[] => {
+      const layer = layerRef.current;
+      if (!layer) return [];
+      const out: HTMLElement[] = [];
+      // Document order, and a row container always precedes its own segments.
+      for (const el of Array.from(
+        layer.querySelectorAll<HTMLElement>(`${ENABLED}, [data-menu-row]`),
+      )) {
+        if (el.hasAttribute('data-menu-row')) {
+          const stop =
+            el.querySelector<HTMLElement>('[aria-checked="true"]') ??
+            el.querySelector<HTMLElement>(ENABLED);
+          if (stop) out.push(stop);
+        } else if (!el.closest('[data-menu-row]')) {
+          out.push(el);
+        }
+      }
+      return out;
+    };
     const onKeyDown = (e: KeyboardEvent): void => {
       if (e.key === 'Escape') {
         // Consume Escape: the menu is the topmost layer, an enclosing surface
@@ -207,6 +228,107 @@ export function MenuItem({
       {children}
       {shortcut != null ? <span className="ws-ctx-sc">{shortcut}</span> : null}
     </button>
+  );
+}
+
+export interface MenuChoice<T extends string> {
+  value: T;
+  /** The segments are icon-only, so this is the accessible name AND the tooltip. */
+  label: string;
+  icon: string;
+}
+
+export interface MenuChoiceRowProps<T extends string> {
+  /** Visible row label; also the group's accessible name. */
+  label: string;
+  options: ReadonlyArray<MenuChoice<T>>;
+  value: T;
+  onChange: (next: T) => void;
+}
+
+/**
+ * A menu row that carries a CHOICE rather than an action: a label on the left,
+ * an inline segmented control on the right, one row (TRA-363 follow-up).
+ *
+ * The alternative — a section header plus one checked item per value — spends
+ * four rows on a three-state preference, inside a popover whose justification
+ * was that a menu item costs no sidebar height. A header above a single control
+ * is weight without information; the row's own label already says what it is.
+ *
+ * ARIA, because a control inside a menu is where this usually goes wrong:
+ * `role="group"` is a legal child of `role="menu"` and the segments are
+ * `menuitemradio`, so the set announces as "Theme, Dark, selected" instead of
+ * three unrelated pressed buttons. Roving tabindex keeps the row a single Tab
+ * stop; `Menu`'s traversal keeps it a single up/down stop.
+ */
+export function MenuChoiceRow<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+}: MenuChoiceRowProps<T>): ReactNode {
+  const rowRef = useRef<HTMLDivElement>(null);
+  /* Focus follows selection, but only when the keyboard put it there. A click
+     selects without stealing focus from wherever it already was. */
+  const keyboardRef = useRef(false);
+
+  useEffect(() => {
+    if (!keyboardRef.current) return;
+    keyboardRef.current = false;
+    rowRef.current?.querySelector<HTMLElement>('[aria-checked="true"]')?.focus();
+  }, [value]);
+
+  const step = (delta: number, e: React.KeyboardEvent): void => {
+    e.preventDefault();
+    e.stopPropagation();
+    const from = Math.max(
+      0,
+      options.findIndex((o) => o.value === value),
+    );
+    const next = options[(from + delta + options.length) % options.length];
+    if (next.value === value) return;
+    keyboardRef.current = true;
+    onChange(next.value);
+  };
+
+  return (
+    <div
+      ref={rowRef}
+      className="ws-ctx-row"
+      role="group"
+      aria-label={label}
+      data-menu-row=""
+      /* Left/right only. Up/down and Home/End are consumed by Menu's document
+         listener in the capture phase before they reach here, which is what
+         keeps them meaning "move between rows". */
+      onKeyDown={(e) => {
+        if (e.key === 'ArrowRight') step(1, e);
+        else if (e.key === 'ArrowLeft') step(-1, e);
+      }}
+    >
+      <span className="ws-ctx-row-label">{label}</span>
+      <div className="lx-seg sz-small ws-ctx-seg">
+        {options.map((option) => {
+          const checked = option.value === value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="menuitemradio"
+              aria-checked={checked}
+              aria-label={option.label}
+              title={option.label}
+              // Roving tabindex: the row is one Tab stop, entered on its value.
+              tabIndex={checked ? 0 : -1}
+              className={'lx-seg-item' + (checked ? ' is-active' : '')}
+              onClick={() => onChange(option.value)}
+            >
+              <Icon name={option.icon} size={14} />
+            </button>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 

--- a/packages/app/src/renderer/lattice/ui/index.ts
+++ b/packages/app/src/renderer/lattice/ui/index.ts
@@ -37,8 +37,22 @@ export type { IslandHeaderProps, MiniButtonProps } from './IslandHeader';
 export { EmptyState } from './EmptyState';
 export type { EmptyStateProps } from './EmptyState';
 
-export { Menu, MenuItem, MenuSection, MenuSeparator, ConfirmPopover, useMenuAnchor } from './Menu';
-export type { MenuProps, MenuItemProps, ConfirmPopoverProps } from './Menu';
+export {
+  ConfirmPopover,
+  Menu,
+  MenuChoiceRow,
+  MenuItem,
+  MenuSection,
+  MenuSeparator,
+  useMenuAnchor,
+} from './Menu';
+export type {
+  ConfirmPopoverProps,
+  MenuChoice,
+  MenuChoiceRowProps,
+  MenuItemProps,
+  MenuProps,
+} from './Menu';
 
 export {
   Card,

--- a/packages/app/src/renderer/styles/island.css
+++ b/packages/app/src/renderer/styles/island.css
@@ -671,6 +671,53 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
 }
 .ws-ctx-section:first-child { padding-top: 4px; }
 
+/* A menu row carrying a CONTROL rather than an action (TRA-363 follow-up).
+   Same 30px box and 8px inset as .ws-ctx-item, so the label, the pill and every
+   item above and below sit on one centre line. No hover fill: the row is not
+   the thing you click, the segments are. */
+.ws-ctx-row {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  height: 30px;
+  padding: 0 8px;
+}
+.ws-ctx-row .ws-ctx-row-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  color: var(--label);
+}
+/* Icon-only segments: drop the text padding, keep the 24px hit floor that
+   controls.css already grows with a pseudo-element. */
+.ws-ctx-row .ws-ctx-seg .lx-seg-item {
+  padding: 0;
+  min-width: 26px;
+}
+/* …and give selection a second cue. Measured on the running renderer: the thumb
+   is 1.19:1 against the track in light and 1.63:1 in dark — under 1.4.11's 3:1,
+   and on a WORD segment that is fine because controls.css deliberately keeps
+   unselected labels at full strength (TRA-292): you can still read "Light".
+   An icon has no such fallback, so here the thumb is the whole message. An
+   unselected icon steps back to --label-secondary — 4.5:1 on the track, still
+   comfortably legible — and the picked one reads at a glance. Hover still
+   brings it back to full: the thumb is what separates hovered from selected. */
+.ws-ctx-row .ws-ctx-seg .lx-seg-item:not(.is-active) {
+  color: var(--label-secondary);
+}
+/* macOS rings the whole TRACK, never one segment — the thumb already says
+   which segment is selected, so a second ring inside it is two answers to one
+   question. */
+.ws-ctx-row .ws-ctx-seg:focus-within {
+  box-shadow: var(--focus-ring);
+}
+.ws-ctx-row .ws-ctx-seg .lx-seg-item:focus-visible {
+  box-shadow: none;
+}
+
 /* Menu header (TRA-363) — what the menu is ABOUT, not something you can pick.
    The app menu has no account to hang on, so the anchor is the product: the
    trigger carries the name, this carries the version and whether it is current.

--- a/packages/app/src/renderer/tabs/Settings.tsx
+++ b/packages/app/src/renderer/tabs/Settings.tsx
@@ -1430,7 +1430,11 @@ function AppearanceCard({
             options={APPEARANCE_OPTIONS}
             value={appearance}
             onChange={onChange}
-            aria-label="Appearance"
+            // "Theme", matching the visible label beside it — an accessible
+            // name that disagrees with the label a sighted user reads out loud
+            // is a voice-control dead end (WCAG 2.5.3). "Appearance" is the
+            // GROUP heading above, and stays that.
+            aria-label="Theme"
           />
         </div>
       </Card>

--- a/packages/app/src/renderer/tabs/__tests__/Settings.appearance.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/Settings.appearance.test.tsx
@@ -31,7 +31,7 @@ beforeEach(() => {
 describe('Settings — Appearance', () => {
   it('offers Auto / Light / Dark even with no daemon', () => {
     render(<Settings appearance="auto" onAppearanceChange={() => {}} />);
-    const select = screen.getByLabelText('Appearance') as HTMLSelectElement;
+    const select = screen.getByLabelText('Theme') as HTMLSelectElement;
     expect([...select.options].map((o) => o.text)).toEqual(['Auto', 'Light', 'Dark']);
     expect(select.value).toBe('auto');
   });
@@ -39,7 +39,7 @@ describe('Settings — Appearance', () => {
   it('reports the picked appearance upwards', () => {
     const onChange = vi.fn();
     render(<Settings appearance="auto" onAppearanceChange={onChange} />);
-    const select = screen.getByLabelText('Appearance') as HTMLSelectElement;
+    const select = screen.getByLabelText('Theme') as HTMLSelectElement;
     select.value = 'dark';
     select.dispatchEvent(new Event('change', { bubbles: true }));
     expect(onChange).toHaveBeenCalledWith('dark');

--- a/packages/app/src/renderer/theme.ts
+++ b/packages/app/src/renderer/theme.ts
@@ -21,10 +21,17 @@ export type Theme = 'light' | 'dark';
 /** What the user picked. `auto` = follow the system, and is the default. */
 export type Appearance = 'auto' | Theme;
 
-export const APPEARANCE_OPTIONS: ReadonlyArray<{ value: Appearance; label: string }> = [
-  { value: 'auto', label: 'Auto' },
-  { value: 'light', label: 'Light' },
-  { value: 'dark', label: 'Dark' },
+/* One list, two surfaces: Settings renders the labels, the app menu's row
+   renders the icons (its segments are icon-only). Same anti-drift rule as
+   src/shared/global-actions.ts — the values and their names are written once. */
+export const APPEARANCE_OPTIONS: ReadonlyArray<{
+  value: Appearance;
+  label: string;
+  icon: string;
+}> = [
+  { value: 'auto', label: 'Auto', icon: 'contrast' },
+  { value: 'light', label: 'Light', icon: 'light_mode' },
+  { value: 'dark', label: 'Dark', icon: 'dark_mode' },
 ];
 
 export function readStoredAppearance(): Appearance {


### PR DESCRIPTION
Follow-up to #516. Appearance shipped in the app menu as an `APPEARANCE` caps header plus three checked items — four rows for one three-state preference, in the menu built to stop the sidebar footer spending a row per thing. A caps header over a single control is weight without information.

## What changes

One row: **`Theme`** on the left, a three-segment icon pill on the right, on the same 30px box, 8px inset and centre line as every item around it. The pill's right edge lands in the same column as an item's shortcut — measured 214.5px for both.

Menu height 323.5px → 236.5px. Keyboard stops 7 → 5.

The three states are unchanged: **Auto / Light / Dark**, with Auto removing the stored key rather than writing a third value.

The generalisable part is a new lattice primitive, `MenuChoiceRow`, plus the rule for when to reach for it, written into `DESIGN.md`: *a choice inside a menu is one labelled row with the control inline, never a section header plus one item per value.* Two to four short values → a segmented pill; more, or values that need words → a pop-up button on the same row shape.

## Keyboard

A control inside a menu has two axes, which is the whole difficulty:

- The row is **one stop** for Up/Down. It is marked `data-menu-row`, and the stop resolves at keypress time to whichever segment is checked — so arrowing past Theme is one press, not three.
- `Menu.tsx` consumes Up/Down/Home/End on document capture, so they never reach the row. Left/Right bubble to it and change the value.
- Roving `tabIndex` puts the single Tab stop on the current value; a keyboard-initiated change moves focus onto the newly checked segment.
- `role="group"` + `role="menuitemradio"` / `aria-checked`. Not `radiogroup` / `radio` — a `radiogroup` is not a legal child of `role="menu"` — and not the shared `SegmentedControl`, whose `aria-pressed` says "toggled" rather than "chosen".
- The focus ring is drawn on the whole **track** via `:focus-within`. macOS never rings one segment of a segmented control.

## Selected, not hovered

The segments are icon-only, so each carries `Auto` / `Light` / `Dark` in both `aria-label` and `title`.

Unselected icons drop to `--label-secondary`. Measured on the running renderer, the selected thumb is **1.19:1** against the track in light and **1.63:1** in dark — under 1.4.11's 3:1. On a *word* segment that is fine, and deliberate (the TRA-292 note in `controls.css`): the word stays readable either way. An icon has no such fallback, so the thumb would be the only cue. The dimmed unselected icon measures 4.5:1 on the track, still comfortably legible, and hover brings it back to full — the thumb is what separates hovered from selected.

Also fixes a Label-in-Name mismatch the row exposed: Settings' appearance control was labelled "Theme" on screen and "Appearance" to a screen reader.

## Verification

Electron window, light and dark, menu open over the vibrancy layer and under Reduce Transparency. Before/after screenshots are on the issue.

`pnpm run typecheck` clean · 350 tests across 34 files pass · `pnpm run build` · `node scripts/design-tokens.mjs` clean.
