### PR TITLE
fix(site): give the landing page the accessibility layer the docs already have (TRA-408)

### DIFF
--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -226,7 +226,11 @@ appearance without a screenshot or a measurement is not a finding.
 - [ ] Exactly one deliberate pattern break on the page.
 
 **Accessibility**
-- [ ] Visible focus ring on every link, button, and scroll region.
+- [ ] Visible focus ring on every link, button, and scroll region — read
+      `outlineColor` off a focused element, in both themes. It must be
+      `--text-display`. Chrome's default is `rgb(153, 200, 255)`; a blue ring
+      means no author rule matched, which is a second accent colour and a
+      finding.
 - [ ] Skip link present and reachable.
 - [ ] `prefers-reduced-motion` honoured.
 - [ ] Tables carry `scope`; images carry `alt`.
@@ -253,3 +257,18 @@ The landing page keeps its own inline copy of the tokens rather than importing
 single file that the SEO agent edits constantly; extracting a shared sheet
 would be a large refactor with a live merge-conflict cost. The tokens in
 Section 1 are the contract — change one, change both files in the same PR.
+
+The same duplication applies to the accessibility layer, and it is easier to
+forget than a token because nothing looks wrong until you press Tab. The
+landing page must carry its own copy of the skip link, the
+`:where(a, button, summary):focus-visible` ring, and the
+`prefers-reduced-motion` block. It shipped without all three while every doc
+page had them, so the busiest page on the site was the only one handing
+readers Chrome's blue ring and playing its count-up animation at people who
+asked the OS for less motion.
+
+The CSS `prefers-reduced-motion` block stops transitions and keyframes, not
+motion driven from JavaScript. The landing page animates a stat count-up over
+1400ms and staggers a segmented bar at 30ms per cell from `setTimeout`; both
+read a `reduceMotion` flag off `matchMedia`. Any new JS-driven motion has to
+read it too — the media query alone will not catch it.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1902,9 +1902,52 @@ layout: null
       }
       .category-sub { font-size: 16px; }
     }
+    /* ── Accessibility layer ──
+       Mirrors docs/assets/css/docs.css. The landing page is a standalone
+       hand-written file, so it does not inherit the sheet the 17 doc pages
+       share; without these three rules it was the only page on the site
+       falling back to Chrome's default focus ring and ignoring
+       prefers-reduced-motion. Standard: docs/DESIGN-WEB.md §5. */
+
+    .skip-link {
+      position: absolute;
+      left: -9999px;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .skip-link:focus {
+      left: 16px;
+      top: 12px;
+      z-index: 200;
+      padding: 10px 16px;
+      background: var(--text-display);
+      color: var(--black);
+    }
+
+    /* The UA ring is rgb(153,200,255) — a second accent colour, which the
+       design system forbids. :where() keeps specificity at 0 so any component
+       that needs its own ring still wins without !important. */
+    :where(a, button, summary):focus-visible {
+      outline: 1px solid var(--text-display);
+      outline-offset: 2px;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      *,
+      *::before,
+      *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
   </style>
 </head>
 <body>
+
+<a class="skip-link" href="#content">Skip to content</a>
 
 <nav>
   <div class="container">
@@ -1933,7 +1976,7 @@ layout: null
   </div>
 </nav>
 
-<main>
+<main id="content">
 
   <!-- ── HERO ── -->
   <section class="hero" style="border-top: none;">
@@ -2769,6 +2812,11 @@ layout: null
 </footer>
 
 <script>
+  // The CSS @media (prefers-reduced-motion) block stops transitions and
+  // keyframes, but not motion driven from JS — the rAF count-up and the
+  // staggered segment fill run regardless. Both check this flag.
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
   // Reveal on scroll
   const observer = new IntersectionObserver((entries) => {
     entries.forEach(e => {
@@ -2783,6 +2831,7 @@ layout: null
   // Stat counters
   function animateNum(el) {
     const target = parseInt(el.dataset.count, 10);
+    if (reduceMotion) { el.textContent = target; return; }
     const duration = 1400;
     const start = performance.now();
     function tick(now) {
@@ -2822,7 +2871,7 @@ layout: null
               setTimeout(() => {
                 s.classList.add('filled');
                 if (idx === filled - 1 && filled === total) s.classList.add('peak');
-              }, idx * 30);
+              }, reduceMotion ? 0 : idx * 30);
             }
           });
           segObs.unobserve(entry.target);


### PR DESCRIPTION
The landing page is a standalone hand-written `docs/index.html` — it does not
load `docs/assets/css/docs.css`, so it never inherited the accessibility layer
that the 17 documentation pages picked up in #540. Three defects, all measured
in Chrome at 1440px and 390px, dark and light:

**1. Chrome's default blue focus ring on all 42 focusable elements.**
`getComputedStyle(el).outlineColor` returned `rgb(153, 200, 255)` for every
link and button except the theme toggle, which had its own rule. That is a
second accent colour, which `DESIGN-WEB.md` §4 forbids outright, and it was
the only page on the site doing it. Now `1px solid var(--text-display)` —
`#FFFFFF` in dark, `#000000` in light, verified in both.

**2. No skip link.** Every doc page has one. On the busiest page of the site a
keyboard reader tabbed through the brand, a status readout and five nav links
before reaching content. Added the same `.skip-link` markup and rule the doc
pages ship, with `<main id="content">` as the target. At 390px it renders at
16,12 and is the topmost element under `elementFromPoint`.

**3. No `prefers-reduced-motion` block at all** — against ~20 transitions, an
infinite `pulse` keyframe on the status dot, `scroll-behavior: smooth`, and
scroll reveals.

The media query only covers CSS. Two of this page's animations are driven from
JS and ran regardless, so both now read a `reduceMotion` flag: the 1400ms rAF
stat count-up and the segmented bar that staggers cells at 30ms each from
`setTimeout`.

### Verification

| Check | Result |
|---|---|
| Focusables with a UA / missing ring | 42 → 0 |
| Ring colour, dark / light | `#FFFFFF` / `#000000` |
| Skip link, 390px | first focusable, rect `16,12`, topmost element |
| Counters at 400ms, reduced motion on | `79` / `58` — instant |
| Counters at 400ms / 2000ms, normal | `11` / `8` → `79` / `58` — still animates |
| `scrollWidth === innerWidth` at 390px | 390 === 390 |

No layout, copy or token change — nothing the SEO agent owns is touched.

### Standard

`DESIGN-WEB.md` §7 now records the duplication, because it is easier to forget
than a token: nothing looks wrong until you press Tab. The landing page must
carry its own copy of these three rules, and any new JS-driven motion has to
read the flag. §5's focus-ring checklist item now says to read `outlineColor`
off a focused element and names `rgb(153, 200, 255)` as the failure signature.

Closes TRA-408.
