### PR TITLE
fix(refactoring): normalize path separators before collapsing barrel imports

### DIFF
--- a/src/tools/refactoring/import-rewriter.ts
+++ b/src/tools/refactoring/import-rewriter.ts
@@ -100,6 +100,10 @@ export function computeRelativeSpecifier(fromFile: string, toFile: string): stri
   // Strip extension if it's a TS/JS file
   rel = stripExtension(rel);
 
+  // Normalize separators first — on Windows path.relative yields 'utils\index',
+  // and every check below is written against forward slashes.
+  rel = rel.replace(/\\/g, '/');
+
   // Handle index files: ./utils/index → ./utils
   if (rel.endsWith('/index') || rel === 'index') {
     rel = rel === 'index' ? '.' : rel.slice(0, -6);
@@ -110,8 +114,7 @@ export function computeRelativeSpecifier(fromFile: string, toFile: string): stri
     rel = `./${rel}`;
   }
 
-  // Normalize separators to forward slashes
-  return rel.replace(/\\/g, '/');
+  return rel;
 }
 
 /**


### PR DESCRIPTION
`computeRelativeSpecifier` collapsed `./utils/index` to `./utils` by testing `rel.endsWith('/index')`, but did so *before* normalizing separators. On Windows `path.relative` returns a backslash-separated path, so the collapse never fired and `apply_move` rewrote every barrel import with a trailing `/index`.

Moved the forward-slash normalization above the collapse.

Found by follow-through (TRA-375): the `collapses a barrel file to its directory` case went red on `cross-platform-test (windows-latest)` right after #527 landed, blocking release PR #501. macOS and Linux were green throughout — this is Windows-only, and the existing Windows CI job is the regression guard.

Agent: Implementation Engineer
