### PR TITLE
fix(app): follow the app's Appearance in the native layer, and floor the sidebar material in light (TRA-369)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -60,10 +60,61 @@ the same reason; non-mac stages paint themselves.
 not the window's vibrant region** (toolbars, the bulk-actions strip).
 
 We deliberately **did not adopt `electron-liquid-glass`.** The native
-`BrowserWindow` vibrancy path gives us the material, follows the system appearance on
-its own, desaturates when the window loses key (`visualEffectState: 'followWindow'`),
-and honours Reduce Transparency for free — with no extra native dependency, no
-feature detection, and no code path that no-ops below macOS 26.
+`BrowserWindow` vibrancy path gives us the material, desaturates when the window loses
+key (`visualEffectState: 'followWindow'`), and honours Reduce Transparency for free —
+with no extra native dependency, no feature detection, and no code path that no-ops
+below macOS 26.
+
+### A native material samples the desktop, so one background proves nothing
+
+This is the thing to internalise before touching the sidebar's material (TRA-369).
+
+`NSVisualEffectView` blends **whatever is composited behind the window** — the
+wallpaper, or another app's window. So the sidebar's tone is not a property of our CSS;
+it is a function of our CSS *and the user's desktop*. Two screenshots of the same build
+in the same appearance can look completely different, and both are real.
+
+Two rules follow, and neither is optional:
+
+1. **Never validate the material against a single background.** The matrix is: light
+   appearance × {dark wallpaper, light wallpaper, a dark window behind, a light window
+   behind} × {window active, window inactive}, then the same set in dark. And it has to
+   be shot in the **Electron window** — there is no `NSVisualEffectView` on the Vite dev
+   server, so none of this is visible in a browser.
+2. **The material never gets to decide how dark the sidebar goes in light appearance.**
+   `--sidebar-scrim` is a stated floor: white at `.70` above the material, so whatever
+   the material renders, the sidebar lands at least 70% of the way from it to white and
+   can never go below `#b2b2b2`. The remaining `.30` still carries the material, so the
+   sidebar keeps picking up the desktop's tint — it just cannot be dragged to grey by a
+   dark desktop and read as dirt beside the white content pane.
+
+   Dark appearance gets **no** floor (`--sidebar-scrim: transparent`). There the
+   material can only take the sidebar toward black, which is where it belongs, and glass
+   is the entire point. Light is the appearance to be careful with; dark is the easy one.
+
+Under `prefers-reduced-transparency: reduce` the sidebar paints `--surface` itself
+rather than letting macOS make the effect view opaque: the system's opaque fill follows
+the *system* appearance, so left alone it disagrees with our content pane whenever the
+app's Appearance choice and the system's differ (`sidebar.css`, accessibility section —
+that rule has to out-specify the `[data-platform="mac"]` one above it).
+
+### The native layer has to be told the app's appearance
+
+The Appearance control writes `[data-theme]` on `<html>`. CSS reads that;
+`NSVisualEffectView` cannot, and neither can the window's `backgroundColor` — both read
+`nativeTheme`. So the renderer mirrors the choice to the main process
+(`set-appearance` IPC → `packages/app/src/main/appearance.ts`), which sets
+`nativeTheme.themeSource`. Without it, Light on a dark system draws a dark vibrancy
+sidebar next to a light content pane.
+
+The choice lives in the renderer's `localStorage`, which main cannot read, so it is also
+mirrored to a one-line file in `userData` and restored **before the first window** —
+`backgroundColor` is read from `nativeTheme` at construction and cannot be fixed
+afterwards.
+
+macOS only. On Windows `nativeTheme.shouldUseDarkColors` also picks the tray icon, which
+has to match the taskbar — the system — not the app's own choice, and once `themeSource`
+overrides it there is no way to read the system value back.
 
 ---
 

--- a/packages/app/src/main/__tests__/appearance.test.ts
+++ b/packages/app/src/main/__tests__/appearance.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  type Appearance,
+  parseAppearance,
+  readAppearance,
+  themeSourceFor,
+  writeAppearance,
+} from '../appearance';
+
+const dirs: string[] = [];
+function tmp(): string {
+  const d = mkdtempSync(path.join(tmpdir(), 'trace-mcp-appearance-'));
+  dirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe('parseAppearance', () => {
+  it('keeps the two explicit choices', () => {
+    expect(parseAppearance('light')).toBe('light');
+    expect(parseAppearance('dark')).toBe('dark');
+  });
+
+  /* Same rule as the renderer: absence of a stored value IS Auto, so there is
+     no third value to write and no way to get stuck on a bogus override. */
+  it('treats anything else as Auto', () => {
+    for (const raw of ['auto', '', 'Light', 'system', null, undefined, 7, {}]) {
+      expect(parseAppearance(raw)).toBe('auto');
+    }
+  });
+});
+
+describe('themeSourceFor', () => {
+  it('maps the app choice onto nativeTheme.themeSource', () => {
+    expect(themeSourceFor('auto')).toBe('system');
+    expect(themeSourceFor('light')).toBe('light');
+    expect(themeSourceFor('dark')).toBe('dark');
+  });
+
+  /* The whole defect TRA-369 fixes: 'system' is what the native layer already
+     did on its own, so Light and Dark must never resolve to it. */
+  it('never sends an explicit choice back to the system appearance', () => {
+    for (const a of ['light', 'dark'] as Appearance[]) {
+      expect(themeSourceFor(a)).not.toBe('system');
+    }
+  });
+});
+
+describe('appearance persistence', () => {
+  it('round-trips every choice', () => {
+    const dir = tmp();
+    for (const a of ['light', 'dark', 'auto'] as Appearance[]) {
+      writeAppearance(dir, a);
+      expect(readAppearance(dir)).toBe(a);
+    }
+  });
+
+  it('reads Auto when nothing was ever written', () => {
+    expect(readAppearance(tmp())).toBe('auto');
+  });
+
+  /* A hand-edited or half-written file must not pin the window to a material
+     the app never chose. */
+  it('reads Auto from a corrupt file', () => {
+    const dir = tmp();
+    writeFileSync(path.join(dir, 'appearance'), 'lig', 'utf8');
+    expect(readAppearance(dir)).toBe('auto');
+  });
+
+  it('tolerates trailing whitespace', () => {
+    const dir = tmp();
+    writeFileSync(path.join(dir, 'appearance'), 'dark\n', 'utf8');
+    expect(readAppearance(dir)).toBe('dark');
+  });
+
+  /* Persisting is best-effort: a theme switch still has to work when userData
+     cannot be written. */
+  it('never throws on an unwritable directory', () => {
+    expect(() => writeAppearance('/dev/null/nope', 'dark')).not.toThrow();
+  });
+});

--- a/packages/app/src/main/appearance.ts
+++ b/packages/app/src/main/appearance.ts
@@ -1,0 +1,54 @@
+/* Appearance → the native layer (TRA-369).
+
+   The Appearance control writes [data-theme] on <html>. CSS reads that;
+   NSVisualEffectView cannot. Until the main process pushes the same choice into
+   `nativeTheme.themeSource`, a window set to Light on a dark system draws a dark
+   vibrancy sidebar next to a light content pane — and `backgroundColor`, picked
+   from `nativeTheme.shouldUseDarkColors` at window construction, is wrong the
+   same way.
+
+   The choice itself lives in the renderer's localStorage, which main cannot
+   read, so it is mirrored to a one-line file in userData. That is what makes the
+   FIRST window of a cold launch open with the material already correct instead
+   of flashing the system appearance until the renderer reports in.
+
+   No `electron` import on purpose: the caller passes the userData directory and
+   applies the returned themeSource, so this stays testable without a display. */
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+/** What the user picked. `auto` = follow the system, and is the default. */
+export type Appearance = 'auto' | 'light' | 'dark';
+/** The matching `nativeTheme.themeSource` value. */
+export type ThemeSource = 'system' | 'light' | 'dark';
+
+const APPEARANCE_FILE = 'appearance';
+
+/** Anything that is not an explicit choice means Auto — same rule as the
+ *  renderer, where absence of the localStorage key IS Auto. */
+export function parseAppearance(raw: unknown): Appearance {
+  return raw === 'light' || raw === 'dark' ? raw : 'auto';
+}
+
+export function themeSourceFor(appearance: Appearance): ThemeSource {
+  return appearance === 'auto' ? 'system' : appearance;
+}
+
+export function readAppearance(userDataDir: string): Appearance {
+  try {
+    return parseAppearance(readFileSync(path.join(userDataDir, APPEARANCE_FILE), 'utf8').trim());
+  } catch {
+    return 'auto';
+  }
+}
+
+export function writeAppearance(userDataDir: string, appearance: Appearance): void {
+  try {
+    mkdirSync(userDataDir, { recursive: true });
+    writeFileSync(path.join(userDataDir, APPEARANCE_FILE), appearance, 'utf8');
+  } catch {
+    // An unwritable userData dir costs one frame of the wrong material on the
+    // next cold launch. Never worth failing a theme switch over.
+  }
+}

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -4,7 +4,7 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs';
 import { registerAppMenu } from './menu';
-import { createTray, showMenuWindow } from './tray';
+import { createTray, restoreAppearance, showMenuWindow } from './tray';
 import {
   hasPendingUpdate as hasPendingUpdateImpl,
   trySpawnApplyHelper as trySpawnApplyHelperImpl,
@@ -1509,6 +1509,10 @@ app.whenReady().then(() => {
   // The application menu carries every accelerator the app answers to —
   // install it before the first window so ⌘, / ⌘R / ⌘1 work on first paint.
   registerAppMenu();
+  // Before the first window: its NSVisualEffectView and its backgroundColor are
+  // both read from nativeTheme at construction, so the app's Appearance choice
+  // has to reach the native layer first or the window opens in the wrong one.
+  restoreAppearance();
   createTray();
   // Open the main window straight away — the tray remains for background control.
   // Users who close the window still have the tray; users who quit via ⌘Q shut down.

--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -2,6 +2,13 @@ import path from 'node:path';
 import { app, BrowserWindow, ipcMain, Menu, nativeImage, nativeTheme, Tray } from 'electron';
 import { TRAFFIC_LIGHT_X, TRAFFIC_LIGHT_Y } from '../shared/chrome-metrics.js';
 import { DaemonClient } from './api-client';
+import {
+  type Appearance,
+  parseAppearance,
+  readAppearance,
+  themeSourceFor,
+  writeAppearance,
+} from './appearance';
 import { ensureDaemon, restartDaemon } from './daemon-lifecycle';
 
 const isMac = process.platform === 'darwin';
@@ -275,15 +282,6 @@ ipcMain.handle('open-clients', () => {
 // IPC: get current platform (renderer needs this to decide whether to show custom tabs)
 ipcMain.handle('get-platform', () => process.platform);
 
-/* The sidebar is transparent so the native NSVisualEffectView shows through,
-   and that view follows `nativeTheme`, not the renderer's [data-theme]. Without
-   this, picking Dark in Settings on a Light Mac left light-mode vibrancy behind
-   dark-mode text: the whole sidebar rendered as an empty pale pane. The
-   renderer's appearance choice has to reach the native layer too. */
-ipcMain.on('set-appearance', (_event, appearance: 'auto' | 'light' | 'dark') => {
-  nativeTheme.themeSource = appearance === 'auto' ? 'system' : appearance;
-});
-
 function hideDockIfNoWindows(): void {
   if (isMac && !menuWindow && projectWindows.size === 0) {
     app.dock?.hide();
@@ -401,6 +399,33 @@ ipcMain.handle('close-current-tab', (event) => {
   const win = BrowserWindow.fromWebContents(event.sender);
   if (win) win.close();
   return { ok: true };
+});
+
+/* ---- Appearance → the native layer (TRA-369) ------------------------------
+   macOS only. On Windows `nativeTheme.shouldUseDarkColors` also picks the tray
+   icon, which has to match the TASKBAR — i.e. the system — not the app's own
+   Appearance choice, and there is no way to read the system value back once
+   themeSource overrides it. macOS is where this matters anyway: it is the only
+   platform with an NSVisualEffectView to keep in sync, and its tray icon is a
+   Template image the system tints on its own. */
+
+/** Call once from whenReady, BEFORE the first window: `backgroundColor` is read
+ *  from `nativeTheme` at construction time. */
+export function restoreAppearance(): void {
+  if (!isMac) return;
+  nativeTheme.themeSource = themeSourceFor(readAppearance(app.getPath('userData')));
+}
+
+function applyAppearance(next: Appearance): void {
+  if (!isMac) return;
+  nativeTheme.themeSource = themeSourceFor(next);
+  writeAppearance(app.getPath('userData'), next);
+}
+
+// IPC: the renderer's Appearance choice. Fire-and-forget — the renderer has
+// already applied [data-theme] itself and does not wait on the native side.
+ipcMain.on('set-appearance', (_event, value: unknown) => {
+  applyAppearance(parseAppearance(value));
 });
 
 // IPC: sync sidebar width across all tabbed windows

--- a/packages/app/src/renderer/__tests__/theme.test.tsx
+++ b/packages/app/src/renderer/__tests__/theme.test.tsx
@@ -106,6 +106,32 @@ describe('useTheme', () => {
     expect(renderHook(() => useTheme()).result.current.appearance).toBe('auto');
   });
 
+  /* TRA-369. [data-theme] is a CSS attribute and the sidebar's material is an
+     NSVisualEffectView — CSS cannot reach it. Unless the choice is mirrored to
+     the main process, Light on a dark system draws a dark sidebar next to a
+     light content pane. Auto has to be mirrored too, or a window pinned to Dark
+     stays dark after the user goes back to Auto. */
+  it('mirrors every appearance to the native layer', () => {
+    const setAppearance = vi.fn();
+    vi.stubGlobal('electronAPI', { setAppearance });
+
+    const { result } = renderHook(() => useTheme());
+    expect(setAppearance).toHaveBeenLastCalledWith('auto');
+
+    act(() => result.current.setAppearance('light'));
+    expect(setAppearance).toHaveBeenLastCalledWith('light');
+
+    act(() => result.current.setAppearance('auto'));
+    expect(setAppearance).toHaveBeenLastCalledWith('auto');
+  });
+
+  /* The bridge is optional (older preload, and the renderer also runs under the
+     dev server), so a missing setAppearance must not take the app down. */
+  it('survives a preload without the bridge', () => {
+    vi.stubGlobal('electronAPI', undefined);
+    expect(() => renderHook(() => useTheme())).not.toThrow();
+  });
+
   it('syncs from another window, including a clear back to Auto', () => {
     const { result } = renderHook(() => useTheme());
     act(() => {

--- a/packages/app/src/renderer/styles/__tests__/tokens.test.ts
+++ b/packages/app/src/renderer/styles/__tests__/tokens.test.ts
@@ -81,6 +81,50 @@ describe('design tokens', () => {
     );
   });
 
+  /* TRA-369. On macOS the sidebar is a native NSVisualEffectView sampling what
+     is behind the WINDOW, so in light appearance its tone is the user's
+     wallpaper's decision unless something puts a floor under it. The floor is
+     --sidebar-scrim: white at alpha a can never render below a*255, whatever
+     the material does. Dark appearance deliberately has none — the material can
+     only take it toward black, which is where it belongs.
+
+     The alpha is the whole guarantee, so it is asserted as a number: drop it and
+     a dark desktop drags the sidebar grey again, with a green build. */
+  it('floors the sidebar material in light and leaves the dark one glass', () => {
+    const sidebarCss = readFileSync(
+      fileURLToPath(new URL('../sidebar.css', import.meta.url)),
+      'utf8',
+    );
+    expect(sidebarCss).toMatch(
+      /\[data-platform="mac"\][^{]*\.ws-sidebar\s*\{[^}]*background:\s*var\(--sidebar-scrim\)/,
+    );
+
+    const values = [...tokensCss.matchAll(/--sidebar-scrim:\s*([^;]+);/g)].map((m) => m[1].trim());
+    // One per appearance block: :root, the dark media query, [data-theme="dark"]
+    // / [data-mode="dark"], and the light stage.
+    expect(values).toHaveLength(4);
+    expect(values.filter((v) => v === 'transparent')).toHaveLength(2);
+    for (const value of values.filter((v) => v !== 'transparent')) {
+      const alpha = Number(/^rgb\(255 255 255 \/ ([0-9.]+)\)$/.exec(value)?.[1]);
+      expect(alpha).toBeGreaterThanOrEqual(0.7);
+      // #b2b2b2 on black — light enough to read as a light sidebar, not as dirt.
+      expect(Math.round(alpha * 255)).toBeGreaterThanOrEqual(178);
+    }
+  });
+
+  /* Reduce Transparency turns the NSVisualEffectView opaque, but it paints the
+     SYSTEM's grey — which follows the system appearance, not the app's. Without
+     this the sidebar disagrees with its own content pane whenever the two differ. */
+  it('paints the sidebar opaque itself under reduced transparency', () => {
+    const sidebarCss = readFileSync(
+      fileURLToPath(new URL('../sidebar.css', import.meta.url)),
+      'utf8',
+    );
+    expect(sidebarCss).toMatch(
+      /@media \(prefers-reduced-transparency: reduce\)\s*\{[^}]*\.ws-sidebar\s*\{[^}]*background:\s*var\(--surface\)/,
+    );
+  });
+
   /* TRA-344. --label-tertiary is decoration only (1.88:1 light / 2.53:1 dark,
      and `prefers-contrast: more` lifts --label-secondary but not it). A rule
      that paints text with it AND sizes that text is by definition styling

--- a/packages/app/src/renderer/styles/sidebar.css
+++ b/packages/app/src/renderer/styles/sidebar.css
@@ -39,8 +39,12 @@
   border-right: 0.5px solid var(--separator);
   -webkit-app-region: no-drag;
 }
+/* macOS: the NSVisualEffectView shows through. It samples what is behind the
+   WINDOW, so in light appearance --sidebar-scrim puts a floor under how dark a
+   dark desktop can drag it; in dark appearance the token is `transparent` and
+   the material is the whole material. See tokens.css and DESIGN.md §1 (TRA-369). */
 .ws-stage[data-platform="mac"] .ws-sidebar {
-  background: transparent;
+  background: var(--sidebar-scrim);
 }
 
 /* The strip the traffic lights sit in, plus the sidebar toggle past them

--- a/packages/app/src/renderer/styles/tokens.css
+++ b/packages/app/src/renderer/styles/tokens.css
@@ -42,6 +42,24 @@
   --surface-sunken: #f5f5f7;
   --surface-raised: #ffffff;
 
+  /* The sidebar's lightness FLOOR (TRA-369). On macOS the sidebar is a native
+     NSVisualEffectView, and it samples whatever is behind the WINDOW — so
+     without a scrim above it the sidebar's tone is the user's wallpaper's
+     decision, not ours: over a dark desktop it goes grey and reads as dirt next
+     to the white content pane.
+
+     White at .70 is a floor with a value you can state without measuring
+     anything: whatever the material renders, the result is at least 70% of the
+     way from it to white, so the sidebar can never go below #b2b2b2 — and since
+     the light `sidebar` material is itself white-tinted, the real worst case
+     over a black desktop lands far above that. The remaining .30 still carries
+     the material, so this is a floor, not an opaque fill: the sidebar keeps
+     picking up the desktop's tint, it just cannot be dragged dark by it.
+
+     Dark appearance gets no floor. The material can only take it toward black,
+     which is where it belongs, and glass is the whole point there. */
+  --sidebar-scrim: rgb(255 255 255 / 0.7);
+
   --fill-quaternary: rgb(0 0 0 / 0.045);
   --fill-tertiary: rgb(0 0 0 / 0.08);
   --fill-secondary: rgb(0 0 0 / 0.12);
@@ -153,6 +171,9 @@
     --surface: #1e1e1e;
     --surface-sunken: #141414;
     --surface-raised: #2a2a2a;
+    /* No floor in dark: the material can only get darker than --surface, which
+       is what glass is for here. See the light value for why. */
+    --sidebar-scrim: transparent;
     --fill-quaternary: rgb(255 255 255 / 0.06);
     --fill-tertiary: rgb(255 255 255 / 0.11);
     --fill-secondary: rgb(255 255 255 / 0.16);
@@ -188,6 +209,8 @@
   --surface: #1e1e1e;
   --surface-sunken: #141414;
   --surface-raised: #2a2a2a;
+  /* No floor in dark — see the light value. */
+  --sidebar-scrim: transparent;
   --fill-quaternary: rgb(255 255 255 / 0.06);
   --fill-tertiary: rgb(255 255 255 / 0.11);
   --fill-secondary: rgb(255 255 255 / 0.16);
@@ -227,6 +250,8 @@
   --surface: #ffffff;
   --surface-sunken: #f5f5f7;
   --surface-raised: #ffffff;
+  /* The sidebar's lightness floor — see the :root value for the measurements. */
+  --sidebar-scrim: rgb(255 255 255 / 0.7);
   --fill-quaternary: rgb(0 0 0 / 0.045);
   --fill-tertiary: rgb(0 0 0 / 0.08);
   --fill-secondary: rgb(0 0 0 / 0.12);

--- a/packages/app/src/renderer/theme.ts
+++ b/packages/app/src/renderer/theme.ts
@@ -55,10 +55,10 @@ export function useTheme(): {
   const [appearance, setStored] = useState<Appearance>(() => readStoredAppearance());
   const [system, setSystem] = useState<Theme>(() => systemTheme());
 
-  // Apply / remove the data-theme attribute on every change, and tell the main
-  // process — the sidebar's vibrancy is a native view that follows nativeTheme,
-  // not [data-theme], so a choice that stops at the DOM leaves light-mode
-  // material behind dark-mode text.
+  // Apply / remove the data-theme attribute on every change, and mirror the
+  // choice to the main process: the sidebar's material is an NSVisualEffectView
+  // and reads `nativeTheme`, which no CSS attribute can reach — a choice that
+  // stops at the DOM leaves light-mode material behind dark-mode text (TRA-369).
   useEffect(() => {
     const html = document.documentElement;
     if (appearance === 'auto') html.removeAttribute('data-theme');


### PR DESCRIPTION
Closes TRA-369.

The sidebar is a native `NSVisualEffectView`, so it blends **whatever is composited behind the window**. Two things followed from that.

## 1. The native layer has to be told the app's Appearance

`[data-theme]` is a CSS attribute; `NSVisualEffectView` cannot read it, and neither can the window's `backgroundColor` — both read `nativeTheme`. #522 (TRA-363) landed the basic wiring while this was in flight: a `set-appearance` IPC that sets `nativeTheme.themeSource`. This keeps that and closes the two holes it left.

- **The first window of a cold launch still opened in the wrong material.** The choice lives in the renderer's `localStorage`, which main cannot read, so `themeSource` was `'system'` until the renderer mounted and reported in — and `backgroundColor` is read from `nativeTheme` *at construction* and cannot be corrected afterwards. It is now mirrored to a one-line file in `userData` and restored from `whenReady`, before the first window.
- **It was not macOS-gated.** On Windows `nativeTheme.shouldUseDarkColors` also picks the tray icon, which has to match the *taskbar* — the system — not the app's own choice, and once `themeSource` overrides it there is no way to read the system value back. macOS is where this matters anyway: it is the only platform with an effect view to keep in sync, and its tray icon is a Template image the system tints itself.

Plus input validation on the IPC boundary (anything that is not `light`/`dark` means Auto, the same rule the renderer uses) and the persistence round-trip, both in `main/appearance.ts` with tests.

## 2. The material had no floor in light appearance

This is the part that survives on current `master` even with `themeSource` correct: a dark desktop still drags the light sidebar grey, where it reads as dirt beside the white content pane. Measured on `master` in light appearance, sidebar swatch: **`#c4c4c4` over a black backdrop** against a `#f3f3f5` content pane. The sidebar's tone was the user's wallpaper's decision, not ours.

`--sidebar-scrim` is white at `.70` above the material in light appearance. That is a floor you can state without measuring anything: whatever the material renders, the result is at least 70% of the way from it to white, so the sidebar can never go below `#b2b2b2`. The remaining `.30` still carries the material, so the sidebar keeps picking up the desktop's tint — it just cannot be dragged dark by it.

**Why a scrim rather than the alternatives.** A different `vibrancy` material leaves the tone a function of the desktop, just with a different curve — no floor, so no guarantee. Dropping vibrancy in light appearance and painting solid near-white *would* hold the floor, but it throws away the material on the one surface the macOS-26 look rests on, and the numbers show it isn't necessary: with the scrim the sidebar still visibly tints toward a deep-blue desktop (`#edeff6`) while never falling below `#ededed`. Translucency survives and the floor holds, so that is the option taken.

Dark appearance keeps the material whole (`--sidebar-scrim: transparent`). There it can only go toward black, which is where it belongs, and glass is the entire point. Light is the appearance to be careful with; dark is the easy one.

`visualEffectState: 'followWindow'` is untouched, as the issue asked.

## Measurements

Captured from the real Electron window with `screencapture` of the on-screen composite — the blend exists nowhere else, and there is no effect view on the Vite dev server. The backdrop was a full-screen window painted a solid colour: to an `NSVisualEffectView` a window behind and a wallpaper behind are the same variable, since it samples the composited backdrop either way. System appearance was **Dark** throughout, which is what makes the pre-#522 defect visible.

Sidebar swatch, sampled from an empty column. "Before" is `2a94e452` — the v3.1.1 line this was reported against, before #522:

| Backdrop | Light before | Light after | Dark before | Dark after |
|---|---|---|---|---|
| black | `#222222` | **`#ededed`** | `#222222` | `#222222` |
| white | `#4f4f4f` | **`#f5f5f5`** | `#4f4f4f` | `#4f4f4f` |
| mid-grey | `#373737` | **`#f3f3f3`** | `#373737` | `#373737` |
| deep blue | `#212549` | **`#edeff6`** | `#212549` | `#212549` |
| black, window inactive | `#242424` | **`#f7f7f7`** | `#242424` | `#242424` |

The content pane next to it is `#f0f0f2`–`#ffffff` in light. Before: a near-black sidebar against a white pane in every light cell. After: the sidebar sits level with its own content pane across every backdrop, active and inactive, and still tints toward the desktop. Dark is unchanged in all five cells — no regression.

Against current `master` (i.e. with #522's `themeSource` already in), the same light/black cell measures `#c4c4c4` → `#ededed`, which is the floor's own contribution isolated from the appearance fix.

Before/after screenshots for every cell are attached to TRA-369.

## Rule recorded

DESIGN.md §1 gains two subsections: that a native material samples the desktop and therefore **cannot be validated against a single background** (with the matrix that has to be shot, in the Electron window), and that the native layer has to be told the app's appearance, first window included. That omission is what let this through twice.

## Tests

- `main/__tests__/appearance.test.ts` — the appearance ↔ `themeSource` mapping (an explicit choice may never resolve to `system`) and the userData round-trip, including corrupt files and an unwritable directory.
- `renderer/__tests__/theme.test.tsx` — every appearance, Auto included, is mirrored to the native layer; a preload without the bridge does not take the app down.
- `renderer/styles/__tests__/tokens.test.ts` — the scrim's alpha is asserted as a number, so the floor cannot be quietly lowered with a green build; dark must stay `transparent`; Reduce Transparency must keep painting `--surface`.

`pnpm test` 378 passed · `pnpm typecheck` · `pnpm build` · `biome ci` clean.

Agent: Design/UX Agent
