### PR TITLE
fix(site): capability marks are monochrome text, not emoji (TRA-447)

### DIFF
--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -110,6 +110,15 @@ Order: sticky header (brand + theme toggle) → `h1` → prose → `Last updated
   head is a Space Mono 10px caps label, not a bold band. Every table is
   wrapped in a focusable `.table-scroll` region by the layout script, so a
   wide tool table scrolls itself instead of the page.
+- Capability marks in a comparison table are **`✓` and `✗` text, never `✅`
+  and `❌`**. The emoji pair is a filled multi-colour icon and a second and
+  third accent colour — 305 of them on `comparisons.html` alone painted the
+  page green and red, which is the one thing red is reserved for. Yes and no
+  separate on **opacity**: `✓` at `--text-display`, `✗` at `--text-disabled`.
+  The layout script wraps each mark in `.mark-yes` / `.mark-no` with
+  `role="img"` and an `aria-label`, so a screen reader reads "Yes" / "No"
+  rather than "check mark" — the emoji's one advantage, kept. Markdown source
+  stays the bare glyph so the table is still scannable in a diff.
 - Code: `--surface` fill, `--border` outline, 4px radius inline / 8px block.
   Syntax highlighting differentiates by **weight and opacity**, not hue.
 - The `See also` footer is a **grid, one cell per link**
@@ -187,7 +196,8 @@ WebP conversion.
 - Zebra-striped tables.
 - Skeleton loaders — use `[LOADING...]`.
 - Toast popups — use inline `[SAVED]` / `[ERROR: …]`.
-- Filled or multi-colour icons, emoji as UI.
+- Filled or multi-colour icons, emoji as UI — including `✅` / `❌` / `⚠️`
+  as capability marks in a table.
 - A second accent colour. Red is the only one.
 - `border-radius` over 16px on a card.
 - Spring or bounce easing. Only `cubic-bezier(0.25, 0.1, 0.25, 1)`.
@@ -222,6 +232,8 @@ appearance without a screenshot or a measurement is not a finding.
 **Type & spacing**
 - [ ] Within the 2 families / 3 sizes / 2 weights budget.
 - [ ] Service labels are Space Mono caps; nothing else is.
+- [ ] No emoji in any rendered page — `grep -c '✅\|❌\|⚠️' docs/*.md
+      docs/vs/*.md` returns 0 for every file.
 - [ ] Exactly one h1; section breaks are 80px, not ad hoc.
 - [ ] Exactly one deliberate pattern break on the page.
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -117,6 +117,18 @@
             firstCell.setAttribute('scope', 'row');
           }
         });
+        // Capability marks are ✓/✗ text, not ✅/❌ emoji (DESIGN-WEB.md §4).
+        // Wrapping them here rather than in the Markdown keeps the source a
+        // scannable table for the SEO agent, gives the mark an accessible
+        // name — a screen reader reads "Yes"/"No", not "check mark" — and
+        // lets "no" sit back at --text-disabled.
+        table.querySelectorAll('td, th').forEach(function (cell) {
+          if (!/[✓✗]/.test(cell.textContent)) return;
+          cell.innerHTML = cell.innerHTML
+            .replace(/✓/g, '<span class="mark mark-yes" role="img" aria-label="Yes">✓</span>')
+            .replace(/✗/g, '<span class="mark mark-no" role="img" aria-label="No">✗</span>');
+        });
+
         // Three-column tool tables are ~700px at their narrowest and used to
         // force the whole page to scroll sideways on a 390px phone. Scroll the
         // table instead, and make the scroller keyboard-reachable.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,7 +1,7 @@
 ---
 title: "Session Analytics & Coverage Intelligence — token savings, wasteful patterns"
 description: "trace-mcp's built-in analytics engine parses AI agent session logs, tracks token savings, detects wasteful patterns, and assesses technology coverage."
-updated: 2026-08-29
+updated: 2026-08-30
 ---
 
 # Session Analytics & Coverage Intelligence

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 ---
 title: "trace-mcp Architecture — indexing pipeline, storage, and MCP server internals"
 description: "How trace-mcp indexes a codebase into a queryable graph: tree-sitter parsing, SQLite + FTS5 storage, optional LSP enrichment, and the MCP server that serves it all."
-updated: 2026-08-29
+updated: 2026-08-30
 ---
 
 # Architecture

--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -456,6 +456,20 @@ main {
   padding-right: 0;
 }
 
+/* Capability marks. The comparison tables used ✅/❌ — emoji as UI, and a
+   green that is a second accent colour. The mark is now plain ✓/✗ text, and
+   yes/no separate on opacity, which is how this system encodes state.
+   `font-variant-emoji: text` keeps a platform from re-colouring them. */
+.prose .mark {
+  font-variant-emoji: text;
+}
+.prose .mark-yes {
+  color: var(--text-display);
+}
+.prose .mark-no {
+  color: var(--text-disabled);
+}
+
 .prose blockquote {
   padding-left: 20px;
   border-left: 1px solid var(--accent);

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -1,7 +1,7 @@
 ---
 title: "Code Graph MCP Server Comparison: trace-mcp vs Repomix, Serena & 20+ alternatives"
 description: "Compare trace-mcp against Repomix, Serena, Kage, codebase-memory-mcp and 20+ MCP code-graph tools — capabilities, language support, GitHub stars. Last verified August 2026."
-updated: 2026-08-29
+updated: 2026-08-30
 ---
 
 # How trace-mcp compares

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -53,17 +53,17 @@ Tools that help AI agents read code with fewer tokens — AST parsing, outlines,
 | Capability | trace-mcp | Repomix | Context Mode | code-review-graph | jCodeMunch | codebase-memory-mcp | cymbal |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **GitHub stars** | 100 | 28.1K | 20.2K | ~19K | 2.6K | 41.1K | 165 |
-| Tree-sitter AST parsing | ✅ {{ site.data.counts.languages }} languages | ✅ compress only (~20) | ❌ no code parsing | ✅ 23 langs + Jupyter | ✅ 70+ languages | ✅ 161 languages | ✅ 22 languages |
-| Token-efficient symbol lookup | ✅ outlines, symbols, bundles | ❌ packs entire files | ✅ sandboxed output (98% reduction) | ✅ | ✅ core focus (~95% reduction) | ✅ | ✅ outline/show/context |
-| Cross-file dependency graph | ✅ directed edge graph | ❌ | ❌ | ✅ incremental knowledge graph | ✅ import graph | ✅ knowledge graph | ✅ refs/importers |
-| Framework-aware edges | ✅ {{ site.data.counts.frameworks }} integrations | ❌ | ❌ | ❌ | ✅ 21 frameworks (route/middleware) | partial (REST routes) | ❌ |
-| Impact analysis | ✅ reverse dep traversal + decorator filter | ❌ | ❌ | ✅ blast-radius + Leiden communities | ✅ blast radius + decorator filter | ✅ detect_changes | ✅ impact command |
-| Call graph | ✅ bidirectional, graph-based | ❌ | ❌ | ✅ graph-based | ✅ AST-based, bidirectional | ✅ trace_call_path | ✅ refs/importers |
-| Refactoring tools | ✅ rename, extract, dead code, codemod | ❌ | ❌ | ❌ | ❌ (dead code detect only) | ❌ | ❌ |
-| Security scanning | ✅ OWASP Top-10, taint | ✅ Secretlint | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Multi-repo subprojects | ✅ cross-repo API linking | ✅ remote repos | ❌ | ✅ multi-repo daemon | ✅ GitHub repos | ✅ cross-service HTTP linking | ❌ |
-| IaC as graph nodes | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ K8s/Kustomize/HCL/Docker | ❌ |
-| Session memory | ✅ built-in | ❌ | ✅ SQLite FTS5 journal | ❌ | ✅ index persistence | ✅ persistent graph | ❌ |
+| Tree-sitter AST parsing | ✓ {{ site.data.counts.languages }} languages | ✓ compress only (~20) | ✗ no code parsing | ✓ 23 langs + Jupyter | ✓ 70+ languages | ✓ 161 languages | ✓ 22 languages |
+| Token-efficient symbol lookup | ✓ outlines, symbols, bundles | ✗ packs entire files | ✓ sandboxed output (98% reduction) | ✓ | ✓ core focus (~95% reduction) | ✓ | ✓ outline/show/context |
+| Cross-file dependency graph | ✓ directed edge graph | ✗ | ✗ | ✓ incremental knowledge graph | ✓ import graph | ✓ knowledge graph | ✓ refs/importers |
+| Framework-aware edges | ✓ {{ site.data.counts.frameworks }} integrations | ✗ | ✗ | ✗ | ✓ 21 frameworks (route/middleware) | partial (REST routes) | ✗ |
+| Impact analysis | ✓ reverse dep traversal + decorator filter | ✗ | ✗ | ✓ blast-radius + Leiden communities | ✓ blast radius + decorator filter | ✓ detect_changes | ✓ impact command |
+| Call graph | ✓ bidirectional, graph-based | ✗ | ✗ | ✓ graph-based | ✓ AST-based, bidirectional | ✓ trace_call_path | ✓ refs/importers |
+| Refactoring tools | ✓ rename, extract, dead code, codemod | ✗ | ✗ | ✗ | ✗ (dead code detect only) | ✗ | ✗ |
+| Security scanning | ✓ OWASP Top-10, taint | ✓ Secretlint | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Multi-repo subprojects | ✓ cross-repo API linking | ✓ remote repos | ✗ | ✓ multi-repo daemon | ✓ GitHub repos | ✓ cross-service HTTP linking | ✗ |
+| IaC as graph nodes | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ K8s/Kustomize/HCL/Docker | ✗ |
+| Session memory | ✓ built-in | ✗ | ✓ SQLite FTS5 journal | ✗ | ✓ index persistence | ✓ persistent graph | ✗ |
 | Written in | TypeScript | TypeScript | TypeScript | Python | Python | C | Go |
 
 _New entrants since April 2026 (local code-graph / packing lane, worth tracking): **Repomix** ships an official MCP server (`--mcp`) + tree-sitter `--compress` (~70% reduction); **tokensave** (601 stars, 40+ tools, 30+ langs, pre-indexed semantic KG); **codegraph** (colbymchenry — function-level dep graph, tree-sitter→SQLite, auto-sync; went viral this cycle, now 68.6K stars; its August 2026 re-measurement claims 62% fewer tokens / 88% fewer tool calls / 44% lower cost across seven repos, with model, queries, run count and a correction to its own earlier harness disclosed — self-run, not third-party reproduced, and the most transparent self-benchmark in this field; see [vs codegraph](/vs/codegraph.html)); **Headroom** (67.6K stars — not a code-graph tool, a generic reversible compression layer for tool outputs/JSON/logs/RAG chunks, deployable as library/proxy/MCP server; its `CodeCompressor` is AST-aware for 7 languages but purely for shrinking output bytes, with no graph, no symbol index, no cross-file edges — complements rather than competes with token-efficient *symbol* lookup); **repo-context-mcp** (nduc99911, 103 stars, TypeScript — three tools: `repo_map` directory tree + entrypoint detection, `search_code` substring grep, `pack_context` token-budgeted markdown pack; no AST parsing, no symbol index, no dependency graph — a lighter-weight cousin of Repomix, not a code-graph competitor). `cymbal` could not be re-verified in June 2026 — possibly renamed or inactive. `Context Mode` **is** active and was re-verified on August 29, 2026 (20.2K stars, last push August 28) — the June "could not verify" note was wrong and is retracted here._
@@ -77,17 +77,17 @@ Tools that persist context across AI agent sessions — activity logs, knowledge
 | Capability | trace-mcp | Kage | MemPalace | claude-mem | mem0 / OpenMemory | engram | ConPort |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **GitHub stars** | 100 | new (2026) | ~56.7K | 91.8K | ~53K | 2.7K | 761 |
-| Cross-session context carryover | ✅ `get_wake_up { scope: "resume" }` + decisions | ✅ git-committed packets | ✅ wings/rooms | ✅ core focus | ✅ multi-level (User/Session/Agent) | ✅ branch-scoped handoffs | ✅ |
-| Cross-session content search | ✅ `search_sessions` FTS5 | partial (JSON packets) | ✅ vector+keyword+temporal (+optional rerank), 96.6% R@5 LongMemEval | ✅ SQLite + Chroma hybrid | ✅ hierarchical, ≤7K tok/retrieval (94.4 LongMemEval) | ✅ local ONNX embeddings | ✅ vector semantic |
-| Decision knowledge graph | ✅ temporal, code-linked | ✅ temporal, code-linked | ✅ temporal + "Closets" storage | ❌ | ✅ temporal + state-key supersession | ❌ | ✅ project-level |
-| Code-graph-aware memory | ✅ decisions → symbols & files | ✅ **+ citation verification (staleness check)** | ❌ text-only | ❌ text-only | ❌ text-only | ❌ text-only | ❌ text-only |
-| Auto-extraction from sessions | ✅ pattern-based (0 LLM calls); hybrid LLM opt-in | ❌ agent-written | ❌ verbatim, zero extraction | ✅ AI-compressed + citations | ✅ single-pass hierarchical LLM | ❌ | ❌ |
-| Wake-up context | ✅ ~300 tok (code-linked decisions) | — | ✅ ~170 tok (AAAK) | ✅ progressive disclosure (~10×) + Endless Mode | ❌ | ❌ | ❌ |
-| Decision enrichment in tools | ✅ impact/plan_turn/resume | ❌ | ❌ standalone | ❌ | ❌ | ❌ | ❌ |
-| Service/subproject scoping | ✅ decisions per service | ❌ | ✅ wings per project | ❌ | ❌ | ✅ per branch | ✅ per workspace |
-| Published retrieval benchmark | ❌ | ❌ | ✅ LongMemEval / LoCoMo / MemBench | ❌ | ✅ LoCoMo / LongMemEval / BEAM | ❌ | ❌ |
-| Code intelligence included | ✅ {{ site.data.counts.tools }} tools, 180+ edge types | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Works as standalone memory | ❌ code-focused | ✅ git-native, code-focused | ✅ general-purpose | ❌ Claude-specific | ✅ agent-agnostic | ✅ agent-agnostic | ✅ project-scoped |
+| Cross-session context carryover | ✓ `get_wake_up { scope: "resume" }` + decisions | ✓ git-committed packets | ✓ wings/rooms | ✓ core focus | ✓ multi-level (User/Session/Agent) | ✓ branch-scoped handoffs | ✓ |
+| Cross-session content search | ✓ `search_sessions` FTS5 | partial (JSON packets) | ✓ vector+keyword+temporal (+optional rerank), 96.6% R@5 LongMemEval | ✓ SQLite + Chroma hybrid | ✓ hierarchical, ≤7K tok/retrieval (94.4 LongMemEval) | ✓ local ONNX embeddings | ✓ vector semantic |
+| Decision knowledge graph | ✓ temporal, code-linked | ✓ temporal, code-linked | ✓ temporal + "Closets" storage | ✗ | ✓ temporal + state-key supersession | ✗ | ✓ project-level |
+| Code-graph-aware memory | ✓ decisions → symbols & files | ✓ **+ citation verification (staleness check)** | ✗ text-only | ✗ text-only | ✗ text-only | ✗ text-only | ✗ text-only |
+| Auto-extraction from sessions | ✓ pattern-based (0 LLM calls); hybrid LLM opt-in | ✗ agent-written | ✗ verbatim, zero extraction | ✓ AI-compressed + citations | ✓ single-pass hierarchical LLM | ✗ | ✗ |
+| Wake-up context | ✓ ~300 tok (code-linked decisions) | — | ✓ ~170 tok (AAAK) | ✓ progressive disclosure (~10×) + Endless Mode | ✗ | ✗ | ✗ |
+| Decision enrichment in tools | ✓ impact/plan_turn/resume | ✗ | ✗ standalone | ✗ | ✗ | ✗ | ✗ |
+| Service/subproject scoping | ✓ decisions per service | ✗ | ✓ wings per project | ✗ | ✗ | ✓ per branch | ✓ per workspace |
+| Published retrieval benchmark | ✗ | ✗ | ✓ LongMemEval / LoCoMo / MemBench | ✗ | ✓ LoCoMo / LongMemEval / BEAM | ✗ | ✗ |
+| Code intelligence included | ✓ {{ site.data.counts.tools }} tools, 180+ edge types | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Works as standalone memory | ✗ code-focused | ✓ git-native, code-focused | ✓ general-purpose | ✗ Claude-specific | ✓ agent-agnostic | ✓ agent-agnostic | ✓ project-scoped |
 | Written in | TypeScript | — | Python | TypeScript | TS + Python | Go / Rust | Python |
 
 > **Key difference:** MemPalace stores "decided to use PostgreSQL" as text in ChromaDB. trace-mcp stores the same decision **linked to `src/db/connection.ts::Pool#class`** — and when you run `get_change_impact` on that symbol, the decision shows up in `linked_decisions`. General-purpose memory tools remember *what you said*. trace-mcp remembers *what you said* AND *which code it's about*.
@@ -101,14 +101,14 @@ Tools that generate docs from code or provide embedding-based code search for AI
 | Capability | trace-mcp | Repomix | DeepContext | smart-coding-mcp | mcp-local-rag¹ | knowledge-rag¹ |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|
 | **GitHub stars** | 100 | ~26.7K | ~300 | ~200 | ~200 | ~60 |
-| Real-time code understanding | ✅ live graph, always current | ❌ snapshot at pack time | ❌ manual reindex | partial (opt-in watcher) | ❌ | partial (file watcher) |
-| Auto-generated project docs | ✅ `generate_docs` from graph | ❌ raw file dump | ❌ | ❌ | ❌ | ❌ |
-| Semantic code search | ✅ `search` + `query_by_intent` | ❌ no search | ✅ Jina embeddings | ✅ nomic embeddings | ✅ vector search | ✅ hybrid + reranking |
-| Framework-aware context | ✅ routes, models, components | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Task-focused context | ✅ `get_task_context` — code subgraph | ❌ packs everything | ❌ | ❌ | ❌ | ❌ |
-| No doc maintenance needed | ✅ derived from code | ✅ repacks on demand | ❌ manual reindex | partial (auto on startup) | ❌ manual ingest | partial (auto-reindex) |
-| Works offline, no API keys | ✅ graph + FTS5 + bundled ONNX embeddings | ✅ | ❌ requires cloud API | ❌ requires local embeddings | ❌ requires local embeddings | ❌ requires local embeddings |
-| Incremental updates | ✅ file watcher, content hash | ❌ full repack | ✅ SHA-256 hashing | ✅ file hash + opt-in watcher | ❌ | ✅ mtime + dedup |
+| Real-time code understanding | ✓ live graph, always current | ✗ snapshot at pack time | ✗ manual reindex | partial (opt-in watcher) | ✗ | partial (file watcher) |
+| Auto-generated project docs | ✓ `generate_docs` from graph | ✗ raw file dump | ✗ | ✗ | ✗ | ✗ |
+| Semantic code search | ✓ `search` + `query_by_intent` | ✗ no search | ✓ Jina embeddings | ✓ nomic embeddings | ✓ vector search | ✓ hybrid + reranking |
+| Framework-aware context | ✓ routes, models, components | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Task-focused context | ✓ `get_task_context` — code subgraph | ✗ packs everything | ✗ | ✗ | ✗ | ✗ |
+| No doc maintenance needed | ✓ derived from code | ✓ repacks on demand | ✗ manual reindex | partial (auto on startup) | ✗ manual ingest | partial (auto-reindex) |
+| Works offline, no API keys | ✓ graph + FTS5 + bundled ONNX embeddings | ✓ | ✗ requires cloud API | ✗ requires local embeddings | ✗ requires local embeddings | ✗ requires local embeddings |
+| Incremental updates | ✓ file watcher, content hash | ✗ full repack | ✓ SHA-256 hashing | ✓ file hash + opt-in watcher | ✗ | ✓ mtime + dedup |
 | Written in | TypeScript | TypeScript | TypeScript | JavaScript | TypeScript | Python |
 
 _¹ mcp-local-rag and knowledge-rag are document RAG tools (PDF, DOCX, Markdown) — not code-specific. Included for comparison as they occupy adjacent mindshare._
@@ -121,23 +121,23 @@ _¹ mcp-local-rag and knowledge-rag are document RAG tools (PDF, DOCX, Markdown)
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **GitHub stars** | 100 | ~28.6K | ~19K | 41.1K | ~900 | ~100 | ~500 |
 | Languages | {{ site.data.counts.languages }} | 40+ (via LSP) | 23 + Jupyter | 161 | 19 | 32 | 28 |
-| Framework integrations | {{ site.data.counts.frameworks }} | ❌ | ❌ (Python entry points only) | ❌ | ❌ | ❌ | ~15 (ORM N+1 / API drift only) |
-| Cross-language edges | ✅ | ❌ | ❌ | ✅ cross-service HTTP | ✅ polyglot dep graph | ❌ | ✅ PHP↔TS API drift |
+| Framework integrations | {{ site.data.counts.frameworks }} | ✗ | ✗ (Python entry points only) | ✗ | ✗ | ✗ | ~15 (ORM N+1 / API drift only) |
+| Cross-language edges | ✓ | ✗ | ✗ | ✓ cross-service HTTP | ✓ polyglot dep graph | ✗ | ✓ PHP↔TS API drift |
 | MCP tools advertised (default) | 28 `minimal` (~9.8K tok, default); 54 `standard` (~19K); {{ site.data.counts.tools }} `full` (~50K) | ~55 | ~28 | 15 all / 11 `analysis` / 7 `scout` (~7K tok) | 21 | 90 | 224 |
-| Session memory | ✅ | ✅ (manual notes) | ❌ | ✅ | ❌ | ❌ | ❌ |
-| CI/PR reports | ✅ | ❌ | ✅ blast-radius GitHub Action | ❌ | ❌ | ❌ | ✅ SARIF 2.1.0 + GH/GL/Azure |
-| Multi-repo subprojects | ✅ | ❌ | ✅ multi-repo daemon | ✅ cross-service | ✅ cross-project search | ❌ | ❌ |
-| Control-flow / data-flow | ✅ CFG w/ basic blocks + loop back-edges + dataflow | ❌ | ❌ | ❌ | ❌ | ✅ CFG w/ basic blocks + loop edges; type-aware taint | ❌ |
-| Security scanning | ✅ OWASP/taint, type-aware pruning | ❌ | ❌ | ❌ | ❌ | ✅ 147 rules (taint/OWASP/CWE) + SBOM + OSV/supply-chain | ❌ |
-| IaC as graph nodes | ✅ K8s/Kustomize/HCL/Docker, cross-file resolved to real nodes | ❌ | ❌ | ✅ K8s/Kustomize/HCL/Docker | ❌ | ❌ | ❌ |
-| Compiler-grade precision | ✅ opt-in LSP + offline SCIP ingestion (`scip_resolved` tier) | ✅ live LSP (rename/refs/diagnostics) | ❌ | ❌ | ❌ | ❌ | ❌ |
-| SARIF / CI-scanning output | ✅ 2.1.0, OASIS-schema-validated | ❌ | ✅ blast-radius GitHub Action | ❌ | ❌ | ❌ | ✅ SARIF 2.1.0 + GH/GL/Azure |
-| Graph visualization | ✅ desktop app (cosmos.gl) | ❌ | ❌ | ✅ 3D web UI | ✅ interactive HTML | ✅ SPA frontend | ❌ |
-| Knowledge graph queries | ✅ `graph_query` | ❌ | ❌ | ✅ Cypher-like | ❌ | ✅ SPARQL / RDF | ❌ |
-| Refactoring tools | ✅ rename/move/signature/codemod/extract¹ | ✅ rename/move/inline/safe-delete | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Antipatterns / clone detection | ✅ 11 antipatterns + 4 code smells (debug artifacts across 10 langs) + AST Type-2 subtree hashing + name/signature duplication | ❌ | ❌ | ✅ MinHash near-clone + Louvain communities | ❌ | ❌ | ✅ 23 patterns + AST Type-2 subtree hashing |
-| Architecture governance | ✅ | ❌ | ✅ Leiden communities | ✅ Louvain communities | ❌ | ❌ | ✅ change-safety gates |
-| Token savings tracking | ✅ | ❌ | ✅ (6.8×–49×) | ✅ | ✅ (~61% claimed) | ❌ | ✅ (~92% claimed) |
+| Session memory | ✓ | ✓ (manual notes) | ✗ | ✓ | ✗ | ✗ | ✗ |
+| CI/PR reports | ✓ | ✗ | ✓ blast-radius GitHub Action | ✗ | ✗ | ✗ | ✓ SARIF 2.1.0 + GH/GL/Azure |
+| Multi-repo subprojects | ✓ | ✗ | ✓ multi-repo daemon | ✓ cross-service | ✓ cross-project search | ✗ | ✗ |
+| Control-flow / data-flow | ✓ CFG w/ basic blocks + loop back-edges + dataflow | ✗ | ✗ | ✗ | ✗ | ✓ CFG w/ basic blocks + loop edges; type-aware taint | ✗ |
+| Security scanning | ✓ OWASP/taint, type-aware pruning | ✗ | ✗ | ✗ | ✗ | ✓ 147 rules (taint/OWASP/CWE) + SBOM + OSV/supply-chain | ✗ |
+| IaC as graph nodes | ✓ K8s/Kustomize/HCL/Docker, cross-file resolved to real nodes | ✗ | ✗ | ✓ K8s/Kustomize/HCL/Docker | ✗ | ✗ | ✗ |
+| Compiler-grade precision | ✓ opt-in LSP + offline SCIP ingestion (`scip_resolved` tier) | ✓ live LSP (rename/refs/diagnostics) | ✗ | ✗ | ✗ | ✗ | ✗ |
+| SARIF / CI-scanning output | ✓ 2.1.0, OASIS-schema-validated | ✗ | ✓ blast-radius GitHub Action | ✗ | ✗ | ✗ | ✓ SARIF 2.1.0 + GH/GL/Azure |
+| Graph visualization | ✓ desktop app (cosmos.gl) | ✗ | ✗ | ✓ 3D web UI | ✓ interactive HTML | ✓ SPA frontend | ✗ |
+| Knowledge graph queries | ✓ `graph_query` | ✗ | ✗ | ✓ Cypher-like | ✗ | ✓ SPARQL / RDF | ✗ |
+| Refactoring tools | ✓ rename/move/signature/codemod/extract¹ | ✓ rename/move/inline/safe-delete | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Antipatterns / clone detection | ✓ 11 antipatterns + 4 code smells (debug artifacts across 10 langs) + AST Type-2 subtree hashing + name/signature duplication | ✗ | ✗ | ✓ MinHash near-clone + Louvain communities | ✗ | ✗ | ✓ 23 patterns + AST Type-2 subtree hashing |
+| Architecture governance | ✓ | ✗ | ✓ Leiden communities | ✓ Louvain communities | ✗ | ✗ | ✓ change-safety gates |
+| Token savings tracking | ✓ | ✗ | ✓ (6.8×–49×) | ✓ | ✓ (~61% claimed) | ✗ | ✓ (~92% claimed) |
 | Written in | TypeScript | Python | Python | C | TypeScript | Rust | Python |
 
 _¹ `apply_codemod` now rewrites on `@ast-grep/napi` (true AST pattern matching, metavariable substitution, no false matches in strings/comments) with automatic regex fallback for non-AST languages; the native binding loads lazily and degrades to regex instead of crashing if missing. `extract_function` is re-enabled with AST free-variable analysis — it detects genuine multi-return-value slices and rejects them with a structured error rather than silently dropping a binding, and lowers `confidence` on shadowed-variable cases instead of misreporting them as clean (see "where competitors lead" below for what deep validation found)._

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -202,15 +202,15 @@ AI features enable semantic search (vector embeddings) and optional LLM-powered 
 
 | Provider | Embeddings | LLM (summarization) | Requires | Setup |
 |---|---|---|---|---|
-| **`onnx`** (default) | ✅ local, offline | ❌ | `@huggingface/transformers` (optional dep) | Zero-config — model auto-downloads (~23 MB) on first use |
-| **`ollama`** | ✅ via Ollama | ✅ via Ollama | Running Ollama instance | Install Ollama + pull models |
-| **`lmstudio`** | ✅ via LM Studio | ✅ via LM Studio | LM Studio server running | OpenAI-compatible, no API key |
-| **`openai`** | ✅ | ✅ | API key | `api_key` or `OPENAI_API_KEY` env |
-| **`anthropic`** | ❌ (no embeddings API) | ✅ | API key | `api_key` or `ANTHROPIC_API_KEY` env |
-| **`gemini`** | ✅ | ✅ | API key | Google Generative Language API (consumer) — `api_key` (AIza…) or `GEMINI_API_KEY` env |
-| **`vertex`** | ✅ | ✅ | OAuth token + GCP project | Google Vertex AI (GCP) — `api_key` = access token, plus `vertex_project` + `vertex_location` |
-| **`voyage`** | ✅ (code-tuned) | ❌ | API key | Voyage AI embeddings only — pair with another provider for inference |
-| **`mistral`** / **`groq`** / **`together`** / **`deepseek`** / **`xai`** | ✅ | ✅ | API key | OpenAI-compatible endpoints — per-provider `*_API_KEY` env |
+| **`onnx`** (default) | ✓ local, offline | ✗ | `@huggingface/transformers` (optional dep) | Zero-config — model auto-downloads (~23 MB) on first use |
+| **`ollama`** | ✓ via Ollama | ✓ via Ollama | Running Ollama instance | Install Ollama + pull models |
+| **`lmstudio`** | ✓ via LM Studio | ✓ via LM Studio | LM Studio server running | OpenAI-compatible, no API key |
+| **`openai`** | ✓ | ✓ | API key | `api_key` or `OPENAI_API_KEY` env |
+| **`anthropic`** | ✗ (no embeddings API) | ✓ | API key | `api_key` or `ANTHROPIC_API_KEY` env |
+| **`gemini`** | ✓ | ✓ | API key | Google Generative Language API (consumer) — `api_key` (AIza…) or `GEMINI_API_KEY` env |
+| **`vertex`** | ✓ | ✓ | OAuth token + GCP project | Google Vertex AI (GCP) — `api_key` = access token, plus `vertex_project` + `vertex_location` |
+| **`voyage`** | ✓ (code-tuned) | ✗ | API key | Voyage AI embeddings only — pair with another provider for inference |
+| **`mistral`** / **`groq`** / **`together`** / **`deepseek`** / **`xai`** | ✓ | ✓ | API key | OpenAI-compatible endpoints — per-provider `*_API_KEY` env |
 
 ### Minimal setup — local embeddings (no API keys)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: "trace-mcp Configuration Reference — all config options (works with none)"
 description: "Every trace-mcp config option in .trace-mcp.json — indexing, quality gates, LSP enrichment, TOON output, telemetry. Configuration is optional; trace-mcp works out of the box for standard projects."
-updated: 2026-08-29
+updated: 2026-08-30
 ---
 
 # Configuration

--- a/docs/decision-memory.md
+++ b/docs/decision-memory.md
@@ -1,7 +1,7 @@
 ---
 title: "Decision Memory — a persistent knowledge graph for architectural decisions"
 description: "trace-mcp's decision knowledge graph captures architectural decisions, tech choices, bug root causes, preferences, and conventions — linked to the code they're about."
-updated: 2026-08-29
+updated: 2026-08-30
 ---
 
 # Decision memory

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,7 +1,7 @@
 ---
 title: "Quality Gates Reference — complexity, security, and coverage thresholds"
 description: "How trace-mcp's quality_gates.rules in .trace-mcp.json override CLI defaults for cyclomatic complexity, security findings, and coverage — with this project's own thresholds as a worked example."
-updated: 2026-08-29
+updated: 2026-08-30
 ---
 
 # Quality gates — this project's thresholds

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -14,31 +14,31 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/comparisons.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/repomix.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/serena.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/codebase-memory-mcp.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/codegraph.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -50,13 +50,13 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/configuration.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/architecture.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -68,37 +68,37 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/analytics.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/toon-savings.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/decision-memory.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/telemetry.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/quality-gates.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/tweakcc.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,7 +1,7 @@
 ---
 title: "Telemetry & Observability — OpenTelemetry spans for every MCP tool call"
 description: "trace-mcp's pluggable observability bridge emits OpenTelemetry-compatible spans for every AI provider call and every MCP tool call."
-updated: 2026-08-29
+updated: 2026-08-30
 ---
 
 # Telemetry & Observability

--- a/docs/toon-savings.md
+++ b/docs/toon-savings.md
@@ -1,7 +1,7 @@
 ---
 title: "TOON Output Format — Measured Token Savings on Real Tool Calls"
 description: "Real-world token measurements for trace-mcp's TOON (Token-Oriented Object Notation) output format across tabular MCP tool responses."
-updated: 2026-08-29
+updated: 2026-08-30
 ---
 
 # TOON Token Savings — Measured

--- a/docs/tweakcc.md
+++ b/docs/tweakcc.md
@@ -1,7 +1,7 @@
 ---
 title: "System Prompt Routing via tweakcc — pairing trace-mcp with Claude Code"
 description: "How to pair trace-mcp with tweakcc to patch Claude Code's system prompts and route tool selection toward trace-mcp instead of native file reads."
-updated: 2026-08-29
+updated: 2026-08-30
 ---
 
 # System Prompt Routing via tweakcc

--- a/docs/vs/codebase-memory-mcp.md
+++ b/docs/vs/codebase-memory-mcp.md
@@ -1,7 +1,7 @@
 ---
 title: "codebase-memory-mcp Alternative: trace-mcp vs codebase-memory-mcp"
 description: "Both build a persistent code knowledge graph for AI agents. Head-to-head on language coverage, advertised tool cost, framework awareness, refactoring and security — including the two places codebase-memory-mcp is clearly ahead."
-updated: 2026-08-29
+updated: 2026-08-30
 ---
 
 # codebase-memory-mcp alternative: trace-mcp vs codebase-memory-mcp

--- a/docs/vs/codebase-memory-mcp.md
+++ b/docs/vs/codebase-memory-mcp.md
@@ -91,24 +91,24 @@ The split is depth versus breadth, in both directions. codebase-memory-mcp is br
 |---|:---:|:---:|
 | **GitHub stars** | 100 | 41.0K |
 | Languages | {{ site.data.counts.languages }} | 161 |
-| Framework integrations | ✅ {{ site.data.counts.frameworks }} | ❌ (partial REST routes) |
-| Persistent knowledge graph | ✅ SQLite + FTS5 | ✅ |
-| Knowledge-graph queries | ✅ `graph_query` | ✅ Cypher-like |
-| Impact analysis | ✅ reverse dependency traversal + decorator filter | ✅ `detect_changes` |
-| Call graph | ✅ bidirectional | ✅ `trace_call_path` |
-| Cross-service / multi-repo | ✅ cross-repo API linking | ✅ cross-service HTTP linking |
-| IaC as graph nodes | ✅ K8s/Kustomize/HCL/Docker, cross-file resolved | ✅ K8s/Kustomize/HCL/Docker |
-| Clone / community detection | ✅ AST Type-2 subtree hashing, 11 antipatterns | ✅ MinHash near-clone, Louvain communities |
-| Refactoring tools | ✅ rename, move, signature, AST codemod, extract | ❌ |
-| Security scanning | ✅ OWASP Top-10, type-aware taint, SARIF 2.1.0 | ❌ |
-| Control-flow graph | ✅ basic blocks, loop back-edges, try/catch merges | ❌ |
-| Quality gates in CI | ✅ complexity / security / coverage thresholds | ❌ |
-| Code-linked decision memory | ✅ decisions bound to symbol IDs, staleness-verified | partial (`manage_adr` markdown documents) |
-| Runtime trace ingestion | ❌ | ✅ `ingest_traces` |
-| Graph visualization | ✅ desktop app | ✅ 3D web UI |
+| Framework integrations | ✓ {{ site.data.counts.frameworks }} | ✗ (partial REST routes) |
+| Persistent knowledge graph | ✓ SQLite + FTS5 | ✓ |
+| Knowledge-graph queries | ✓ `graph_query` | ✓ Cypher-like |
+| Impact analysis | ✓ reverse dependency traversal + decorator filter | ✓ `detect_changes` |
+| Call graph | ✓ bidirectional | ✓ `trace_call_path` |
+| Cross-service / multi-repo | ✓ cross-repo API linking | ✓ cross-service HTTP linking |
+| IaC as graph nodes | ✓ K8s/Kustomize/HCL/Docker, cross-file resolved | ✓ K8s/Kustomize/HCL/Docker |
+| Clone / community detection | ✓ AST Type-2 subtree hashing, 11 antipatterns | ✓ MinHash near-clone, Louvain communities |
+| Refactoring tools | ✓ rename, move, signature, AST codemod, extract | ✗ |
+| Security scanning | ✓ OWASP Top-10, type-aware taint, SARIF 2.1.0 | ✗ |
+| Control-flow graph | ✓ basic blocks, loop back-edges, try/catch merges | ✗ |
+| Quality gates in CI | ✓ complexity / security / coverage thresholds | ✗ |
+| Code-linked decision memory | ✓ decisions bound to symbol IDs, staleness-verified | partial (`manage_adr` markdown documents) |
+| Runtime trace ingestion | ✗ | ✓ `ingest_traces` |
+| Graph visualization | ✓ desktop app | ✓ 3D web UI |
 | MCP tools advertised (default) | 28 (~11.6K tok); {{ site.data.counts.tools }} on `full` | 15 (~7K tok); profiles: 11 / 7 |
 | Supply-chain posture | OpenSSF Scorecard, CodeQL, Semgrep | SLSA L3, VirusTotal, OpenSSF Scorecard |
-| Published benchmark | ❌ | ✅ preprint, not independently reproduced |
+| Published benchmark | ✗ | ✓ preprint, not independently reproduced |
 | Written in | TypeScript | C |
 
 ## When to pick codebase-memory-mcp

--- a/docs/vs/codegraph.md
+++ b/docs/vs/codegraph.md
@@ -1,7 +1,7 @@
 ---
 title: "CodeGraph MCP Alternative: trace-mcp vs codegraph for AI coding agents"
 description: "codegraph advertises one tool and optimises for orienting an agent in an unfamiliar repo; trace-mcp ships a broad graph with refactoring, security scanning and code-linked memory. Head-to-head on tool surface, language and framework coverage, benchmarks — plus where codegraph is clearly ahead."
-updated: 2026-08-29
+updated: 2026-08-30
 ---
 
 # CodeGraph MCP alternative: trace-mcp vs codegraph

--- a/docs/vs/codegraph.md
+++ b/docs/vs/codegraph.md
@@ -94,24 +94,24 @@ Pick codegraph if the job is *orient an agent in a repository it has never seen*
 | **GitHub stars** | 102 | ~68.6K |
 | License | MIT | MIT |
 | Languages | {{ site.data.counts.languages }} (tree-sitter) | 34 (tree-sitter, Rust kernel + WASM fallback) |
-| Framework integrations | ✅ {{ site.data.counts.frameworks }} | ✅ 17 (route → handler) |
-| Framework edges beyond routing | ✅ controller → template, model → table, component → component | partial — route → handler, plus React Native `component`/`property` nodes |
-| Cross-language edges | ✅ | ✅ Swift ↔ ObjC, RN bridge / TurboModules / Expo / Fabric |
+| Framework integrations | ✓ {{ site.data.counts.frameworks }} | ✓ 17 (route → handler) |
+| Framework edges beyond routing | ✓ controller → template, model → table, component → component | partial — route → handler, plus React Native `component`/`property` nodes |
+| Cross-language edges | ✓ | ✓ Swift ↔ ObjC, RN bridge / TurboModules / Expo / Fabric |
 | MCP tools defined | {{ site.data.counts.tools }} | 8 |
 | MCP tools advertised by default | 28 (~11.6K tok) | **1** (`codegraph_explore`) |
-| Rest of the surface reachable | ✅ `load_tools`, one call | ✅ `CODEGRAPH_MCP_TOOLS` env allowlist, restart |
-| Persistent graph across restarts | ✅ SQLite + FTS5 | ✅ SQLite |
-| Runs fully local, no API key | ✅ | ✅ |
-| Incremental re-index on save | ✅ | ✅ debounced file watcher |
-| Impact analysis | ✅ reverse traversal + decorator filter | ✅ `codegraph_impact` (behind the allowlist) |
-| Refactoring tools | ✅ rename, move, signature, AST codemod, extract | ❌ |
-| Security scanning | ✅ OWASP Top-10, type-aware taint | ❌ |
-| Control-flow / data-flow | ✅ CFG with basic blocks and loop back-edges | ❌ |
-| SARIF / CI output | ✅ 2.1.0, schema-validated | ❌ |
-| Session memory | ✅ code-linked decision graph | ❌ |
-| Multi-repo | ✅ cross-repo API linking into one graph | partial — queries other separately-indexed projects by path |
-| Graph visualization | ✅ desktop app | ❌ |
-| Published A/B token benchmark | ❌ per-repo `get_real_savings` instead | ✅ 7 repos, methodology disclosed |
+| Rest of the surface reachable | ✓ `load_tools`, one call | ✓ `CODEGRAPH_MCP_TOOLS` env allowlist, restart |
+| Persistent graph across restarts | ✓ SQLite + FTS5 | ✓ SQLite |
+| Runs fully local, no API key | ✓ | ✓ |
+| Incremental re-index on save | ✓ | ✓ debounced file watcher |
+| Impact analysis | ✓ reverse traversal + decorator filter | ✓ `codegraph_impact` (behind the allowlist) |
+| Refactoring tools | ✓ rename, move, signature, AST codemod, extract | ✗ |
+| Security scanning | ✓ OWASP Top-10, type-aware taint | ✗ |
+| Control-flow / data-flow | ✓ CFG with basic blocks and loop back-edges | ✗ |
+| SARIF / CI output | ✓ 2.1.0, schema-validated | ✗ |
+| Session memory | ✓ code-linked decision graph | ✗ |
+| Multi-repo | ✓ cross-repo API linking into one graph | partial — queries other separately-indexed projects by path |
+| Graph visualization | ✓ desktop app | ✗ |
+| Published A/B token benchmark | ✗ per-repo `get_real_savings` instead | ✓ 7 repos, methodology disclosed |
 | Written in | TypeScript | TypeScript + Rust kernel |
 
 Verified on August 29, 2026 against codegraph's source and README at commit `6a056ec` — the `main` head, shipped after the `v1.6.0` tag. Tool-surface claims come from the source; language, framework and bridging counts come from the README's own tables, which the source directory layout corroborates.

--- a/docs/vs/repomix.md
+++ b/docs/vs/repomix.md
@@ -91,20 +91,20 @@ If you are picking between them, the question is not "which is better" — it is
 |---|:---:|:---:|
 | **GitHub stars** | 100 | 28.1K |
 | Model | live index (SQLite + FTS5) | one-shot pack |
-| Tree-sitter AST parsing | ✅ {{ site.data.counts.languages }} languages | ✅ `--compress` only (~20) |
-| Token-efficient symbol lookup | ✅ outlines, symbols, bundles | ❌ packs entire files |
-| Cross-file dependency graph | ✅ directed edge graph | ❌ |
-| Framework-aware edges | ✅ {{ site.data.counts.frameworks }} integrations | ❌ |
-| Call graph | ✅ bidirectional, graph-based | ❌ |
-| Impact analysis | ✅ reverse dependency traversal | ❌ |
-| Search | ✅ FTS5 + embeddings + graph | ❌ no search |
-| Refactoring tools | ✅ rename, move, signature, codemod, extract | ❌ |
-| Security scanning | ✅ OWASP Top-10, taint analysis | ✅ Secretlint (secrets only) |
-| Freshness | ✅ incremental, file-watcher, content hash | ❌ snapshot at pack time, full repack |
-| Remote repositories | ✅ multi-repo subprojects | ✅ packs remote repos directly |
-| Official MCP server | ✅ core product | ✅ `--mcp` |
+| Tree-sitter AST parsing | ✓ {{ site.data.counts.languages }} languages | ✓ `--compress` only (~20) |
+| Token-efficient symbol lookup | ✓ outlines, symbols, bundles | ✗ packs entire files |
+| Cross-file dependency graph | ✓ directed edge graph | ✗ |
+| Framework-aware edges | ✓ {{ site.data.counts.frameworks }} integrations | ✗ |
+| Call graph | ✓ bidirectional, graph-based | ✗ |
+| Impact analysis | ✓ reverse dependency traversal | ✗ |
+| Search | ✓ FTS5 + embeddings + graph | ✗ no search |
+| Refactoring tools | ✓ rename, move, signature, codemod, extract | ✗ |
+| Security scanning | ✓ OWASP Top-10, taint analysis | ✓ Secretlint (secrets only) |
+| Freshness | ✓ incremental, file-watcher, content hash | ✗ snapshot at pack time, full repack |
+| Remote repositories | ✓ multi-repo subprojects | ✓ packs remote repos directly |
+| Official MCP server | ✓ core product | ✓ `--mcp` |
 | Setup cost | index build, then instant queries | none, but re-pack on every change |
-| Works offline, no API keys | ✅ | ✅ |
+| Works offline, no API keys | ✓ | ✓ |
 | Written in | TypeScript | TypeScript |
 
 ## When to pick Repomix

--- a/docs/vs/repomix.md
+++ b/docs/vs/repomix.md
@@ -1,7 +1,7 @@
 ---
 title: "Repomix Alternative: trace-mcp vs Repomix for AI code context"
 description: "Repomix packs your repository into one prompt. trace-mcp indexes it into a queryable graph. Head-to-head on token cost, freshness, search, and refactoring — plus when Repomix is still the right pick."
-updated: 2026-08-29
+updated: 2026-08-30
 ---
 
 # Repomix alternative: trace-mcp vs Repomix

--- a/docs/vs/serena.md
+++ b/docs/vs/serena.md
@@ -1,7 +1,7 @@
 ---
 title: "Serena MCP Alternative: trace-mcp vs Serena for agent code navigation"
 description: "Serena drives a live language server; trace-mcp precomputes a framework-aware code graph. Head-to-head on precision, startup cost, refactoring, security and memory — plus where Serena is clearly ahead."
-updated: 2026-08-29
+updated: 2026-08-30
 ---
 
 # Serena MCP alternative: trace-mcp vs Serena

--- a/docs/vs/serena.md
+++ b/docs/vs/serena.md
@@ -91,22 +91,22 @@ Pick Serena if precision on one well-supported language is the whole job. Pick t
 |---|:---:|:---:|
 | **GitHub stars** | 100 | ~28.5K |
 | Languages | {{ site.data.counts.languages }} (tree-sitter) | 40+ (via LSP) |
-| Requires a language server | ❌ optional enrichment | ✅ core premise |
+| Requires a language server | ✗ optional enrichment | ✓ core premise |
 | Reference precision by default | AST-resolved (tiered) | compiler-grade (LSP) |
-| Compiler-grade path | ✅ opt-in LSP + offline SCIP ingestion | ✅ live LSP |
-| Framework integrations | ✅ {{ site.data.counts.frameworks }} | ❌ |
-| Cross-language edges | ✅ | ❌ |
-| Persistent graph across restarts | ✅ SQLite + FTS5 | ❌ per-session |
-| Impact analysis | ✅ reverse dependency traversal + decorator filter | ❌ |
-| Call graph | ✅ bidirectional, graph-based | partial (LSP call hierarchy) |
-| Refactoring tools | ✅ rename, move, signature, AST codemod, extract | ✅ rename, move, inline, safe-delete |
-| Live debugger | ❌ deliberately out of lane | ✅ breakpoints, variable inspection |
-| Session memory | ✅ code-linked decision graph | ✅ manual notes |
-| Security scanning | ✅ OWASP Top-10, type-aware taint | ❌ |
-| Control-flow / data-flow | ✅ CFG with basic blocks and loop back-edges | ❌ |
-| SARIF / CI output | ✅ 2.1.0, schema-validated | ❌ |
-| Multi-repo subprojects | ✅ cross-repo API linking | ❌ |
-| Graph visualization | ✅ desktop app | ❌ |
+| Compiler-grade path | ✓ opt-in LSP + offline SCIP ingestion | ✓ live LSP |
+| Framework integrations | ✓ {{ site.data.counts.frameworks }} | ✗ |
+| Cross-language edges | ✓ | ✗ |
+| Persistent graph across restarts | ✓ SQLite + FTS5 | ✗ per-session |
+| Impact analysis | ✓ reverse dependency traversal + decorator filter | ✗ |
+| Call graph | ✓ bidirectional, graph-based | partial (LSP call hierarchy) |
+| Refactoring tools | ✓ rename, move, signature, AST codemod, extract | ✓ rename, move, inline, safe-delete |
+| Live debugger | ✗ deliberately out of lane | ✓ breakpoints, variable inspection |
+| Session memory | ✓ code-linked decision graph | ✓ manual notes |
+| Security scanning | ✓ OWASP Top-10, type-aware taint | ✗ |
+| Control-flow / data-flow | ✓ CFG with basic blocks and loop back-edges | ✗ |
+| SARIF / CI output | ✓ 2.1.0, schema-validated | ✗ |
+| Multi-repo subprojects | ✓ cross-repo API linking | ✗ |
+| Graph visualization | ✓ desktop app | ✗ |
 | MCP tools advertised (default) | 28 (~11.6K tok); {{ site.data.counts.tools }} on `full` | ~55 |
 | Written in | TypeScript | Python |
 

--- a/tests/docs/no-emoji-marks.test.ts
+++ b/tests/docs/no-emoji-marks.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Emoji-free rendered pages (TRA-447).
+ *
+ * docs/DESIGN-WEB.md §4 forbids emoji as UI: they are filled multi-colour
+ * icons, and on trace-mcp.com red is reserved as the single accent. The
+ * comparison tables had drifted to 305 ✅/❌ marks on comparisons.html alone,
+ * painting the page green and red. Capability marks are now ✓/✗ text, styled
+ * by opacity through .mark-yes / .mark-no.
+ *
+ * Only the reader-facing surfaces are guarded. docs/llms-full.txt is machine
+ * input, not a rendered page, so it is out of scope.
+ *
+ * ↔ and → are not on this list on purpose: they carry meaning in the tables
+ * ("Swift ↔ ObjC", "route → handler") and render as monochrome text, so a
+ * blanket \p{Extended_Pictographic} guard would be wrong here.
+ */
+
+const DOCS = join(import.meta.dirname, '..', '..', 'docs');
+
+const FORBIDDEN = ['✅', '❌', '⚠️', '✔️', '✖️', '🟢', '🟡', '🔴'];
+
+function renderedPages(): string[] {
+  const md = readdirSync(DOCS).filter((f) => f.endsWith('.md') && f !== 'DESIGN-WEB.md');
+  const vs = readdirSync(join(DOCS, 'vs')).map((f) => join('vs', f));
+  return [...md, ...vs, 'index.html'];
+}
+
+describe('rendered pages carry no emoji', () => {
+  it.each(renderedPages())('%s', (page) => {
+    const source = readFileSync(join(DOCS, page), 'utf-8');
+    const found = FORBIDDEN.filter((glyph) => source.includes(glyph));
+    expect(
+      found,
+      `emoji in docs/${page} — use ✓/✗ text marks instead (docs/DESIGN-WEB.md §4)`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
The comparison tables had drifted to `✅`/`❌` emoji as capability marks — **305 of them on `comparisons.html` alone**, plus the four `/vs/` head-to-head pages and the embedding-provider table in `configuration.html`.

`docs/DESIGN-WEB.md` §4 forbids emoji as UI for two reasons that both bite here: they are filled multi-colour icons, and red is the site's single accent. A page that paints half its cells green and the other half red has three accents and no hierarchy left to spend.

## What changed

Marks are now `✓`/`✗` text. Yes and no separate on **opacity** — `✓` at `--text-display`, `✗` at `--text-disabled` — which is how this system encodes state everywhere else.

The layout script wraps each mark in `.mark-yes` / `.mark-no` with `role="img"` and an `aria-label`, so a screen reader reads "Yes"/"No" rather than "check mark". That was the emoji's one real advantage and it is kept. Markdown source keeps the bare glyph so the tables stay scannable in a diff — the SEO agent edits these files constantly.

## Measured

Rendered at 1440px on `comparisons.html`, both themes, headless Chrome. `✗` at `--text-disabled` is 4.54:1 on `#F5F5F5` (light) and 4.6:1 on `#000` (dark) — AA either way.

Screenshots of the same table region, before and after, are in the TRA-447 issue thread.

## Guard

`tests/docs/no-emoji-marks.test.ts` checks every rendered page. Verified it fails on a reintroduced `✅` and passes clean. It lists the glyphs rather than matching `\p{Extended_Pictographic}`, because `↔` is in that property and carries meaning in these tables ("Swift ↔ ObjC").

`docs/DESIGN-WEB.md` records the rule in §2, §4 and the review checklist, same PR.

Closes TRA-447.
