### PR TITLE
fix(app): the projects table shades what its pinned column covers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -470,6 +470,28 @@ whole indicator; the open menu is the rest of it
 (`.ws-sb-row[aria-expanded='true']:focus-visible { box-shadow: none }`). The ring
 stays for the case it is actually for: the row focused with the menu closed.
 
+### A pinned column shades what it covers, or it is lying about the table
+
+A table wider than its pane freezes its identity columns left and its actions right, and
+the rows then slide *underneath* them. That is only legible if the pinned column casts a
+shade over what it covers. Without one the covered content simply stops, and a table
+whose last visible column is Symbols reads as a table that ends at Symbols — at the
+default 960×700 window the workspace table is 1025px in a 707px pane, so four of its ten
+columns sat under the Actions pin with nothing to say so, and a right-aligned `1,043`
+painted down to `1,0`, which reads as the value rather than as half of it.
+
+The shade is `±10px 0 12px -10px var(--scroll-edge-shade)` alongside the hairline, and it
+is **directional**: only the side that still hides content is coloured, so a table
+scrolled to its end shows a plain seam. Toggle it by writing the colour, not the shadow —
+`--edge-shade-left` / `--edge-shade-right` on the scroll container is one style write per
+scroll event instead of a boolean threaded through every cell.
+
+**`box-shadow` does not paint on a cell in a collapsed table.** Chromium drops it, so a
+seam declared on a `td` under `border-collapse: collapse` is a seam that does not exist —
+this one was declared in TRA-265 and never rendered a pixel. Tables that pin columns use
+`border-collapse: separate` with `border-spacing: 0`, which also moves the row hairline
+from the `<tr>` (ignored in the separated model) onto the cells.
+
 ### States are part of the component, not an afterthought
 
 Every data surface owes four states, and each has a house form:
@@ -1207,6 +1229,7 @@ new evidence.
 | Verify in the Electron window, not in Chrome | `navigator.userAgent` says "Mac" in Chrome on macOS too, so the renderer draws the 44px traffic-light reservation with no traffic lights in it — a band that does not exist in the real app. A screenshot off `vite dev` in a browser is a different product. (Nikolai, 2026-08-29; the rule itself lands with TRA-354.) |
 | A rule the enforcement cannot see is a comment | §8 rule 1 named `rgb()` from day one and `tokenGuard()` never counted it, so the ban held for hex and lapsed for `rgb()` — which is how a 3.89:1 label sat on the sidebar with a green build. When a rule goes into §8, check the script actually implements all of it. |
 | The last tile still hand-rolling its material is the one nobody looks at | The sidebar's update card kept `--fill-tertiary` at an 8px radius and a private `.btn-prominent` through the whole TRA-290 migration, because it only appears when there is an update — so every review of the sidebar was a review of a sidebar without it. When a migration says "every surface", enumerate the surfaces that are conditionally rendered too. |
+| A seam you cannot see is a seam you do not have | The workspace table's frozen columns declared a `-1px 0 0 var(--separator)` hairline on the pinned cells from the day they landed, and Chromium had been discarding it the whole time — `box-shadow` does not paint on cells under `border-collapse: collapse`. Nobody noticed, because the failure mode of a missing seam is a table that looks finished. Check a decorative declaration renders; only a screenshot or `getComputedStyle` on the running renderer can tell you it did. |
 | A row label never repeats its own control's verb | "Temporary pause" beside a "Pause for 10 minutes" button wrapped to two lines at the 640px minimum and added no meaning. The label names the subject ("Enforcement"), the control names the action. |
 
 ---

--- a/packages/app/src/renderer/styles/island.css
+++ b/packages/app/src/renderer/styles/island.css
@@ -957,3 +957,28 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
   font-size: 11px;
   opacity: 0.8;
 }
+
+/* ============================================================================
+   WORKSPACE TABLE — .ws-table (TRA-452)
+
+   Separated borders, not collapsed. Chromium drops `box-shadow` on table cells
+   in the collapsed model, so the seam the pinned columns have declared since
+   TRA-265 never painted a pixel — and with it went the only sign that four of
+   the ten columns sit under the Actions pin at the default window width.
+   The separated model draws borders on cells rather than rows, so the row
+   hairline moves here from the `<tr>`; the windowing spacers carry a colspan
+   and get none.
+   ============================================================================ */
+.ws-table {
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.ws-table th,
+.ws-table td {
+  border-bottom: 0.5px solid var(--separator);
+}
+
+.ws-table td[colspan] {
+  border-bottom: 0;
+}

--- a/packages/app/src/renderer/styles/tokens.css
+++ b/packages/app/src/renderer/styles/tokens.css
@@ -92,6 +92,10 @@
   --badge-purple-fg: #8643a8;
 
   --shadow-panel: 0 8px 24px rgb(0 0 0 / 0.16), 0 0 0 0.5px rgb(0 0 0 / 0.08);
+  /* The shade a pinned table column casts over the rows sliding under it.
+     Only the colour is a token — the offset and blur belong to the seam
+     that draws it, and it is set to transparent when nothing is hidden. */
+  --scroll-edge-shade: rgb(0 0 0 / 0.18);
 
   /* ---- Type scale — macOS text styles. Nothing at 9, 12.5, 13.5, 14, 16, 18. */
   --text-large-title: 26px;
@@ -213,6 +217,7 @@
     --badge-blue-fg: #3d9eff;
     --badge-purple-fg: #cb79f4;
     --shadow-panel: 0 8px 24px rgb(0 0 0 / 0.45), 0 0 0 0.5px rgb(255 255 255 / 0.08);
+    --scroll-edge-shade: rgb(0 0 0 / 0.5);
   }
 }
 
@@ -250,6 +255,7 @@
   --badge-blue-fg: #3d9eff;
   --badge-purple-fg: #cb79f4;
   --shadow-panel: 0 8px 24px rgb(0 0 0 / 0.45), 0 0 0 0.5px rgb(255 255 255 / 0.08);
+  --scroll-edge-shade: rgb(0 0 0 / 0.5);
 }
 
 /* A light stage inside a dark root has to walk the palette back. */
@@ -291,6 +297,7 @@
   --badge-blue-fg: #0059cf;
   --badge-purple-fg: #8643a8;
   --shadow-panel: 0 8px 24px rgb(0 0 0 / 0.16), 0 0 0 0.5px rgb(0 0 0 / 0.08);
+  --scroll-edge-shade: rgb(0 0 0 / 0.18);
 }
 
 /* ============================================================================

--- a/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
@@ -98,7 +98,10 @@ const STICKY_HEADER_BG = overPane('var(--fill-quaternary)');
  * ten columns are under the Actions pin, so getting it backwards is silent.
  */
 export function scrollEdges(scrollLeft: number, scrollWidth: number, clientWidth: number) {
-  return { left: scrollLeft > 0, right: scrollLeft < scrollWidth - clientWidth - 1 };
+  return {
+    left: scrollLeft > 0,
+    right: scrollLeft < scrollWidth - clientWidth - 1,
+  };
 }
 
 /**

--- a/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
@@ -92,13 +92,33 @@ const SELECT_COL_W = 32;
 const overPane = (tint: string) => `linear-gradient(${tint}, ${tint}), var(--surface)`;
 const STICKY_HEADER_BG = overPane('var(--fill-quaternary)');
 
-/** Sticky cells need their own background — rows slide underneath them. */
+/**
+ * Whether the table still hides content on each side of its pinned columns.
+ * Exported for the unit test: the shade is the only thing that says four of the
+ * ten columns are under the Actions pin, so getting it backwards is silent.
+ */
+export function scrollEdges(scrollLeft: number, scrollWidth: number, clientWidth: number) {
+  return { left: scrollLeft > 0, right: scrollLeft < scrollWidth - clientWidth - 1 };
+}
+
+/**
+ * Sticky cells need their own background — rows slide underneath them.
+ *
+ * The seam also carries a soft shade, coloured by `--edge-shade-{side}` on the
+ * scroll container, so a pinned column reads as floating over the rows it
+ * covers. Without it the default 960×700 window showed Files → Symbols →
+ * Actions and looked finished, while Dead exports, Untested, Grade and Security
+ * sat under the Actions pin — 318 px of a 1025 px table, with a right-aligned
+ * `1,043` painted down to `1,0` (TRA-452).
+ */
 function stickyCell(side: 'left' | 'right', offset: number, bg: string, seam = true): CSSProperties {
+  const dir = side === 'left' ? 1 : -1;
+  const shade = `${dir * 10}px 0 12px -10px var(--edge-shade-${side})`;
   return {
     position: 'sticky',
     [side]: offset,
     background: bg,
-    boxShadow: seam ? (side === 'left' ? '1px 0 0 var(--separator)' : '-1px 0 0 var(--separator)') : undefined,
+    boxShadow: seam ? `${dir}px 0 0 var(--separator), ${shade}` : undefined,
   };
 }
 
@@ -203,7 +223,6 @@ function Row({
       className="cursor-pointer transition-colors"
       style={{
         height: ROW_H,
-        borderBottom: '0.5px solid var(--separator)',
         background: highlighted ? bg : undefined,
         outline: cursored ? '2px solid var(--accent)' : undefined,
         outlineOffset: -2,
@@ -239,7 +258,14 @@ function Row({
       <td className="px-3 max-w-[200px]">
         <div className="flex items-center gap-1.5">
           <StatusDot tone={dotTone} pulse={dotTone === 'green'} />
-          <span style={{ color: 'var(--label-secondary)' }}>{statusLabel(project.displayStatus)}</span>
+          {/* Chinese "正常" is two characters, and auto table layout will break
+              between them the moment the column is squeezed — one glyph per
+              line, 8px tall. Nothing stops it in a language with no spaces but
+              refusing the break, which also gives the column a min-content
+              width the layout has to honour. */}
+          <span className="whitespace-nowrap" style={{ color: 'var(--label-secondary)' }}>
+            {statusLabel(project.displayStatus)}
+          </span>
         </div>
         {project.error && (
           <div className="text-[11px] truncate" style={{ color: 'var(--status-red)' }} title={project.error}>
@@ -352,19 +378,34 @@ export function WorkspaceTableView({
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportH, setViewportH] = useState(0);
+  const [edges, setEdges] = useState({ left: false, right: false });
   const [cursor, setCursor] = useState(-1);
   const [confirmRoot, setConfirmRoot] = useState<string | null>(null);
   const [menu, setMenu] = useState<{ x: number; y: number; project: ProjectViewModel } | null>(null);
 
+  /* Measured on mount and on every resize, not only on scroll: whether the
+     table overflows is a function of the pane's width, and narrowing the window
+     never fires a scroll event. */
   useEffect(() => {
-    setViewportH(scrollRef.current?.clientHeight ?? 0);
+    const el = scrollRef.current;
+    if (!el) return;
+    const measure = () => {
+      setViewportH(el.clientHeight);
+      setEdges(scrollEdges(el.scrollLeft, el.scrollWidth, el.clientWidth));
+    };
+    measure();
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
   }, []);
 
   const handleScroll = (e: UIEvent<HTMLDivElement>) => {
-    const top = e.currentTarget.scrollTop;
-    setScrollTop(top);
-    setViewportH(e.currentTarget.clientHeight);
-    onScroll?.(top);
+    const el = e.currentTarget;
+    setScrollTop(el.scrollTop);
+    setViewportH(el.clientHeight);
+    setEdges(scrollEdges(el.scrollLeft, el.scrollWidth, el.clientWidth));
+    onScroll?.(el.scrollTop);
   };
 
   const { start, end } = visibleRange(projects.length, scrollTop, viewportH);
@@ -392,11 +433,18 @@ export function WorkspaceTableView({
       aria-label={t('projectsGrid')}
       aria-rowcount={projects.length}
       className="flex-1 overflow-auto"
-      style={{
-        borderRadius: 12,
-        border: '0.5px solid var(--separator)',
-        background: 'var(--surface)',
-      }}
+      style={
+        {
+          borderRadius: 12,
+          border: '0.5px solid var(--separator)',
+          background: 'var(--surface)',
+          /* One write here instead of threading two booleans through every row:
+             the pinned cells always declare the shade, this decides whether it
+             has a colour. */
+          '--edge-shade-left': edges.left ? 'var(--scroll-edge-shade)' : 'transparent',
+          '--edge-shade-right': edges.right ? 'var(--scroll-edge-shade)' : 'transparent',
+        } as CSSProperties
+      }
       onScroll={handleScroll}
       onKeyDown={(e) => {
         if (e.key === 'ArrowDown') {
@@ -414,13 +462,17 @@ export function WorkspaceTableView({
         }
       }}
     >
-      <table className="w-full border-collapse text-[13px]">
+      {/* `.ws-table` is separated borders, not collapsed: Chromium drops
+          box-shadow on cells in the collapsed model, which is why the pinned
+          seams below have declared a hairline since TRA-265 and never drawn
+          one. The row hairline lives on the cells there. */}
+      <table className="ws-table w-full text-[13px]">
         {/* STICKY_HEADER_BG, not a bare --fill-quaternary: that token is
             translucent, so rows scrolling under a sticky header showed
             straight through the column labels. Same reason the pinned cells
             below stack their tint over --surface. */}
         <thead className="sticky top-0 z-10" style={{ background: STICKY_HEADER_BG }}>
-          <tr style={{ borderBottom: '0.5px solid var(--separator)' }}>
+          <tr>
             <th
               className="px-1 w-8"
               style={{ ...stickyCell('left', 0, STICKY_HEADER_BG, false), zIndex: 1 }}

--- a/packages/app/src/renderer/workspace/__tests__/WorkspaceTableView.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/WorkspaceTableView.test.tsx
@@ -3,7 +3,13 @@
  */
 import { render, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { ROW_H, WINDOW_THRESHOLD, WorkspaceTableView, visibleRange } from '../WorkspaceTableView';
+import {
+  ROW_H,
+  WINDOW_THRESHOLD,
+  WorkspaceTableView,
+  scrollEdges,
+  visibleRange,
+} from '../WorkspaceTableView';
 import type { ProjectViewModel } from '../types';
 
 const PROJECT: ProjectViewModel = {
@@ -77,6 +83,36 @@ describe('WorkspaceTableView frozen columns', () => {
       expect(cell.style.right).toBe('0px');
       expect(cell.style.background).not.toBe('');
     }
+  });
+
+  // At the default 960×700 window the table is 1025 px in a 707 px pane, so
+  // Dead exports, Untested, Grade and Security sit under the Actions pin. The
+  // seam has to shade, or the table reads as finished at Symbols (TRA-452).
+  it('draws the pinned seams with a shade the scroll state can colour', () => {
+    const container = renderTable();
+    const cells = container.querySelectorAll('thead th, tbody td');
+    const project = cells[1] as HTMLElement;
+    const actions = cells[container.querySelectorAll('thead th').length - 1] as HTMLElement;
+    expect(project.style.boxShadow).toContain('var(--edge-shade-left)');
+    expect(actions.style.boxShadow).toContain('var(--edge-shade-right)');
+    // The checkbox column is the inner half of the left pin — one shade per
+    // pinned group, cast by the cell the rows actually slide under.
+    expect((cells[0] as HTMLElement).style.boxShadow).toBe('');
+  });
+
+  it('shades only the side that still hides content', () => {
+    // Scrolled hard left: 318 px hidden to the right, nothing to the left.
+    expect(scrollEdges(0, 1025, 707)).toEqual({ left: false, right: true });
+    expect(scrollEdges(318, 1025, 707)).toEqual({ left: true, right: false });
+    expect(scrollEdges(160, 1025, 707)).toEqual({ left: true, right: true });
+    // A table that fits its pane is not hiding anything on either side.
+    expect(scrollEdges(0, 707, 707)).toEqual({ left: false, right: false });
+  });
+
+  it('keeps a two-character status label on one line', () => {
+    const container = renderTable();
+    const label = within(container).getByText('OK');
+    expect(label.className).toContain('whitespace-nowrap');
   });
 
   it('leaves the scrolling middle columns unpinned', () => {


### PR DESCRIPTION
Closes TRA-453.

## The problem

At the default 960×700 window the workspace projects table is **1025 px of table in a 707 px pane**. Four of its ten columns — Dead exports, Untested, Grade, Security — sit under the pinned Actions column, and nothing says so. The last visible column is Symbols, so it reads as a table that ends at Symbols.

Measured on the running Electron renderer over CDP (`packages/app/scripts/electron-cdp.mjs`, 960×700, English, light):

| | |
|---|---|
| Grid viewport | 707 px |
| Table content | 1025 px |
| Hidden | 318 px (31%) |
| Actions pin | x 844–944 |
| Under it | Symbols 792–868, Dead exports 868–963, Untested 964–1037, Grade 1037–1093, Security 1093–1162 |

**The seam that would have said so has never rendered.** `stickyCell()` has declared `box-shadow: -1px 0 0 var(--separator)` on the pinned cells since TRA-265, and Chromium drops `box-shadow` on table cells under `border-collapse: collapse`. Pixel-sampling the seam column in a CDP capture of the running window returns 255 across it in light mode — before and after adding a much heavier shadow. Flipping the live table to `border-collapse: separate` over CDP makes it appear at once. That is the actual cause, and it had been silently true for as long as the frozen columns have existed.

Chinese gets the sharp end of it in both directions. `assetfeed`'s Dead exports is `1,043`, right-aligned, ending 17 px under the pin — with no seam it renders as `1,0`, which reads as the value rather than as half of it. And the status label `正常` is two characters with no space, so auto table layout squeezed the column to 51 px and broke between them: one glyph per line, 8 px tall.

## The change

- **`.ws-table`** (`styles/island.css`) — `border-collapse: separate; border-spacing: 0`, so cell shadows paint at all. The row hairline moves from the `<tr>`, which the separated model ignores, onto the cells; the windowing spacers carry a `colspan` and get none.
- **`stickyCell()`** — hairline plus a soft directional shade, `±10px 0 12px -10px var(--edge-shade-{side})`. One shade per pinned group, cast by the cell the rows actually slide under.
- **`--scroll-edge-shade`** (`styles/tokens.css`) — `rgb(0 0 0 / 0.18)` light, `rgb(0 0 0 / 0.5)` dark, in all four appearance blocks. Only the colour is a token; the offset and blur belong to the seam that draws it.
- **`scrollEdges(scrollLeft, scrollWidth, clientWidth)`** drives `--edge-shade-left` / `--edge-shade-right` on the scroll container — one style write per scroll event instead of two booleans threaded through every cell. A `ResizeObserver` recomputes it too, because narrowing the window changes whether the table overflows and never fires a scroll event. That also fixes a stale `viewportH` after a resize, which the row windowing was reading.
- **`whitespace-nowrap`** on the status label. It also gives the column a min-content width the table layout has to honour: 51 px → 65 px in Chinese, one line.

Below `TABLE_MIN_PANE_W` the workspace already falls back to the Compact view, where all four metrics are badges — so this is the wide-window case only, which is the one that looked correct.

## Verification

On the running Electron window, not `vite dev` in a browser (DESIGN.md §9).

- Seam pixel column at a row's mid-height, light: **255 everywhere before, 216 at the darkest after** — the shade is on screen, not just in the stylesheet.
- Shade direction, measured live: `{left: transparent, right: shaded}` at `scrollLeft 0`; both shaded mid-scroll; `{left: shaded, right: transparent}` at the end.
- Chinese status column 51 px → 65 px, label on one line.
- Shot in light, dark and Reduce Transparency, plus the 640×420 window minimum (which is Compact, unchanged).
- `pnpm --filter trace-mcp-app test` — 46 files, 490 tests, green. `typecheck` clean. `design-tokens.mjs --check` clean.

Four tests added: the pinned seams carry a shade the scroll state can colour, the inner half of the left pin carries none, `scrollEdges` shades only the side still hiding content, and the status label refuses to break.

## DESIGN.md

New §5 subsection "A pinned column shades what it covers, or it is lying about the table", and a decision-log line: *a seam you cannot see is a seam you do not have* — check a decorative declaration renders, because the failure mode of a missing seam is a table that looks finished.
