### PR TITLE
fix(docs): name the seven tools retired in v2.0.0, and hint them at call time (TRA-412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 * seven MCP tools are removed. Each was a deprecated alias for a superset tool that already covered it:
 
+| Retired tool (1.x) | Replacement (2.0) |
+|---|---|
+| `pin_symbol { symbol_id }` | `pin { symbol_id }` |
+| `pin_file { file_path }` | `pin { file_path }` |
+| `search_with_mode { query, mode }` | `search { query, retriever: mode }` |
+| `get_dead_exports { file_pattern }` | `get_dead_code { file_pattern, mode: "exports_only" }` |
+| `get_untested_exports { file_pattern }` | `get_untested_symbols { file_pattern, scope: "exports_only" }` |
+| `get_session_resume { max_sessions }` | `get_wake_up { scope: "resume", max_sessions }` |
+| `get_project_memo { include_history, limit }` | `get_wake_up { scope: "project", include_history, history_limit }` |
+
+Every call is expressible in the replacement without loss of behaviour or response shape. Full notes: [Migrating from 1.x](https://trace-mcp.com/tools-reference.html).
+
+Two rarely-used `search` parameters were also removed: `fusion_weights` (per-channel weights now come from `~/.trace-mcp/tuning.jsonc`, written by `tune_weights`) and `fusion_debug`.
+
 ### Features
 
 * retire the 7 deprecated consolidation aliases, cut the search schema (TRA-240) ([#415](https://github.com/nikolai-vysotskyi/trace-mcp/issues/415)) ([9459d4c](https://github.com/nikolai-vysotskyi/trace-mcp/commit/9459d4ce5cb305c2f89b5b7cee2cb7f4798fc1da))

--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ Full docs live at **[trace-mcp.com](https://trace-mcp.com/)** (same content as `
 |---|---|
 | [Supported frameworks](https://trace-mcp.com/supported-frameworks.html) | Complete list of languages, frameworks, ORMs, UI libraries, and what each extracts |
 | [Tools reference](https://trace-mcp.com/tools-reference.html) | All 169 MCP tools with descriptions and usage examples |
+| [Migrating from 1.x](https://trace-mcp.com/tools-reference.html) | The seven tools retired in 2.0 (`get_dead_exports`, `get_session_resume`, …) and the call that replaces each |
 | [Configuration](https://trace-mcp.com/configuration.html) | Config options, AI setup, environment variables, security settings |
 | [Architecture](https://trace-mcp.com/architecture.html) | How indexing works, plugin system, project structure, tech stack |
 | [Decision memory](https://trace-mcp.com/decision-memory.html) | Decision knowledge graph, session mining, cross-session search, wake-up context |

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -299,3 +299,19 @@ structure in the whole tool schema, paid by every client on every session.
 Together these changes cut the always-on tool surface from 148 to 141
 registrations and the serialized schema every MCP client without lazy tool
 loading pays at session start from 90,579 to 86,217 characters.
+
+Calling a retired name no longer fails with a bare "not found": the server
+answers with the replacement call, so a stale `CLAUDE.md` is a one-line fix
+rather than a dead end.
+
+### Migrating to 3.0 — Node 22
+
+3.0 raised the Node floor: Node 20 and 21 are no longer supported, and
+`node >= 22` is required. No tool signature or response shape changed. If
+`npx -y trace-mcp@latest serve` started failing at startup rather than at a
+tool call, check `node --version` first.
+
+Both majors landed within a day of each other (2.0.0 on 2026-08-28, 3.0.0 on
+2026-08-29), so an install floating on `latest` may have taken both at once.
+Pin a major in your MCP client config (`trace-mcp@3`) if you would rather
+adopt them deliberately.

--- a/src/server/__tests__/retired-tools.test.ts
+++ b/src/server/__tests__/retired-tools.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Retired-tool hints (TRA-412).
+ *
+ * The behaviour that matters is on the wire: calling a name retired in v2.0.0
+ * must come back naming its replacement, while an ordinary typo must keep the
+ * SDK's message and every live tool must stay callable. So this drives a real
+ * McpServer + Client pair rather than calling the wrapper directly.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { installRetiredToolHints, RETIRED_TOOL_REPLACEMENTS } from '../retired-tools.js';
+
+async function harness() {
+  const server = new McpServer({ name: 'test', version: '0.0.0' });
+  server.tool('search', 'Run search.', { q: z.string() }, async () => ({
+    content: [{ type: 'text' as const, text: 'search ran' }],
+  }));
+  installRetiredToolHints(server);
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { server, client };
+}
+
+/** The error text the SDK surfaces for a failed tools/call. */
+async function callError(client: Client, name: string): Promise<string> {
+  try {
+    const res = await client.callTool({ name, arguments: {} });
+    return (res.content as Array<{ text: string }>)[0]?.text ?? '';
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+describe('retired-tool hints (TRA-412)', () => {
+  it('names the replacement for every tool retired in v2.0.0', async () => {
+    const { client } = await harness();
+    for (const [retired, replacement] of Object.entries(RETIRED_TOOL_REPLACEMENTS)) {
+      const text = await callError(client, retired);
+      expect(text, retired).toContain(`Tool ${retired} was removed in trace-mcp v2.0.0`);
+      expect(text, retired).toContain(replacement);
+    }
+    await client.close();
+  });
+
+  it('leaves an ordinary unknown name on the SDK message', async () => {
+    const { client } = await harness();
+    expect(await callError(client, 'get_dead_exprots')).toMatch(/get_dead_exprots not found/);
+    await client.close();
+  });
+
+  it('does not disturb a live tool', async () => {
+    const { client } = await harness();
+    const res = await client.callTool({ name: 'search', arguments: { q: 'x' } });
+    expect((res.content as Array<{ text: string }>)[0].text).toBe('search ran');
+    await client.close();
+  });
+
+  it('keeps the retired names off tools/list, so the schema saving stands', async () => {
+    const { client } = await harness();
+    const names = (await client.listTools()).tools.map((t) => t.name);
+    expect(names).toEqual(['search']);
+    await client.close();
+  });
+});

--- a/src/server/retired-tools.ts
+++ b/src/server/retired-tools.ts
@@ -1,0 +1,69 @@
+/**
+ * Retired-tool hints (TRA-412).
+ *
+ * v2.0.0 removed seven deprecated aliases. An agent whose CLAUDE.md, saved
+ * workflow, or habit still names one gets the SDK's bare `Tool X not found`,
+ * which is a dead end — the user reads it as flakiness and stops using the
+ * tool. Re-registering the names as tombstones would undo the schema saving
+ * the removal bought, so instead we wrap the already-installed `tools/call`
+ * handler and rewrite the not-found message for those seven names only.
+ * Zero cost on `tools/list` and on every client's schema payload.
+ */
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+/** Retired tool name → the call that replaces it, verbatim from PR #415. */
+export const RETIRED_TOOL_REPLACEMENTS: Readonly<Record<string, string>> = {
+  pin_symbol: 'pin { symbol_id }',
+  pin_file: 'pin { file_path }',
+  search_with_mode: 'search { query, retriever: mode }',
+  get_dead_exports: 'get_dead_code { file_pattern, mode: "exports_only" }',
+  get_untested_exports: 'get_untested_symbols { file_pattern, scope: "exports_only" }',
+  get_session_resume: 'get_wake_up { scope: "resume", max_sessions }',
+  get_project_memo: 'get_wake_up { scope: "project", include_history, history_limit }',
+};
+
+/** Self-service error text for a retired name, or `null` if the name is not one. */
+export function retiredToolMessage(name: string): string | null {
+  const replacement = RETIRED_TOOL_REPLACEMENTS[name];
+  if (!replacement) return null;
+  return (
+    `Tool ${name} was removed in trace-mcp v2.0.0. Use ${replacement} instead — ` +
+    `it accepts the same arguments and returns the same shape. ` +
+    `Full migration table: https://trace-mcp.com/tools-reference.html`
+  );
+}
+
+/**
+ * Wraps the SDK's `tools/call` handler so a retired name fails with its
+ * replacement instead of a bare "not found". Call once, after every
+ * `register*Tools()` — the SDK installs the handler lazily on the first
+ * `server.tool(...)`, so there is nothing to wrap before that.
+ */
+export function installRetiredToolHints(server: McpServer): void {
+  // ponytail: reaches into the SDK's private handler map, same monkey-patch
+  // style as installToolGate. No public seam exists; no-ops if the shape
+  // changes, so a future SDK bump degrades to today's bare message.
+  const handlers = (
+    server.server as unknown as {
+      _requestHandlers?: Map<string, (request: unknown, extra: unknown) => Promise<unknown>>;
+    }
+  )._requestHandlers;
+  const inner = handlers?.get('tools/call');
+  if (!handlers || !inner) return;
+
+  handlers.set('tools/call', async (request: unknown, extra: unknown) => {
+    const result = await inner(request, extra);
+    const name = (request as { params?: { name?: unknown } } | undefined)?.params?.name;
+    const hint = typeof name === 'string' ? retiredToolMessage(name) : null;
+    if (!hint) return result;
+
+    // The SDK turns its own `Tool X not found` McpError into an isError
+    // result rather than rejecting, so rewrite the text, not an exception.
+    const r = result as { isError?: boolean; content?: Array<{ type: string; text?: string }> };
+    const first = r?.isError ? r.content?.[0] : undefined;
+    if (first?.type === 'text' && first.text?.includes(`Tool ${name} not found`)) {
+      return { ...r, content: [{ ...first, text: hint }, ...(r.content ?? []).slice(1)] };
+    }
+    return result;
+  });
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -60,6 +60,7 @@ import { validatePath } from '../utils/security.js';
 import { createExploredTracker } from './explored-tracker.js';
 import { startHeartbeat } from './heartbeat.js';
 import { buildInstructions } from './instructions.js';
+import { installRetiredToolHints } from './retired-tools.js';
 import { resolvePresetName } from './tool-filter.js';
 import { installToolGate } from './tool-gate.js';
 import type { MetaContext, ProjectRelay, ServerContext, ToolHandlerMap } from './types.js';
@@ -696,6 +697,10 @@ export function createServer(
   registerMemoryTools(server, ctx);
   registerKnowledgeTools(server, ctx);
   registerSessionTools(server, metaCtx);
+
+  // Must run after the last registration: the SDK installs its `tools/call`
+  // handler lazily on the first `server.tool(...)` (TRA-412).
+  installRetiredToolHints(server);
 
   return { server, journal, dispose, toolHandlers };
 }

--- a/tests/docs/changelog-breaking-changes.test.ts
+++ b/tests/docs/changelog-breaking-changes.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Breaking-change notes must actually say what broke (TRA-412).
+ *
+ * v2.0.0 shipped a `⚠ BREAKING CHANGES` section whose only bullet ended in a
+ * colon: release-please dropped the Markdown table that followed it in the
+ * commit footer. Users who had lost seven MCP tools got no replacement names
+ * anywhere they would look. A note that renders as a dangling colon should
+ * not be publishable, so assert the shape here rather than in review.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const CHANGELOG = readFileSync(join(process.cwd(), 'CHANGELOG.md'), 'utf8');
+
+/** `### ⚠ BREAKING CHANGES` body text, keyed by the release heading above it. */
+function breakingSections(): Array<{ release: string; body: string }> {
+  const lines = CHANGELOG.split('\n');
+  const out: Array<{ release: string; body: string }> = [];
+  let release = '(unknown)';
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith('## ')) release = lines[i];
+    if (!lines[i].startsWith('### ') || !lines[i].includes('BREAKING CHANGES')) continue;
+    const body: string[] = [];
+    for (let k = i + 1; k < lines.length && !lines[k].startsWith('#'); k++) body.push(lines[k]);
+    out.push({ release, body: body.join('\n') });
+  }
+  return out;
+}
+
+describe('CHANGELOG breaking-change notes', () => {
+  const sections = breakingSections();
+
+  it('finds the breaking-change sections it is meant to guard', () => {
+    expect(sections.length).toBeGreaterThan(0);
+  });
+
+  it.each(sections.map((s) => [s.release, s.body] as const))(
+    'has a non-empty body under %s',
+    (_release, body) => {
+      expect(body.trim()).not.toBe('');
+    },
+  );
+
+  it.each(sections.map((s) => [s.release, s.body] as const))(
+    'does not trail off mid-sentence under %s',
+    (_release, body) => {
+      // A bullet ending in ':' promises a list or table that must follow it.
+      const bullets = body.split('\n').filter((l) => l.trimStart().startsWith('* '));
+      for (const bullet of bullets) {
+        if (!bullet.trimEnd().endsWith(':')) continue;
+        const after = body.slice(body.indexOf(bullet) + bullet.length).trim();
+        expect(after, `dangling colon: ${bullet.trim()}`).not.toBe('');
+      }
+    },
+  );
+
+  it('names every tool retired in 2.0.0', () => {
+    const v2 = sections.find((s) => s.release.includes('[2.0.0]'));
+    expect(v2).toBeDefined();
+    for (const name of [
+      'pin_symbol',
+      'pin_file',
+      'search_with_mode',
+      'get_dead_exports',
+      'get_untested_exports',
+      'get_session_resume',
+      'get_project_memo',
+    ]) {
+      expect(v2?.body).toContain(name);
+    }
+  });
+});


### PR DESCRIPTION
Closes TRA-412.

## The problem

`v2.0.0` removed seven MCP tools. The breaking-change note that reached users — [the release page](https://github.com/nikolai-vysotskyi/trace-mcp/releases/tag/v2.0.0) and `CHANGELOG.md` — read in full:

> * seven MCP tools are removed. Each was a deprecated alias for a superset tool that already covered it:

The colon was followed by nothing. release-please dropped the Markdown table from the `BREAKING CHANGE:` commit footer, so the retired→replacement mapping only ever existed in the body of PR #415.

That matters because README and `docs/configuration.md` both recommend floating installs (`npm install -g trace-mcp`, `npx -y trace-mcp@latest serve`), so v2.0.0 reached every unpinned user without action on their part, and the failure mode is silent: an agent's `CLAUDE.md` names `get_dead_exports`, the call returns `Tool get_dead_exports not found` mid-session, and the user concludes the tool is flaky rather than deprecated. Almost nobody files an issue for that — this surfaced from a release-artifact audit, not a bug report.

## Changes

**1. `CHANGELOG.md` — restore the table** under the v2.0.0 breaking-change note, plus the two removed `search` params (`fusion_weights`, `fusion_debug`).

**2. `tests/docs/changelog-breaking-changes.test.ts` — make it unpublishable again.** Asserts every `⚠ BREAKING CHANGES` section has a non-empty body, that no bullet trails off at a colon with nothing after it, and that the v2.0.0 section names all seven tools.

**3. `src/server/retired-tools.ts` — self-service at the point of failure.** A call to a retired name now answers:

```
Tool get_dead_exports was removed in trace-mcp v2.0.0. Use
get_dead_code { file_pattern, mode: "exports_only" } instead — it accepts the
same arguments and returns the same shape. Full migration table:
https://trace-mcp.com/tools-reference.html
```

Implementation note: this wraps the SDK's already-installed `tools/call` handler and rewrites the message for those seven names only. It deliberately does **not** re-register them as tombstone tools — that would put seven entries back on `tools/list` and undo the schema saving the removal bought. `tools/list` and the serialized schema every client pays for at session start are byte-identical; a test asserts that. The SDK converts its own `Tool X not found` `McpError` into an `isError` result rather than rejecting, so the wrapper post-processes the result instead of catching.

**4. `docs/tools-reference.md`, `README.md` — cover v3 and make the section findable.** The v2 mapping table already lived in `tools-reference.md`; added the 3.0 Node 22 floor next to it (v2.0.0 and v3.0.0 shipped ~13 hours apart, so an unpinned user could take two majors in one day) and a `Migrating from 1.x` row in the README docs table so a user searching a retired tool name lands on the replacement.

## Test evidence

```
pnpm run build   ✓
pnpm run lint    ✓ (tsc --noEmit)
pnpm run test    ✓ 822 passed | 2 skipped (824 files), 9119 passed | 8 skipped
```

New coverage: 4 wire-level tests in `src/server/__tests__/retired-tools.test.ts` (real `McpServer` + `Client` over `InMemoryTransport`) — each retired name returns its replacement, an ordinary typo keeps the SDK message, a live tool is undisturbed, and `tools/list` is unchanged. Plus 10 in `tests/docs/changelog-breaking-changes.test.ts`.

Agent: Lead Engineer
