### PR TITLE
fix(config): index every registered language by default (TRA-400)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,12 +149,12 @@ You can add **more** directory names to skip via `.traceignore` or the `ignore.d
 Two different things can leave a folder out of the index — check which one applies:
 
 1. **The folder name collides with a built-in skip dir** (e.g. you have your own `vendor/` or `build/` with real source in it). There's currently no per-project way to un-skip a built-in name — rename the folder, or [open an issue](https://github.com/nikolai-vysotskyi/trace-mcp/issues) if this collision is common enough to warrant a config override.
-2. **The folder just isn't a built-in skip dir, but nothing in `include` matches its files** (e.g. a `k8s/` folder of YAML manifests — no default `include` pattern covers `*.yaml`). Add an explicit pattern:
+2. **The folder just isn't a built-in skip dir, but nothing in `include` matches its files.** The default `include` covers every extension a registered language plugin claims, *except* the pure data formats — JSON, XML (`.xml`, `.svg`, `.csproj`, ...) and INI (`.ini`, `.conf`, `.properties`, ...) — which are left out because lockfiles and fixtures would swamp the index. Add an explicit pattern for those:
 
    ```jsonc
    // .trace-mcp/.config.json
    {
-     "include": ["k8s/**/*.{yaml,yml}"]
+     "include": ["schemas/**/*.json"]
    }
    ```
 

--- a/docs/language-matrix.md
+++ b/docs/language-matrix.md
@@ -12,7 +12,7 @@ trace-mcp ships 81 language plugins. They are not equally deep, and this
 page says how deep each one is. Every language in the list gets symbol
 extraction; call graphs and type edges are a much smaller set.
 
-- **indexed with the default config:** 24 (the rest need an `include` entry — see below)
+- **indexed with the default config:** 78 (the rest need an `include` entry — see below)
 - **tree-sitter parser:** 29 · **regex parser:** 46 · **custom parser:** 6
 - **import edges:** 66
 - **call edges (`get_call_graph`, call-aware `find_usages`):** 3
@@ -30,14 +30,21 @@ extraction; call graphs and type edges are a much smaller set.
 | Types | Type-annotation or inheritance edges are resolved. |
 | Tests | At least one test exercises this plugin directly. |
 
-**Default config vs. plugin count.** The default `include` list targets a
-mainstream extension set under the common source roots. 57
-of the 81 plugins are not reached by it, so those languages index
-nothing until you say so explicitly:
+**Default config vs. plugin count.** The default `include` is one global glob
+over every extension the plugins below claim, so 78 of
+the 81 plugins run wherever their files live in the repo — no
+directory anchoring. The remaining 3
+are pure data formats, left out because lockfiles, fixtures and `.svg` would
+swamp the index for little symbol value. Ask for them explicitly if you want
+them:
 
 ```json
-{ "include": ["src/**/*.{ts,tsx}", "**/*.vhd", "**/*.lua"] }
+{ "include": ["schemas/**/*.json", "k8s/**/*.xml"] }
 ```
+
+Note that `include` in a project config **replaces** the built-in list rather
+than adding to it, so copy the default glob alongside your addition if you
+still want the rest of the repo indexed.
 
 A regex plugin still gives you working `search`, `get_outline` and symbol
 navigation — that covers most "find it and read it" work. What it does not give
@@ -49,84 +56,84 @@ unless you enable LSP enrichment (`lsp.enabled: true`) or ingest a SCIP index.
 
 | Language | Extensions | Parser | Default | Imports | Calls | Types | Tests |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| ada | .adb .ads .ada | regex (multi-pass) | — | yes | — | — | yes |
-| al | .al | regex | — | — | — | — | yes |
-| apex | .cls .trigger .apex | regex (multi-pass) | — | yes | — | — | yes |
-| assembly | .asm .s .S | regex | — | — | — | — | yes |
-| astro | .astro | tree-sitter | — | — | — | — | yes |
-| autohotkey | .ahk .ah2 | regex | — | — | — | — | yes |
-| bash | .sh .bash .zsh | tree-sitter | — | — | — | — | yes |
+| ada | .adb .ads .ada | regex (multi-pass) | yes | yes | — | — | yes |
+| al | .al | regex | yes | — | — | — | yes |
+| apex | .cls .trigger .apex | regex (multi-pass) | yes | yes | — | — | yes |
+| assembly | .asm .s .S | regex | yes | — | — | — | yes |
+| astro | .astro | tree-sitter | yes | — | — | — | yes |
+| autohotkey | .ahk .ah2 | regex | yes | — | — | — | yes |
+| bash | .sh .bash .zsh | tree-sitter | yes | — | — | — | yes |
 | blade | .blade.php | regex | yes | yes | — | — | yes |
 | c | .c .h | tree-sitter | yes | yes | — | — | yes |
-| clojure | .clj .cljs .cljc .edn | regex | — | yes | — | — | — |
-| cmake | .cmake CMakeLists.txt | regex | — | yes | — | — | — |
-| cobol | .cob .cbl .cpy .cobol | regex (multi-pass) | — | yes | — | — | yes |
-| common-lisp | .lisp .lsp .cl .asd | regex (multi-pass) | — | yes | — | — | yes |
+| clojure | .clj .cljs .cljc .edn | regex | yes | yes | — | — | — |
+| cmake | .cmake CMakeLists.txt | regex | yes | yes | — | — | — |
+| cobol | .cob .cbl .cpy .cobol | regex (multi-pass) | yes | yes | — | — | yes |
+| common-lisp | .lisp .lsp .cl .asd | regex (multi-pass) | yes | yes | — | — | yes |
 | cpp | .cpp .cxx .cc .hpp | tree-sitter | yes | yes | — | — | yes |
 | csharp | .cs | tree-sitter | yes | yes | — | — | yes |
-| css | .css .scss .sass .less | tree-sitter | — | yes | — | — | yes |
-| cuda | .cu .cuh | regex | — | yes | — | — | — |
-| d | .d .di | regex (multi-pass) | — | yes | — | — | yes |
+| css | .css .scss .sass .less | tree-sitter | yes | yes | — | — | yes |
+| cuda | .cu .cuh | regex | yes | yes | — | — | — |
+| d | .d .di | regex (multi-pass) | yes | yes | — | — | yes |
 | dart | .dart | tree-sitter | yes | yes | — | — | yes |
-| dockerfile | Dockerfile .dockerfile | regex | — | yes | — | — | yes |
-| ejs | .ejs | regex | — | yes | — | — | yes |
-| elisp | .el .elc | tree-sitter | — | — | — | — | — |
+| dockerfile | Dockerfile .dockerfile | regex | yes | yes | — | — | yes |
+| ejs | .ejs | regex | yes | yes | — | — | yes |
+| elisp | .el .elc | tree-sitter | yes | — | — | — | — |
 | elixir | .ex .exs | tree-sitter | yes | yes | — | — | yes |
-| elm | .elm | tree-sitter | — | — | — | — | — |
-| erlang | .erl .hrl | regex | — | yes | — | — | yes |
+| elm | .elm | tree-sitter | yes | — | — | — | — |
+| erlang | .erl .hrl | regex | yes | yes | — | — | yes |
 | form | .frm .prc .h | regex | yes | yes | — | — | — |
-| fortran | .f .f90 .f95 .f03 | regex | — | yes | — | — | yes |
-| fsharp | .fs .fsi .fsx | regex (multi-pass) | — | yes | — | — | — |
-| gdscript | .gd | regex | — | yes | — | — | yes |
-| gleam | .gleam | regex | — | yes | — | — | yes |
-| glsl | .glsl .vert .frag .geom | regex | — | yes | — | — | — |
+| fortran | .f .f90 .f95 .f03 | regex | yes | yes | — | — | yes |
+| fsharp | .fs .fsi .fsx | regex (multi-pass) | yes | yes | — | — | — |
+| gdscript | .gd | regex | yes | yes | — | — | yes |
+| gleam | .gleam | regex | yes | yes | — | — | yes |
+| glsl | .glsl .vert .frag .geom | regex | yes | yes | — | — | — |
 | go | .go | tree-sitter | yes | yes | — | — | yes |
-| graphql | .graphql .gql | custom | — | — | — | — | yes |
-| groovy | .groovy .gradle .gvy | regex | — | yes | — | — | yes |
-| haskell | .hs .lhs | regex | — | yes | — | — | yes |
-| hcl | .tf .hcl .tfvars | custom | — | yes | — | — | yes |
-| html | .html .htm | tree-sitter | — | yes | — | — | yes |
+| graphql | .graphql .gql | custom | yes | — | — | — | yes |
+| groovy | .groovy .gradle .gvy | regex | yes | yes | — | — | yes |
+| haskell | .hs .lhs | regex | yes | yes | — | — | yes |
+| hcl | .tf .hcl .tfvars | custom | yes | yes | — | — | yes |
+| html | .html .htm | tree-sitter | yes | yes | — | — | yes |
 | ini | .ini .cfg .conf .properties | regex | — | — | — | — | — |
 | java | .java | tree-sitter | yes | yes | — | — | yes |
 | json | .json .jsonc .json5 | tree-sitter | — | yes | — | — | yes |
-| julia | .jl | regex | — | yes | — | — | yes |
+| julia | .jl | regex | yes | yes | — | — | yes |
 | kotlin | .kt .kts | tree-sitter | yes | yes | — | — | yes |
-| lean | .lean | regex | — | yes | — | — | — |
-| lua | .lua .luau | tree-sitter | — | yes | — | — | yes |
+| lean | .lean | regex | yes | yes | — | — | — |
+| lua | .lua .luau | tree-sitter | yes | yes | — | — | yes |
 | magma | .m .mag .magma | regex | yes | yes | — | — | — |
-| makefile | Makefile makefile .mk GNUmakefile | regex | — | yes | — | — | — |
+| makefile | Makefile makefile .mk GNUmakefile | regex | yes | yes | — | — | — |
 | markdown | .md .mdx .markdown .qmd | custom | yes | — | — | — | yes |
 | matlab | .m .mlx .mat | regex (multi-pass) | yes | yes | — | — | yes |
-| meson | meson.build meson_options.txt | regex | — | — | — | — | — |
-| nim | .nim .nims .nimble | regex | — | yes | — | — | yes |
-| nix | .nix | regex | — | yes | — | — | yes |
+| meson | meson.build meson_options.txt | regex | yes | — | — | — | — |
+| nim | .nim .nims .nimble | regex | yes | yes | — | — | yes |
+| nix | .nix | regex | yes | yes | — | — | yes |
 | objc | .m .mm | tree-sitter | yes | yes | — | — | yes |
-| ocaml | .ml .mli | tree-sitter | — | yes | — | — | yes |
-| pascal | .pas .dpr .dpk .lpr | regex (multi-pass) | — | yes | — | — | yes |
-| perl | .pl .pm .t | regex | — | yes | — | — | yes |
+| ocaml | .ml .mli | tree-sitter | yes | yes | — | — | yes |
+| pascal | .pas .dpr .dpk .lpr | regex (multi-pass) | yes | yes | — | — | yes |
+| perl | .pl .pm .t | regex | yes | yes | — | — | yes |
 | php | .php | tree-sitter | yes | yes | yes | — | yes |
-| plsql | .pls .plb .pck .pkb | regex (multi-pass) | — | yes | — | — | yes |
-| powershell | .ps1 .psm1 .psd1 | regex (multi-pass) | — | yes | — | — | yes |
-| prisma | .prisma | custom | — | — | — | — | yes |
-| protobuf | .proto | regex | — | yes | — | — | yes |
+| plsql | .pls .plb .pck .pkb | regex (multi-pass) | yes | yes | — | — | yes |
+| powershell | .ps1 .psm1 .psd1 | regex (multi-pass) | yes | yes | — | — | yes |
+| prisma | .prisma | custom | yes | — | — | — | yes |
+| protobuf | .proto | regex | yes | yes | — | — | yes |
 | python | .py .pyi | tree-sitter | yes | yes | yes | yes | yes |
-| r | .r .R .Rmd | regex | — | yes | — | — | yes |
+| r | .r .R .Rmd | regex | yes | yes | — | — | yes |
 | ruby | .rb .rake | tree-sitter | yes | yes | — | — | yes |
 | rust | .rs | tree-sitter | yes | yes | — | — | yes |
 | scala | .scala .sc | tree-sitter | yes | yes | — | — | yes |
-| solidity | .sol | tree-sitter | — | yes | — | — | yes |
-| sql | .sql | regex | — | — | — | — | yes |
+| solidity | .sol | tree-sitter | yes | yes | — | — | yes |
+| sql | .sql | regex | yes | — | — | — | yes |
 | svelte | .svelte | regex | yes | yes | — | — | — |
 | swift | .swift | tree-sitter | yes | yes | — | — | yes |
-| tcl | .tcl .tk .itcl .itk | regex (multi-pass) | — | yes | — | — | yes |
-| toml | .toml | tree-sitter | — | yes | — | — | yes |
-| typescript | .ts .tsx .js .jsx | tree-sitter | yes | yes | yes | yes | yes |
-| verilog | .v .sv .svh .vh | regex | — | yes | — | — | yes |
-| verse | .verse | regex | — | — | — | — | yes |
-| vhdl | .vhd .vhdl .vho .vhs | regex | — | yes | — | — | yes |
-| vimscript | .vim .vimrc | regex | — | yes | — | — | — |
+| tcl | .tcl .tk .itcl .itk | regex (multi-pass) | yes | yes | — | — | yes |
+| toml | .toml | tree-sitter | yes | yes | — | — | yes |
+| typescript | .ts .tsx .mts .cts | tree-sitter | yes | yes | yes | yes | yes |
+| verilog | .v .sv .svh .vh | regex | yes | yes | — | — | yes |
+| verse | .verse | regex | yes | — | — | — | yes |
+| vhdl | .vhd .vhdl .vho .vhs | regex | yes | yes | — | — | yes |
+| vimscript | .vim .vimrc | regex | yes | yes | — | — | — |
 | vue | .vue | tree-sitter | yes | — | — | — | yes |
 | wolfram | .wl .wls .m .nb | regex | yes | yes | — | — | — |
 | xml | .xml .xul .xsl .xslt | custom | — | yes | — | — | yes |
-| yaml | .yaml .yml | custom | — | yes | — | — | yes |
-| zig | .zig .zon | tree-sitter | — | yes | — | — | yes |
+| yaml | .yaml .yml | custom | yes | yes | — | — | yes |
+| zig | .zig .zon | tree-sitter | yes | yes | — | — | yes |

--- a/scripts/language-matrix.ts
+++ b/scripts/language-matrix.ts
@@ -184,14 +184,21 @@ extraction; call graphs and type edges are a much smaller set.
 | Types | Type-annotation or inheritance edges are resolved. |
 | Tests | At least one test exercises this plugin directly. |
 
-**Default config vs. plugin count.** The default \`include\` list targets a
-mainstream extension set under the common source roots. ${counts.total - counts.indexedByDefault}
-of the ${counts.total} plugins are not reached by it, so those languages index
-nothing until you say so explicitly:
+**Default config vs. plugin count.** The default \`include\` is one global glob
+over every extension the plugins below claim, so ${counts.indexedByDefault} of
+the ${counts.total} plugins run wherever their files live in the repo — no
+directory anchoring. The remaining ${counts.total - counts.indexedByDefault}
+are pure data formats, left out because lockfiles, fixtures and \`.svg\` would
+swamp the index for little symbol value. Ask for them explicitly if you want
+them:
 
 \`\`\`json
-{ "include": ["src/**/*.{ts,tsx}", "**/*.vhd", "**/*.lua"] }
+{ "include": ["schemas/**/*.json", "k8s/**/*.xml"] }
 \`\`\`
+
+Note that \`include\` in a project config **replaces** the built-in list rather
+than adding to it, so copy the default glob alongside your addition if you
+still want the rest of the repo indexed.
 
 A regex plugin still gives you working \`search\`, \`get_outline\` and symbol
 navigation — that covers most "find it and read it" work. What it does not give

--- a/src/__tests__/default-include-coverage.test.ts
+++ b/src/__tests__/default-include-coverage.test.ts
@@ -1,0 +1,83 @@
+import picomatch from 'picomatch';
+import { describe, expect, it } from 'vitest';
+import { DATA_ONLY_LANGUAGES, TraceMcpConfigSchema } from '../config.js';
+import { createAllLanguagePlugins } from '../indexer/plugins/language/all.js';
+
+/**
+ * TRA-400: the shipped default `include` used to reach 24 of the 81 registered
+ * language plugins — a repo's VHDL, Terraform, SQL, CSS or shell indexed
+ * nothing at all. The default is now derived from the plugin registry, but as a
+ * literal string (config load must not import tree-sitter grammars). This test
+ * is the thing that keeps the two in sync: register a plugin with a new
+ * extension and the default include has to grow with it, or fail here.
+ */
+
+const defaults = TraceMcpConfigSchema.parse({});
+const isIncluded = picomatch(defaults.include);
+const isExcluded = picomatch(defaults.exclude);
+
+/** A repo-relative sample path for an extension or bare filename a plugin claims. */
+function samplePath(claim: string): string {
+  return claim.startsWith('.') ? `pkg/sample${claim}` : `pkg/${claim}`;
+}
+
+const plugins = createAllLanguagePlugins().map((p) => ({
+  language: p.manifest.name.replace(/-language$/, ''),
+  claims: [...p.supportedExtensions],
+}));
+
+const dataOnly = new Set<string>(DATA_ONLY_LANGUAGES);
+
+describe('default include globs', () => {
+  it('registers at least the 80 language plugins this test was written against', () => {
+    expect(plugins.length).toBeGreaterThanOrEqual(80);
+  });
+
+  it.each(plugins.filter((p) => !dataOnly.has(p.language)))(
+    'indexes every file $language claims',
+    ({ claims }) => {
+      for (const claim of claims) {
+        const path = samplePath(claim);
+        expect(isIncluded(path), `${path} is not matched by the default include`).toBe(true);
+        expect(isExcluded(path), `${path} is removed by the default exclude`).toBe(false);
+      }
+    },
+  );
+
+  it.each([...dataOnly])('leaves %s out of the default index', (language) => {
+    const plugin = plugins.find((p) => p.language === language);
+    expect(
+      plugin,
+      `DATA_ONLY_LANGUAGES names ${language}, which is not a registered plugin`,
+    ).toBeDefined();
+    for (const claim of plugin?.claims ?? []) {
+      // composer.json is the one deliberate exception — Laravel package
+      // discovery reads it, so it is included by name rather than by extension.
+      expect(isIncluded(samplePath(claim))).toBe(false);
+    }
+  });
+
+  it('keeps every default include pattern global so monorepo re-anchoring is a no-op', () => {
+    expect(defaults.include.filter((p) => !p.startsWith('**/'))).toEqual([]);
+  });
+
+  it('still excludes the vendored trees the global globs now reach', () => {
+    for (const path of [
+      'node_modules/left-pad/index.js',
+      'vendor/laravel/framework/src/Foo.php',
+      '.terraform/modules/vpc/main.tf',
+      'target/release/build/foo/out/gen.rs',
+      'Pods/Alamofire/Source/Alamofire.swift',
+      'coverage/lcov-report/prettify.js',
+      'public/js/app.min.js',
+      'assets/site.min.css',
+      '.venv/lib/site-packages/requests/api.py',
+      'obj/Debug/AssemblyInfo.cs',
+    ]) {
+      // `.terraform` and `.venv` are dot-directories, which fast-glob skips via
+      // `dot: false`; the rest have to be caught by an explicit exclude.
+      const skipped = isExcluded(path) || path.split('/').some((seg) => seg.startsWith('.'));
+      expect(skipped, `${path} would be indexed`).toBe(true);
+    }
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -789,13 +789,50 @@ const VaultConfigSchema = z
   .prefault({});
 
 /**
- * Source-file extensions for the directory-rooted default include globs
- * (`src/`, `lib/`, `app/`, `test/`, `tests/`, `routes/`). Kept language-complete
- * across the mainstream set trace-mcp has first-class plugins for, so coverage
- * does not silently depend on which directory a language's code lives in.
+ * Language plugins whose files are NOT indexed by the shipped default
+ * `include`. These are pure data/config formats where the volume in a typical
+ * repo (lockfiles, fixtures, generated project files, `.svg`) dwarfs the value
+ * of the symbols extracted. The plugins themselves work fine — a project that
+ * wants them adds `**\/*.json` (etc.) to its own `include`.
+ */
+export const DATA_ONLY_LANGUAGES = ['json', 'xml', 'ini'] as const;
+
+/**
+ * Every file extension claimed by a registered language plugin, minus
+ * `DATA_ONLY_LANGUAGES`. Previously this was a hand-written list of 32
+ * extensions rooted at `src/ lib/ app/ test/ tests/ routes/ ...`, which reached
+ * 24 of the 81 registered plugins — a repo's VHDL, Terraform, SQL, CSS or shell
+ * indexed nothing at all under the shipped defaults (TRA-400).
+ *
+ * Kept as a literal rather than imported from `PluginRegistry` on purpose:
+ * loading config must not pull in every tree-sitter grammar. Drift is caught by
+ * `src/__tests__/default-include-coverage.test.ts`, which fails if a plugin
+ * claims an extension this string is missing.
  */
 const SOURCE_EXTS =
-  'ts,tsx,mts,cts,js,jsx,mjs,cjs,py,pyi,go,rs,java,kt,kts,rb,php,vue,svelte,scala,cs,swift,dart,ex,exs,c,h,cc,cpp,hpp,cxx,m,mm';
+  'ada,adb,ads,ah2,ahk,al,apex,asd,asdf,asm,astro,bash,blade.php,c,cbl,cc,cjs,cl,clj,cljc,' +
+  'cljs,cls,cmake,cob,cobol,comp,cpp,cpy,cs,css,cts,cu,cuh,cxx,d,dart,di,dockerfile,dpk,dpr,' +
+  'edn,' +
+  'ejs,el,elc,elm,erl,ex,exs,f,f03,f08,f90,f95,fnc,for,fpp,frag,frm,fs,fsi,fsx,gd,geom,' +
+  'gleam,glsl,go,gql,gradle,graphql,groovy,gvy,h,h++,hcl,hh,hpp,hrl,hs,htm,html,hxx,inc,ino,' +
+  'itcl,itk,java,jl,js,jsx,kt,kts,lean,less,lhs,lisp,lpr,lsp,lua,luau,m,mag,magma,markdown,' +
+  'mat,md,mdx,mjs,mk,ml,mli,mlx,mm,mt,mts,nb,nim,nimble,nims,nix,pas,pck,pde,php,pkb,pks,' +
+  'pl,plb,' +
+  'pls,plsql,pm,pp,prc,prisma,proto,ps1,psd1,psm1,py,pyi,qmd,r,R,rake,rb,Rmd,rs,s,S,sass,sc,' +
+  'scala,scss,sh,sol,sql,styl,stylus,sv,svelte,svh,swift,t,tcl,tesc,tese,tf,tfvars,tk,tm,' +
+  'toml,trg,trigger,ts,tsx,typ,v,verse,vert,vh,vhd,vhdl,vho,vhs,vim,vimrc,vue,wl,wls,yaml,' +
+  'yml,zig,zon,zsh';
+
+/** Extensionless filenames claimed by language plugins (CMake, Docker, Make, Meson). */
+const SOURCE_FILENAMES = [
+  'CMakeLists.txt',
+  'Dockerfile',
+  'GNUmakefile',
+  'Makefile',
+  'makefile',
+  'meson.build',
+  'meson_options.txt',
+];
 
 export const TraceMcpConfigSchema = z.object({
   root: z.string().default('.'),
@@ -804,45 +841,19 @@ export const TraceMcpConfigSchema = z.object({
       path: z.string().default('.trace-mcp/index.db'),
     })
     .prefault({}),
+  // Every pattern here is global (`**/`) on purpose. The previous defaults
+  // anchored most languages to `src/ lib/ app/ test/ tests/ routes/ ...`, which
+  // made coverage depend on repo layout and needed a per-framework glob for
+  // every convention that deviated (Laravel `resources/`, Nuxt `pages/`,
+  // `public/js/`, ...). One global extension glob subsumes all of them, and
+  // keeps the monorepo re-anchoring fallbacks in `file-collector.ts` from
+  // having to run at all for a default config. Noise is bounded by `exclude`.
   include: z.array(z.string()).default([
-    // Common source roots — language-complete so a FastAPI/Flask/Django app
-    // under `app/` (or a Go/Rust/Java service) is indexed the same as `src/`.
-    // Previously `app/**` omitted `py` (and go/rs/java/kt), so Python projects
-    // that keep all code under `app/` (the FastAPI convention) indexed nothing.
-    `src/**/*.{${SOURCE_EXTS}}`,
-    `lib/**/*.{${SOURCE_EXTS}}`,
-    `app/**/*.{${SOURCE_EXTS}}`,
-    `test/**/*.{${SOURCE_EXTS}}`,
-    `tests/**/*.{${SOURCE_EXTS}}`,
-    `routes/**/*.{${SOURCE_EXTS}}`,
-    // Python projects frequently place packages at arbitrary roots (a flat
-    // `main.py` + `routers/` + `models/`, or a top-level `<pkg>/` directory)
-    // rather than under src/app/lib. Index every `.py`/`.pyi` outside the
-    // excluded virtualenv/cache dirs so Python coverage does not depend on a
-    // particular layout. Mirrors the existing global markdown glob below.
-    '**/*.{py,pyi}',
-    // .NET solutions place projects at arbitrary root dirs (core/, data/,
-    // identity/, Source/ ...) rather than src/lib/app, so a directory-rooted
-    // glob misses most of the code (#242, piranha.core). Index every `.cs`
-    // outside the excluded build-output dirs, mirroring the Python glob above.
-    '**/*.cs',
-    'database/migrations/**/*.php',
-    'resources/js/**/*.{vue,ts,tsx,js,jsx}',
-    'resources/assets/**/*.{vue,ts,tsx,js,jsx}',
-    'resources/views/**/*.{blade.php,js}',
-    // Laravel release-based deployments (e.g., resources/release-v8/js/...)
-    'resources/release-*/**/*.{vue,ts,tsx,js,jsx}',
-    // Public assets that are hand-written (not compiled)
-    'public/js/**/*.js',
-    // Laravel auto-registered package providers (composer.json extra.laravel)
-    'composer.json',
-    'nova-components/*/composer.json',
-    'pages/**/*.{vue,ts,tsx,js,jsx}',
-    'components/**/*.{vue,ts,tsx,js,jsx}',
-    'composables/**/*.{ts,tsx,js,jsx}',
-    'server/**/*.{ts,tsx,js,jsx}',
-    // Markdown knowledge graph — Obsidian/Logseq/plain MD vaults
-    '**/*.{md,mdx,markdown}',
+    `**/*.{${SOURCE_EXTS}}`,
+    ...SOURCE_FILENAMES.map((name) => `**/${name}`),
+    // Laravel auto-registered package providers (composer.json extra.laravel).
+    // JSON is otherwise not indexed by default — see DATA_ONLY_LANGUAGES.
+    '**/composer.json',
   ]),
   exclude: z.array(z.string()).default([
     '**/vendor/**',
@@ -878,6 +889,15 @@ export const TraceMcpConfigSchema = z.object({
     '**/obj/**',
     '**/bin/Debug/**',
     '**/bin/Release/**',
+    // Vendored / generated trees the now-global include globs would otherwise
+    // reach (TRA-400). `target/` is scoped to Rust's build profiles so a Java
+    // or Maven `target/src` still indexes.
+    '**/target/debug/**',
+    '**/target/release/**',
+    '**/Pods/**',
+    '**/coverage/**',
+    '**/*.min.js',
+    '**/*.min.css',
   ]),
   // Directory symlinks are not followed during indexing by default — a symlink
   // cycling back to an ancestor (e.g. Ansible Molecule's `roles/<role> -> ../../../`

--- a/src/indexer/plugins/language/typescript/index.ts
+++ b/src/indexer/plugins/language/typescript/index.ts
@@ -49,7 +49,10 @@ export class TypeScriptLanguagePlugin implements LanguagePlugin {
     priority: 5,
   };
 
-  supportedExtensions = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
+  // `.mts`/`.cts` are plain TypeScript (Node's explicit ESM/CJS variants) and
+  // are already treated as such by the LSP, codemod and import-rewriter tables —
+  // this plugin was the only place that dropped them, so they parsed nowhere.
+  supportedExtensions = ['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs'];
   supportedVersions = ['12', '14', '16', '17', '18', '19', '20', '21', '22', '23', '24'];
 
   async extractSymbols(

--- a/tests/init/config-generator.test.ts
+++ b/tests/init/config-generator.test.ts
@@ -22,11 +22,16 @@ function makeDetection(overrides: Partial<DetectionResult> = {}): DetectionResul
 describe('generateConfig', () => {
   it('generates a comprehensive fallback config when no frameworks or languages detected', () => {
     const config = generateConfig(makeDetection());
-    // Fallback now uses the comprehensive schema defaults so a non-framework or
-    // monorepo-container root still picks up framework dirs of nested subprojects.
-    expect(config.include!.some((p) => p.includes('src/'))).toBe(true);
-    expect(config.include!.some((p) => p.includes('routes/'))).toBe(true);
-    expect(config.include!.some((p) => p.includes('pages/'))).toBe(true);
+    // Fallback uses the schema defaults, which are global extension globs
+    // (TRA-400) — no directory anchoring, so a non-framework or
+    // monorepo-container root picks up nested subprojects wherever they live.
+    expect(config.include!.every((p) => p.startsWith('**/'))).toBe(true);
+    for (const ext of ['ts', 'py', 'go', 'php', 'vhd', 'tf', 'sql', 'css']) {
+      expect(
+        config.include!.some((p) => p.includes(`,${ext},`) || p.includes(`{${ext},`)),
+        `default include does not reach .${ext}`,
+      ).toBe(true);
+    }
     // And excludes the universal junk (vendor was previously missing).
     expect(config.exclude!.some((p) => p.includes('vendor'))).toBe(true);
     expect(config.exclude!.some((p) => p.includes('node_modules'))).toBe(true);


### PR DESCRIPTION
Closes TRA-400.

## The problem

The shipped default `include` was a hand-written 32-extension string anchored to `src/ lib/ app/ test/ tests/ routes/ ...`. It reached **24 of the 81 registered language plugins**. The other 57 indexed nothing at all until the user wrote their own `include` — and not just exotic ones: `css`, `html`, `bash`, `sql`, `yaml`, `hcl`, `graphql`, `lua`, `astro` were all invisible by default.

The directory anchoring was the other half of the problem. Coverage depended on repo layout, and every convention that deviated needed its own glob (Laravel `resources/`, Nuxt `pages/`, `public/js/`, ...). hashicorp/terraform keeps its Go under `internal/`, so the old defaults indexed **34 files there — all of them markdown**.

## The change

`include` becomes global extension globs derived from the plugin registry, minus the pure data formats (`DATA_ONLY_LANGUAGES` = JSON/XML/INI), whose lockfiles, fixtures and `.svg` would swamp an index for little symbol value. Those plugins still work — a project that wants them adds `**/*.json` to its own `include`.

30 patterns → 9, all global. That also means the monorepo re-anchoring fallbacks in `file-collector.ts` stop running for a default config.

The extension list stays a **literal**, not an import of `PluginRegistry`: loading config must not pull in every tree-sitter grammar. `src/__tests__/default-include-coverage.test.ts` is what keeps the two in sync — it fails if a plugin claims an extension the default include misses. Verified by removing `zig` from the string and watching it fail.

Of the four options in the issue this is essentially #2 (derive from the registry, exclude data/config formats). I skipped #3 (teach `trace-mcp init` to emit a repo-specific `include`) — with the default now covering everything a repo contains, there is nothing left for it to add.

## Measured file counts

Default config, old include/exclude vs new, `fast-glob` only:

| repo | before | after | glob time |
|---|---|---|---|
| trace-mcp | 1798 | 2047 | 38ms → 34ms |
| laravel/framework | 3012 | 3137 | 88ms → 125ms |
| VUnit/vunit | 163 | 654 | 43ms → 38ms |
| hashicorp/terraform | 34 | **4315** | 124ms → 162ms |

VUnit picks up the 330 `.vhd` files from the TRA-395 measurement; terraform picks up 1997 `.go`, 1739 `.tf`, 494 `.hcl`. Glob time is flat — the 187-extension brace compiles to one picomatch alternation, not 187 patterns.

## Also in here

- Excludes for the vendored/generated trees the global globs now reach: `target/{debug,release}` (scoped to Rust's build profiles so a Maven `target/src` still indexes), `Pods/`, `coverage/`, `*.min.{js,css}`.
- `.mts`/`.cts` registered on the TypeScript plugin. `src/lsp/config.ts`, `src/tools/refactoring/codemod-ast.ts` and `import-rewriter.ts` already treat them as TypeScript; the language plugin was the only place that dropped them, so they parsed nowhere. Same class of bug as the unregistered VHDL plugin in #547.
- `docs/configuration.md`: the "no default `include` pattern covers `*.yaml`" example is no longer true; replaced with the JSON/XML/INI case, which is.

## Upgrade note

Existing projects index more files on the next run. Repos already near `security.max_files` (default 10000) may now cross it and hit the existing truncation warning — raise the limit or narrow `include`.

## Coordination with #547

#547 adds `docs/language-matrix.md` with an `indexedByDefault` column computed from `TraceMcpConfigSchema`, plus a test asserting the file is regenerated. This PR flips ~57 of those rows. Whichever of the two lands second needs a `pnpm tsx scripts/language-matrix.ts` regen on rebase. I have already added VHDL's `.vhd/.vhdl/.vho/.vhs` to the extension list so #547's plugin registration lands green either way.

## Test evidence

```
pnpm run typecheck   clean
pnpm run test        817 passed | 2 skipped (819 files), 9048 passed | 8 skipped
pnpm exec biome ci   1568 files, no findings
```

Agent: Lead Engineer
