### PR TITLE
fix(app): group the app menu by what an item does, and take the theme pill's proportions from the reference (TRA-376)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -329,7 +329,7 @@ because re-adding a banned body under a new key is the same regression wearing a
 
 | Rejected | Why | Use instead |
 |---|---|---|
-| `auto_awesome` (sparkles) | Decorates rather than names. It is the AI-marketing glyph; on a developer tool it reads as ornament and says nothing about what the item does. | The glyph for the destination — `description` for `View changelog`. |
+| `auto_awesome` (sparkles) | Decorates rather than names. It is the AI-marketing glyph; on a developer tool it reads as ornament and says nothing about what the item does. | The glyph for the destination — `scroll` for `View changelog`. |
 | `forum` (speech bubbles) | Promises a conversation with a person. Nothing in this app is one: `Get help` opens GitHub issues, `Ask` queries the indexed graph. | `help` (question mark in a circle) for help; `search` for Ask. |
 
 Judge the replacement at the size it renders, not on the 24-grid. `manage_search`
@@ -340,6 +340,13 @@ handle. A glyph that only reads at 24px is not a glyph this app has a use for.
 **When a reference is supplied, match it.** If it looks wrong for us, say so in the PR
 and argue it. A substitution nobody mentions costs a review round every time, and it
 is how this pair shipped in the first place.
+
+That happened twice on the same item. Sparkles were replaced with `description`, a
+plain page — the *category* the reference belonged to, not the glyph in it. The
+reference was a rolled sheet, which is now `scroll`, and a changelog is a running
+record you scroll through rather than a document you open. **Matching a reference
+means the glyph in it**, not the nearest thing already in the set: if the set has no
+match, draw one and say in the PR that you did.
 
 ### Prominent buttons are flat
 
@@ -371,6 +378,16 @@ every window; it belongs in the Settings screen, which is where macOS puts it.
 Selection follows the macOS active/inactive pair: `--fill-tertiary` when the sidebar
 does not own focus, `--accent-fill` + `--on-accent` when it does
 (`.ws-sidebar:focus-within`).
+
+**A row holding a menu open shows its open state, and nothing else.** The trigger
+keeps DOM focus while its menu is up, so the house `*:focus-visible` ring — a 3px
+accent halo over a **1px inset accent border** — sat on the row for as long as the
+menu stayed open whenever it had been opened from the keyboard. On a full-width row
+that inset border is a rectangle, and a blue rectangle around a row reads as a
+focused text field, not as a trigger holding its state. `--fill-tertiary` is the
+whole indicator; the open menu is the rest of it
+(`.ws-sb-row[aria-expanded='true']:focus-visible { box-shadow: none }`). The ring
+stays for the case it is actually for: the row focused with the menu closed.
 
 ### States are part of the component, not an afterthought
 
@@ -527,6 +544,13 @@ same reason.
 The footer never grows a second row for any of this. If a new global action needs a
 home, it is a menu item.
 
+**Grouping in the app menu is by what an item does, not by what is left over.**
+Settings alone, then the choices, then the actions — and inside the actions,
+everything that *leaves for a browser* is one group and everything that *acts on
+this app* is another. `Check for updates…` sat flush under `Get help` and read as a
+third GitHub page. `AppMenu` splits on `url`, which every entry already declares, so
+a new action lands in the right group without that file learning its name.
+
 ### A choice in a menu is one row, not a group of items
 
 A menu item is a **destination or a command**: you pick it, something happens, the
@@ -567,6 +591,14 @@ What the row has to get right, all of it enforced by
   unselected icon drops to `--label-secondary`.
 - **Picking a value does not close the menu.** The point of an inline switcher is
   watching the app change under it. A command still closes; a choice does not.
+- **The pill's proportions come from the reference, not from the nearest size
+  token.** Icon-only segments shipped on `sz-small`: a 20px track, 16px segments and
+  a 14px glyph, which left **1px** of air above and below the icon — while
+  `.lx-seg.sz-small`'s `padding: 0 8px` won the cascade and ran the segments 30px
+  wide. Squeezed on one axis, loose on the other. The shape to hold is *air inside
+  the segment, little outside the pill*: the default 24px track, 24×20 segments, a
+  12px glyph — 6px beside the icon, 4px above it, and 3px between pill and row.
+  A segment never goes under the 24px hit-target floor to look squarer.
 
 ### Every string comes from the catalogue, and the length is not yours to assume
 
@@ -881,6 +913,8 @@ new evidence.
 | 20px controls keep the painted macOS small size, hit target grown by pseudo-element | The painted size is *correct*; only the hit box was wrong. Growing the box moves no pixel. |
 | Prominent buttons are a flat accent capsule | macOS 26 dropped the gradient + bezel entirely. |
 | Segmented selection is the thumb, and unselected labels stay at `--label` | macOS draws unselected segments at full strength; `--label-secondary` on the recessed track measured 4.45:1. |
+| An icon-only segment gets the 24px track, not `sz-small` (TRA-376) | At 20px the track leaves 1px above a 14px glyph, and `sz-small`'s `padding: 0 8px` wins the cascade over the menu's own `padding: 0` — squeezed vertically, loose horizontally. |
+| A menu trigger with its menu open draws no focus ring (TRA-376) | The house ring carries a 1px **inset** accent border. On a full-width row, held for as long as the menu is up, that is a blue rectangle that reads as a focused text field. |
 | Badge tint at 18% with a per-tone `--badge-*-fg` label | White-on-a-light-fill was 1.6:1. The tone's own hue, darkened until it clears AA over its own tint, is legible in both appearances. |
 | Badges/chips/headers are sentence case | ALL CAPS is reserved for the 10px group header and nowhere else. |
 | Cards are opaque with a hairline, no shadow, no glass | Cards are content. The active KPI tile painted on accent measured 3.28:1 and pushed its footnote to 4.45:1. |

--- a/packages/app/src/renderer/components/AppMenu.tsx
+++ b/packages/app/src/renderer/components/AppMenu.tsx
@@ -111,11 +111,19 @@ export function AppMenu({
     </MenuItem>
   );
 
-  /* Settings sits alone above Appearance, the way it does in the app menu on
-     macOS; the rest follow the group. Split by id rather than by index so a
-     reordered shared list cannot silently move an item into the wrong group. */
+  /* Three groups, not two. Settings sits alone above Theme, the way it does in
+     the app menu on macOS. Below Theme the remaining actions split on what they
+     DO: `links` leave for a browser, `commands` act on this app — so
+     "Check for updates…" gets its own group rather than trailing the two GitHub
+     pages as if it were a third destination (TRA-376).
+
+     The split is on `url`, not on an id list: an action that opens a page is
+     already declared that way in global-actions.ts, so a new entry lands in the
+     right group without this file learning its name. */
   const settings = GLOBAL_ACTIONS.find((a) => a.id === 'settings');
   const rest = GLOBAL_ACTIONS.filter((a) => a.id !== 'settings');
+  const links = rest.filter((a) => a.url);
+  const commands = rest.filter((a) => !a.url);
 
   return (
     <div className="ws-sb-footer">
@@ -159,7 +167,9 @@ export function AppMenu({
             onChange={onAppearanceChange}
           />
           <MenuSeparator />
-          {rest.map(item)}
+          {links.map(item)}
+          {links.length > 0 && commands.length > 0 && <MenuSeparator />}
+          {commands.map(item)}
         </Menu>
       )}
     </div>

--- a/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
@@ -165,6 +165,21 @@ describe('sidebar app menu', () => {
     expect(onCheckForUpdate).toHaveBeenCalled();
   });
 
+  /* TRA-376. "Check for updates…" acts on the app; the two above it leave for
+     a browser. It sat flush under "Get help" as if it were a third GitHub page.
+     Pinned by position, not by count, so adding a fourth link cannot quietly
+     re-merge the groups. */
+  it('separates the action on the app from the links that leave it', () => {
+    const { trigger } = renderMenu();
+    const menu = openMenu(trigger);
+    const check = within(menu).getByRole('menuitem', { name: /Check for updates/ });
+    expect(check.previousElementSibling?.getAttribute('role')).toBe('separator');
+
+    const help = within(menu).getByRole('menuitem', { name: /Get help/ });
+    const changelog = within(menu).getByRole('menuitem', { name: /View changelog/ });
+    expect(help.previousElementSibling).toBe(changelog);
+  });
+
   it('arrows through the items and wraps', () => {
     const { trigger } = renderMenu({ appearance: 'auto' });
     const menu = openMenu(trigger);

--- a/packages/app/src/renderer/lattice/__tests__/icons.test.ts
+++ b/packages/app/src/renderer/lattice/__tests__/icons.test.ts
@@ -53,7 +53,7 @@ describe('icon set', () => {
     expect(names).not.toContain('forum');
     // The replacements the reference asked for, present and spelled as used.
     expect(names).toContain('help');
-    expect(names).toContain('description');
+    expect(names).toContain('scroll');
   });
 
   /* A global action's `icon` is a string looked up at render time, so a name

--- a/packages/app/src/renderer/lattice/icons.tsx
+++ b/packages/app/src/renderer/lattice/icons.tsx
@@ -38,6 +38,12 @@ const GLYPHS: Record<string, string> = {
   folder_open:
     '<path d="M3 6a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v2H3z"/><path d="M3 10h18l-2 8a2 2 0 0 1-2 1H5a2 2 0 0 1-2-2z"/>',
   description: '<path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/>',
+  /* A rolled sheet — curl at the top left, curl at the bottom. This is the
+     glyph Nikolai supplied for "View changelog" (TRA-376); `description`, the
+     plain page, was a second substitution for it. A changelog is a running
+     record you scroll through, which is what separates the two. */
+  scroll:
+    '<path d="M19 17V5a2 2 0 0 0-2-2H4"/><path d="M8 21h12a2 2 0 0 0 2-2v-1a1 1 0 0 0-1-1H11a1 1 0 0 0-1 1v1a2 2 0 1 1-4 0V5a2 2 0 1 0-4 0v2a1 1 0 0 0 1 1h3"/>',
   data_object:
     '<path d="M9 5a3 3 0 0 0-3 3v2a2 2 0 0 1-2 2 2 2 0 0 1 2 2v2a3 3 0 0 0 3 3M15 5a3 3 0 0 1 3 3v2a2 2 0 0 0 2 2 2 2 0 0 0-2 2v2a3 3 0 0 1-3 3"/>',
   function: '<path d="M19 5h-3a3 3 0 0 0-3 3v8a3 3 0 0 1-3 3H7M8 12h8"/>',

--- a/packages/app/src/renderer/lattice/ui/Menu.tsx
+++ b/packages/app/src/renderer/lattice/ui/Menu.tsx
@@ -307,7 +307,11 @@ export function MenuChoiceRow<T extends string>({
       }}
     >
       <span className="ws-ctx-row-label">{label}</span>
-      <div className="lx-seg sz-small ws-ctx-seg">
+      {/* No `sz-small`: at 20px the track left 1px above and below a 14px glyph
+          while the segments ran 30px wide, which is the squeeze Nikolai saw —
+          crushed vertically, loose horizontally (TRA-376). The default 24px
+          track carries square 20px segments; island.css sets their geometry. */}
+      <div className="lx-seg ws-ctx-seg">
         {options.map((option) => {
           const checked = option.value === value;
           return (
@@ -323,7 +327,7 @@ export function MenuChoiceRow<T extends string>({
               className={'lx-seg-item' + (checked ? ' is-active' : '')}
               onClick={() => onChange(option.value)}
             >
-              <Icon name={option.icon} size={14} />
+              <Icon name={option.icon} size={12} />
             </button>
           );
         })}

--- a/packages/app/src/renderer/styles/island.css
+++ b/packages/app/src/renderer/styles/island.css
@@ -691,11 +691,28 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
   font-size: 13px;
   color: var(--label);
 }
-/* Icon-only segments: drop the text padding, keep the 24px hit floor that
-   controls.css already grows with a pseudo-element. */
+/* Icon-only segments, sized off the reference Nikolai gave (shadcnblocks
+   theme-switcher) rather than re-derived: a square segment inside the track,
+   with the icon a little over half its box, and the track's own inset small
+   next to it. The reference runs 36 / 28 / 16 — track, segment, icon — so the
+   segment is 78% of the track, the icon 57% of the segment, and every gap
+   around the icon is equal.
+
+   The first cut inverted that. `sz-small` made the track 20px, which left 1px
+   above and below a 14px glyph, while `padding: 0` here lost the cascade to
+   `.lx-seg.sz-small .lx-seg-item { padding: 0 8px }` (same specificity, later
+   file) and ran the segments 30px wide. Crushed vertically, loose horizontally
+   — 5px of air outside the pill and 1px inside it (TRA-376).
+
+   Now: the default 24px track, 24×20 segments, a 12px icon — 83% and 55%, so
+   6px of air beside the glyph and 4px above it, and 3px between the pill and
+   the row's 30px box. Dropping the padding is the whole change; the segment
+   then sits on `.lx-seg`'s own 24px min-width, which is also the hit-target
+   floor TRA-293 established (the ::after in controls.css grows the other axis).
+   A 20px square would read closer to the reference still, but only by taking
+   the segment under that floor or overlapping its neighbour's hit box. */
 .ws-ctx-row .ws-ctx-seg .lx-seg-item {
   padding: 0;
-  min-width: 26px;
 }
 /* …and give selection a second cue. Measured on the running renderer: the thumb
    is 1.19:1 against the track in light and 1.63:1 in dark — under 1.4.11's 3:1,

--- a/packages/app/src/renderer/styles/sidebar.css
+++ b/packages/app/src/renderer/styles/sidebar.css
@@ -196,6 +196,19 @@
 .ws-sb-row[aria-expanded='true'] {
   background: var(--fill-tertiary);
 }
+/* …and while it is up, the fill is the ONLY thing the row draws. Open it from
+   the keyboard and the trigger keeps DOM focus, so the house `*:focus-visible`
+   ring — a 3px accent halo over a 1px inset accent border — painted a solid
+   blue rectangle around the row for as long as the menu stayed open. On a
+   full-width row that reads as a focused text field, not as a menu trigger
+   holding its state (TRA-376). macOS draws neither: an open pop-up button
+   shows that it is open and lets the menu itself carry focus.
+
+   Scoped to the open state on purpose. Tab to this row with the menu closed
+   and the ring is still there — that is the case a focus ring is for. */
+.ws-sb-row[aria-expanded='true']:focus-visible {
+  box-shadow: none;
+}
 
 /* Pop-up affordance on a row that opens a menu. Unlike .ws-sb-trailing this is
    always visible — it is not an action revealed on hover, it is the row saying

--- a/packages/app/src/shared/global-actions.ts
+++ b/packages/app/src/shared/global-actions.ts
@@ -48,12 +48,13 @@ export const GLOBAL_ACTIONS: readonly GlobalAction[] = [
   },
   /* "View changelog", not "What's new": the item opens the releases page, and
      someone checking whether a specific fix shipped searches for the word
-     "changelog". The glyph names the destination — a document, not sparkles. */
+     "changelog". The glyph is the rolled sheet from the reference Nikolai gave
+     — not sparkles, and not the plain page that replaced them (TRA-376). */
   {
     id: 'view-changelog',
     label: 'View changelog',
     url: 'https://github.com/nikolai-vysotskyi/trace-mcp/releases',
-    icon: 'description',
+    icon: 'scroll',
   },
   /* A question mark, not a speech bubble: this opens GitHub issues, and a
      speech bubble would promise a person on the other end. */


### PR DESCRIPTION
Nikolai's review of the app menu as shipped (#516 / #522) — four defects, one popover, one PR. TRA-376.

## 1. `Check for updates…` gets its own group

It sat flush under `Get help`, reading as a third GitHub page. Grouping in this menu is now by **what an item does**: Settings alone, then the choice, then the links that leave for a browser, then the actions on this app.

`AppMenu` splits on `url` — a property every entry in `global-actions.ts` already declares — rather than on an id list, so a new action lands in the right group without that file learning its name. Pinned by position in `AppMenu.test.tsx`, not by count.

I did **not** move it up to the version header. The header is text, not a control; a button inside it would be a shape this app has nowhere else, and the item would lose the ⌘-column alignment it shares with Settings.

## 2. `View changelog` — the glyph from the reference, not the nearest one in the set

The reference is a rolled sheet. It shipped as `description`, a plain page. That is the second substitution on this item: sparkles were replaced with the *category* the reference belonged to instead of the glyph in it.

New `scroll` glyph in `lattice/icons.tsx`, drawn on the 24 grid at the house stroke. `description` stays — it is still in use elsewhere; the `icons.test.ts` guard now asserts `scroll` instead.

## 3. The Theme pill, measured

The pill was squeezed on one axis and loose on the other, and the cause was a cascade bug: `sz-small` set the track to 20px, and `.lx-seg.sz-small .lx-seg-item { padding: 0 8px }` in `controls.css` beat the menu's own `padding: 0` in `island.css` (same specificity, later file). So the icons had **1px** of air above and below and **8px** either side.

Measured on the running Electron renderer, dark, menu open:

| | Before | After | Reference (shadcnblocks theme-switcher) |
|---|---|---|---|
| Track | 98 × 20 | **80 × 24** | 36 tall |
| Track padding | 2px | 2px | 4px (11% of track) |
| Segment | 30 × 16 | **24 × 20** | 28 × 28 |
| Segment ÷ track height | 80% | **83%** | 78% |
| Icon | 14 | **12** | 16 |
| Air beside the icon | 8px | **6px** | 6px |
| Air above the icon | **1px** | **4px** | 6px |
| Pill to row edge | 5px | **3px** | — |
| Hit target | 30 × 24 | 24 × 24 | — |

Row height stays 30px, and the row's label, track, all three segments and the active glyph still share one centre line (460.5px), with the track's right edge at 214.5px — the same column as Settings' `⌘,`, which is the TRA-370 rule.

The one place I did not follow the reference: its segments are square. A 20×20 segment here would drop under the 24px hit-target floor TRA-293 established, and growing the pseudo-element to compensate would overlap the neighbouring segment's hit box across the 2px gap. 24×20 is the closest shape that keeps the floor.

## 4. No blue box on the trigger

The row keeps DOM focus while its menu is up. Open it from the keyboard and the house `*:focus-visible` ring applies — and that ring is a 3px accent halo over a **1px inset accent border**. On a 208px-wide row, held for as long as the menu stays open, the inset border is a blue rectangle that reads as a focused text field.

Reproduced before touching it (`matches(':focus-visible') === true`, `box-shadow: 0 0 0 3px …, inset 0 0 0 1px var(--accent)`). Now `.ws-sb-row[aria-expanded='true']:focus-visible { box-shadow: none }`: the open state is the `--fill-tertiary` fill plus the menu itself, which is what macOS draws for an open pop-up button. The ring stays for the case a focus ring is for — the row focused with the menu closed.

## Verification

Electron window (`scripts/electron-cdp.mjs launch`), dark and light, menu opened with the trigger keyboard-focused so the ring state is the one Nikolai hit; plus Reduce Transparency + Increase Contrast in light. Values above are `getBoundingClientRect` / `getComputedStyle` on the running renderer, not read off the CSS.

382 tests across 38 files, typecheck, build and the token-contrast script all clean. Biome does not cover `packages/app`.

## Written down

`DESIGN.md`: the app-menu grouping rule (§6), the pill's proportions and the hit-target floor that caps them (§6), an open menu trigger drawing no focus ring (§5), and — the half that caused defect 2 — matching a reference means the glyph in it, not the nearest thing already in the set (§5). Two decision-log rows.

Closes TRA-376.
