### PR TITLE
docs: reclassify GA4 telemetry credentials as public by design (TRA-380)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,9 @@ jobs:
       CI: 'true'
       # Baked into the published build's anonymous active-install ping
       # (src/telemetry/usage-ping.ts) via tsup.config.ts's `define` block.
+      # Public by design: both values ship as plaintext in dist/ and a GA4
+      # api_secret is write-only. Stored as Actions secrets for convenience,
+      # not confidentiality — see SECURITY.md "Telemetry Credentials".
       # TRACE_MCP_TELEMETRY=off still disables it at runtime.
       TRACE_MCP_GA_MEASUREMENT_ID: ${{ secrets.TRACE_MCP_GA_MEASUREMENT_ID }}
       TRACE_MCP_GA_API_SECRET: ${{ secrets.TRACE_MCP_GA_API_SECRET }}

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ trace-mcp sends at most one anonymous ping per day, per install, to help us coun
 - **Anonymous** — a random install id (`~/.trace-mcp/telemetry-state.json`), the trace-mcp version, Node major version, and OS platform. No project names, file paths, query content, code, or anything else that could identify you or your codebase.
 - **Opt-out** — set `TRACE_MCP_TELEMETRY=off` to disable it entirely.
 - **Small blast radius by construction** — transport is [GA4's Measurement Protocol](https://developers.google.com/analytics/devguides/collection/protocol/ga4), a single HTTP POST, not a custom backend or SDK.
+- **Its credentials are public by design** — the GA4 measurement id and write-only `api_secret` are compiled into the published bundle, so you can read exactly where the ping goes. See [SECURITY.md](SECURITY.md#telemetry-credentials--public-by-design).
 
 Source: [`src/telemetry/usage-ping.ts`](src/telemetry/usage-ping.ts).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -234,6 +234,36 @@ A missing or invalid attestation means the package was **not** built by the offi
 
 ---
 
+## Telemetry Credentials — Public by Design
+
+The anonymous active-install ping (`src/telemetry/usage-ping.ts`) uses GA4's
+Measurement Protocol. Its two credentials — a measurement id and an
+`api_secret` — are **inlined into the published bundle at build time**
+(`tsup.config.ts`, `define` block) and are therefore readable as plaintext by
+anyone who runs `npm install trace-mcp`. This is intended, not a leak.
+
+* **A GA4 `api_secret` is write-only.** It can send events to the property; it
+  cannot read reports, users, or any other data. Baking one into a distributed
+  client is the documented way GA4 Measurement Protocol works for client-side
+  apps.
+* **They are stored as GitHub Actions secrets for convenience, not
+  confidentiality.** The `npm` environment keeps them out of git history and
+  makes rotation a one-place edit. It does not — and is not meant to — keep
+  them out of users' hands.
+* **Rotating them is not a mitigation.** The next release republishes the new
+  value. Report an actual problem with the property (spam, quota abuse)
+  instead; the fix for that is a server-side proxy, not a rotation.
+* **The counts are unauthenticated.** Anyone holding the extracted credentials
+  can post arbitrary `client_id`s, so active-install numbers are a
+  lower-confidence signal that can be inflated by a third party. Treat them as
+  directional, not as an auditable metric.
+
+Source maps (`dist/*.map`) are published alongside the bundle so that stack
+traces from user installs are readable. They contain the same credentials as
+the bundle, which — given the above — adds no exposure.
+
+---
+
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability, please report it responsibly:
@@ -267,3 +297,4 @@ If you discover a security vulnerability, please report it responsibly:
 | Auto-update Gatekeeper check | `spctl -a -t exec` on staged bundle | No |
 | Auto-update opt-out | Disabled when set | Yes (`TRACE_MCP_NO_AUTO_UPDATE=1`) |
 | npm provenance attestation | Sigstore/OIDC on every release | No |
+| GA4 telemetry credentials | Public by design, ship in `dist/`, write-only | Yes (`TRACE_MCP_TELEMETRY=off`) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,6 +45,13 @@ day, opt-out via `TRACE_MCP_TELEMETRY=off`). Read it in the GA4 property
 `G-WSYYT2WZJV`. Refresh the line below monthly so future revisions see a
 trend instead of re-deriving one.
 
+Caveat when citing it: the ping's credentials ship in plaintext inside the
+published npm package (public by design — see SECURITY.md "Telemetry
+Credentials"), so the events are **unauthenticated and can be inflated by
+anyone**. Active installs is the best adoption signal we have, not an
+auditable one; read it as a trend, and treat a sudden step change as
+suspect until corroborated.
+
 **npm weekly downloads are not an adoption metric** and should not be cited
 as one. Measured 2026-08-28 (TRA-273): 9,013 downloads over 92 days, but
 every daily peak is a publish day — 226 on 08-10 (v1.47.0), 344 on 08-17

--- a/src/telemetry/usage-ping.ts
+++ b/src/telemetry/usage-ping.ts
@@ -13,8 +13,11 @@
  * run or maintain. TRACE_MCP_GA_MEASUREMENT_ID/TRACE_MCP_GA_API_SECRET
  * override at runtime; published builds fall back to credentials baked in
  * at build time via tsup's `define` (same mechanism as PKG_VERSION_INJECTED)
- * so installs report without per-user setup. See README "Usage telemetry"
- * for how to opt out (TRACE_MCP_TELEMETRY=off).
+ * so installs report without per-user setup. Those baked-in credentials are
+ * public by design — they ship as plaintext in the published bundle, and a
+ * GA4 api_secret is write-only. The counts they produce are therefore
+ * unauthenticated and inflatable; see SECURITY.md "Telemetry Credentials".
+ * See README "Usage telemetry" for how to opt out (TRACE_MCP_TELEMETRY=off).
  */
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -107,10 +107,20 @@ const require = __tmcpCreateRequire(import.meta.url);`,
   define: {
     PKG_VERSION_INJECTED: JSON.stringify(version),
     // Default GA4 Measurement Protocol credentials for the anonymous
-    // active-install ping (src/telemetry/usage-ping.ts), supplied by CI as
-    // build-time secrets (TRACE_MCP_GA_MEASUREMENT_ID/TRACE_MCP_GA_API_SECRET
-    // in the `npm` GitHub Actions environment) — never committed here. Local
-    // dev builds get empty strings, so the ping stays inert unless the
+    // active-install ping (src/telemetry/usage-ping.ts), supplied by CI from
+    // TRACE_MCP_GA_MEASUREMENT_ID/TRACE_MCP_GA_API_SECRET in the `npm` GitHub
+    // Actions environment.
+    //
+    // These are PUBLIC BY DESIGN, not confidential: inlining them here means
+    // they ship as plaintext literals in every published dist/ bundle and are
+    // readable by anyone who runs `npm install trace-mcp`. A GA4 Measurement
+    // Protocol api_secret is write-only — it cannot read the property — so the
+    // exposure is bounded to "anyone can send us fake events". They live in
+    // GitHub secrets for convenience of rotation, not for confidentiality.
+    // Rotating them changes nothing; the next release republishes the new
+    // value. See SECURITY.md "Telemetry Credentials".
+    //
+    // Local dev builds get empty strings, so the ping stays inert unless the
     // runtime env vars of the same name are set. Fully disabled at runtime
     // via TRACE_MCP_TELEMETRY=off.
     GA_MEASUREMENT_ID_INJECTED: JSON.stringify(process.env.TRACE_MCP_GA_MEASUREMENT_ID ?? ''),


### PR DESCRIPTION
Closes TRA-380.

The GA4 telemetry `api_secret` is stored as a GitHub Actions secret in the restricted `npm` environment and described in `tsup.config.ts` as "never committed here" — but `tsup`'s `define` block inlines it into the bundle, so it ships as a plaintext literal in `dist/index.js`, `dist/cli.js`, and both source maps of every published release. The handling implied a confidentiality the value never had.

This is a posture finding, not a leak: a GA4 Measurement Protocol `api_secret` is **write-only** (it cannot read the property), and baking one into a distributed client is the documented way GA4 MP works. So the right output is a written decision, not a rotation — rotating would be theatre, since the next release republishes the new value.

**What changed** (documentation only, no behaviour change):

- `SECURITY.md` — new "Telemetry Credentials — Public by Design" section explaining why the values ship publicly, why rotation is not a mitigation, and that the resulting install counts are unauthenticated. Adds a row to the Summary of Controls table. Also records the separate call on `dist/*.map`: keep publishing them (readable stack traces from user installs), since they expose nothing the bundle does not.
- `tsup.config.ts`, `.github/workflows/release.yml`, `src/telemetry/usage-ping.ts` — comments corrected; the secrets live in CI for rotation convenience, not confidentiality.
- `README.md` — the telemetry section now states the credentials are readable in the bundle (a transparency point, given the surrounding privacy claims).
- `docs/ROADMAP.md` — active installs is the adoption metric of record, so it now carries the caveat that the events are unauthenticated and inflatable; read as a trend, treat step changes as suspect.

Explicitly not done: rotating the secret, and moving it to a runtime-only env var (that would silently disable telemetry for every user — a product change, not a security fix).

**Test evidence:** `pnpm exec tsc --noEmit` clean; `pnpm exec vitest run src/telemetry` → 8 files, 48 tests passed. No source logic touched.

Agent: Lead Engineer
