### PR TITLE
docs: rewrite the landing page and README framing in a plain voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@
   <sub>Based on early benchmarks across agent workflows with repeated context and dependency traversal.</sub>
 </p>
 
-> AI systems don't scale because they recompute instead of reuse. Every turn, the agent re-reads the same files, re-traverses the same dependencies, and re-inflates the context window with structure it already discovered. Token bills grow. Latency grows. Reasoning quality drops. The model isn't the bottleneck — the recomputation leak is.
+> AI agents pay repeatedly for work they have already done. Every turn, the agent re-reads the same files, re-traverses the same dependencies, and re-inflates the context window with structure it discovered five steps ago. That repeated work is most of what a long session costs in tokens and latency.
 >
-> trace-mcp builds a framework-aware graph of your codebase **once**, then serves it through MCP so the agent reasons from a precomputed structure instead of brute-reading the repo. Ask *"what breaks if I change this model?"* — instead of 80 Grep calls and 190 file reads, the agent calls `get_change_impact` once and gets the blast radius across PHP, Vue, migrations, and DI. One tool call replaces ~42 minutes of agent exploration. 87 framework integrations across 81 languages, 169 tools.
+> trace-mcp builds a framework-aware graph of your codebase **once**, then serves it through MCP so the agent reasons from a precomputed structure instead of brute-reading the repo. Ask *"what breaks if I change this model?"* — instead of 80 Grep calls and 190 file reads, the agent calls `get_change_impact` once and gets the blast radius across PHP, Vue, migrations, and DI. 87 framework integrations across 81 languages, 169 tools.
 >
-> **The same engine indexes markdown vaults.** `[[wikilinks]]` become first-class edges, frontmatter and `#tags` become metadata, headings become nested sections. `find_usages` returns backlinks. `apply_rename` rewrites every link to a renamed note. One MCP for code and knowledge — no second tool to plug in.
+> **The same engine indexes markdown vaults.** `[[wikilinks]]` become first-class edges, frontmatter and `#tags` become metadata, headings become nested sections. `find_usages` returns backlinks. `apply_rename` rewrites every link to a renamed note. One MCP server covers both code and knowledge; there is no second tool to plug in.
 
 <p align="center">
   <img src="docs/images/app-graph.webp" alt="trace-mcp app — GPU graph explorer visualizing symbol connections, light appearance" width="820" height="512" loading="lazy" />
@@ -45,18 +45,18 @@
 
 ---
 
-## Why this matters
+## The problem
 
-AI is bottlenecked not by models, but by **recomputation**. Agents treat the context window like a database — they re-read the same files, re-traverse the same dependencies, and re-inflate context every turn with structure they already computed five steps ago. Token bills, latency, and hallucinations all grow with project size instead of with task complexity.
+The binding constraint is **recomputation**, not model capability. Agents treat the context window like a database — they re-read the same files, re-traverse the same dependencies, and re-inflate context every turn with structure they already computed five steps ago. Token bills, latency, and hallucinations all grow with project size instead of with task complexity.
 
 trace-mcp closes the recomputation leak. The graph is built once, kept incrementally fresh, and served to every agent that asks — so the same work isn't paid for over and over.
 
 - **Lower cost** — fewer tokens per successful answer, on average and at peak
 - **Lower latency** — fewer sequential tool calls, fewer round-trips to the model
 - **Higher accuracy** — less noise in context means fewer hallucinations and stronger first-response correctness
-- **Production stability** — context that scales with project size, not against it
+- **Production stability** — context growth tracks task complexity rather than repository size
 
-We started with code intelligence — the hardest, noisiest context most agents handle today — and the same engine now indexes markdown knowledge vaults (Obsidian, Logseq, plain MD) as a peer domain. Wikilinks, tags, frontmatter, and embeds become graph edges and symbol metadata; `search`, `find_usages`, `get_change_impact`, and `apply_rename` work identically over both.
+We started with code intelligence, where the repetition is most expensive, and the same engine now indexes markdown knowledge vaults (Obsidian, Logseq, plain MD) as a peer domain. Wikilinks, tags, frontmatter, and embeds become graph edges and symbol metadata; `search`, `find_usages`, `get_change_impact`, and `apply_rename` work identically over both.
 
 ---
 
@@ -74,7 +74,7 @@ We started with code intelligence — the hardest, noisiest context most agents 
 | "What notes link to this concept?" | Backlinks across the vault, with section + alias context | `find_usages` on a `note:<basename>` symbol |
 | "What breaks if I rename this note?" | Every `[[wikilink]]` and `[text](path.md)` that references it | `get_change_impact` — wikilink-aware reverse graph |
 
-**Four things no other tool does:**
+**Four capabilities that are rare among adjacent tools:**
 
 1. **Framework-aware edges** — trace-mcp understands that `Inertia::render('Users/Show')` connects PHP to Vue, that `@Injectable()` creates a DI dependency, that `$user->posts()` means a `posts` table from migrations. 87 framework integrations.
 
@@ -82,7 +82,7 @@ We started with code intelligence — the hardest, noisiest context most agents 
 
 3. **Cross-session intelligence** — past sessions are mined for decisions and indexed for search. When you start a new session, `get_wake_up` gives you orientation in ~300 tokens; `plan_turn` shows relevant past decisions for your task; `get_wake_up { scope: "resume" }` carries over structural context from previous sessions.
 
-4. **Code and knowledge in one graph** — point trace-mcp at a markdown vault (Obsidian, Logseq, plain MD) and the same engine indexes it: each note becomes a `note:<basename>` symbol, headings become nested sections, `[[wikilinks]]` and `![[embeds]]` become graph edges, frontmatter and `#tags` ride on metadata. PageRank, Signal Fusion ranking, embeddings, and rename refactoring all apply unchanged. The agent does not learn a second tool — it learns one graph that happens to contain both your codebase and your second brain.
+4. **Code and knowledge in one graph** — point trace-mcp at a markdown vault (Obsidian, Logseq, plain MD) and the same engine indexes it: each note becomes a `note:<basename>` symbol, headings become nested sections, `[[wikilinks]]` and `![[embeds]]` become graph edges, frontmatter and `#tags` ride on metadata. PageRank, Signal Fusion ranking, embeddings, and rename refactoring all apply unchanged. The agent does not learn a second tool: it is the same graph, holding both the codebase and the notes.
 
 ---
 
@@ -154,7 +154,7 @@ trace-mcp combines **code graph navigation**, **cross-session memory**, and **re
 
 ---
 
-## Token reduction — measured, not marketed
+## Token reduction — what we measured
 
 AI agents burn tokens recomputing what they already discovered last turn — re-reading files, re-traversing dependencies, re-inflating context. trace-mcp replaces that with **precision context**: only the symbols, edges, and signatures relevant to the query, served from a graph that was computed once.
 
@@ -190,11 +190,11 @@ Composite task              223,721 tokens      14,245 tokens       93.6%
 Total                       702,532 tokens      50,812 tokens       92.8%
 ```
 
-Across 11 structured task categories, recomputation drops by **up to ~99% per call** when the agent reuses the graph instead of re-reading files — peaks where the math gets dramatic. Read that as a *peak structured-task result on a well-supported TS/Vue codebase*, not a number you should expect on every project. In production, on mixed workloads, expect **~40–50% on average**. Less noise in context also means fewer hallucinations and better first-response accuracy — a quality benefit you don't see in token counts.
+Across 11 structured task categories, recomputation drops by **up to ~99% per call** when the agent reuses the graph instead of re-reading files. Read that as a *peak structured-task result on a well-supported TS/Vue codebase*, not a number you should expect on every project. In production, on mixed workloads, expect **~40–50% on average**. Less noise in context also means fewer hallucinations and better first-response accuracy — a quality benefit you don't see in token counts.
 
 **Savings scale with project size.** On a 650-file project, structured-task savings cluster around ~522K tokens per session. On a 5,000-file enterprise codebase, savings grow **non-linearly** — without trace-mcp, the agent reads more wrong files before finding the right one. With trace-mcp, graph traversal stays O(relevant edges), not O(total files).
 
-**Composite tasks deliver the biggest wins.** A single `get_task_context` call replaces a chain of ~10 sequential operations (search → get_symbol × 5 → Read × 3 → Grep × 2). That's **one round-trip instead of ten** — fewer tokens, lower latency, and one clean answer instead of ten partial ones.
+**Composite tasks deliver the biggest wins.** A single `get_task_context` call replaces a chain of ~10 sequential operations (search → get_symbol × 5 → Read × 3 → Grep × 2). That's **one round-trip instead of ten**, which is where most of the latency saving comes from.
 
 ### Run it yourself
 
@@ -326,7 +326,7 @@ Then in your MCP client:
 
 ## Local-first by design
 
-trace-mcp runs entirely on your machine. Your source code is never the product.
+trace-mcp runs entirely on your machine. Nothing about your source code is uploaded, and there is no account to create.
 
 - **Indexing happens locally.** The MCP server is a Node process you run yourself — stdio or `http://127.0.0.1:3741`.
 - **Index lives in `~/.trace-mcp/`**, never inside your project and never uploaded. Your repo directory stays clean unless you opt into `.traceignore` or `.trace-mcp/.config.json`.
@@ -334,7 +334,7 @@ trace-mcp runs entirely on your machine. Your source code is never the product.
 - **No telemetry about your code, queries, or usage.** The only thing that ever leaves your machine is described below — nothing else is phoned home.
 - **What your AI client sees is governed by your AI client.** trace-mcp returns graph results over MCP; how Claude Code / Cursor / Codex / Windsurf forward them to a model is up to that client's privacy model.
 - **The daemon trusts loopback and nothing else.** `serve-http` is unauthenticated by design: a caller on `127.0.0.1` is already you. A non-loopback `--host` is therefore refused unless you pass `--allow-remote` and front the port with your own auth — see [Configuration](https://trace-mcp.com/configuration.html#http-daemon--one-warm-index-shared-across-many-projects).
-- **To wipe everything**, delete `~/.trace-mcp/`. That is the entire footprint.
+- **To wipe everything**, delete `~/.trace-mcp/` — that directory is the whole footprint.
 
 ### Usage telemetry
 
@@ -374,7 +374,7 @@ Picking **Max** during `trace-mcp init` (the default) layers on two more amplifi
 - **tweakcc system-prompt rewrites** patch Claude Code's core tool descriptions so the model internalizes "use trace-mcp search" instead of "use Grep" from the start. Claude Code only.
 - **`agent_behavior: "strict"`** ships a compact set of discipline rules via MCP instructions — no flattery, disagree on wrong premises, never fabricate, goal-driven execution, 2-strike session hygiene, no drive-by refactors. Cross-client (Claude Code, Cursor, Codex, Windsurf) and auto-updates on `npm upgrade trace-mcp` without re-running `init`.
 
-This is the "make every teammate's agent behave like a senior engineer by default" setup. Tune or disable via `tools.agent_behavior` in `~/.trace-mcp/.config.json` — see [Tool exposure & agent behavior](https://trace-mcp.com/configuration.html#tool-exposure--agent-behavior).
+This is the setup for making the same discipline rules apply to every teammate's agent without asking anyone to configure it. Tune or disable via `tools.agent_behavior` in `~/.trace-mcp/.config.json` — see [Tool exposure & agent behavior](https://trace-mcp.com/configuration.html#tool-exposure--agent-behavior).
 
 ---
 
@@ -448,7 +448,7 @@ If you're shipping AI features in production — internal copilots, customer-fac
 
 **What you get:** a clear, before/after report on whether context optimization moves the metrics that matter for your stack — and a path to scale usage with confidence instead of throttling it on cost.
 
-We're not optimizing for cost reduction in isolation. We're optimizing for systems that work at scale: teams that move from unstable usage to reliable production and *then* grow their LLM footprint.
+The target is a system that stays predictable as usage grows, not a one-off cost cut: teams usually want to reach reliable production first and expand their LLM footprint after.
 
 **Get in touch:** open an issue at [github.com/nikolai-vysotskyi/trace-mcp/issues](https://github.com/nikolai-vysotskyi/trace-mcp/issues) tagged `pilot`, or reach out to [@nikolai-vysotskyi](https://github.com/nikolai-vysotskyi).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@ layout: null
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 
   <!-- ── Primary Meta ── -->
-  <title>trace-mcp — Make AI agents understand your codebase, not just read it</title>
+  <title>trace-mcp — precomputed code intelligence for AI coding agents</title>
   <meta name="description" content="A structured map of your codebase for AI agents. trace-mcp indexes your repo once so agents stop re-reading the same files every turn. ~40–50% fewer tokens on average, faster responses, more reliable at scale. Open source, local-first, MCP-native.">
   <meta name="keywords" content="ai execution layer, recomputation, context bloat, token reduction, ai agents, mcp, model context protocol, code intelligence, code graph, llm developer tools, agent observability, agent optimization, claude code, cursor, windsurf, dependency graph, tree-sitter, lsp">
   <meta name="author" content="Nikolai Vysotskyi">
@@ -52,7 +52,7 @@ layout: null
   <meta property="og:site_name" content="trace-mcp">
   <meta property="og:locale" content="en_US">
   <meta property="og:url" content="https://trace-mcp.com/">
-  <meta property="og:title" content="trace-mcp — Make AI agents understand your codebase, not just read it">
+  <meta property="og:title" content="trace-mcp — precomputed code intelligence for AI coding agents">
   <meta property="og:description" content="A structured map of your codebase for AI agents. Stop paying for the same re-reads every turn. ~40–50% fewer tokens, faster responses, more reliable at scale.">
   <meta property="og:image" content="https://trace-mcp.com/og-image.png">
   <meta property="og:image:secure_url" content="https://trace-mcp.com/og-image.png">
@@ -63,7 +63,7 @@ layout: null
 
   <!-- ── Twitter / X Card ── -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="trace-mcp — Make AI agents understand your codebase, not just read it">
+  <meta name="twitter:title" content="trace-mcp — precomputed code intelligence for AI coding agents">
   <meta name="twitter:description" content="A structured map of your codebase for AI agents. ~40–50% fewer tokens, faster responses, more reliable at scale. Open source, local-first.">
   <meta name="twitter:image" content="https://trace-mcp.com/og-image.png">
   <meta name="twitter:image:alt" content="trace-mcp graph explorer visualizing symbol connections across a codebase">
@@ -1989,7 +1989,7 @@ layout: null
       </div>
 
       <h1 class="hero-headline">
-        Make AI agents understand your codebase &mdash; <span class="em">not just read it.</span>
+        Your agent re-reads the same code every turn. <span class="em">trace-mcp indexes it once.</span>
       </h1>
 
       <p class="hero-desc">
@@ -2020,7 +2020,7 @@ layout: null
         <span class="dot"></span>
         <span>MIT licensed</span>
         <span class="dot"></span>
-        <span>Used in real LLM workflows</span>
+        <span>Works with Claude Code, Cursor, Windsurf</span>
         <span class="dot"></span>
         <span>Runs locally &middot; no data leaves your machine</span>
       </p>
@@ -2142,7 +2142,7 @@ layout: null
         <div class="section-meta-tag"><span class="label">001 / Problem</span></div>
         <div>
           <h2 class="section-title">AI agents recompute work <span class="em">they've already done.</span></h2>
-          <p class="section-lede">Every turn, the agent re-reads the same files, re-traverses the same dependencies, and re-inflates the context window with structure it discovered five steps ago. Token bills grow. Latency grows. Reasoning quality drops. The model isn't the bottleneck &mdash; the recomputation leak is.</p>
+          <p class="section-lede">Every turn, the agent re-reads the same files, re-traverses the same dependencies, and re-inflates the context window with structure it discovered five steps ago. That repeated work is most of what a long session costs in tokens and latency.</p>
         </div>
       </div>
 
@@ -2181,7 +2181,7 @@ layout: null
       </div>
 
       <div class="sol-block reveal">
-        <p class="sol-lede">Show the leak. Explain it. Close it. <span class="em">Keep it closed.</span></p>
+        <p class="sol-lede">Measure what the agent reads, explain why it reads it twice, remove the repeated work, <span class="em">and keep it from coming back.</span></p>
         <div class="sol-list">
           <div class="sol-item">
             <span class="sol-mark">01</span>
@@ -2217,7 +2217,7 @@ layout: null
 
       <div class="definition reveal">
         <div class="def-text">
-          <h3>This is how agents stop <span class="em">recomputing and start reusing.</span></h3>
+          <h3>What the agent queries <span class="em">instead of your files.</span></h3>
           <p><strong>Computed once</strong> &mdash; every symbol, every edge, across {{ site.data.counts.languages }} languages in one directed graph. The agent queries it instead of rediscovering it each turn.</p>
           <p><strong>Framework-aware</strong> &mdash; routes to controllers, Inertia to Vue, Eloquent to migrations. {{ site.data.counts.frameworks }} integrations capture edges the agent would otherwise reconstruct from raw files.</p>
           <p><strong>Compiler-grade where it matters</strong> &mdash; optional LSP enrichment with <code>tsserver</code>, <code>pyright</code>, <code>gopls</code> for call resolution that survives across calls.</p>
@@ -2265,8 +2265,8 @@ layout: null
       <div class="section-meta">
         <div class="section-meta-tag"><span class="label">004 / How It Works</span></div>
         <div>
-          <h2 class="section-title">Three steps. <span class="em">Setup in minutes.</span></h2>
-          <p class="section-lede">Connect. Index. Expose. After that, agents operate with full context &mdash; and the graph stays in sync automatically as you code.</p>
+          <h2 class="section-title">Three steps to <span class="em">a working index.</span></h2>
+          <p class="section-lede">Connect the repo, let it index, point your MCP client at it. The graph then stays in sync automatically as you code.</p>
         </div>
       </div>
 
@@ -2316,8 +2316,8 @@ layout: null
       <div class="section-meta">
         <div class="section-meta-tag"><span class="label">005 / Core Capabilities</span></div>
         <div>
-          <h2 class="section-title">The five calls that <span class="em">replace 90% of recomputation.</span></h2>
-          <p class="section-lede">Five tools from a surface of {{ site.data.counts.tools }} &mdash; the ones agents reach for first. Each one collapses what would otherwise be a chain of Reads, Greps, and Globs into a single graph query. Token cost drops; the answer gets sharper.</p>
+          <h2 class="section-title">The five calls agents <span class="em">reach for first.</span></h2>
+          <p class="section-lede">Five tools from a surface of {{ site.data.counts.tools }} &mdash; the ones agents reach for first. Each one collapses what would otherwise be a chain of Reads, Greps, and Globs into a single graph query.</p>
         </div>
       </div>
 
@@ -2387,7 +2387,7 @@ layout: null
         </div>
       </div>
 
-      <p class="compare-coda">Agents need <span class="em">reuse, not more search.</span></p>
+      <p class="compare-coda">The difference shows up <span class="em">on the second question, not the first.</span></p>
       <p class="tool-more">Side-by-side tables against every comparable tool: <a href="/comparisons.html">Comparisons &rarr;</a></p>
     </div>
   </section>
@@ -2398,7 +2398,7 @@ layout: null
       <div class="section-meta">
         <div class="section-meta-tag"><span class="label">007 / Differentiation</span></div>
         <div>
-          <h2 class="section-title">Reuse is the unlock, <span class="em">not more search.</span></h2>
+          <h2 class="section-title">Why a graph beats <span class="em">a better search index.</span></h2>
         </div>
       </div>
 
@@ -2410,8 +2410,7 @@ layout: null
           <li><span class="num">/ 04</span><span><strong>Reuse survives the session</strong> &mdash; incremental reindex, decision memory, agent-behavior rules keep cost from rebounding.</span></li>
         </ul>
         <p class="diff-quote">
-          This is <span class="neg">not code search.</span><br>
-          This is <span class="pos">recomputation &rarr; reuse</span> for AI systems.
+          A text index is re-ranked on every query. A graph is <span class="pos">computed once and traversed</span> &mdash; so the second question about a repo costs a fraction of the first.
         </p>
       </div>
     </div>
@@ -2520,7 +2519,7 @@ layout: null
         <div class="section-meta-tag"><span class="label">011 / Ecosystem</span></div>
         <div>
           <h2 class="section-title">{{ site.data.counts.frameworks }} integrations. <span class="em">{{ site.data.counts.languages }} languages.</span></h2>
-          <p class="section-lede">Each integration adds framework-specific edges &mdash; routes, components, migrations, queries &mdash; not just syntax parsing. Plugin API is open: write your own for a niche framework in under a day.</p>
+          <p class="section-lede">Each integration adds framework-specific edges &mdash; routes, components, migrations, queries &mdash; not just syntax parsing. The plugin API is open; most plugins are 200&ndash;500 lines of TypeScript.</p>
         </div>
       </div>
 
@@ -2729,7 +2728,7 @@ layout: null
         <span class="em">The execution layer for AI systems.</span>
       </h2>
       <p class="category-sub">
-        AI systems don't scale because they recompute instead of reuse. Every turn costs tokens, latency, and reasoning quality on work the agent has already done. trace-mcp turns recomputation into a precomputed, queryable structure &mdash; starting with code, where the noise is loudest, and extending to anywhere agents pay twice for the same answer.
+        AI systems pay repeatedly for work they have already done: every turn re-derives structure the agent held a few steps earlier. trace-mcp precomputes that structure once and serves it over MCP. Code is where the repetition is most expensive today, which is where we started.
       </p>
     </div>
   </section>
@@ -2740,11 +2739,11 @@ layout: null
     <div class="container cta-content">
       <span class="label cta-label">/ Open Source · Mit License · Zero Api Keys</span>
       <h2 class="cta-headline">
-        Stop burning tokens.<br>
-        <span class="em">Make AI work at scale.</span>
+        Index once,<br>
+        <span class="em">query for the rest of the session.</span>
       </h2>
       <p class="cta-sub">
-        ~40&ndash;50% lower token usage on average in production. Up to 94&ndash;99% in structured tasks. One install. Every project. Every AI agent that speaks MCP.
+        <a href="/reduce-claude-code-token-usage.html">~40&ndash;50% lower token usage on average</a>, and up to 94&ndash;99% on structured tasks. One install, and every MCP-capable agent in the project gets the same graph.
       </p>
       <div class="cta-buttons">
         <a href="#install" class="btn btn-primary">


### PR DESCRIPTION
Closes TRA-418.

A detect-only `no-ai-slop` pass over the repo found the machine-authored voice concentrated in exactly two files: `docs/index.html` and the framing sections of `README.md`. The engineering docs — perf, security, contributing, design, the `/vs/` argument bodies — read as written by someone with opinions and measurements, and are untouched here.

## What changed

The dominant tell was the **negation kicker** ("not X — Y"), used nine times across the two files, several times to make the same point:

| Was | Now |
|---|---|
| "Make AI agents understand your codebase — not just read it." (H1, `<title>`, og, twitter) | "Your agent re-reads the same code every turn. trace-mcp indexes it once." |
| "This is not code search. This is recomputation → reuse for AI systems." | "A text index is re-ranked on every query. A graph is computed once and traversed — so the second question about a repo costs a fraction of the first." |
| "Reuse is the unlock, not more search." | "Why a graph beats a better search index." |
| "Agents need reuse, not more search." | "The difference shows up on the second question, not the first." |
| "The model isn't the bottleneck — the recomputation leak is." (both files) | "That repeated work is most of what a long session costs in tokens and latency." |
| "AI is bottlenecked not by models, but by recomputation." | "The binding constraint is recomputation, not model capability." |
| "## Token reduction — measured, not marketed" | "## Token reduction — what we measured" |

Plus the fragmented triplets ("Show the leak. Explain it. Close it. Keep it closed.", "Stop burning tokens. / Make AI work at scale.", "Three steps. Setup in minutes.") and two puffery headings ("## Why this matters", "Four things no other tool does").

## Four claims dropped or sourced

These were wrong or unsupportable independent of voice:

- `index.html` — **"The five calls that replace 90% of recomputation."** Unsourced, and contradicted by the site's own 40–50% figure. Now "The five calls agents reach for first."
- `index.html` — **"Used in real LLM workflows"** as a trust badge. Unverifiable. Now names the clients that actually work: Claude Code, Cursor, Windsurf.
- `index.html` — **"write your own for a niche framework in under a day"**. Unsupported. Replaced with the 200–500 line figure the README already states.
- `README.md` — **"One tool call replaces ~42 minutes of agent exploration."** Suspiciously precise, unsourced. Dropped; the concrete "80 Grep calls and 190 file reads" comparison in the same sentence already carries the point.

The final CTA's ~40–50% claim now links to `/reduce-claude-code-token-usage.html`, which carries the honest methodology disclosure ("our own aggregate figure from our own usage, not a third-party benchmark"). That was finding #7 of the SEO audit and it was one line, so it is here rather than in TRA-419.

## Test evidence

```
pnpm vitest run tests/docs
 Test Files  7 passed (7)
      Tests  84 passed (84)
```

`readme-claims.test.ts` (58 assertions against `_data/counts.yml` and the real tool surface) passes unchanged — no number claims were touched.

Docs and site copy only; no code changes.

Agent: Lead Engineer