### PR TITLE
fix(app): every unpackaged build runs as an accessory app (TRA-407)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -968,6 +968,12 @@ agent launches:
 
 - **The app: never shown.** `electron-cdp.mjs launch` is hidden and accessory by default.
   A visible window needs `--visible` and a reason stated where you use it.
+- **Every unpackaged build is accessory**, not only the ones launched through that script.
+  A plain `electron .` gets no Dock icon and no ⌘-Tab entry, because a rule that holds only
+  when somebody remembers a flag is not a rule. A shipped build is a real app and keeps
+  both. The opt-out for a human debugging the dev build is `TRACE_MCP_WINDOW_MODE=visible`
+  (`electron-cdp.mjs --visible` sets it). The decision itself is one pure function,
+  `shouldRunAsAccessory` in `src/shared/window-mode.ts`.
 - **The browser: `--headless --isolated`.** Headless removes the window entirely and
   screenshots still come out; `--isolated` gives Chrome a throwaway profile so it can
   never adopt or disturb the one the user has open. Both belong in the MCP server's own

--- a/packages/app/scripts/electron-cdp.mjs
+++ b/packages/app/scripts/electron-cdp.mjs
@@ -94,8 +94,13 @@ function launch(visible) {
      then has to stay on top, or Chromium stops compositing an occluded window
      and the shot comes back as the frame it painted minutes ago. */
   const env = { ...process.env };
-  if (visible) env.TRACE_MCP_DEV_ALWAYS_ON_TOP = '1';
-  else env.TRACE_MCP_WINDOW_MODE = 'hidden';
+  /* `visible` has to say so explicitly: an unpackaged build is accessory by
+     default (no Dock icon, no ⌘-Tab), and the one run that wants eyes on it
+     wants a normal foreground app too. */
+  if (visible) {
+    env.TRACE_MCP_WINDOW_MODE = 'visible';
+    env.TRACE_MCP_DEV_ALWAYS_ON_TOP = '1';
+  } else env.TRACE_MCP_WINDOW_MODE = 'hidden';
   delete env.ELECTRON_RUN_AS_NODE;
   const child = spawn(
     electron,

--- a/packages/app/src/main/__tests__/window-mode.test.ts
+++ b/packages/app/src/main/__tests__/window-mode.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { parseWindowMode, shouldRunAsAccessory } from '../../shared/window-mode';
+
+describe('parseWindowMode', () => {
+  it('accepts the two known modes and rejects anything else', () => {
+    expect(parseWindowMode('hidden')).toBe('hidden');
+    expect(parseWindowMode('visible')).toBe('visible');
+    expect(parseWindowMode(undefined)).toBeUndefined();
+    expect(parseWindowMode('')).toBeUndefined();
+    expect(parseWindowMode('Hidden')).toBeUndefined();
+  });
+});
+
+describe('shouldRunAsAccessory', () => {
+  it('leaves a shipped build a normal app with a Dock icon', () => {
+    expect(shouldRunAsAccessory(undefined, true)).toBe(false);
+  });
+
+  it('defaults an unpackaged build to accessory, so a dev run cannot steal the Space', () => {
+    expect(shouldRunAsAccessory(undefined, false)).toBe(true);
+  });
+
+  it('honours the explicit visible opt-out even when unpackaged', () => {
+    expect(shouldRunAsAccessory('visible', false)).toBe(false);
+  });
+
+  it('honours hidden even in a packaged build, for capture runs on the artifact', () => {
+    expect(shouldRunAsAccessory('hidden', true)).toBe(true);
+  });
+});

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import fs from 'fs';
 import { t } from './i18n';
 import { registerAppMenu } from './menu';
-import { createTray, HIDDEN_WINDOWS, restoreAppearance, showMenuWindow } from './tray';
+import { ACCESSORY_APP, createTray, restoreAppearance, showMenuWindow } from './tray';
 import {
   hasPendingUpdate as hasPendingUpdateImpl,
   trySpawnApplyHelper as trySpawnApplyHelperImpl,
@@ -24,13 +24,13 @@ const UPDATE_CHANNEL = updateChannelFor(process.platform);
 // if GPU process crashes resurface.
 app.commandLine.appendSwitch('enable-features', 'SharedArrayBuffer');
 
-// A hidden-window run must not become the active application either: launching a
-// regular app activates it, and macOS follows that to the app's Space, pulling
+// A development or capture run must not become the active application: launching
+// a regular app activates it, and macOS follows that to the app's Space, pulling
 // whoever is at the keyboard out of what they were in. Accessory policy keeps the
 // process out of the Dock and out of ⌘-Tab — and it is set here, before `ready`,
 // because by the time the first window exists the activation has already
-// happened (TRA-403).
-if (HIDDEN_WINDOWS) app.setActivationPolicy('accessory');
+// happened (TRA-403). A shipped build is never accessory; see window-mode.ts.
+if (ACCESSORY_APP) app.setActivationPolicy('accessory');
 
 // Prevent multiple instances. If a second launch happens, bring the existing
 // window forward instead of letting the new process die silently.

--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { app, BrowserWindow, ipcMain, Menu, nativeImage, nativeTheme, Tray } from 'electron';
 import { TRAFFIC_LIGHT_X, TRAFFIC_LIGHT_Y, trafficLightYFor } from '../shared/chrome-metrics.js';
+import { parseWindowMode, shouldRunAsAccessory } from '../shared/window-mode.js';
 import { DaemonClient } from './api-client';
 import {
   type Appearance,
@@ -32,6 +33,23 @@ const isMac = process.platform === 'darwin';
  */
 export const HIDDEN_WINDOWS =
   process.env.TRACE_MCP_WINDOW_MODE === 'hidden' || process.env.TRACE_MCP_AGENT_RUN === '1';
+
+/**
+ * Run as a background process with no Dock icon and no ⌘-Tab entry.
+ *
+ * Every unpackaged build defaults to this, not just the hidden-window capture
+ * runs: an agent that starts `electron .` by hand hits the same activation, and
+ * a rule that only holds when somebody remembers a flag is not a rule. A shipped
+ * build is unaffected — it is a real app and keeps its Dock icon. Pass
+ * `TRACE_MCP_WINDOW_MODE=visible` (or `electron-cdp.mjs --visible`) to opt a dev
+ * run back into being a normal foreground app.
+ *
+ * A hidden-window run is always accessory, packaged or not: a capture against
+ * the shipped artifact must not activate it either.
+ */
+export const ACCESSORY_APP =
+  HIDDEN_WINDOWS ||
+  shouldRunAsAccessory(parseWindowMode(process.env.TRACE_MCP_WINDOW_MODE), app.isPackaged);
 
 // macOS: Template images (auto-tinted by the system)
 // Windows: separate light/dark icons (white for dark taskbar, black for light)

--- a/packages/app/src/shared/window-mode.ts
+++ b/packages/app/src/shared/window-mode.ts
@@ -1,0 +1,26 @@
+/**
+ * Who gets a Dock icon, and who runs as a background (accessory) process.
+ *
+ * macOS follows an app activation to the Space that app's window lives on, so
+ * any run that becomes the active application drags whoever is at the keyboard
+ * out of what they were in — out of a full-screen app, onto another desktop.
+ * A shipped build is a real app and must keep its Dock icon and ⌘-Tab entry.
+ * An unpackaged build is a development or agent-harness run, and those happen
+ * on a machine somebody else is using, so they default to accessory.
+ *
+ * `TRACE_MCP_WINDOW_MODE=visible` is the opt-out: it asks for a normal app with
+ * a Dock icon and ⌘-Tab, which is what a human debugging the dev build wants.
+ * `hidden` forces accessory even in a packaged build, for capture runs against
+ * the shipped artifact.
+ */
+export type WindowMode = 'hidden' | 'visible' | undefined;
+
+export function parseWindowMode(raw: string | undefined): WindowMode {
+  return raw === 'hidden' || raw === 'visible' ? raw : undefined;
+}
+
+export function shouldRunAsAccessory(mode: WindowMode, isPackaged: boolean): boolean {
+  if (mode === 'hidden') return true;
+  if (mode === 'visible') return false;
+  return !isPackaged;
+}


### PR DESCRIPTION
## Problem

#554 gave the app an accessory activation policy — no Dock icon, no ⌘-Tab entry, never the active application, so macOS has nothing to follow to another Space. But it was gated on `TRACE_MCP_WINDOW_MODE=hidden`, which only `scripts/electron-cdp.mjs` sets. A run that starts `electron .` directly still activated the app and still yanked whoever was at the keyboard out of their full-screen app.

A rule that holds only when somebody remembers a flag is not a rule.

## Change

Accessory becomes the default for every unpackaged build. A shipped build is untouched — it is a real app and keeps its Dock icon and ⌘-Tab entry.

| Build | `TRACE_MCP_WINDOW_MODE` | Dock icon / ⌘-Tab |
|---|---|---|
| packaged | unset | yes |
| packaged | `hidden` | no — capture run against the shipped artifact |
| unpackaged | unset | **no** — new default |
| unpackaged | `visible` | yes — the opt-out |
| unpackaged | `hidden` | no |

`electron-cdp.mjs --visible` now sets `visible` as well as the always-on-top flag: the one run that wants eyes on the window wants a normal foreground app too.

The decision is a pure function, `shouldRunAsAccessory` in `packages/app/src/shared/window-mode.ts`, so it is unit-tested rather than an inline env check nobody can exercise. `app.setActivationPolicy` still runs before `ready` — by the time the first window exists the activation has already happened.

## Test evidence

```
pnpm run lint          tsc --noEmit, clean
pnpm run format:check  Checked 1626 files, no fixes applied
pnpm run build         Build success
pnpm run test          820 passed | 2 skipped (822 files)
                       9090 passed | 8 skipped (9098 tests)
packages/app test      45 files, 443 tests passed
```

Four new cases in `packages/app/src/main/__tests__/window-mode.test.ts` cover each row of the table above, including the one that matters most: a packaged build with no env var is never accessory.

Documented in `DESIGN.md` beside the existing harness rules.

Agent: Lead Engineer