### PR TITLE
fix(app): guard setActivationPolicy on darwin, give dev:electron the visible opt-out

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -972,8 +972,10 @@ agent launches:
   A plain `electron .` gets no Dock icon and no ⌘-Tab entry, because a rule that holds only
   when somebody remembers a flag is not a rule. A shipped build is a real app and keeps
   both. The opt-out for a human debugging the dev build is `TRACE_MCP_WINDOW_MODE=visible`
-  (`electron-cdp.mjs --visible` sets it). The decision itself is one pure function,
-  `shouldRunAsAccessory` in `src/shared/window-mode.ts`.
+  (`electron-cdp.mjs --visible` and `pnpm dev:electron` both set it). The decision itself is
+  one pure function, `shouldRunAsAccessory` in `src/shared/window-mode.ts`; applying it is
+  guarded on darwin, since `setActivationPolicy` is macOS-only and the default now reaches
+  every unpackaged run on every platform.
 - **The browser: `--headless --isolated`.** Headless removes the window entirely and
   screenshots still come out; `--isolated` gives Chrome a throwaway profile so it can
   never adopt or disturb the one the user has open. Both belong in the MCP server's own

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,7 +6,7 @@
   "main": "dist/main/index.js",
   "scripts": {
     "dev": "vite",
-    "dev:electron": "tsc -p tsconfig.main.json && node scripts/patch-electron-dev.mjs && unset ELECTRON_RUN_AS_NODE && electron .",
+    "dev:electron": "tsc -p tsconfig.main.json && node scripts/patch-electron-dev.mjs && unset ELECTRON_RUN_AS_NODE && TRACE_MCP_WINDOW_MODE=visible electron .",
     "build:renderer": "vite build",
     "build:main": "tsc -p tsconfig.main.json",
     "build": "pnpm run build:renderer && pnpm run build:main",

--- a/packages/app/src/main/__tests__/window-mode.test.ts
+++ b/packages/app/src/main/__tests__/window-mode.test.ts
@@ -1,5 +1,9 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { parseWindowMode, shouldRunAsAccessory } from '../../shared/window-mode';
+
+const APP_DIR = path.join(__dirname, '..', '..', '..');
 
 describe('parseWindowMode', () => {
   it('accepts the two known modes and rejects anything else', () => {
@@ -26,5 +30,22 @@ describe('shouldRunAsAccessory', () => {
 
   it('honours hidden even in a packaged build, for capture runs on the artifact', () => {
     expect(shouldRunAsAccessory('hidden', true)).toBe(true);
+  });
+});
+
+// The two call sites the decision above only matters through. Asserted against
+// the source because neither can be exercised from a unit test: one needs a
+// non-darwin Electron, the other is a package script.
+describe('activation policy call sites', () => {
+  it('guards setActivationPolicy on darwin — it does not exist elsewhere', () => {
+    const src = fs.readFileSync(path.join(APP_DIR, 'src/main/index.ts'), 'utf-8');
+    const call = src.split('\n').find((l) => l.includes('app.setActivationPolicy('));
+    expect(call).toBeDefined();
+    expect(call).toMatch(/process\.platform === 'darwin'/);
+  });
+
+  it('gives the dev:electron script the visible opt-out', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(APP_DIR, 'package.json'), 'utf-8'));
+    expect(pkg.scripts['dev:electron']).toContain('TRACE_MCP_WINDOW_MODE=visible');
   });
 });

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -30,7 +30,11 @@ app.commandLine.appendSwitch('enable-features', 'SharedArrayBuffer');
 // process out of the Dock and out of ⌘-Tab — and it is set here, before `ready`,
 // because by the time the first window exists the activation has already
 // happened (TRA-403). A shipped build is never accessory; see window-mode.ts.
-if (ACCESSORY_APP) app.setActivationPolicy('accessory');
+// Guarded on darwin because `setActivationPolicy` is a macOS-only method — it
+// does not exist on the Windows/Linux `app` object, and since TRA-407 made
+// ACCESSORY_APP true for *every* unpackaged build, an unguarded call would
+// throw on the first line of every `electron .` run off macOS.
+if (ACCESSORY_APP && process.platform === 'darwin') app.setActivationPolicy('accessory');
 
 // Prevent multiple instances. If a second launch happens, bring the existing
 // window forward instead of letting the new process die silently.


### PR DESCRIPTION
Follow-up to #559 (TRA-407). That change was right; making `ACCESSORY_APP` true for every unpackaged build turned a branch almost nobody took into one every `electron .` run hits, which exposes two things.

**`setActivationPolicy` is macOS-only.** `electron.d.ts` marks it `@platform darwin`; it is not defined on the Windows/Linux `app` object. Before #559 the call fired only when someone set `TRACE_MCP_WINDOW_MODE=hidden`, so an off-macOS dev run never reached it. Now it runs on the first lines of every unpackaged launch on every platform. Guarded on darwin — the activation policy has no meaning on Windows or Linux, so the guard costs nothing there.

**`dev:electron` had no opt-out.** The issue's table names "a human debugging the dev build" as the case `TRACE_MCP_WINDOW_MODE=visible` exists for, and `electron-cdp.mjs --visible` was the only path setting it — so `pnpm dev:electron` came up with no Dock icon and no ⌘-Tab entry. It sets `visible` now.

Not changed: `scripts/capture-screenshots.mjs` also runs unpackaged and is therefore accessory now, but it activates explicitly with `app.focus({ steal: true })`, and an accessory app can be activated programmatically — so its traffic lights should still come up coloured. Left alone rather than changed on a guess; if a publication capture comes back rejecting grey lights, `TRACE_MCP_WINDOW_MODE=visible` on that spawn is the fix.

## Tests

Both call sites are asserted against the source in `window-mode.test.ts` — neither is reachable from a unit test here (one needs a non-darwin Electron, the other is a package script). The source assert earned its keep immediately: the first version of it matched the comment line above the call and failed.

- `pnpm --dir packages/app run test` — 445 passed (45 files)
- `pnpm run test` — 9105 passed, 8 skipped (822 files)
- `pnpm --dir packages/app run typecheck` + `build`, `pnpm run lint`, `pnpm run format:check` — clean

Agent: Lead Engineer
