### PR TITLE
fix(daemon): stop the health watchdog from killing a busy daemon (TRA-421)

### DIFF
--- a/packages/app/src/main/daemon-lifecycle.ts
+++ b/packages/app/src/main/daemon-lifecycle.ts
@@ -141,3 +141,55 @@ export function restartDaemon(): { ok: boolean; error?: string } {
 export function stopDaemon(): { ok: boolean; error?: string } {
   return runDaemonCommand('stop');
 }
+
+/**
+ * Is the daemon process provably alive right now, independent of /health?
+ *
+ * Mirrors src/daemon/lifecycle.ts: isDaemonProcessAlive(). Kept as a local
+ * ~10-line read for the same reason getLauncherDir() is duplicated above — the
+ * Electron main bundle compiles standalone and cannot import from src/.
+ *
+ * The daemon registers its own PID at startup (TRA-421), so an unanswered
+ * /health with this returning `true` means "busy", not "dead".
+ */
+export function isDaemonProcessAlive(): boolean {
+  try {
+    const raw = fs.readFileSync(path.join(getLauncherDir(), 'daemon.pid'), 'utf-8');
+    const pid = parseInt(raw.split(/\r?\n/)[0]?.trim() ?? '', 10);
+    if (!Number.isInteger(pid) || pid <= 0) return false;
+    process.kill(pid, 0); // signal 0 = liveness probe, delivers nothing
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * How long a live-but-unresponsive daemon is left alone before the watchdog
+ * treats it as wedged and restarts it anyway. A cold start over O(40)
+ * registered projects can starve the event loop well past the 5s /health
+ * timeout; restarting mid-startup just replays the same slow start.
+ */
+export const WEDGED_DAEMON_MS = 5 * 60_000;
+
+/**
+ * Health-watchdog restart policy (TRA-421).
+ *
+ * The observed failure was 626 daemon restarts in 13 hours: /health timed out
+ * while the daemon was busy, the watchdog read that as death, `daemon restart`
+ * killed a warming daemon, and the next one started the same slow warm-up. The
+ * existing `DAEMON_STARTUP_GRACE_MS` only delayed each iteration — it never
+ * broke the cycle, because after the grace window the daemon was still busy.
+ *
+ * The rule that does break it: never kill a process that is provably running.
+ * Restart only when the daemon is actually gone, or when it has been alive but
+ * mute for longer than any legitimate warm-up.
+ */
+export function shouldRestartUnreachableDaemon(state: {
+  processAlive: boolean;
+  unreachableForMs: number;
+  wedgedAfterMs?: number;
+}): boolean {
+  if (!state.processAlive) return true;
+  return state.unreachableForMs >= (state.wedgedAfterMs ?? WEDGED_DAEMON_MS);
+}

--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -10,7 +10,12 @@ import {
   themeSourceFor,
   writeAppearance,
 } from './appearance';
-import { ensureDaemon, restartDaemon } from './daemon-lifecycle';
+import {
+  ensureDaemon,
+  isDaemonProcessAlive,
+  restartDaemon,
+  shouldRestartUnreachableDaemon,
+} from './daemon-lifecycle';
 import { t } from './i18n';
 
 const isMac = process.platform === 'darwin';
@@ -109,6 +114,13 @@ const VERSION_MISMATCH_RESTART_COOLDOWN_MS = 60_000;
  */
 let lastDaemonStartAttempt = 0;
 const DAEMON_STARTUP_GRACE_MS = 60_000;
+/**
+ * When the daemon first stopped answering /health in the current outage, or 0
+ * while it is reachable. Feeds `shouldRestartUnreachableDaemon` so a daemon
+ * that is provably running gets left alone until it has been mute for longer
+ * than any legitimate warm-up (TRA-421).
+ */
+let firstUnreachableAt = 0;
 
 const daemon = new DaemonClient();
 
@@ -672,6 +684,7 @@ async function checkHealth(): Promise<void> {
       daemonReachable = true;
       consecutiveFailures = 0;
       _lastRestartAttempt = 0;
+      firstUnreachableAt = 0;
       setTrayIcon(true);
       tray.setContextMenu(buildContextMenu());
       return;
@@ -679,6 +692,7 @@ async function checkHealth(): Promise<void> {
 
     daemonReachable = false;
     setTrayIcon(false);
+    if (firstUnreachableAt === 0) firstUnreachableAt = Date.now();
 
     // Grace period after a recent ensure/restart: a freshly spawned daemon
     // may be busy with post-update migrations, FK recovery, or a cold reindex
@@ -693,6 +707,23 @@ async function checkHealth(): Promise<void> {
     }
 
     consecutiveFailures++;
+
+    // TRA-421: never kill a process that is provably running. A missed /health
+    // means "no answer", not "no daemon" — and restarting a busy daemon just
+    // replays its slow startup, which is how 626 restarts happened in 13 hours.
+    // The startup grace above only spaced those restarts out; this stops them.
+    if (
+      !shouldRestartUnreachableDaemon({
+        processAlive: isDaemonProcessAlive(),
+        unreachableForMs: Date.now() - firstUnreachableAt,
+      })
+    ) {
+      if (consecutiveFailures === 1) {
+        console.log('[trace-mcp] daemon unreachable but process is alive — waiting, not restarting');
+      }
+      tray.setContextMenu(buildContextMenu());
+      return;
+    }
 
     if (shouldAttemptRestart(consecutiveFailures)) {
       // First failure → try a soft start (noop if already running, stale PID, etc.).

--- a/scripts/postinstall-control-plane.mjs
+++ b/scripts/postinstall-control-plane.mjs
@@ -36,7 +36,11 @@ import { fileURLToPath } from 'node:url';
 // v3: forces regeneration of v2 plists that embedded a concrete cli.js path
 // (drift between src/daemon/lifecycle.ts and this script). v3 uses the launcher
 // shim everywhere so node-version swaps don't pin the daemon to a stale binary.
-const PLIST_VERSION = 3;
+// v4: adds ExitTimeOut — launchd's 5s default SIGKILLed the daemon mid-cleanup
+// (TRA-421), losing both the shutdown log line and the graceful DB close.
+const PLIST_VERSION = 4;
+/** Seconds launchd waits after SIGTERM before SIGKILL. Mirrors PLIST_EXIT_TIMEOUT_SEC. */
+const PLIST_EXIT_TIMEOUT_SEC = 30;
 const PLIST_LABEL = 'com.trace-mcp.server';
 const PLIST_MARKER = `trace-mcp plist v${PLIST_VERSION}`;
 const DEFAULT_DAEMON_PORT = 3741;
@@ -238,6 +242,8 @@ function generatePlist(binaryPath, port) {
   <true/>
   <key>ThrottleInterval</key>
   <integer>5</integer>
+  <key>ExitTimeOut</key>
+  <integer>${PLIST_EXIT_TIMEOUT_SEC}</integer>
   <key>StandardOutPath</key>
   <string>${DAEMON_LOG_PATH}</string>
   <key>StandardErrorPath</key>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,12 @@ import { hardenStdio } from './server/transport-hardening.js';
 import { installProcessSafetyNet } from './server/process-safety-net.js';
 import { startParentDeathWatch } from './server/parent-death-watch.js';
 import { armBoundedExit } from './server/bounded-shutdown.js';
-import { startDaemonLogRotation } from './daemon/lifecycle.js';
+import {
+  clearOwnDaemonPidFile,
+  logPreviousExit,
+  startDaemonLogRotation,
+  writeOwnDaemonPidFile,
+} from './daemon/lifecycle.js';
 
 if (process.argv.includes('serve') || process.argv.length === 2) {
   hardenStdio();
@@ -477,6 +482,14 @@ program
     // Rotate daemon.log from within the long-lived daemon — the spawn-point
     // rotation only fires at restart, so a long-running daemon never rotated it.
     startDaemonLogRotation();
+    // TRA-421: say what launchd recorded about the previous run *before* doing
+    // anything else, so a crash loop is visible in daemon.log itself rather
+    // than only via `launchctl print` after someone thinks to look.
+    logPreviousExit();
+    // TRA-421: register our own PID so clients can tell "busy" from "dead"
+    // without /health. Under launchd nobody else writes this file, which left
+    // the #237 restart-war guard permanently disarmed on macOS.
+    writeOwnDaemonPidFile();
     // Auto-update (same logic as serve)
     const globalRaw = loadGlobalConfigRaw();
     if (globalRaw.auto_update !== false) {
@@ -2824,6 +2837,9 @@ program
       clearInterval(rateBucketCleanup);
       clearInterval(clientSweep);
       await projectManager.shutdown();
+      // Drop our PID registration last: while it exists, clients treat the
+      // daemon as alive-but-busy and refuse to restart it (TRA-421).
+      clearOwnDaemonPidFile();
       httpServer.close(() => process.exit(0));
     };
     process.on('SIGINT', shutdown);

--- a/src/daemon/__tests__/app-restart-policy.test.ts
+++ b/src/daemon/__tests__/app-restart-policy.test.ts
@@ -1,0 +1,66 @@
+/**
+ * TRA-421 regression guard: the desktop health watchdog must not restart a
+ * daemon that is provably running.
+ *
+ * Field evidence (2026-08-29, Nikolai's Mac): 626 daemon restarts in 13 hours,
+ * median uptime 22 s, every graceful shutdown logged `reason: SIGTERM`, and
+ * every one correlated with a launcher exec of `daemon restart` (222 such execs
+ * inside 6-second windows around shutdowns, against ~1.4 expected by chance).
+ * /health timed out while the daemon warmed O(40) registered projects; the
+ * watchdog read that as death and killed it; the replacement repeated the same
+ * slow warm-up.
+ *
+ * The policy under test lives in the Electron main bundle (which compiles
+ * standalone and cannot import from src/), but the test lives here so the root
+ * suite — the one CI actually runs — enforces it. The module imports only Node
+ * builtins, so there is no Electron dependency to satisfy.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  shouldRestartUnreachableDaemon,
+  WEDGED_DAEMON_MS,
+} from '../../../packages/app/src/main/daemon-lifecycle.js';
+
+describe('shouldRestartUnreachableDaemon', () => {
+  it('does not restart a live daemon that is merely slow to answer /health', () => {
+    expect(shouldRestartUnreachableDaemon({ processAlive: true, unreachableForMs: 30_000 })).toBe(
+      false,
+    );
+  });
+
+  it('restarts when the daemon process is actually gone', () => {
+    expect(shouldRestartUnreachableDaemon({ processAlive: false, unreachableForMs: 0 })).toBe(true);
+  });
+
+  it('restarts a live daemon that has been mute past the wedged threshold', () => {
+    expect(
+      shouldRestartUnreachableDaemon({
+        processAlive: true,
+        unreachableForMs: WEDGED_DAEMON_MS + 1,
+      }),
+    ).toBe(true);
+  });
+
+  /**
+   * The bound the issue asks for, expressed as the thing that actually caused
+   * it: replay a 13-hour outage at the tray's 5 s poll cadence and count
+   * restarts. The old policy fired one every ~60-75 s (the startup grace window
+   * only spaced them out, it never broke the cycle).
+   */
+  it('caps restarts over a 13-hour outage of a live-but-busy daemon', () => {
+    const POLL_MS = 5_000;
+    const OUTAGE_MS = 13 * 60 * 60_000;
+    let restarts = 0;
+    let unreachableSince = 0;
+    for (let t = 0; t < OUTAGE_MS; t += POLL_MS) {
+      const unreachableForMs = t - unreachableSince;
+      if (shouldRestartUnreachableDaemon({ processAlive: true, unreachableForMs })) {
+        restarts++;
+        unreachableSince = t; // a restart resets the outage clock
+      }
+    }
+    const hours = OUTAGE_MS / 3_600_000;
+    expect(restarts / hours).toBeLessThanOrEqual(12);
+    expect(restarts).toBeLessThan(626);
+  });
+});

--- a/src/daemon/__tests__/daemon-self-pid.test.ts
+++ b/src/daemon/__tests__/daemon-self-pid.test.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Isolate TRACE_MCP_HOME before global.ts resolves it — see
+// ../../../tests/daemon/daemon-process-alive.test.ts for the same guard against clobbering a live
+// daemon's ~/.trace-mcp/daemon.pid.
+const TMP_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-selfpid-'));
+process.env.TRACE_MCP_DATA_DIR = TMP_HOME;
+
+const { afterAll, describe, expect, it } = await import('vitest');
+const { clearOwnDaemonPidFile, isDaemonProcessAlive, writeOwnDaemonPidFile } = await import(
+  '../lifecycle.js'
+);
+
+/**
+ * TRA-421: daemon.pid used to be written only by `ensureDaemonGeneric` — the
+ * detached-spawn path taken on Windows and Linux. Under launchd (macOS, the
+ * platform the 626-restarts-in-13-hours loop was observed on) nothing wrote it,
+ * so `isDaemonProcessAlive()` — the #237 "don't kill a busy daemon" guard —
+ * was hardwired to `false` and every client fell through to kill+restart.
+ *
+ * The daemon now registers its own PID at startup, on every platform.
+ */
+describe('daemon self-registers its PID', () => {
+  afterAll(() => {
+    try {
+      fs.rmSync(TMP_HOME, { recursive: true, force: true });
+    } catch {
+      /* fine */
+    }
+  });
+
+  it('makes the alive-probe true regardless of how the daemon was started', () => {
+    expect(isDaemonProcessAlive()).toBe(false);
+    writeOwnDaemonPidFile();
+    expect(fs.readFileSync(path.join(TMP_HOME, 'daemon.pid'), 'utf-8')).toMatch(
+      new RegExp(`^${process.pid}\\b`),
+    );
+    expect(isDaemonProcessAlive()).toBe(true);
+  });
+
+  it('clears the registration on graceful shutdown', () => {
+    writeOwnDaemonPidFile();
+    clearOwnDaemonPidFile();
+    expect(fs.existsSync(path.join(TMP_HOME, 'daemon.pid'))).toBe(false);
+    expect(isDaemonProcessAlive()).toBe(false);
+  });
+});

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -34,7 +34,18 @@ const PLIST_LABEL = 'com.trace-mcp.server';
 // MUST match scripts/postinstall-control-plane.mjs::PLIST_VERSION — keep in sync.
 // v3: prefer the launcher shim as ProgramArguments so Node-version drift can't
 // pin the daemon to a stale dist/cli.js.
-const PLIST_VERSION = 3;
+// v4: ExitTimeOut — launchd's default 5s is shorter than a graceful shutdown
+// that closes every project DB, so launchd SIGKILLed the daemon mid-cleanup
+// (LastExitStatus=9) and the buffered "Daemon shutting down" line died with it.
+const PLIST_VERSION = 4;
+/**
+ * Seconds launchd waits after SIGTERM before escalating to SIGKILL. Graceful
+ * shutdown closes DBs, tears down watchers and flushes indexes for every
+ * registered project; on a machine with O(40) projects that does not fit in
+ * launchd's 5s default. Must exceed the daemon's own bounded hard-exit
+ * (src/server/bounded-shutdown.ts) so *we* decide when to give up, not launchd.
+ */
+const PLIST_EXIT_TIMEOUT_SEC = 30;
 const PLIST_MARKER = `trace-mcp plist v${PLIST_VERSION}`;
 const isMac = process.platform === 'darwin';
 const isWin = process.platform === 'win32';
@@ -171,6 +182,8 @@ function generatePlist(binaryPath: string, port: number): string {
   <true/>
   <key>ThrottleInterval</key>
   <integer>5</integer>
+  <key>ExitTimeOut</key>
+  <integer>${PLIST_EXIT_TIMEOUT_SEC}</integer>
   <key>StandardOutPath</key>
   <string>${DAEMON_LOG_PATH}</string>
   <key>StandardErrorPath</key>
@@ -585,6 +598,93 @@ function readDaemonPid(): number | null {
   return null;
 }
 
+/**
+ * Append one pino-shaped NDJSON record straight to daemon.log (TRA-421).
+ *
+ * Attribution has to bypass `logger`, which writes to *this* process's stderr.
+ * For the daemon that stderr is daemon.log (launchd redirects it), but for a
+ * short-lived `trace-mcp daemon restart` — the process that actually kills the
+ * daemon — stderr goes to whoever spawned it, and the desktop app discards it.
+ * That is why 626 restarts in one day left no record of who asked for them.
+ * Best-effort: a failed append must never break a lifecycle command.
+ */
+function appendDaemonLog(msg: string, fields: Record<string, unknown>): void {
+  try {
+    const record = {
+      level: 30,
+      time: Date.now(),
+      pid: process.pid,
+      name: 'trace-mcp',
+      ...fields,
+      msg,
+    };
+    fs.appendFileSync(DAEMON_LOG_PATH, `${JSON.stringify(record)}\n`);
+  } catch {
+    /* log attribution is best-effort */
+  }
+}
+
+/**
+ * Who is asking for this stop/restart? `process.argv` of the *calling* CLI plus
+ * its parent PID is enough to tell a human `trace-mcp daemon restart` apart
+ * from the desktop app's health watchdog apart from a hook-spawned CLI.
+ */
+function logLifecycleRequest(action: 'stop' | 'restart'): void {
+  appendDaemonLog(`Daemon ${action} requested`, {
+    action,
+    requesterPid: process.pid,
+    requesterPpid: process.ppid,
+    // argv[0] is node and argv[1] the cli.js path — the subcommand is what matters.
+    requesterArgs: process.argv.slice(2, 6),
+    managedBy: process.env.TRACE_MCP_MANAGED_BY ?? 'cli',
+  });
+}
+
+/**
+ * Register the *running daemon's* own PID so `isDaemonProcessAlive()` works on
+ * every platform (TRA-421).
+ *
+ * Before this, daemon.pid was written only by `ensureDaemonGeneric` — the
+ * detached-spawn path used on Windows/Linux. On macOS the daemon runs under
+ * launchd, nobody wrote the file, and so the #237 "provably alive, don't kill a
+ * busy daemon" guard silently evaluated to `false` forever on the platform the
+ * restart war was actually observed on.
+ */
+export function writeOwnDaemonPidFile(): void {
+  try {
+    if (!fs.existsSync(TRACE_MCP_HOME)) fs.mkdirSync(TRACE_MCP_HOME, { recursive: true });
+    writePidFile(process.pid, captureProcessStartToken(process.pid));
+  } catch (err) {
+    logger.warn({ err: String(err) }, 'Could not write daemon.pid');
+  }
+}
+
+/** Remove daemon.pid on graceful shutdown. Best-effort; never throws. */
+export function clearOwnDaemonPidFile(): void {
+  try {
+    fs.unlinkSync(getPidFilePath());
+  } catch {
+    /* already gone */
+  }
+}
+
+/**
+ * Log what launchd recorded about the *previous* run, at daemon start (TRA-421).
+ *
+ * `getLaunchdLastExit()` existed (TRA-267) but was only surfaced by
+ * `daemon status`, which nobody runs during a crash loop. Emitting it on every
+ * boot means daemon.log itself says "the last run died to code 9 after 22s"
+ * instead of requiring `launchctl` archaeology after the fact.
+ */
+export function logPreviousExit(): void {
+  const info = getLaunchdLastExit();
+  if (!info) return;
+  logger.info(
+    { exitCode: info.exitCode, exitReason: info.reason, launchdRuns: info.runs },
+    'Previous daemon run exited (launchd post-mortem)',
+  );
+}
+
 function stopDaemonByPid(): void {
   const pid = readDaemonPid();
   if (pid === null) return;
@@ -711,6 +811,7 @@ export function stopDaemon(): void {
   // Record an explicit opt-out so the next stdio session doesn't silently
   // reinstall the daemon the user just removed (#202).
   disableDaemon('trace-mcp daemon stop');
+  logLifecycleRequest('stop');
   if (isMac) stopDaemonMac();
   else stopDaemonByPid();
 }
@@ -722,6 +823,7 @@ export function restartDaemon(opts?: { port?: number }): EnsureResult {
   const port = opts?.port ?? DEFAULT_DAEMON_PORT;
   // An explicit restart is a clear intent to run the daemon — clear any opt-out.
   enableDaemon();
+  logLifecycleRequest('restart');
   return isMac ? restartDaemonMac(port) : restartDaemonGeneric(port);
 }
 

--- a/tests/scripts/postinstall-control-plane.test.ts
+++ b/tests/scripts/postinstall-control-plane.test.ts
@@ -181,4 +181,31 @@ describe('postinstall-control-plane', () => {
     expect(lifecycleMatch?.[1]).toBeDefined();
     expect(scriptMatch?.[1]).toBe(lifecycleMatch?.[1]);
   });
+
+  /**
+   * TRA-421: launchd's default ExitTimeOut is 5s. Graceful shutdown closes a DB
+   * per registered project, overran that, and launchd SIGKILLed the daemon
+   * (LastExitStatus=9) — taking the buffered "Daemon shutting down" line with
+   * it, which is why 210 of 624 restarts left no trace at all. Both plist
+   * templates must set it, and to the same value.
+   */
+  it('both plist templates set a matching ExitTimeOut', () => {
+    const script = fs.readFileSync(SCRIPT_PATH, 'utf-8');
+    const lifecycle = fs.readFileSync(
+      path.join(REPO_ROOT, 'src', 'daemon', 'lifecycle.ts'),
+      'utf-8',
+    );
+    const pattern = /const PLIST_EXIT_TIMEOUT_SEC\s*=\s*(\d+)/;
+    const scriptTimeout = script.match(pattern)?.[1];
+    const lifecycleTimeout = lifecycle.match(pattern)?.[1];
+    expect(scriptTimeout).toBeDefined();
+    expect(scriptTimeout).toBe(lifecycleTimeout);
+    // Must exceed the daemon's own 5s bounded hard-exit so we decide when to
+    // give up, not launchd.
+    expect(Number(scriptTimeout)).toBeGreaterThan(5);
+    for (const src of [script, lifecycle]) {
+      expect(src).toContain('<key>ExitTimeOut</key>');
+      expect(src).toContain('<integer>${PLIST_EXIT_TIMEOUT_SEC}</integer>');
+    }
+  });
 });


### PR DESCRIPTION
Fixes TRA-421.

## What was happening

626 daemon restarts in 13 hours on a field machine (2026-08-29), median uptime 22 s. Every graceful shutdown logged `reason: SIGTERM`; launchd recorded `LastExitStatus = 9`.

## Who was sending the SIGTERM

Correlating `daemon.log` shutdowns against `launcher.log`: 222 launcher execs with exactly two arguments landed inside 6-second windows around shutdowns, against ~1.4 expected by chance (those windows cover 0.0095 % of the log's timeline). Two arguments is `daemon restart` — precisely what `packages/app/src/main/daemon-lifecycle.ts::runDaemonCommand` spawns. The sender is the desktop app's tray `/health` watchdog.

## Why the existing guard didn't stop it

`isDaemonProcessAlive()` exists for exactly this — #237's "an unanswered `/health` is not proof of death, don't kill a busy daemon". It reads `~/.trace-mcp/daemon.pid`, and that file was written **only** by `ensureDaemonGeneric`, the detached-spawn path used on Windows and Linux. Under launchd nobody wrote it. Verified on the affected machine: `~/.trace-mcp/daemon.pid` does not exist. So on macOS the probe returned `false` forever and every caller fell through to kill+restart.

The tray's `DAEMON_STARTUP_GRACE_MS` (60 s) only spaced the restarts out — after the grace window the daemon was still warming, so failures resumed and the next restart landed ~60–75 s later. That is the observed cadence.

## Changes

- **`src/cli.ts`, `src/daemon/lifecycle.ts`** — the daemon registers its own PID at startup on every platform (`writeOwnDaemonPidFile`) and clears it on graceful shutdown. This arms the alive-probe under launchd, which in turn arms the existing #237 guard in `tryAutoSpawnDaemon`.
- **`packages/app/src/main/`** — `shouldRestartUnreachableDaemon`: restart only a daemon that is actually gone, or one alive but mute past 5 minutes. Never kill a process that is provably running.
- **plist v4** — `ExitTimeOut = 30`. launchd's 5 s default raced the daemon's own 5 s bounded exit and SIGKILLed it mid-cleanup; that is why 210 of 624 restarts left no shutdown line at all. Bumped in both `src/daemon/lifecycle.ts` and `scripts/postinstall-control-plane.mjs`.
- **Attribution** — `daemon stop` / `daemon restart` append the requesting PID, PPID and argv straight to `daemon.log`. `logger` writes to the *calling* process's stderr, which the desktop app discards; that is why 626 restarts left no record of who asked.
- **Post-mortem at boot** — a daemon start logs `getLaunchdLastExit()`. It existed (TRA-267) but was only surfaced by `daemon status`, which nobody runs during a crash loop.

## Tests

Guards live in `src/daemon/__tests__/`, not `tests/daemon/` — CI's sharded run excludes the latter.

- `app-restart-policy.test.ts` — replays a 13-hour outage at the tray's 5 s poll and asserts a restart-rate bound (old policy: ~50/h; new: ≤ 12/h, and one per wedged window in practice).
- `daemon-self-pid.test.ts` — the alive-probe is true regardless of how the daemon was started, false after graceful shutdown.
- `postinstall-control-plane.test.ts` — pins `ExitTimeOut` across both plist templates and above the daemon's own 5 s hard exit.

Evidence: `pnpm run build`, `pnpm run lint`, `pnpm --dir packages/app run typecheck` all clean; CI-shaped suite 8611 passed / 5 skipped; `tests/daemon` 222 passed.

## Note on rollout

The plist version bump means installed daemons regenerate and rebootstrap once on the next `daemon start`/`restart` after upgrading. No schema or MCP tool-contract change.
