### PR TITLE
feat(app): a Language row in the app menu and in Settings (TRA-388)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -735,6 +735,29 @@ not glyphs, and the list is only going to grow. Language names are written in th
 own language ("Русский", not "Russian"): someone hunting for their language is
 looking for what they call it.
 
+As shipped (TRA-388), with two languages, that is a pill — and the first **word**
+segments the row has carried, which is a mode of `MenuChoiceRow`, not a second
+control: a `MenuChoice` gives `text` instead of `icon` and the track takes `is-text`.
+Two things come back off the icon geometry, and both are the same rule seen twice —
+*a word is its own fallback, a glyph is not*:
+
+- **The visible text is the two-letter form, the full name is the accessible name.**
+  A segment has room for "EN", not for "Русский"; `aria-label` and `title` carry the
+  name in full, exactly as the icon segments carry theirs. The pop-up button in
+  Settings has the width, so there it is the full name.
+- **A word segment keeps its padding and its colour.** `0 8px` puts the segment at
+  34px against the icon square's 24px — measured 73.9px for the two-language track,
+  right-aligned at the same 214.5px as the Theme pill and an item's shortcut, so the
+  rows share a column. And unselected stays at `--label` (13.11:1 light, 8.88:1 dark)
+  rather than dropping to `--label-secondary`: the dimming exists because an
+  unselected icon has only the 1.19:1 thumb to go on, and dimming a readable word
+  would say "disabled" instead of "not chosen".
+
+**Both surfaces read `LOCALES`**, through `localeOptions()` in `renderer/i18n/`, the
+same way Theme's two surfaces read `appearanceOptions()`. And unlike Theme, Language
+is not a prop: `setLocale` already persists, mirrors to the main process and syncs
+across windows, so a component that needs the value calls `useLocale()`.
+
 ### The window minimum is a size that has to work
 
 `main/tray.ts` sets `minWidth: 640, minHeight: 420`. Every surface must be usable
@@ -1084,6 +1107,10 @@ new evidence.
 | A choice in a menu is one row with the control inline, not a header plus one item per value | Appearance first shipped as an `APPEARANCE` caps header over three checked items: four rows for one three-state preference, in the menu built to stop the footer spending a row per thing. A header over a single control is weight without information. One row, name left, pill right, on the shared centre line — and the rule is written for every future choice, not solved for Theme (TRA-363). |
 | A choice row is `group` + `menuitemradio`, one keyboard stop, and does not close the menu | `radiogroup` is not a legal child of `role="menu"`, and the shared `SegmentedControl`'s `aria-pressed` says "toggled" rather than "chosen". The row is one Up/Down stop resolved to the checked segment, Left/Right move inside it, and picking a value leaves the menu open — an inline switcher exists so you can watch the app change under it. |
 | Icon-only segments dim when unselected; word segments do not | The selected thumb is 1.19:1 light / 1.63:1 dark against the track. On a word that is enough because the word stays readable (TRA-292); an icon has no fallback, so the only cue would be a sub-3:1 fill. Unselected icons drop to `--label-secondary` (4.5:1 on the track). |
+| A choice row's segments carry words when no glyph names the value, and keep their colour | Language is the case: "EN" is not a symbol anyone drew. `MenuChoiceRow` grew a `text` mode rather than a second control, and `is-text` gives the segment its `0 8px` back (34px, against the icon square's 24px) and leaves it at `--label` — 13.11:1 light, 8.88:1 dark. Dimming a word that stays perfectly readable reads as disabled, not as unchosen (TRA-388). |
+| Language names are never translated, and the short form is only what is *visible* | Someone hunting for their language is looking for "Русский", not for whatever the current language calls it — so `LOCALES` is `i18n-exempt` by design. The menu row shows "RU" because a segment has no room for the word; the full name is its `aria-label` and `title`, and Settings' pop-up button, which has the width, shows the name itself. |
+| The app's own preferences are one group, headed "App" against the "Daemon" card above it | The group was headed "Appearance" while Theme was the only thing in it. Adding Language made that heading a lie, and "Language" over a row labelled "Language" would have been a header over a single control — the thing this file bans in menus for the same reason. "General" was already the first schema group on the same screen (TRA-388). |
+| A preference with no second owner is read where it is used, not passed down | `appearance` is a prop because App.tsx also mirrors it to the main process for the sidebar's vibrancy view. `setLocale` already persists, mirrors and syncs across windows itself, so `useLocale()` at the point of use is the whole wiring — a prop would have been plumbing with a second copy of the state at the end of it. |
 | A global action is defined once, in `src/shared/global-actions.ts` | The native menu and the app menu both offer Settings / View changelog / Get help / Check for updates. Two hand-maintained lists drift — a relabelled item, a moved key, an action added to one and forgotten in the other. Neither surface types a label; both read the entry. |
 | A glyph names the action; sparkles and speech bubbles are banned by name | `auto_awesome` decorates instead of naming — it says "exciting", not what the item does. `forum` promises a person to talk to, and no surface here provides one. Both shipped anyway, against a reference that showed the right glyphs, which is the second half of this decision: when a reference is supplied, match it or argue it in the PR — never substitute silently. |
 | "View changelog", not "What's new" | The item opens the releases page. Someone checking whether a specific fix shipped searches for the word "changelog"; "What's new" describes a feeling about the page, not the page. |

--- a/packages/app/src/renderer/components/AppMenu.tsx
+++ b/packages/app/src/renderer/components/AppMenu.tsx
@@ -22,7 +22,7 @@ import { Icon } from '../lattice/icons';
 import { Menu, MenuChoiceRow, MenuItem, MenuSeparator, useMenuAnchor } from '../lattice/ui';
 import { GLOBAL_ACTIONS, type GlobalAction } from '../../shared/global-actions.js';
 import { appearanceOptions, type Appearance } from '../theme.js';
-import { t } from '../i18n/index.js';
+import { localeOptions, t, useLocale } from '../i18n/index.js';
 import { describeStaleRoots, formatAgo, type UpdateState } from '../update-check.js';
 import { SidebarRow } from './SidebarRow';
 
@@ -84,6 +84,11 @@ export function AppMenu({
   // Unnamespaced: the shared action list carries fully-qualified keys, because
   // the native menu resolves the same ones in the main process.
   const { t } = useTranslation();
+  /* Not a prop, unlike `appearance`: the language has no second owner. `theme`
+     is passed down because App.tsx also mirrors it to the main process for the
+     sidebar's NSVisualEffectView; `setLocale` already does its own mirroring
+     and its own cross-window sync, so a prop would only be plumbing. */
+  const { locale, setLocale } = useLocale();
   const open = menu.at !== null;
   const summary = updateSummary(update, checking);
 
@@ -194,6 +199,17 @@ export function AppMenu({
             options={appearanceOptions()}
             value={appearance}
             onChange={onAppearanceChange}
+          />
+          {/* Same group as Theme, no separator between them: both are app
+              preferences you may want to try, as opposed to the commands below.
+              Two languages fit a pill; the segments carry the two-letter form
+              because a language name is a word, and the full name — written in
+              its own language — is the accessible name and the tooltip. */}
+          <MenuChoiceRow
+            label={t('shell:language')}
+            options={localeOptions()}
+            value={locale}
+            onChange={setLocale}
           />
           <MenuSeparator />
           {links.map(item)}

--- a/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
@@ -10,9 +10,10 @@
      focus comes back to the trigger instead of landing on <body>. */
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GLOBAL_ACTIONS } from '../../../shared/global-actions.js';
-import { t } from '../../i18n';
+import { LOCALE_KEY } from '../../../shared/i18n/locales.js';
+import { setLocale, t } from '../../i18n';
 import type { UpdateState } from '../../update-check.js';
 import { AppMenu, type AppMenuProps } from '../AppMenu';
 
@@ -46,6 +47,13 @@ function openMenu(trigger: HTMLElement): HTMLElement {
 beforeEach(() => {
   openExternal.mockReset();
   (window as unknown as { electronAPI: unknown }).electronAPI = { openExternal };
+});
+
+/* The Language row switches for real — there is no store to fake, which is the
+   point of it. Put the language back so the rest of the file reads English. */
+afterEach(() => {
+  setLocale('en');
+  localStorage.removeItem(LOCALE_KEY);
 });
 
 describe('sidebar app menu', () => {
@@ -126,6 +134,60 @@ describe('sidebar app menu', () => {
     expect(options.map((o) => o.tabIndex)).toEqual([-1, -1, 0]);
   });
 
+  /* TRA-388. Same row shape as Theme, with the one difference the values force:
+     a language name is a word, so the segments carry the two-letter form and
+     the full name — written in its OWN language, never translated — is the
+     accessible name and the tooltip. */
+  it('offers Language as one labelled row whose segments are words', () => {
+    const { trigger } = renderMenu();
+    const row = within(openMenu(trigger)).getByRole('group', { name: 'Language' });
+
+    const options = within(row).getAllByRole('menuitemradio');
+    expect(options.map((o) => o.textContent)).toEqual(['EN', 'RU']);
+    expect(options.map((o) => o.getAttribute('aria-label'))).toEqual(['English', 'Русский']);
+    expect(options.map((o) => o.getAttribute('title'))).toEqual(['English', 'Русский']);
+    expect(options.map((o) => o.getAttribute('aria-checked'))).toEqual(['true', 'false']);
+    expect(options[0].className).toContain('is-active');
+    // The track says it holds words, which is what island.css keys the padding
+    // and the full-strength unselected colour off.
+    expect(row.querySelector('.ws-ctx-seg')?.className).toContain('is-text');
+    expect(options.map((o) => o.tabIndex)).toEqual([0, -1]);
+  });
+
+  it('switches the whole menu at once, without closing it', () => {
+    const { trigger } = renderMenu();
+    const menu = openMenu(trigger);
+    const row = within(menu).getByRole('group', { name: 'Language' });
+
+    fireEvent.click(within(row).getByRole('menuitemradio', { name: 'Русский' }));
+
+    // The row it lives in, and a neighbour it does not own: the switch is the
+    // whole UI, not one label.
+    expect(within(menu).getByRole('group', { name: 'Язык' })).toBeTruthy();
+    expect(within(menu).getByRole('group', { name: 'Оформление' })).toBeTruthy();
+    expect(localStorage.getItem(LOCALE_KEY)).toBe('ru');
+    // …and the menu is still open to see it happen.
+    expect(screen.queryByRole('menu')).not.toBeNull();
+  });
+
+  it('moves within the Language row on left/right and past it on down', () => {
+    const { trigger } = renderMenu();
+    const menu = openMenu(trigger);
+    const checked = within(menu).getByRole('menuitemradio', { name: 'English' });
+
+    fireEvent.keyDown(checked, { key: 'ArrowRight' });
+    expect(within(menu).getByRole('group', { name: 'Язык' })).toBeTruthy();
+
+    fireEvent.keyDown(within(menu).getByRole('menuitemradio', { name: 'Русский' }), {
+      key: 'ArrowLeft',
+    });
+    expect(within(menu).getByRole('group', { name: 'Language' })).toBeTruthy();
+
+    // Down out of the row reaches the items below, not the next segment.
+    fireEvent.keyDown(document, { key: 'End' });
+    expect(document.activeElement?.textContent).toContain('Check for updates');
+  });
+
   /* The hard part Lead Engineer called out: two axes in one menu. Up/down has
      to keep moving between rows while left/right moves inside the switcher. */
   it('moves within the switcher on left/right and out of it on up/down', () => {
@@ -146,9 +208,12 @@ describe('sidebar app menu', () => {
     fireEvent.keyDown(checked, { key: 'ArrowLeft' });
     expect(onAppearanceChange).toHaveBeenLastCalledWith('auto');
 
-    // …and down again leaves the row entirely, rather than stepping to Dark.
+    // …and down again leaves the row entirely, rather than stepping to Dark:
+    // the next stop is the Language row, then the first real item after it.
     fireEvent.keyDown(document, { key: 'ArrowDown' });
     expect(row.contains(document.activeElement)).toBe(false);
+    expect(document.activeElement?.getAttribute('aria-label')).toBe('English');
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
     expect(document.activeElement?.textContent).toContain('View changelog');
   });
 
@@ -184,12 +249,12 @@ describe('sidebar app menu', () => {
   it('arrows through the items and wraps', () => {
     const { trigger } = renderMenu({ appearance: 'auto' });
     const menu = openMenu(trigger);
-    /* The stop list, not the element list: the Theme row contributes ONE stop
-       (its checked segment), so up/down sees actions + 1. */
+    /* The stop list, not the element list: each choice row contributes ONE stop
+       (its checked segment), so up/down sees actions + 2. */
     const all = Array.from(
       menu.querySelectorAll<HTMLElement>('[role^="menuitem"]'),
     ).filter((el) => !el.closest('[data-menu-row]') || el.getAttribute('aria-checked') === 'true');
-    expect(all.length).toBe(GLOBAL_ACTIONS.length + 1); // + the Theme row
+    expect(all.length).toBe(GLOBAL_ACTIONS.length + 2); // + Theme and Language
 
     // Nothing is highlighted until the first arrow — a macOS menu does not
     // preselect its first item.

--- a/packages/app/src/renderer/i18n/index.ts
+++ b/packages/app/src/renderer/i18n/index.ts
@@ -16,9 +16,27 @@ import i18next from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import { useCallback, useEffect, useState } from 'react';
 import { CATALOGS, NAMESPACES } from '../../shared/i18n/catalog/index.js';
-import { DEFAULT_LOCALE, LOCALE_KEY, isLocale, pickLocale, type Locale } from '../../shared/i18n/locales.js';
+import {
+  DEFAULT_LOCALE,
+  LOCALES,
+  LOCALE_KEY,
+  isLocale,
+  pickLocale,
+  type Locale,
+} from '../../shared/i18n/locales.js';
 
 export { LOCALES, type Locale } from '../../shared/i18n/locales.js';
+
+/* One list, two surfaces: the app menu's row renders `text`, Settings renders
+   `label`. Same anti-drift rule as theme.ts's appearanceOptions().
+
+   Nothing here goes through `t` — a language list is the one place where
+   translating the entries is wrong, so this is not a function for the reason
+   appearanceOptions() is one (see LocaleInfo.label). It is a function so both
+   surfaces get the same shape without either of them knowing LocaleInfo. */
+export function localeOptions(): ReadonlyArray<{ value: Locale; label: string; text: string }> {
+  return LOCALES.map((l) => ({ value: l.code, label: l.label, text: l.short }));
+}
 
 /** The stored choice, or the best match for the system's languages. */
 export function initialLocale(): Locale {

--- a/packages/app/src/renderer/lattice/ui/Menu.tsx
+++ b/packages/app/src/renderer/lattice/ui/Menu.tsx
@@ -233,9 +233,14 @@ export function MenuItem({
 
 export interface MenuChoice<T extends string> {
   value: T;
-  /** The segments are icon-only, so this is the accessible name AND the tooltip. */
+  /** The accessible name AND the tooltip. For an icon segment it is the only name;
+      for a word segment it is the long form the short text abbreviates. */
   label: string;
-  icon: string;
+  /** An icon segment. Omit it and give `text` when no glyph names the value. */
+  icon?: string;
+  /** A word segment: the short visible form ("EN"). Language names are words,
+      not glyphs, so the Language row uses this (TRA-388). */
+  text?: string;
 }
 
 export interface MenuChoiceRowProps<T extends string> {
@@ -310,8 +315,9 @@ export function MenuChoiceRow<T extends string>({
       {/* No `sz-small`: at 20px the track left 1px above and below a 14px glyph
           while the segments ran 30px wide, which is the squeeze Nikolai saw —
           crushed vertically, loose horizontally (TRA-376). The default 24px
-          track carries square 20px segments; island.css sets their geometry. */}
-      <div className="lx-seg ws-ctx-seg">
+          track carries square 20px segments; island.css sets their geometry.
+          `is-text` swaps that square for a padded word segment. */}
+      <div className={'lx-seg ws-ctx-seg' + (options[0]?.icon ? '' : ' is-text')}>
         {options.map((option) => {
           const checked = option.value === value;
           return (
@@ -327,7 +333,7 @@ export function MenuChoiceRow<T extends string>({
               className={'lx-seg-item' + (checked ? ' is-active' : '')}
               onClick={() => onChange(option.value)}
             >
-              <Icon name={option.icon} size={12} />
+              {option.icon ? <Icon name={option.icon} size={12} /> : option.text}
             </button>
           );
         })}

--- a/packages/app/src/renderer/styles/island.css
+++ b/packages/app/src/renderer/styles/island.css
@@ -725,6 +725,21 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
 .ws-ctx-row .ws-ctx-seg .lx-seg-item:not(.is-active) {
   color: var(--label-secondary);
 }
+/* A WORD segment, for a value no glyph can name — the Language row (TRA-388).
+   Two things come back off the icon geometry above. The padding, because "EN"
+   is 18px of type and the icon square's 24px min-width would leave 3px a side:
+   0 8px puts the segment at 34px, so the two-language track measures 76px and
+   still lands well inside the row's 214.5px. And full-strength colour when
+   unselected — the dimming above exists because an icon has nothing but the
+   1.19:1 thumb to fall back on, whereas controls.css deliberately keeps
+   unselected WORDS at --label (TRA-292): "RU" stays readable either way, and
+   dimming it would read as disabled. */
+.ws-ctx-row .ws-ctx-seg.is-text .lx-seg-item {
+  padding: 0 8px;
+}
+.ws-ctx-row .ws-ctx-seg.is-text .lx-seg-item:not(.is-active) {
+  color: var(--label);
+}
 /* macOS rings the whole TRACK, never one segment — the thumb already says
    which segment is selected, so a second ring inside it is two answers to one
    question. */

--- a/packages/app/src/renderer/tabs/Settings.tsx
+++ b/packages/app/src/renderer/tabs/Settings.tsx
@@ -30,7 +30,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { OllamaPanel } from '../components/OllamaPanel';
-import { t } from '../i18n';
+import { localeOptions, t, useLocale } from '../i18n';
 import { Icon } from '../lattice/icons';
 import {
   Badge,
@@ -1431,37 +1431,73 @@ function BottomBar({
   );
 }
 
-/* Appearance — an app preference, not a daemon setting, so it is its own group
-   above the schema-driven list rather than a section inside it. It moved here
-   from the sidebar footer, which was carrying two 28px rows under a 38px update
-   banner (TRA-306). It renders in the daemon-down and loading states too: the
-   theme is stored in localStorage and has nothing to do with the daemon, so
-   losing the connection must not take the appearance switcher with it. */
-function AppearanceCard({
+/* The app's own preferences — Theme and Language — as opposed to the daemon's
+   configuration in every group below. That is why it is its own group above the
+   schema-driven list rather than a section inside it, and why it is headed
+   "App" against the "Daemon" card directly above: the group used to be headed
+   "Appearance" over a single "Theme" row, which worked only while Theme was the
+   only thing in it. A heading that repeats its one row's label is weight
+   without information, and "General" is already the first schema group on this
+   same screen (TRA-388).
+
+   Theme moved here from the sidebar footer, which was carrying two 28px rows
+   under a 38px update banner (TRA-306). The card renders in the daemon-down and
+   loading states too: both preferences live in localStorage and have nothing to
+   do with the daemon, so losing the connection must not take them with it. */
+function PrefRow({
+  label,
+  last,
+  children,
+}: {
+  label: string;
+  last?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="flex items-center gap-2"
+      style={{ minHeight: 36, padding: '0 12px', borderBottom: rowBorder(last ?? false) }}
+    >
+      <span className="flex-1 text-[13px] leading-4" style={{ color: 'var(--label)' }}>
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+function AppPrefsCard({
   appearance,
   onChange,
 }: {
   appearance: Appearance;
   onChange: (next: Appearance) => void;
 }) {
+  const { locale, setLocale } = useLocale();
   return (
-    <Section title={t('settings:appearance.title')}>
+    <Section title={t('settings:app.title')}>
       <Card>
-        <div className="flex items-center gap-2" style={{ minHeight: 36, padding: '0 12px' }}>
-          <span className="flex-1 text-[13px] leading-4" style={{ color: 'var(--label)' }}>
-            {t('settings:appearance.theme')}
-          </span>
+        {/* Each control's accessible name matches the visible label beside it —
+            a name that disagrees with the label a sighted user reads out loud is
+            a voice-control dead end (WCAG 2.5.3). "App" is the GROUP heading. */}
+        <PrefRow label={t('settings:appearance.theme')}>
           <PopUpButton
             options={appearanceOptions()}
             value={appearance}
             onChange={onChange}
-            // "Theme", matching the visible label beside it — an accessible
-            // name that disagrees with the label a sighted user reads out loud
-            // is a voice-control dead end (WCAG 2.5.3). "Appearance" is the
-            // GROUP heading above, and stays that.
             aria-label={t('settings:appearance.theme')}
           />
-        </div>
+        </PrefRow>
+        {/* Full names here, not the menu row's two letters — a pop-up button has
+            the width for them, and they are written in their own language. */}
+        <PrefRow label={t('settings:app.language')} last>
+          <PopUpButton
+            options={localeOptions()}
+            value={locale}
+            onChange={setLocale}
+            aria-label={t('settings:app.language')}
+          />
+        </PrefRow>
       </Card>
     </Section>
   );
@@ -1597,7 +1633,7 @@ export function Settings({
         </Toolbar>
         <div className="flex-1 overflow-auto flex flex-col">
           <div className="px-4 pt-4 mx-auto w-full" style={{ maxWidth: 720 }}>
-            <AppearanceCard appearance={appearance} onChange={onAppearanceChange} />
+            <AppPrefsCard appearance={appearance} onChange={onAppearanceChange} />
           </div>
           <div className="flex-1 flex items-center justify-center">
           {/* A finished fetch that produced nothing is not still loading. The
@@ -1767,10 +1803,15 @@ export function Settings({
                 </div>
               </Card>
 
+              {/* Searchable by the group's name, by either row's label, and by
+                  the language names themselves — someone looking for Russian
+                  types "Рус", not "language". */}
               {(!q ||
-                t('settings:appearance.title').toLowerCase().includes(q) ||
-                t('settings:appearance.theme').toLowerCase().includes(q)) && (
-                <AppearanceCard appearance={appearance} onChange={onAppearanceChange} />
+                t('settings:app.title').toLowerCase().includes(q) ||
+                t('settings:appearance.theme').toLowerCase().includes(q) ||
+                t('settings:app.language').toLowerCase().includes(q) ||
+                localeOptions().some((l) => l.label.toLowerCase().includes(q))) && (
+                <AppPrefsCard appearance={appearance} onChange={onAppearanceChange} />
               )}
 
               <SectionList

--- a/packages/app/src/renderer/tabs/__tests__/Settings.appearance.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/Settings.appearance.test.tsx
@@ -5,8 +5,10 @@
 // that does — and it has to keep offering all three states even when the
 // daemon is unreachable, because the theme lives in localStorage and has
 // nothing to do with the daemon.
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LOCALE_KEY } from '../../../shared/i18n/locales.js';
+import { setLocale } from '../../i18n';
 import { Settings } from '../Settings';
 
 beforeEach(() => {
@@ -28,7 +30,12 @@ beforeEach(() => {
   );
 });
 
-describe('Settings — Appearance', () => {
+afterEach(() => {
+  setLocale('en');
+  localStorage.removeItem(LOCALE_KEY);
+});
+
+describe('Settings — app preferences', () => {
   it('offers Auto / Light / Dark even with no daemon', () => {
     render(<Settings appearance="auto" onAppearanceChange={() => {}} />);
     const select = screen.getByLabelText('Theme') as HTMLSelectElement;
@@ -43,5 +50,26 @@ describe('Settings — Appearance', () => {
     select.value = 'dark';
     select.dispatchEvent(new Event('change', { bubbles: true }));
     expect(onChange).toHaveBeenCalledWith('dark');
+  });
+
+  /* TRA-388. The same choice as the app menu's Language row, on the surface
+     people go to looking for settings — and with the room for the full names
+     rather than the row's two letters. Written in their own language: someone
+     hunting for Russian is looking for "Русский". */
+  it('offers Language beside Theme, in the languages own names', () => {
+    render(<Settings appearance="auto" onAppearanceChange={() => {}} />);
+    const select = screen.getByLabelText('Language') as HTMLSelectElement;
+    expect([...select.options].map((o) => o.text)).toEqual(['English', 'Русский']);
+    expect(select.value).toBe('en');
+  });
+
+  it('switches the surface at runtime and persists the choice', () => {
+    render(<Settings appearance="auto" onAppearanceChange={() => {}} />);
+    fireEvent.change(screen.getByLabelText('Language'), { target: { value: 'ru' } });
+
+    // No prop to report upwards to and no restart: the screen is already Russian.
+    expect(screen.getByLabelText('Язык')).toBeTruthy();
+    expect(screen.getByLabelText('Тема')).toBeTruthy();
+    expect(localStorage.getItem(LOCALE_KEY)).toBe('ru');
   });
 });

--- a/packages/app/src/shared/i18n/catalog/en/settings.ts
+++ b/packages/app/src/shared/i18n/catalog/en/settings.ts
@@ -38,8 +38,9 @@ export const settings = {
   'uptime.hours': '{{value}}h',
   'uptime.hoursMinutes': '{{hours}}h {{minutes}}m',
 
-  /* ── Appearance (an app preference, not a daemon setting) ──────────── */
-  'appearance.title': 'Appearance',
+  /* ── App preferences (not daemon settings) ─────────────────────────── */
+  'app.title': 'App',
+  'app.language': 'Language',
   'appearance.theme': 'Theme',
 
   /* ── Daemon-down and loading states ────────────────────────────────── */

--- a/packages/app/src/shared/i18n/catalog/en/shell.ts
+++ b/packages/app/src/shared/i18n/catalog/en/shell.ts
@@ -27,6 +27,7 @@ export const shell = {
   resizeSidebar: 'Resize sidebar',
   appMenu: 'App menu',
   theme: 'Theme',
+  language: 'Language',
   themeAuto: 'Auto',
   themeLight: 'Light',
   themeDark: 'Dark',

--- a/packages/app/src/shared/i18n/catalog/ru/settings.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/settings.ts
@@ -29,7 +29,8 @@ export const settings = {
   'uptime.hours': '{{value}} ч',
   'uptime.hoursMinutes': '{{hours}} ч {{minutes}} мин',
 
-  'appearance.title': 'Оформление',
+  'app.title': 'Приложение',
+  'app.language': 'Язык',
   'appearance.theme': 'Тема',
 
   'empty.loading': 'Загрузка настроек…',

--- a/packages/app/src/shared/i18n/catalog/ru/shell.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/shell.ts
@@ -23,6 +23,7 @@ export const shell = {
   resizeSidebar: 'Изменить ширину боковой панели',
   appMenu: 'Меню приложения',
   theme: 'Оформление',
+  language: 'Язык',
   themeAuto: 'Авто',
   themeLight: 'Светлое',
   themeDark: 'Тёмное',


### PR DESCRIPTION
The control for the i18n plumbing TRA-379 shipped. TRA-388.

`useLocale()` / `LOCALES` already existed; this is the surface, in both places Appearance appears.

## The shape: a pill, with word segments

`DESIGN.md` → "a choice in a menu is one row" leaves the shape to the option count: two to four values → a segmented pill, more than four or values that need words → a pop-up button on the same row shape. With two languages we are on the pill side of that line, and the file's own Language paragraph already said so.

The complication it also named: **language names are words**. `MenuChoiceRow` rendered icon-only segments, so it grew a `text` mode rather than a second control — a `MenuChoice` now gives `text` instead of `icon`, and the track takes `is-text`. The segment shows the two-letter form because it has room for "EN" and not for "Русский"; the full name is the `aria-label` and the `title`, exactly as an icon segment carries its name. Settings' pop-up button has the width, so there it shows the name itself.

Two things a word segment takes back from the icon geometry, and both are one rule seen twice — *a word is its own fallback, a glyph is not*:

- **Padding.** `0 8px` against the icon square's `padding: 0`. Without it "RU" sits on the 24px hit-target min-width with ~3px a side.
- **Colour.** Unselected stays at `--label`. The dimming to `--label-secondary` exists because an unselected icon has only the 1.19:1 thumb to go on (`DESIGN.md`, TRA-292); a readable word dimmed reads as *disabled*, not as *not chosen*.

## Measured, in the Electron window

`packages/app/scripts/electron-cdp.mjs`, offscreen window, menu open, light:

| | Theme (icons) | Language (words) |
|---|---|---|
| Row | 209 × 30 | 209 × 30 |
| Track | 80 × 24 | 73.9 × 24 |
| Segment | 24 × 20 | 33.7 / 34.2 × 20 |
| Segment padding | 0 | 0 8px |
| Track right edge | **214.5** | **214.5** |

214.5px is the column an item's shortcut lands in (`⌘,` on Settings) — the two choice rows and every item above and below them share it. Row height and centre line are unchanged.

Contrast, composited on the running renderer (menu surface → track → thumb):

| | light | dark |
|---|---|---|
| "RU", unselected | 13.11:1 | 8.88:1 |
| "EN", selected | 15.08:1 | 14.24:1 |

## Settings: the group is now "App"

It was headed "Appearance", which worked only while Theme was the one thing in it. A second Section titled "Language" over a row labelled "Language" would be a header over a single control — what this file bans in menus, for the same reason — and "General" is already the first schema group on the same screen. "App" against the "Daemon" card directly above it is the honest pair. The card still renders in the daemon-down and loading states; both preferences are localStorage and have nothing to do with the daemon.

Search on that screen now matches the group name, either row's label, **and the language names themselves** — someone looking for Russian types "Рус", not "language".

## Not a prop

`appearance` is passed down because App.tsx also mirrors it to the main process for the sidebar's vibrancy view. `setLocale` already persists, mirrors and syncs across windows on its own, so `useLocale()` at the point of use is the whole wiring; a prop would be plumbing with a second copy of the state at the end of it.

## Tests

`AppMenu.test.tsx` covers the Language row the way it covers Theme — word segments and their names, roles and `aria-checked`, roving `tabIndex`, left/right inside the row, up/down past it (the two choice rows are now two stops, not eight), and that picking a language switches the whole menu **without closing it**. `Settings.appearance.test.tsx` covers the pop-up button and that the choice persists to `localStorage`.

`pnpm test` 450 passed · `typecheck` clean · `check:i18n` clean · `build` clean.

## Screenshots

Taken and reviewed in the Electron window — app menu light/dark × EN/RU, Settings EN/RU, and one at Reduce Transparency + Increase Contrast. GitHub has no CLI upload path for images, and no PR in this repo embeds one, so they are attached to TRA-388 on the board rather than inline here; the numbers above are what they show.

Agent: Design/UX Agent
