### PR TITLE
fix(app): give Insights' report picker a narrow form so every report stays reachable

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -588,6 +588,21 @@ you undo them:
   picker out of reach the same way. This lives in the shared `Toolbar` primitive
   (`lattice/ui/Surface.tsx`), so every surface built on it inherits the behaviour — do
   not re-declare a height on top.
+- **A control that cannot shrink needs a narrow form, not just a wrapping row.**
+  `flex-wrap` gives an oversized control its own line; it cannot make that control
+  narrower. A segmented control is sized by its labels and is one flex item, so
+  once it is wider than the line it overflows no matter how the row wraps. Give it
+  a pop-up button below the width where its segments fit — that is what macOS does,
+  and `PopUpButton` already exists. Insights' report picker was 371px in a 262px
+  band at the 640px window minimum with the sidebar at `SIDEBAR_MAX`: it ran 96.6px
+  past the window and left "Risk hotspots" 14 of its 108px, so that report could not
+  be selected at all.
+- **Decide a collapse from a width the collapsing thing cannot change.** Measure the
+  toolbar, not the control's own slot. The slot is narrower beside a title and
+  full-width once the control wraps to a line of its own, so a slot-based threshold
+  is bistable — "segments, wrapped" and "pop-up, inline" are both self-consistent at
+  the same window size, and which one you get depends on which way the user last
+  resized.
 - **A control that can shrink declares a length `flex-basis`, not `auto`.** A wrapping
   flex line is laid out from each item's *hypothetical* size, so `flex-basis: auto`
   advertises a control's full content width and breaks the row before it has spent
@@ -870,6 +885,8 @@ new evidence.
 | The toolbar sits **above** the KPI strip, not below it | Chrome above content. With the strip first, 357px of tiles pushed the toolbar's bottom 33px past a 420px window and nothing on the surface could scroll it back. |
 | A toolbar has `min-height: 52px` and wraps, never a fixed `height` | A non-wrapping 52px row inside `overflow-x: hidden` ran 51px past a 420px pane and put + Add's chevron and the overflow menu outside the window. |
 | The wrap rule belongs to the shared `Toolbar`, not to each surface | Fixed on the Workspace header in TRA-292 and nowhere else, so four surfaces built on the primitive still clipped: at 640×420 Memory overflowed 333px with its search, its prominent "Add decision" and its overflow menu at zero visible pixels and no scrollable ancestor. |
+| An unshrinkable control gets a narrow form; wrapping alone does not save it | `flex-wrap` gives a segmented control its own line but cannot narrow it. Insights' 371px picker in a 262px band ran 96.6px past a 640px window and left "Risk hotspots" 14 of its 108px — unreachable. Below the width where the segments fit it is a `PopUpButton`. |
+| A collapse threshold reads a width the collapsing thing cannot change | Measured against its own slot, the Insights picker was bistable: the slot is narrower beside the title and full-width once the picker wraps, so both controls were self-consistent at one window size and the render depended on which way the user had resized. The toolbar's width is the honest input. |
 | A shrinkable control declares a length `flex-basis`, never `auto` | A wrapping flex line breaks on hypothetical sizes, so `flex-basis: auto` spends none of the control's slack first. `.lx-search` on `auto` wrapped Memory's toolbar at the default 960px window; on `1 1 140px` capped at `max-content` it renders identically and holds one row to a 740px pane. |
 | Breakpoints are read off the **pane**, and computed rather than picked | The sidebar is resizable 180–320px, so window width is not a proxy for room. `kpiStripHeight()` reproduces the measured 357px; a guessed number drifts the first time a tile changes. |
 | Narrow gives up the comparison, then the table, never the value | The number and the project name are the screen; the footnote and the metric columns are elaboration. Compact already renders a legible row at 420px. |

--- a/packages/app/src/renderer/tabs/Insights.tsx
+++ b/packages/app/src/renderer/tabs/Insights.tsx
@@ -16,8 +16,8 @@
  * pattern established by R08 (Notebook) so the project-root vitest config can
  * test pure logic without pulling in React under pnpm --frozen-lockfile.
  */
-import { useCallback, useState } from 'react';
-import { Badge, Button, EmptyState, SegmentedControl, Toolbar } from '../lattice/ui';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Badge, Button, EmptyState, PopUpButton, SegmentedControl, Toolbar } from '../lattice/ui';
 import {
   INSIGHT_REPORTS,
   REPORT_BY_ID,
@@ -57,6 +57,27 @@ function initialReportStates(): Record<ReportId, ReportState> {
     states[r.id] = { status: 'idle', rows: null };
   }
   return states;
+}
+
+/* The report picker is a segmented control while its segments fit, and a pop-up
+   button when they do not — the macOS answer to a picker that outgrows its row.
+
+   A segmented control cannot shrink: its segments are sized by their labels, so
+   it is a single flex item wider than the line it sits on. The toolbar's
+   `flex-wrap` (TRA-347) gives it its own row but cannot make it narrower, and
+   the band clips. Measured on the running renderer at the 640px window minimum
+   with the sidebar at its own maximum — both supported settings, `SIDEBAR_MAX`
+   is 320 and the resizer's End key goes straight there — the 371px picker ran
+   96.6px past the window's right edge and left "Risk hotspots" 14 of its 108px.
+   That report could not be selected at all.
+
+   The threshold is the control's own measured width, not a picked number, so
+   retitling a report moves it on its own. */
+export function pickerFits(availableW: number, intrinsicW: number): boolean {
+  // Before either has been measured, assume it fits: the segmented control is
+  // the richer control and the pop-up is the fallback, never the default.
+  if (availableW <= 0 || intrinsicW <= 0) return true;
+  return availableW >= intrinsicW;
 }
 
 /* Empty-state glyphs, one per report — a report pane with no data still needs
@@ -118,6 +139,44 @@ export function Insights({
     [client, root],
   );
 
+  /* Measure the toolbar, not the picker's own slot. The slot is narrower when
+     it shares the line with the title and full-width once the picker wraps to
+     a line of its own — so a slot-based threshold is bistable: at the same
+     window and sidebar size, "segments, wrapped" and "pop-up, inline" are both
+     self-consistent, and which one you get depends on the order the user
+     resized in. The toolbar's width is the one number the picker cannot
+     influence, and it is also the real constraint: the segments are usable if
+     they fit a full line, since `flex-wrap` will give them one. */
+  const pickerRef = useRef<HTMLSpanElement>(null);
+  const intrinsicW = useRef(0);
+  const [availW, setAvailW] = useState(0);
+  const segmented = pickerFits(availW, intrinsicW.current);
+
+  useEffect(() => {
+    const bar = pickerRef.current?.closest('[role="toolbar"]');
+    if (!bar || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver((entries) => {
+      const w = Math.round(entries[0]?.contentRect.width ?? 0);
+      setAvailW((prev) => (prev === w ? prev : w));
+    });
+    ro.observe(bar);
+    return () => ro.disconnect();
+  }, []);
+
+  /* Record the segments' own width while they are on screen — after the swap
+     they are gone. Measure the control, not the slot: the segmented control is
+     `flex-shrink: 0`, so its box is its intrinsic width at any slot size, while
+     the slot's `scrollWidth` collapses to the slot's own width whenever there
+     is room to spare and would ratchet the threshold up until the segments
+     could never come back. */
+  useEffect(() => {
+    const seg = pickerRef.current?.querySelector('.lx-seg');
+    if (seg) {
+      const w = Math.round(seg.getBoundingClientRect().width);
+      if (w > 0) intrinsicW.current = w;
+    }
+  });
+
   const focusedDef = REPORT_BY_ID[focused];
   const focusedState = states[focused];
   const running = focusedState.status === 'running';
@@ -133,17 +192,27 @@ export function Insights({
         <h1 className="t-title-3" style={{ color: 'var(--label)', margin: 0, flexShrink: 0 }}>
           Insights
         </h1>
-        <SegmentedControl
-          aria-label="Report"
-          value={focused}
-          onChange={setFocused}
-          options={INSIGHT_REPORTS.map((r) => ({
-            value: r.id,
-            label: r.title,
-            title: r.description,
-          }))}
-        />
-        <span style={{ flex: 1 }} />
+        <span ref={pickerRef} style={{ display: 'flex', flex: '1 1 auto', minWidth: 0 }}>
+          {segmented ? (
+            <SegmentedControl
+              aria-label="Report"
+              value={focused}
+              onChange={setFocused}
+              options={INSIGHT_REPORTS.map((r) => ({
+                value: r.id,
+                label: r.title,
+                title: r.description,
+              }))}
+            />
+          ) : (
+            <PopUpButton
+              aria-label="Report"
+              value={focused}
+              onChange={setFocused}
+              options={INSIGHT_REPORTS.map((r) => ({ value: r.id, label: r.title }))}
+            />
+          )}
+        </span>
         {/* One Run on screen at a time: while the report has never been run,
             the empty state below carries it — repeating it here would put two
             accent-filled buttons on one screen for one command. */}

--- a/packages/app/src/renderer/tabs/__tests__/insights.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/insights.test.tsx
@@ -9,7 +9,7 @@
  * locked out here. */
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { INSIGHT_REPORTS, Insights, type InsightsClient } from '../Insights';
+import { INSIGHT_REPORTS, Insights, type InsightsClient, pickerFits } from '../Insights';
 
 const client = (rows = [{ primary: 'app/Models/User.php', badge: '12' }]): InsightsClient => ({
   runReport: vi.fn().mockResolvedValue({ rows }),
@@ -56,5 +56,47 @@ describe('Insights', () => {
     (document.querySelector('.lx-btn.v-prominent') as HTMLButtonElement).click();
     await waitFor(() => expect(screen.getByText('Nothing to report')).toBeTruthy());
     expect(document.querySelector('.ws-center-empty .gi')).toBeTruthy();
+  });
+});
+
+/* The picker outgrew its row at supported settings: at the 640px window minimum
+   with the sidebar at SIDEBAR_MAX (320) the 371px segmented control ran 96.6px
+   past the window's right edge, leaving "Risk hotspots" 14 of its 108px — that
+   report could not be selected at all. Below the width where the segments fit,
+   the picker becomes a pop-up button.
+
+   jsdom does no layout and has no ResizeObserver, so the swap itself cannot be
+   rendered here; the decision is a pure function and that is what is pinned.
+   The measured widths above are what make the numbers here real. */
+describe('pickerFits', () => {
+  const SEGMENTS_W = 371; // measured on the running renderer, regular tier
+
+  it('keeps the segments while the toolbar can hold them', () => {
+    expect(pickerFits(402, SEGMENTS_W)).toBe(true); // sidebar 180 @ 640
+    expect(pickerFits(SEGMENTS_W, SEGMENTS_W)).toBe(true); // exactly enough
+    expect(pickerFits(642, SEGMENTS_W)).toBe(true); // 960 window
+  });
+
+  it('falls back to the pop-up once they cannot fit', () => {
+    expect(pickerFits(SEGMENTS_W - 1, SEGMENTS_W)).toBe(false);
+    expect(pickerFits(362, SEGMENTS_W)).toBe(false); // sidebar 220 @ 640
+    expect(pickerFits(262, SEGMENTS_W)).toBe(false); // sidebar 320 @ 640
+  });
+
+  it('shows the segments until something has actually been measured', () => {
+    // The pop-up is the fallback, never what a first paint drops to.
+    expect(pickerFits(0, 0)).toBe(true);
+    expect(pickerFits(0, SEGMENTS_W)).toBe(true);
+    expect(pickerFits(262, 0)).toBe(true);
+  });
+
+  it('is decided by one width, so the same size always renders the same control', () => {
+    // Guards the bistable version this replaced: the picker's own slot is
+    // narrower beside the title than on a wrapped line of its own, so a
+    // slot-based threshold settled into either control depending on which way
+    // the user had resized. Widening then narrowing must land where it started.
+    const widths = [402, 362, 262, 362, 402];
+    const seen = widths.map((w) => pickerFits(w, SEGMENTS_W));
+    expect(seen).toEqual([true, false, false, false, true]);
   });
 });


### PR DESCRIPTION
## The problem

Insights' report picker is a segmented control, sized by its labels. A segmented control cannot shrink and is a single flex item, so once it is wider than the line it sits on it overflows however the row wraps — the toolbar's `flex-wrap` (TRA-347) gives it its own line but cannot make it narrower.

Measured on the running renderer at the 640px window minimum with the sidebar at its own maximum. Both are supported settings: `SIDEBAR_MAX` is 320, it persists, and the resizer's End key goes straight there.

| | |
|---|---|
| Picker width | 371px |
| Band width | 262px |
| Past the window's right edge | **96.6px** |
| `Risk hotspots` visible | **14px of 108px** |

That report could not be selected at all. Reproduced through the real resizer, not by forcing styles.

## The fix

Below the width where the segments fit, the picker becomes a `PopUpButton` — the macOS answer to a picker that outgrows its row, and a primitive this app already has. The threshold is the segmented control's own measured width rather than a picked number, so retitling a report moves it automatically.

**The decision reads the toolbar's width, not the picker's own slot.** A slot-based threshold is bistable: the slot is narrower beside the title and full-width once the picker wraps to a line of its own, so "segments, wrapped" and "pop-up, inline" are *both* self-consistent at one window size. I hit this while sweeping the sidebar — 180px rendered segments on a fresh load and the pop-up when arrived at from 320px. The toolbar's width is the one input the picker cannot influence, and it is also the real constraint: the segments are usable if they fit a full line, because `flex-wrap` will give them one.

## Verified on the running renderer

| Window | Sidebar | Before | After |
|---|---|---|---|
| 640 | 180 | segments, fits | segments, fits |
| 640 | 220 | segments, 9px past the band | pop-up, overflow 0 |
| 640 | 260 | segments, 36.6px past the window | pop-up, overflow 0 |
| 640 | 320 | segments, **96.6px past the window** | pop-up, overflow 0 |
| 960 | 180–320 | segments, fits | segments, fits — unchanged |

Sweeping the sidebar 180 → 320 → 180 now returns to the control it started on at every step. At 960 the segments hold across the entire sidebar range, so the common case is untouched — the pop-up only ever appears where the segments genuinely cannot fit.

Band height at the worst case drops from 65px (two wrapped lines) to 44px (one), and all three reports are present in the pop-up.

## Tests

`pickerFits` is a pure predicate and is pinned directly, including a case that guards the bistable version this replaced. jsdom does no layout and has no `ResizeObserver`, so the swap itself cannot be rendered there — the existing test that asserts the segmented control by default still passes for that reason, which is the correct default.

385/385 app tests, typecheck, renderer build and `design-tokens.mjs` all pass.

> `build:main` fails in my workdir on a missing `electron-updater` module in `src/main/index.ts` — a file this PR does not touch. I confirmed the same failure on clean master before my change; it is a local `node_modules` gap, not a defect here.

DESIGN.md updated in the same PR: two new rules (an unshrinkable control needs a narrow form, not just a wrapping row; a collapse threshold reads a width the collapsing thing cannot change) plus both decision-log entries.
