### PR TITLE
fix(app): accessory activation policy by default for unpackaged builds

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -968,6 +968,15 @@ agent launches:
 
 - **The app: never shown.** `electron-cdp.mjs launch` is hidden and accessory by default.
   A visible window needs `--visible` and a reason stated where you use it.
+- **Every unpackaged build is accessory, flag or no flag** (TRA-407). Tying it to
+  `TRACE_MCP_WINDOW_MODE=hidden` made it a rule that held only when somebody remembered
+  the flag, and `electron .` run straight from a checkout still stole the screen. The
+  decision now lives in one pure function, `packages/app/src/main/activation-policy.ts`:
+  `hidden` is always accessory; a packaged build is otherwise always `regular` (it is a
+  real app); an unpackaged build is accessory unless it asks for `TRACE_MCP_WINDOW_MODE=visible`,
+  which is what `electron-cdp.mjs --visible` sets — the one run that wants eyes on the
+  window wants a foreground app too. `TRACE_MCP_AGENT_RUN=1` forces accessory in any
+  build, packaged included.
 - **The browser: `--headless --isolated`.** Headless removes the window entirely and
   screenshots still come out; `--isolated` gives Chrome a throwaway profile so it can
   never adopt or disturb the one the user has open. Both belong in the MCP server's own

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,7 +6,7 @@
   "main": "dist/main/index.js",
   "scripts": {
     "dev": "vite",
-    "dev:electron": "tsc -p tsconfig.main.json && node scripts/patch-electron-dev.mjs && unset ELECTRON_RUN_AS_NODE && electron .",
+    "dev:electron": "tsc -p tsconfig.main.json && node scripts/patch-electron-dev.mjs && unset ELECTRON_RUN_AS_NODE && TRACE_MCP_WINDOW_MODE=visible electron .",
     "build:renderer": "vite build",
     "build:main": "tsc -p tsconfig.main.json",
     "build": "pnpm run build:renderer && pnpm run build:main",

--- a/packages/app/scripts/electron-cdp.mjs
+++ b/packages/app/scripts/electron-cdp.mjs
@@ -94,8 +94,12 @@ function launch(visible) {
      then has to stay on top, or Chromium stops compositing an occluded window
      and the shot comes back as the frame it painted minutes ago. */
   const env = { ...process.env };
-  if (visible) env.TRACE_MCP_DEV_ALWAYS_ON_TOP = '1';
-  else env.TRACE_MCP_WINDOW_MODE = 'hidden';
+  if (visible) {
+    env.TRACE_MCP_DEV_ALWAYS_ON_TOP = '1';
+    /* An unpackaged build is accessory by default (TRA-407); the one run that
+       wants eyes on the window wants a normal foreground app too. */
+    env.TRACE_MCP_WINDOW_MODE = 'visible';
+  } else env.TRACE_MCP_WINDOW_MODE = 'hidden';
   delete env.ELECTRON_RUN_AS_NODE;
   const child = spawn(
     electron,

--- a/packages/app/src/main/__tests__/activation-policy.test.ts
+++ b/packages/app/src/main/__tests__/activation-policy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { activationPolicyFor } from '../activation-policy';
+
+describe('activationPolicyFor', () => {
+  it('leaves a shipped build a normal foreground app', () => {
+    expect(activationPolicyFor(undefined, true)).toBe('regular');
+    expect(activationPolicyFor('visible', true)).toBe('regular');
+  });
+
+  it('keeps an unpackaged build out of the Dock by default', () => {
+    expect(activationPolicyFor(undefined, false)).toBe('accessory');
+    expect(activationPolicyFor('', false)).toBe('accessory');
+  });
+
+  it('gives the dev build a foreground opt-out', () => {
+    expect(activationPolicyFor('visible', false)).toBe('regular');
+  });
+
+  it('never activates for a hidden-window run, packaged or not', () => {
+    expect(activationPolicyFor('hidden', false)).toBe('accessory');
+    expect(activationPolicyFor('hidden', true)).toBe('accessory');
+  });
+
+  it('never activates for a run that announced itself as an agent run', () => {
+    expect(activationPolicyFor(undefined, true, true)).toBe('accessory');
+    expect(activationPolicyFor('visible', true, true)).toBe('accessory');
+    expect(activationPolicyFor('visible', false, true)).toBe('accessory');
+  });
+
+  it('treats an unrecognised mode as the default for the build', () => {
+    expect(activationPolicyFor('nonsense', false)).toBe('accessory');
+    expect(activationPolicyFor('nonsense', true)).toBe('regular');
+  });
+});

--- a/packages/app/src/main/activation-policy.ts
+++ b/packages/app/src/main/activation-policy.ts
@@ -1,0 +1,33 @@
+/**
+ * Whether this process is allowed to be a normal foreground app (TRA-407).
+ *
+ * A regular macOS app activates on launch, and macOS follows that activation to
+ * the Space the app's window lives on — so an agent run that starts the dev
+ * build drags whoever is at the keyboard out of their full-screen app. Every
+ * unpackaged build is therefore `accessory` by default: no Dock icon, no ⌘-Tab,
+ * no activation. TRA-403 made that true only under
+ * `TRACE_MCP_WINDOW_MODE=hidden`, i.e. only when somebody remembered the flag.
+ *
+ * A shipped build is a real app and stays `regular` unless the run announces
+ * itself — `TRACE_MCP_WINDOW_MODE=hidden`, or `TRACE_MCP_AGENT_RUN=1` from an
+ * agent launching the packaged app some other way (TRA-403).
+ *
+ *   | build      | TRACE_MCP_WINDOW_MODE | policy    |
+ *   |------------|-----------------------|-----------|
+ *   | packaged   | unset                 | regular   |
+ *   | packaged   | hidden                | accessory |
+ *   | unpackaged | unset                 | accessory |
+ *   | unpackaged | visible               | regular   |
+ *   | unpackaged | hidden                | accessory |
+ */
+export type ActivationPolicy = 'regular' | 'accessory';
+
+export function activationPolicyFor(
+  windowMode: string | undefined,
+  packaged: boolean,
+  agentRun = false,
+): ActivationPolicy {
+  if (windowMode === 'hidden' || agentRun) return 'accessory';
+  if (packaged) return 'regular';
+  return windowMode === 'visible' ? 'regular' : 'accessory';
+}

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -5,7 +5,8 @@ import path from 'path';
 import fs from 'fs';
 import { t } from './i18n';
 import { registerAppMenu } from './menu';
-import { createTray, HIDDEN_WINDOWS, restoreAppearance, showMenuWindow } from './tray';
+import { activationPolicyFor } from './activation-policy';
+import { createTray, restoreAppearance, showMenuWindow } from './tray';
 import {
   hasPendingUpdate as hasPendingUpdateImpl,
   trySpawnApplyHelper as trySpawnApplyHelperImpl,
@@ -24,13 +25,22 @@ const UPDATE_CHANNEL = updateChannelFor(process.platform);
 // if GPU process crashes resurface.
 app.commandLine.appendSwitch('enable-features', 'SharedArrayBuffer');
 
-// A hidden-window run must not become the active application either: launching a
-// regular app activates it, and macOS follows that to the app's Space, pulling
-// whoever is at the keyboard out of what they were in. Accessory policy keeps the
-// process out of the Dock and out of ⌘-Tab — and it is set here, before `ready`,
+// Launching a regular app activates it, and macOS follows that to the app's
+// Space, pulling whoever is at the keyboard out of what they were in. Accessory
+// policy keeps the process out of the Dock and out of ⌘-Tab — see
+// activation-policy.ts for which builds get it. Set here, before `ready`,
 // because by the time the first window exists the activation has already
-// happened (TRA-403).
-if (HIDDEN_WINDOWS) app.setActivationPolicy('accessory');
+// happened (TRA-403, TRA-407).
+// `setActivationPolicy` exists on macOS only.
+if (process.platform === 'darwin') {
+  app.setActivationPolicy(
+    activationPolicyFor(
+      process.env.TRACE_MCP_WINDOW_MODE,
+      app.isPackaged,
+      process.env.TRACE_MCP_AGENT_RUN === '1',
+    ),
+  );
+}
 
 // Prevent multiple instances. If a second launch happens, bring the existing
 // window forward instead of letting the new process die silently.

--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -28,7 +28,11 @@ const isMac = process.platform === 'darwin';
  * Set by `scripts/electron-cdp.mjs`. `TRACE_MCP_AGENT_RUN=1` is the same
  * request from the other direction — "nobody is looking at this run" — and is
  * what an agent launching the app some other way sets. Never set in a shipped
- * build; a human running `pnpm dev` has neither and sees today's behaviour.
+ * build.
+ *
+ * This governs whether a window is mapped. Whether the process shows up in the
+ * Dock and ⌘-Tab is a separate decision — see `activation-policy.ts`, which is
+ * accessory for every unpackaged build whether or not either variable is set.
  */
 export const HIDDEN_WINDOWS =
   process.env.TRACE_MCP_WINDOW_MODE === 'hidden' || process.env.TRACE_MCP_AGENT_RUN === '1';

--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -875,9 +875,12 @@ async function capture(manifest, only) {
     // Always-on-top for the same reason the flag exists: Chromium stops
     // compositing an occluded window, and a window capture of one is a stale
     // frame. Nothing else may cover the window while it is being photographed.
+    // `visible` opts this unpackaged run out of the accessory default (TRA-407):
+    // a window whose app is not active draws grey traffic lights, and the
+    // publication capture refuses those.
     {
       cwd: path.join(REPO_ROOT, 'packages/app'),
-      env: { ...env, TRACE_MCP_DEV_ALWAYS_ON_TOP: '1' },
+      env: { ...env, TRACE_MCP_DEV_ALWAYS_ON_TOP: '1', TRACE_MCP_WINDOW_MODE: 'visible' },
       stdio: 'ignore',
     },
   );


### PR DESCRIPTION
`#554` (TRA-403) gave the app an accessory activation policy, but only under `TRACE_MCP_WINDOW_MODE=hidden` — which only `scripts/electron-cdp.mjs` sets. An agent that starts `electron .` from a checkout still activated the app and still pulled whoever was at the keyboard onto another Space.

## Change

The decision is one pure function, `packages/app/src/main/activation-policy.ts`:

| build | `TRACE_MCP_WINDOW_MODE` | policy |
|---|---|---|
| packaged | unset | `regular` |
| packaged | `hidden` | `accessory` |
| unpackaged | unset | **`accessory`** (new) |
| unpackaged | `visible` | `regular` |
| unpackaged | `hidden` | `accessory` |

`main/index.ts` calls it instead of the inline `if (HIDDEN_WINDOWS)` env check (guarded on darwin — `setActivationPolicy` is macOS-only; the old call site was not).

Three unpackaged runs that legitimately want a foreground app now say so explicitly:

- `electron-cdp.mjs --visible` — the one run that wants eyes on the window.
- `dev:electron` — the human debugging the dev build.
- `scripts/capture-screenshots.mjs` — not in the issue, but it launches an *unpackaged* Electron and photographs the window; a non-active app draws grey traffic lights and the script refuses those frames. Without the opt-out this change would have broken publication capture.

`HIDDEN_WINDOWS` stays as-is: it governs whether a window is mapped, which is a separate decision from Dock/⌘-Tab presence. Documented in `DESIGN.md` next to the existing harness rules.

## Tests

`packages/app/src/main/__tests__/activation-policy.test.ts` — all five table rows plus unrecognised-mode fallback, including "a shipped build is never accessory unless it asked".

- `pnpm --dir packages/app run test` — 443 passed (45 files)
- `pnpm run test` — 9100 passed, 8 skipped (822 files)
- `pnpm --dir packages/app run typecheck` + `build`, `pnpm run lint`, `pnpm run build`, `pnpm run format:check` — clean

Closes TRA-407.

Agent: Lead Engineer
