### PR TITLE
fix(logger): serialize Errors logged under the `error` key

### DIFF
--- a/src/__tests__/logger-error-serializer.test.ts
+++ b/src/__tests__/logger-error-serializer.test.ts
@@ -1,0 +1,49 @@
+// TRA-420: the daemon logged 196 errors in one day as `"error":{}` — no name,
+// no message, no stack — because pino only applies its error serializer to the
+// `err` key while 80 call sites in this repo log under `error`. Without the
+// serializer, every "Watcher error" / "Embedding batch failed" entry in
+// daemon.log is undiagnosable, which is exactly what blocked root-causing the
+// daemon restart storm. Asserts against the real logger, not a local pino.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { logger } from '../logger.js';
+
+/** Emit one line through the real logger and parse what hit stderr. */
+function logAndCapture(bindings: Record<string, unknown>): Record<string, unknown> {
+  let line = '';
+  const spy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+    line = String(chunk);
+    return true;
+  });
+  try {
+    logger.error(bindings, 'boom');
+  } finally {
+    spy.mockRestore();
+  }
+  expect(line, 'logger wrote nothing to stderr — is the level above error?').not.toBe('');
+  return JSON.parse(line);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('logger error serialization', () => {
+  for (const key of ['error', 'err']) {
+    it(`serializes an Error logged under "${key}" into type/message/stack`, () => {
+      const out = logAndCapture({ [key]: new TypeError('watcher exploded') });
+      const payload = out[key] as Record<string, unknown>;
+
+      expect(payload).toBeTruthy();
+      expect(payload.type).toBe('TypeError');
+      expect(payload.message).toBe('watcher exploded');
+      expect(String(payload.stack)).toContain('watcher exploded');
+      // The regression: an unserialized Error stringifies to exactly `{}`.
+      expect(JSON.stringify(payload)).not.toBe('{}');
+    });
+  }
+
+  it('leaves a non-Error value under "error" usable', () => {
+    const out = logAndCapture({ error: 'plain string failure' });
+    expect(out.error).toBe('plain string failure');
+  });
+});

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -9,6 +9,18 @@ export const logger = pino(
   {
     name: 'trace-mcp',
     level,
+    // An Error's own properties are non-enumerable, so pino's default JSON
+    // stringify renders `logger.error({ error: e }, ...)` as `"error":{}` —
+    // name, message and stack all vanish. pino only applies its built-in
+    // error serializer to the `err` key, and 80 call sites in this repo use
+    // `error`. Field evidence (TRA-420): a day of daemon.log held 137
+    // "Watcher error", 47 "Embedding batch failed" and 12 "File change
+    // handler failed" entries, every one of them with an empty error object
+    // and therefore undiagnosable. Serialize both key names.
+    serializers: {
+      err: pino.stdSerializers.err,
+      error: pino.stdSerializers.err,
+    },
   },
   process.stderr,
 );


### PR DESCRIPTION
## Problem

pino applies its built-in error serializer only to the `err` key. 80 call sites in this repo log under `error` instead:

```ts
logger.error({ error: e }, 'Embedding batch failed');
```

An `Error`'s own properties are non-enumerable, so `JSON.stringify` renders that as `"error":{}` — name, message and stack all gone.

## Evidence

One day of `~/.trace-mcp/daemon.log` on a real machine (TRA-420 run, 2026-08-29):

| entries | message | logged error |
|--------:|---------|--------------|
| 137 | `Watcher error` | `{}` |
| 47 | `Embedding batch failed` | `{}` |
| 12 | `File change handler failed` | `{}` |

Every daemon-side failure that day was unattributable. That is what blocked root-causing the daemon restart storm the same log file recorded (626 `serve-http` starts in 13 hours) — filed separately.

## Fix

Register `pino.stdSerializers.err` for both `err` and `error`. One config change; all 80 call sites start emitting `type` / `message` / `stack` with no edit.

## Test

`src/__tests__/logger-error-serializer.test.ts` asserts against the real exported `logger` (spying on `process.stderr.write`), not a locally-built pino — so removing the serializer breaks it. Verified red before the fix, green after; non-`Error` values under `error` still pass through unchanged.

- `pnpm run test` — 9122 passed, 8 skipped (823 files)
- `pnpm run build` — success
- `biome check` on both changed files — clean

Agent: Lead Engineer