### PR TITLE
fix(daemon): build each MCP session from a freshly loaded config (TRA-373)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -453,6 +453,8 @@ The `tools.*` section controls what the MCP server injects into every session �
 | `tools.meta_fields` | `true` | Meta fields in responses (`_hints`, `_budget_warning`, etc.). Set `false` or list to narrow |
 | `tools.compact_schemas` | `false` | Strip advanced/optional params from tool schemas. Cuts schema size ~42% (measured 2026-08-29) |
 
+Every `tools.*` option works from a project-local config file (`.trace-mcp/.config.json`) as well as the global one — none of them are global-only. The tool surface is built once per MCP session, so a change takes effect on the next session (restart the MCP client); the daemon does not need restarting.
+
 ### Agent behavior rules
 
 `tools.agent_behavior` appends generic discipline rules (anti-sycophancy, anti-fabrication, goal-driven execution, 2-strike session hygiene, no drive-by refactors) to the server instructions. These are client-agnostic — every MCP-compatible client (Claude Code, Cursor, Codex, Windsurf, …) receives them.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -700,6 +700,17 @@ program
       // only supports one transport at a time. All sessions share the same
       // underlying Store/Pipeline/Registry via the managed project.
       // TopologyStore and DecisionStore are shared via resource pool.
+      // `managed.config` was loaded once, when the daemon first added this
+      // project, and is never refreshed — so a session would be served a tool
+      // surface built from whatever the config said back then. Everything
+      // `tools.*` shapes (description_verbosity, instructions_verbosity,
+      // descriptions, compact_schemas, meta_fields, agent_behavior) is baked
+      // into createServer(), so the stale copy silently ignored the user's
+      // config (TRA-373). Re-read it per session; fall back to the cached copy
+      // if the file is unreadable or invalid.
+      const freshConfig = await loadConfig(projectRoot);
+      const sessionConfig = freshConfig.isOk() ? freshConfig.value : managed.config;
+
       const baseDeps = resourcePool.acquire(projectRoot, managed.config);
       const deps = {
         ...baseDeps,
@@ -723,7 +734,7 @@ program
       const handle = createServer(
         managed.store,
         managed.registry,
-        managed.config,
+        sessionConfig,
         managed.root,
         managed.progress,
         deps,

--- a/tests/server/tools-list-wire-verbosity.test.ts
+++ b/tests/server/tools-list-wire-verbosity.test.ts
@@ -1,0 +1,125 @@
+/**
+ * TRA-373 — `tools.description_verbosity` / `tools.instructions_verbosity`
+ * must shrink the *wire payload*, not just parse.
+ *
+ * Two guards, mirroring the split used by tests/daemon/sse-pipeline-events.ts:
+ *
+ *  1. Behavioural: drive a real MCP client over an in-memory transport
+ *     through `initialize` + `tools/list` and assert the serialized payload
+ *     actually shrinks. A refactor that keeps the config field but stops
+ *     applying it to descriptions/instructions fails here.
+ *
+ *  2. Source guardrail: the daemon builds each session's server inside a
+ *     Commander closure in src/cli.ts, which cannot be imported. The bug this
+ *     issue reports was that closure passing `managed.config` — loaded once
+ *     when the daemon first added the project and never refreshed — so every
+ *     session got a tool surface built from a stale config. Parse cli.ts and
+ *     fail if the session server is built from anything but a freshly loaded
+ *     config.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { describe, expect, it } from 'vitest';
+
+import { TraceMcpConfigSchema, type TraceMcpConfig } from '../../src/config.js';
+import { initializeDatabase } from '../../src/db/schema.js';
+import { Store } from '../../src/db/store.js';
+import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import { ProgressState } from '../../src/progress.js';
+import { createServer } from '../../src/server/server.js';
+
+type Verbosity = 'full' | 'minimal' | 'none';
+
+interface Measurement {
+  toolCount: number;
+  wireBytes: number;
+  descriptionBytes: number;
+  instructionBytes: number;
+}
+
+function configFor(verbosity: Verbosity): TraceMcpConfig {
+  return TraceMcpConfigSchema.parse({
+    tools: {
+      preset: 'standard',
+      description_verbosity: verbosity,
+      instructions_verbosity: verbosity,
+    },
+  });
+}
+
+/** Boot a server at `verbosity` and measure what an MCP client actually receives. */
+async function measure(verbosity: Verbosity): Promise<Measurement> {
+  const db = initializeDatabase(':memory:');
+  const store = new Store(db);
+  const registry = PluginRegistry.createWithDefaults();
+  const progress = new ProgressState(db);
+  const handle = createServer(store, registry, configFor(verbosity), process.cwd(), progress, {});
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'tra-373-probe', version: '1.0.0' });
+  try {
+    await Promise.all([handle.server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const { tools } = await client.listTools();
+    return {
+      toolCount: tools.length,
+      wireBytes: JSON.stringify(tools).length,
+      descriptionBytes: tools.reduce((sum, t) => sum + (t.description?.length ?? 0), 0),
+      instructionBytes: (client.getInstructions() ?? '').length,
+    };
+  } finally {
+    await client.close().catch(() => {});
+    handle.dispose();
+    db.close();
+  }
+}
+
+describe('TRA-373: verbosity settings shrink the tools/list wire payload', () => {
+  it('full > minimal > none, on descriptions, instructions and total bytes', async () => {
+    const full = await measure('full');
+    const minimal = await measure('minimal');
+    const none = await measure('none');
+
+    // Same surface — verbosity trims content, it must not drop tools.
+    expect(full.toolCount).toBeGreaterThan(0);
+    expect(minimal.toolCount).toBe(full.toolCount);
+    expect(none.toolCount).toBe(full.toolCount);
+
+    // Descriptions are ~57% of the default wire; `none` must strip them.
+    expect(none.descriptionBytes).toBeLessThan(full.descriptionBytes * 0.3);
+    expect(minimal.descriptionBytes).toBeLessThan(full.descriptionBytes * 0.75);
+
+    // Server instructions (the tool-routing block).
+    expect(full.instructionBytes).toBeGreaterThan(1000);
+    expect(none.instructionBytes).toBe(0);
+    expect(minimal.instructionBytes).toBeLessThan(full.instructionBytes * 0.5);
+
+    // The point of the setting: a materially cheaper session.
+    expect(none.wireBytes).toBeLessThan(full.wireBytes * 0.6);
+  }, 120_000);
+});
+
+describe('TRA-373: the daemon builds each session from a freshly loaded config', () => {
+  const cliSource = fs.readFileSync(
+    path.join(import.meta.dirname, '..', '..', 'src', 'cli.ts'),
+    'utf-8',
+  );
+
+  /** Body of `async function createSessionTransport(...)`, up to `await handle.server.connect`. */
+  function sessionTransportBody(): string {
+    const start = cliSource.indexOf('async function createSessionTransport(');
+    expect(start).toBeGreaterThan(-1);
+    const end = cliSource.indexOf('await handle.server.connect(transport)', start);
+    expect(end).toBeGreaterThan(start);
+    return cliSource.slice(start, end);
+  }
+
+  it('re-reads the config per session instead of reusing the cached ProjectManager copy', () => {
+    const body = sessionTransportBody();
+    expect(body).toMatch(/await loadConfig\(projectRoot\)/);
+    // The regression: passing the daemon-lifetime cached config to createServer.
+    expect(body).not.toMatch(/createServer\(\s*[\s\S]*?managed\.config,[\s\S]*?managed\.progress/);
+  });
+});


### PR DESCRIPTION
Fixes TRA-373.

## Diagnosis (differs from the issue's hypothesis)

Not project-local vs global. The **local (no-daemon) path already honoured both files correctly**; the **daemon path ignored both**.

`createSessionTransport` in `src/cli.ts` built each session's server with `managed.config` — the config `ProjectManager` loaded once, when the daemon first added the project, and never refreshed. Everything `tools.*` shapes is baked into `createServer()` at that moment: `description_verbosity`, `instructions_verbosity`, `descriptions`, `compact_schemas`, `meta_fields`, `agent_behavior`.

Only `preset` appeared to work because `ProxyBackend` re-filters `tools/list` by name at the session boundary (TRA-250). So the tool count looked right while the payload was the daemon's, byte for byte, whatever the user had configured — exactly the "looks like the file was read and honoured" symptom in the report.

Evidence that it is the daemon, not the config file: with a daemon whose cached config said `none`, a session asking for `full` got `none`. The reporter's daemon happened to be built with `full`, which is why all three of their runs read as `full`.

## Fix

Re-read the config per session in `createSessionTransport`, using the `freshConfig`/`managed.config` fallback idiom already present elsewhere in `cli.ts`. One config read per MCP session; falls back to the cached copy if the file is unreadable or invalid.

## Evidence

Built CLI, live daemon, project-local `.trace-mcp/.config.json`, only the verbosity value changing between runs, measured on the real `initialize` + `tools/list` round-trip:

| verbosity | tools | `tools/list` wire | description bytes | instructions bytes |
|---|---:|---:|---:|---:|
| before — full / minimal / none | 54 | 30,126 B | 2,855 | 0 |
| after — `full` | 54 | 67,776 B | 22,531 | 6,195 |
| after — `minimal` | 54 | 34,147 B | 6,876 | 374 |
| after — `none` | 54 | 30,126 B | 2,855 | 0 |

`none` now cuts the wire payload 56% (~10.5K tokens/session), matching the local path exactly.

## Scope items

1. **Verbosity from a project-local config** — fixed.
2. **Audit of the rest of `tools.*`** — the fix is on the whole config object, so `include`, `exclude`, `descriptions`, `meta_fields`, `compact_schemas` and `agent_behavior` all apply from the project file on both paths. No key is global-only; `docs/configuration.md` now says so, plus the one real caveat: the surface is built per MCP session, so a change lands on the next session (restart the client — the daemon does not need restarting).
3. **Regression test** — `tests/server/tools-list-wire-verbosity.test.ts`. Drives a real MCP client over an in-memory transport and asserts the serialized `tools/list` payload and the `initialize` instructions actually shrink. Plus a source guardrail on `createSessionTransport` (it lives in a Commander closure that cannot be imported — same split as `tests/daemon/sse-pipeline-events.test.ts`). Verified the guardrail fails against the pre-fix `src/cli.ts`.
4. **Doc caveats** — no-op: the "set those globally until this is fixed" notes described in the issue are not present in `docs/reduce-claude-code-token-usage.md` or `docs/comparisons.md` on `master`. Nothing to drop.

The "middle setting that keeps the first sentence" idea is left out of scope, as the issue suggested — `minimal` already does roughly that (22.5 KB → 6.9 KB of descriptions).

## Test evidence

- `pnpm run test` — 815 files passed, 8940 tests passed, 8 skipped.
- `pnpm run typecheck` — clean.
- `pnpm exec biome ci` on touched files — clean.

Agent: Lead Engineer
