### PR TITLE
fix(docs): install surfaces advertised the 99% peak as the token average (TRA-393)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "trace-mcp",
   "version": "3.2.0",
   "mcpName": "io.github.nikolai-vysotskyi/trace-mcp",
-  "description": "Framework-aware code intelligence MCP server — 87 framework integrations, 80 languages, up to 99% token reduction",
+  "description": "Framework-aware code intelligence MCP server — 87 framework integrations, 80 languages, 40–50% fewer tokens on average",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -49,6 +49,13 @@
     "url": "https://github.com/nikolai-vysotskyi/trace-mcp"
   },
   "keywords": [
+    "mcp-server",
+    "claude-code",
+    "cursor",
+    "ai-agents",
+    "code-graph",
+    "dependency-graph",
+    "token-optimization",
     "mcp",
     "code-intelligence",
     "laravel",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.nikolai-vysotskyi/trace-mcp",
-  "description": "Framework-aware code intelligence: 80 languages, 87 frameworks, 169 tools, up to 99% fewer tokens",
+  "description": "Framework-aware code intelligence: 80 languages, 87 frameworks, 169 tools, 40–50% fewer tokens",
   "repository": {
     "url": "https://github.com/nikolai-vysotskyi/trace-mcp",
     "source": "github"

--- a/tests/plugin/manifest-sync.test.ts
+++ b/tests/plugin/manifest-sync.test.ts
@@ -121,7 +121,9 @@ describe('install-surface token claims stay honest', () => {
   for (const path of surfaces) {
     it(`${path} does not claim 9x% fewer tokens`, () => {
       const text = readFileSync(join(REPO_ROOT, ...path.split('/')), 'utf8');
-      const claim = text.match(/9\d\s*%[^"]{0,40}?token/i);
+      // Both orders — "99% fewer tokens" and "token usage by 99%" — and decimals.
+      const pct = String.raw`9\d(?:\.\d+)?\s*%`;
+      const claim = text.match(new RegExp(`${pct}[^"]{0,40}?token|token[^"]{0,40}?${pct}`, 'i'));
       expect(
         claim?.[0],
         `${path} advertises a peak token number as if it were the average. ` +

--- a/tests/plugin/manifest-sync.test.ts
+++ b/tests/plugin/manifest-sync.test.ts
@@ -81,6 +81,13 @@ describe('MCP registry manifest (server.json)', () => {
     expect(server.name).toBe(pkg.mcpName);
   });
 
+  it('description fits the registry schema limit (100 chars)', () => {
+    // TRA-393: the published schema caps ServerDetail.description at 100 —
+    // a longer string is rejected at publish time, not at build time, so the
+    // failure only shows up as a silently stale registry listing.
+    expect((server.description as string).length).toBeLessThanOrEqual(100);
+  });
+
   it('release-please is configured to bump both version fields', () => {
     const config = readJson('release-please-config.json') as {
       packages: Record<string, { 'extra-files': Array<{ path: string; jsonpath: string }> }>;
@@ -91,6 +98,37 @@ describe('MCP registry manifest (server.json)', () => {
     expect(paths).toContain('$.version');
     expect(paths).toContain('$.packages[0].version');
   });
+});
+
+/**
+ * TRA-393: the install surfaces (npm page, MCP registry, plugin marketplaces)
+ * are where people decide whether to try trace-mcp, and they were advertising
+ * "up to 99% token reduction" while README and the homepage say 40–50% on
+ * average and reserve 99% for *redundant processing* on structured calls.
+ * The strongest, least defensible version of the claim was on the surfaces
+ * with the least room to qualify it. Keep 99% attached to what it measures.
+ */
+describe('install-surface token claims stay honest', () => {
+  const surfaces = [
+    'package.json',
+    'server.json',
+    '.claude-plugin/plugin.json',
+    '.claude-plugin/marketplace.json',
+    '.codex-plugin/plugin.json',
+    '.codex-plugin/marketplace.json',
+  ];
+
+  for (const path of surfaces) {
+    it(`${path} does not claim 9x% fewer tokens`, () => {
+      const text = readFileSync(join(REPO_ROOT, ...path.split('/')), 'utf8');
+      const claim = text.match(/9\d\s*%[^"]{0,40}?token/i);
+      expect(
+        claim?.[0],
+        `${path} advertises a peak token number as if it were the average. ` +
+          'The average is 40–50%; 99% is "less redundant processing" on structured calls.',
+      ).toBeUndefined();
+    });
+  }
 });
 
 describe('Codex CLI plugin manifests', () => {


### PR DESCRIPTION
npm's package description and `server.json` (published to the MCP registry) both sold trace-mcp as **"up to 99% token reduction"**. README and the homepage say **40–50% on average**, and reserve 99% for *less redundant processing* on structured calls. The strongest, least defensible version of the claim was sitting on the two surfaces where people decide whether to install — and with the least room to qualify it.

Verified live: `registry.npmjs.org/trace-mcp` (3.2.0, published today) and the MCP registry entry both carry the 99% wording.

Changes:
- `package.json` / `server.json` descriptions → "40–50% fewer tokens (on average)".
- `package.json` keywords: added `mcp-server`, `claude-code`, `cursor`, `ai-agents`, `code-graph`, `dependency-graph`, `token-optimization` — npm search ranks on keywords and the old set (laravel/vue/nuxt/inertia) missed every term this product is actually searched by.
- `tests/plugin/manifest-sync.test.ts`: two guards — no install surface may attach a 9x% number to "token", and `server.json.description` must fit the registry schema's 100-char cap (the first draft of this fix was 105 chars, which would have been rejected at publish time and silently frozen the listing).

Tests: `manifest-sync` + `readme-claims` — 79 passed. Guard verified failing when the old wording is restored.

Agent: SEO Agent