### PR TITLE
ci: drop nosemgrep-suppressed findings from the Semgrep SARIF (TRA-411)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -60,6 +60,13 @@ jobs:
 
           semgrep "$@" --sarif --output semgrep.sarif || true
 
+          # Drop findings an inline `nosemgrep` already suppressed (TRA-411).
+          # Semgrep still writes them into the SARIF tagged
+          # `suppressions: [{kind: inSource}]`, and code-scanning opens an alert
+          # for them anyway — which kept "Semgrep OSS" red on master over a
+          # finding that is mitigated and annotated at the call site.
+          python3 -c 'import json,sys; p="semgrep.sarif"; d=json.load(open(p)); [r.__setitem__("results",[x for x in r.get("results",[]) if not x.get("suppressions")]) for r in d.get("runs",[])]; json.dump(d,open(p,"w"))'
+
           if [ -n "$BASELINE_SHA" ]; then
             echo "::group::Gate: findings introduced vs ${BASELINE_SHA}"
             semgrep "$@" --baseline-commit "$BASELINE_SHA" --error


### PR DESCRIPTION
Fixes the red `Semgrep OSS` code-scanning check on master (TRA-411).

## Root cause

The inline suppression in `packages/app/src/renderer/tabs/configSchema.ts:78` *is* honoured — verified locally with semgrep 1.175.0 and the same rule set as CI:

- with nosemgrep active: `Findings: 0`
- with `--disable-nosem`: `Findings: 1` (`ajinabraham.njsscan.dos.regex_injection.regex_injection_dos`)

But `--sarif` still emits the suppressed finding, tagged `"suppressions": [{"kind": "inSource"}]`. GitHub code scanning opens an alert for it regardless, so alert #1215 sits open on master and the check reads red on every PR touching that file.

## Fix

Filter results carrying a `suppressions` entry out of `semgrep.sarif` before upload. Tool metadata and the run itself are untouched, so the analysis still lands under the `semgrep` category and code scanning auto-closes alert #1215 on the next master run.

This is option 1 from the issue: suppression stays inline, next to the code and reviewable in a diff, instead of excluding the rule repo-wide (which would also blind us to genuine user-controlled-regex findings elsewhere). The diff-scoped gate scan is unchanged.

## Test evidence

Ran the filter over the real SARIF produced by the CI rule set on that file:

```
results after filter: 0
runs/tool intact: Semgrep OSS 113 rules
```
