### PR TITLE
fix(app): one state for a slow daemon, and numbers that go stale instead of blank

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -426,6 +426,27 @@ Every data surface owes four states, and each has a house form:
   never indexed" are different sentences. "0 of 0 dependencies covered" is an empty
   state, not a full green meter.
 
+### One condition gets one sentence, and stale beats empty
+
+Two rules for a surface whose data source can be slow, and both were broken at once in
+TRA-397 — a busy daemon produced three different banners in sequence and then replaced
+every number with an em dash.
+
+**A timeout threshold is not a diagnosis.** "The request is taking a while", "the feed
+dropped" and "the request failed" are one condition — the service is busy — seen at three
+moments. Reduce them to one state with one line before they reach the screen, and hold it
+steady: degradation waits out a grace period (`DEGRADED_GRACE_MS`) so a feed that blinks
+does not blink a banner with it, while recovery publishes immediately. Escalating copy
+makes a working app look broken. Keep apart only what the user would act on differently —
+"busy" and "not running" are two states because one is a wait and the other is a button.
+
+**Values that were true a minute ago outrank no values at all.** A refresh that fails must
+leave the last good ones on screen, cache them across launches, and say once — above them,
+where they are read before the numbers are — that they are the last indexed ones. Em dashes
+and "Couldn't be measured" are for a number nobody has ever had, not for one that is a few
+minutes old. The corollary: that line has to match the screen. Saying "these are the last
+indexed numbers" over a row of em dashes is the same lie in the other direction.
+
 ---
 
 ## 6. Layout skeleton

--- a/packages/app/src/renderer/workspace/Workspace.tsx
+++ b/packages/app/src/renderer/workspace/Workspace.tsx
@@ -138,6 +138,31 @@ function openProjectWindow(root: string): void {
 
 // ── Panes ────────────────────────────────────────────────────────────────
 
+/**
+ * The one line for "the daemon is busy" (TRA-397).
+ *
+ * Two halves, each decided by something the reader can see for themselves.
+ * The first says what the daemon is doing: with the feed up we know, and with
+ * it down we say "busy" rather than guessing at indexing. The second describes
+ * the numbers next to it, so it has to follow whether there are any — telling
+ * someone they are looking at the last indexed numbers over a row of em dashes
+ * is the same lie the old copy told, in the other direction.
+ */
+export function busyMessage(o: {
+  connected: boolean;
+  indexing: number;
+  total: number;
+  haveNumbers: boolean;
+}): string {
+  const lead =
+    o.connected && o.indexing > 0
+      ? `Indexing ${o.indexing} of ${o.total} projects`
+      : 'The daemon is busy';
+  return o.haveNumbers
+    ? `${lead}. These are the last indexed numbers.`
+    : `${lead}. The numbers arrive when it's done.`;
+}
+
 /** The pane shown when the daemon is not answering at all. */
 function DaemonDownPane({ restarting, onRestart }: { restarting: boolean; onRestart: () => void }) {
   return (
@@ -248,32 +273,32 @@ export function Workspace() {
   const effectiveView: ViewMode = narrow ? 'compact' : view;
 
   // ── Render ───────────────────────────────────────────────────────────
-  // The live feed being down does not mean there is nothing to show: the
-  // metrics cache usually still has every project. Only take over the pane
-  // when we genuinely have nothing to render.
-  const disconnected = !data.connected && !data.loading;
-  const daemonDown = disconnected && data.projects.length === 0;
-  const showEmpty = !data.loading && !disconnected && data.projects.length === 0;
+  // Two states, not four. `unreachable` takes the pane and offers the process
+  // to start; `stale` keeps every number where it is and says once that they
+  // are a snapshot. A slow daemon is never allowed to reach the first branch.
+  const daemonDown = data.daemonState === 'unreachable';
+  const showEmpty = !data.loading && !daemonDown && data.projects.length === 0;
   const selectedProjects = visible.filter((p) => selection.selected.has(p.root));
   // One diagnosis at a time. When DaemonDownPane has taken over the pane it
-  // already says what happened and offers the fix; letting the metrics banner
-  // through as well put "taking too long — it may still be indexing" directly
-  // above "The daemon isn't running", which are different diagnoses.
+  // already says what happened and offers the fix, so the banner stays out of
+  // the way — two sentences about the same daemon is what this looked like
+  // before (TRA-397).
   const banner = daemonDown
     ? null
-    : disconnected
-    ? {
-        message: 'Live updates are off — the daemon stopped answering. These numbers are the last indexed snapshot.',
-        action: 'restart' as const,
-      }
-    : data.error
-      ? {
-          // A busy daemon is not a broken one — say which, and offer the
-          // action that matches. Retrying a timeout is right; restarting isn't.
-          message: data.error,
-          action: 'retry' as const,
-        }
-      : null;
+    : // A mutation that failed said something specific and actionable; that
+      // outranks "the numbers are a moment old".
+      data.error
+      ? { message: data.error }
+      : data.daemonState === 'stale'
+        ? {
+            message: busyMessage({
+              connected: data.connected,
+              indexing: kpis.indexing,
+              total: kpis.totalProjects,
+              haveNumbers: !data.metricsLoading,
+            }),
+          }
+        : null;
 
   const viewProps = {
     projects: visible,
@@ -293,9 +318,12 @@ export function Workspace() {
     <div ref={paneRef} className="flex flex-col h-full overflow-hidden relative">
       <WorkspaceHeader
         kpis={kpis}
-        metricsLoading={data.metricsLoading && data.error === null}
+        metricsLoading={data.metricsLoading && data.errorKind === null}
         listLoading={data.loading}
-        metricsFailed={data.metricsLoading && data.error !== null}
+        // Em dashes are for a number nobody has, not for a number that is a
+        // few minutes old: `metricsLoading` is already false whenever a
+        // snapshot was restored, so this only fires on a cold, failed start.
+        metricsFailed={data.metricsLoading && data.errorKind !== null}
         listFailed={daemonDown}
         filter={filter}
         onFilterChange={setFilter}
@@ -307,36 +335,31 @@ export function Workspace() {
         dense={dense}
         hideViewToggle={narrow}
         rightExtra={<AddProjectControl onAdd={(root) => data.addProject(root)} />}
-      />
-
-      {banner && (
-        <div
-          role="status"
-          className="mx-4 mt-3 px-3 py-2 rounded-lg text-[13px] flex items-center gap-2"
-          style={{
-            background: 'color-mix(in srgb, var(--status-orange) 9%, transparent)',
-            color: 'var(--label)',
-            border: '0.5px solid color-mix(in srgb, var(--status-orange) 30%, transparent)',
-          }}
-        >
-          <span>{banner.message}</span>
-          {/* The action belongs next to the sentence that needs it, not 1400px
-              away at the far right of the window. */}
-          {banner.action === 'restart' ? (
-            <Button
-              size="small"
-              onClick={() => void data.restartDaemon()}
-              disabled={data.restarting}
+        // Above the tiles, not below them: the line that says these numbers
+        // are a snapshot has to be read before the numbers are.
+        banner={
+          banner && (
+            <div
+              role="status"
+              className="mx-4 mt-3 px-3 py-2 rounded-lg text-[13px] flex items-center gap-2"
+              style={{
+                background: 'color-mix(in srgb, var(--status-orange) 9%, transparent)',
+                color: 'var(--label)',
+                border: '0.5px solid color-mix(in srgb, var(--status-orange) 30%, transparent)',
+              }}
             >
-              {data.restarting ? 'Starting…' : 'Start daemon'}
-            </Button>
-          ) : (
-            <Button size="small" onClick={() => void data.refresh()} disabled={data.refreshing}>
-              {data.refreshing ? 'Retrying…' : 'Try again'}
-            </Button>
-          )}
-        </div>
-      )}
+              <span>{banner.message}</span>
+              {/* The action belongs next to the sentence that needs it, not
+                  1400px away at the far right of the window. Restarting the
+                  daemon is not offered here — a busy daemon does not need
+                  restarting, and one that is actually down has its own pane. */}
+              <Button size="small" onClick={() => void data.refresh()} disabled={data.refreshing}>
+                {data.refreshing ? 'Retrying…' : 'Try again'}
+              </Button>
+            </div>
+          )
+        }
+      />
 
       <div className="flex-1 min-h-0 flex flex-col px-4 pb-4 pt-3">
         {daemonDown ? (

--- a/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
@@ -75,6 +75,12 @@ export interface WorkspaceHeaderProps {
   hideViewToggle?: boolean;
   /** Slot rendered at the end of the toolbar row (typically AddProjectControl). */
   rightExtra?: ReactNode;
+  /**
+   * Slot between the toolbar and the KPI grid, for the line that qualifies the
+   * numbers below it — "these are the last indexed numbers". Below the grid it
+   * would be a footnote to figures the reader has already believed (TRA-397).
+   */
+  banner?: ReactNode;
 }
 
 const STATUS_CHIPS: Array<{ key: ProjectHealthStatus; label: string; title: string }> = [
@@ -142,6 +148,7 @@ export function WorkspaceHeader({
   dense = false,
   hideViewToggle = false,
   rightExtra,
+  banner,
 }: WorkspaceHeaderProps) {
   // Locally-debounced search so typing doesn't spam upstream re-renders.
   const [queryDraft, setQueryDraft] = useState(filter.query);
@@ -234,6 +241,8 @@ export function WorkspaceHeader({
           />
         </span>
       </Toolbar>
+
+      {banner}
 
       {/* ── KPI grid ───────────────────────────────────────────────── */}
       <div className="flex items-stretch gap-4 px-4 pt-4 pb-3 flex-wrap">

--- a/packages/app/src/renderer/workspace/__tests__/Workspace.degraded.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/Workspace.degraded.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * TRA-397 — one slow daemon used to produce three different banners and then
+ * throw the numbers away. What this pins down:
+ *
+ *  - a slow daemon with cached values keeps the values and says so once;
+ *  - a slow daemon with no cached values still says the same one thing;
+ *  - a daemon that never answered is still its own screen, with the process
+ *    to start on it.
+ */
+import { render, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Workspace, busyMessage } from '../Workspace';
+import type { ProjectViewModel } from '../types';
+import type { UseWorkspaceProjectsResult } from '../useWorkspaceProjects';
+
+const cached: ProjectViewModel[] = [
+  {
+    root: '/Users/nikolai/Projects/alpha',
+    name: 'alpha',
+    displayStatus: 'ok',
+    lastIndexed: '2026-08-29T09:00:00Z',
+    totalFiles: 1200,
+    totalSymbols: 9800,
+    techDebtGrade: 'A',
+    securityFindings: 0,
+    deadExports: 0,
+    hasMetrics: true,
+    inDaemon: true,
+  },
+];
+
+const OK: UseWorkspaceProjectsResult = {
+  projects: cached,
+  loading: false,
+  metricsLoading: false,
+  refreshing: false,
+  error: null,
+  errorKind: null,
+  daemonState: 'ok',
+  connected: true,
+  restarting: false,
+  addProject: async () => {},
+  removeProject: async () => {},
+  reindexProject: async () => {},
+  reindexMany: async () => {},
+  removeMany: async () => {},
+  refresh: async () => {},
+  restartDaemon: async () => {},
+};
+
+let data: UseWorkspaceProjectsResult = OK;
+
+vi.mock('../useWorkspaceProjects', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useWorkspaceProjects')>()),
+  useWorkspaceProjects: () => data,
+}));
+
+/** The rendered value of one KPI tile, e.g. "1.2k" or "—". */
+function kpi(label: string): string {
+  const value = document.querySelector(`[data-kpi="${label}"] [data-kpi-value]`);
+  return value?.textContent ?? '';
+}
+
+function banners(): string[] {
+  return screen.queryAllByRole('status').map((el) => el.textContent ?? '');
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem('trace-mcp.workspace.view', 'table');
+  data = OK;
+});
+
+describe('a slow daemon', () => {
+  it('keeps the cached numbers on screen under exactly one banner', () => {
+    data = { ...OK, daemonState: 'stale', errorKind: 'timeout' };
+    render(<Workspace />);
+
+    expect(banners()).toHaveLength(1);
+    expect(banners()[0]).toContain('These are the last indexed numbers.');
+    // The values that were valid a minute ago are still the values.
+    expect(kpi('Files')).toBe('1.2k');
+    expect(kpi('Symbols')).toBe('9.8k');
+    expect(screen.queryByText("Couldn't be measured")).toBeNull();
+    // Slow is not down: no "start the daemon" anywhere on the screen.
+    expect(screen.queryByText('Start daemon')).toBeNull();
+  });
+
+  it('says the same one thing when the feed is down instead of the fetch', () => {
+    const slow = render(<Workspace />);
+    data = { ...OK, daemonState: 'stale', connected: false };
+    slow.rerender(<Workspace />);
+    expect(banners()).toHaveLength(1);
+    expect(banners()[0]).toContain('These are the last indexed numbers.');
+  });
+
+  it('reads as unknown, not as zero, when there is no snapshot to fall back on', () => {
+    data = {
+      ...OK,
+      projects: [],
+      metricsLoading: true,
+      daemonState: 'stale',
+      errorKind: 'timeout',
+    };
+    render(<Workspace />);
+
+    expect(banners()).toHaveLength(1);
+    // …and the line above them must not claim otherwise.
+    expect(banners()[0]).toContain("The numbers arrive when it's done.");
+    expect(kpi('Files')).toBe('—');
+    expect(screen.getAllByText("Couldn't be measured").length).toBeGreaterThan(0);
+  });
+
+  it('offers the retry that matches, and never a restart', () => {
+    data = { ...OK, daemonState: 'stale', errorKind: 'offline' };
+    render(<Workspace />);
+    expect(within(screen.getByRole('status')).getByRole('button')).toHaveProperty(
+      'textContent',
+      'Try again',
+    );
+  });
+});
+
+describe('an unreachable daemon', () => {
+  it('is its own screen, with no second sentence above it', () => {
+    data = { ...OK, projects: [], daemonState: 'unreachable', connected: false };
+    render(<Workspace />);
+
+    expect(screen.getByText("The daemon isn't running")).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Start daemon' })).toBeTruthy();
+    expect(banners()).toHaveLength(0);
+  });
+});
+
+describe('busyMessage', () => {
+  const withNumbers = { connected: true, indexing: 3, total: 12, haveNumbers: true };
+
+  it('reports progress when the feed can tell us any', () => {
+    expect(busyMessage(withNumbers)).toMatch(/^Indexing 3 of 12 projects\./);
+  });
+
+  it('does not guess at indexing with the feed down', () => {
+    expect(busyMessage({ ...withNumbers, connected: false })).toMatch(/^The daemon is busy\./);
+    expect(busyMessage({ ...withNumbers, indexing: 0 })).toMatch(/^The daemon is busy\./);
+  });
+
+  it('only claims there are numbers when there are', () => {
+    expect(busyMessage(withNumbers)).toContain('These are the last indexed numbers.');
+    expect(busyMessage({ ...withNumbers, haveNumbers: false })).toContain(
+      "The numbers arrive when it's done.",
+    );
+  });
+});

--- a/packages/app/src/renderer/workspace/__tests__/Workspace.sort.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/Workspace.sort.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../useWorkspaceProjects', () => ({
     refreshing: false,
     error: null,
     errorKind: null,
+    daemonState: 'ok',
     connected: true,
     restarting: false,
     addProject: async () => {},

--- a/packages/app/src/renderer/workspace/__tests__/useWorkspaceProjects.test.ts
+++ b/packages/app/src/renderer/workspace/__tests__/useWorkspaceProjects.test.ts
@@ -1,12 +1,24 @@
 /**
+ * @vitest-environment jsdom
+ *
  * TRA-264 — a failed metrics fetch must not be reported as loaded, or the KPI
  * strip swaps its `—` placeholders for hard zeros and presents the failure as
  * real data.
+ *
+ * TRA-397 — and it must not throw the previous numbers away either. A slow
+ * daemon is one state, not three escalating ones.
  */
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { classifyMetricsError, describeMetricsError, fetchMetricsOnce } from '../useWorkspaceProjects';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  classifyMetricsError,
+  deriveDaemonState,
+  fetchMetricsOnce,
+  loadMetricsSnapshot,
+  saveMetricsSnapshot,
+} from '../useWorkspaceProjects';
+import type { ProjectHealthMetrics } from '../types';
 
-const setters = () => ({ setMetrics: vi.fn(), setError: vi.fn() });
+const setters = () => ({ setMetrics: vi.fn(), setErrorKind: vi.fn() });
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -19,7 +31,7 @@ describe('fetchMetricsOnce', () => {
     const s = setters();
     expect(await fetchMetricsOnce(s)).toBe(true);
     expect(s.setMetrics).toHaveBeenCalledWith([{ root: '/a' }]);
-    expect(s.setError).toHaveBeenCalledWith(null);
+    expect(s.setErrorKind).toHaveBeenCalledWith(null);
   });
 
   it('returns false on a network failure and never publishes metrics', async () => {
@@ -27,23 +39,14 @@ describe('fetchMetricsOnce', () => {
     const s = setters();
     expect(await fetchMetricsOnce(s)).toBe(false);
     expect(s.setMetrics).not.toHaveBeenCalled();
+    expect(s.setErrorKind).toHaveBeenCalledWith('offline');
   });
 
   it('returns false on a non-OK response', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503, json: async () => ({}) }));
     const s = setters();
     expect(await fetchMetricsOnce(s)).toBe(false);
-    expect(s.setError).toHaveBeenCalledWith(expect.stringContaining('HTTP 503'));
-  });
-});
-
-describe('describeMetricsError', () => {
-  it('replaces raw transport messages with an actionable one', () => {
-    for (const raw of ['Failed to fetch', 'Load failed', 'Connection refused']) {
-      expect(describeMetricsError(new Error(raw))).toBe(
-        "Couldn't load project metrics — daemon not responding.",
-      );
-    }
+    expect(s.setErrorKind).toHaveBeenCalledWith('server');
   });
 
   // TRA-292: a daemon alive on /health but eight seconds deep in indexing
@@ -51,13 +54,54 @@ describe('describeMetricsError', () => {
   // user to restart a service that is working.
   it('calls a timeout slow, not unreachable', () => {
     for (const err of [new Error('The operation was aborted'), new Error('signal timed out')]) {
-      expect(describeMetricsError(err)).toMatch(/still be indexing/);
+      expect(classifyMetricsError(err)).toBe('timeout');
     }
     expect(classifyMetricsError({ name: 'TimeoutError', message: '' })).toBe('timeout');
+    expect(classifyMetricsError(new Error('cache rebuild failed'))).toBe('server');
+  });
+});
+
+describe('deriveDaemonState', () => {
+  const base = { loading: false, connected: true, liveProjects: 3, metricsErrorKind: null };
+
+  it('is ok while the daemon has not answered yet', () => {
+    // Not "failing" — not asked yet. The skeleton owns this moment.
+    expect(deriveDaemonState({ ...base, loading: true, connected: false, liveProjects: 0 })).toBe(
+      'ok',
+    );
   });
 
-  it('keeps a meaningful server message', () => {
-    expect(describeMetricsError(new Error('cache rebuild failed'))).toContain('cache rebuild failed');
-    expect(classifyMetricsError(new Error('cache rebuild failed'))).toBe('server');
+  it('is ok when everything answers', () => {
+    expect(deriveDaemonState(base)).toBe('ok');
+  });
+
+  // The three banners the user cycled through were these three inputs.
+  it('reads every degraded input as the same one state', () => {
+    expect(deriveDaemonState({ ...base, metricsErrorKind: 'timeout' })).toBe('stale');
+    expect(deriveDaemonState({ ...base, metricsErrorKind: 'offline' })).toBe('stale');
+    expect(deriveDaemonState({ ...base, metricsErrorKind: 'server' })).toBe('stale');
+    expect(deriveDaemonState({ ...base, connected: false })).toBe('stale');
+  });
+
+  it('keeps a daemon that never answered at all distinct', () => {
+    expect(deriveDaemonState({ ...base, connected: false, liveProjects: 0 })).toBe('unreachable');
+  });
+});
+
+describe('metrics snapshot', () => {
+  const rows = [{ root: '/a', name: 'a', totalFiles: 12 }] as unknown as ProjectHealthMetrics[];
+
+  beforeEach(() => localStorage.clear());
+
+  it('round-trips the last successful response', () => {
+    saveMetricsSnapshot(rows);
+    expect(loadMetricsSnapshot()).toEqual(rows);
+  });
+
+  it('starts cold rather than throwing on a corrupted snapshot', () => {
+    localStorage.setItem('trace-mcp.workspace.metrics', '{not json');
+    expect(loadMetricsSnapshot()).toEqual([]);
+    localStorage.setItem('trace-mcp.workspace.metrics', '"a string"');
+    expect(loadMetricsSnapshot()).toEqual([]);
   });
 });

--- a/packages/app/src/renderer/workspace/useWorkspaceProjects.ts
+++ b/packages/app/src/renderer/workspace/useWorkspaceProjects.ts
@@ -10,6 +10,12 @@
  * pipeline state (indexing / embedding / computing / pending → ready /
  * error), schedule a debounced re-fetch of metrics. Plus a 5-minute polling
  * fallback that matches the server-side cache TTL.
+ *
+ * Degraded behaviour (TRA-397): the last successful metrics response is kept
+ * in localStorage, so a launch against a daemon that is busy indexing opens on
+ * the last known numbers instead of on em dashes. A slow daemon and a
+ * disconnected feed collapse into one {@link DaemonState}: the app is showing a
+ * snapshot, and it says so once rather than escalating through three sentences.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DAEMON_FETCH_TIMEOUT_MS, useDaemon } from '../hooks/useDaemon';
@@ -23,6 +29,37 @@ const BASE = 'http://127.0.0.1:3741';
 
 export const AUTO_REFRESH_INTERVAL_MS = 300_000; // 5 min — matches backend cache TTL.
 export const STATUS_TRANSITION_DEBOUNCE_MS = 1000;
+
+/**
+ * How long a degraded reading has to hold before the banner appears. The event
+ * feed drops and re-opens in well under a second while the daemon is loaded,
+ * and a banner that blinks in and out of a screen reads as broken rather than
+ * busy. Recovery is published immediately — only degradation waits.
+ */
+export const DEGRADED_GRACE_MS = 1500;
+
+/** Last successful `/api/dashboard/projects` response, kept across launches. */
+const LS_METRICS_KEY = 'trace-mcp.workspace.metrics';
+
+export function loadMetricsSnapshot(): ProjectHealthMetrics[] {
+  try {
+    const raw = localStorage.getItem(LS_METRICS_KEY);
+    const parsed = raw ? (JSON.parse(raw) as unknown) : null;
+    return Array.isArray(parsed) ? (parsed as ProjectHealthMetrics[]) : [];
+  } catch {
+    // Corrupted JSON, or a sandboxed renderer with no storage — start cold.
+    return [];
+  }
+}
+
+export function saveMetricsSnapshot(metrics: ProjectHealthMetrics[]): void {
+  try {
+    localStorage.setItem(LS_METRICS_KEY, JSON.stringify(metrics));
+  } catch {
+    // Quota or sandbox. A missing snapshot costs one screen of em dashes, so
+    // there is nothing worth reporting to the user here.
+  }
+}
 
 // ── Exported pure helpers (testable without React) ────────────────────────
 
@@ -61,9 +98,16 @@ export interface UseWorkspaceProjectsResult {
    */
   metricsLoading: boolean;
   refreshing: boolean;
+  /**
+   * A mutation that failed and has something to say — a reindex or a remove.
+   * A metrics fetch never lands here: "the numbers are a moment old" is a
+   * state, not an error, and it is reported through {@link daemonState}.
+   */
   error: string | null;
-  /** Why `error` happened — drives the wording and the offered action. */
+  /** Why the last metrics fetch failed, if it did. */
   errorKind: MetricsErrorKind | null;
+  /** One reading of how much the daemon is answering. */
+  daemonState: DaemonState;
   connected: boolean;
   restarting: boolean;
   addProject(root: string): Promise<void>;
@@ -82,10 +126,45 @@ export interface UseWorkspaceProjectsResult {
  */
 export type MetricsErrorKind = 'timeout' | 'offline' | 'server';
 
+/**
+ * How much of the daemon is answering, as one value.
+ *
+ * The three failures a user could hit here — a metrics read that timed out, a
+ * metrics read refused, an event feed that dropped — are one condition seen at
+ * three thresholds, not three things to act on differently. Escalating through
+ * a sentence each made a busy daemon look like a broken app (TRA-397), so they
+ * collapse to `stale`: what is on screen is the last indexed snapshot, and it
+ * stays on screen.
+ *
+ * `unreachable` is kept apart because it is genuinely different and genuinely
+ * actionable — the daemon never answered at all, so there is a process to
+ * start rather than a wait to sit through.
+ */
+export type DaemonState = 'ok' | 'stale' | 'unreachable';
+
+/**
+ * Pure state reduction — no timers, no React. `loading` wins: the first
+ * moment of a launch is the skeleton's, and a daemon that has not answered
+ * *yet* is not a daemon that is failing to.
+ */
+export function deriveDaemonState(o: {
+  /** The daemon's own first read is still in flight. */
+  loading: boolean;
+  /** The event feed is open. */
+  connected: boolean;
+  /** Projects the daemon itself has named this session. */
+  liveProjects: number;
+  metricsErrorKind: MetricsErrorKind | null;
+}): DaemonState {
+  if (o.loading) return 'ok';
+  // No feed and nothing the daemon ever told us: it isn't running.
+  if (!o.connected) return o.liveProjects > 0 ? 'stale' : 'unreachable';
+  return o.metricsErrorKind === null ? 'ok' : 'stale';
+}
+
 interface MetricsSetters {
   setMetrics: (m: ProjectHealthMetrics[]) => void;
-  setError: (e: string | null) => void;
-  setErrorKind?: (k: MetricsErrorKind | null) => void;
+  setErrorKind: (k: MetricsErrorKind | null) => void;
 }
 
 /** Classify a fetch rejection. A timeout means slow, not gone. */
@@ -98,45 +177,27 @@ export function classifyMetricsError(err: unknown): MetricsErrorKind {
 }
 
 /**
- * Turn a raw fetch rejection into something a user can act on. `Failed to
- * fetch` / `The operation was aborted` are the browser's own words for "the
- * socket died" and mean nothing to the person reading the banner.
- */
-export function describeMetricsError(err: unknown): string {
-  switch (classifyMetricsError(err)) {
-    case 'timeout':
-      return 'The daemon is taking too long to answer — it may still be indexing.';
-    case 'offline':
-      return "Couldn't load project metrics — daemon not responding.";
-    default: {
-      const raw = (err as Error)?.message ?? '';
-      return raw ? `Couldn't load project metrics — ${raw}` : "Couldn't load project metrics.";
-    }
-  }
-}
-
-/**
  * Fetch the dashboard cache once. Exported so tests can drive it directly.
  * Returns true only when metrics actually landed — the caller uses that to
  * decide whether the KPI strip may stop rendering `—` placeholders.
+ *
+ * A failure publishes a *kind*, never a sentence: the copy the user reads is
+ * one line owned by the surface, not three lines assembled here from whichever
+ * transport error arrived first.
  */
 export async function fetchMetricsOnce(setters: MetricsSetters): Promise<boolean> {
   try {
     const res = await fetch(`${BASE}/api/dashboard/projects`, { signal: AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS) }); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
     if (!res.ok) {
-      const body = (await res.json().catch(() => ({}))) as { error?: string };
-      setters.setError(`Couldn't load project metrics — ${body.error ?? `HTTP ${res.status}`}`);
-      setters.setErrorKind?.('server');
+      setters.setErrorKind('server');
       return false;
     }
     const data = (await res.json()) as { projects: ProjectHealthMetrics[] };
     setters.setMetrics(data.projects ?? []);
-    setters.setError(null);
-    setters.setErrorKind?.(null);
+    setters.setErrorKind(null);
     return true;
   } catch (err) {
-    setters.setError(describeMetricsError(err));
-    setters.setErrorKind?.(classifyMetricsError(err));
+    setters.setErrorKind(classifyMetricsError(err));
     return false;
   }
 }
@@ -144,8 +205,11 @@ export async function fetchMetricsOnce(setters: MetricsSetters): Promise<boolean
 export function useWorkspaceProjects(): UseWorkspaceProjectsResult {
   const daemon = useDaemon();
 
-  const [metrics, setMetrics] = useState<ProjectHealthMetrics[]>([]);
-  const [metricsLoaded, setMetricsLoaded] = useState(false);
+  // Open on the last snapshot rather than on nothing: a launch against a
+  // daemon that is mid-index used to spend its first eight seconds showing
+  // em dashes for numbers that were sitting on disk the whole time.
+  const [metrics, setMetrics] = useState<ProjectHealthMetrics[]>(loadMetricsSnapshot);
+  const [metricsLoaded, setMetricsLoaded] = useState(() => metrics.length > 0);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [errorKind, setErrorKind] = useState<MetricsErrorKind | null>(null);
@@ -156,9 +220,16 @@ export function useWorkspaceProjects(): UseWorkspaceProjectsResult {
 
   // Single-flight metrics fetch. Only a *successful* fetch clears the loading
   // flag — otherwise the KPI strip would swap `—` placeholders for hard zeros
-  // and present a failed fetch as real data (TRA-264).
+  // and present a failed fetch as real data (TRA-264). A failure also leaves
+  // `metrics` alone, so whatever is on screen stays on screen.
   const fetchMetrics = useCallback(async () => {
-    const ok = await fetchMetricsOnce({ setMetrics, setError, setErrorKind });
+    const ok = await fetchMetricsOnce({
+      setMetrics: (m) => {
+        setMetrics(m);
+        saveMetricsSnapshot(m);
+      },
+      setErrorKind,
+    });
     if (ok) setMetricsLoaded(true);
   }, []);
 
@@ -235,6 +306,26 @@ export function useWorkspaceProjects(): UseWorkspaceProjectsResult {
   // We're loading when neither source has produced anything yet.
   const loading = daemon.loading && !metricsLoaded && projects.length === 0;
 
+  // One reading, held steady. Degradation waits out DEGRADED_GRACE_MS so a
+  // feed that blinks doesn't blink a banner with it; recovery is immediate,
+  // because there is no reason to keep telling someone their data is old
+  // once it isn't.
+  const observedState = deriveDaemonState({
+    loading: daemon.loading,
+    connected: daemon.connected,
+    liveProjects: daemon.projects.length,
+    metricsErrorKind: errorKind,
+  });
+  const [daemonState, setDaemonState] = useState<DaemonState>('ok');
+  useEffect(() => {
+    if (observedState === 'ok') {
+      setDaemonState('ok');
+      return;
+    }
+    const t = setTimeout(() => setDaemonState(observedState), DEGRADED_GRACE_MS);
+    return () => clearTimeout(t);
+  }, [observedState]);
+
   return {
     projects,
     loading,
@@ -242,6 +333,7 @@ export function useWorkspaceProjects(): UseWorkspaceProjectsResult {
     refreshing,
     error,
     errorKind,
+    daemonState,
     connected: daemon.connected,
     restarting: daemon.restarting,
     addProject: daemon.addProject,


### PR DESCRIPTION
Closes TRA-397.

## What was wrong

One slow daemon produced three banners in sequence:

1. `The daemon is taking too long to answer — it may still be indexing.`
2. `Live updates are off — the daemon stopped answering. These numbers are the last indexed snapshot.`
3. `Couldn't load project metrics — daemon not responding.`

They are not three conditions anyone can act on differently — they are one condition (the daemon is busy) seen at three timeout thresholds. Cycling between them makes a working app look broken. And the third one threw the numbers away: KPI tiles to "Couldn't be measured", table rows to em dashes, on a machine where all that data existed and was valid.

## What it does now

**One state.** `deriveDaemonState` reduces `{loading, connected, liveProjects, metricsErrorKind}` to `ok | stale | unreachable`. Every degraded input — a metrics read that timed out, one that was refused, an HTTP error, a dropped event feed — is `stale`: one banner, one line. Degradation waits out a 1.5s grace so a feed that blinks doesn't blink a banner with it; recovery publishes immediately.

**`unreachable` stays its own screen.** A daemon that never answered at all is a button, not a wait, so `DaemonDownPane` and "Start daemon" are unchanged and the banner stays out of its way. The banner no longer offers a restart at all — a busy daemon does not need restarting.

**The numbers stay.** The last successful `/api/dashboard/projects` response is cached in `localStorage`, so a launch against a daemon mid-index opens on the last known numbers instead of on em dashes. `metricsFailed` (em dash + "Couldn't be measured") now only fires when there is genuinely nothing to show.

**The line moved above the tiles.** Sentence that qualifies the numbers, then the numbers — not the other way round. `WorkspaceHeader` grew a `banner` slot between the toolbar and the KPI grid.

**Copy.** Two halves, each decided by something the reader can see:

| feed | numbers | line |
|---|---|---|
| up, 3 indexing | yes | `Indexing 3 of 12 projects. These are the last indexed numbers.` |
| up, 3 indexing | no | `Indexing 3 of 12 projects. The numbers arrive when it's done.` |
| down | yes | `The daemon is busy. These are the last indexed numbers.` |

Progress is reported when the feed can tell us any, and never guessed at when it can't — "may still be indexing" was a shrug. The second half follows whether there are numbers, because telling someone they are looking at the last indexed numbers over a row of em dashes is the same lie in the other direction.

`describeMetricsError` is gone: a fetch publishes a *kind*, never a sentence. `error` is now only for a mutation that failed and has something specific to say (a reindex, a remove).

## Verification

Real Electron window, `electron-cdp.mjs` + CDP. The daemon holding 3741 on this machine is hung (19s to answer `/api/projects` with an empty body — the TRA-396 condition) and is not ours to stop, so the transport was stubbed inside the page: the app's own fetch paths, its 8s timeout, the grace period, the state machine and every component ran for real.

Polling the banner for 30s in the slow state: **2 distinct states — none, then one wording that never changed.** That list used to have three entries.

Tests: `deriveDaemonState` over every degraded input, snapshot round-trip and corruption, and three rendered scenarios — slow daemon with cached values, slow daemon with none, unreachable daemon. 428 tests pass, typecheck clean, `check:i18n` clean.

Screenshots (light, dark, Reduce Transparency, Increase Contrast, 640×420 minimum window, and the unreachable pane) are on TRA-397.

## Also

`DESIGN.md` §5 gains the two rules this cost, written for the class rather than for this screen: a timeout threshold is not a diagnosis, and values that were true a minute ago outrank no values at all.
