### PR TITLE
fix(app): the AppKit tab bar is 28px, not 36 — traffic lights sat 4px low

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -627,19 +627,26 @@ Opening a project opens a native macOS **tab**, so the normal state of this app 
 tabbed window — not an edge case. AppKit then draws a tab bar, and because the window is
 `titleBarStyle: 'hiddenInset'` (full-size content view) it draws it **over** the web
 contents: `innerHeight` stays equal to `outerHeight`, nothing reflows, and the tab bar
-simply covers the top 36px of whatever the renderer painted. That is the whole of the
+simply covers the top 28px of whatever the renderer painted. That is most of the
 band above, so the surface toolbar and the sidebar toggle went from "misaligned" to
 "gone" (TRA-399).
 
 The rule that follows: **a band we do not draw still has to be reserved.** The tab bar is
 AppKit's, we cannot restyle it and we cannot ask whether it is up — so:
 
-- `MAC_TAB_BAR_H` (36px, measured, `chrome-metrics.ts`) and `--mac-tabbar-h` are one
+- `MAC_TAB_BAR_H` (28px, measured, `chrome-metrics.ts`) and `--mac-tabbar-h` are one
   number, exactly like `TOP_BAND_H`. The stage reserves it with `padding-top` while
   `data-tabbar="on"`, and the app's own band starts below it. Never draw into it.
+- **Measure a band we do not draw with a marker, never by eye.** Paint the renderer a
+  colour macOS chrome never uses, photograph the window, and read the first row where
+  that colour survives — that row is the band's bottom edge and nothing else can be
+  mistaken for it. Asking "where does the sidebar's material resume?" instead is how
+  this constant shipped as 36 for a release (TRA-432): 36 is where our own reserved
+  band ended, and an over-reserved band looks exactly like a taller bar.
 - **The traffic lights belong to whichever band holds the top line**, not to a constant.
-  With no tab bar that is our 44px band (centre 22); with one it is AppKit's 36px tab bar
-  (centre 18). `trafficLightYFor(tabBarVisible)` is the only place that chooses.
+  With no tab bar that is our 44px band (centre 22); with one it is AppKit's 28px tab bar
+  (centre 14, the tab pill's own centre line). `trafficLightYFor(tabBarVisible)` is the
+  only place that chooses.
 - **`trafficLightPosition` is applied once, at window creation, and AppKit re-lays the
   title bar out under it.** So every event that can change the tab count re-applies it —
   `show`, `focus`, `closed`, `did-finish-load` — synchronously and again a frame later,

--- a/packages/app/src/renderer/styles/tokens.css
+++ b/packages/app/src/renderer/styles/tokens.css
@@ -154,7 +154,7 @@
      shrinks, because the window is full-size content view. Reserve it or it
      covers the whole top band above. Same owner, same guard:
      src/shared/chrome-metrics.ts (MAC_TAB_BAR_H) and tokens.test.ts. */
-  --mac-tabbar-h: 36px;
+  --mac-tabbar-h: 28px;
 
   /* ---- Motion */
   --dur-micro: 120ms;

--- a/packages/app/src/shared/chrome-metrics.ts
+++ b/packages/app/src/shared/chrome-metrics.ts
@@ -41,14 +41,26 @@ export const TRAFFIC_LIGHT_Y = centreLightsIn(TOP_BAND_H);
    swallows whatever the app drew on that line, which is the entire surface
    toolbar plus the sidebar toggle.
 
-   Measured on macOS 26.5 / Electron 41.10.6 by photographing the window
-   (`screencapture -l<CGWindowID>`) with two tabs open and reading the column
-   profile down the sidebar: the tab bar's plate runs from y=0 to y=36.0, and
-   the sidebar's own material resumes at 36.0. If a future macOS changes the
-   metric, this is the one constant that absorbs it. */
+   Measured on macOS 26.5 / Electron 41.10.6, two tabs open, by the MARKER ROW:
+   paint the whole renderer a colour macOS chrome never uses (#FF00FF), then
+   photograph the window (`screencapture -l<CGWindowID>`) and read the row
+   profile. The first fully magenta row IS the bar's bottom edge, because the
+   bar is the only thing that can cover the marker. y=0..27.5 is plate (the last
+   two of those rows being its separator), y=28.0 is the first clean marker row.
+
+   Read it that way and only that way. TRA-432: the first measurement asked
+   "where does the sidebar's material resume?" instead, got 36.0, and shipped
+   it — but 36.0 is where OUR OWN reserved band ends, not the bar. The 8px
+   between them is this constant over-reserving, rendered in the window's
+   backdrop, which looks exactly like a bar that is 8px taller. A band 8px too
+   tall centres the traffic lights 4px too low, and that is what users saw. The
+   marker row cannot make that mistake: nothing but the bar hides the marker.
+
+   If a future macOS changes the metric, this is the one constant that absorbs
+   it — re-measure with the marker, do not eyeball a screenshot. */
 
 /** Height of the AppKit tab bar on a tabbed window, in CSS px. */
-export const MAC_TAB_BAR_H = 36;
+export const MAC_TAB_BAR_H = 28;
 
 /** Offset that centres the lights in the TAB BAR, which owns the top band then. */
 export const TRAFFIC_LIGHT_Y_TABBED = centreLightsIn(MAC_TAB_BAR_H);


### PR DESCRIPTION
## What

`MAC_TAB_BAR_H` was 36. The AppKit tab bar is **28** CSS px. One constant drives two
things — where the traffic lights are centred while AppKit owns the top line, and how much
space the renderer reserves for a band it does not draw — so one wrong number produced both
the reported symptom and an invisible one.

## The measurement, and why the old one was wrong

**Method: the marker row.** Paint the whole renderer `#FF00FF`, a colour macOS chrome uses
nowhere. The window is `titleBarStyle: 'hiddenInset'` (full-size content view), so the web
contents starts at window y=0 and the bar is painted *over* it. Photograph the window
(`screencapture -l<CGWindowID>`) and read the row profile: **the first fully magenta row is
the bar's bottom edge**, because nothing else can cover the marker.

macOS 26.5, Electron 41.10.6, two tabs, 2× capture:

| window y (CSS px) | marker fraction |
|---|---|
| 0 … 25.5 | 0.02 – 0.08 (plate) |
| 26.0 … 27.5 | 0.08 (the plate's separator) |
| **28.0** and below | **1.000** |

The same 28.0 falls out of the shipped 3.3.0 build in the reported screenshot, read as a
pixel profile rather than by eye: the tab pill runs y=2 → 26 (centre **14.0**), its
separator 26 → 28, and the first row of app-coloured pixels is at 28.0.

The old note measured "where the sidebar's own material resumes" and got 36.0. That reading
is real — but 36.0 is where **our own reserved band** ends, not the bar. The 8px between
them is this constant over-reserving, painted in the window backdrop, which looks exactly
like a bar that is 8px taller. The comment in `chrome-metrics.ts` now says which question to
ask, and why the other one lies.

## Verified on the real app, two tabs, before → after

Same window, same build, same conditions; the app launched with
`TRACE_MCP_WINDOW_MODE=hidden` and shown with `showInactive()` only, so the run never took
the screen.

| | before (36) | after (28) |
|---|---|---|
| traffic lights' centre | 18.0 | **14.0** |
| tab pill's centre (AppKit's own) | 14.0 | 14.0 |
| app content starts at | 36.0 | **28.0** |
| dead gap under the bar | 8px | none |
| one tab: lights' centre | 22.0 | 22.0 (`TOP_BAND_H`/2, untouched) |

Both consequences hold: the lights land on the tab row's centre line, **and** the bar still
does not overlap the surface toolbar — Search, Filter, Table/Compact, Add and the sidebar
toggle all sit clear of it (TRA-399). Screenshots of both states are on the issue.

## Not doing: the leading inset

The report also asks whether the tab strip can start to the right of the traffic lights. It
cannot: the bar is drawn by AppKit and Electron exposes no leading-inset control for it,
only `trafficLightPosition` / `setWindowButtonPosition` for the buttons. The only way to an
inset is a renderer-drawn tab strip, which costs drag-between-windows, ⌘⇧[ / ⌘⇧], the Window
menu and the tab overview for a cosmetic gain. Declined.

## Checks

`pnpm run test` (445 passed), `pnpm run typecheck`, `pnpm run build`, `biome ci` — all clean
in `packages/app`. `tokens.test.ts` and `tab-chrome.test.ts` already derive everything from
the constant, so no test needed a new literal.

Fixes TRA-432
