### PR TITLE
feat(app): translate the application menu, the tray and the main-process dialog (TRA-386)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -135,6 +135,9 @@ packages/app/src/shared/i18n/
 packages/app/src/renderer/i18n/
   index.ts                # i18next init, setLocale, useLocale, t
   format.ts               # Intl wrappers: relativeTime, formatDate, formatNumber
+packages/app/src/main/
+  i18n.ts                 # the main process's own i18next instance, and its t
+  locale.ts               # the choice mirrored to userData, so main can read it
 ```
 
 **Why i18next.** Plurals. Russian needs four forms where English needs two, and the
@@ -173,6 +176,16 @@ pnpm --filter trace-mcp-app run test         # catalogue parity, plurals, Intl o
 `check-i18n.mjs` scans an allowlist, not the whole tree: string extraction lands
 surface by surface, and the `CHECKED` array at the top of the script is how a finished
 slice records that it is finished. Extract a surface → add its path there.
+
+**The main process** (the application menu, the tray, dialogs) has no React and
+cannot read the renderer's `localStorage`, so the language is mirrored to a one-line
+file in `userData` — exactly the arrangement `main/appearance.ts` uses for the theme.
+The renderer's `setLocale` sends `set-locale` over IPC, and `main/menu.ts` writes the
+file, switches its instance and rebuilds both surfaces: `Menu.setApplicationMenu`
+replaces the menu wholesale, there is no per-item relabel. Main-process code calls
+`t('menu:file')` from `main/i18n`. Standard macOS items stay on their Electron
+`role` — the OS supplies those labels already translated, and hand-translating one
+is how a menu ends up half in each language.
 
 ## Desktop app update channels
 

--- a/packages/app/scripts/check-i18n.mjs
+++ b/packages/app/scripts/check-i18n.mjs
@@ -6,10 +6,12 @@
  * records that it is finished. Adding a path here without extracting it turns
  * the build red, which is the only enforcement that survives a busy week.
  *
- * What it catches: JSX text nodes and the four attributes that carry prose
- * (title, label, placeholder, aria-label). What it does not: a string handed to
- * a function, or one built by concatenation — those need a parser and review
- * catches them. A line ending in `// i18n-exempt` is skipped, for the handful
+ * What it catches: JSX text nodes, the four attributes that carry prose (title,
+ * label, placeholder, aria-label), and the same words as object properties —
+ * `label: 'File'` is how the main process builds a menu, and without that rule
+ * an allowlisted menu.ts would pass while reading every string inline. What it
+ * does not: a string handed to a function, or one built by concatenation —
+ * those need a parser and review catches them. A line ending in `// i18n-exempt` is skipped, for the handful
  * of literals that are genuinely not prose (a URL, a keyboard glyph).
  *
  * Run: pnpm --filter trace-mcp-app run check:i18n
@@ -22,12 +24,18 @@ const ROOT = resolve(import.meta.dirname, '..');
 
 /** Extracted surfaces. Grow this as slices land; never shrink it. */
 const CHECKED = [
-  'src/shared/i18n',
+  'src/main/menu.ts',
+  'src/main/tray.ts',
   'src/renderer/i18n',
   'src/renderer/update-check.ts',
+  'src/shared/global-actions.ts',
+  'src/shared/i18n',
 ];
 
 const PROSE_ATTRS = /\b(?:title|label|placeholder|aria-label)=(["'])([^"'{}]+)\1/g;
+/* The same words as an object property — a menu template, a dialog options bag,
+   a tray item. `toolTip` is Electron's spelling. */
+const PROSE_PROPS = /\b(?:title|label|placeholder|toolTip):\s*(["'])([^"'{}]+)\1/g;
 /* A JSX text node: between `>` and `<`, with no braces (an expression is not a
    literal) and at least two letters in a row somewhere. The lookbehind keeps
    `=>` out of it — `(a) => b < c` is a comparison, not a rendered string. */
@@ -39,6 +47,9 @@ function isProse(text) {
   const t = text.trim();
   if (t.length < 3) return false;
   if (!/[A-Za-z]{2}/.test(t)) return false;
+  // Code, not prose: the JSX-text rule cannot tell `a > 0 && b <` from a
+  // rendered string, and an operator in the middle settles it.
+  if (/&&|\|\||===|!==|=>/.test(t)) return false;
   // Identifiers and paths — `data-menu-row`, `src/renderer`, `useTheme`.
   if (!/\s/.test(t) && /[/_.:]|[a-z][A-Z]/.test(t)) return false;
   return true;
@@ -67,7 +78,7 @@ for (const path of CHECKED) {
     const lines = readFileSync(file, 'utf8').split('\n');
     lines.forEach((line, i) => {
       if (line.includes('i18n-exempt') || COMMENT.test(line)) return;
-      for (const re of [PROSE_ATTRS, JSX_TEXT]) {
+      for (const re of [PROSE_ATTRS, PROSE_PROPS, JSX_TEXT]) {
         re.lastIndex = 0;
         let m;
         while ((m = re.exec(line))) {

--- a/packages/app/src/main/__tests__/locale.test.ts
+++ b/packages/app/src/main/__tests__/locale.test.ts
@@ -1,0 +1,67 @@
+/* The mirror file is the only thing the main process knows about the language
+   (TRA-386): localStorage lives in the renderer, and the application menu is
+   built before any window exists. If this file is misread, the whole menu bar
+   and the tray come up in the wrong language on every cold launch.
+
+   Shape and cases follow appearance.test.ts — same failure mode, same rules. */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { Locale } from '../../shared/i18n/locales.js';
+import { t } from '../i18n';
+import { readLocale, writeLocale } from '../locale';
+
+const dirs: string[] = [];
+function tmp(): string {
+  const d = mkdtempSync(path.join(tmpdir(), 'trace-mcp-locale-'));
+  dirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe('locale persistence', () => {
+  it('round-trips every language the app ships', () => {
+    const dir = tmp();
+    for (const l of ['en', 'ru'] as Locale[]) {
+      writeLocale(dir, l);
+      expect(readLocale(dir)).toBe(l);
+    }
+  });
+
+  it('reads English when nothing was ever written', () => {
+    expect(readLocale(tmp())).toBe('en');
+  });
+
+  /* A hand-edited file, or a language dropped from LOCALES in a later release,
+     must not leave the menu bar reading raw keys. */
+  it('reads English from a file naming a language we do not ship', () => {
+    const dir = tmp();
+    writeFileSync(path.join(dir, 'locale'), 'kl', 'utf8');
+    expect(readLocale(dir)).toBe('en');
+  });
+
+  it('tolerates trailing whitespace', () => {
+    const dir = tmp();
+    writeFileSync(path.join(dir, 'locale'), 'ru\n', 'utf8');
+    expect(readLocale(dir)).toBe('ru');
+  });
+
+  it('never throws on an unwritable directory', () => {
+    expect(() => writeLocale('/dev/null/nope', 'ru')).not.toThrow();
+  });
+});
+
+describe('main-process i18n', () => {
+  /* The main process has no react-i18next and no components; a namespaced key
+     resolving to itself is what a broken catalogue registration looks like. */
+  it('resolves the namespaces the menu and the tray read', () => {
+    expect(t('menu:file')).toBe('File');
+    expect(t('tray:daemonRunning')).toBe('Daemon running');
+  });
+});

--- a/packages/app/src/main/__tests__/menu.test.ts
+++ b/packages/app/src/main/__tests__/menu.test.ts
@@ -47,9 +47,10 @@ vi.mock('electron', () => ({
   shell: { openExternal: vi.fn() },
 }));
 
-vi.mock('../tray', () => ({ showMenuWindow: vi.fn() }));
+vi.mock('../tray', () => ({ showMenuWindow: vi.fn(), refreshTrayMenu: vi.fn() }));
 
 import { GLOBAL_ACTIONS } from '../../shared/global-actions.js';
+import { startI18n, t } from '../i18n';
 import { buildAppMenu, forgetWindowSections, setWindowSections } from '../menu';
 
 function menu(label: string): Item[] {
@@ -107,7 +108,7 @@ describe('application menu', () => {
   it('carries every shared global action, by the shared label', () => {
     const labels = template.flatMap((top) => (top.submenu ?? []).map((i) => i.label));
     for (const action of GLOBAL_ACTIONS) {
-      expect(labels).toContain(action.label);
+      expect(labels).toContain(t(action.labelKey));
     }
   });
 
@@ -183,6 +184,23 @@ describe('application menu', () => {
     } finally {
       if (platform) Object.defineProperty(process, 'platform', platform);
       vi.resetModules();
+    }
+  });
+
+  /* TRA-386: `Menu.setApplicationMenu` replaces the menu wholesale, so a
+     language change has to rebuild every label — a bar half in Russian is the
+     failure this pins. */
+  it('rebuilds every top-level title in the active language', () => {
+    startI18n('ru');
+    try {
+      buildAppMenu();
+      const titles = template.map((m) => m.label);
+      expect(titles).toContain('Файл');
+      expect(titles).toContain('Справка');
+      expect(menu('Правка').map((i) => i.label ?? i.role)).toContain('Найти');
+    } finally {
+      startI18n('en');
+      buildAppMenu();
     }
   });
 

--- a/packages/app/src/main/i18n.ts
+++ b/packages/app/src/main/i18n.ts
@@ -1,0 +1,49 @@
+/* i18n for the main process (TRA-386).
+
+   i18next's core is framework-agnostic — react-i18next is a separate package we
+   simply do not import here — and it is a runtime `dependency`, not a dev one,
+   so it survives electron-builder packaging into the app bundle.
+
+   `createInstance()` rather than the default export: the renderer has its own
+   instance in another process entirely, and keeping them separate means a test
+   that loads both modules in one vitest worker does not have them fight over a
+   single global language. */
+
+import i18next, { type i18n as I18n } from 'i18next';
+
+import { CATALOGS, NAMESPACES } from '../shared/i18n/catalog/index.js';
+import { DEFAULT_LOCALE, isLocale, type Locale } from '../shared/i18n/locales.js';
+
+const instance: I18n = i18next.createInstance();
+let started = false;
+
+/** Idempotent: tests import this per file and must not re-init. */
+export function startI18n(locale: Locale = DEFAULT_LOCALE): void {
+  if (!started) {
+    started = true;
+    void instance.init({
+      lng: locale,
+      fallbackLng: DEFAULT_LOCALE,
+      resources: CATALOGS,
+      ns: NAMESPACES as string[],
+      defaultNS: 'common',
+      interpolation: { escapeValue: false },
+      returnNull: false,
+      initImmediate: false,
+    });
+  } else if (instance.language !== locale) {
+    void instance.changeLanguage(locale);
+  }
+}
+
+/** Namespaced key — `t('menu:file')`. There are no React components here, so
+    there is no `useTranslation` and every caller reads the current language at
+    the moment it builds a menu. */
+export function t(key: string, options?: Record<string, unknown>): string {
+  if (!started) startI18n();
+  return instance.t(key, options) as string;
+}
+
+export function currentLocale(): Locale {
+  return isLocale(instance.language) ? instance.language : DEFAULT_LOCALE;
+}

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -3,6 +3,7 @@ import { execFile, spawn } from 'child_process';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
+import { t } from './i18n';
 import { registerAppMenu } from './menu';
 import { createTray, restoreAppearance, showMenuWindow } from './tray';
 import {
@@ -42,7 +43,7 @@ const dockIconPath = path.join(__dirname, '..', '..', 'build', 'icon.png');
 ipcMain.handle('select-folder', async () => {
   const result = await dialog.showOpenDialog({
     properties: ['openDirectory', 'createDirectory'],
-    title: 'Select project root',
+    title: t('menu:selectProjectRoot'),
   });
   if (result.canceled || result.filePaths.length === 0) return null;
   return result.filePaths[0];

--- a/packages/app/src/main/locale.ts
+++ b/packages/app/src/main/locale.ts
@@ -1,0 +1,37 @@
+/* Language → the native layer (TRA-386).
+
+   Same problem appearance.ts solves, same solution: the choice lives in the
+   renderer's localStorage, which the main process cannot read, so it is
+   mirrored to a one-line file in userData. That is what makes the FIRST
+   application menu of a cold launch already be in the user's language instead
+   of flashing English until a window reports in — and `Menu.setApplicationMenu`
+   replaces the menu wholesale, so "fix it later" means rebuilding all of it.
+
+   No `electron` import on purpose: the caller passes the userData directory, so
+   this stays testable without a display. */
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { DEFAULT_LOCALE, isLocale, type Locale } from '../shared/i18n/locales.js';
+
+const LOCALE_FILE = 'locale';
+
+export function readLocale(userDataDir: string): Locale {
+  try {
+    const raw = readFileSync(path.join(userDataDir, LOCALE_FILE), 'utf8').trim();
+    return isLocale(raw) ? raw : DEFAULT_LOCALE;
+  } catch {
+    return DEFAULT_LOCALE;
+  }
+}
+
+export function writeLocale(userDataDir: string, locale: Locale): void {
+  try {
+    mkdirSync(userDataDir, { recursive: true });
+    writeFileSync(path.join(userDataDir, LOCALE_FILE), locale, 'utf8');
+  } catch {
+    // An unwritable userData dir costs one cold launch in the wrong language.
+    // Never worth failing a language switch over.
+  }
+}

--- a/packages/app/src/main/menu.ts
+++ b/packages/app/src/main/menu.ts
@@ -27,7 +27,10 @@ import {
   type MenuItemConstructorOptions,
 } from 'electron';
 import { type GlobalActionId, globalAction } from '../shared/global-actions.js';
-import { showMenuWindow } from './tray';
+import { isLocale } from '../shared/i18n/locales.js';
+import { startI18n, t } from './i18n';
+import { readLocale, writeLocale } from './locale';
+import { refreshTrayMenu, showMenuWindow } from './tray';
 
 const isMac = process.platform === 'darwin';
 
@@ -74,8 +77,12 @@ function actionItem(id: GlobalActionId): MenuItemConstructorOptions {
   const action = globalAction(id);
   const url = action.url;
   return url
-    ? { label: action.label, click: () => void shell.openExternal(url) }
-    : { label: action.label, accelerator: action.accelerator, click: () => send(action.id) };
+    ? { label: t(action.labelKey), click: () => void shell.openExternal(url) }
+    : {
+        label: t(action.labelKey),
+        accelerator: action.accelerator,
+        click: () => send(action.id),
+      };
 }
 
 function sectionItems(): MenuItemConstructorOptions[] {
@@ -117,16 +124,24 @@ export function buildAppMenu(): Menu {
      all — they go to the bottom of File, which is where Windows and Linux users
      look for them anyway. Ctrl+, still works; the accelerator is the same. */
   const fileMenu: MenuItemConstructorOptions = {
-    label: 'File',
+    label: t('menu:file'),
     submenu: [
       // The menu window IS this app's main window: ⌘N creates it when it has
       // been closed, and brings it forward when it hasn't.
-      { label: 'New window', accelerator: 'CmdOrCtrl+N', click: () => showMenuWindow() },
-      { label: 'Open project…', accelerator: 'CmdOrCtrl+O', click: () => send('open-project') },
-      { label: 'Quick open…', accelerator: 'CmdOrCtrl+Shift+O', click: () => send('quick-open') },
+      { label: t('menu:newWindow'), accelerator: 'CmdOrCtrl+N', click: () => showMenuWindow() },
+      {
+        label: t('menu:openProject'),
+        accelerator: 'CmdOrCtrl+O',
+        click: () => send('open-project'),
+      },
+      {
+        label: t('menu:quickOpen'),
+        accelerator: 'CmdOrCtrl+Shift+O',
+        click: () => send('quick-open'),
+      },
       { type: 'separator' },
-      { label: 'Close tab', accelerator: 'CmdOrCtrl+W', role: 'close' },
-      { label: 'Close window', accelerator: 'CmdOrCtrl+Shift+W', click: closeWindowGroup },
+      { label: t('menu:closeTab'), accelerator: 'CmdOrCtrl+W', role: 'close' },
+      { label: t('menu:closeWindow'), accelerator: 'CmdOrCtrl+Shift+W', click: closeWindowGroup },
       ...(isMac
         ? []
         : ([
@@ -141,7 +156,7 @@ export function buildAppMenu(): Menu {
   // Plain roles, so undo/redo/cut/copy/paste keep working inside every text
   // field — that is what they are here for, not decoration.
   const editMenu: MenuItemConstructorOptions = {
-    label: 'Edit',
+    label: t('menu:edit'),
     submenu: [
       { role: 'undo' },
       { role: 'redo' },
@@ -151,15 +166,15 @@ export function buildAppMenu(): Menu {
       { role: 'paste' },
       { role: 'selectAll' },
       { type: 'separator' },
-      { label: 'Find', accelerator: 'CmdOrCtrl+F', click: () => send('find') },
+      { label: t('menu:find'), accelerator: 'CmdOrCtrl+F', click: () => send('find') },
     ],
   };
 
   const viewMenu: MenuItemConstructorOptions = {
-    label: 'View',
+    label: t('menu:view'),
     submenu: [
       {
-        label: 'Toggle sidebar',
+        label: t('menu:toggleSidebar'),
         accelerator: 'CmdOrCtrl+Alt+S',
         click: () => send('toggle-sidebar'),
       },
@@ -167,7 +182,7 @@ export function buildAppMenu(): Menu {
         ? ([{ type: 'separator' }, ...sections] as MenuItemConstructorOptions[])
         : []),
       { type: 'separator' },
-      { label: 'Reload', accelerator: 'CmdOrCtrl+R', role: 'reload' },
+      { label: t('menu:reload'), accelerator: 'CmdOrCtrl+R', role: 'reload' },
       { type: 'separator' },
       { role: 'resetZoom' },
       { role: 'zoomIn' },
@@ -178,7 +193,7 @@ export function buildAppMenu(): Menu {
   };
 
   const windowMenu: MenuItemConstructorOptions = {
-    label: 'Window',
+    label: t('menu:window'),
     role: 'window',
     submenu: [
       { role: 'minimize' },
@@ -198,14 +213,17 @@ export function buildAppMenu(): Menu {
   };
 
   // Plain label, no `role: 'help'`: AppKit recognises a menu titled "Help" and
-  // adds the system Help search to it itself.
+  // adds the system Help search to it itself. It matches on the localised title
+  // from the app's own bundle, which an Electron app does not have — so in
+  // Russian the system search item drops out. A translated menu bar is worth
+  // more than a search field over documentation we do not ship as Apple Help.
   const helpMenu: MenuItemConstructorOptions = {
-    label: 'Help',
+    label: t('menu:help'),
     submenu: [
       // "Documentation", not the old "trace-mcp help": next to the shared
       // "Get help" item, two things called help and pointing at different
       // pages is a coin toss.
-      { label: 'Documentation', click: () => void shell.openExternal(DOCS_URL) },
+      { label: t('menu:documentation'), click: () => void shell.openExternal(DOCS_URL) },
       actionItem('get-help'),
       actionItem('view-changelog'),
       // On macOS these live in the app menu; elsewhere Help is where they go.
@@ -233,14 +251,33 @@ export function installAppMenu(): void {
   Menu.setApplicationMenu(buildAppMenu());
 }
 
-/** Call once from whenReady. Rebuilds on focus so ⌘1…⌘9 always name the
-    sections of the window the user is actually looking at. */
+/** Call once from whenReady, before the first window. Rebuilds on focus so
+    ⌘1…⌘9 always name the sections of the window the user is actually looking
+    at, and on a language change because `Menu.setApplicationMenu` replaces the
+    menu wholesale — there is no per-item relabel to reach for. */
 export function registerAppMenu(): void {
+  // The language the renderer chose last run, mirrored to userData because
+  // localStorage is not readable from here (locale.ts). Before the first
+  // build, so the cold-launch menu is already in it.
+  startI18n(readLocale(app.getPath('userData')));
+
   ipcMain.on('window-sections', (event, sections: WindowSection[]) => {
     if (!Array.isArray(sections)) return;
     setWindowSections(event.sender.id, sections);
     event.sender.once('destroyed', () => forgetWindowSections(event.sender.id));
   });
+
+  /* The renderer's language choice, mirroring `set-appearance`. Handled here
+     rather than in tray.ts so the redraw can reach both surfaces: tray.ts is
+     imported BY this file, and the reverse import would close a cycle. */
+  ipcMain.on('set-locale', (_event, value: unknown) => {
+    if (!isLocale(value)) return;
+    writeLocale(app.getPath('userData'), value);
+    startI18n(value);
+    installAppMenu();
+    refreshTrayMenu();
+  });
+
   installAppMenu();
   app.on('browser-window-focus', () => installAppMenu());
 }

--- a/packages/app/src/main/preload.ts
+++ b/packages/app/src/main/preload.ts
@@ -62,6 +62,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   setAppearance: (appearance: 'auto' | 'light' | 'dark'): void => {
     ipcRenderer.send('set-appearance', appearance);
   },
+  /** Mirror the renderer's language choice into the main process, which draws
+      the application menu and the tray and cannot read localStorage. */
+  setLocale: (locale: string): void => {
+    ipcRenderer.send('set-locale', locale);
+  },
   syncSidebarWidth: (width: number): void => {
     ipcRenderer.send('sync-sidebar-width', width);
   },

--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -10,6 +10,7 @@ import {
   writeAppearance,
 } from './appearance';
 import { ensureDaemon, restartDaemon } from './daemon-lifecycle';
+import { t } from './i18n';
 
 const isMac = process.platform === 'darwin';
 
@@ -208,7 +209,7 @@ function getTabList(focusedWebContentsId?: number): TabInfo[] {
   if (menuWindow && !menuWindow.isDestroyed()) {
     tabs.push({
       id: 'menu',
-      title: 'Menu',
+      title: t('tray:menuWindow'),
       type: 'menu',
       active: menuWindow.webContents.id === focusedWebContentsId,
     });
@@ -311,7 +312,7 @@ export function showMenuWindow(tab?: string): void {
   }
 
   menuWindow.webContents.on('did-finish-load', () => {
-    menuWindow?.setTitle('Menu');
+    menuWindow?.setTitle(t('tray:menuWindow'));
   });
 
   menuWindow.once('ready-to-show', () => {
@@ -482,18 +483,18 @@ function createDotIcon(hex: string, glow: boolean): Electron.NativeImage {
 }
 
 function buildContextMenu(): Menu {
-  const statusLabel = daemonReachable ? 'Daemon running' : 'Daemon stopped';
+  const statusLabel = daemonReachable ? t('tray:daemonRunning') : t('tray:daemonStopped');
   const dotIcon = createDotIcon(daemonReachable ? '#34c759' : '#8e8e93', daemonReachable);
 
   return Menu.buildFromTemplate([
     { label: statusLabel, enabled: false, icon: dotIcon },
     { type: 'separator' },
-    { label: 'Workspace', click: () => showWindow('workspace') },
-    { label: 'MCP Clients', click: () => showWindow('clients') },
-    { label: 'Settings', click: () => showWindow('settings') },
+    { label: t('tray:workspace'), click: () => showWindow('workspace') },
+    { label: t('tray:clients'), click: () => showWindow('clients') },
+    { label: t('tray:settings'), click: () => showWindow('settings') },
     { type: 'separator' },
     {
-      label: 'Quit trace-mcp',
+      label: t('tray:quit'),
       click: () => {
         cleanup();
         app.quit();
@@ -509,7 +510,18 @@ function setTrayIcon(reachable: boolean): void {
     img.setTemplateImage(true);
   }
   tray.setImage(img);
-  tray.setToolTip(reachable ? 'trace-mcp — running' : 'trace-mcp — daemon unreachable');
+  tray.setToolTip(reachable ? t('tray:tooltipRunning') : t('tray:tooltipStopped'));
+}
+
+/** Redraw everything the tray shows in words, after a language change. The IPC
+    that triggers it lives in menu.ts — this file is imported BY that one, and
+    importing back would close a cycle. No-op before `createTray`. */
+export function refreshTrayMenu(): void {
+  if (!tray || tray.isDestroyed()) return;
+  setTrayIcon(daemonReachable);
+  tray.setContextMenu(buildContextMenu());
+  if (menuWindow && !menuWindow.isDestroyed()) menuWindow.setTitle(t('tray:menuWindow'));
+  broadcastTabList();
 }
 
 function shouldAttemptRestart(failureTick: number): boolean {

--- a/packages/app/src/renderer/components/AppMenu.tsx
+++ b/packages/app/src/renderer/components/AppMenu.tsx
@@ -17,6 +17,7 @@
    Appearance is not in that list: it is a preference with three states, it also
    lives in Settings, and it exists on no other surface to drift against. */
 
+import { useTranslation } from 'react-i18next';
 import { Icon } from '../lattice/icons';
 import { Menu, MenuChoiceRow, MenuItem, MenuSeparator, useMenuAnchor } from '../lattice/ui';
 import { GLOBAL_ACTIONS, type GlobalAction } from '../../shared/global-actions.js';
@@ -70,6 +71,9 @@ export function AppMenu({
   onSettings,
 }: AppMenuProps) {
   const menu = useMenuAnchor();
+  // Unnamespaced: the shared action list carries fully-qualified keys, because
+  // the native menu resolves the same ones in the main process.
+  const { t } = useTranslation();
   const open = menu.at !== null;
   const summary = updateSummary(update, checking);
 
@@ -107,7 +111,7 @@ export function AppMenu({
       disabled={action.id === 'check-for-update' && checking}
       onClick={runAction(action)}
     >
-      {action.label}
+      {t(action.labelKey)}
     </MenuItem>
   );
 

--- a/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
@@ -12,6 +12,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { GLOBAL_ACTIONS } from '../../../shared/global-actions.js';
+import { t } from '../../i18n';
 import type { UpdateState } from '../../update-check.js';
 import { AppMenu, type AppMenuProps } from '../AppMenu';
 
@@ -72,7 +73,7 @@ describe('sidebar app menu', () => {
     const { trigger } = renderMenu();
     const menu = openMenu(trigger);
     for (const action of GLOBAL_ACTIONS) {
-      const item = within(menu).getByRole('menuitem', { name: new RegExp(action.label) });
+      const item = within(menu).getByRole('menuitem', { name: new RegExp(t(action.labelKey)) });
       if (action.shortcut) expect(item.textContent).toContain(action.shortcut);
     }
   });

--- a/packages/app/src/renderer/electron.d.ts
+++ b/packages/app/src/renderer/electron.d.ts
@@ -37,6 +37,7 @@ declare global {
       onFullscreenChanged: (callback: (isFullscreen: boolean) => void) => () => void;
       onTabBarChanged: (callback: (visible: boolean) => void) => () => void;
       setAppearance: (appearance: 'auto' | 'light' | 'dark') => void;
+      setLocale: (locale: string) => void;
       syncSidebarWidth: (width: number) => void;
       onSidebarWidthChanged: (callback: (width: number) => void) => () => void;
       checkForUpdate: () => Promise<{

--- a/packages/app/src/renderer/i18n/index.ts
+++ b/packages/app/src/renderer/i18n/index.ts
@@ -71,6 +71,9 @@ export function setLocale(next: Locale): void {
   }
   void i18next.changeLanguage(next);
   applyLocale(next);
+  // The native menu and the tray are drawn by the main process, which cannot
+  // read localStorage — same mirror `setAppearance` uses for the theme.
+  window.electronAPI?.setLocale?.(next);
 }
 
 /** Current language plus the setter, and a re-render when either window changes it. */

--- a/packages/app/src/shared/global-actions.ts
+++ b/packages/app/src/shared/global-actions.ts
@@ -26,7 +26,10 @@ export type GlobalActionId = 'settings' | 'check-for-update' | 'view-changelog' 
 export interface GlobalAction {
   /** Also the `app-command` name the native menu sends to the focused window. */
   id: GlobalActionId;
-  label: string;
+  /** Catalogue key, not a string: this list is read by the native menu in the
+      main process and by the in-app menu in the renderer, and each has its own
+      i18next instance to resolve it with. */
+  labelKey: string;
   /** Electron accelerator for the application menu. */
   accelerator?: string;
   /** The same key drawn as a macOS glyph, for the in-app menu's hint column. */
@@ -41,7 +44,7 @@ export interface GlobalAction {
 export const GLOBAL_ACTIONS: readonly GlobalAction[] = [
   {
     id: 'settings',
-    label: 'Settings…',
+    labelKey: 'menu:settings',
     accelerator: 'CmdOrCtrl+,',
     shortcut: '⌘,',
     icon: 'settings',
@@ -52,7 +55,7 @@ export const GLOBAL_ACTIONS: readonly GlobalAction[] = [
      — not sparkles, and not the plain page that replaced them (TRA-376). */
   {
     id: 'view-changelog',
-    label: 'View changelog',
+    labelKey: 'menu:viewChangelog',
     url: 'https://github.com/nikolai-vysotskyi/trace-mcp/releases',
     icon: 'scroll',
   },
@@ -60,13 +63,13 @@ export const GLOBAL_ACTIONS: readonly GlobalAction[] = [
      speech bubble would promise a person on the other end. */
   {
     id: 'get-help',
-    label: 'Get help',
+    labelKey: 'menu:getHelp',
     url: 'https://github.com/nikolai-vysotskyi/trace-mcp/issues',
     icon: 'help',
   },
   {
     id: 'check-for-update',
-    label: 'Check for updates…',
+    labelKey: 'menu:checkForUpdate',
     icon: 'refresh',
   },
 ];

--- a/packages/app/src/shared/i18n/catalog/en/index.ts
+++ b/packages/app/src/shared/i18n/catalog/en/index.ts
@@ -3,9 +3,11 @@
    slices running at once do not both rewrite the same catalogue file. */
 
 import { common } from './common.js';
+import { menu } from './menu.js';
+import { tray } from './tray.js';
 import { update } from './update.js';
 
-export const en = { common, update };
+export const en = { common, menu, tray, update };
 
 /** The source language's shape. Other catalogues are checked against it by
     catalog-parity.test.ts, not by the type system: plural forms differ per

--- a/packages/app/src/shared/i18n/catalog/en/menu.ts
+++ b/packages/app/src/shared/i18n/catalog/en/menu.ts
@@ -1,0 +1,37 @@
+/* The native application menu (main/menu.ts) and the four shared global actions
+   the in-app menu draws from the same list. Wording is unchanged from those two
+   files — this namespace moved the strings, it did not rewrite them.
+
+   Standard macOS items (About, Services, Hide, Quit, the Edit roles, the zoom
+   and window roles) are NOT here on purpose: Electron takes those labels from
+   the OS, already in the system language. Hand-translating a role's label is
+   how an app ends up with a Russian "Скрыть" next to an English "Services".
+
+   `selectProjectRoot` is the folder picker File ▸ Open project… opens — it is
+   this menu's dialog, so it lives with the item that raises it. */
+
+export const menu = {
+  file: 'File',
+  newWindow: 'New window',
+  openProject: 'Open project…',
+  quickOpen: 'Quick open…',
+  closeTab: 'Close tab',
+  closeWindow: 'Close window',
+  edit: 'Edit',
+  find: 'Find',
+  view: 'View',
+  toggleSidebar: 'Toggle sidebar',
+  reload: 'Reload',
+  window: 'Window',
+  help: 'Help',
+  documentation: 'Documentation',
+  selectProjectRoot: 'Select project root',
+
+  // The shared global actions (src/shared/global-actions.ts). Both the native
+  // menu and the sidebar's app menu render these, which is why the list holds a
+  // key rather than a string.
+  settings: 'Settings…',
+  viewChangelog: 'View changelog',
+  getHelp: 'Get help',
+  checkForUpdate: 'Check for updates…',
+} as const;

--- a/packages/app/src/shared/i18n/catalog/en/tray.ts
+++ b/packages/app/src/shared/i18n/catalog/en/tray.ts
@@ -1,0 +1,18 @@
+/* The tray: its context menu, its tooltip, and the title the menu window and
+   its tab carry. Wording is unchanged from main/tray.ts.
+
+   "trace-mcp" is the product's name and stays in Latin in every language — a
+   translated brand is a brand nobody can search for. */
+
+export const tray = {
+  daemonRunning: 'Daemon running',
+  daemonStopped: 'Daemon stopped',
+  workspace: 'Workspace',
+  clients: 'MCP Clients',
+  settings: 'Settings',
+  quit: 'Quit trace-mcp',
+  tooltipRunning: 'trace-mcp — running',
+  tooltipStopped: 'trace-mcp — daemon unreachable',
+  /** Window and tab title of the menu window. */
+  menuWindow: 'Menu',
+} as const;

--- a/packages/app/src/shared/i18n/catalog/ru/index.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/index.ts
@@ -1,4 +1,6 @@
 import { common } from './common.js';
+import { menu } from './menu.js';
+import { tray } from './tray.js';
 import { update } from './update.js';
 
-export const ru = { common, update };
+export const ru = { common, menu, tray, update };

--- a/packages/app/src/shared/i18n/catalog/ru/menu.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/menu.ts
@@ -1,0 +1,26 @@
+/* Menu titles follow the Russian macOS convention: «Файл», «Правка», «Вид»,
+   «Окно», «Справка» — the same words the system's own menus use, so the app's
+   bar reads as one bar and not as a translation sitting next to the OS. */
+
+export const menu = {
+  file: 'Файл',
+  newWindow: 'Новое окно',
+  openProject: 'Открыть проект…',
+  quickOpen: 'Быстрое открытие…',
+  closeTab: 'Закрыть вкладку',
+  closeWindow: 'Закрыть окно',
+  edit: 'Правка',
+  find: 'Найти',
+  view: 'Вид',
+  toggleSidebar: 'Скрыть или показать боковую панель',
+  reload: 'Обновить',
+  window: 'Окно',
+  help: 'Справка',
+  documentation: 'Документация',
+  selectProjectRoot: 'Выберите папку проекта',
+
+  settings: 'Настройки…',
+  viewChangelog: 'Список изменений',
+  getHelp: 'Получить помощь',
+  checkForUpdate: 'Проверить обновления…',
+} as const;

--- a/packages/app/src/shared/i18n/catalog/ru/tray.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/tray.ts
@@ -1,0 +1,15 @@
+/* «Служба» for the daemon: it is the word Russian users of a menu-bar app
+   expect for a background process, and "демон" reads as a transliteration
+   rather than as something you can start and stop. */
+
+export const tray = {
+  daemonRunning: 'Служба работает',
+  daemonStopped: 'Служба остановлена',
+  workspace: 'Рабочая область',
+  clients: 'Клиенты MCP',
+  settings: 'Настройки',
+  quit: 'Завершить trace-mcp',
+  tooltipRunning: 'trace-mcp — работает',
+  tooltipStopped: 'trace-mcp — служба недоступна',
+  menuWindow: 'Меню',
+} as const;

--- a/packages/app/src/shared/i18n/locales.ts
+++ b/packages/app/src/shared/i18n/locales.ts
@@ -23,8 +23,8 @@ export type Locale = 'en' | 'ru';
 export const DEFAULT_LOCALE: Locale = 'en';
 
 export const LOCALES: readonly LocaleInfo[] = [
-  { code: 'en', label: 'English', short: 'EN' },
-  { code: 'ru', label: 'Русский', short: 'RU' },
+  { code: 'en', label: 'English', short: 'EN' }, // i18n-exempt — see LocaleInfo.label
+  { code: 'ru', label: 'Русский', short: 'RU' }, // i18n-exempt
 ];
 
 /** Same shape as THEME_KEY: one localStorage key, absent means "not chosen". */


### PR DESCRIPTION
Slice 4 of TRA-379 (TRA-386), and the only one outside the renderer.

Builds on #535 (the i18n runtime), which merged while this was in flight — rebased onto master, so the diff below is the slice only.

## What moved

- `main/menu.ts` — every label the app owns (`File`, `New window`, `Open project…`, `Find`, `Toggle sidebar`, `Documentation`, the menu titles) now reads `t('menu:…')`. Standard macOS items (About, Services, Hide, Quit, the Edit/zoom/window roles) stay on their Electron `role`: the OS already supplies those labels in the system language, and hand-translating one is how a menu bar ends up half in each.
- `main/tray.ts` — status line, context menu, tooltip, and the menu window's title/tab title.
- `main/index.ts` — the folder picker's `Select project root`, the one dialog string under `src/main/`.
- `shared/global-actions.ts` — `label: string` → `labelKey: string`. It is read by both processes, each with its own i18next instance, so the shared list can only hold a key. Both call sites updated (`main/menu.ts`, renderer `AppMenu.tsx`) and both anti-drift tests still assert the English wording, through `t()`.

Two new namespaces: `menu` and `tray`, en + ru.

## The part that is not extraction

The main process cannot read the renderer's `localStorage`. `main/locale.ts` mirrors the choice to a one-line file in `userData`, copying `main/appearance.ts` exactly (same shape, same best-effort write, no `electron` import so it is testable without a display). `main/i18n.ts` is a `createInstance()` i18next over the same `shared/i18n/catalog` — i18next core is framework-agnostic and already a runtime `dependency`, so it survives electron-builder packaging.

`registerAppMenu()` starts it from the file before the first build, so a cold launch opens with the menu already in the user's language. The renderer's `setLocale` sends `set-locale`; `menu.ts` owns the handler (not `tray.ts` — that file is imported *by* menu.ts and the reverse import would close a cycle) and redraws both surfaces, because `Menu.setApplicationMenu` replaces the menu wholesale.

## Also

`check-i18n.mjs` grew a rule: it only matched `label=` (JSX). A main-process menu is built from `label: 'File'` object properties, so an allowlisted `menu.ts` would have passed while reading every string inline. Added `PROSE_PROPS`, plus an operator guard that kills a pre-existing false positive on `a > 0 && b <`. `CHECKED` now lists this slice's paths.

Known trade-off, noted in the code: AppKit adds the system Help search to a menu titled "Help", matching the localised title from the app's own bundle — which an Electron app does not have. In Russian that search item drops out. A translated menu bar is worth more than a search field over documentation we do not ship as Apple Help.

## Test evidence

```
pnpm --filter trace-mcp-app run check:i18n   check-i18n: 6 extracted paths clean
pnpm --filter trace-mcp-app run typecheck    clean
pnpm --filter trace-mcp-app test             41 files, 403 tests passed
pnpm --filter trace-mcp-app run build        clean
biome ci                                     1618 files, no fixes
```

New: `main/__tests__/locale.test.ts` (round-trip, unknown language, corrupt file, unwritable dir, and the two namespaces resolving). `menu.test.ts` gained a test that every top-level title rebuilds in Russian.

Closes TRA-386.
