### PR TITLE
perf(app): stop shipping react-i18next in app.asar, measure startup on the renderer's own clock (TRA-398)

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -3,17 +3,31 @@
 Machine-readable history lives in [`baseline.json`](./baseline.json) — append one `runs[]`
 entry per measurement pass, never rewrite an old one. This file is the human summary.
 
-## Current numbers (1.51.1, `9459d4ce`, macOS 26.5 / arm64, median of 3)
+## Current numbers (3.2.0, `6ebbbd56`, macOS 26.5 / arm64, median of 3)
 
 | Metric | Value | Ceiling | Status |
 |---|---|---|---|
-| `cold_start_ms` | 349 | 3000 | ok |
-| `window_interactive_ms` | 121 | — | ok |
+| `renderer_fcp_ms` | 220 | — | ok — **the startup metric of record** |
+| `cold_start_ms` | 1005 | 3000 | ok, but load-sensitive (see below) |
+| `window_interactive_ms` | 612 | — | load-sensitive, do not trend it |
 | `heap_idle_mb` (5 min idle) | 9.5 | — | ok |
 | `main_cpu_idle_pct` | 0 | 2 | ok |
-| `renderer_bundle_kb` | 1461 | — | ok |
-| `artifact_mb.mac_asar` | 1.6 | ×1.5 growth | ok |
-| `artifact_mb.mac_app_unpacked` | 264.8 | ×1.5 growth | ok (Electron framework is ~263 MB of it) |
+| `renderer_bundle_kb` | 1700 | — | +16% vs 1461 — warning, noted not filed |
+| `artifact_mb.mac_asar` | 4.85 | ×1.5 growth | was 5.8, fixed this run (see below) |
+| `artifact_mb.mac_app_unpacked` | 268.1 | ×1.5 growth | ok (Electron framework is ~263 MB of it) |
+
+### Which startup number to trend
+
+`cold_start_ms` and `window_interactive_ms` are wall-clock across the harness's 20 ms
+poll loop and its CDP round-trips. On a busy machine that inflates them by hundreds of
+milliseconds while the app itself is unchanged — the 2026-08-29 run measured 349 → 1005 ms
+on a machine at load average 11–22 and none of it was the product. `renderer_fcp_ms` is
+read off the renderer's own clock after the fact and carries none of that, so **compare
+`renderer_fcp_ms` across runs**; treat the other two as a sanity check against the 3 s
+ceiling only.
+
+When a run has to happen on a loaded machine, an interleaved A/B — alternating one sample
+of each build, several rounds — cancels the drift that a back-to-back A-then-B run does not.
 
 `ui_p95_ms`, `heap_after_workload_mb` and `heap_growth_mb_per_hour` are still unfilled in
 `baseline.json`. The harness that produces them landed with TRA-258 and has been run
@@ -104,6 +118,23 @@ doesn't list it. That shipped 27.5 MB of `@luma.gl`, `@cosmos.gl`, `d3-*`, `micr
 and friends into every release — all of which Vite had already bundled into
 `dist/renderer`. The main process imports nothing but Node builtins and `electron`, so
 `!node_modules/**` is safe. The `menubar` dependency was unused and was dropped.
+
+**2026-08-29 — the redesign and i18n cost nothing at startup (negative result).**
+Interleaved A/B of `9459d4ce` (the 2026-08-28 baseline), `9cdccf9b` (pre-i18n) and
+`6ebbbd56` (HEAD), 7 rounds of one sample each: median FCP 288 / 300 / 284 ms. The whole
+macOS 26 redesign and the i18n runtime are invisible in renderer boot. The same rounds
+read on `window_interactive_ms` claimed +188%, which was the harness, not the app — that
+is why `renderer_fcp_ms` exists.
+
+**2026-08-29 — `app.asar` 1.6 MB → 5.8 MB → 4.85 MB.**
+TRA-257's blanket `!node_modules/**` had to become an explicit `node_modules/**` include
+so the main process keeps `electron-updater` on Windows. That re-admitted every production
+dependency, and the i18n work made `react-i18next` (1.0 MB) plus its `@babel/runtime` tree
+(1.1 MB) production dependencies even though Vite already bundles them into
+`dist/renderer` — 3.6× growth, past the ×1.5 ceiling. `react-i18next` moved to
+devDependencies. The remaining 4.85 MB is genuine main-process runtime. The rule is now a
+test: `packages/app/src/main/__tests__/packaged-deps.test.ts` fails if a package lands in
+`dependencies` without the main process importing it.
 
 **2026-08-28 — lazy-loading the graph view is not worth it (negative result).**
 `@cosmos.gl/graph` is 702 KB and loads eagerly: `GraphExplorerGPU` is a static import

--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -42,7 +42,7 @@
           "main_cpu_idle_pct": 0
         }
       ],
-      "notes": "Installation run — first entry in the series, no regression comparison possible. Harness: packages/app/scripts/perf-measure.mjs (CDP against a production build, throwaway --user-data-dir per sample). Startup, idle heap and idle CPU are all far inside the absolute ceilings (349 ms vs 3000, 0% vs 2%). Artifact fix landed in this same run: app.asar 21.8 MB -> 1.6 MB and the .app 286 MB -> 265 MB by excluding node_modules from the electron-builder file set (the main process imports only Node builtins + electron; Vite already bundles every renderer dep) and dropping the unused `menubar` dependency. Startup timings are unaffected by that change — the dev launch path never touches the asar; the 439 ms measured earlier in the same session vs 349 ms here is machine warm-up, not a code delta. Measured negative result: stubbing out the 702 KB cosmos.gl chunk (eagerly loaded via a static import in the entry chunk) moved cold start only 439 -> 417 ms (~5%), so lazy-loading the graph view is not worth the refactor at this size. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour not measured this run — they need a fixed indexed project fixture, which the next run should add."
+      "notes": "Installation run \u2014 first entry in the series, no regression comparison possible. Harness: packages/app/scripts/perf-measure.mjs (CDP against a production build, throwaway --user-data-dir per sample). Startup, idle heap and idle CPU are all far inside the absolute ceilings (349 ms vs 3000, 0% vs 2%). Artifact fix landed in this same run: app.asar 21.8 MB -> 1.6 MB and the .app 286 MB -> 265 MB by excluding node_modules from the electron-builder file set (the main process imports only Node builtins + electron; Vite already bundles every renderer dep) and dropping the unused `menubar` dependency. Startup timings are unaffected by that change \u2014 the dev launch path never touches the asar; the 439 ms measured earlier in the same session vs 349 ms here is machine warm-up, not a code delta. Measured negative result: stubbing out the 702 KB cosmos.gl chunk (eagerly loaded via a static import in the entry chunk) moved cold start only 439 -> 417 ms (~5%), so lazy-loading the graph view is not worth the refactor at this size. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour not measured this run \u2014 they need a fixed indexed project fixture, which the next run should add."
     },
     {
       "date": "2026-08-28T17:15:00Z",
@@ -71,7 +71,35 @@
           "app_network_utility": 19
         }
       },
-      "notes": "Daemon memory, not the Electron app (GPU out of scope). Source of the 3.34 GB `node` process in the Activity Monitor screenshot: `serve-http`. Identified from the daemon's own vitals heartbeat in ~/.trace-mcp/daemon.log — peak sample was rss 3619 MB / heap_used 2758 MB at uptime 66 s with projects_loaded=107, against a 166 MB idle baseline with 0 projects. Cause is startup fan-out, not a leak: loadAllRegistered() eagerly added all 110 registered projects. Controlled measurement in an isolated TRACE_MCP_DATA_DIR with 40 *empty* two-file projects: 212 MB (n=1) -> 381 MB (n=10) -> 1198 MB (n=40), i.e. ~9 MB of LIVE JS heap per loaded project (423 MB heapUsed after a forced CDP GC) before the project holds any code. Not a leak — after the idle-unload sweep dropped all 40 projects a forced GC returned heapUsed to 62 MB and RSS to 198 MB; the flat `heap_used_mb` seen in vitals on an idle daemon is stale-since-last-GC reporting, and macOS holds RSS pages well past the heap shrinking, so both Activity Monitor and vitals rss overstate. Fix: `daemon_eager_load_projects` (default 8) caps startup loading to the most recently indexed projects; the rest lazily load on first MCP connect via the existing idle-unload reload path. Same 40-project fixture after the fix: peak 378 MB (-67%), settled 253 MB, and a deferred project still serves (initialize -> 200, project reaches ready). Single real repo (this one, ~900 files) on the fixed daemon: peak 442 MB, 312 MB after a 10-minute settle. Harness: scale-probe.mjs / lazy-check.mjs / mem-probe.mjs from the TRA-278 workdir (not committed — they drive a real daemon against throwaway data dirs)."
+      "notes": "Daemon memory, not the Electron app (GPU out of scope). Source of the 3.34 GB `node` process in the Activity Monitor screenshot: `serve-http`. Identified from the daemon's own vitals heartbeat in ~/.trace-mcp/daemon.log \u2014 peak sample was rss 3619 MB / heap_used 2758 MB at uptime 66 s with projects_loaded=107, against a 166 MB idle baseline with 0 projects. Cause is startup fan-out, not a leak: loadAllRegistered() eagerly added all 110 registered projects. Controlled measurement in an isolated TRACE_MCP_DATA_DIR with 40 *empty* two-file projects: 212 MB (n=1) -> 381 MB (n=10) -> 1198 MB (n=40), i.e. ~9 MB of LIVE JS heap per loaded project (423 MB heapUsed after a forced CDP GC) before the project holds any code. Not a leak \u2014 after the idle-unload sweep dropped all 40 projects a forced GC returned heapUsed to 62 MB and RSS to 198 MB; the flat `heap_used_mb` seen in vitals on an idle daemon is stale-since-last-GC reporting, and macOS holds RSS pages well past the heap shrinking, so both Activity Monitor and vitals rss overstate. Fix: `daemon_eager_load_projects` (default 8) caps startup loading to the most recently indexed projects; the rest lazily load on first MCP connect via the existing idle-unload reload path. Same 40-project fixture after the fix: peak 378 MB (-67%), settled 253 MB, and a deferred project still serves (initialize -> 200, project reaches ready). Single real repo (this one, ~900 files) on the fixed daemon: peak 442 MB, 312 MB after a 10-minute settle. Harness: scale-probe.mjs / lazy-check.mjs / mem-probe.mjs from the TRA-278 workdir (not committed \u2014 they drive a real daemon against throwaway data dirs)."
+    },
+    {
+      "date": "2026-08-29T13:35:00Z",
+      "app_version": "3.2.0",
+      "commit": "6ebbbd56",
+      "env": {
+        "os": "macOS 26.5",
+        "arch": "arm64",
+        "node": "22.22.3"
+      },
+      "samples": 3,
+      "metrics": {
+        "cold_start_ms": 1005,
+        "window_interactive_ms": 612,
+        "renderer_fcp_ms": 220,
+        "ui_p95_ms": null,
+        "heap_idle_mb": 9.5,
+        "heap_after_workload_mb": null,
+        "heap_growth_mb_per_hour": null,
+        "main_cpu_idle_pct": 0,
+        "renderer_bundle_kb": 1700,
+        "artifact_mb": {
+          "mac_app_unpacked": 268.1,
+          "mac_asar": 4.85,
+          "win": null
+        }
+      },
+      "notes": "MACHINE WAS LOADED \u2014 load average 11-22 throughout (a dozen sibling agent checkouts running their own Electron builds). cold_start_ms and window_interactive_ms are NOT comparable to run 1's 349/121: both are wall-clock across this harness's 20 ms poll loop and CDP round-trips, which a loaded machine inflates by hundreds of ms. Do not read the 349 -> 1005 as a regression. This run adds renderer_fcp_ms, read off the renderer's own clock after the fact and so free of harness latency; use it as the startup metric of record from now on. Interleaved A/B on this same loaded machine, 7 rounds, one sample each, alternating builds: 9459d4ce (run 1's commit) median FCP 288 ms, 9cdccf9b (pre-i18n) 300 ms, 6ebbbd56 (HEAD) 284 ms. Renderer boot is flat-to-slightly-better across the whole range \u2014 the macOS 26 redesign and the i18n runtime cost nothing measurable at startup. The same interleave on window_interactive_ms said 176 -> 507 ms (+188%), which was entirely the harness; that is what motivated the new metric. renderer_bundle_kb 1461 -> 1700 (+16%, warning zone, no issue): i18next+react-i18next runtime +48 KB (e0ec6cc2), the en/ru catalogues +65 KB (TRA-384/385/386), rest CSS/app. REGRESSION FOUND AND FIXED THIS RUN: mac_asar 1.6 -> 5.8 MB (3.6x, past the 1.5x ceiling). TRA-257's blanket !node_modules/** had to be replaced by an explicit node_modules/** include so the main process keeps electron-updater; that re-admitted every production dependency, and the i18n PR made react-i18next (1.0 MB) plus its @babel/runtime tree (1.1 MB) production dependencies even though Vite already bundles them into dist/renderer. Moving react-i18next to devDependencies: 5.8 -> 4.85 MB. The remaining 4.85 is genuine main-process runtime (electron-updater + js-yaml + i18next, which the app menu/tray need). Guarded by packages/app/src/main/__tests__/packaged-deps.test.ts. Process-tree RSS (tree_rss_*) deliberately not taken: a dozen unrelated agent Electron trees were resident, so any ps-based tree number would have been noise. Take those on a quiet machine; run 2's daemon numbers still stand."
     }
   ]
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,8 +22,7 @@
   "packageManager": "pnpm@10.33.0",
   "dependencies": {
     "electron-updater": "^6.6.2",
-    "i18next": "^25.10.10",
-    "react-i18next": "^16.6.6"
+    "i18next": "^25.10.10"
   },
   "overrides": {
     "@luma.gl/core": "9.2.6",
@@ -67,6 +66,7 @@
     "jsdom": "^30.0.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
+    "react-i18next": "^16.6.6",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.0",
     "sharp": "^0.35.3",

--- a/packages/app/pnpm-lock.yaml
+++ b/packages/app/pnpm-lock.yaml
@@ -28,9 +28,6 @@ importers:
       i18next:
         specifier: ^25.10.10
         version: 25.10.10(typescript@7.0.2)
-      react-i18next:
-        specifier: ^16.6.6
-        version: 16.6.6(i18next@25.10.10(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
     devDependencies:
       '@cosmos.gl/graph':
         specifier: 3.4.1
@@ -74,6 +71,9 @@ importers:
       react-dom:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
+      react-i18next:
+        specifier: ^16.6.6
+        version: 16.6.6(i18next@25.10.10(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.18)(react@19.2.8)

--- a/packages/app/scripts/perf-measure.mjs
+++ b/packages/app/scripts/perf-measure.mjs
@@ -199,6 +199,16 @@ async function runSample({ idleSeconds }) {
       cold_start_ms: interactiveAt - t0,
       // Renderer-side share: first renderer bytes → interactive.
       window_interactive_ms: round(interactiveAt - timeOrigin, 0),
+      // Read off the renderer's own clock after the fact, so — unlike the two
+      // above — it carries none of this harness's polling and CDP round-trip
+      // latency. On a loaded machine those two inflate by hundreds of ms while
+      // this one does not, which is what makes it the comparable number.
+      renderer_fcp_ms: round(
+        await cdp.evaluate(
+          `performance.getEntriesByType('paint').find(e => e.name === 'first-contentful-paint')?.startTime ?? null`,
+        ) ?? NaN,
+        0,
+      ),
     };
 
     if (idleSeconds > 0) {
@@ -639,6 +649,7 @@ const entry = {
   metrics: {
     cold_start_ms: median(samples.map((s) => s.cold_start_ms)),
     window_interactive_ms: median(samples.map((s) => s.window_interactive_ms)),
+    renderer_fcp_ms: median(samples.map((s) => s.renderer_fcp_ms)),
     ui_p95_ms: workload.ui_p95_ms,
     heap_idle_mb: last.heap_idle_mb ?? null,
     heap_after_workload_mb: workload.heap_after_workload_mb,

--- a/packages/app/src/main/__tests__/packaged-deps.test.ts
+++ b/packages/app/src/main/__tests__/packaged-deps.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `electron-builder.yml` packages production `dependencies` into app.asar
+ * (`node_modules/**` is listed there so the main process keeps electron-updater
+ * on Windows). Anything Vite already bundles into dist/renderer therefore ships
+ * twice if it is a production dependency — that is how react-i18next and its
+ * @babel/runtime tree grew app.asar from 1.6 MB to 5.8 MB.
+ *
+ * The rule: a package belongs in `dependencies` only if the MAIN process imports
+ * it at runtime. Renderer-only packages go in devDependencies.
+ */
+const appDir = path.resolve(import.meta.dirname, '..', '..', '..');
+const pkg = JSON.parse(readFileSync(path.join(appDir, 'package.json'), 'utf8'));
+
+const MAIN_RUNTIME_DEPS = [
+  'electron-updater', // main process, Windows update path
+  'i18next', // main process menu/tray/dialog strings (react-i18next is renderer-only)
+];
+
+describe('packaged production dependencies', () => {
+  it('ships only what the main process needs at runtime', () => {
+    expect(Object.keys(pkg.dependencies ?? {}).sort()).toEqual([...MAIN_RUNTIME_DEPS].sort());
+  });
+
+  it('keeps react-i18next out of the shipped bundle', () => {
+    // Renderer-only: Vite bundles it, and it drags @babel/runtime in with it.
+    expect(pkg.dependencies?.['react-i18next']).toBeUndefined();
+    expect(pkg.devDependencies?.['react-i18next']).toBeDefined();
+  });
+});

--- a/packages/app/src/main/__tests__/packaged-deps.test.ts
+++ b/packages/app/src/main/__tests__/packaged-deps.test.ts
@@ -12,8 +12,8 @@ import { describe, expect, it } from 'vitest';
  * The rule: a package belongs in `dependencies` only if the MAIN process imports
  * it at runtime. Renderer-only packages go in devDependencies.
  */
-const appDir = path.resolve(import.meta.dirname, '..', '..', '..');
-const pkg = JSON.parse(readFileSync(path.join(appDir, 'package.json'), 'utf8'));
+// vitest runs with packages/app as its root, as the other main-process tests assume.
+const pkg = JSON.parse(readFileSync(path.resolve(process.cwd(), 'package.json'), 'utf8'));
 
 const MAIN_RUNTIME_DEPS = [
   'electron-updater', // main process, Windows update path


### PR DESCRIPTION
## What

Two findings from this Electron App Performance pass, one fix each.

### 1. `app.asar` regressed 1.6 MB → 5.8 MB (3.6×, past the baseline's ×1.5 artifact ceiling)

TRA-257's blanket `!node_modules/**` had to become an explicit `node_modules/**` include so the main process keeps `electron-updater` on Windows. That re-admitted every production dependency — and the i18n work made `react-i18next` (1.0 MB) plus its `@babel/runtime` tree (1.1 MB) production dependencies even though Vite already bundles them into `dist/renderer`.

Only `i18next` itself is main-process runtime (menu, tray, dialog strings). `react-i18next` moves to `devDependencies`: **5.8 MB → 4.85 MB**, verified by a real `electron-builder --dir` pack. The remaining 4.85 MB is genuine main-process runtime (`electron-updater` + `js-yaml` + `i18next`).

`packages/app/src/main/__tests__/packaged-deps.test.ts` now fails if a package lands in `dependencies` without the main process importing it.

### 2. The startup metric was measuring the harness, not the app

`cold_start_ms` and `window_interactive_ms` are wall-clock across the harness's 20 ms poll loop and its CDP round-trips. This run happened on a machine at load average 11–22 and they read 349 → 1005 ms / 121 → 612 ms — an apparent +188% regression that is not in the product.

New `renderer_fcp_ms` reads first-contentful-paint off the renderer's own clock after the fact, so it carries none of that latency. Interleaved A/B on the same loaded machine, 7 rounds of one sample each, alternating builds:

| build | median `renderer_fcp_ms` |
|---|---|
| `9459d4ce` (run 1's baseline commit) | 288 ms |
| `9cdccf9b` (pre-i18n) | 300 ms |
| `6ebbbd56` (HEAD) | **284 ms** |

Renderer boot is flat-to-slightly-better across the whole range. The macOS 26 redesign and the i18n runtime cost nothing measurable at startup.

## Also recorded, no fix

- `renderer_bundle_kb` 1461 → 1700 (+16%, warning zone, no issue filed): i18n runtime +48 KB, en/ru catalogues +65 KB, rest CSS/app.
- Process-tree RSS (`tree_rss_*`) deliberately not taken this run — a dozen unrelated agent Electron trees were resident, so any `ps`-based number would have been noise. Run 2's daemon numbers stand.

## Test evidence

- `pnpm -C packages/app run test` — 42 files, 418 tests passed (was 41/416; +2 from the new guard).
- `pnpm -C packages/app run typecheck` — clean.
- `pnpm -C packages/app run check:i18n` — 20 extracted paths clean.
- `pnpm -C packages/app run pack` — app.asar 4.85 MB, bundle 268.1 MB.

Closes TRA-398's measurement pass; `docs/perf/baseline.json` gains run 3 and `docs/perf/README.md` documents which startup number to trend.

Agent: Lead Engineer