### PR TITLE
fix(site): a scrollable table says so (TRA-461)

### DIFF
--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -110,6 +110,17 @@ Order: sticky header (brand + theme toggle) → `h1` → prose → `Last updated
   head is a Space Mono 10px caps label, not a bold band. Every table is
   wrapped in a focusable `.table-scroll` region by the layout script, so a
   wide tool table scrolls itself instead of the page.
+- **A scroll region says so.** A region with more to the right carries a
+  `scroll →` label — Space Mono 10px caps at `--text-disabled`, right-aligned
+  10px above the head row, the same instrument-label voice as the `thead`.
+  The script adds it only while the region is genuinely scrollable and not
+  yet at its end, and re-measures on resize and after the webfonts land.
+  Without it the last column simply ends mid-word: macOS hides the overlay
+  scrollbar at rest and a phone never draws one, so nothing on screen
+  distinguishes "scrolls" from "clipped". This is not a mobile-only case —
+  three of the five tables on `comparisons.html` overflow the 880px prose
+  column at 1440px. No fade or gradient mask: gradients in chrome are out
+  (§4), and a fade states less than a word does.
 - Capability marks in a comparison table are **`✓` and `✗` text, never `✅`
   and `❌`**. The emoji pair is a filled multi-colour icon and a second and
   third accent colour — 305 of them on `comparisons.html` alone painted the
@@ -228,6 +239,9 @@ appearance without a screenshot or a measurement is not a finding.
 - [ ] `document.documentElement.scrollWidth === window.innerWidth` at the
       narrow width — no sideways page scroll.
 - [ ] Wide tables scroll themselves, not the page.
+- [ ] Every region where `scrollWidth > clientWidth` shows the `scroll →`
+      label, and every region that fits does not — count both, at 1440px and
+      at 390px.
 
 **Type & spacing**
 - [ ] Within the 2 families / 3 sizes / 2 weights budget.

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -143,6 +143,42 @@
         }
       });
 
+      // A scroll region with nothing left to see is indistinguishable from a
+      // table clipped mid-word. macOS hides the overlay scrollbar at rest and
+      // a phone never draws one, so the last column just ends. Label the
+      // region when — and only when — it actually has more to the right.
+      (function () {
+        var regions = [].slice.call(document.querySelectorAll('.table-scroll'));
+        if (!regions.length) return;
+        regions.forEach(function (region) {
+          var hint = document.createElement('div');
+          hint.className = 'table-hint';
+          hint.setAttribute('aria-hidden', 'true');
+          hint.textContent = 'scroll →';
+          region.parentNode.insertBefore(hint, region);
+          region.addEventListener('scroll', function () {
+            measure(region, hint);
+          });
+        });
+        function measure(region, hint) {
+          var more = region.scrollWidth - region.clientWidth - region.scrollLeft > 1;
+          hint.classList.toggle('is-visible', more);
+        }
+        function measureAll() {
+          regions.forEach(function (region) {
+            measure(region, region.previousElementSibling);
+          });
+        }
+        measureAll();
+        // Fonts land after first paint and change every column width with them.
+        if (document.fonts && document.fonts.ready) document.fonts.ready.then(measureAll);
+        var pending = 0;
+        window.addEventListener('resize', function () {
+          cancelAnimationFrame(pending);
+          pending = requestAnimationFrame(measureAll);
+        });
+      })();
+
       // Theme toggle — mirrors the landing page control and shares its key.
       (function () {
         var root = document.documentElement;

--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -419,6 +419,27 @@ main {
 .prose .table-scroll {
   overflow-x: auto;
 }
+/* Instrument label for a region that has more to the right — same voice as
+   the thead label it sits above. The script adds .is-visible only while the
+   region is actually scrollable and not yet at its end. */
+.prose .table-hint {
+  display: none;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-disabled);
+  text-align: right;
+  margin-bottom: 10px;
+}
+.prose .table-hint.is-visible {
+  display: block;
+}
+/* The label belongs to the table under it: 10px, not the 20px paragraph gap.
+   Hidden, it contributes no margin and the table keeps its own 20px. */
+.prose .table-hint.is-visible + .table-scroll {
+  margin-top: 0;
+}
 .prose table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
Doc tables are wrapped in a focusable `.table-scroll` region so a wide table scrolls itself instead of the page. Nothing on screen said the region existed. macOS hides the overlay scrollbar at rest and a phone never draws one, so a reader sees a comparison table whose last column simply ends mid-word.

Measured in headless Chrome against the live site:

- `comparisons.html` at 1440×900: three of five regions overflow the 880px prose column (`clientWidth` 816 vs `scrollWidth` 1025 / 1056 / 1255). Not a mobile-only case.
- `tools-reference.html` at 390×844: four of sixteen overflow (350 vs 373–461).

The region now carries a `scroll →` label — Space Mono 10px caps at `--text-disabled`, right-aligned 10px above the head row, the same instrument-label voice as the `thead` under it. The script adds `.is-visible` only while the region is genuinely scrollable **and** not yet scrolled to its end, and re-measures on resize and after `document.fonts.ready`, since the webfonts change every column width when they land.

No fade or gradient mask: gradients in chrome are out (`DESIGN-WEB.md` §4), and a word states the affordance better than a fade does. The label is `aria-hidden` — the region already announces itself as "Scrollable table".

Verified in the browser with the change injected into the live pages: 4 of 16 labels visible at 390px on `tools-reference.html`, 0 of 16 at 1440px on the same page, 3 of 5 at 1440px on `comparisons.html`, and the label clears itself once the region is scrolled to the end. Screenshotted in dark at 390px and light at 1440px.

`DESIGN-WEB.md` gains the rule (§2) and a review-checklist line that counts labels against overflowing regions in both directions.
