### PR TITLE
docs: add ops/distribution.md, the external listings ledger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,3 +260,15 @@ These workflows define which trace-mcp tools MUST be used at each stage. Follow 
 1. `audit_config` {} — check for stale references in CLAUDE.md/settings
 2. `self_audit` {} — dead exports, untested code, hotspots
 3. `get_tech_debt` {} — per-module tech debt grades
+
+## External listings and distribution
+
+`ops/distribution.md` is the ledger of every directory and registry that lists
+trace-mcp: what each one currently shows, how it can be changed, what it costs,
+and what previous runs already ruled out. **Read it before touching any listing,
+directory submission, or registry, and update it in the same change.** It exists
+because that work is invisible from the code — without it each run re-discovers
+the same closed doors and sometimes decides the opposite of the last one.
+
+Numbers quoted to the outside world come from `docs/_data/counts.yml`. Never
+hand-type a tool/language/framework count into a listing, a form, or `server.json`.

--- a/ops/distribution.md
+++ b/ops/distribution.md
@@ -17,7 +17,9 @@ Rules for keeping it honest:
 - Record the **decisions and the dead ends** too, not just the state. A closed
   door with no reason written down gets pushed on again next month.
 - Numbers quoted to the outside world come from `docs/_data/counts.yml`
-  (currently 169 tools / 80 languages / 87 frameworks). Never hand-type them.
+  (169 tools / 81 languages / 87 frameworks as of 2026-08-29). Never hand-type
+  them, and re-read the file rather than trusting a number written here: the
+  language count moved from 80 to 81 within a day of this ledger being started.
 
 ## Surfaces
 
@@ -26,7 +28,7 @@ Rules for keeping it honest:
 | [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) | Yes — `io.github.nikolai-vysotskyi/trace-mcp` | Current: 3.1.1, correct counts | Automatic: `.github/workflows/publish-mcp-registry.yml` republishes `server.json` on every release (GitHub OIDC, no secret) | 2026-08-29 |
 | [glama.ai](https://glama.ai/mcp/servers/nikolai-vysotskyi/trace-mcp) | Yes | Correct — scrapes README/npm live | Nothing to do; fix the README and it follows | 2026-08-29 |
 | [pulsemcp.com](https://www.pulsemcp.com/servers/nikolai-vysotskyi-trace) | Yes | **Stale: "44+ tools"** — their hand-written `server.json`, kept "until the maintainer publishes to the official registry" | Their submissions are **paused**; their own submit page says publishing to the official registry is the fix. Done 2026-08-29 — waiting on their next sync | 2026-08-29 |
-| [mcpservers.org](https://mcpservers.org/servers/nikolai-vysotskyi/trace-mcp) | Yes | Body correct; **header stale**: "53 framework integrations across 68 languages, 100+ tools" | Free form at `/submit` (no account, needs a contact email). Correction submitted 2026-08-29, review ≤12h. Premium $39 — declined | 2026-08-29 |
+| [mcpservers.org](https://mcpservers.org/servers/nikolai-vysotskyi/trace-mcp) | Yes | Body correct; **header stale**: "53 framework integrations across 68 languages, 100+ tools" | Free form at `/submit` (no account, needs a contact email). Correction submitted 2026-08-29, review ≤12h — but it said "80 languages … up to 99% fewer tokens", and master has since moved to 81 languages and a 40–50% claim, so re-submit once it lands. Premium $39 — declined | 2026-08-29 |
 | [mcpmarket.com](https://mcpmarket.com/server/trace) | Yes, as **"Trace"** | Same stale "53 frameworks / 68 languages" copy | No self-serve edit. $29 paid listing, or email support@mcpmarket.com. Free queue re-submit answers "already listed" | 2026-08-29 |
 | [mcp.so](https://mcp.so) | **No** | — | **Free submission no longer exists** — `/submit` offers only "Pay and submit automatically", $39. They ingest the official registry, so expect a free pickup | 2026-08-29 |
 | [smithery.ai](https://smithery.ai) | **No** | — | Requires a Smithery account via GitHub OAuth — an agent must not authorize that on Nikolai's behalf. They also ingest the official registry | 2026-08-29 |

--- a/ops/distribution.md
+++ b/ops/distribution.md
@@ -1,0 +1,66 @@
+# Distribution ledger — where trace-mcp is listed, and what we already found out
+
+Every external surface that lists trace-mcp, what it currently shows, and how it
+can be changed. Not a public page: `ops/` is outside the Jekyll site in `docs/`.
+
+**Read this before any distribution / directory / listing work. Update it in the
+same change that touched a surface.** Without it every run re-discovers the same
+things — that mcp.so dropped free submissions, that PulseMCP submissions are
+paused — and either wastes the run or reaches a different conclusion than the
+last one did.
+
+Rules for keeping it honest:
+
+- Record what you **verified**, with the date you verified it. "Absent from a
+  WebSearch" is not "absent" — TRA-352 called mcpmarket.com missing on that basis
+  and it had been listed all along.
+- Record the **decisions and the dead ends** too, not just the state. A closed
+  door with no reason written down gets pushed on again next month.
+- Numbers quoted to the outside world come from `docs/_data/counts.yml`
+  (currently 169 tools / 80 languages / 87 frameworks). Never hand-type them.
+
+## Surfaces
+
+| Surface | Listed | What it shows | How to change it | Verified |
+|---|---|---|---|---|
+| [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) | Yes — `io.github.nikolai-vysotskyi/trace-mcp` | Current: 3.1.1, correct counts | Automatic: `.github/workflows/publish-mcp-registry.yml` republishes `server.json` on every release (GitHub OIDC, no secret) | 2026-08-29 |
+| [glama.ai](https://glama.ai/mcp/servers/nikolai-vysotskyi/trace-mcp) | Yes | Correct — scrapes README/npm live | Nothing to do; fix the README and it follows | 2026-08-29 |
+| [pulsemcp.com](https://www.pulsemcp.com/servers/nikolai-vysotskyi-trace) | Yes | **Stale: "44+ tools"** — their hand-written `server.json`, kept "until the maintainer publishes to the official registry" | Their submissions are **paused**; their own submit page says publishing to the official registry is the fix. Done 2026-08-29 — waiting on their next sync | 2026-08-29 |
+| [mcpservers.org](https://mcpservers.org/servers/nikolai-vysotskyi/trace-mcp) | Yes | Body correct; **header stale**: "53 framework integrations across 68 languages, 100+ tools" | Free form at `/submit` (no account, needs a contact email). Correction submitted 2026-08-29, review ≤12h. Premium $39 — declined | 2026-08-29 |
+| [mcpmarket.com](https://mcpmarket.com/server/trace) | Yes, as **"Trace"** | Same stale "53 frameworks / 68 languages" copy | No self-serve edit. $29 paid listing, or email support@mcpmarket.com. Free queue re-submit answers "already listed" | 2026-08-29 |
+| [mcp.so](https://mcp.so) | **No** | — | **Free submission no longer exists** — `/submit` offers only "Pay and submit automatically", $39. They ingest the official registry, so expect a free pickup | 2026-08-29 |
+| [smithery.ai](https://smithery.ai) | **No** | — | Requires a Smithery account via GitHub OAuth — an agent must not authorize that on Nikolai's behalf. They also ingest the official registry | 2026-08-29 |
+
+## Findings that should not be re-derived
+
+**The official registry was the root cause of everything else** (TRA-352,
+2026-08-29). We had never published, so directories scraped whatever they could
+reach and drifted. Publishing fixed the class, not just the instance. Two things
+blocked publishing and are now fixed in `server.json`: the registry caps
+`description` at **100 characters** (ours was 118 — a hard 422), and the npm
+package entry needed `registryBaseUrl`.
+
+**"53 framework integrations across 68 languages, 100+ tools"** is an old README
+snapshot. It appears on both mcpservers.org and mcpmarket.com, which means those
+two cached it years apart from the same source and neither re-crawls. Anywhere
+else that string turns up is the same fossil, not a new problem.
+
+**Paid placements have not been bought.** mcp.so $39, mcpmarket $29,
+mcpservers.org $39 premium — all declined on 2026-08-29 in favour of waiting for
+free registry ingestion. Paid infrastructure is Nikolai's call, not an agent's;
+if the free pickup fails, come back with the measured cost of the miss rather
+than re-asking the open question.
+
+**TRA-263's "165 tools" is stale.** `docs/_data/counts.yml` says 169 and the
+README already agreed. TRA-346's "141 schema-carrying tools" answers a different
+question and is not a competing count.
+
+## Channels that need a human
+
+Not blockers to route around — genuinely outside what an agent may do alone:
+
+- **Smithery** — creating the account means authorizing a third-party OAuth app
+  against Nikolai's GitHub.
+- **Anything paid** — see above.
+- Everything else here was self-serve: the mcpservers.org form takes a repo URL
+  and an email, and the registry publish needs no credential at all in CI.


### PR DESCRIPTION
Directory and registry work leaves no trace in the code, so every run re-discovers the same closed doors. TRA-352 hit this twice in one day: it recorded mcpmarket.com as missing on the strength of an empty web search (we had been listed there all along, as "Trace"), and it re-checked mcp.so's submission flow that a previous run had already priced.

`ops/distribution.md` records, per surface: whether we're listed, what it currently shows, how it can be changed, what that costs, and the date it was last verified — plus the findings that should not be re-derived (the 100-char registry description cap, the fossil "53 frameworks / 68 languages" README snapshot, which paid placements were declined and why).

`ops/` sits outside the Jekyll site in `docs/`, so this is not published.

CLAUDE.md now points at it: read before touching any listing, update in the same change, and never hand-type a count that `docs/_data/counts.yml` owns.

Refs TRA-352.

Agent: Lead Engineer