### PR TITLE
fix(update): stop re-downloading and re-staging the version already installed

### DIFF
--- a/scripts/postinstall-app.mjs
+++ b/scripts/postinstall-app.mjs
@@ -262,10 +262,20 @@ async function main() {
   // Guard against shell-hostile asset names even though we use execFileSync.
   if (!/^[A-Za-z0-9._-]+\.zip$/.test(asset.name)) return;
 
+  // Compare with the leading `v` stripped from both sides. The marker has two
+  // writers that disagree on format: this script writes `release.tag_name`
+  // ("v3.2.0") while apply-pending-update.mjs writes the normalized pending
+  // version ("3.2.0"). A raw comparison therefore never matches after a
+  // GUI-applied update, so every later `npm install -g trace-mcp` re-downloads
+  // the full ~110 MB zip and re-stages the version already installed — and
+  // because the apply path rewrites the marker in the same stripped form, the
+  // loop never settles: the app shows a permanent "restart to install" banner
+  // for the build it is already running.
+  const stripV = (v) => v.replace(/^v/, '');
   const markerPath = path.join(INSTALL_DIR, '.trace-mcp-version');
   if (fs.existsSync(markerPath)) {
     const installed = fs.readFileSync(markerPath, 'utf-8').trim();
-    if (installed === release.tag_name) return;
+    if (stripV(installed) === stripV(release.tag_name)) return;
   }
 
   // Require a sibling checksum asset — no checksum, no update.

--- a/tests/scripts/postinstall-app.test.ts
+++ b/tests/scripts/postinstall-app.test.ts
@@ -274,4 +274,33 @@ describe.skipIf(process.platform !== 'darwin')('postinstall-app.mjs bundle swap'
     expect(fs.statSync(fx.appPath).mtimeMs).toBe(before);
     expect(stdout).not.toContain('updated to');
   });
+
+  // The marker has two writers that disagree on format: this script writes
+  // `tag_name` ("v3.1.1"), apply-pending-update.mjs writes the normalized
+  // pending version ("3.1.1"). The test above only ever covered the first
+  // form, so the mismatch was invisible: after any GUI-applied update every
+  // later install re-downloaded the whole zip and re-staged a version already
+  // installed, leaving a "restart to install" banner that never cleared.
+  it('is a no-op when the marker was written by the GUI apply path (no leading v)', async () => {
+    installBundle('3.1.1');
+    publishRelease('3.1.1');
+    fs.writeFileSync(path.join(fx.installDir, '.trace-mcp-version'), '3.1.1');
+
+    const before = fs.statSync(fx.appPath).mtimeMs;
+    const stdout = await runPostinstall();
+
+    expect(fs.statSync(fx.appPath).mtimeMs).toBe(before);
+    expect(stdout).not.toContain('updated to');
+  });
+
+  it('does not stage a phantom pending update for the running version', async () => {
+    installBundle('3.1.1');
+    publishRelease('3.1.1');
+    fs.writeFileSync(path.join(fx.installDir, '.trace-mcp-version'), '3.1.1');
+
+    await runPostinstall({ appRunning: true });
+
+    expect(fs.existsSync(path.join(fx.installDir, '.trace-mcp-pending.zip'))).toBe(false);
+    expect(fs.existsSync(path.join(fx.installDir, '.trace-mcp-pending-version'))).toBe(false);
+  });
 });


### PR DESCRIPTION
## What

`.trace-mcp-version` has two writers that disagree on format:

- `scripts/postinstall-app.mjs` writes `release.tag_name` → `v3.2.0`
- `scripts/apply-pending-update.mjs` writes the normalized pending version → `3.2.0`

postinstall compared the marker against `tag_name` raw, so after any GUI-applied update ("Restart to install") the short-circuit never matched again.

## Impact — reproduced, not inferred

Run end-to-end against the real published v3.2.0 release, with an old bundle in an isolated `HOME`:

| marker on disk | app running | result |
|---|---|---|
| `v3.2.0` (postinstall wrote it) | no | no-op in **0.1s** ✅ |
| `3.2.0` (GUI apply wrote it) | no | full **111 MB** re-download + re-swap of an already-current bundle, **33s** ❌ |
| `3.2.0` (GUI apply wrote it) | yes | stages a pending zip for the **running** version → "restart to install" banner for the build already installed ❌ |

The loop never settles: the apply path rewrites the marker in the same stripped form, so the next `npm install -g trace-mcp` re-stages again. The needless swap also reopens the interrupted-swap crash window that `recoverInterruptedSwap()` exists to clean up, for zero benefit.

**This is live.** On the maintainer's machine right now, `~/Applications/.trace-mcp-version` reads `3.2.0` while the installed bundle is 3.2.0 — i.e. already in the loop.

## Fix

Compare with the leading `v` stripped from both sides.

Normalizing on read rather than aligning the writers is deliberate: it also heals the markers already sitting on disk, so affected installs recover on the next CLI update instead of after one more wasted 111 MB cycle. `getInstalledAppVersion()` in `src/cli/install-app.ts` already normalizes exactly this way — postinstall was the lone raw comparison.

## Tests

The existing no-op regression test only ever wrote the `v`-prefixed form, which is precisely why this was invisible to it. Added:

- `is a no-op when the marker was written by the GUI apply path (no leading v)`
- `does not stage a phantom pending update for the running version`

Verified locally:

- `pnpm run test` → **820 files, 9083 tests passed**, 2 skipped
- `pnpm run build` → success
- `pnpm run lint` (`tsc --noEmit`) → clean
- Manual end-to-end against the real GitHub release: a genuine 2.1.0 → 3.2.0 upgrade across a major gap still swaps correctly and writes `v3.2.0`; the stale-format marker case is now a 0.1s no-op with no pending files staged.

No MCP tool contract or on-disk schema change.

Refs TRA-405, follow-up to TRA-357.
