### PR TITLE
fix(app): point the quarantine command at the real install path

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -642,7 +642,12 @@ ipcMain.handle('check-for-update', async () => {
   // in because the user's own npm may own a root the static scan never guesses.
   const { configRoot, binRoot } = await resolveNpmRoots();
   const staleRoots = staleRootClientsUse(configRoot, binRoot);
-  return staleRoots.length > 0 ? { ...result, staleRoots } : result;
+  // The manual-install card's `xattr` command has to name the bundle the user
+  // actually has. Hard-coding `/Applications` missed every install under
+  // `~/Applications` — which is the locator's *first* fallback directory, so
+  // far from an exotic case (TRA-460).
+  const withPath = BUNDLE_PATH ? { ...result, installPath: BUNDLE_PATH } : result;
+  return staleRoots.length > 0 ? { ...withPath, staleRoots } : withPath;
 });
 
 async function checkForUpdate() {

--- a/packages/app/src/main/preload.ts
+++ b/packages/app/src/main/preload.ts
@@ -87,6 +87,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     stuck?: boolean;
     /** Global npm roots holding an older trace-mcp than the newest install on this machine. */
     staleRoots?: { root: string; version: string }[];
+    /** Absolute path to the running `.app`, so copyable commands name the real install. */
+    installPath?: string;
   }> => ipcRenderer.invoke('check-for-update'),
   checkPendingUpdate: (): Promise<{ pending: boolean; version?: string }> =>
     ipcRenderer.invoke('check-pending-update'),

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -20,7 +20,7 @@ import {
 } from './lattice/ui';
 import {
   formatAgo,
-  QUARANTINE_COMMAND,
+  quarantineCommand,
   type UpdateCheck,
   useUpdateCheck,
 } from './update-check.js';
@@ -580,7 +580,10 @@ export function UpdateCard({ update }: { update: UpdateCheck }) {
             escape hatch that ends in an error dialog is not an escape hatch —
             the card carries the command that clears it (TRA-431). */}
         <CardSubtitle>{t('cardStuckQuarantine')}</CardSubtitle>
-        <CommandLine command={QUARANTINE_COMMAND} label={t('copyQuarantineCommand')} />
+        <CommandLine
+          command={quarantineCommand(state.installPath)}
+          label={t('copyQuarantineCommand')}
+        />
       </CardShell>
     );
   }

--- a/packages/app/src/renderer/electron.d.ts
+++ b/packages/app/src/renderer/electron.d.ts
@@ -49,6 +49,8 @@ declare global {
         stuck?: boolean;
         /** Global npm roots holding an older trace-mcp than the newest install on this machine. */
         staleRoots?: { root: string; version: string }[];
+        /** Absolute path to the running `.app`, so copyable commands name the real install. */
+        installPath?: string;
       }>;
       checkPendingUpdate: () => Promise<{ pending: boolean; version?: string }>;
       applyUpdate: () => Promise<{

--- a/packages/app/src/renderer/i18n/__tests__/i18n.test.ts
+++ b/packages/app/src/renderer/i18n/__tests__/i18n.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { LOCALE_KEY } from '../../../shared/i18n/locales.js';
 import { currentLocale, i18next, initialLocale, setLocale, t } from '../index.js';
 import { formatDate, formatNumber, relativeTime } from '../format.js';
-import { describeStaleRoots, formatAgo } from '../../update-check.js';
+import { describeStaleRoots, formatAgo, quarantineCommand } from '../../update-check.js';
 
 const NOW = Date.UTC(2026, 7, 29, 12, 0, 0);
 
@@ -116,5 +116,26 @@ describe('update-check strings', () => {
     expect(ru.label).toBe('MCP-клиенты работают на v2.9.0');
     expect(ru.title).toContain(`${root}/trace-mcp`);
     expect(ru.title).toContain(ru.command);
+  });
+
+  /* The command is the manual-install card's only working action, so it has to
+     name the bundle the user really has. `/Applications` was hard-coded while
+     the locator prefers `~/Applications` — `xattr` then fails on a path that
+     does not exist and the escape hatch dead-ends (TRA-460). */
+  it('clears quarantine on the install we actually found', () => {
+    expect(quarantineCommand('/Users/x/Applications/trace-mcp.app')).toBe(
+      'xattr -dr com.apple.quarantine /Users/x/Applications/trace-mcp.app',
+    );
+  });
+
+  it('falls back to /Applications when the bundle path is unknown', () => {
+    expect(quarantineCommand()).toBe('xattr -dr com.apple.quarantine /Applications/trace-mcp.app');
+    expect(quarantineCommand('')).toBe('xattr -dr com.apple.quarantine /Applications/trace-mcp.app');
+  });
+
+  it('quotes a path the shell would otherwise split', () => {
+    expect(quarantineCommand('/Users/x/My Apps/trace-mcp.app')).toBe(
+      "xattr -dr com.apple.quarantine '/Users/x/My Apps/trace-mcp.app'",
+    );
   });
 });

--- a/packages/app/src/renderer/update-check.ts
+++ b/packages/app/src/renderer/update-check.ts
@@ -24,6 +24,8 @@ export type UpdateState = {
   error?: string;
   stuck?: boolean;
   staleRoots?: { root: string; version: string }[];
+  /** Absolute path to the running `.app`, so copyable commands name the real install. */
+  installPath?: string;
 };
 
 /**
@@ -59,14 +61,29 @@ export function describeStaleRoots(staleRoots: { root: string; version: string }
   };
 }
 
+/** Quote a path for copy-paste into a shell, only when it needs it. */
+function shellQuote(p: string): string {
+  return /^[A-Za-z0-9._/-]+$/.test(p) ? p : `'${p.replace(/'/g, `'\\''`)}'`;
+}
+
 /**
  * macOS builds are ad-hoc signed and not notarized, so a browser-downloaded
  * copy carries `com.apple.quarantine` and Gatekeeper refuses it with "trace-mcp
  * is damaged and can't be opened" — the dead end the manual-install card sent a
  * user into (TRA-431). Until releases are notarized, the card ships the one
  * command that clears the flag.
+ *
+ * It has to name the path the user actually installs into. `/Applications` was
+ * hard-coded, but `locateInstalledApp` prefers `~/Applications` — its first
+ * fallback directory — so an install that lives there got a command pointing at
+ * a path that does not exist. `xattr` then fails with "No such file or
+ * directory" and the escape hatch dead-ends exactly like the download it was
+ * added to rescue. The main process sends the running bundle's path; the
+ * hard-coded default only applies when it could not be derived (dev mode).
  */
-export const QUARANTINE_COMMAND = 'xattr -dr com.apple.quarantine /Applications/trace-mcp.app';
+export function quarantineCommand(bundlePath?: string): string {
+  return `xattr -dr com.apple.quarantine ${shellQuote(bundlePath || '/Applications/trace-mcp.app')}`;
+}
 
 export function formatAgo(ts?: number, now: number = Date.now()): string {
   if (!ts) return t('common:never');


### PR DESCRIPTION
## What

The manual-install card's `xattr -dr com.apple.quarantine` command hard-coded `/Applications/trace-mcp.app`. It now names the bundle the user actually has.

## Why

That card is the honest replacement for a green "Up to date" when the CLI moved but the `.app` did not (TRA-357). Its download dead-ends on Gatekeeper — our macOS builds are ad-hoc signed — so TRA-431 added the quarantine command as the one action that works.

But `locateInstalledApp` lists `~/Applications` **first** among its fallback directories. An install living there got a command pointing at a path that does not exist, `xattr` failed with "No such file or directory", and the escape hatch dead-ended exactly like the download it was added to rescue.

This is not hypothetical: on the machine this was found on, the maintained install is `~/Applications/trace-mcp.app`.

## How

The main process already derives the running bundle's path for `INSTALL_DIR`. It now ships it with the update-check payload as `installPath`, and the card builds the command from it. `/Applications` remains the fallback for when it cannot be derived (dev mode). Paths that need shell quoting get it.

Six files, no new i18n keys — the command is not translated.

## Testing

- `pnpm run test` — 9173 passed, 8 skipped (831 files)
- `pnpm --filter trace-mcp-app run test` — 493 passed (46 files), including 3 new cases: real install path, fallback when unknown, and a path with a space
- `pnpm run lint` (tsc --noEmit) — clean
- `pnpm run build` and `pnpm --filter trace-mcp-app run build` — clean

Verified separately this run that the update pipeline itself is healthy: npm `3.5.0` matches GitHub `v3.5.0`, all four release artifacts carry a `.sha256` sibling, and a real 1.48.0 → 3.5.0 upgrade in an isolated `HOME` located the install via the marker, downloaded, verified the checksum, and staged the pending bundle correctly.
