### PR TITLE
fix(daemon): enforce the loaded-project cap in steady state, not just at boot

### DIFF
--- a/docs/daemon-memory.md
+++ b/docs/daemon-memory.md
@@ -1,0 +1,94 @@
+# Daemon memory: what it costs and what caps it
+
+The HTTP daemon is a background process. If it outweighs the user's browser it
+has failed regardless of how fast queries are. This page records what the
+resident set is actually made of, measured rather than estimated, and which
+knob bounds each part.
+
+## Measured attribution (TRA-422)
+
+macOS 26.5, Apple Silicon, daemon v3.2.0 at rest, 11 projects loaded, no query
+traffic. `ps -o rss=` reported 1.55 GB; `vmmap -summary` splits it:
+
+| Region | Resident | What it is | Bounded by |
+|---|---:|---|---|
+| Memory Tag 255 | 714 MB | V8 heap + Node allocations. `heap_used` was 370–515 MB at the same moment, so V8 holds roughly 2× its live set in committed pages it has not returned to the OS. | project count |
+| `mapped file` | 380 MB | SQLite `mmap` of each project's `index.db`. | `index_mmap_mb` × project count |
+| `MALLOC_SMALL` | 258 MB (206 MB dirty) | Native allocations: SQLite page cache, tree-sitter trees. | `index_cache_mb` × connections |
+| `MALLOC_SMALL (empty)` | 104 MB (22 MB dirty) | Freed, not returned to the OS. | — |
+| `__TEXT` / `__LINKEDIT` / `__OBJC_RO` / `__DATA*` | ~330 MB | Node binary and native modules. Clean, file-backed, shared with every other Node process on the machine. | fixed |
+| page table in kernel | 55 MB | Cost of the ~112 GB of virtual address space V8 reserves. | fixed |
+
+The `mapped file` rows are per-project and worth reading directly:
+
+```
+64.0M  63.6M  .trace-mcp/index/thewed-2f9565b74fb5.db
+64.0M  63.7M  .trace-mcp/index/general-e8778b435c05.db
+64.0M  63.3M  .trace-mcp/index/assetfeed-76da1a753b39.db
+34.1M  33.4M  .trace-mcp/index/workdir-45190de3e39c.db
+...
+```
+
+Three DBs are larger than the 64 MB `index_mmap_mb` window and sit at the cap
+with essentially every mapped page resident — a full-table scan touches the
+whole window. Smaller DBs are mapped in their entirety. Average across the 11:
+**34.5 MB per project from mmap alone.**
+
+**Marginal cost of one loaded project: ~100 MB resident** (~35 MB mmap, ~23 MB
+native page cache and tree-sitter, the balance V8 heap). Fixed floor with zero
+projects loaded is ~165 MB RSS, of which ~330 MB of library text is shared.
+
+A JS heap snapshot was not the right instrument here: the V8 heap is only ~28 %
+of RSS, so it cannot attribute the other 72 %.
+
+## The ceiling
+
+`daemon_eager_load_projects` (default **8**) is the number of projects the
+daemon keeps resident. 8 × ~100 MB ≈ 800 MB marginal on top of the ~350 MB
+fixed footprint. Raise it on a big machine with few repos; lower it if the
+daemon is competing for memory.
+
+Two rules enforce it, both in the sweep armed by `startIdleUnloadSweep`:
+
+- **TTL** — `project_idle_unload_minutes` (default 30) unloads any project not
+  touched in that long.
+- **LRU ceiling** — anything above `daemon_eager_load_projects` is unloaded
+  least-recently-accessed first, regardless of TTL.
+
+Before TRA-422 only the TTL existed and the eager cap applied at startup only,
+so lazy loads (`/mcp` auto-register, `/api/projects/reindex-file`) drifted past
+it unchecked: a daemon that booted with `eager: 8, deferred: 34` was holding 11
+projects three minutes later, with nothing to bring it back down.
+
+Both rules skip projects that are `starting`/`indexing` or have live clients
+(`resourcePool.getRefCount > 0`). The ceiling is therefore best-effort: a
+daemon with 11 busy projects stays at 11 rather than tearing down work in
+flight. Set either knob to 0 to disable that rule; with both at 0 no timer is
+armed.
+
+Unloading is in-memory only. The project stays in the registry and reloads
+lazily on its next request (503 + `Retry-After` while it warms, the same path a
+cold-start project takes).
+
+## Reproducing the measurement
+
+```bash
+PID=$(curl -s http://127.0.0.1:3741/health | python3 -c 'import sys,json;print(json.load(sys.stdin)["pid"])')
+ps -o rss= -p "$PID"                 # total RSS in KB
+vmmap -summary "$PID"                # region breakdown
+vmmap "$PID" | grep 'mapped file'    # per-project index.db mmap residency
+```
+
+`Daemon vitals` lines in `~/.trace-mcp/daemon.log` carry `rss_mb`,
+`heap_used_mb` and `projects_loaded` every 60 s, which is the cheap way to
+watch the floor over time.
+
+## Known caveat
+
+The sweep runs every 5 minutes, so a burst of lazy loads can sit above the
+ceiling for up to one interval before it is enforced. Enforcing on each
+`addProject` instead would close that window; it was not worth the coupling
+until the delay is shown to matter.
+
+The sweep also cannot help a daemon that does not live long enough to run it —
+see TRA-421 on daemon restarts.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2862,11 +2862,21 @@ program
     // SQLite cache/mmap for projects nobody has touched recently. Stays
     // registered — reloads lazily on the next request (see the /mcp
     // auto-register path and /api/projects/reindex-file). 0 disables.
+    // The same sweep also enforces `daemon_eager_load_projects` as a steady-state
+    // LRU ceiling, not just a startup budget: lazy loads (auto-register,
+    // reindex-file) used to walk past it unchecked — TRA-422 measured an
+    // eager-8 daemon holding 11 projects within three minutes of boot, ~100 MB
+    // resident each. See docs/daemon-memory.md for the attribution.
     const configuredIdleUnloadMinutes =
       typeof globalRaw.project_idle_unload_minutes === 'number'
         ? globalRaw.project_idle_unload_minutes
         : 30;
+    const configuredMaxLoadedProjects =
+      typeof globalRaw.daemon_eager_load_projects === 'number'
+        ? globalRaw.daemon_eager_load_projects
+        : 8;
     projectManager.startIdleUnloadSweep(configuredIdleUnloadMinutes * 60_000, {
+      maxLoaded: configuredMaxLoadedProjects,
       onUnloaded: (roots) => {
         for (const root of roots) {
           // Same cleanup as the DELETE endpoint: without it the progress

--- a/src/config.ts
+++ b/src/config.ts
@@ -1012,6 +1012,15 @@ export const TraceMcpConfigSchema = z.object({
    * (TRA-278), so an unbounded eager load turned ~100 registered repos into a
    * multi-GB RSS spike at every daemon start. 0 disables the cap and restores
    * the old load-everything behaviour.
+   *
+   * TRA-422: this is also the daemon's steady-state ceiling, not just its
+   * startup budget. The idle-unload sweep evicts least-recently-accessed
+   * projects back down to this number, so lazy loads can no longer drift past
+   * it. The rationale for 8: a fully warmed project costs ~100 MB resident on
+   * a real machine (measured via vmmap — ~35 MB SQLite mmap of its index.db,
+   * ~23 MB native page cache and tree-sitter, the rest V8 heap), so 8 caps the
+   * marginal cost at ~800 MB on top of the daemon's ~350 MB fixed footprint.
+   * Attribution and the measuring procedure: docs/daemon-memory.md.
    */
   daemon_eager_load_projects: z.number().int().min(0).max(1000).default(8),
   /**

--- a/src/daemon/__tests__/project-manager-loaded-cap.test.ts
+++ b/src/daemon/__tests__/project-manager-loaded-cap.test.ts
@@ -1,0 +1,139 @@
+/**
+ * TRA-422 regression guard: `daemon_eager_load_projects` is a steady-state
+ * ceiling, not just a startup budget.
+ *
+ * A loaded project costs ~100 MB resident (docs/daemon-memory.md), and before
+ * this guard the eager cap only applied at boot — lazy loads (auto-register,
+ * reindex-file) walked past it, so a daemon booted with 8 projects was holding
+ * 11 three minutes later with nothing to bring it back down. Asserting RSS
+ * directly would be flaky on CI runners; asserting the eviction that bounds it
+ * is deterministic, and it is the thing that actually broke.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { ProjectManager } from '../project-manager.js';
+
+type Status = 'ready' | 'indexing' | 'starting';
+
+/** Install fake loaded projects and stub the real teardown. Returns the roots stopped. */
+function harness(
+  specs: Array<{ root: string; lastAccessedAt: number; status?: Status; refCount?: number }>,
+): { pm: ProjectManager; stopped: string[] } {
+  const pm = new ProjectManager();
+  const projects = (pm as unknown as { projects: Map<string, unknown> }).projects;
+  for (const s of specs) {
+    projects.set(s.root, {
+      root: s.root,
+      lastAccessedAt: s.lastAccessedAt,
+      status: s.status ?? 'ready',
+    });
+  }
+  (pm as unknown as { resourcePool: { getRefCount(root: string): number } }).resourcePool = {
+    getRefCount: (root) => specs.find((s) => s.root === root)?.refCount ?? 0,
+  };
+  const stopped: string[] = [];
+  (pm as unknown as { stopProject(root: string): Promise<void> }).stopProject = async (root) => {
+    stopped.push(root);
+    projects.delete(root);
+  };
+  return { pm, stopped };
+}
+
+const now = Date.now();
+
+describe('unloadIdleProjects — loaded-project ceiling', () => {
+  it('evicts down to maxLoaded, least-recently-accessed first', async () => {
+    const { pm, stopped } = harness([
+      { root: '/a', lastAccessedAt: now - 5_000 },
+      { root: '/b', lastAccessedAt: now - 4_000 },
+      { root: '/c', lastAccessedAt: now - 3_000 },
+      { root: '/d', lastAccessedAt: now - 2_000 },
+      { root: '/e', lastAccessedAt: now - 1_000 },
+    ]);
+
+    const unloaded = await pm.unloadIdleProjects(0, 3);
+
+    expect(unloaded.sort()).toEqual(['/a', '/b']);
+    expect(stopped.sort()).toEqual(['/a', '/b']);
+    expect(pm.listProjects()).toHaveLength(3);
+  });
+
+  it('never evicts a busy or indexing project to satisfy the ceiling', async () => {
+    // Only /e is evictable, so the daemon stays over the cap rather than
+    // tearing down work in flight — the ceiling is best-effort by design.
+    const { pm } = harness([
+      { root: '/a', lastAccessedAt: now - 5_000, refCount: 1 },
+      { root: '/b', lastAccessedAt: now - 4_000, status: 'indexing' },
+      { root: '/c', lastAccessedAt: now - 3_000, status: 'starting' },
+      { root: '/d', lastAccessedAt: now - 2_000, refCount: 2 },
+      { root: '/e', lastAccessedAt: now - 1_000 },
+    ]);
+
+    expect(await pm.unloadIdleProjects(0, 1)).toEqual(['/e']);
+    expect(pm.listProjects()).toHaveLength(4);
+  });
+
+  it('is a no-op while at or under the ceiling', async () => {
+    const { pm, stopped } = harness([
+      { root: '/a', lastAccessedAt: now - 5_000 },
+      { root: '/b', lastAccessedAt: now - 1_000 },
+    ]);
+
+    expect(await pm.unloadIdleProjects(0, 2)).toEqual([]);
+    expect(stopped).toEqual([]);
+  });
+
+  it('combines with the idle TTL without double-counting an eviction', async () => {
+    // /a is both the LRU and past the 2s TTL. Over the cap by one, so exactly
+    // one project goes — not two.
+    const { pm } = harness([
+      { root: '/a', lastAccessedAt: now - 10_000 },
+      { root: '/b', lastAccessedAt: now - 1_000 },
+      { root: '/c', lastAccessedAt: now - 500 },
+    ]);
+
+    expect(await pm.unloadIdleProjects(2_000, 2)).toEqual(['/a']);
+  });
+
+  it('maxLoaded = 0 leaves the ceiling off (TTL-only, as before)', async () => {
+    const { pm } = harness([
+      { root: '/a', lastAccessedAt: now - 5_000 },
+      { root: '/b', lastAccessedAt: now - 4_000 },
+      { root: '/c', lastAccessedAt: now - 3_000 },
+    ]);
+
+    expect(await pm.unloadIdleProjects(0, 0)).toEqual([]);
+  });
+});
+
+describe('startIdleUnloadSweep — ceiling wiring', () => {
+  it('arms the timer for a ceiling even when the TTL is disabled', async () => {
+    vi.useFakeTimers();
+    try {
+      const { pm, stopped } = harness([
+        { root: '/a', lastAccessedAt: now - 5_000 },
+        { root: '/b', lastAccessedAt: now - 1_000 },
+      ]);
+      pm.startIdleUnloadSweep(0, { intervalMs: 1_000, maxLoaded: 1 });
+      await vi.advanceTimersByTimeAsync(1_100);
+      expect(stopped).toEqual(['/a']);
+      pm.stopIdleUnloadSweep();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('arms nothing when both the TTL and the ceiling are off', async () => {
+    vi.useFakeTimers();
+    try {
+      const { pm, stopped } = harness([
+        { root: '/a', lastAccessedAt: now - 5_000 },
+        { root: '/b', lastAccessedAt: now - 1_000 },
+      ]);
+      pm.startIdleUnloadSweep(0, { intervalMs: 1_000, maxLoaded: 0 });
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(stopped).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -1047,31 +1047,57 @@ export class ProjectManager {
    * arrives (existing `addProject()` cold-start path — 503 + Retry-After
    * while it warms, see cli.ts serve-http Phase 5.1).
    *
+   * `maxLoaded > 0` additionally enforces a hard ceiling on how many projects
+   * stay resident: anything above it is evicted least-recently-accessed first,
+   * regardless of `idleMs`. Without this, `daemon_eager_load_projects` was a
+   * startup budget only — lazy loads walked straight past it (TRA-422: an
+   * eager-8 daemon sat at 11 loaded projects three minutes after boot, and at
+   * a measured ~100 MB resident per loaded project that is ~300 MB nobody
+   * capped). Same exemptions as the TTL path apply, so a busy or indexing
+   * project is never evicted just to satisfy the ceiling.
+   *
    * Returns the roots that were unloaded (mainly for tests/telemetry).
    */
-  async unloadIdleProjects(idleMs: number): Promise<string[]> {
-    if (idleMs <= 0) return [];
+  async unloadIdleProjects(idleMs: number, maxLoaded = 0): Promise<string[]> {
+    if (idleMs <= 0 && maxLoaded <= 0) return [];
     const now = Date.now();
-    const candidates: string[] = [];
+    const evictable: ManagedProject[] = [];
     for (const managed of this.projects.values()) {
       if (managed.status === 'starting' || managed.status === 'indexing') continue;
-      if (now - managed.lastAccessedAt < idleMs) continue;
       if ((this.resourcePool?.getRefCount(managed.root) ?? 0) > 0) continue;
-      candidates.push(managed.root);
+      evictable.push(managed);
+    }
+    const candidates = new Set<string>();
+    if (idleMs > 0) {
+      for (const managed of evictable) {
+        if (now - managed.lastAccessedAt >= idleMs) candidates.add(managed.root);
+      }
+    }
+    if (maxLoaded > 0 && this.projects.size > maxLoaded) {
+      const overBy = this.projects.size - maxLoaded;
+      const lruFirst = [...evictable].sort((a, b) => a.lastAccessedAt - b.lastAccessedAt);
+      for (const managed of lruFirst) {
+        if (candidates.size >= overBy) break;
+        candidates.add(managed.root);
+      }
     }
     for (const root of candidates) {
-      logger.info({ projectRoot: root, idleMs }, 'Unloading idle project (stays registered)');
+      logger.info(
+        { projectRoot: root, idleMs, maxLoaded },
+        'Unloading idle project (stays registered)',
+      );
       await this.stopProject(root);
     }
-    return candidates;
+    return [...candidates];
   }
 
   /**
    * Start the periodic idle-unload sweep. `intervalMs` defaults to 5 minutes
    * per the design; `idleMs` is `project_idle_unload_minutes * 60_000` (0
-   * disables — no timer is armed). Idempotent: calling twice replaces the
-   * previous timer. The interval is unref'd so it never keeps the daemon
-   * process alive on its own.
+   * disables the TTL rule). `opts.maxLoaded` is the LRU ceiling
+   * (`daemon_eager_load_projects`, 0 = unlimited). No timer is armed when both
+   * are off. Idempotent: calling twice replaces the previous timer. The
+   * interval is unref'd so it never keeps the daemon process alive on its own.
    *
    * `onUnloaded` fires after each sweep tick that unloaded at least one
    * project — cli.ts uses it to tear down its per-project bookkeeping
@@ -1080,13 +1106,14 @@ export class ProjectManager {
    */
   startIdleUnloadSweep(
     idleMs: number,
-    opts?: { intervalMs?: number; onUnloaded?: (roots: string[]) => void },
+    opts?: { intervalMs?: number; maxLoaded?: number; onUnloaded?: (roots: string[]) => void },
   ): void {
     this.stopIdleUnloadSweep();
-    if (idleMs <= 0) return;
+    const maxLoaded = opts?.maxLoaded ?? 0;
+    if (idleMs <= 0 && maxLoaded <= 0) return;
     this.idleUnloadTimer = setInterval(
       () => {
-        this.unloadIdleProjects(idleMs)
+        this.unloadIdleProjects(idleMs, maxLoaded)
           .then((roots) => {
             if (roots.length > 0) opts?.onUnloaded?.(roots);
           })


### PR DESCRIPTION
Closes TRA-422.

## What was wrong

`daemon_eager_load_projects` (default 8) capped how many projects the daemon loads at **startup**. Nothing capped it afterwards — lazy loads via `/mcp` auto-register and `/api/projects/reindex-file` walked straight past it. On Nikolai's machine a daemon that logged `eager: 8, deferred: 34` was reporting `projects_loaded: 11` three minutes later, with no path back down.

The idle-unload sweep existed but is time-based only, and in a 19 MB `daemon.log` it has fired **zero** times — the daemon never survives its 30-minute TTL (see TRA-421).

## Attribution — measured, not estimated

`vmmap` on the live daemon (11 projects loaded, at rest, 1.55 GB RSS):

| Region | Resident | What |
|---|---:|---|
| Memory Tag 255 | 714 MB | V8 heap + Node allocations (`heap_used` was 370–515 MB — V8 holds ~2× its live set) |
| `mapped file` | 380 MB | SQLite mmap of each project's `index.db` |
| `MALLOC_SMALL` | 258 MB | SQLite page cache, tree-sitter trees |
| `MALLOC_SMALL (empty)` | 104 MB | freed, not returned to the OS |
| `__TEXT`/`__LINKEDIT`/`__OBJC_RO` | ~330 MB | node binary + native modules (clean, shared) |
| kernel page table | 55 MB | cost of V8's ~112 GB virtual reservation |

Per-project mmap residency reads directly off `vmmap`:

```
64.0M  63.6M  index/thewed-2f9565b74fb5.db     <- at the index_mmap_mb cap
64.0M  63.7M  index/general-e8778b435c05.db    <- at the cap
64.0M  63.3M  index/assetfeed-76da1a753b39.db  <- at the cap
34.1M  33.4M  index/workdir-45190de3e39c.db
```

**Marginal cost of one loaded project: ~100 MB resident.** Fixed floor with zero projects: ~165 MB RSS.

A JS heap snapshot — what the issue asked for — would have attributed only ~28 % of RSS and missed the mmap and native halves entirely. `vmmap` is the right instrument here; the docs record why.

## The change

The existing sweep now also enforces `daemon_eager_load_projects` as a steady-state LRU ceiling, independent of the `project_idle_unload_minutes` TTL. Same exemptions as the TTL rule — a `starting`/`indexing` project or one with live clients is never torn down to satisfy the ceiling, so the ceiling is best-effort by design. Either knob at 0 disables its rule; with both off, no timer is armed.

Rationale for 8, now written into the config doc comment and `docs/daemon-memory.md`: 8 × ~100 MB ≈ 800 MB marginal on top of the ~350 MB fixed footprint. Re-tuning it is a one-line config change against a recorded measurement.

No new config key — one number governs both the startup budget and the ceiling rather than two knobs that must agree.

## Test evidence

`src/daemon/__tests__/project-manager-loaded-cap.test.ts` — 7 tests: LRU eviction order, the busy/indexing exemption, no-op at or under the cap, TTL-and-ceiling composition without double-counting, `maxLoaded: 0` off, and both sweep-wiring paths.

An RSS assertion in CI would be flaky on shared runners, so the guard asserts the eviction that bounds RSS instead, and `docs/daemon-memory.md` records the reproducible `vmmap` procedure. Calling that out explicitly since the issue asked for an RSS guard.

```
pnpm run build   ✅
pnpm run lint    ✅ (tsc --noEmit)
pnpm run test    ✅ 823 files, 9126 passed | 8 skipped
```

## Not in scope here

- `index_mmap_mb: 64` is the largest single per-project item (~35 MB avg). The ceiling reduces it by holding fewer projects; re-tuning the window itself is a separate perf/RSS tradeoff against a default that was already tuned once.
- The sweep runs every 5 minutes, so a burst of lazy loads can sit above the ceiling for up to one interval. Enforcing on each `addProject` would close that window; not worth the coupling until the delay is shown to matter. Noted in the docs.
- The sweep still cannot help a daemon that does not live long enough to run it — that is TRA-421.

Agent: Lead Engineer
