### PR TITLE
chore(deps): unblock i18next 26 + react-i18next 17, restore the commander hold

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,21 @@ updates:
       - dependency-name: "@types/node"
         update-types:
           - version-update:semver-major
+      # commander@15 declares `engines.node >=22.12.0`; our `engines.node` is
+      # >=22.0.0, so taking it would silently break installs on Node 22.0-22.11
+      # without a support-policy change we have no reason to make — commander 14
+      # is doing the job. Removed in #482 on the assumption that the >=22 floor
+      # already covered it (TRA-329); restored in TRA-463 with the exact gap
+      # written down. Lift this together with the `engines.node` floor.
+      #
+      # Note for whoever lifts it: this YAML entry is not the only thing holding
+      # commander 15 back. PR #197 was closed with `@dependabot ignore this
+      # major version`, which lives in Dependabot's own per-repo state — deleting
+      # the entry here does NOT clear it. Comment `@dependabot unignore
+      # commander` on any Dependabot PR (or reopen #197) as well.
+      - dependency-name: "commander"
+        update-types:
+          - version-update:semver-major
     groups:
       production-minor-patch:
         dependency-type: production

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,7 +22,7 @@
   "packageManager": "pnpm@10.33.0",
   "dependencies": {
     "electron-updater": "^6.6.2",
-    "i18next": "^25.10.10"
+    "i18next": "^26.4.0"
   },
   "overrides": {
     "@luma.gl/core": "9.2.6",
@@ -66,7 +66,7 @@
     "jsdom": "^30.0.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "react-i18next": "^16.6.6",
+    "react-i18next": "^17.0.12",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.0",
     "sharp": "^0.35.3",

--- a/packages/app/pnpm-lock.yaml
+++ b/packages/app/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
         specifier: ^6.6.2
         version: 6.8.9
       i18next:
-        specifier: ^25.10.10
-        version: 25.10.10(typescript@7.0.2)
+        specifier: ^26.4.0
+        version: 26.4.0(typescript@7.0.2)
     devDependencies:
       '@cosmos.gl/graph':
         specifier: 3.4.1
@@ -72,8 +72,8 @@ importers:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
       react-i18next:
-        specifier: ^16.6.6
-        version: 16.6.6(i18next@25.10.10(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
+        specifier: ^17.0.12
+        version: 17.0.12(i18next@26.4.0(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.18)(react@19.2.8)
@@ -1849,8 +1849,8 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
-  html-parse-stringify@3.1.0:
-    resolution: {integrity: sha512-E0oAXcELOtsXe+BmpJ2EZyedbldPpriV5vICzEuo6xjC/D1lDukOI7KrpfQGF2Qc4wWEy0nk3bFORS2K5ZAhFQ==}
+  html-parse-stringify@4.0.1:
+    resolution: {integrity: sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
@@ -1870,10 +1870,10 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  i18next@25.10.10:
-    resolution: {integrity: sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==}
+  i18next@26.4.0:
+    resolution: {integrity: sha512-rsmK5bFqsD1AetSFSIa43wtNR4WpvvH4p0tLEsTxkC7QTrfdFm06nbQ95bh8Og4wwaCnUEcm9DVYL2cgxitiQg==}
     peerDependencies:
-      typescript: ^5 || ^6
+      typescript: ^5 || ^6 || ^7
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -2454,14 +2454,14 @@ packages:
     peerDependencies:
       react: ^19.2.8
 
-  react-i18next@16.6.6:
-    resolution: {integrity: sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==}
+  react-i18next@17.0.12:
+    resolution: {integrity: sha512-lFWPEGkxQ6RhusdUkysFBD58VHfSSzvHBzqMgN0SvfVpdQGfwtNkStTqdy08/sJd7s807qqutgx93fRpD0DJ3Q==}
     peerDependencies:
-      i18next: '>= 25.10.9'
+      i18next: '>= 26.2.0'
       react: '>= 16.8.0'
       react-dom: '*'
       react-native: '*'
-      typescript: ^5 || ^6
+      typescript: ^5 || ^6 || ^7
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -2896,10 +2896,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  void-elements@3.1.0:
-    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
-    engines: {node: '>=0.10.0'}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -4706,9 +4702,7 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
-  html-parse-stringify@3.1.0:
-    dependencies:
-      void-elements: 3.1.0
+  html-parse-stringify@4.0.1: {}
 
   html-url-attributes@3.0.1: {}
 
@@ -4733,9 +4727,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  i18next@25.10.10(typescript@7.0.2):
-    dependencies:
-      '@babel/runtime': 7.29.7
+  i18next@26.4.0(typescript@7.0.2):
     optionalDependencies:
       typescript: 7.0.2
 
@@ -5469,11 +5461,11 @@ snapshots:
       react: 19.2.8
       scheduler: 0.27.0
 
-  react-i18next@16.6.6(i18next@25.10.10(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2):
+  react-i18next@17.0.12(i18next@26.4.0(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2):
     dependencies:
       '@babel/runtime': 7.29.7
-      html-parse-stringify: 3.1.0
-      i18next: 25.10.10(typescript@7.0.2)
+      html-parse-stringify: 4.0.1
+      i18next: 26.4.0(typescript@7.0.2)
       react: 19.2.8
       use-sync-external-store: 1.6.0(react@19.2.8)
     optionalDependencies:
@@ -5965,8 +5957,6 @@ snapshots:
       jsdom: 30.0.1(@noble/hashes@2.3.0)
     transitivePeerDependencies:
       - msw
-
-  void-elements@3.1.0: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/packages/app/src/main/i18n.ts
+++ b/packages/app/src/main/i18n.ts
@@ -29,7 +29,6 @@ export function startI18n(locale: Locale = DEFAULT_LOCALE): void {
       defaultNS: 'common',
       interpolation: { escapeValue: false },
       returnNull: false,
-      initImmediate: false,
     });
   } else if (instance.language !== locale) {
     void instance.changeLanguage(locale);


### PR DESCRIPTION
Closes the two Dependabot silences found in the TRA-462 sweep (TRA-463).

## i18next 25 → 26, react-i18next 16 → 17

`i18next@26.0.0` shipped 2026-03-28; the app was on `^25.10.10` with no ignore entry and no PR ever opened for it. `react-i18next@17` peers `i18next >= 26.2.0`, so it could never have been proposed on its own — the two move together or not at all.

One breaking change touches us: **i18next 26 removed `initImmediate`**. `src/main/i18n.ts` passed `initImmediate: false` to force a synchronous init, which is what lets `t()` return a real string on the next line when the tray/menu is built. With inline `resources` and no async backend, init in 26 is synchronous regardless, so the option is just dropped. `src/main/__tests__/locale.test.ts` already covers that path (`t()` immediately after `startI18n()`), and it passes.

The renderer init needed no change. `initImmediate` was the only removed option we used — `returnNull` is still valid in 26.

Evidence, all in `packages/app`:
- `pnpm run typecheck` — clean
- `pnpm run build` (vite renderer + `tsc -p tsconfig.main.json`) — clean; the `tsc --noEmit` typecheck does **not** cover the main process, so `build:main` is what caught `initImmediate`
- `pnpm run check:i18n` — 87 files clean
- `pnpm run test` — 46 files, 501 tests passing

## commander major ignore, restored

`#482` (TRA-329) removed it, reasoning that the >=22 Node floor satisfied commander 15. It doesn't quite: `commander@15.0.0` declares `engines.node >=22.12.0`, our root `engines.node` is `>=22.0.0`, so Node 22.0–22.11 installs would break. commander 14 gives us no reason to move the support floor, so the hold is the honest state and the config now says so with the exact gap written down.

The comment also records what #482 couldn't have known: PR #197 was closed with `@dependabot ignore this major version`, which lives in Dependabot's own per-repo state. Deleting the YAML entry never unignored anything — commander 15 was held either way. Lifting this needs both the YAML entry gone *and* `@dependabot unignore commander` on a Dependabot PR, and the comment says so, so the next run doesn't rediscover it.

No source change, config only.
