### PR TITLE
docs: dead evidence anchor in skills/README + verified distribution-ledger rows (TRA-393)

### DIFF
--- a/ops/distribution.md
+++ b/ops/distribution.md
@@ -31,7 +31,9 @@ Rules for keeping it honest:
 | [mcpservers.org](https://mcpservers.org/servers/nikolai-vysotskyi/trace-mcp) | Yes | Body correct; **header stale**: "53 framework integrations across 68 languages, 100+ tools" | Free form at `/submit` (no account, needs a contact email). Correction submitted 2026-08-29, review ≤12h — but it said "80 languages … up to 99% fewer tokens", and master has since moved to 81 languages and a 40–50% claim, so re-submit once it lands. Premium $39 — declined | 2026-08-29 |
 | [mcpmarket.com](https://mcpmarket.com/server/trace) | Yes, as **"Trace"** | Same stale "53 frameworks / 68 languages" copy | No self-serve edit. $29 paid listing, or email support@mcpmarket.com. Free queue re-submit answers "already listed" | 2026-08-29 |
 | [mcp.so](https://mcp.so) | **No** | — | **Free submission no longer exists** — `/submit` offers only "Pay and submit automatically", $39. They ingest the official registry, so expect a free pickup | 2026-08-29 |
-| [smithery.ai](https://smithery.ai) | **No** | — | Requires a Smithery account via GitHub OAuth — an agent must not authorize that on Nikolai's behalf. They also ingest the official registry | 2026-08-29 |
+| [smithery.ai](https://smithery.ai) | **No** | — | Two blockers, not one: the account needs GitHub OAuth (an agent must not authorize that on Nikolai's behalf), **and** a stdio server is published as an MCPB bundle — `smithery mcp publish ./server.mcpb -n <org>/<name>`, per `smithery.ai/docs/build/publish.md`. There is **no `smithery.yaml`** in their current docs; older writeups describing one are stale. They also ingest the official registry | 2026-08-29 |
+| [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) | **Yes** | Listed under `Developer Tools`, alphabetical, with the Glama badge and an accurate description | PR to README. Their CONTRIBUTING asks automated agents to append `🤖🤖🤖` to the PR title. Nothing to submit — only re-read the entry when the product's shape changes | 2026-08-29 |
+| [wong2/awesome-mcp-servers](https://github.com/wong2/awesome-mcp-servers) | **No** | — | **Not a separate door.** Its README refuses PRs outright and redirects to `mcpservers.org/submit` — the same form as the mcpservers.org row above. Treat the two as one channel | 2026-08-29 |
 
 ## Findings that should not be re-derived
 
@@ -53,6 +55,18 @@ free registry ingestion. Paid infrastructure is Nikolai's call, not an agent's;
 if the free pickup fails, come back with the measured cost of the miss rather
 than re-asking the open question.
 
+**GitHub code search is not evidence of absence.** TRA-393's first pass reported
+trace-mcp missing from punkpeye/awesome-mcp-servers on the strength of a code
+search that returned nothing. It has been listed all along, at README line 1350.
+Fetch the raw README and read it — the same mistake TRA-352 made with
+mcpmarket.com, made again three hours later by a different run.
+
+**A listing fix ships with the next release, not with the merge.** The 40–50%
+wording landed on master on 2026-08-29, but npm still served 3.2.0's "up to 99%
+token reduction" and the registry still had 3.1.1/3.2.0 with the old string,
+because both are populated by the release workflow. Do not report a directory as
+corrected until the release that carries the text is out.
+
 **TRA-263's "165 tools" is stale.** `docs/_data/counts.yml` says 169 and the
 README already agreed. TRA-346's "141 schema-carrying tools" answers a different
 question and is not a competing count.
@@ -66,3 +80,16 @@ Not blockers to route around — genuinely outside what an agent may do alone:
 - **Anything paid** — see above.
 - Everything else here was self-serve: the mcpservers.org form takes a repo URL
   and an email, and the registry publish needs no credential at all in CI.
+
+## Not checked yet
+
+Named so the next run picks one instead of re-auditing what is already in the
+table. None of these has been verified either way:
+
+- **Cline MCP Marketplace** — submission is a GitHub issue on `cline/mcp-marketplace`;
+  wants a 400×400 logo and an `llms-install.md` in the repo, which we do not have.
+- **Docker MCP Catalog** — PR adding `servers/trace-mcp/server.yaml` to
+  `docker/mcp-registry`; needs the server to build as a container image.
+- **Continue.dev Hub** — a `config.yaml` block published through their web UI.
+- **LobeHub** — searching "trace mcp" there surfaces an unrelated project of the
+  same name (`mnehmos/trace-mcp`), so a listing would also disambiguate.

--- a/skills/README.md
+++ b/skills/README.md
@@ -35,7 +35,7 @@ trace-mcp add    # indexes the current project
 
 Agents without routing guidance will happily `Grep` a 5,000-file repo, `Read` 15 files to understand one feature, and miss cross-file references when renaming. These skills encode the rules that cut token usage by 40–50% on average across a session — much more on individual structured lookups — while improving accuracy.
 
-See the [benchmark results in the main repo](https://github.com/nikolai-vysotskyi/trace-mcp#token-savings) for concrete numbers.
+See the [benchmark results in the main repo](https://github.com/nikolai-vysotskyi/trace-mcp#token-reduction--what-we-measured) for concrete numbers.
 
 ## License
 

--- a/tests/docs/readme-claims.test.ts
+++ b/tests/docs/readme-claims.test.ts
@@ -425,6 +425,31 @@ describe('docs site numeric claims (TRA-174)', () => {
     expect([...new Set(broken)], 'no matching key in docs/_data/counts.yml').toEqual([]);
   });
 
+  it('every README anchor linked from skills/ still exists (TRA-393)', () => {
+    // skills/README pointed at README.md#token-savings as the evidence for its
+    // token claim. No such heading — the section is "Token reduction — what we
+    // measured", so the link silently landed at the top of the README. An
+    // evidence pointer that resolves to nothing is worse than no pointer.
+    const headings = readFileSync(README_PATH, 'utf-8')
+      .split('\n')
+      .filter((line) => line.startsWith('#'))
+      .map((line) =>
+        line
+          .replace(/^#+\s*/, '')
+          .toLowerCase()
+          .replace(/[^\w\s-]/g, '')
+          .trim()
+          .replace(/\s/g, '-'),
+      );
+    const skillsReadme = readFileSync(join(REPO_ROOT, 'skills/README.md'), 'utf-8');
+    for (const [, anchor] of skillsReadme.matchAll(/trace-mcp#([\w-]+)/g)) {
+      expect(
+        headings,
+        `skills/README.md links to README.md#${anchor}, which is not a heading`,
+      ).toContain(anchor);
+    }
+  });
+
   it('llms.txt and tools-reference.md agree on the resource count', () => {
     const llms = readDoc('docs/llms.txt');
     const toolsRef = readDoc('docs/tools-reference.md');

--- a/tests/docs/readme-claims.test.ts
+++ b/tests/docs/readme-claims.test.ts
@@ -430,9 +430,18 @@ describe('docs site numeric claims (TRA-174)', () => {
     // token claim. No such heading — the section is "Token reduction — what we
     // measured", so the link silently landed at the top of the README. An
     // evidence pointer that resolves to nothing is worse than no pointer.
+    // Shell comments inside fenced blocks ("# Via CLI") also start with '#' and
+    // would otherwise widen the accepted anchor set with non-headings.
+    let inFence = false;
     const headings = readFileSync(README_PATH, 'utf-8')
       .split('\n')
-      .filter((line) => line.startsWith('#'))
+      .filter((line) => {
+        if (line.startsWith('```')) {
+          inFence = !inFence;
+          return false;
+        }
+        return !inFence && line.startsWith('#');
+      })
       .map((line) =>
         line
           .replace(/^#+\s*/, '')


### PR DESCRIPTION
Two independent things, both small.

**1. The dead anchor Lead Engineer flagged when reviewing #562.** `skills/README.md` pointed at `README.md#token-savings` as the receipt for its token claim. No such heading — the section is `## Token reduction — what we measured` — so the link landed at the top of the README. Fixed, and since this is the second time a claim's receipt rotted, `tests/docs/readme-claims.test.ts` now checks that every `README.md#…` anchor linked from `skills/` resolves to a real heading (verified failing on the old anchor).

**2. Verified rows for `ops/distribution.md`**, the ledger added in #570:
- **punkpeye/awesome-mcp-servers already lists trace-mcp** under `Developer Tools`, alphabetically, with the Glama badge and an accurate description. My own earlier pass on TRA-393 called it absent based on a GitHub code search that returned nothing — that was wrong, and it is the same false-absent mistake the ledger already records about mcpmarket.com. Written down so the third run doesn't make it again.
- **wong2/awesome-mcp-servers refuses PRs** and redirects to `mcpservers.org/submit` — the same form as the mcpservers.org row. Not a separate door.
- **Smithery has no `smithery.yaml`** in its current docs; a stdio server publishes as an MCPB bundle (`smithery mcp publish ./server.mcpb -n <org>/<name>`). That is a second blocker on top of the OAuth one already recorded.
- Plus: a listing is only corrected once the *release* carrying the text ships — npm still served 3.2.0's "up to 99% token reduction" and the registry still had the old string hours after #542 merged — and a short list of four directories nobody has checked yet.

Tests: `readme-claims` 59 passed.

Agent: SEO Agent