### PR TITLE
fix(app): a glyph names the action — drop sparkles and speech bubbles (TRA-363)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -265,6 +265,31 @@ already exists here** — that is how the app ended up with four different pill 
 | `EmptyState` | full and `compact`. |
 | `Menu` / `MenuItem` / `MenuSection` / `MenuSeparator` / `ConfirmPopover` / `useMenuAnchor` | one anchor implementation shared by every surface. |
 
+### An icon names the action
+
+A glyph is a **name**, not decoration. A glyph that decorates rather than names —
+sparkles, and anything else that says "exciting" instead of saying what the item does
+— does not go into the interface. When an item leads somewhere specific, the glyph
+matches the destination: a question mark for help, a document for a changelog.
+
+Two glyphs are **rejected by name**, and a test enforces it
+(`lattice/__tests__/icons.test.ts` scans the whole renderer, not just the icon map,
+because re-adding a banned body under a new key is the same regression wearing a hat):
+
+| Rejected | Why | Use instead |
+|---|---|---|
+| `auto_awesome` (sparkles) | Decorates rather than names. It is the AI-marketing glyph; on a developer tool it reads as ornament and says nothing about what the item does. | The glyph for the destination — `description` for `View changelog`. |
+| `forum` (speech bubbles) | Promises a conversation with a person. Nothing in this app is one: `Get help` opens GitHub issues, `Ask` queries the indexed graph. | `help` (question mark in a circle) for help; `search` for Ask. |
+
+Judge the replacement at the size it renders, not on the 24-grid. `manage_search`
+was the first pick for Ask and lost on the render: its two answer lines are 3 units
+apart, which is 2.2px at the 18px sidebar size, and they smudge into the magnifier's
+handle. A glyph that only reads at 24px is not a glyph this app has a use for.
+
+**When a reference is supplied, match it.** If it looks wrong for us, say so in the PR
+and argue it. A substitution nobody mentions costs a review round every time, and it
+is how this pair shipped in the first place.
+
 ### Prominent buttons are flat
 
 macOS 26 dropped the gradient and the bezel. `.lx-btn.v-prominent` is a flat
@@ -429,7 +454,7 @@ stylesheets and `tray.ts` ever drift apart again.
 ### Where a global action lives
 
 An action that belongs to the app rather than to the surface in front of you —
-Settings, Check for updates, What's new, Get help — has exactly two homes, and
+Settings, Check for updates, View changelog, Get help — has exactly two homes, and
 **one definition**: `packages/app/src/shared/global-actions.ts`.
 
 - The **native application menu** (`main/menu.ts`) builds its items from that list.
@@ -773,7 +798,9 @@ new evidence.
 | A choice in a menu is one row with the control inline, not a header plus one item per value | Appearance first shipped as an `APPEARANCE` caps header over three checked items: four rows for one three-state preference, in the menu built to stop the footer spending a row per thing. A header over a single control is weight without information. One row, name left, pill right, on the shared centre line — and the rule is written for every future choice, not solved for Theme (TRA-363). |
 | A choice row is `group` + `menuitemradio`, one keyboard stop, and does not close the menu | `radiogroup` is not a legal child of `role="menu"`, and the shared `SegmentedControl`'s `aria-pressed` says "toggled" rather than "chosen". The row is one Up/Down stop resolved to the checked segment, Left/Right move inside it, and picking a value leaves the menu open — an inline switcher exists so you can watch the app change under it. |
 | Icon-only segments dim when unselected; word segments do not | The selected thumb is 1.19:1 light / 1.63:1 dark against the track. On a word that is enough because the word stays readable (TRA-292); an icon has no fallback, so the only cue would be a sub-3:1 fill. Unselected icons drop to `--label-secondary` (4.5:1 on the track). |
-| A global action is defined once, in `src/shared/global-actions.ts` | The native menu and the app menu both offer Settings / What's new / Get help / Check for updates. Two hand-maintained lists drift — a relabelled item, a moved key, an action added to one and forgotten in the other. Neither surface types a label; both read the entry. |
+| A global action is defined once, in `src/shared/global-actions.ts` | The native menu and the app menu both offer Settings / View changelog / Get help / Check for updates. Two hand-maintained lists drift — a relabelled item, a moved key, an action added to one and forgotten in the other. Neither surface types a label; both read the entry. |
+| A glyph names the action; sparkles and speech bubbles are banned by name | `auto_awesome` decorates instead of naming — it says "exciting", not what the item does. `forum` promises a person to talk to, and no surface here provides one. Both shipped anyway, against a reference that showed the right glyphs, which is the second half of this decision: when a reference is supplied, match it or argue it in the PR — never substitute silently. |
+| "View changelog", not "What's new" | The item opens the releases page. Someone checking whether a specific fix shipped searches for the word "changelog"; "What's new" describes a feeling about the page, not the page. |
 | "Up to date" belongs in the app menu's header, not in a sidebar row | It is the answer to a question you only ask when you go looking, and it belongs next to the action that re-asks it. A permanent strip pays 28px in every window, forever, to report the absence of news. The states you can *act* on — update available, restart pending, bundle stuck — still get a card in the sidebar. |
 | A menu anchors on the app, because there is no account to anchor on | The pattern this came from is an account menu, held together by an identity at the top. We have no users. The product is the identity: the trigger carries the name, the header carries the version and whether it is current. |
 | In a menu, focus IS the highlight — and the only one | Arrowing moves real DOM focus, so `:focus` has to paint the same accent fill `:hover` does. The house `*:focus-visible` ring on top of that fill drew a blue halo round an already-blue row, which reads as a button on a surface; macOS draws the fill and nothing else. |

--- a/packages/app/src/main/__tests__/menu.test.ts
+++ b/packages/app/src/main/__tests__/menu.test.ts
@@ -113,7 +113,7 @@ describe('application menu', () => {
 
   it('sends the shared list’s URL actions to the browser, not to a window', () => {
     click(menu('Help'), 'Get help');
-    click(menu('Help'), "What's new");
+    click(menu('Help'), 'View changelog');
     expect(sent).toEqual([]); // neither is an app-command
   });
 

--- a/packages/app/src/main/menu.ts
+++ b/packages/app/src/main/menu.ts
@@ -207,7 +207,7 @@ export function buildAppMenu(): Menu {
       // pages is a coin toss.
       { label: 'Documentation', click: () => void shell.openExternal(DOCS_URL) },
       actionItem('get-help'),
-      actionItem('whats-new'),
+      actionItem('view-changelog'),
       // On macOS these live in the app menu; elsewhere Help is where they go.
       ...(isMac
         ? []

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -60,7 +60,12 @@ function normalizeGlobalTab(value: string | null | undefined): GlobalTab {
 type ProjectTab = 'overview' | 'ask' | 'graph' | 'activity' | 'memory' | 'notebook' | 'insights';
 const PROJECT_TABS: { id: ProjectTab; label: string; icon: string }[] = [
   { id: 'overview', label: 'Overview', icon: 'grid_view' },
-  { id: 'ask', label: 'Ask', icon: 'forum' },
+  /* Not a speech bubble (DESIGN.md §5): Ask queries the indexed graph and hands
+     back an answer — a search phrased in words, not a conversation with a
+     person. `manage_search` was the first choice and lost on the render: its
+     two answer lines sit 3 units apart on the 24 grid, which is 2.2px at the
+     18px sidebar size, and they smudge into the magnifier's handle. */
+  { id: 'ask', label: 'Ask', icon: 'search' },
   { id: 'graph', label: 'Graph', icon: 'hub' },
   { id: 'activity', label: 'Activity', icon: 'timeline' },
   { id: 'memory', label: 'Memory', icon: 'neurology' },

--- a/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
@@ -148,7 +148,7 @@ describe('sidebar app menu', () => {
     // …and down again leaves the row entirely, rather than stepping to Dark.
     fireEvent.keyDown(document, { key: 'ArrowDown' });
     expect(row.contains(document.activeElement)).toBe(false);
-    expect(document.activeElement?.textContent).toContain("What's new");
+    expect(document.activeElement?.textContent).toContain('View changelog');
   });
 
   it('runs the commands and opens the links', () => {

--- a/packages/app/src/renderer/lattice/__tests__/icons.test.ts
+++ b/packages/app/src/renderer/lattice/__tests__/icons.test.ts
@@ -1,0 +1,68 @@
+/* TRA-363. An icon NAMES the action (DESIGN.md §5). Two glyphs were rejected by
+   name and this is the guard that keeps them out — a comment in icons.tsx did
+   not stop the first one, because the pressure to reach for sparkles comes from
+   whoever is adding the next "exciting" item, not from whoever reads the set.
+
+   `auto_awesome` (sparkles) decorates rather than names: it says "exciting"
+   instead of saying what the item does, and on a developer tool it reads as AI
+   marketing. `forum` (speech bubbles) promises a conversation with a person,
+   which nothing in this app provides — Get help opens GitHub issues, Ask
+   queries the indexed graph.
+
+   The scan is over source TEXT, not over the glyph map, because re-adding a
+   banned body under a new key is the same regression wearing a hat. */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { GLOBAL_ACTIONS } from '../../../shared/global-actions.js';
+
+const SRC = fileURLToPath(new URL('../../..', import.meta.url));
+const ICONS = readFileSync(fileURLToPath(new URL('../icons.tsx', import.meta.url)), 'utf8');
+
+/** Every .ts/.tsx under src/, minus this file and the generated icon blobs. */
+function sources(dir: string, out: Array<[string, string]> = []): Array<[string, string]> {
+  for (const entry of readdirSync(dir)) {
+    const path = `${dir}/${entry}`;
+    if (statSync(path).isDirectory()) {
+      sources(path, out);
+    } else if (/\.tsx?$/.test(entry) && entry !== 'icons.test.ts' && !entry.includes('generated')) {
+      out.push([path.slice(SRC.length), readFileSync(path, 'utf8')]);
+    }
+  }
+  return out;
+}
+
+/** The glyph keys icons.tsx actually defines. */
+function glyphNames(): string[] {
+  const body = ICONS.slice(ICONS.indexOf('const GLYPHS'), ICONS.indexOf('function Icon'));
+  return [...body.matchAll(/^ {2}([a-z][a-z0-9_]*):/gm)].map((m) => m[1]);
+}
+
+describe('icon set', () => {
+  it('carries no sparkles and no speech bubbles, anywhere', () => {
+    const offenders = sources(SRC)
+      .filter(([, text]) => /\bauto_awesome\b|\bforum\b/.test(text.replace(/\/\*[\s\S]*?\*\//g, '')))
+      .map(([name]) => name);
+    expect(offenders).toEqual([]);
+  });
+
+  it('does not define either rejected glyph under any key', () => {
+    const names = glyphNames();
+    expect(names).not.toContain('auto_awesome');
+    expect(names).not.toContain('forum');
+    // The replacements the reference asked for, present and spelled as used.
+    expect(names).toContain('help');
+    expect(names).toContain('description');
+  });
+
+  /* A global action's `icon` is a string looked up at render time, so a name
+     that does not exist draws nothing at all — silently, and only in the app
+     menu, which is the surface least likely to be open while you work. */
+  it('gives every global action a glyph that exists', () => {
+    const names = glyphNames();
+    for (const action of GLOBAL_ACTIONS) {
+      expect(names, `${action.id} → ${action.icon}`).toContain(action.icon);
+    }
+  });
+});

--- a/packages/app/src/renderer/lattice/icons.tsx
+++ b/packages/app/src/renderer/lattice/icons.tsx
@@ -72,10 +72,19 @@ const GLYPHS: Record<string, string> = {
   mic: '<rect x="9" y="3" width="6" height="11" rx="3"/><path d="M5 11a7 7 0 0 0 14 0M12 18v3"/>',
   image: '<rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="9" cy="9" r="2"/><path d="M21 15l-5-5L5 21"/>',
   person: '<circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/>',
-  auto_awesome:
-    '<path d="M12 3l1.8 4.7L18.5 9l-4.7 1.8L12 15l-1.8-4.7L5.5 9l4.7-1.8z"/><path d="M18 15l.9 2.1L21 18l-2.1.9L18 21l-.9-2.1L15 18l2.1-.9z"/>',
-  forum:
-    '<path d="M4 4h12a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H9l-4 3v-3H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"/><path d="M20 9h0a2 2 0 0 1 2 2v9l-3-2"/>',
+  // Question mark in a circle — the glyph for help. Honest about what help is
+  // here: a page of answers, not someone waiting to talk to you.
+  help:
+    '<circle cx="12" cy="12" r="9"/><path d="M9.6 9.3a2.5 2.5 0 1 1 3.3 2.4c-.6.2-.9.8-.9 1.4v.4"/><circle cx="12" cy="16.6" r="0.7" fill="currentColor" stroke="none"/>',
+  /* REMOVED, and not to be re-added under any name (DESIGN.md §5):
+     - `auto_awesome` (sparkles) — decorates rather than names. It is the
+       AI-marketing glyph; on a developer tool it says "exciting" instead of
+       saying what the item does. `View changelog` uses `description`.
+     - `forum` (speech bubbles) — promises a conversation with a person. Every
+       place we used it opens a page or a text field instead: `Get help` opens
+       GitHub issues (`help`), Ask queries the index (`search`).
+     A glyph is a name, not decoration. If you reach for either of these, the
+     item you are labelling probably has a more specific destination to name. */
   pause: '<path d="M8 5v14M16 5v14"/>',
   play_arrow: '<path d="M7 5v14l12-7z"/>',
   download: '<path d="M12 3v12M7 10l5 5 5-5M5 21h14"/>',

--- a/packages/app/src/renderer/tabs/AskTab.tsx
+++ b/packages/app/src/renderer/tabs/AskTab.tsx
@@ -520,7 +520,7 @@ export function AskTab({ root }: { root: string }) {
           <div className="ask-scroll">
             <div className="ask-measure ask-empty">
               <EmptyState
-                icon="forum"
+                icon="search"
                 title="Connect an AI provider"
                 subtitle="Ask answers questions about this project using a model you supply. Add one in Settings to turn it on."
                 action={
@@ -608,7 +608,7 @@ export function AskTab({ root }: { root: string }) {
           ) : messages.length === 0 && !streaming && !busy && !error ? (
             <div className="ask-measure ask-empty">
               <EmptyState
-                icon="forum"
+                icon="search"
                 title="Ask anything about this codebase"
                 subtitle="Answers are grounded in the indexed graph — the files, symbols and decisions this project already has."
               />

--- a/packages/app/src/shared/global-actions.ts
+++ b/packages/app/src/shared/global-actions.ts
@@ -21,7 +21,7 @@
    and it exists only in the in-app menu and Settings — a list with one member
    cannot drift. */
 
-export type GlobalActionId = 'settings' | 'check-for-update' | 'whats-new' | 'get-help';
+export type GlobalActionId = 'settings' | 'check-for-update' | 'view-changelog' | 'get-help';
 
 export interface GlobalAction {
   /** Also the `app-command` name the native menu sends to the focused window. */
@@ -46,17 +46,22 @@ export const GLOBAL_ACTIONS: readonly GlobalAction[] = [
     shortcut: '⌘,',
     icon: 'settings',
   },
+  /* "View changelog", not "What's new": the item opens the releases page, and
+     someone checking whether a specific fix shipped searches for the word
+     "changelog". The glyph names the destination — a document, not sparkles. */
   {
-    id: 'whats-new',
-    label: "What's new",
+    id: 'view-changelog',
+    label: 'View changelog',
     url: 'https://github.com/nikolai-vysotskyi/trace-mcp/releases',
-    icon: 'auto_awesome',
+    icon: 'description',
   },
+  /* A question mark, not a speech bubble: this opens GitHub issues, and a
+     speech bubble would promise a person on the other end. */
   {
     id: 'get-help',
     label: 'Get help',
     url: 'https://github.com/nikolai-vysotskyi/trace-mcp/issues',
-    icon: 'forum',
+    icon: 'help',
   },
   {
     id: 'check-for-update',


### PR DESCRIPTION
Follow-up to #516 / #522. The app menu shipped with two glyphs and a label that did not match the reference supplied with the original request.

## Three fixes

| | Before | After |
|---|---|---|
| Help | `forum` — speech bubbles | `help` — question mark in a circle |
| Changelog | `auto_awesome` — sparkles | `description` — document with a folded corner |
| Its label | `What's new` | `View changelog` |

A speech bubble promises a conversation with a person; this item opens GitHub issues. Sparkles decorate rather than name — they say "exciting" instead of saying what the item does, and on a developer tool that reads as AI marketing. "View changelog" is what the item actually opens, and it is the word someone searches for when checking whether a specific fix shipped. The `GlobalActionId` follows the label (`whats-new` → `view-changelog`).

## The sweep

Both glyphs are removed from the icon set, not just unreferenced. The only other `forum` was the **Ask** tab and its two empty states.

Ask now takes `search`: it queries the indexed graph and hands back an answer — a search phrased in words, not a conversation. **`manage_search` was my first pick there and lost on the render**, which is why the rule below says to judge a glyph at the size it ships at: its two answer lines sit 3 units apart on the 24 grid, 2.2px at the 18px sidebar size, and they smudged into the magnifier's handle. Before/after of the tab strip are on the issue.

If Ask should keep a conversation-family glyph — it is a real transcript UI, with streaming replies and slash commands, so the case is arguable — say so and I will change it. I am flagging it rather than deciding it quietly, which is the point of the next section.

## The rule, in `DESIGN.md` §5

> An icon names the action. A glyph that decorates rather than names it — sparkles, and anything else that says "exciting" instead of what the item does — does not go into the interface. When an item leads somewhere specific, the glyph matches the destination: a question mark for help, a document for a changelog.

Both rejected glyphs are recorded there by name with their replacements, so they cannot come back through another surface. Plus the half that caused this: **when a reference is supplied, match it — and if it looks wrong for us, argue it in the PR rather than substituting silently.** A substitution nobody mentions costs a review round every time, and that is exactly how this pair shipped.

## Guard

`lattice/__tests__/icons.test.ts` scans the whole renderer, not just the glyph map — re-adding a banned body under a new key is the same regression wearing a hat. It also asserts that every global action's glyph exists: an icon name is a string looked up at render time, so a typo draws nothing at all, silently, on the surface least likely to be open while you work.

## Verification

Electron window, light and dark: the app menu and the project sidebar's tab strip, before and after. `pnpm run typecheck` clean · 360 tests across 36 files pass · `pnpm run build` · `node scripts/design-tokens.mjs` clean.
