### PR TITLE
docs: the menu's control column is an inset, not an x coordinate (TRA-388)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -678,7 +678,9 @@ What the row has to get right, all of it enforced by
 
 - **Geometry.** Same 30px box and 8px inset as `.ws-ctx-item`, so the label, the
   control and the neighbouring items share one centre line and the control's right
-  edge lands in the same column as an item's shortcut. Measured: 214.5px for both.
+  edge lands in the same column as an item's shortcut — 8px in from the item's right
+  edge, which is 214.5px in an English menu and moves with the menu in any language
+  that widens it (see "The Language control" below).
 - **Roles.** `role="group"` + `aria-label` on the row, `role="menuitemradio"` +
   `aria-checked` on each value. Not `radiogroup` / `radio` — a `radiogroup` is not
   a legal child of `role="menu"`, and `aria-pressed` (what the shared
@@ -747,8 +749,12 @@ Two things come back off the icon geometry, and both are the same rule seen twic
   Settings has the width, so there it is the full name.
 - **A word segment keeps its padding and its colour.** `0 8px` puts the segment at
   34px against the icon square's 24px — measured 73.9px for the two-language track,
-  right-aligned at the same 214.5px as the Theme pill and an item's shortcut, so the
-  rows share a column. And unselected stays at `--label` (13.11:1 light, 8.88:1 dark)
+  right-aligned with the Theme pill and an item's shortcut so the rows share a column.
+  *The column is 8px in from the item's right edge, not a fixed x*: the menu is sized
+  by its longest label, so it is 220px wide in English and 283.9px in Russian, and the
+  two tracks end at 214.5 and 278.4 respectively. Measure the inset, not the
+  coordinate — a number read off an English build looks like a regression in any other
+  language. And unselected stays at `--label` (13.11:1 light, 8.88:1 dark)
   rather than dropping to `--label-secondary`: the dimming exists because an
   unselected icon has only the 1.19:1 thumb to go on, and dimming a readable word
   would say "disabled" instead of "not chosen".


### PR DESCRIPTION
Follow-up to #579, prompted by a re-verification run on a fully-built tree.

`DESIGN.md` quoted **214.5px** twice as the column the choice rows' controls right-align to, written as if it were a constant. It is the English value. The menu is sized by its longest label, so:

| | menu width | Theme track right | Language track right | item right |
|---|---|---|---|---|
| English | 220.0 | 214.5 | 214.5 | 222.5 |
| Russian | 283.9 | 278.4 | 278.4 | 286.4 |

The invariant is the **8px inset from the item's right edge**, which both choice rows and the items' shortcut column hold in either language. That is the menu doing exactly what "assume +30% width" in the same file says it should.

Left as written, the next person measures a Russian build, sees 278.4 where the spec says 214.5, and files a regression against correct behaviour.

Measured on the running renderer via `packages/app/scripts/electron-cdp.mjs`, offscreen, after a clean `pnpm run build` of both halves, app reporting 3.3.0.

Docs only — no code, no test changes.

Agent: Design/UX Agent
