### PR TITLE
fix(app): drive the app without taking the screen (TRA-403)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -912,11 +912,18 @@ node packages/app/scripts/electron-cdp.mjs shot before/graph-light.png \
 
 `launch` runs the app with `--remote-debugging-port=9222` under its own `--user-data-dir`
 (so it does not lose Electron's single-instance lock to an installed trace-mcp.app) and
-sets `TRACE_MCP_DEV_ALWAYS_ON_TOP=1`. That last part is not cosmetic: Chromium stops
-compositing a fully occluded window, and a CDP screenshot of one hangs or hands back the
-frame it painted minutes ago — a stale-pixel "after" shot that looks like a fix. Any CDP
-client can attach to `http://127.0.0.1:9222` once it is up, including `chrome-devtools`
+**never puts a window on screen**. The window is created, loads and paints; it is simply
+never mapped, and the process runs as a macOS accessory app, so it takes no Dock tile, no
+⌘-Tab entry and no activation. Everything here drives the app over CDP, which does not
+care whether the window is visible — and the person at the keyboard does (TRA-403). Any
+CDP client can attach to `http://127.0.0.1:9222` once it is up, including `chrome-devtools`
 MCP via `--browser-url`.
+
+`launch --visible` puts it on screen for the one case that needs eyes on the running app,
+and then also sets `TRACE_MCP_DEV_ALWAYS_ON_TOP=1`: Chromium stops compositing a fully
+*occluded* window, and a CDP screenshot of one hands back the frame it painted minutes ago
+— a stale-pixel "after" shot that looks like a fix. An unmapped window is not an occluded
+one; it keeps painting, and its screenshots are current (measured, not assumed).
 
 The one thing a CDP capture cannot show is the native frame: the traffic lights are drawn
 by macOS outside the web contents, so they are absent from the PNG even though the strip
@@ -930,6 +937,28 @@ fixed set of images `docs/` and trace-mcp.com ship, from a seeded sandbox, and c
 whether the committed ones are stale. Use that one for anything committed to the repo; use
 `electron-cdp.mjs` when you need to point a debugger at the app you are running right now
 and shoot a surface it has no manifest entry for.
+
+### A review run never takes the screen from the person using the machine
+
+Design work here runs on a Mac somebody is working on, and macOS follows an app activation
+to the Space that app's window is on — so a harness that shows a window yanks them out of
+their full-screen app, and hourly runs do it hourly (TRA-403). The rule for anything an
+agent launches:
+
+- **The app: never shown.** `electron-cdp.mjs launch` is hidden and accessory by default.
+  A visible window needs `--visible` and a reason stated where you use it.
+- **The browser: `--headless --isolated`.** Headless removes the window entirely and
+  screenshots still come out; `--isolated` gives Chrome a throwaway profile so it can
+  never adopt or disturb the one the user has open. Both belong in the MCP server's own
+  arguments, not in a per-call flag somebody will forget.
+- **Never call `app.focus()`, `win.focus()`, `win.show()`, `showInactive()` or
+  `shell.openExternal` from a harness path.** `tests/scripts/capture-screenshots.test.ts`
+  reads these files and fails when one appears: in `tray.ts` every show goes through
+  `presentWindow`, which returns early under `TRACE_MCP_WINDOW_MODE=hidden`; in
+  `electron-cdp.mjs` there are none at all.
+- **The one exception is the publication capture**, which cannot avoid activating the app
+  (a window whose app is not active draws grey traffic lights, and those are refused). It
+  pays for the exception by waiting for an idle machine — see docs/development.md.
 
 ### A published screenshot shows the window, or it is not a screenshot of the app
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -341,6 +341,7 @@ pnpm run build                       # the CLI bundle the demo daemon runs from
 pnpm --dir packages/app run build    # the renderer being photographed
 node scripts/capture-screenshots.mjs             # regenerate everything
 node scripts/capture-screenshots.mjs app-graph   # just one (marker left alone)
+node scripts/capture-screenshots.mjs --now       # …without waiting for an idle machine
 node scripts/capture-screenshots.mjs --check     # are the committed ones stale?
 ```
 
@@ -362,6 +363,17 @@ window's CGWindowID over its Node inspector and hands it to
 returned as alpha. This makes the script macOS-only, and it steals focus for
 the length of the run — the window has to be key, or the buttons photograph
 grey.
+
+**So it waits until nobody is at the machine.** Owning the screen is not
+optional here and both ways out were measured and rejected:
+`webContents.capturePage()` on an unshown window returns square opaque corners
+and no buttons, and `showInactive()` plus `screencapture` returns the corners
+but grey buttons — both are frames `checkWindowChrome` refuses. What the run
+can do is not take the screen from somebody: it reads `HIDIdleTime` and defers
+(exit code 75, nothing written) unless the machine has been untouched for five
+minutes, and it activates the app once per run rather than once per shot. Pass
+`--now` when you are the one asking for it and are willing to lose the front
+for a couple of minutes.
 
 **Every frame is inspected before it becomes a file.** `checkWindowChrome`
 looks for the two things a capture of the web contents can never have —

--- a/packages/app/scripts/electron-cdp.mjs
+++ b/packages/app/scripts/electron-cdp.mjs
@@ -8,6 +8,7 @@
  * tab has. This script is the launch path for that.
  *
  *   node scripts/electron-cdp.mjs launch            # build + run with CDP on :9222
+ *   node scripts/electron-cdp.mjs launch --visible  # …and put it on screen
  *   node scripts/electron-cdp.mjs shot out.png      # screenshot the current page
  *   node scripts/electron-cdp.mjs shot out.png --view=project --tab=graph --dark
  *
@@ -15,6 +16,10 @@
  * trace-mcp.app for Electron's single-instance lock. Once it is up, an external
  * CDP client can attach to http://127.0.0.1:9222 — including chrome-devtools
  * MCP, which takes `--browser-url http://127.0.0.1:9222`.
+ *
+ * The window is never shown unless you ask for it. Everything here drives the
+ * app over CDP, which does not care whether the window is on screen — and the
+ * person at the keyboard does (TRA-403).
  */
 import { spawn } from 'node:child_process';
 import { mkdirSync, writeFileSync } from 'node:fs';
@@ -77,10 +82,20 @@ async function connect(wsUrl) {
   };
 }
 
-function launch() {
+function launch(visible) {
   mkdirSync(USER_DATA_DIR, { recursive: true });
   const electron = path.join(APP_DIR, 'node_modules', '.bin', 'electron');
-  const env = { ...process.env, TRACE_MCP_DEV_ALWAYS_ON_TOP: '1' };
+  /* Nothing on screen by default. A review run happens while somebody is using
+     the machine, and macOS follows an app activation to that app's Space — a
+     visible window pulls them out of whatever they were in (TRA-403). The
+     renderer paints either way, and a CDP screenshot of an unmapped window is a
+     real frame, so `shot` loses nothing.
+     `--visible` is for the one case that needs eyes on the running window; it
+     then has to stay on top, or Chromium stops compositing an occluded window
+     and the shot comes back as the frame it painted minutes ago. */
+  const env = { ...process.env };
+  if (visible) env.TRACE_MCP_DEV_ALWAYS_ON_TOP = '1';
+  else env.TRACE_MCP_WINDOW_MODE = 'hidden';
   delete env.ELECTRON_RUN_AS_NODE;
   const child = spawn(
     electron,
@@ -124,9 +139,9 @@ async function shot(outFile, opts) {
     await sleep(opts.settleMs);
   }
   mkdirSync(path.dirname(path.resolve(outFile)), { recursive: true });
-  /* Needs a visible window: an occluded one stops compositing, and the capture
-     then either hangs or hands back the last frame it painted. `launch` sets
-     TRACE_MCP_DEV_ALWAYS_ON_TOP for exactly this reason. */
+  /* Works on the unmapped window `launch` opens — an unshown window is not an
+     occluded one, and Chromium keeps painting it. (An occluded *visible* window
+     is the stale-pixel case, which is why `--visible` implies always-on-top.) */
   const { data } = await cdp.send('Page.captureScreenshot', { format: 'png' });
   writeFileSync(outFile, Buffer.from(data, 'base64'));
   cdp.close();
@@ -135,7 +150,7 @@ async function shot(outFile, opts) {
 
 const [cmd, ...rest] = process.argv.slice(2);
 if (cmd === 'launch') {
-  launch();
+  launch(rest.includes('--visible'));
 } else if (cmd === 'shot') {
   const out = rest.find((a) => !a.startsWith('--'));
   if (!out) throw new Error('usage: electron-cdp.mjs shot <out.png> [--url=…] [--dark|--light]');
@@ -152,6 +167,8 @@ if (cmd === 'launch') {
     click: flag('click'),
   });
 } else {
-  console.error('usage: electron-cdp.mjs launch | shot <out.png> [--url=…] [--dark|--light]');
+  console.error(
+    'usage: electron-cdp.mjs launch [--visible] | shot <out.png> [--url=…] [--dark|--light]',
+  );
   process.exit(1);
 }

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import fs from 'fs';
 import { t } from './i18n';
 import { registerAppMenu } from './menu';
-import { createTray, restoreAppearance, showMenuWindow } from './tray';
+import { createTray, HIDDEN_WINDOWS, restoreAppearance, showMenuWindow } from './tray';
 import {
   hasPendingUpdate as hasPendingUpdateImpl,
   trySpawnApplyHelper as trySpawnApplyHelperImpl,
@@ -23,6 +23,14 @@ const UPDATE_CHANNEL = updateChannelFor(process.platform);
 // from 60 to ~20 on full-window views. Re-enable the defensive flags only
 // if GPU process crashes resurface.
 app.commandLine.appendSwitch('enable-features', 'SharedArrayBuffer');
+
+// A hidden-window run must not become the active application either: launching a
+// regular app activates it, and macOS follows that to the app's Space, pulling
+// whoever is at the keyboard out of what they were in. Accessory policy keeps the
+// process out of the Dock and out of ⌘-Tab — and it is set here, before `ready`,
+// because by the time the first window exists the activation has already
+// happened (TRA-403).
+if (HIDDEN_WINDOWS) app.setActivationPolicy('accessory');
 
 // Prevent multiple instances. If a second launch happens, bring the existing
 // window forward instead of letting the new process die silently.

--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -14,6 +14,21 @@ import { t } from './i18n';
 
 const isMac = process.platform === 'darwin';
 
+/**
+ * Render the app without ever putting a window on screen (TRA-403).
+ *
+ * Agent harnesses drive this app on a machine somebody is using: macOS follows
+ * an app activation to the Space that app's window lives on, so a review run
+ * that shows a window drags the user out of their full-screen app. With
+ * `TRACE_MCP_WINDOW_MODE=hidden` the window is created, loads and paints, but is
+ * never mapped — no Dock icon, no activation, nothing on screen — and a CDP
+ * screenshot of it is a real, current frame (measured: `Page.captureScreenshot`
+ * on an unmapped window returns the same pixels as on a visible one).
+ *
+ * Set by `scripts/electron-cdp.mjs`. Never set in a shipped build.
+ */
+export const HIDDEN_WINDOWS = process.env.TRACE_MCP_WINDOW_MODE === 'hidden';
+
 // macOS: Template images (auto-tinted by the system)
 // Windows: separate light/dark icons (white for dark taskbar, black for light)
 const ASSETS = path.join(__dirname, '..', '..', 'assets');
@@ -194,6 +209,14 @@ function ensureDockVisible(): void {
   }
 }
 
+/** Put a loaded window on screen — the one place that shows and focuses one. */
+function presentWindow(win: BrowserWindow): void {
+  if (HIDDEN_WINDOWS) return;
+  ensureDockVisible();
+  win.show();
+  win.focus();
+}
+
 /* ---- The native tab bar (macOS), and the two things it breaks (TRA-399) ----
 
    Every window we open carries the same `tabbingIdentifier`, so a second window
@@ -309,12 +332,12 @@ function broadcastTabList(): void {
 ipcMain.handle('focus-tab', (_event, tabId: string) => {
   if (tabId === 'menu') {
     if (menuWindow && !menuWindow.isDestroyed()) {
-      menuWindow.focus();
+      presentWindow(menuWindow);
     }
   } else {
     const win = projectWindows.get(tabId);
     if (win && !win.isDestroyed()) {
-      win.focus();
+      presentWindow(win);
     }
   }
   broadcastTabList();
@@ -353,9 +376,7 @@ export function showMenuWindow(tab?: string): void {
     if (tab) {
       menuWindow.loadURL(getRendererUrl({ view: 'menu', tab }));
     }
-    ensureDockVisible();
-    menuWindow.show();
-    menuWindow.focus();
+    presentWindow(menuWindow);
     return;
   }
 
@@ -375,9 +396,7 @@ export function showMenuWindow(tab?: string): void {
   });
 
   menuWindow.once('ready-to-show', () => {
-    ensureDockVisible();
-    menuWindow?.show();
-    menuWindow?.focus();
+    if (menuWindow) presentWindow(menuWindow);
     broadcastTabList();
   });
 
@@ -396,7 +415,7 @@ function openProjectTab(root: string): void {
   // If project already open, focus its tab
   const existing = projectWindows.get(root);
   if (existing && !existing.isDestroyed()) {
-    existing.focus();
+    if (!HIDDEN_WINDOWS) existing.focus();
     return;
   }
 
@@ -416,9 +435,7 @@ function openProjectTab(root: string): void {
   }
 
   win.once('ready-to-show', () => {
-    ensureDockVisible();
-    win.show();
-    win.focus();
+    presentWindow(win);
     broadcastTabList();
   });
 
@@ -683,7 +700,7 @@ async function checkHealth(): Promise<void> {
 if (isMac) {
   app.on('new-window-for-tab', () => {
     if (menuWindow && !menuWindow.isDestroyed()) {
-      menuWindow.focus();
+      presentWindow(menuWindow);
     } else {
       showMenuWindow();
     }

--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -3,7 +3,8 @@
  * Regenerate every screenshot docs/ and trace-mcp.com ship, from a seeded
  * demo state, in one command:
  *
- *   node scripts/capture-screenshots.mjs          # capture
+ *   node scripts/capture-screenshots.mjs          # capture, once the machine is idle
+ *   node scripts/capture-screenshots.mjs --now    # capture even if somebody is using it
  *   node scripts/capture-screenshots.mjs --check  # are the committed ones stale?
  *
  * Why it drives the real Electron window and not a browser: the renderer is a
@@ -37,6 +38,19 @@
  * nothing of the machine that took the shot. Reduce Transparency is therefore
  * no longer emulated — that was a workaround for a renderer-side capture, which
  * could only ever show a see-through hole where the sidebar is.
+ *
+ * This run owns the screen, and that is not fixable (TRA-403). Both ways of
+ * capturing without one were measured on this app, and both produce exactly the
+ * frame `checkWindowChrome` exists to refuse:
+ *   - `webContents.capturePage()` on a window that is never shown → square,
+ *     fully opaque corners and no traffic lights: a picture of a web page;
+ *   - `showInactive()` + `screencapture -l` → the corners come back, but AppKit
+ *     draws the buttons of a window whose app is not active in grey.
+ * Coloured buttons mean the app is frontmost, so a published screenshot costs
+ * one activation. What this script owes the person at the keyboard is therefore
+ * not "never activate" but "never do it while they are there": it waits for the
+ * machine to be idle (see `mayStartCapture`) unless told `--now`, and it
+ * activates once per run rather than once per shot.
  */
 
 import { execFileSync, spawn } from 'node:child_process';
@@ -112,6 +126,43 @@ export function readMarker(markerPath = MARKER_PATH) {
   } catch {
     return null;
   }
+}
+
+// ── Idle gate (pure — unit-tested in tests/scripts/capture-screenshots.test.ts) ──
+
+/** How long the machine must have been untouched before a capture may start.
+ *  A run takes a couple of minutes and holds the front the whole time. */
+export const IDLE_REQUIRED_S = 300;
+/** Nothing else on this machine can tell a capture run that a person is here. */
+export const IDLE_EXIT_CODE = 75; // EX_TEMPFAIL — "not now, ask again later"
+
+/** Seconds since the last keyboard or mouse event, out of `ioreg -c IOHIDSystem`.
+ *  `HIDIdleTime` is in nanoseconds; absent on a machine with no HID at all. */
+export function parseIdleSeconds(ioregOutput) {
+  const match = /"HIDIdleTime"\s*=\s*(\d+)/.exec(ioregOutput ?? '');
+  return match ? Number(match[1]) / 1e9 : null;
+}
+
+/**
+ * May this run take over the screen? Only when nobody is at the keyboard —
+ * or when a human asked for it explicitly with `--now`.
+ *
+ * `idleSeconds` of `null` means the idle time could not be read. That is a
+ * "don't know", and a capture run that does not know whether someone is
+ * watching does not go ahead.
+ */
+export function mayStartCapture(idleSeconds, { force = false } = {}) {
+  if (force) return { ok: true, reason: null };
+  if (idleSeconds === null) {
+    return { ok: false, reason: 'cannot tell whether anyone is at the machine — pass --now' };
+  }
+  if (idleSeconds < IDLE_REQUIRED_S) {
+    return {
+      ok: false,
+      reason: `the machine was in use ${Math.round(idleSeconds)}s ago; a capture activates the app and would pull whoever is here out of what they are doing (needs ${IDLE_REQUIRED_S}s idle, or --now)`,
+    };
+  }
+  return { ok: true, reason: null };
 }
 
 // ── Window chrome (pure — unit-tested in tests/scripts/capture-screenshots.test.ts) ──
@@ -258,6 +309,21 @@ export function decodePng(buf) {
 
 function git(args, cwd = REPO_ROOT) {
   return execFileSync('git', args, { cwd, encoding: 'utf-8' }).trim();
+}
+
+/** Seconds since the last human input on this machine, or null if unknowable. */
+function idleSeconds() {
+  try {
+    return parseIdleSeconds(
+      // `-r` roots the search at IOHIDSystem itself; without it the properties
+      // of the class are not printed at all and the idle time reads as unknown.
+      execFileSync('/usr/sbin/ioreg', ['-c', 'IOHIDSystem', '-r', '-d', '1', '-w', '0'], {
+        encoding: 'utf-8',
+      }),
+    );
+  } catch {
+    return null;
+  }
 }
 
 function log(msg) {
@@ -517,14 +583,18 @@ async function sizeWindow(main, viewport) {
  * Make the window key and frontmost, and name it. Both matter: a window that is
  * not key draws its traffic lights grey, and Chromium stops compositing an
  * occluded one — `screencapture` would then photograph a stale frame.
+ *
+ * Only when it is not already: the run takes the front once and keeps it, so
+ * the machine is grabbed a single time rather than once per shot (TRA-403).
  */
 async function frontWindowId(main) {
   const id = await mainEval(
     main,
-    `app.focus({ steal: true });
-     win.show();
-     win.moveTop();
-     win.focus();
+    `if (!win.isFocused()) {
+       app.focus({ steal: true });
+       win.moveTop();
+       win.focus();
+     }
      return win.getMediaSourceId();`,
   );
   const windowId = Number(String(id).split(':')[1]);
@@ -907,6 +977,14 @@ async function main() {
     const result = checkFreshness(readMarker(), currentState());
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     process.exit(result.fresh ? 0 : 1);
+  }
+
+  // The run activates the app to photograph it, so it waits for the machine to
+  // be free rather than taking it from somebody (TRA-403).
+  const gate = mayStartCapture(idleSeconds(), { force: argv.includes('--now') });
+  if (!gate.ok) {
+    log(`deferred — ${gate.reason}`);
+    process.exit(IDLE_EXIT_CODE);
   }
 
   const only = argv.filter((a) => !a.startsWith('-'));

--- a/tests/scripts/capture-screenshots.test.ts
+++ b/tests/scripts/capture-screenshots.test.ts
@@ -7,8 +7,11 @@ import {
   checkWindowChrome,
   CHROME_STRIP,
   decodePng,
+  IDLE_REQUIRED_S,
   IMAGES_DIR,
   MANIFEST_PATH,
+  mayStartCapture,
+  parseIdleSeconds,
   readMarker,
   REPO_ROOT,
 } from '../../scripts/capture-screenshots.mjs';
@@ -45,6 +48,109 @@ describe('checkFreshness', () => {
 
   it('is stale — not fresh-by-default — when no capture has ever run', () => {
     expect(checkFreshness(null, current).fresh).toBe(false);
+  });
+});
+
+describe('the idle gate', () => {
+  const IOREG = '    | | |   "HIDIdleTime" = 421000000000\n    | | |   "HIDBuild" = "x"';
+
+  it('reads the idle time out of ioreg, in seconds', () => {
+    expect(parseIdleSeconds(IOREG)).toBe(421);
+  });
+
+  it('has no idle time to report when ioreg says nothing about HID', () => {
+    expect(parseIdleSeconds('+-o Root  <class IORegistryEntry>')).toBeNull();
+    expect(parseIdleSeconds(undefined)).toBeNull();
+  });
+
+  it('lets a capture start on a machine nobody has touched', () => {
+    expect(mayStartCapture(IDLE_REQUIRED_S + 1)).toEqual({ ok: true, reason: null });
+  });
+
+  it('defers while somebody is using the machine', () => {
+    const verdict = mayStartCapture(12);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain('12s ago');
+  });
+
+  it('defers when it cannot tell — not knowing is not permission', () => {
+    expect(mayStartCapture(null).ok).toBe(false);
+  });
+
+  it('goes ahead anyway when a human asked for it', () => {
+    expect(mayStartCapture(0, { force: true }).ok).toBe(true);
+    expect(mayStartCapture(null, { force: true }).ok).toBe(true);
+  });
+});
+
+/* TRA-403: three agents drive this app and a browser on a machine somebody is
+   working on. macOS follows an app activation to that app's Space, so every
+   show/focus call in a harness path is a chance to yank the user out of their
+   full-screen app — and each of the ones below was one until it was removed. */
+describe('no harness path steals the screen', () => {
+  const SCREEN_API = /\.show\(\)|\.showInactive\(|\.focus\(|\.moveTop\(|shell\.openExternal/;
+
+  /** Source lines that call one, ignoring comments and doc blocks. */
+  function screenCalls(source: string) {
+    return source
+      .split('\n')
+      .map((text, index) => ({ line: index + 1, text: text.trim() }))
+      .filter(
+        ({ text }) => SCREEN_API.test(text) && !text.startsWith('*') && !text.startsWith('//'),
+      );
+  }
+
+  /** The line range of a function, from its header to the closing brace. */
+  function bodyOf(source: string, header: string) {
+    const lines = source.split('\n');
+    const start = lines.findIndex((l) => l.startsWith(header));
+    expect(start, `${header} — did it get renamed?`).toBeGreaterThan(-1);
+    const end = lines.findIndex((l, i) => i > start && l === '}');
+    return { start: start + 1, end: end + 1 };
+  }
+
+  it('the review harness shows nothing at all', () => {
+    const source = fs.readFileSync(
+      path.join(REPO_ROOT, 'packages/app/scripts/electron-cdp.mjs'),
+      'utf-8',
+    );
+    expect(screenCalls(source)).toEqual([]);
+  });
+
+  it('the publication capture takes the front in one place only', () => {
+    const file = path.join(REPO_ROOT, 'scripts/capture-screenshots.mjs');
+    const source = fs.readFileSync(file, 'utf-8');
+    // It cannot avoid taking it: AppKit draws the traffic lights of a window
+    // whose app is not active in grey, and `checkWindowChrome` refuses those.
+    const allowed = [
+      bodyOf(source, 'async function sizeWindow'),
+      bodyOf(source, 'async function frontWindowId'),
+    ];
+    for (const call of screenCalls(source)) {
+      expect(
+        allowed.some((r) => call.line >= r.start && call.line <= r.end),
+        `capture-screenshots.mjs:${call.line} — ${call.text}`,
+      ).toBe(true);
+    }
+  });
+
+  it('the app shows a window in one place, and that place can be told not to', () => {
+    const file = path.join(REPO_ROOT, 'packages/app/src/main/tray.ts');
+    const source = fs.readFileSync(file, 'utf-8');
+    const present = bodyOf(source, 'function presentWindow');
+    expect(source).toContain('if (HIDDEN_WINDOWS) return;');
+    // …and the Dock icon with it: `ensureDockVisible` is reached through
+    // `presentWindow` and nowhere else, so a hidden run takes no Dock tile.
+    expect(source.match(/ensureDockVisible\(\);/g)).toHaveLength(1);
+    const dock = bodyOf(source, 'function ensureDockVisible');
+    const allowed = [present, dock];
+    for (const call of screenCalls(source)) {
+      const sanctioned = allowed.some((r) => call.line >= r.start && call.line <= r.end);
+      expect(
+        sanctioned || call.text.includes('HIDDEN_WINDOWS'),
+        `tray.ts:${call.line} — ${call.text} escapes the hidden-window check`,
+      ).toBe(true);
+    }
   });
 });
 


### PR DESCRIPTION
Agent runs were taking the screen: `electron-cdp.mjs` showed an always-on-top window for
the length of every design review, and the publication capture activated the app once per
shot. macOS follows an app activation to the Space that app's window is on, so each run
pulled whoever was at the keyboard out of their full-screen app — hourly, from three
agents.

## The review harness: nothing on screen at all

`node packages/app/scripts/electron-cdp.mjs launch` now runs the app hidden. The window is
created, loads and paints; it is never mapped, and the process runs as a macOS accessory
app — no Dock tile, no ⌘-Tab entry, no activation. Everything here drives the app over CDP,
which does not care whether a window is visible.

`--visible` puts it on screen when a human wants to watch, and only then sets
`TRACE_MCP_DEV_ALWAYS_ON_TOP=1` (an occluded *visible* window stops compositing and hands
back stale pixels; an unmapped one keeps painting).

App side: `TRACE_MCP_WINDOW_MODE=hidden` makes `presentWindow()` — now the only place in
`tray.ts` that shows or focuses a window — return early.

## The publication capture cannot go hidden. Measured, not assumed.

The issue asked for `webContents.capturePage()` on an unshown window. I ran both candidates
against this app before writing any of this, and both produce exactly the frame
`checkWindowChrome` exists to refuse (TRA-354 / TRA-366 / TRA-390 shipped one three times):

| how | rounded corners | traffic lights | `checkWindowChrome` |
|---|---|---|---|
| `capturePage()`, window never shown | ✗ square, opaque | ✗ absent | **rejected** |
| `showInactive()` + `screencapture -l` | ✓ alpha | ✗ grey (app not active) | **rejected** |
| activate + `screencapture -l` | ✓ alpha | ✓ colour | accepted |

Coloured buttons mean the app is frontmost — AppKit draws the buttons of a window whose app
is inactive in grey. A published screenshot therefore costs one activation, and no amount
of code removes that.

So the capture pays for it differently: it **waits for the machine to be free**. It reads
`HIDIdleTime` and defers with exit code 75, writing nothing, unless nobody has touched the
keyboard or mouse for five minutes; `--now` is the override for when you are the one asking.
And it activates once per run instead of once per shot.

## Guard

`tests/scripts/capture-screenshots.test.ts` reads all three files and fails when a
show/focus/`shell.openExternal` call appears outside the one place allowed to make it:
`electron-cdp.mjs` may have none, `capture-screenshots.mjs` only inside `sizeWindow` /
`frontWindowId`, `tray.ts` only inside `presentWindow` (or behind an explicit
`HIDDEN_WINDOWS` check). It also pins `ensureDockVisible` to that single call site, so a
hidden run cannot grow a Dock icon.

## Verified on the running app

Asked the app itself over its main-process inspector, and the machine over System Events:

| | hidden (new default) | `--visible` (old behaviour) |
|---|---|---|
| `win.isVisible()` | `false` | window shown, `alwaysOnTop: true` |
| frontmost app during the run | unchanged | **the harness itself** |
| listed in Dock / ⌘-Tab | no | — |
| CDP screenshot | 125 KB, current frame | 124 KB |

Then the real publication path, after the change, on an idle machine:
`[screenshots] app-graph.webp — 131 KB, window chrome verified` — traffic lights and
rounded corners intact with a single activation. The idle gate was exercised both ways:
`deferred — the machine was in use 219s ago … (needs 300s idle, or --now)` at 219s, and a
full capture at 308s.

Not verified: I could not sit in front of a full-screen app on another Space and watch,
so "the Space does not change" rests on the two things that cause a Space switch — the
activation and the mapped window — being measurably absent.

Root suite 8977 passed, app suite 416 passed, `biome ci` clean, typecheck and both builds
clean.

Closes TRA-403.
