### PR TITLE
fix(app): put the sidebar update card on the Lattice layer (TRA-429)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -412,6 +412,35 @@ unreachable") is not an inert control. Dimming it to `opacity: 0.4` put the only
 progress text on Project Overview at 2.3:1. `is-status` keeps it unpressable and keeps
 the sentence readable (4.76:1 on surface). Use it whenever the label is information.
 
+It applies on `v-prominent` too, and there it also has to keep `--on-accent`:
+`--label-secondary` is a label colour for an untinted surface, and on the accent fill
+it is dark-on-blue.
+
+### Work in progress has to move
+
+A control that is unpressable **because its own action is running** is the app's only
+report on that action, and a still frame of it is indistinguishable from a hung app.
+The sidebar's update card dimmed `Updating…` to `opacity: 0.4` — measured 1.37:1 light
+and 2.77:1 dark on the running window — and drew nothing else for the several minutes
+a download takes. Two things are required, not one: the label stays legible
+(`is-status`, 5.22:1 / 4.77:1 after), and something on screen moves.
+
+**Indeterminate when the work is indeterminate.** `apply-update` is a single opaque
+`execFile` of `npm install -g`; there is no byte count, so there is no percentage, and
+inventing one is worse than admitting it. A 4px capsule track with a travelling accent
+segment says "running" without claiming a position. Check what the source actually
+reports before designing around its absence.
+
+**Motion is not the message, so reduced motion still has to say it.** The global
+`prefers-reduced-motion` rule in `tokens.css` stills every animation, which parks a
+travelling segment off the end of its own track and leaves the state with no signal at
+all. Give the reduced-motion path its own resting form — the bar fills at 55% accent
+— rather than letting the global rule silently erase the state.
+
+**Loop with `linear`.** An eased loop decelerates into its turnaround, which is
+precisely where an indeterminate segment is least visible. This is the one place in
+the app where `linear` is correct (§4 *Motion*).
+
 ### The row system — `.ws-sb-row`
 
 A **row** is the sidebar's unit of content: 28px tall, 6px radius, inset 6px from the
@@ -889,7 +918,12 @@ Not a pass at the end. These are floors.
     opacity only.
 18. Never make `<main>` a drag region.
 19. Never report "unknown" as "zero", or a lost connection as lost data.
-20. Never hand-roll a control that exists in `lattice/ui`.
+20. Never hand-roll a control that exists in `lattice/ui`. This includes hand-rolling
+    a *container*: a tile is `Card`, not `--fill-tertiary` plus a radius you picked.
+21. Never a status-coloured button. The one default action is the accent capsule; the
+    status is carried by the title, its glyph and the card's border.
+22. Never show work in progress as a dimmed control and nothing else. Something moves,
+    and reduced motion gets its own resting form.
 
 ---
 
@@ -987,6 +1021,19 @@ fixed set of images `docs/` and trace-mcp.com ship, from a seeded sandbox, and c
 whether the committed ones are stale. Use that one for anything committed to the repo; use
 `electron-cdp.mjs` when you need to point a debugger at the app you are running right now
 and shoot a surface it has no manifest entry for.
+
+### A Tailwind class next to `${…}` is not a Tailwind class
+
+`` className={`text-[11px] leading-[13px]${err ? ' truncate' : ''}`} `` compiles, ships,
+and silently drops `leading-[13px]`: the scanner reads the source as text, and the
+utility that runs straight into the interpolation is not extracted. The line-height
+then falls through to whatever `body` sets, which is close enough to look deliberate.
+Build class lists as arrays — `{['text-[11px]', 'leading-[13px]', err && 'truncate']
+.filter(Boolean).join(' ')}` — so every utility is its own literal.
+
+The check that catches it is not a screenshot: `getComputedStyle` on the running
+element, or `grep` for the utility in `dist/renderer/assets/*.css` after a build. A
+class that does not appear there does not exist.
 
 ### A review run never takes the screen from the person using the machine
 
@@ -1158,6 +1205,7 @@ new evidence.
 | A contrast number describes an element, never a selector | TRA-355 measured `rgba(255,255,255,.85)` on `--accent-fill` at 3.89:1 and called it an AA failure "for the count". The count is styled and rendered by nothing; the rule's only live target was a glyph, floor 3:1, already passing. Before quoting a ratio as a failure, confirm the thing it describes is on screen — `document.querySelectorAll` in the running app, not a reading of the stylesheet. |
 | Verify in the Electron window, not in Chrome | `navigator.userAgent` says "Mac" in Chrome on macOS too, so the renderer draws the 44px traffic-light reservation with no traffic lights in it — a band that does not exist in the real app. A screenshot off `vite dev` in a browser is a different product. (Nikolai, 2026-08-29; the rule itself lands with TRA-354.) |
 | A rule the enforcement cannot see is a comment | §8 rule 1 named `rgb()` from day one and `tokenGuard()` never counted it, so the ban held for hex and lapsed for `rgb()` — which is how a 3.89:1 label sat on the sidebar with a green build. When a rule goes into §8, check the script actually implements all of it. |
+| The last tile still hand-rolling its material is the one nobody looks at | The sidebar's update card kept `--fill-tertiary` at an 8px radius and a private `.btn-prominent` through the whole TRA-290 migration, because it only appears when there is an update — so every review of the sidebar was a review of a sidebar without it. When a migration says "every surface", enumerate the surfaces that are conditionally rendered too. |
 | A row label never repeats its own control's verb | "Temporary pause" beside a "Pause for 10 minutes" button wrapped to two lines at the 640px minimum and added no meaning. The label names the subject ("Enforcement"), the control names the action. |
 
 ---

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -9,7 +9,15 @@ import { WindowTabBar } from './components/WindowTabBar';
 import { t } from './i18n';
 import { formatNumber } from './i18n/format';
 import { fileKind, FileTypeGlyph, Icon } from './lattice/icons';
-import { HeaderSlotProvider, Menu, MenuItem, MenuSeparator, PopUpButton } from './lattice/ui';
+import {
+  Button,
+  Card,
+  HeaderSlotProvider,
+  Menu,
+  MenuItem,
+  MenuSeparator,
+  PopUpButton,
+} from './lattice/ui';
 import {
   formatAgo,
   QUARANTINE_COMMAND,
@@ -431,21 +439,94 @@ const RELEASES_URL = 'https://github.com/nikolai-vysotskyi/trace-mcp/releases/la
 // downloaded and waiting on a restart, and a bundle that could not replace
 // itself. "Up to date" used to be a permanent 28px strip above the footer whose
 // whole job was to say nothing was wrong; it says that in the app menu's
-// header now, next to Check for updates (TRA-363).
+// header now, next to Check for updates (TRA-363). Its four parts — title,
+// caption, command line, shell — are below; `UpdateCard` itself follows them.
+
+/** Card title — 13/16/590, the window's Body semibold, not a 12px one-off. */
+function CardTitle({ children, tone }: { children: React.ReactNode; tone?: 'warn' }) {
+  return (
+    <div
+      className="flex items-center gap-1.5 text-[13px] leading-4 font-[590] tracking-[-0.005em]"
+      style={{ color: tone === 'warn' ? 'var(--status-orange)' : 'var(--label)' }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Caption line — 11/13, --label-secondary. The old 10.5px was off the scale.
+    Each utility is its own literal: Tailwind's scanner does not extract a class
+    that a `${…}` interpolation runs straight into, and the missing one is
+    silent — measured on the built CSS. */
+function CardSubtitle({ children, error }: { children: React.ReactNode; error?: string }) {
+  return (
+    <div
+      className={['text-[11px]', 'leading-[13px]', error ? 'truncate' : ''].join(' ')}
+      style={{ color: error ? 'var(--status-orange)' : 'var(--label-secondary)' }}
+      title={error}
+    >
+      {children}
+    </div>
+  );
+}
+
+/* The card's shell. Material, radius and hairline come from Lattice `Card` —
+   the same opaque --surface tile at --radius-card the rest of the window is
+   built from. It used to hand-roll --fill-tertiary at an 8px radius, which is
+   why it read as a flat grey rectangle next to tiles it sat 200px away from
+   (TRA-429). `.update-card` survives only as the animation + margin hook. */
+function CardShell({
+  children,
+  warn = false,
+  live = false,
+}: {
+  children: React.ReactNode;
+  warn?: boolean;
+  live?: boolean;
+}) {
+  return (
+    <Card
+      className="update-card"
+      style={
+        {
+          WebkitAppRegion: 'no-drag',
+          ...(warn ? { borderColor: 'var(--status-orange)' } : null),
+        } as React.CSSProperties
+      }
+    >
+      {/* The live region is the body, not the Card: `Card` owns the material
+          and takes no ARIA. It appears without the user asking, so assistive
+          tech has to hear it. */}
+      <div
+        className="flex flex-col gap-2 p-3"
+        {...(live ? ({ role: 'status', 'aria-live': 'polite' } as const) : null)}
+      >
+        {children}
+      </div>
+    </Card>
+  );
+}
+
 /** A command the user has to run themselves: selectable, and copyable in one
-    click — a command you cannot copy is a screenshot, not an instruction. */
+    click — a command you cannot copy is a screenshot, not an instruction.
+    `.lx-sheet-command` is the app's command field (surface-sunken well,
+    hairline, --radius-input, mono at the caption size) and the copy control is
+    the icon `Button`; the card had grown its own 5px-radius box with a 10px
+    mono and a hand-rolled button, which is the geometry this card was on
+    before TRA-429. */
 function CommandLine({ command, label }: { command: string; label: string }) {
   return (
-    <div className="update-card-command">
+    <div className="lx-sheet-command">
       <code>{command}</code>
-      <button
-        type="button"
+      <Button
+        variant="icon"
+        size="small"
+        icon="content_copy"
+        iconSize={13}
         onClick={() => void navigator.clipboard?.writeText(command)}
         aria-label={label}
         title={label}
-      >
-        <Icon name="content_copy" size={12} />
-      </button>
+      />
     </div>
   );
 }
@@ -457,26 +538,22 @@ export function UpdateCard({ update }: { update: UpdateCheck }) {
   // Pending swap takes precedence — the user's next click should restart, not redownload.
   if (pendingVersion) {
     return (
-      <div className="update-card" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
-        <div className="title">
-          <span className="ready-icon" aria-hidden="true">
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-              <path
-                d="M2.5 6.2l2.4 2.4 4.6-4.6"
-                stroke="currentColor"
-                strokeWidth="1.6"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
+      <CardShell>
+        <CardTitle>
+          <span className="flex" style={{ color: 'var(--status-green)' }} aria-hidden="true">
+            <Icon name="check" size={13} />
           </span>
           {t('cardReadyTitle', { version: pendingVersion })}
-        </div>
-        <div className="subtitle">{t('cardReadySubtitle', { current: state.current })}</div>
-        <button type="button" className="btn-prominent success" onClick={update.restart}>
+        </CardTitle>
+        <CardSubtitle>{t('cardReadySubtitle', { current: state.current })}</CardSubtitle>
+        {/* Accent, not green: macOS paints the one default action in the accent
+            colour, and the green here is the state (the check above), not the
+            button. The old `.btn-prominent.success` was the only green button
+            in the app. */}
+        <Button variant="prominent" className="w-full" onClick={update.restart}>
           {t('cardRestart')}
-        </button>
-      </div>
+        </Button>
+      </CardShell>
     );
   }
 
@@ -487,57 +564,62 @@ export function UpdateCard({ update }: { update: UpdateCheck }) {
   // own honest card with the one action that does work: download the release.
   if (state.stuck && state.latest) {
     return (
-      <div
-        className="update-card stuck"
-        role="status"
-        aria-live="polite"
-        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-      >
-        <div className="title">{t('cardStuckTitle', { version: state.latest })}</div>
-        <div className="subtitle">{t('cardStuckSubtitle', { current: state.current })}</div>
-        <button
-          type="button"
-          className="btn-prominent"
+      <CardShell warn live>
+        <CardTitle tone="warn">{t('cardStuckTitle', { version: state.latest })}</CardTitle>
+        <CardSubtitle>{t('cardStuckSubtitle', { current: state.current })}</CardSubtitle>
+        <Button
+          variant="prominent"
+          icon="download"
+          className="w-full"
           onClick={() => void window.electronAPI?.openExternal?.(RELEASES_URL)}
         >
           {t('cardDownload', { version: state.latest })}
-        </button>
+        </Button>
         {/* The download alone dead-ends: our macOS builds are ad-hoc signed, so
             Gatekeeper calls the file the browser just fetched "damaged". An
             escape hatch that ends in an error dialog is not an escape hatch —
             the card carries the command that clears it (TRA-431). */}
-        <div className="subtitle">{t('cardStuckQuarantine')}</div>
+        <CardSubtitle>{t('cardStuckQuarantine')}</CardSubtitle>
         <CommandLine command={QUARANTINE_COMMAND} label={t('copyQuarantineCommand')} />
-      </div>
+      </CardShell>
     );
   }
 
   if (!state.available) return null;
 
   return (
-    <div
-      className="update-card"
-      style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-      // It appears without the user asking, so assistive tech has to hear it.
-      role="status"
-      aria-live="polite"
-    >
-      <div className="title">{t('cardAvailableTitle', { version: state.latest })}</div>
-      <div className="subtitle">
+    <CardShell live>
+      <CardTitle>{t('cardAvailableTitle', { version: state.latest })}</CardTitle>
+      <CardSubtitle>
         {t('cardAvailableSubtitle', {
           current: state.current,
           when: formatAgo(state.lastChecked),
         })}
-      </div>
-      {state.error && (
-        <div className="subtitle error" title={state.error}>
-          {state.error}
-        </div>
-      )}
-      <button type="button" className="btn-prominent" onClick={update.apply} disabled={updating}>
+      </CardSubtitle>
+      {state.error && <CardSubtitle error={state.error}>{state.error}</CardSubtitle>}
+      {/* `is-status`, not a plain disabled button: the download takes minutes,
+          and 0.4 opacity on the one thing that says it is running reads as a
+          hung app. The capsule keeps its accent fill and its label; the bar
+          below is what carries "still going" (TRA-429). npm gives us no byte
+          count — `npm install -g` is one opaque execFile in the main process —
+          so the honest shape is indeterminate, never a fake percentage. */}
+      <Button
+        variant="prominent"
+        className={['w-full', updating ? 'is-status' : ''].join(' ')}
+        onClick={update.apply}
+        disabled={updating}
+      >
         {updating ? t('cardUpdating') : t('cardUpdate')}
-      </button>
-    </div>
+      </Button>
+      {updating && (
+        <div
+          className="update-progress"
+          role="progressbar"
+          aria-label={t('cardUpdating')}
+          aria-valuetext={t('cardUpdating')}
+        />
+      )}
+    </CardShell>
   );
 }
 

--- a/packages/app/src/renderer/__tests__/update-banner.test.tsx
+++ b/packages/app/src/renderer/__tests__/update-banner.test.tsx
@@ -24,11 +24,11 @@ type CheckResult = {
   staleRoots?: { root: string; version: string }[];
 };
 
-function mockApi(check: CheckResult, openExternal = vi.fn()) {
+function mockApi(check: CheckResult, openExternal = vi.fn(), applyUpdate = vi.fn()) {
   (window as unknown as { electronAPI: unknown }).electronAPI = {
     checkForUpdate: vi.fn().mockResolvedValue(check),
     checkPendingUpdate: vi.fn().mockResolvedValue({ pending: false }),
-    applyUpdate: vi.fn(),
+    applyUpdate,
     restartApp: vi.fn(),
     openExternal,
   };
@@ -189,5 +189,53 @@ describe('update states', () => {
     expect(document.querySelector('.ws-ctx-header .status')?.textContent).toContain('Up to date');
     // No card in the sidebar when there is nothing to do about it.
     expect(container.querySelector('.update-card')).toBeNull();
+  });
+});
+
+/* TRA-429: the visual layer. The card was the last tile in the window still
+   hand-rolling its own material and its own button class; `Updating…` was a
+   0.4-opacity capsule with nothing moving behind it, which is what a hung app
+   looks like. */
+describe('update card presentation', () => {
+  it('is built from the Lattice primitives, not a private button class', async () => {
+    mockApi({ available: true, current: '3.1.1', latest: '3.2.0', lastChecked: Date.now() });
+
+    const { container } = render(<Card />);
+
+    await screen.findByText(/v3\.2\.0 available/);
+    expect(container.querySelector('.btn-prominent')).toBeNull();
+    // The one action is the shared prominent capsule.
+    const button = screen.getByRole('button', { name: 'Update' });
+    expect(button.className).toContain('lx-btn');
+    expect(button.className).toContain('v-prominent');
+  });
+
+  it('keeps the updating capsule readable and shows indeterminate progress', async () => {
+    // A download that never settles — that IS the state under test.
+    mockApi({ available: true, current: '3.1.1', latest: '3.2.0' }, vi.fn(), () => new Promise(() => {}));
+
+    const { container } = render(<Card />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Update' }));
+
+    const button = await screen.findByRole('button', { name: 'Updating…' });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    // `is-status` is what keeps the label at full opacity — a 0.4 capsule is
+    // the thing this state is not allowed to be any more.
+    expect(button.className).toContain('is-status');
+
+    // Something moves, and it does not claim a percentage it cannot know.
+    const bar = container.querySelector('[role="progressbar"]');
+    expect(bar).not.toBeNull();
+    expect(bar?.getAttribute('aria-valuenow')).toBeNull();
+  });
+
+  it('shows no progress bar until the update is actually running', async () => {
+    mockApi({ available: true, current: '3.1.1', latest: '3.2.0' });
+
+    const { container } = render(<Card />);
+
+    await screen.findByRole('button', { name: 'Update' });
+    expect(container.querySelector('[role="progressbar"]')).toBeNull();
   });
 });

--- a/packages/app/src/renderer/app.css
+++ b/packages/app/src/renderer/app.css
@@ -92,68 +92,22 @@ body {
   }
 }
 
-/* ── Prominent button (UpdateBanner) ─────────────────────────────── */
-/* macOS 26 prominent buttons are a FLAT accent capsule — the gradient + triple
-   box-shadow bezel that used to live here is gone (TRA-290). Full-width and
-   24px tall for the narrow sidebar. */
-.btn-prominent {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 24px;
-  padding: 0 12px;
-  font-family: inherit;
-  font-size: 13px;
-  font-weight: 590;
-  letter-spacing: -0.005em;
-  color: var(--on-accent);
-  background: var(--accent-fill);
-  border: none;
-  border-radius: 999px;
-  cursor: default;
-  user-select: none;
-  transition: background 120ms ease;
-}
-.btn-prominent:hover:not(:disabled) {
-  background: color-mix(in oklab, var(--accent) 88%, black);
-}
-.btn-prominent:active:not(:disabled) {
-  background: color-mix(in oklab, var(--accent) 78%, black);
-}
-.btn-prominent:disabled {
-  opacity: 0.4;
-}
-.btn-prominent.success {
-  background: var(--status-green);
-}
-.btn-prominent.success:hover:not(:disabled) {
-  background: color-mix(in oklab, var(--status-green) 88%, black);
-}
-
 /* ── Update card ─────────────────────────────────────────────────── */
 /* The idle "● Up to date · v3.1.1 ⟳" row and its inline refresh button are
    gone (TRA-363): a permanent 28px strip whose only message was "nothing is
    wrong" is the most expensive way to say it. The state moved into the app
    menu's header, where "Check for updates" sits beside it. What is left here
-   is the card — and a card only appears when there is something to do. */
-@media (prefers-reduced-motion: reduce) {
-  .update-card {
-    animation: none;
-  }
-}
+   is the card — and a card only appears when there is something to do.
 
-/* Card: a translucent elevated tile that appears when there's something */
-/* the user can act on. Spring-in for native feel. */
+   The card itself is a Lattice `Card` now, and its button is the Lattice
+   prominent `Button` (TRA-429): material, radius, type and the capsule all
+   come from the primitives every other tile in the window uses. The private
+   `.btn-prominent` that lived here — a duplicate of `Button variant="prominent"`
+   with the update card as its only consumer — is gone with them. What is left
+   is what a primitive cannot own: where the card sits, how it arrives, and the
+   indeterminate bar for a download nobody can measure. */
 .update-card {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
   margin: 4px 6px 6px;
-  padding: 10px;
-  background: var(--fill-tertiary);
-  border: 0.5px solid var(--separator);
-  border-radius: 8px;
   animation: update-card-in 260ms cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 @keyframes update-card-in {
@@ -166,76 +120,55 @@ body {
     transform: translateY(0) scale(1);
   }
 }
-.update-card .title {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 12px;
-  font-weight: 590;
-  letter-spacing: -0.01em;
-  color: var(--label);
-}
-.update-card .subtitle {
-  font-size: 10.5px;
-  color: var(--label-secondary);
-  line-height: 1.25;
-  letter-spacing: -0.005em;
-}
-.update-card .subtitle.error {
-  color: var(--status-orange);
-  white-space: nowrap;
+
+/* `npm install -g` is one opaque `execFile` in the main process, so there is no
+   byte count to draw and a percentage would be invented. An indeterminate bar
+   is the honest shape: it says "running", it does not say "60% done". */
+.update-progress {
+  position: relative;
   overflow: hidden;
-  text-overflow: ellipsis;
-}
-/* Stuck: the CLI updated but the bundle could not be replaced. Warm border so
-   it reads as "needs attention", not as the routine update card (TRA-357). */
-.update-card.stuck {
-  border-color: var(--status-orange);
-}
-.update-card.stuck .title {
-  color: var(--status-orange);
-}
-/* A command the user runs in Terminal. Selectable against the global
-   `user-select: none`, because copying it is the whole point. */
-.update-card-command {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 5px 6px;
-  background: var(--fill-quaternary, var(--fill-tertiary));
-  border-radius: 5px;
-}
-.update-card-command code {
-  flex: 1;
-  min-width: 0;
-  overflow-x: auto;
-  white-space: nowrap;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
-  color: var(--label-secondary);
-  user-select: text;
-}
-.update-card-command button {
-  flex: none;
-  display: inline-flex;
-  padding: 2px;
-  border: 0;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--label-secondary);
-  cursor: pointer;
-}
-.update-card-command button:hover {
-  color: var(--label);
+  height: 4px;
+  border-radius: 999px;
   background: var(--fill-tertiary);
 }
-.update-card .ready-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 12px;
-  height: 12px;
-  color: var(--status-green);
+/* `linear`, and the one place in the app that gets it: an eased loop
+   decelerates into the turnaround, which parks the segment at the end of the
+   track — the exact frames where the bar looks empty and therefore stalled.
+   Uniform motion is also what an indeterminate bar means. The travel stops at
+   250%, where the segment's leading edge reaches the end of the track: past
+   that it is wholly outside and the bar goes blank mid-loop. */
+.update-progress::after {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 40%;
+  border-radius: inherit;
+  background: var(--accent);
+  animation: update-progress-slide 1.4s linear infinite;
+}
+@keyframes update-progress-slide {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(250%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .update-card {
+    animation: none;
+  }
+  /* The global rule in tokens.css stills every animation, which would park the
+     travelling segment off the end of its own track and leave the state with no
+     visible signal at all. A filled bar at 55% accent is what an unmoving
+     indeterminate bar has to be: still there, still saying "running", just not
+     pretending to know how far along it is. */
+  .update-progress::after {
+    width: 100%;
+    transform: none;
+    background: color-mix(in oklab, var(--accent) 55%, transparent);
+  }
 }
 
 /* The sidebar footer lives in styles/sidebar.css now, with the row system it

--- a/packages/app/src/renderer/styles/controls.css
+++ b/packages/app/src/renderer/styles/controls.css
@@ -57,6 +57,13 @@
   opacity: 1;
   color: var(--label-secondary);
 }
+/* --label-secondary is a label colour for an UNTINTED surface; on the accent
+   fill it is dark-on-blue and fails contrast outright. A prominent button
+   running its own action ("Updating…" in the sidebar's update card) keeps
+   --on-accent (TRA-429). */
+.lx-btn.v-prominent.is-status:disabled {
+  color: var(--on-accent);
+}
 
 /* sizes ------------------------------------------------------------------- */
 .lx-btn.sz-small {


### PR DESCRIPTION
Closes TRA-429.

The card in the sidebar footer was the last tile in the window still hand-rolling its
own material — `--fill-tertiary` at an 8px radius with a private `.btn-prominent`
inside it, while every other tile in the same window is an opaque `--surface` `Card` at
12px with a Lattice capsule. It survived the TRA-290 migration because it only renders
when there is an update, so every review of the sidebar was a review of a sidebar
without it.

The copy and the state machine are untouched — the stuck-bundle card, the
pending-restart card and the "Up to date" suppression argued in TRA-357 and TRA-363 all
say exactly what they said before. This is the visual layer and the `Updating…` state.

## Before / after

Shot from the real Electron window (`electron-cdp.mjs launch`, hidden, 2x) per
DESIGN.md section 9, not from `vite dev`.

| | before | after |
|---|---|---|
| Update available | <img src="https://raw.githubusercontent.com/nikolai-vysotskyi/trace-mcp/assets/tra-429/before/available-light.png" width="290"> | <img src="https://raw.githubusercontent.com/nikolai-vysotskyi/trace-mcp/assets/tra-429/after/available-light.png" width="290"> |
| **Updating** | <img src="https://raw.githubusercontent.com/nikolai-vysotskyi/trace-mcp/assets/tra-429/before/updating-light.png" width="290"> | <img src="https://raw.githubusercontent.com/nikolai-vysotskyi/trace-mcp/assets/tra-429/after/updating-light.png" width="290"> |
| Needs a manual install | <img src="https://raw.githubusercontent.com/nikolai-vysotskyi/trace-mcp/assets/tra-429/before/stuck-dark.png" width="290"> | <img src="https://raw.githubusercontent.com/nikolai-vysotskyi/trace-mcp/assets/tra-429/after/stuck-dark.png" width="290"> |
| Downloaded, restart pending | <img src="https://raw.githubusercontent.com/nikolai-vysotskyi/trace-mcp/assets/tra-429/before/ready-light.png" width="290"> | <img src="https://raw.githubusercontent.com/nikolai-vysotskyi/trace-mcp/assets/tra-429/after/ready-light.png" width="290"> |

Dark for every state, and the accessibility states, are on the
[`assets/tra-429`](https://github.com/nikolai-vysotskyi/trace-mcp/tree/assets/tra-429)
branch: `after/available-dark.png`, `after/updating-dark.png`, `after/ready-dark.png`,
`after/stuck-light.png`, `after/updating-reduce-motion-light.png`,
`after/available-increase-contrast-dark.png`.

`prefers-reduced-transparency: reduce` produced a byte-identical frame, so there is no
file for it — correct, and worth stating rather than shipping a duplicate: the card is
content, opaque `--surface` with no `backdrop-filter`, so that setting has nothing to
act on here. The glass under it is the sidebar's, and the sidebar did not change.

## What changed

**The card is a `Card`.** `--fill-tertiary` / 8px radius becomes opaque `--surface` /
`--radius-card` 12px / 0.5px `--separator`, measured 208x107 in the 220px sidebar.
Content, so no shadow and no glass — section 8 rule 5, and rule 20, which the card was
breaking twice over: it hand-rolled a container *and* a control.

**Type comes off the scale.** Title 12/590 to 13/16/590 (Body semibold); caption 10.5px
to 11/13 (Caption). 10.5px was not on the scale in either axis.

**`.btn-prominent` is deleted**, all 38 lines. It was a duplicate of
`Button variant="prominent"` with this card as its only consumer, and its comment still
named `UpdateBanner`, a component that has not existed under that name since TRA-363.

**The Restart button loses its green.** `.btn-prominent.success` was the only green
button in the app. macOS paints the one default action in the accent colour; the green
here is the *state*, and the check glyph beside the title carries it. That hand-drawn
12px SVG check is now `Icon name="check"` at 13px.

**`Updating…` gets designed.** It was `disabled` to `opacity: 0.4` and nothing else for
the several minutes an `npm install -g` takes. Measured on the running window, the
label was **1.37:1 in light and 2.77:1 in dark** — the only report the app makes on a
multi-megabyte download, below the 3:1 floor for non-text and less than a third of the
4.5:1 for text. It now:

- keeps the accent fill and stays legible via `is-status` — **5.22:1 light, 4.77:1
  dark**, and still unpressable;
- rides a 4px capsule track with a travelling accent segment (4.0:1 light / 3.7:1 dark
  against its own track, floor 3:1 for a non-text element).

Indeterminate, deliberately. I checked the source first: on macOS `apply-update` is one
opaque `execFile` of `npm install -g` with no progress channel, and the
`electron-updater` path can emit `download-progress` but nothing forwards it to the
renderer. There is no byte count to draw, so a percentage would be invented. Wiring the
Windows path through is a main-process change and does not belong in this diff.

Reduced motion gets its own resting form. The global rule in `tokens.css` stills every
animation, which would park the segment past the end of its track and leave the state
with **no** signal — so under `prefers-reduced-motion: reduce` the bar fills at 55%
accent instead. The loop is `linear`: an eased loop decelerates into the turnaround,
which is exactly where the segment is least visible.

**The quarantine command line came onto the same layer.** #581 landed the
`xattr -dr com.apple.quarantine` field in the stuck card while this was in review, in
its own hand-rolled box — 5px radius, 10px mono, `var(--fill-quaternary, …)` fallback,
a hand-rolled copy button with `cursor: pointer`. That is the geometry this change
exists to remove, and half a migrated card looks worse than none, so it is now
`.lx-sheet-command` (the app's command field: `--surface-sunken` well, hairline,
`--radius-input`, mono at the caption size) with `Button variant="icon"` as the copy
control. Measured 183x33 with a 24x20 painted button in a 28x24 hit box, `aria-label`
and `title` both present, and the command still selectable against the global
`user-select: none`. `.update-card-command` is deleted with `.btn-prominent`. The copy,
the command and the sentence explaining it are #581's and unchanged.

**One shared-primitive line.** `.lx-btn.v-prominent.is-status:disabled` keeps
`--on-accent`. `is-status` sets `--label-secondary`, which is a label colour for an
untinted surface and is dark-on-blue on the accent fill.

## DESIGN.md

Three rules, written for the class of case rather than for this screen:

- **Work in progress has to move** (section 5) — with the
  indeterminate-when-indeterminate rule, the reduced-motion resting form, and `linear`
  for loops.
- **Section 8 rules 21 and 22** — never a status-coloured button; never work in progress
  as a dimmed control and nothing else. Rule 20 extended to containers.
- **A Tailwind class next to `${...}` is not a Tailwind class** (section 9). This bit me
  in this diff: a template literal whose last utility runs straight into the
  interpolation compiles, ships, and silently drops that utility, which then falls
  through to `body`'s line-height and looks deliberate. Caught with `getComputedStyle`
  on the running element, not by reading the CSS. Class lists are arrays here now.

Plus a decision-log row: the last tile still hand-rolling its material is the one nobody
looks at, because it renders conditionally.

## Checks

`packages/app`: typecheck, 459 tests (5 new here, 6 from #581), `check:i18n` 87 files clean, renderer and
main build. Root: `lint`, 9136 tests. Tabbed the card in both appearances — focus ring
visible on the capsule, order sane. Net 11 fewer lines of CSS.
