### PR TITLE
ci(codeql): exclude js/path-injection, encoding the TRA-301 decision (TRA-381)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -13,6 +13,31 @@ name: trace-mcp CodeQL config
 queries:
   - uses: security-extended
 
+query-filters:
+  # js/path-injection: excluded (TRA-381). 211 of 337 dismissed alerts on this
+  # repo were this one rule — a 0% true-positive rate over 211 alerts — and the
+  # count was still growing: every PR touching a filesystem read re-raised the
+  # class and someone re-dismissed it by hand.
+  #
+  # The underlying trust-boundary question was settled in TRA-301 (option 4,
+  # PR #459, v2.1.0): the daemon's only path source is the project root it was
+  # pointed at, reached over a loopback-only bind (`src/daemon/bind-host.ts`),
+  # so "user-provided value" here means "the local user who started the daemon".
+  # That decision is a property of the bind, not of a sanitizer call, which is
+  # why a model pack declaring `validatePath`/`guardPath` would not have helped:
+  # sampled alerts (e.g. `src/indexer/monorepo.ts`, `src/utils/traceignore.ts`)
+  # taint `rootPath` straight into `readFileSync` with no sanitizer node on the
+  # path at all — `src/utils/safe-fs.ts` documents that it validates nothing on
+  # purpose.
+  #
+  # Cost of this exclusion, stated plainly: a genuinely untrusted path source
+  # would now be silenced. REVERT THIS BLOCK if any of these become true:
+  #   - the daemon gains a remote or shared (non-loopback) bind
+  #   - `/mcp` or `/api` gain authentication, making them a real trust boundary
+  #   - a path source appears that is not the registered project root
+  - exclude:
+      id: js/path-injection
+
 paths-ignore:
   # Test code is not attack surface: it runs on developer machines against
   # fixtures we author. Temp-file and path handling here is deliberate.


### PR DESCRIPTION
## Problem

`js/path-injection` accounts for **211 of 337** dismissed code-scanning alerts on this repo — a **0% true-positive rate over 211 alerts** — and the rate is rising (198 dismissed 08-25, 99 on 08-29). `CodeQL` is a required check on `master`, so every PR touching a filesystem read re-raises the class and costs a manual re-dismissal. The rule carries no signal but still bills triage time.

The root cause was settled in **TRA-301** (option 4, PR #459, shipped v2.1.0) — but the decision was only ever written into dismissal comments, which CodeQL cannot read.

## Change

One `query-filters` block in `.github/codeql/codeql-config.yml` (the file that already documents the TRA-255 scoping decision in exactly this style), carrying the TRA-301 rationale and explicit revert conditions:

- daemon gains a remote or shared (non-loopback) bind
- `/mcp` or `/api` gain authentication, becoming a real trust boundary
- a path source appears that is not the registered project root

## Why not a sanitizer model pack

TRA-381 recommended sampling the 211 before choosing. I did: the alerts span 19 directories under `src/`, and the sampled ones (`src/indexer/monorepo.ts:117`, `src/utils/traceignore.ts:79`, `src/init/detector.ts:134`) taint `rootPath` straight into `readFileSync` with **no sanitizer node on the path at all**. `src/utils/safe-fs.ts` states outright that it does no path validation on purpose. A pack declaring `validatePath`/`guardPath` as sanitizers would have covered a minority; the actual safety argument is the loopback bind (`src/daemon/bind-host.ts`), which a model pack can't express.

## Cost, stated plainly

A genuinely untrusted path source would now be silenced. Given the daemon's only path source is the registered project root behind a loopback bind, that window is narrow — and the revert conditions above are in the config comment, not just here.

## Verification

- Config parses; `query-filters` reads `[{"exclude":{"id":"js/path-injection"}}]`, `queries` and `paths-ignore` unchanged.
- `.github/workflows/codeql.yml:44` already points at this config file.
- Real proof is the next CodeQL run on this PR raising zero `js/path-injection` alerts.

## Not done

6 dismissals carry a now-stale note ("Authenticating it is tracked in TRA-301; revert this dismissal if that lands"). GitHub rejects editing the comment of an already-dismissed alert (`400 Alert is already dismissed`) — it would need reopen + re-dismiss. All 6 are `js/path-injection`, so they are frozen history that can no longer re-raise; the config comment is now the authoritative record. Left alone deliberately.

Closes TRA-381.

Agent: Lead Engineer