### PR TITLE
fix(app): honour TRACE_MCP_AGENT_RUN as well (TRA-403)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -954,8 +954,9 @@ agent launches:
 - **Never call `app.focus()`, `win.focus()`, `win.show()`, `showInactive()` or
   `shell.openExternal` from a harness path.** `tests/scripts/capture-screenshots.test.ts`
   reads these files and fails when one appears: in `tray.ts` every show goes through
-  `presentWindow`, which returns early under `TRACE_MCP_WINDOW_MODE=hidden`; in
-  `electron-cdp.mjs` there are none at all.
+  `presentWindow`, which returns early under `TRACE_MCP_WINDOW_MODE=hidden` (or
+  `TRACE_MCP_AGENT_RUN=1`, the same request from an agent launching the app some other
+  way); in `electron-cdp.mjs` there are none at all.
 - **The one exception is the publication capture**, which cannot avoid activating the app
   (a window whose app is not active draws grey traffic lights, and those are refused). It
   pays for the exception by waiting for an idle machine — see docs/development.md.

--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -25,9 +25,13 @@ const isMac = process.platform === 'darwin';
  * screenshot of it is a real, current frame (measured: `Page.captureScreenshot`
  * on an unmapped window returns the same pixels as on a visible one).
  *
- * Set by `scripts/electron-cdp.mjs`. Never set in a shipped build.
+ * Set by `scripts/electron-cdp.mjs`. `TRACE_MCP_AGENT_RUN=1` is the same
+ * request from the other direction — "nobody is looking at this run" — and is
+ * what an agent launching the app some other way sets. Never set in a shipped
+ * build; a human running `pnpm dev` has neither and sees today's behaviour.
  */
-export const HIDDEN_WINDOWS = process.env.TRACE_MCP_WINDOW_MODE === 'hidden';
+export const HIDDEN_WINDOWS =
+  process.env.TRACE_MCP_WINDOW_MODE === 'hidden' || process.env.TRACE_MCP_AGENT_RUN === '1';
 
 // macOS: Template images (auto-tinted by the system)
 // Windows: separate light/dark icons (white for dark taskbar, black for light)

--- a/tests/scripts/capture-screenshots.test.ts
+++ b/tests/scripts/capture-screenshots.test.ts
@@ -152,6 +152,15 @@ describe('no harness path steals the screen', () => {
       ).toBe(true);
     }
   });
+
+  it('answers to both names an agent run is announced under', () => {
+    // `TRACE_MCP_WINDOW_MODE=hidden` is what this repo's dev script sets;
+    // `TRACE_MCP_AGENT_RUN=1` is what an agent launching the app another way
+    // sets. A run that announces itself and still gets a window is the bug.
+    const source = fs.readFileSync(path.join(REPO_ROOT, 'packages/app/src/main/tray.ts'), 'utf-8');
+    expect(source).toContain("process.env.TRACE_MCP_WINDOW_MODE === 'hidden'");
+    expect(source).toContain("process.env.TRACE_MCP_AGENT_RUN === '1'");
+  });
 });
 
 /* A frame the size and shape of what `screencapture -l` returns: a window with


### PR DESCRIPTION
#554 landed the hidden-window gate reading `TRACE_MCP_WINDOW_MODE=hidden`, which
`packages/app/scripts/electron-cdp.mjs` sets by default. Agents that launch the app some
other way have been told to announce themselves with `TRACE_MCP_AGENT_RUN=1` — and a run
that announces itself and still gets a window on screen is exactly the failure the gate
exists to prevent. So the gate reads both names.

A human running `pnpm dev` sets neither and sees today's behaviour, unchanged.

Verified on the running app, not from the diff: launched with `TRACE_MCP_AGENT_RUN=1` and
asked the main process directly — `isVisible(): false`, never focused, `alwaysOnTop:
false`, and the frontmost application never became the harness.

One assertion added to the existing guard test so a future edit cannot drop either name.

TRA-403.
