### PR TITLE
fix(app): the native tab bar is a second top band, not a replacement (TRA-399)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -559,6 +559,37 @@ Two things to know before touching the offset:
 `src/renderer/styles/__tests__/tokens.test.ts` fail if the constant, the token, the
 stylesheets and `tray.ts` ever drift apart again.
 
+### The second top band: the native tab bar is macOS's, not ours
+
+Opening a project opens a native macOS **tab**, so the normal state of this app is a
+tabbed window — not an edge case. AppKit then draws a tab bar, and because the window is
+`titleBarStyle: 'hiddenInset'` (full-size content view) it draws it **over** the web
+contents: `innerHeight` stays equal to `outerHeight`, nothing reflows, and the tab bar
+simply covers the top 36px of whatever the renderer painted. That is the whole of the
+band above, so the surface toolbar and the sidebar toggle went from "misaligned" to
+"gone" (TRA-399).
+
+The rule that follows: **a band we do not draw still has to be reserved.** The tab bar is
+AppKit's, we cannot restyle it and we cannot ask whether it is up — so:
+
+- `MAC_TAB_BAR_H` (36px, measured, `chrome-metrics.ts`) and `--mac-tabbar-h` are one
+  number, exactly like `TOP_BAND_H`. The stage reserves it with `padding-top` while
+  `data-tabbar="on"`, and the app's own band starts below it. Never draw into it.
+- **The traffic lights belong to whichever band holds the top line**, not to a constant.
+  With no tab bar that is our 44px band (centre 22); with one it is AppKit's 36px tab bar
+  (centre 18). `trafficLightYFor(tabBarVisible)` is the only place that chooses.
+- **`trafficLightPosition` is applied once, at window creation, and AppKit re-lays the
+  title bar out under it.** So every event that can change the tab count re-applies it —
+  `show`, `focus`, `closed`, `did-finish-load` — synchronously and again a frame later,
+  because the tab bar comes and goes asynchronously. Without that, closing back to one tab
+  left the lights 6px high until a window resize forced a layout pass, which is the "nudge
+  the window and it fixes itself" users report.
+- The 78px that clears the lights in `.ws-sidebar-titlebar` goes away with them: while the
+  tab bar holds the lights, reserving their width leaves the toggle floating in a gap.
+
+`src/main/__tests__/tab-chrome.test.ts` drives the real window events and fails if any of
+those stops firing.
+
 ### Where a global action lives
 
 An action that belongs to the app rather than to the surface in front of you —

--- a/packages/app/src/main/__tests__/tab-chrome.test.ts
+++ b/packages/app/src/main/__tests__/tab-chrome.test.ts
@@ -1,0 +1,204 @@
+/* TRA-399. Opening a project opens a native macOS tab, and AppKit answers with
+   a tab bar — a second top band, on top of the one the app draws. Two things
+   have to be re-derived every time the tab count crosses 1, and neither was:
+
+   - the renderer has to reserve the tab bar's height, or the tab bar covers the
+     surface toolbar and the sidebar toggle outright;
+   - the traffic lights have to be re-placed for the band that now holds them,
+     because `trafficLightPosition` is applied once at window creation and
+     AppKit re-lays the title bar out underneath it. The window kept an offset
+     measured against a band that was no longer there until a resize forced a
+     layout pass — which is exactly the "nudge the window and it fixes itself"
+     the bug was reported as.
+
+   The old code fired only from `projectWindows.size === 0`, i.e. only when the
+   LAST project tab closed, and never touched the button position at all. These
+   tests drive the real window events. */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MAC_TAB_BAR_H,
+  TOP_BAND_H,
+  TRAFFIC_LIGHT_X,
+  TRAFFIC_LIGHT_Y,
+  TRAFFIC_LIGHT_Y_TABBED,
+  trafficLightCentreY,
+  trafficLightYFor,
+} from '../../shared/chrome-metrics.js';
+
+/** A stand-in for one BrowserWindow, recording what the app does to its chrome. */
+class FakeWindow {
+  static all: FakeWindow[] = [];
+  handlers = new Map<string, Array<() => void>>();
+  buttonPositions: Array<{ x: number; y: number }> = [];
+  sent: Array<{ channel: string; args: unknown[] }> = [];
+  destroyed = false;
+  wcHandlers = new Map<string, Array<() => void>>();
+  webContents = {
+    id: FakeWindow.all.length + 1,
+    isDestroyed: () => this.destroyed,
+    send: (channel: string, ...args: unknown[]) => this.sent.push({ channel, args }),
+    on: (event: string, fn: () => void) => {
+      const list = this.wcHandlers.get(event) ?? [];
+      list.push(fn);
+      this.wcHandlers.set(event, list);
+    },
+    emit: (event: string) => {
+      for (const fn of this.wcHandlers.get(event) ?? []) fn();
+    },
+    setWindowOpenHandler: vi.fn(),
+  };
+
+  constructor() {
+    FakeWindow.all.push(this);
+  }
+
+  listen(event: string, fn: () => void): void {
+    const list = this.handlers.get(event) ?? [];
+    list.push(fn);
+    this.handlers.set(event, list);
+  }
+  on = (event: string, fn: () => void) => this.listen(event, fn);
+  once = (event: string, fn: () => void) => this.listen(event, fn);
+  emit(event: string): void {
+    for (const fn of this.handlers.get(event) ?? []) fn();
+  }
+
+  isDestroyed = () => this.destroyed;
+  setWindowButtonPosition = (p: { x: number; y: number }) => this.buttonPositions.push(p);
+  loadURL = () => this.webContents.emit('did-finish-load');
+  // Real windows emit these; the events are how the app learns the tab count moved.
+  show = () => this.emit('show');
+  focus = () => this.emit('focus');
+  setTitle = vi.fn();
+  addTabbedWindow = vi.fn();
+
+  /** The last chrome state this window was told to adopt. */
+  get chrome() {
+    const tabbar = this.sent.filter((s) => s.channel === 'tabbar-changed').at(-1);
+    return {
+      lightY: this.buttonPositions.at(-1)?.y,
+      lightX: this.buttonPositions.at(-1)?.x,
+      tabBarVisible: tabbar?.args[0],
+    };
+  }
+}
+
+vi.mock('electron', () => ({
+  app: { dock: { show: vi.fn(), hide: vi.fn(), setIcon: vi.fn() }, on: vi.fn(), getVersion: () => '0' },
+  BrowserWindow: Object.assign(FakeWindow, {
+    getAllWindows: () => FakeWindow.all.filter((w) => !w.destroyed),
+    getFocusedWindow: () => null,
+    fromWebContents: () => null,
+  }),
+  ipcMain: { handle: vi.fn(), on: vi.fn() },
+  Menu: { buildFromTemplate: vi.fn(() => ({})), setApplicationMenu: vi.fn() },
+  nativeImage: { createFromPath: vi.fn(), createEmpty: vi.fn(() => ({ addRepresentation: vi.fn() })) },
+  nativeTheme: { shouldUseDarkColors: false, on: vi.fn() },
+  Tray: vi.fn(),
+  shell: { openExternal: vi.fn() },
+}));
+
+vi.mock('../api-client', () => ({
+  DaemonClient: class {
+    health = vi.fn();
+  },
+}));
+vi.mock('../daemon-lifecycle', () => ({ ensureDaemon: vi.fn(), restartDaemon: vi.fn() }));
+vi.mock('../i18n', () => ({ t: (k: string) => k, startI18n: vi.fn() }));
+
+/**
+ * A fresh tray module on a fresh set of windows, with the menu window and one
+ * project tab open — the state the bug is reported in. `tray.ts` keeps its
+ * windows in module scope, so each test needs its own copy of the module.
+ */
+async function openMenuAndProject() {
+  FakeWindow.all.length = 0;
+  vi.resetModules();
+  const platform = process.platform;
+  Object.defineProperty(process, 'platform', { value: 'darwin' });
+  const { showMenuWindow } = await import('../tray.js');
+  const { ipcMain } = await import('electron');
+  try {
+    showMenuWindow();
+    const menu = FakeWindow.all[0];
+    menu.emit('ready-to-show');
+
+    // Newest registration first: the ipcMain mock outlives vi.resetModules(),
+    // so earlier tests' handlers — bound to their own module state — are still
+    // in the call list, and the oldest one would open nothing.
+    const calls = [...(ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls].reverse();
+    const openProject = calls.find((c: unknown[]) => c[0] === 'open-project-tab')?.[1] as (
+      event: unknown,
+      root: string,
+    ) => unknown;
+    openProject({}, '/tmp/demo');
+    const project = FakeWindow.all[1];
+    project.emit('ready-to-show');
+    return { menu, project };
+  } finally {
+    Object.defineProperty(process, 'platform', { value: platform });
+  }
+}
+
+describe('the traffic lights follow whichever band owns the top line', () => {
+  it('centres them in the app band when there is no tab bar', () => {
+    expect(trafficLightCentreY(trafficLightYFor(false))).toBe(TOP_BAND_H / 2);
+    expect(trafficLightYFor(false)).toBe(TRAFFIC_LIGHT_Y);
+  });
+
+  it('centres them in the tab bar when AppKit is drawing one', () => {
+    expect(trafficLightCentreY(trafficLightYFor(true))).toBe(MAC_TAB_BAR_H / 2);
+    expect(trafficLightYFor(true)).toBe(TRAFFIC_LIGHT_Y_TABBED);
+  });
+
+  it('does not reuse one offset for both bands', () => {
+    expect(TRAFFIC_LIGHT_Y_TABBED).not.toBe(TRAFFIC_LIGHT_Y);
+  });
+});
+
+describe('window chrome is re-derived when the tab count crosses 1', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it('reserves the tab bar and moves the lights into it when a tab opens', async () => {
+    const { menu, project } = await openMenuAndProject();
+    vi.runAllTimers();
+
+    for (const win of [menu, project]) {
+      expect(win.chrome.tabBarVisible).toBe(true);
+      expect(win.chrome.lightY).toBe(TRAFFIC_LIGHT_Y_TABBED);
+      expect(win.chrome.lightX).toBe(TRAFFIC_LIGHT_X);
+    }
+  });
+
+  /* The reported bug: after closing back to one tab the lights kept the tabbed
+     offset until the window was resized. Nothing re-applied the position. */
+  it('puts the lights back on the app band when the tab closes — no resize', async () => {
+    const { menu, project } = await openMenuAndProject();
+    vi.runAllTimers();
+
+    project.destroyed = true;
+    project.emit('closed');
+    vi.runAllTimers();
+
+    expect(menu.chrome.tabBarVisible).toBe(false);
+    expect(menu.chrome.lightY).toBe(TRAFFIC_LIGHT_Y);
+    expect(trafficLightCentreY(menu.chrome.lightY as number)).toBe(TOP_BAND_H / 2);
+  });
+
+  /* The old signal was `projectWindows.size === 0`, so closing the MENU tab —
+     leaving one project window, no tab bar — told nobody anything. */
+  it('reports the tab bar gone when the menu tab is the one that closes', async () => {
+    const { menu, project } = await openMenuAndProject();
+    vi.runAllTimers();
+
+    menu.destroyed = true;
+    menu.emit('closed');
+    vi.runAllTimers();
+
+    expect(project.chrome.tabBarVisible).toBe(false);
+    expect(project.chrome.lightY).toBe(TRAFFIC_LIGHT_Y);
+  });
+});

--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { app, BrowserWindow, ipcMain, Menu, nativeImage, nativeTheme, Tray } from 'electron';
-import { TRAFFIC_LIGHT_X, TRAFFIC_LIGHT_Y } from '../shared/chrome-metrics.js';
+import { TRAFFIC_LIGHT_X, TRAFFIC_LIGHT_Y, trafficLightYFor } from '../shared/chrome-metrics.js';
 import { DaemonClient } from './api-client';
 import {
   type Appearance,
@@ -149,6 +149,15 @@ function setupWindowEvents(win: BrowserWindow): void {
   win.on('enter-full-screen', () => safeSend(win, 'fullscreen-changed', true));
   win.on('leave-full-screen', () => safeSend(win, 'fullscreen-changed', false));
 
+  /* Every event that can change how many tabs the group holds, or that gives a
+     renderer that missed the last broadcast a chance to catch up. 'closed' is
+     the one the bug was reported against; 'focus' also covers a tab dragged out
+     into its own window, which fires nothing else we can see. */
+  win.on('show', syncTabChromeSoon);
+  win.on('focus', syncTabChromeSoon);
+  win.on('closed', syncTabChromeSoon);
+  win.webContents.on('did-finish-load', syncTabChrome);
+
   // Auto-reload on renderer crash (GPU crash, OOM, etc.)
   win.webContents.on('render-process-gone', (_event, details) => {
     console.error(`[trace-mcp] renderer crashed in window: reason=${details.reason}`);
@@ -185,12 +194,62 @@ function ensureDockVisible(): void {
   }
 }
 
-/** Notify ALL windows whether the native tab bar is visible (macOS) */
-function broadcastTabBar(visible: boolean): void {
-  const allWindows = [menuWindow, ...projectWindows.values()];
-  for (const win of allWindows) {
+/* ---- The native tab bar (macOS), and the two things it breaks (TRA-399) ----
+
+   Every window we open carries the same `tabbingIdentifier`, so a second window
+   is a second TAB, and AppKit answers with a tab bar. Two consequences, both of
+   which have to be re-derived whenever the tab count crosses 1:
+
+   1. The tab bar is painted over the top of the web contents (the window is
+      full-size content view, so the viewport never shrinks). The renderer has
+      to reserve MAC_TAB_BAR_H or the tab bar covers its whole top band — the
+      Files/Symbols control, Filter, Search, Fit, Live, ··· and the sidebar
+      toggle, all of them, unreachable. `tabbar-changed` is that signal.
+
+   2. The traffic lights are ours to place, and the band they belong to changes:
+      44px while we own the top line, 36px (the tab bar) while AppKit does.
+      `trafficLightPosition` is applied once at window creation, and AppKit
+      re-lays the title bar out when the tab bar comes and goes — so the custom
+      offset has to be re-applied, or the lights keep an offset measured against
+      a band that is no longer there until something else forces a layout pass.
+      A window resize was the "fix" users found. */
+
+/** Is AppKit drawing a tab bar? True exactly when the group holds >1 tab. */
+function tabBarVisible(): boolean {
+  return isMac && BrowserWindow.getAllWindows().filter((w) => !w.isDestroyed()).length > 1;
+}
+
+/**
+ * Re-derive both, for every window, from the tab count that holds right now.
+ * Idempotent and cheap, so it can be called from anything that might have
+ * changed the answer rather than only from the one path we thought of.
+ */
+function syncTabChrome(): void {
+  if (!isMac) return;
+  const visible = tabBarVisible();
+  const y = trafficLightYFor(visible);
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) continue;
+    try {
+      win.setWindowButtonPosition({ x: TRAFFIC_LIGHT_X, y });
+    } catch {
+      /* window torn down between the guard and the call */
+    }
     safeSend(win, 'tabbar-changed', visible);
   }
+}
+
+/**
+ * The same, once the run loop has caught up. AppKit adds and removes the tab
+ * bar asynchronously around 'closed' and 'ready-to-show', so a position written
+ * synchronously can be measured against the title bar we are leaving rather
+ * than the one we are arriving at. Running it twice costs nothing and removes
+ * the race — never rely on the synchronous pass alone.
+ */
+function syncTabChromeSoon(): void {
+  if (!isMac) return;
+  syncTabChrome();
+  setTimeout(syncTabChrome, 120);
 }
 
 // ── Custom tab bar for Windows ─────────────────────────────────
@@ -360,10 +419,6 @@ function openProjectTab(root: string): void {
     ensureDockVisible();
     win.show();
     win.focus();
-    // First project tab opened → tab bar is now visible (macOS native tabs)
-    if (isMac) {
-      broadcastTabBar(true);
-    }
     broadcastTabList();
   });
 
@@ -378,10 +433,6 @@ function openProjectTab(root: string): void {
 
   win.on('closed', () => {
     projectWindows.delete(root);
-    // If no more project tabs, tab bar disappears (only menu window left)
-    if (isMac && projectWindows.size === 0) {
-      broadcastTabBar(false);
-    }
     hideDockIfNoWindows();
     broadcastTabList();
   });

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -585,6 +585,7 @@ export function App() {
   const [sidebarWidth, setSidebarWidth] = useState(readSidebarWidth);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(readSidebarCollapsed);
   const [_isFullscreen, setIsFullscreen] = useState(false);
+  const [tabBarVisible, setTabBarVisible] = useState(false);
   const [quickOpen, setQuickOpen] = useState(false);
   const [quickFiles, setQuickFiles] = useState<string[]>([]);
   /* The element surfaces portal their toolbar into. Callback ref rather than
@@ -846,6 +847,13 @@ export function App() {
     }
   }, []);
 
+  /* Opening a project opens a native macOS tab, and AppKit then paints its tab
+     bar over the top of the web contents — the viewport does not shrink, so
+     everything we draw on the top line ends up underneath it (TRA-399). The
+     main process reports the tab bar's presence; the stage reserves its height.
+     Wired here rather than in the sidebar because the whole window shifts. */
+  useEffect(() => window.electronAPI?.onTabBarChanged?.(setTabBarVisible), []);
+
   const isGraph = isProject && projectTab === 'graph';
   const needsFlexLayout = isProject && (projectTab === 'graph' || projectTab === 'ask');
   /* Surfaces that draw their own toolbar own the whole pane: a 16px inset turns
@@ -882,6 +890,7 @@ export function App() {
       className="ws-stage flex flex-col h-screen"
       data-mode={theme}
       data-platform={hasInsetTitleBar() ? 'mac' : 'other'}
+      data-tabbar={tabBarVisible ? 'on' : undefined}
     >
       {showOnboarding && <GuardOnboarding onClose={() => setShowOnboarding(false)} />}
       {quickOpen && <QuickOpen items={quickOpenItems()} onClose={() => setQuickOpen(false)} />}

--- a/packages/app/src/renderer/styles/__tests__/tokens.test.ts
+++ b/packages/app/src/renderer/styles/__tests__/tokens.test.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
+  MAC_TAB_BAR_H,
   TOP_BAND_H,
   TRAFFIC_LIGHT_D,
   TRAFFIC_LIGHT_Y,
@@ -197,6 +198,24 @@ describe('design tokens', () => {
         expect(body, `${selector} not found`).toBeDefined();
         expect(body).toMatch(/height:\s*var\(--top-band-h\)/);
       }
+    });
+
+    /* TRA-399. The macOS tab bar is a SECOND band on the same line, drawn by
+       AppKit over the top of the web contents — the viewport never shrinks, so
+       without a reservation the tab bar simply covers the band above and every
+       control on it. Same discipline as --top-band-h: one owner, one token. */
+    it('generates --mac-tabbar-h from src/shared/chrome-metrics.ts', () => {
+      expect(tokensCss).toMatch(new RegExp(`--mac-tabbar-h:\\s*${MAC_TAB_BAR_H}px`));
+    });
+
+    it('reserves the tab bar on macOS instead of drawing under it', () => {
+      const sidebarCss = readFileSync(
+        fileURLToPath(new URL('../sidebar.css', import.meta.url)),
+        'utf8',
+      );
+      expect(sidebarCss).toMatch(
+        /\[data-platform="mac"\]\[data-tabbar="on"\]\s*\{[^}]*padding-top:\s*var\(--mac-tabbar-h\)/,
+      );
     });
 
     it('leaves no stylesheet writing a band height by hand', () => {

--- a/packages/app/src/renderer/styles/sidebar.css
+++ b/packages/app/src/renderer/styles/sidebar.css
@@ -17,6 +17,16 @@
   background: var(--surface-sunken, var(--surface));
 }
 
+/* The native macOS tab bar is AppKit's band, not ours, and it is painted OVER
+   the top of the web contents — `innerHeight` never shrinks, so without this
+   the tab bar simply covers the app's own top band and every control on it
+   (TRA-399). Reserve its height so our band starts below it instead of under
+   it. Only on macOS, and only while a tab bar is actually up: the main process
+   sets data-tabbar from the live tab count. */
+.ws-stage[data-platform="mac"][data-tabbar="on"] {
+  padding-top: var(--mac-tabbar-h);
+}
+
 .ws-shell {
   display: flex;
   flex: 1;
@@ -408,6 +418,17 @@
 /* Collapsed sidebar on macOS: the traffic lights land on this header instead. */
 .ws-stage[data-platform="mac"] .ws-shell.is-collapsed .ws-content-head {
   padding-left: 78px;
+}
+
+/* …and the 78px that clears the traffic lights goes with them. With a tab bar
+   up the lights are in AppKit's band, not ours, so reserving their width here
+   would leave the sidebar toggle floating in a gap nothing occupies. 6px lines
+   its box up with the selection pills below it. */
+.ws-stage[data-platform="mac"][data-tabbar="on"] .ws-sidebar-titlebar {
+  padding-left: 6px;
+}
+.ws-stage[data-platform="mac"][data-tabbar="on"] .ws-shell.is-collapsed .ws-content-head {
+  padding-left: 12px;
 }
 .ws-content-body {
   flex: 1;

--- a/packages/app/src/renderer/styles/tokens.css
+++ b/packages/app/src/renderer/styles/tokens.css
@@ -146,6 +146,13 @@
      and styles/__tests__/tokens.test.ts fails if these two drift apart. */
   --top-band-h: 44px;
 
+  /* The band we do NOT draw (TRA-399). A macOS tabbed window grows an AppKit
+     tab bar, painted over the top of the web contents — the viewport never
+     shrinks, because the window is full-size content view. Reserve it or it
+     covers the whole top band above. Same owner, same guard:
+     src/shared/chrome-metrics.ts (MAC_TAB_BAR_H) and tokens.test.ts. */
+  --mac-tabbar-h: 36px;
+
   /* ---- Motion */
   --dur-micro: 120ms;
   --dur-standard: 200ms;

--- a/packages/app/src/shared/chrome-metrics.ts
+++ b/packages/app/src/shared/chrome-metrics.ts
@@ -26,12 +26,41 @@ export const TRAFFIC_LIGHT_D = 12;
    changes the button's frame, this is the constant that absorbs it. */
 const TRAFFIC_LIGHT_FRAME_INSET = 1;
 
+/** Offset that centres the lights in a band this tall. Never write it by hand. */
+const centreLightsIn = (bandH: number): number =>
+  (bandH - TRAFFIC_LIGHT_D) / 2 - TRAFFIC_LIGHT_FRAME_INSET;
+
 /** Offset that centres the lights in the band. Never write this number down. */
-export const TRAFFIC_LIGHT_Y = (TOP_BAND_H - TRAFFIC_LIGHT_D) / 2 - TRAFFIC_LIGHT_FRAME_INSET;
+export const TRAFFIC_LIGHT_Y = centreLightsIn(TOP_BAND_H);
+
+/* ---- The second band, the one we do not draw (TRA-399) --------------------
+   A macOS tabbed window grows an AppKit tab bar. The window is
+   `titleBarStyle: 'hiddenInset'`, i.e. full-size content view, so the web
+   contents does NOT shrink — `innerHeight` stays equal to `outerHeight` and the
+   tab bar is painted OVER the top of the renderer. Reserve its height or it
+   swallows whatever the app drew on that line, which is the entire surface
+   toolbar plus the sidebar toggle.
+
+   Measured on macOS 26.5 / Electron 41.10.6 by photographing the window
+   (`screencapture -l<CGWindowID>`) with two tabs open and reading the column
+   profile down the sidebar: the tab bar's plate runs from y=0 to y=36.0, and
+   the sidebar's own material resumes at 36.0. If a future macOS changes the
+   metric, this is the one constant that absorbs it. */
+
+/** Height of the AppKit tab bar on a tabbed window, in CSS px. */
+export const MAC_TAB_BAR_H = 36;
+
+/** Offset that centres the lights in the TAB BAR, which owns the top band then. */
+export const TRAFFIC_LIGHT_Y_TABBED = centreLightsIn(MAC_TAB_BAR_H);
+
+/** The offset that holds right now. The lights belong to whichever band is on
+    the window's top line — ours at 44px, AppKit's tab bar at 36px. */
+export const trafficLightYFor = (tabBarVisible: boolean): number =>
+  tabBarVisible ? TRAFFIC_LIGHT_Y_TABBED : TRAFFIC_LIGHT_Y;
 
 /** Distance from the window's leading edge to the first light. */
 export const TRAFFIC_LIGHT_X = 14;
 
-/** Where the lights' centre lands, given TRAFFIC_LIGHT_Y — the band's centre. */
-export const trafficLightCentreY = (): number =>
-  TRAFFIC_LIGHT_Y + TRAFFIC_LIGHT_FRAME_INSET + TRAFFIC_LIGHT_D / 2;
+/** Where the lights' centre lands, given an offset — that band's centre. */
+export const trafficLightCentreY = (y: number = TRAFFIC_LIGHT_Y): number =>
+  y + TRAFFIC_LIGHT_FRAME_INSET + TRAFFIC_LIGHT_D / 2;


### PR DESCRIPTION
Closes TRA-399.

Opening a project opens a native macOS tab, so a tabbed window is the app's normal state — not an edge case. AppKit answers with a tab bar, and because the window is `titleBarStyle: 'hiddenInset'` (full-size content view) it draws that tab bar **over** the web contents: `innerHeight` stays equal to `outerHeight`, nothing reflows, and the tab bar simply covers the top 36px of whatever the renderer painted. That is the whole of the app's own band.

## What was broken

1. **The surface toolbar disappeared with a second tab open.** Files/Symbols, Filter, Search, Fit, Live, the `···` menu and the sidebar toggle were all still rendered — at y=0..44, underneath an opaque AppKit tab bar. Unreachable, not just misaligned.
2. **Closing back to one tab left the traffic lights high** until a window resize forced a layout pass. `trafficLightPosition` is applied once at window creation; AppKit re-lays the title bar out when the tab bar comes and goes, and nothing re-applied it.
3. **In the tabbed state the lights were 4px low** — they sat at the 44px band's centre (22) while the band actually holding them was AppKit's 36px tab bar (centre 18). Not in the report, but visible once the app's band moves out from under the tab bar.

The old signal was `projectWindows.size === 0`, so it fired only when the last *project* tab closed — closing the menu tab told nobody anything — and it never touched the button position at all.

## What changed

- `MAC_TAB_BAR_H = 36` joins `TOP_BAND_H` in `chrome-metrics.ts`, with `--mac-tabbar-h` generated from it. Measured, not guessed: `screencapture -l<CGWindowID>` with two tabs open, reading the column profile down the sidebar — the tab bar's plate runs 0→36.0 and the sidebar's own material resumes at 36.0.
- The stage reserves it (`padding-top` under `[data-tabbar="on"]`), so the app's band starts below the tab bar instead of under it. The 78px that clears the traffic lights goes away with them, so the sidebar toggle doesn't float in a gap nothing occupies.
- `trafficLightYFor(tabBarVisible)` is the only place that chooses the offset: our 44px band (centre 22) or AppKit's 36px tab bar (centre 18).
- `syncTabChrome()` re-derives both for every window from the live tab count, driven by `show` / `focus` / `closed` / `did-finish-load`, synchronously and again 120ms later — AppKit adds and removes the tab bar asynchronously, so a position written synchronously can be measured against the title bar we are leaving.

## Measured on the real Electron window

`screencapture -l<CGWindowID>`, light and dark, sidebar expanded and collapsed. Traffic-light centre from the red button's pixel row profile; band geometry from `getBoundingClientRect()`.

| state | lights' centre | app band | sidebar first row | toolbar |
|---|---|---|---|---|
| one tab (before & after) | 22 | 0–44, centre 22 | 44 | reachable |
| two tabs — **before** | 22 (4px low in a 36px bar) | 0–44, **under the tab bar** | 44 | **hidden** |
| two tabs — **after** | **18** = 36/2 | **36–80, centre 58** | **80** | reachable |
| back to one — **before** | 16 (6px high) until a resize | 0–44 | 44 | reachable |
| back to one — **after** | **22**, no resize needed | 0–44, centre 22 | 44 | reachable |
| back to one, then resized | 22 (unchanged) | 0–44 | 44 | reachable |

The "6px high" number is measured off the reporter's own two screenshots — the light's centre sits 32 device px below the window's top edge in the broken frame and 44 in the corrected one, i.e. 22 → 16 CSS px. (The issue estimated ~11px from the scaled-down image.) The stale-layout state itself did not reproduce here on macOS 26.5 / Electron 41.10.6 — `close()` happens to relayout correctly on this build — so the guard is written against the cause rather than the symptom: the position is now re-applied on every event that can change the tab count, whichever AppKit path produced the change.

## Tests

`src/main/__tests__/tab-chrome.test.ts` drives the real window events against a fake `BrowserWindow` and asserts the button position and the `tabbar-changed` broadcast after a tab opens, after the project tab closes, and after the *menu* tab closes. All three fail on the old code. `tokens.test.ts` pins `--mac-tabbar-h` to `MAC_TAB_BAR_H` and the reservation rule, the same way it already pins `--top-band-h`.

`DESIGN.md` gains "The second top band: the native tab bar is macOS's, not ours", next to the existing top-band section.

Agent: Design/UX Agent
