### PR TITLE
fix(registry): stop persisting one-shot agent-run checkouts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,6 +100,7 @@ import {
   listProjects,
   pruneStaleProjects,
   resolveRegisteredAncestor,
+  sweepEphemeralDbs,
   updateLastIndexed,
 } from './registry.js';
 import { isKnownSubproject, resolveDeepestKnownRoot } from './subproject/resolve.js';
@@ -3088,6 +3089,12 @@ program
         // `prune` will always classify as live, so the registry grew one row —
         // and one permanently-reindexed project — per run, forever. Age since
         // registration is the signal; see ProjectManager.sweepEphemeralProjects.
+        //
+        // TRA-396: those rows only exist on registries written before one-shot
+        // workdirs stopped being persisted at all. Their *DBs* still need
+        // collecting, and so do the ones current runs leave behind — neither
+        // has a registry row to hang a sweep off, so sweepEphemeralDbs works
+        // straight off the index directory and mtime.
         const ephemeralSweep = async () => {
           try {
             const removed = await projectManager.sweepEphemeralProjects();
@@ -3099,6 +3106,17 @@ program
             }
           } catch (err) {
             logger.warn({ err }, 'sweepEphemeralProjects failed (non-fatal)');
+          }
+          try {
+            const removedDbs = sweepEphemeralDbs();
+            if (removedDbs.length > 0) {
+              logger.info(
+                { removedDbs },
+                `Deleted ${removedDbs.length} abandoned one-shot workdir index DB(s)`,
+              );
+            }
+          } catch (err) {
+            logger.warn({ err }, 'sweepEphemeralDbs failed (non-fatal)');
           }
         };
         await ephemeralSweep();

--- a/src/daemon/__tests__/project-manager-ephemeral-sweep.test.ts
+++ b/src/daemon/__tests__/project-manager-ephemeral-sweep.test.ts
@@ -6,6 +6,11 @@
  * because this very daemon keeps reindexing them. `sweepEphemeralProjects`
  * uses age since registration instead.
  *
+ * TRA-396: `registerProject` no longer persists such roots at all, so this
+ * sweep now only drains rows written by earlier versions — which is what the
+ * tests below construct directly. New checkouts are covered by
+ * `tests/registry.test.ts`.
+ *
  * Mocks IndexingPipeline + FileWatcher + createServer like
  * project-manager-last-indexed.test.ts so only the sweep wiring is under test.
  */
@@ -66,6 +71,31 @@ async function backdate(root: string, hours: number): Promise<void> {
   writeFileSync(REGISTRY_PATH, JSON.stringify(reg));
 }
 
+/**
+ * Write a one-shot workdir row straight into registry.json, `addedAt` already
+ * backdated. Since TRA-396 `registerProject` refuses to persist these, so this
+ * is the only way to reproduce what the sweep exists to drain: registries
+ * written by an earlier version.
+ */
+async function writeLegacyEphemeralRow(root: string, ageHours: number): Promise<void> {
+  const { ensureGlobalDirs, getDbPath, REGISTRY_PATH } = await import('../../global.js');
+  ensureGlobalDirs();
+  let reg: { version: number; projects: Record<string, unknown> };
+  try {
+    reg = JSON.parse(readFileSync(REGISTRY_PATH, 'utf-8'));
+  } catch {
+    reg = { version: 1, projects: {} };
+  }
+  reg.projects[root] = {
+    name: root.split('/').pop(),
+    root,
+    dbPath: getDbPath(root),
+    lastIndexed: null,
+    addedAt: new Date(Date.now() - ageHours * 60 * 60 * 1000).toISOString(),
+  };
+  writeFileSync(REGISTRY_PATH, JSON.stringify(reg));
+}
+
 beforeEach(() => {
   tmpHome = mkdtempSync(join(tmpdir(), 'trace-mcp-ephemeral-sweep-'));
   vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
@@ -90,11 +120,10 @@ afterEach(async () => {
 describe('ProjectManager.sweepEphemeralProjects (TRA-335)', () => {
   it('deregisters a one-shot workdir past the TTL even though its root still exists', async () => {
     const { ProjectManager } = await import('../project-manager.js');
-    const { listProjects, registerProject } = await import('../../registry.js');
+    const { listProjects } = await import('../../registry.js');
 
     const stale = makeEphemeralWorkdir('run-old');
-    registerProject(stale);
-    await backdate(stale, 96);
+    await writeLegacyEphemeralRow(stale, 96);
 
     const pm = new ProjectManager();
     pmRef = pm;
@@ -108,8 +137,7 @@ describe('ProjectManager.sweepEphemeralProjects (TRA-335)', () => {
     const { listProjects, registerProject } = await import('../../registry.js');
 
     const fresh = makeEphemeralWorkdir('run-new');
-    registerProject(fresh);
-    await backdate(fresh, 2);
+    await writeLegacyEphemeralRow(fresh, 2);
 
     const normal = join(tmpHome, 'real-project');
     mkdirSync(normal, { recursive: true });
@@ -129,11 +157,10 @@ describe('ProjectManager.sweepEphemeralProjects (TRA-335)', () => {
 
   it('skips a workdir that a run is still holding open', async () => {
     const { ProjectManager } = await import('../project-manager.js');
-    const { listProjects, registerProject } = await import('../../registry.js');
+    const { listProjects } = await import('../../registry.js');
 
     const busy = makeEphemeralWorkdir('run-busy');
-    registerProject(busy);
-    await backdate(busy, 96);
+    await writeLegacyEphemeralRow(busy, 96);
 
     const pm = new ProjectManager();
     pmRef = pm;

--- a/src/global.ts
+++ b/src/global.ts
@@ -38,6 +38,17 @@ export const GLOBAL_CONFIG_PATH = path.join(TRACE_MCP_HOME, '.config.json');
 /** Directory for per-project SQLite databases. */
 export const INDEX_DIR = path.join(TRACE_MCP_HOME, 'index');
 
+/**
+ * Index DBs for one-shot agent-run checkouts (TRA-396). Kept in their own
+ * subdirectory because those roots are never written to registry.json, so a
+ * registry-driven sweep can't reach their DBs and `prune` can only class them
+ * as `orphan_unregistered` — a category soft GC deliberately never deletes,
+ * since for a *normal* project it just means "not re-added yet". The
+ * directory is the marker that makes them safely collectable by age; see
+ * `sweepEphemeralDbs` in registry.ts.
+ */
+export const EPHEMERAL_INDEX_DIR = path.join(INDEX_DIR, 'ephemeral');
+
 /** Global project registry. */
 export const REGISTRY_PATH = path.join(TRACE_MCP_HOME, 'registry.json');
 
@@ -258,7 +269,7 @@ export const DEFAULT_CONFIG_JSONC = `{
 
 /** Ensure ~/.trace-mcp/ and ~/.trace-mcp/index/ exist. */
 export function ensureGlobalDirs(): void {
-  fs.mkdirSync(INDEX_DIR, { recursive: true });
+  fs.mkdirSync(EPHEMERAL_INDEX_DIR, { recursive: true }); // also creates INDEX_DIR
 
   // Restrict the data dir + index dir to 0700 so DB sidecars (WAL/SHM that
   // come and go with write activity) are protected by the parent ACL even
@@ -268,7 +279,7 @@ export function ensureGlobalDirs(): void {
   // global.ts under `node --experimental-strip-types` and can't resolve
   // `.js → .ts` imports of sibling modules.
   if (process.platform !== 'win32') {
-    for (const dir of [TRACE_MCP_HOME, INDEX_DIR]) {
+    for (const dir of [TRACE_MCP_HOME, INDEX_DIR, EPHEMERAL_INDEX_DIR]) {
       try {
         fs.chmodSync(dir, 0o700);
       } catch {
@@ -332,6 +343,17 @@ export function getSnapshotPath(projectRoot: string): string {
 export function getDbPath(projectRoot: string): string {
   const absRoot = path.resolve(projectRoot);
   return path.join(INDEX_DIR, `${projectName(absRoot)}-${projectHash(absRoot)}.db`);
+}
+
+/**
+ * Same as {@link getDbPath} but under {@link EPHEMERAL_INDEX_DIR}. Used for
+ * one-shot agent-run checkouts that couldn't share a canonical sibling's DB,
+ * so the leftover is collectable by age instead of sitting in the main index
+ * dir forever with no registry row to explain it (TRA-396).
+ */
+export function getEphemeralDbPath(projectRoot: string): string {
+  const absRoot = path.resolve(projectRoot);
+  return path.join(EPHEMERAL_INDEX_DIR, `${projectName(absRoot)}-${projectHash(absRoot)}.db`);
 }
 
 /**

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -7,12 +7,20 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {
   ensureGlobalDirs,
+  EPHEMERAL_INDEX_DIR,
   getDbPath,
+  getEphemeralDbPath,
   getProjectRemoteIdentity,
   projectName,
   REGISTRY_PATH,
 } from './global.js';
-import { announceDbHolder, hasLiveHolder, releaseDbHolder } from './db-holders.js';
+import {
+  announceDbHolder,
+  hasLiveHolder,
+  hasLiveHolderOrUnknown,
+  releaseDbHolder,
+  removeHoldersDir,
+} from './db-holders.js';
 import { initializeGuard } from './guard-init.js';
 import { atomicWriteJson } from './utils/atomic-write.js';
 import { readIfExists } from './utils/safe-fs.js';
@@ -87,6 +95,26 @@ function emptyRegistry(): Registry {
 const MTIME_GRANULARITY_MS = 50;
 let _registryCache: { mtimeMs: number; size: number; reg: Registry } | null = null;
 
+/**
+ * Registrations for one-shot agent-run checkouts — process-local, never
+ * written to registry.json (TRA-396).
+ *
+ * A Multica task workdir is queried for the lifetime of exactly one run and
+ * then abandoned *in place*: the runtime does not delete it, so every
+ * presence-based signal reads it as a live project forever. Persisting it
+ * enrols a dead checkout in every daemon start and every background reindex
+ * rotation from then on. One reported machine accumulated 77 of them —
+ * mostly checkouts of the same repo — which pinned the daemon at ~120% CPU
+ * and starved the desktop app's metrics call into a timeout.
+ *
+ * Keeping the entry here means the run that created the checkout still
+ * resolves its own project normally, and nothing outlives the process that
+ * registered it. Age-based eviction (`findEphemeralProjects` /
+ * `ProjectManager.sweepEphemeralProjects`) still exists for rows written by
+ * versions before this one.
+ */
+const _ephemeralEntries = new Map<string, RegistryEntry>();
+
 /** Keys that would reach `Object.prototype` if used as a `projects` map key. */
 const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'] as const;
 
@@ -154,16 +182,23 @@ export function registerProject(
   const absRoot = path.resolve(root);
   const reg = loadRegistry();
 
-  if (reg.projects[absRoot] && !opts) {
+  // TRA-396: a one-shot agent-run checkout is scratch — index it for this
+  // process, but keep it out of registry.json. `opts` only ever comes from an
+  // explicit multi-root `add`/`init`, which is a deliberate act and stays
+  // persistent even for a workdir-shaped path.
+  const ephemeral = !opts && isEphemeralProjectRoot(absRoot);
+
+  const existing = ephemeral ? _ephemeralEntries.get(absRoot) : reg.projects[absRoot];
+  if (existing && !opts) {
     // Already registered: the dbPath decision was made on a previous run, but
     // this process is about to open that DB, so re-announce the holder (TRA-304)
     // — that is what stops a *sibling* checkout from sharing it while we're up.
     try {
-      announceDbHolder(reg.projects[absRoot].dbPath, absRoot);
+      announceDbHolder(existing.dbPath, absRoot);
     } catch {
       /* best effort — an unannounced holder only costs isolation, not safety */
     }
-    return reg.projects[absRoot];
+    return existing;
   }
 
   // TRA-38: a fresh checkout of a repo that's already registered somewhere
@@ -186,8 +221,17 @@ export function registerProject(
   // re-evaluated per query, so "a sibling was live when we registered" is a
   // proxy for "concurrent", not a guarantee. It is a good proxy only because
   // registration happens at run start; don't read it as airtight.
+  //
+  // For an ephemeral root this is also the "same remote means same project"
+  // path (TRA-396 item 2): `listProjects()` no longer returns other ephemeral
+  // checkouts, so the only match a workdir can find is the canonical project,
+  // and twenty checkouts of one repo resolve to one index instead of twenty.
   const shareWithSibling = sibling ? claimSharedDb(sibling.dbPath, absRoot) : false;
-  const dbPath = shareWithSibling ? sibling!.dbPath : getDbPath(absRoot);
+  const dbPath = shareWithSibling
+    ? sibling!.dbPath
+    : ephemeral
+      ? getEphemeralDbPath(absRoot)
+      : getDbPath(absRoot);
   try {
     if (!shareWithSibling) announceDbHolder(dbPath, absRoot);
   } catch {
@@ -208,8 +252,12 @@ export function registerProject(
     ...(opts?.children && { children: opts.children }),
   };
 
-  reg.projects[absRoot] = entry;
-  saveRegistry(reg);
+  if (ephemeral) {
+    _ephemeralEntries.set(absRoot, entry);
+  } else {
+    reg.projects[absRoot] = entry;
+    saveRegistry(reg);
+  }
   // TRA-341: registration is where a project becomes real, so it is where the
   // guard's coach grace period is armed. Only on this path — an already
   // registered project returns above and is past its onboarding window.
@@ -279,7 +327,9 @@ export function resolveRegisteredAncestor(requestedRoot: string): RegistryEntry 
 
   let dir = absRequested;
   while (true) {
-    const direct = reg.projects[dir];
+    // Ephemeral roots live only in this process (TRA-396) but must still route
+    // their own subdirectory requests, e.g. `<workdir>/packages/app`.
+    const direct = reg.projects[dir] ?? _ephemeralEntries.get(dir);
     if (direct) return direct;
     const viaMultiRoot = childToParent.get(dir);
     if (viaMultiRoot) return viaMultiRoot;
@@ -292,13 +342,17 @@ export function resolveRegisteredAncestor(requestedRoot: string): RegistryEntry 
 
 export function unregisterProject(root: string): void {
   const absRoot = path.resolve(root);
+  _ephemeralEntries.delete(absRoot);
   const reg = loadRegistry();
+  if (!(absRoot in reg.projects)) return; // ephemeral, or already gone — nothing to rewrite
   delete reg.projects[absRoot];
   saveRegistry(reg);
 }
 
 export function getProject(root: string): RegistryEntry | null {
   const absRoot = path.resolve(root);
+  const ephemeral = _ephemeralEntries.get(absRoot);
+  if (ephemeral) return ephemeral;
   const reg = loadRegistry();
   return reg.projects[absRoot] ?? null;
 }
@@ -492,6 +546,15 @@ export function findUnregisteredNestedRepos(maxDepth = 4): UnregisteredNestedRep
 const EPHEMERAL_WORKDIR_PATTERN =
   /[/\\]multica_workspaces[^/\\]*[/\\][^/\\]+[/\\][^/\\]+[/\\]workdir$/i;
 
+/**
+ * True when `root` is a one-shot agent-run checkout (see
+ * {@link EPHEMERAL_WORKDIR_PATTERN}). Such roots are never persisted to
+ * registry.json — see the `_ephemeralEntries` note above.
+ */
+export function isEphemeralProjectRoot(root: string): boolean {
+  return EPHEMERAL_WORKDIR_PATTERN.test(path.resolve(root));
+}
+
 export interface EphemeralProjectCandidate {
   name: string;
   root: string;
@@ -505,6 +568,11 @@ export interface EphemeralProjectCandidate {
  * ever revisits these — the run that created them finished long ago — but
  * they stay registered forever, permanently reindexed alongside real
  * projects and holding onto their index DB on disk.
+ *
+ * Since TRA-396 `registerProject` no longer writes such roots at all, so this
+ * only ever finds rows left by an earlier version — which is exactly the
+ * backlog (77 on the reported machine) that has to drain before the daemon
+ * recovers. Keep it until those registries are realistically all swept.
  */
 export function findEphemeralProjects(minAgeHours = 24): EphemeralProjectCandidate[] {
   const now = Date.now();
@@ -594,6 +662,54 @@ export function sweepMissingRoots(graceDays = 7): MissingRootSweepResult {
 
   if (changed) saveRegistry(reg);
   return { removed, newlyMissing };
+}
+
+/**
+ * Delete index DBs under {@link EPHEMERAL_INDEX_DIR} whose run ended more than
+ * `maxAgeHours` ago, and return the base paths removed (TRA-396).
+ *
+ * This is the eviction path that does not depend on anyone deleting the
+ * checkout directory — the exact case the presence-based sweeps miss, since
+ * agent runtimes leave their workdirs on disk forever. mtime across the DB and
+ * its WAL/SHM sidecars is the clock (an active run keeps writing), and a live
+ * holder marker vetoes deletion, so this cannot pull a DB out from under a
+ * running agent.
+ */
+export function sweepEphemeralDbs(maxAgeHours = 24): string[] {
+  const cutoff = Date.now() - maxAgeHours * 60 * 60 * 1000;
+  const removed: string[] = [];
+  let files: string[];
+  try {
+    files = fs.readdirSync(EPHEMERAL_INDEX_DIR);
+  } catch {
+    return removed; // never created — no ephemeral checkout has run here
+  }
+
+  for (const file of files) {
+    if (!file.endsWith('.db')) continue;
+    const base = path.join(EPHEMERAL_INDEX_DIR, file);
+    let newestMtime = 0;
+    for (const suffix of MISSING_ROOT_SIDECARS) {
+      try {
+        newestMtime = Math.max(newestMtime, fs.statSync(base + suffix).mtimeMs);
+      } catch {
+        /* sidecar absent */
+      }
+    }
+    if (newestMtime === 0 || newestMtime >= cutoff) continue;
+    if (hasLiveHolderOrUnknown(base)) continue;
+
+    for (const suffix of MISSING_ROOT_SIDECARS) {
+      try {
+        fs.unlinkSync(base + suffix);
+      } catch {
+        /* absent sidecar or already gone — fine */
+      }
+    }
+    removeHoldersDir(base);
+    removed.push(base);
+  }
+  return removed;
 }
 
 export interface RegistryFileInspection {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -118,6 +118,11 @@ const _ephemeralEntries = new Map<string, RegistryEntry>();
 /** Keys that would reach `Object.prototype` if used as a `projects` map key. */
 const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'] as const;
 
+/** True when `key` would reach `Object.prototype` through a `projects[key]` write. */
+function isDangerousRegistryKey(key: string): boolean {
+  return (DANGEROUS_KEYS as readonly string[]).includes(key);
+}
+
 function loadRegistry(): Registry {
   // Stat and read through one descriptor: the metadata we key the cache on then
   // describes exactly the bytes we parsed, even if the file is replaced midway.
@@ -255,6 +260,13 @@ export function registerProject(
   if (ephemeral) {
     _ephemeralEntries.set(absRoot, entry);
   } else {
+    // `absRoot` is path.resolve() output, so a bare `__proto__` can't reach
+    // here — but this is the one write into the persisted map, and loadRegistry
+    // already drops these keys on the way in. Keep the barrier on both sides
+    // rather than only the read (CodeQL js/remote-property-injection).
+    if (isDangerousRegistryKey(absRoot)) {
+      throw new Error(`Refusing to register an unsafe project root: ${absRoot}`);
+    }
     reg.projects[absRoot] = entry;
     saveRegistry(reg);
   }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -118,11 +118,6 @@ const _ephemeralEntries = new Map<string, RegistryEntry>();
 /** Keys that would reach `Object.prototype` if used as a `projects` map key. */
 const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'] as const;
 
-/** True when `key` would reach `Object.prototype` through a `projects[key]` write. */
-function isDangerousRegistryKey(key: string): boolean {
-  return (DANGEROUS_KEYS as readonly string[]).includes(key);
-}
-
 function loadRegistry(): Registry {
   // Stat and read through one descriptor: the metadata we key the cache on then
   // describes exactly the bytes we parsed, even if the file is replaced midway.
@@ -257,19 +252,15 @@ export function registerProject(
     ...(opts?.children && { children: opts.children }),
   };
 
+  // TRA-396: process-local only — never written to registry.json.
   if (ephemeral) {
     _ephemeralEntries.set(absRoot, entry);
-  } else {
-    // `absRoot` is path.resolve() output, so a bare `__proto__` can't reach
-    // here — but this is the one write into the persisted map, and loadRegistry
-    // already drops these keys on the way in. Keep the barrier on both sides
-    // rather than only the read (CodeQL js/remote-property-injection).
-    if (isDangerousRegistryKey(absRoot)) {
-      throw new Error(`Refusing to register an unsafe project root: ${absRoot}`);
-    }
-    reg.projects[absRoot] = entry;
-    saveRegistry(reg);
+    initializeGuard(absRoot);
+    return entry;
   }
+
+  reg.projects[absRoot] = entry;
+  saveRegistry(reg);
   // TRA-341: registration is where a project becomes real, so it is where the
   // guard's coach grace period is armed. Only on this path — an already
   // registered project returns above and is past its onboarding window.

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -2,14 +2,18 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { ensureGlobalDirs, REGISTRY_PATH } from '../src/global.js';
+import { announceDbHolder } from '../src/db-holders.js';
+import { EPHEMERAL_INDEX_DIR, ensureGlobalDirs, REGISTRY_PATH } from '../src/global.js';
 import {
   findEphemeralProjects,
   findOverlapForNewRoot,
   findOverlappingProjects,
   findUnregisteredNestedRepos,
+  getProject,
+  listProjects,
   registerProject,
   resolveRegisteredAncestor,
+  sweepEphemeralDbs,
 } from '../src/registry.js';
 
 let savedRegistry: string | null = null;
@@ -44,6 +48,23 @@ function makeEphemeralWorkdir(): string {
   return dir;
 }
 
+/**
+ * Write a registry row for an ephemeral workdir the way versions before
+ * TRA-396 did. `registerProject` no longer persists these at all, but field
+ * registries are full of them and `findEphemeralProjects` is what drains them.
+ */
+function registerLegacyEphemeral(root: string, ageHours: number): void {
+  const reg = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
+  reg.projects[root] = {
+    name: path.basename(root),
+    root,
+    dbPath: path.join(os.tmpdir(), `${path.basename(root)}.db`),
+    lastIndexed: null,
+    addedAt: new Date(Date.now() - ageHours * 60 * 60 * 1000).toISOString(),
+  };
+  fs.writeFileSync(REGISTRY_PATH, JSON.stringify(reg, null, 2));
+}
+
 function setAddedAt(root: string, iso: string): void {
   const reg = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
   reg.projects[root].addedAt = iso;
@@ -57,8 +78,7 @@ describe('registry cache invalidation', () => {
   // reproduces that collision deterministically on every platform.
   it('does not serve a stale registry when a rewrite reuses the same mtime', () => {
     const workdir = makeEphemeralWorkdir();
-    registerProject(workdir);
-    setAddedAt(workdir, new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString());
+    registerLegacyEphemeral(workdir, 48);
     const sameTick = Math.floor(Date.now() / 1000) - 3600; // whole seconds: exact on every fs
     fs.utimesSync(REGISTRY_PATH, sameTick, sameTick);
     expect(findEphemeralProjects()).toHaveLength(1); // populates the cache
@@ -267,15 +287,14 @@ describe('findEphemeralProjects', () => {
 
   it('ignores a freshly-added ephemeral workdir (younger than minAgeHours)', () => {
     const workdir = makeEphemeralWorkdir();
-    registerProject(workdir);
+    registerLegacyEphemeral(workdir, 0);
 
     expect(findEphemeralProjects()).toEqual([]);
   });
 
   it('flags an ephemeral workdir older than the default 24h threshold', () => {
     const workdir = makeEphemeralWorkdir();
-    registerProject(workdir);
-    setAddedAt(workdir, new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString());
+    registerLegacyEphemeral(workdir, 48);
 
     const found = findEphemeralProjects();
     expect(found).toHaveLength(1);
@@ -285,10 +304,126 @@ describe('findEphemeralProjects', () => {
 
   it('respects a custom minAgeHours threshold', () => {
     const workdir = makeEphemeralWorkdir();
-    registerProject(workdir);
-    setAddedAt(workdir, new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString());
+    registerLegacyEphemeral(workdir, 2);
 
     expect(findEphemeralProjects(24)).toEqual([]);
     expect(findEphemeralProjects(1)).toHaveLength(1);
+  });
+});
+
+// TRA-396: the checkout directory is never deleted by the runtime, so every
+// presence-based signal reads an abandoned workdir as live. Not persisting it
+// in the first place is what keeps it out of the daemon's reindex rotation —
+// 77 of these on one machine pinned the daemon and timed out the app's
+// metrics call.
+describe('ephemeral workdirs are never persisted', () => {
+  function registryProjects(): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8')).projects;
+  }
+
+  it('keeps a one-shot workdir out of registry.json', () => {
+    const workdir = makeEphemeralWorkdir();
+    registerProject(workdir);
+
+    expect(registryProjects()).toEqual({});
+    expect(listProjects()).toEqual([]);
+  });
+
+  it('still resolves the workdir for the run that registered it', () => {
+    const workdir = makeEphemeralWorkdir();
+    const entry = registerProject(workdir);
+
+    expect(getProject(workdir)?.root).toBe(workdir);
+    expect(resolveRegisteredAncestor(path.join(workdir, 'packages', 'app'))?.root).toBe(workdir);
+    // Its DB lives in the ephemeral index dir so it stays collectable by age.
+    expect(entry.dbPath.startsWith(EPHEMERAL_INDEX_DIR + path.sep)).toBe(true);
+  });
+
+  it('leaves the registry empty after a saturating burst of agent runs', () => {
+    const workdirs = Array.from({ length: 80 }, () => makeEphemeralWorkdir());
+    for (const w of workdirs) registerProject(w);
+
+    // The daemon's cold start and its background rotation both read this map;
+    // an empty one is what keeps a foreground metrics call off the queue.
+    expect(Object.keys(registryProjects())).toHaveLength(0);
+    expect(listProjects()).toEqual([]);
+  });
+
+  it('still persists a workdir-shaped root registered as an explicit multi-root', () => {
+    const workdir = makeEphemeralWorkdir();
+    const child = path.join(workdir, 'pkg');
+    fs.mkdirSync(child, { recursive: true });
+    registerProject(workdir, { type: 'multi-root', children: [child] });
+
+    expect(Object.keys(registryProjects())).toEqual([workdir]);
+  });
+
+  it('does not report a non-persisted workdir as an eviction candidate', () => {
+    const workdir = makeEphemeralWorkdir();
+    registerProject(workdir);
+
+    expect(findEphemeralProjects(0)).toEqual([]);
+  });
+});
+
+// The case #487 missed: the checkout directory still exists, so nothing that
+// keys on presence will ever reclaim its index. Age off the DB itself does.
+describe('sweepEphemeralDbs', () => {
+  function makeEphemeralDb(name: string, ageHours: number): string {
+    fs.mkdirSync(EPHEMERAL_INDEX_DIR, { recursive: true });
+    const db = path.join(EPHEMERAL_INDEX_DIR, `${name}.db`);
+    fs.writeFileSync(db, 'x');
+    const t = Date.now() / 1000 - ageHours * 3600;
+    fs.utimesSync(db, t, t);
+    return db;
+  }
+
+  afterEach(() => {
+    fs.rmSync(EPHEMERAL_INDEX_DIR, { recursive: true, force: true });
+  });
+
+  it('deletes an abandoned DB whose checkout directory still exists', () => {
+    const workdir = makeEphemeralWorkdir();
+    expect(fs.existsSync(workdir)).toBe(true); // the runtime never cleans it up
+    const db = makeEphemeralDb(`abandoned-${path.basename(path.dirname(workdir))}`, 48);
+
+    expect(sweepEphemeralDbs(24)).toEqual([db]);
+    expect(fs.existsSync(db)).toBe(false);
+  });
+
+  it('keeps a DB still inside the age window', () => {
+    const db = makeEphemeralDb('recent', 2);
+
+    expect(sweepEphemeralDbs(24)).toEqual([]);
+    expect(fs.existsSync(db)).toBe(true);
+  });
+
+  it('keeps an old DB a live holder still has open', () => {
+    const db = makeEphemeralDb('busy', 48);
+    announceDbHolder(db, '/some/running/workdir');
+
+    expect(sweepEphemeralDbs(24)).toEqual([]);
+    expect(fs.existsSync(db)).toBe(true);
+  });
+
+  it('treats a fresh WAL sidecar as activity on an otherwise old DB', () => {
+    const db = makeEphemeralDb('walwrites', 48);
+    fs.writeFileSync(`${db}-wal`, 'x');
+
+    expect(sweepEphemeralDbs(24)).toEqual([]);
+    expect(fs.existsSync(db)).toBe(true);
+  });
+
+  it('deletes sidecars alongside the base DB', () => {
+    const db = makeEphemeralDb('sidecars', 48);
+    for (const suffix of ['-wal', '-shm']) {
+      fs.writeFileSync(db + suffix, 'x');
+      const t = Date.now() / 1000 - 48 * 3600;
+      fs.utimesSync(db + suffix, t, t);
+    }
+
+    expect(sweepEphemeralDbs(24)).toEqual([db]);
+    expect(fs.existsSync(`${db}-wal`)).toBe(false);
+    expect(fs.existsSync(`${db}-shm`)).toBe(false);
   });
 });


### PR DESCRIPTION
Closes TRA-396.

## The cause

A Multica task workdir is queried for the lifetime of exactly one run and then abandoned **in place** — the runtime never deletes it, so every presence-based signal reads it as a live project forever. Persisting it enrolled a dead checkout in every daemon start and every background reindex rotation from then on.

On the reported machine: 90 registered projects, 77 of them agent checkouts (mostly of this same repo), `~/.trace-mcp/index` at 4.8 GB / 643 entries, daemon at ~120% CPU and 1.1 GB RSS. A metrics call from the app queued behind that and timed out.

TRA-335 (#487) could not reach this: it drains rows *after the fact* by age, and `prune` classifies them as live because the directory is still there.

## The change

- **`registerProject` keeps workdir-shaped roots out of registry.json.** They go into a process-local map instead. The run that created the checkout still resolves its own project through `getProject` / `resolveRegisteredAncestor`; nothing outlives the process that registered it. An explicit multi-root `add`/`init` is a deliberate act and still persists.
- **Same remote means same project.** Because `listProjects()` no longer returns other ephemeral checkouts, the existing remote-identity lookup (TRA-38 / TRA-304) can only match the canonical project — twenty checkouts of one repo resolve to one index instead of twenty.
- **Eviction that does not depend on directory deletion.** DBs that could not share a sibling land in `~/.trace-mcp/index/ephemeral/`; `sweepEphemeralDbs` collects them by mtime (across the DB and its WAL/SHM sidecars) with a live-holder veto, wired into the daemon's existing hourly ephemeral sweep. No registry row and no directory check involved.
- `findEphemeralProjects` / `ProjectManager.sweepEphemeralProjects` stay, now scoped to draining registries written by earlier versions — the 77-row backlog still has to clear.

## Bounding background work

Already in place and unchanged: eager load capped at `daemon_eager_load_projects` (default 8), parallel `addProject` setup capped at 2, `indexAll` semaphore-gated. Those caps were being spent on ephemeral checkouts because `selectEagerLoadRoots` picks the most recently indexed — and the constantly-reindexed workdirs always won. With the registry clean they go to real projects, so no new cap was added.

## Tests

`tests/registry.test.ts`:

- a one-shot workdir never appears in registry.json or `listProjects()`
- the registering run still resolves it, including subdirectory requests, and its DB is under the ephemeral index dir
- a burst of 80 agent runs leaves the registry empty — the map the daemon's cold start and reindex rotation both read
- an explicit multi-root registration of a workdir-shaped root still persists
- `sweepEphemeralDbs`: **deletes an abandoned DB whose checkout directory still exists** (the case #487 missed), keeps one inside the age window, keeps one a live holder has open, treats a fresh WAL sidecar as activity, and removes sidecars with the base DB

`src/daemon/__tests__/project-manager-ephemeral-sweep.test.ts` now constructs legacy rows directly, since `registerProject` refuses to create them.

Local: `pnpm test` 8975 passed / 8 skipped (818 files), `pnpm run build`, `pnpm run typecheck`, `biome ci` all clean.

## Note

`trace-mcp add <multica-workdir>` now registers for the session only and won't show up in `trace-mcp list`. That is the intended reading of "never enter the persistent registry", but it is a visible behaviour change if someone was deliberately adding one.

Agent: Implementation Engineer
