### PR TITLE
fix(workspace): two overlapping KPI sets stop wearing the grammar of a partition (TRA-459)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -865,7 +865,7 @@ the pane with one `ResizeObserver` and derive from it. `Workspace.tsx` is the pa
 `TABLE_MIN_PANE_W` is *computed* from the table's own frozen columns plus a minimum
 scroll window, and `isDensePane()` compares the pane's height against
 `kpiStripHeight(paneW)` rather than against a guessed breakpoint — which is why it
-reproduces the measured 357px exactly instead of drifting from it.
+reproduces the strip's measured height exactly instead of drifting from it.
 
 **What gives way, in order.** Never the identity of the screen; always the
 elaboration.
@@ -1211,7 +1211,9 @@ new evidence.
 | An unshrinkable control gets a narrow form; wrapping alone does not save it | `flex-wrap` gives a segmented control its own line but cannot narrow it. Insights' 371px picker in a 262px band ran 96.6px past a 640px window and left "Risk hotspots" 14 of its 108px — unreachable. Below the width where the segments fit it is a `PopUpButton`. |
 | A collapse threshold reads a width the collapsing thing cannot change | Measured against its own slot, the Insights picker was bistable: the slot is narrower beside the title and full-width once the picker wraps, so both controls were self-consistent at one window size and the render depended on which way the user had resized. The toolbar's width is the honest input. |
 | A shrinkable control declares a length `flex-basis`, never `auto` | A wrapping flex line breaks on hypothetical sizes, so `flex-basis: auto` spends none of the control's slack first. `.lx-search` on `auto` wrapped Memory's toolbar at the default 960px window; on `1 1 140px` capped at `max-content` it renders identically and holds one row to a 740px pane. |
-| Breakpoints are read off the **pane**, and computed rather than picked | The sidebar is resizable 180–320px, so window width is not a proxy for room. `kpiStripHeight()` reproduces the measured 357px; a guessed number drifts the first time a tile changes. |
+| Breakpoints are read off the **pane**, and computed rather than picked | The sidebar is resizable 180–320px, so window width is not a proxy for room. `kpiStripHeight()` is derived from the tile's own geometry; a guessed number drifts the first time a tile changes — as it did when the comparison line went from one reserved line to two (TRA-459). |
+| A share of a total is only for a set that really is a **part of that total** | Healthy and Needs attention are overlapping predicates — a grade-B project with 15 dead exports is in both — so "57% of 53 projects" beside "83% of 53 projects" is the grammar of a partition on numbers that do not partition anything. Two shares of one denominator get added by every reader who sees them side by side. A comparison line for an overlapping set names its criterion instead. |
+| A comparison line reserves its height, it does not measure it | The catalogue runs +30% longer in German and Russian and a tile is 132–214px wide, so whether the line wraps is not a property of the design. `KpiTile` reserves two 13px lines whatever the string does, which is what lets one `TILE_H` constant hold: measured on the running renderer, every tile is 112px in en/de/ja and both criterion lines are 26px in ru. The reservation is a floor, not a cap — Russian's delta caption (`↑+105.6k по сравнению с: 9 минут назад`) still runs to four lines and takes its row to 138px, which is a separate defect and not something `TILE_H` can absorb. |
 | Narrow gives up the comparison, then the table, never the value | The number and the project name are the screen; the footnote and the metric columns are elaboration. Compact already renders a legible row at 420px. |
 | A view toggle with one usable option is hidden, not disabled | A disabled segment is a control with nothing to choose. The stored preference is untouched and returns with the width. |
 | Migrate a screen **whole**, one screen per PR | A half-migrated screen looks worse than the un-migrated one; a big-bang redesign PR never lands. |

--- a/packages/app/src/renderer/workspace/Workspace.tsx
+++ b/packages/app/src/renderer/workspace/Workspace.tsx
@@ -82,7 +82,11 @@ function loadFilter(): WorkspaceFilter {
 // Pane and strip geometry, all read off the rendered surface rather than guessed.
 const TILE_MIN_W = 132; // KpiTile's flex basis
 const TILE_GAP = 16; // gap-4
-const TILE_H = 99; // a full-height tile: 16 + 13 + 4 + 32 + 4 + 13 + 16 + hairlines
+// A full-height tile: 16 + 13 + 4 + 32 + 4 + 26 + 16 + hairlines. The comparison
+// line reserves two 13px lines rather than one, because at 132–214px of tile a
+// criterion or a long translation wraps and a one-line constant would then
+// under-report the strip by 13px a row (TRA-459).
+const TILE_H = 112;
 const STRIP_PAD = 28; // pt-4 + pb-3
 const TOOLBAR_H = 52;
 const PANE_PAD = 32; // px-4, both sides
@@ -103,8 +107,8 @@ export const TABLE_MIN_PANE_W = PANE_PAD + FROZEN_COLS_W + MIN_SCROLL_WINDOW;
 
 /**
  * How tall the full-height KPI strip would be in a pane this wide. The tiles
- * flex-wrap, so width decides how many rows of 99px there are — at the app's
- * 640px minimum window this returns 357, which is what the strip measured.
+ * flex-wrap, so width decides how many rows of 112px there are — at the app's
+ * 640px minimum window that is three rows, 396px.
  */
 export function kpiStripHeight(paneW: number): number {
   const inner = Math.max(0, paneW - PANE_PAD);

--- a/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
@@ -11,7 +11,7 @@
  *             put + Add's chevron and the overflow menu out of reach entirely.
  *  KPI grid — six content cards, each in card anatomy (label → value →
  *             comparison). Opaque, hairline, no shadow, no glass. `dense`
- *             collapses each to a 36px line when the pane cannot afford 99px.
+ *             collapses each to a 36px line when the pane cannot afford 112px.
  *
  * Receives all data + state via props; does not call useWorkspaceProjects.
  */
@@ -133,7 +133,16 @@ function toggleInList<T>(list: T[] | null, value: T): T[] | null {
   return arr.length === 0 ? null : arr;
 }
 
-/** `n` as a share of `total`, e.g. "36% of 116 projects". */
+/**
+ * `n` as a share of `total`, e.g. "36% of 116 projects".
+ *
+ * Only for a metric that really is a subset of the workspace — Indexing is a
+ * state every project is either in or not. Healthy and Needs attention are
+ * overlapping predicates (a grade-B project with 15 dead exports is in both),
+ * so a share reads as a partition it isn't: 57% + 83% of the same 53 projects
+ * is impossible arithmetic on the face of the strip (TRA-459). Those two name
+ * their criterion instead.
+ */
 function share(n: number, total: number): string {
   if (total === 0) return t('workspace:kpiNoProjectsYet');
   return t('workspace:kpiShare', {
@@ -322,7 +331,9 @@ export function WorkspaceHeader({
           dense={dense}
           pending={metricsLoading}
           unavailable={metricsFailed}
-          footnote={share(kpis.healthy, kpis.totalProjects)}
+          footnote={
+            kpis.totalProjects === 0 ? t('kpiNoProjectsYet') : t('kpiHealthyCriteria')
+          }
           active={filter.preset === 'healthy'}
           onClick={() => togglePreset('healthy')}
         />
@@ -333,7 +344,9 @@ export function WorkspaceHeader({
           dense={dense}
           pending={metricsLoading}
           unavailable={metricsFailed}
-          footnote={share(kpis.needsAttention, kpis.totalProjects)}
+          footnote={
+            kpis.totalProjects === 0 ? t('kpiNoProjectsYet') : t('kpiNeedsAttentionCriteria')
+          }
           active={filter.preset === 'needs_attention'}
           onClick={() => togglePreset('needs_attention')}
         />

--- a/packages/app/src/renderer/workspace/__tests__/Workspace.pane.test.ts
+++ b/packages/app/src/renderer/workspace/__tests__/Workspace.pane.test.ts
@@ -18,16 +18,16 @@ const pane = (winW: number, winH: number) => ({ w: winW - 220, h: winH - 44 });
 
 describe('kpiStripHeight', () => {
   it('reproduces the strip measured at the minimum window', () => {
-    // 640 − 220 = a 420px pane: two tiles per row, three rows of 99px.
-    expect(kpiStripHeight(420)).toBe(357);
+    // 640 − 220 = a 420px pane: two tiles per row, three rows of 112px.
+    expect(kpiStripHeight(420)).toBe(396);
   });
 
   it('is one row of tiles once the pane fits all six', () => {
-    expect(kpiStripHeight(1060)).toBe(99 + 28);
+    expect(kpiStripHeight(1060)).toBe(112 + 28);
   });
 
   it('never divides by a zero-width pane', () => {
-    expect(kpiStripHeight(0)).toBe(6 * 99 + 5 * 16 + 28);
+    expect(kpiStripHeight(0)).toBe(6 * 112 + 5 * 16 + 28);
   });
 });
 
@@ -67,7 +67,7 @@ describe('isNarrowPane', () => {
 describe('isDensePane', () => {
   it('is dense at the app minimum window', () => {
     const p = pane(640, 420);
-    // 376 − 52 toolbar − 357 strip is negative: the list had nowhere to be.
+    // 376 − 52 toolbar − 396 strip is negative: the list had nowhere to be.
     expect(isDensePane(p.w, p.h)).toBe(true);
   });
 

--- a/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
@@ -26,6 +26,7 @@ function renderHeader(
     listFailed: boolean;
     dense: boolean;
     hideViewToggle: boolean;
+    kpis: WorkspaceKpis;
   }> = {},
 ) {
   const { container } = render(
@@ -165,13 +166,31 @@ describe('WorkspaceHeader KPI strip', () => {
       expect(lines[2]).not.toBe('');
     }
   });
+
+  it('does not give two overlapping sets the grammar of a partition', () => {
+    // Healthy is (grade A or B) AND no security findings; Needs attention is
+    // (grade D or F) OR findings OR ≥10 dead exports. A grade-B project with 15
+    // dead exports is in both, so the workspace this was measured on had 30
+    // healthy and 44 needing attention out of 53 — printed as shares that was
+    // "57% of 53 projects" beside "83% of 53 projects" (TRA-459).
+    renderHeader(false, {
+      kpis: { ...ZERO_KPIS, totalProjects: 53, healthy: 30, needsAttention: 44, indexing: 4 },
+    });
+    for (const label of ['Healthy', 'Needs attention']) {
+      const comparison = kpiTile(label).children[2]!.textContent!;
+      expect(comparison).not.toMatch(/%/);
+      expect(comparison).not.toMatch(/\d/);
+    }
+    // Indexing really is a subset of the workspace, so it keeps its share.
+    expect(kpiTile('Indexing').children[2]!.textContent).toBe('8% of 53 projects');
+  });
 });
 
 describe('WorkspaceHeader at a pane that cannot afford the full layout', () => {
   beforeEach(() => localStorage.clear());
 
   it('puts the toolbar above the KPI strip so chrome is never pushed off-window', () => {
-    // Six full tiles are 357px. With them first, a 420px window — the app's own
+    // Six full tiles are 396px. With them first, a 420px window — the app's own
     // minimum (main/tray.ts) — left the toolbar and the whole list below the
     // bottom edge with no scroll container to reach them (TRA-325).
     renderHeader(false);

--- a/packages/app/src/renderer/workspace/components/KpiTile.tsx
+++ b/packages/app/src/renderer/workspace/components/KpiTile.tsx
@@ -29,9 +29,9 @@ export interface KpiTileProps {
   footnote?: string;
   tone?: KpiTone;
   /**
-   * The pane is too short or too narrow to spend 99px per tile. Collapses the
+   * The pane is too short or too narrow to spend 112px per tile. Collapses the
    * card to one 36px line — label at the leading edge, value at the trailing
-   * edge — and drops the comparison. Six full tiles are 357px tall, which at
+   * edge — and drops the comparison. Six full tiles are 396px tall, which at
    * the app's 420px minimum window height leaves the toolbar and the whole
    * project list below the window edge with nothing to scroll (TRA-325).
    */
@@ -182,14 +182,25 @@ export function KpiTile({
 
       {/* The comparison line is the first thing to go when the pane is short:
           it is the tallest part of the tile and the only part a user can
-          reconstruct by widening the window. The value never goes. */}
-      {dense ? null : pending && !unavailable ? (
-        // `unavailable` outranks `pending`: a fetch that finished and failed is
-        // not still loading, so the skeleton must not win when both are set.
-        <Skeleton width={92} height={11} />
-      ) : (
-        <span className="text-[11px] leading-[13px]" style={{ color: 'var(--label-secondary)' }}>
-          {unavailable ? (
+          reconstruct by widening the window. The value never goes.
+
+          Two lines are reserved whatever the string does. A tile is 132–214px
+          wide and the catalogue runs +30% longer than English in German and
+          Russian, so whether this wraps is not something the layout gets to
+          assume — and `kpiStripHeight()` in Workspace.tsx sizes the whole strip
+          off one constant tile height. Reserving the second line keeps that
+          constant true in every language instead of only in English. */}
+      {dense ? null : (
+        <span
+          className="text-[11px] leading-[13px]"
+          style={{ color: 'var(--label-secondary)', minHeight: 26, display: 'block' }}
+        >
+          {/* `unavailable` outranks `pending`: a fetch that finished and failed
+              is not still loading, so the skeleton must not win when both are
+              set. */}
+          {pending && !unavailable ? (
+            <Skeleton width={92} height={11} />
+          ) : unavailable ? (
             t('kpiUnavailable')
           ) : delta !== null ? (
             <DeltaChip delta={delta} caption={deltaCaption} />

--- a/packages/app/src/shared/i18n/catalog/de/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/de/workspace.ts
@@ -62,6 +62,8 @@ export const workspace = {
   kpiNoProjectsYet: 'noch keine Projekte',
   kpiNothingIndexedYet: 'noch nichts indexiert',
   kpiNothingRunning: 'nichts läuft',
+  kpiHealthyCriteria: 'Note A oder B, keine Sicherheitsfunde',
+  kpiNeedsAttentionCriteria: 'niedrige Note oder Funde',
   kpiShare_one: '{{percent}} % von {{total}} Projekt',
   kpiShare_other: '{{percent}} % von {{total}} Projekten',
   kpiDeltaCaption: 'ggü. {{when}}',

--- a/packages/app/src/shared/i18n/catalog/en/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/en/workspace.ts
@@ -73,6 +73,13 @@ export const workspace = {
   kpiNoProjectsYet: 'no projects yet',
   kpiNothingIndexedYet: 'nothing indexed yet',
   kpiNothingRunning: 'nothing running',
+  /**
+   * What each preset tile counts. Healthy and Needs attention are
+   * overlapping predicates, not two halves of the workspace, so their
+   * comparison line names the criterion instead of a share of a total.
+   */
+  kpiHealthyCriteria: 'grade A or B, no security findings',
+  kpiNeedsAttentionCriteria: 'low grade or any findings',
   kpiShare_one: '{{percent}}% of {{total}} project',
   kpiShare_other: '{{percent}}% of {{total}} projects',
   /** `when` is a relative time from i18n/format.ts, e.g. "3 days ago". */

--- a/packages/app/src/shared/i18n/catalog/es/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/es/workspace.ts
@@ -60,6 +60,8 @@ export const workspace = {
   kpiNoProjectsYet: 'todavía sin proyectos',
   kpiNothingIndexedYet: 'todavía sin indexar',
   kpiNothingRunning: 'nada en marcha',
+  kpiHealthyCriteria: 'nota A o B, sin hallazgos de seguridad',
+  kpiNeedsAttentionCriteria: 'nota baja o algún hallazgo',
   kpiShare_one: '{{percent}} % de {{total}} proyecto',
   kpiShare_many: '{{percent}} % de {{total}} de proyectos',
   kpiShare_other: '{{percent}} % de {{total}} proyectos',

--- a/packages/app/src/shared/i18n/catalog/fr/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/fr/workspace.ts
@@ -62,6 +62,8 @@ export const workspace = {
   kpiNoProjectsYet: 'aucun projet pour l’instant',
   kpiNothingIndexedYet: 'rien d’indexé pour l’instant',
   kpiNothingRunning: 'rien en cours',
+  kpiHealthyCriteria: 'note A ou B, aucune alerte de sécurité',
+  kpiNeedsAttentionCriteria: 'note basse ou des résultats',
   kpiShare_one: '{{percent}} % de {{total}} projet',
   kpiShare_many: '{{percent}} % de {{total}} projets',
   kpiShare_other: '{{percent}} % de {{total}} projets',

--- a/packages/app/src/shared/i18n/catalog/hi/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/hi/workspace.ts
@@ -58,6 +58,8 @@ export const workspace = {
   kpiNoProjectsYet: 'अभी कोई प्रोजेक्ट नहीं',
   kpiNothingIndexedYet: 'अभी कुछ इंडेक्स नहीं हुआ',
   kpiNothingRunning: 'कुछ नहीं चल रहा',
+  kpiHealthyCriteria: 'ग्रेड A या B, कोई सिक्योरिटी findings नहीं',
+  kpiNeedsAttentionCriteria: 'कम ग्रेड या कोई findings',
   kpiShare_one: '{{total}} प्रोजेक्ट का {{percent}}%',
   kpiShare_other: '{{total}} प्रोजेक्ट का {{percent}}%',
   kpiDeltaCaption: '{{when}} की तुलना में',

--- a/packages/app/src/shared/i18n/catalog/ja/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/ja/workspace.ts
@@ -54,6 +54,8 @@ export const workspace = {
   kpiNoProjectsYet: 'プロジェクトなし',
   kpiNothingIndexedYet: '未インデックス',
   kpiNothingRunning: '実行中なし',
+  kpiHealthyCriteria: '評価 A か B、セキュリティの検出なし',
+  kpiNeedsAttentionCriteria: '低い評価または検出あり',
   kpiShare_other: '{{total}} 件中 {{percent}}%',
   kpiDeltaCaption: '{{when}}との比較',
   kpiNoChange: '変化なし',

--- a/packages/app/src/shared/i18n/catalog/ko/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/ko/workspace.ts
@@ -54,6 +54,8 @@ export const workspace = {
   kpiNoProjectsYet: '아직 프로젝트 없음',
   kpiNothingIndexedYet: '아직 인덱싱된 것 없음',
   kpiNothingRunning: '실행 중인 것 없음',
+  kpiHealthyCriteria: '등급 A 또는 B, 보안 발견 항목 없음',
+  kpiNeedsAttentionCriteria: '낮은 등급 또는 발견 항목 있음',
   kpiShare_other: '프로젝트 {{total}}개 중 {{percent}}%',
   kpiDeltaCaption: '{{when}} 대비',
   kpiNoChange: '변화 없음',

--- a/packages/app/src/shared/i18n/catalog/pt-BR/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/pt-BR/workspace.ts
@@ -62,6 +62,8 @@ export const workspace = {
   kpiNoProjectsYet: 'nenhum projeto ainda',
   kpiNothingIndexedYet: 'nada indexado ainda',
   kpiNothingRunning: 'nada em execução',
+  kpiHealthyCriteria: 'nota A ou B, sem achados de segurança',
+  kpiNeedsAttentionCriteria: 'nota baixa ou algum achado',
   kpiShare_one: '{{percent}}% de {{total}} projeto',
   kpiShare_many: '{{percent}}% de {{total}} de projetos',
   kpiShare_other: '{{percent}}% de {{total}} projetos',

--- a/packages/app/src/shared/i18n/catalog/ru/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/workspace.ts
@@ -73,6 +73,8 @@ export const workspace = {
   kpiNoProjectsYet: 'проектов пока нет',
   kpiNothingIndexedYet: 'пока ничего не проиндексировано',
   kpiNothingRunning: 'ничего не выполняется',
+  kpiHealthyCriteria: 'оценка A или B, без уязвимостей',
+  kpiNeedsAttentionCriteria: 'низкая оценка или находки',
   kpiShare_one: '{{percent}}% из {{total}} проекта',
   kpiShare_few: '{{percent}}% из {{total}} проектов',
   kpiShare_many: '{{percent}}% из {{total}} проектов',

--- a/packages/app/src/shared/i18n/catalog/zh/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/workspace.ts
@@ -53,6 +53,8 @@ export const workspace = {
   kpiNoProjectsYet: '还没有项目',
   kpiNothingIndexedYet: '还没有索引任何内容',
   kpiNothingRunning: '没有任务在运行',
+  kpiHealthyCriteria: '等级 A 或 B，无安全问题',
+  kpiNeedsAttentionCriteria: '等级低或存在问题',
   kpiShare_other: '{{total}} 个项目中的 {{percent}}%',
   kpiDeltaCaption: '对比{{when}}',
   kpiNoChange: '无变化',


### PR DESCRIPTION
Two adjacent KPI tiles printed two shares of the same denominator:

- **Healthy** — 30 — "57% of 53 projects"
- **Needs attention** — 44 — "83% of 53 projects"

57 + 83 = 140. The numbers were right; the sentence under them was not.

## Why they overlap

`workspace/types.ts` — Healthy is `(grade A or B) AND securityFindings === 0`;
Needs attention is `(grade D or F) OR securityFindings > 0 OR deadExports >= 10`.
A grade-B project with 15 dead exports is counted in both, and a clean grade-C
project is in neither. The two are neither exclusive nor exhaustive, so
`share()`'s "N% of M projects" gave them the grammar of a partition they do not
form — and two percentages of one total get added by every reader who sees them
side by side.

## What changed

Both tiles name their criterion instead of a fraction:

| Tile | Before | After |
|---|---|---|
| Healthy | `57% of 53 projects` | `grade A or B, no security findings` |
| Needs attention | `83% of 53 projects` | `low grade or any findings` |
| Indexing | `8% of 53 projects` | unchanged |

Indexing keeps `share()` — it really is a subset of a state machine every
project is either in or not, which is the case the helper was written for. Its
docstring now says so.

"findings" is the app's own umbrella: the Filter menu's **Findings** section
holds both *Has security findings* and *Has dead exports*. Healthy is stricter
than that (it only requires no security findings), so it says the narrower word.
Ten catalogues updated.

## Layout

A criterion is longer than a percentage, so `KpiTile` now reserves two 13px
lines for the comparison whatever the string does, and `TILE_H` in
`Workspace.tsx` goes 99 → 112. That is not overhead the wording invented — the
one-line constant was already a bet on English. Measured on the running
renderer with `electron-cdp.mjs`:

- every tile is **112px** in `en`, `de`, `ja`
- both criterion lines are **26px** (two lines) in `ru`, the longest catalogue
- at 640×420 `isDensePane` still collapses the strip and drops the line entirely

The reservation is a floor, not a cap. One pre-existing case still exceeds it:
Russian's delta caption (`↑+105.6k по сравнению с: 9 минут назад`) runs to four
lines and takes its row to 138px. That is a separate defect, called out in
DESIGN.md rather than left as a false invariant.

## Tests

`WorkspaceHeader.test.tsx` gains a regression test on the measured numbers
(53 projects, 30 healthy, 44 needing attention): neither tile's comparison may
contain a digit or a `%`, and Indexing must still read `8% of 53 projects`.
`Workspace.pane.test.ts` expectations move to the new tile height (357 → 396 at
the minimum pane). Full suite, typecheck, `check:i18n` and build green locally.

DESIGN.md gains two decision-log rows: when a share is allowed, and that a
comparison line reserves its height rather than measuring it.

Closes TRA-459.

Agent: Design/UX Agent
