### PR TITLE
fix(app): the KPI strip is a grid of equal tracks, not a wrapping flexbox (TRA-467)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -867,6 +867,30 @@ scroll window, and `isDensePane()` compares the pane's height against
 `kpiStripHeight(paneW)` rather than against a guessed breakpoint — which is why it
 reproduces the strip's measured height exactly instead of drifting from it.
 
+**A card grid responds by changing its column count, never its card width.** Cards
+in a dashboard are one size at any given width — the reader compares them, and a
+card that is wider than its neighbour is making a claim the data is not making.
+So the KPI strip is a `grid` of equal `minmax(0, 1fr)` tracks, and only the number
+of tracks reads the pane.
+
+Do not build it out of `flex-wrap` plus `flex: 1 1 <basis>`. That packs as many
+cards as fit and then hands the whole leftover width to whichever cards landed in
+the last row. Measured in the Electron window at a 1000px window: five tiles at
+137px and a sixth at **748px**, all six carrying the same three lines (TRA-467).
+The stretch is not a fallback that only fires at odd sizes — it fires at every
+width where the count does not divide evenly, which included the app's own
+default.
+
+**Pick a column count that divides the number of cards** (six cards → 6 / 3 / 2 / 1).
+Then every row is full, so there is no ragged tail to stretch and no trailing dead
+space either — the two things a card grid can get wrong, removed by the same
+constraint.
+
+**The count and the strip's height are one number.** `kpiColumns(paneW)` in
+`workspace/Workspace.tsx` is the single source; `kpiStripHeight()` divides by it
+rather than re-deriving the packing rule, and `isDensePane()` reads that. Two
+copies of a layout rule is the failure recorded under "The top band".
+
 **What gives way, in order.** Never the identity of the screen; always the
 elaboration.
 
@@ -1214,6 +1238,7 @@ new evidence.
 | Breakpoints are read off the **pane**, and computed rather than picked | The sidebar is resizable 180–320px, so window width is not a proxy for room. `kpiStripHeight()` is derived from the tile's own geometry; a guessed number drifts the first time a tile changes — as it did when the comparison line went from one reserved line to two (TRA-459). |
 | A share of a total is only for a set that really is a **part of that total** | Healthy and Needs attention are overlapping predicates — a grade-B project with 15 dead exports is in both — so "57% of 53 projects" beside "83% of 53 projects" is the grammar of a partition on numbers that do not partition anything. Two shares of one denominator get added by every reader who sees them side by side. A comparison line for an overlapping set names its criterion instead. |
 | A comparison line reserves its height, it does not measure it | The catalogue runs +30% longer in German and Russian and a tile is 132–214px wide, so whether the line wraps is not a property of the design. `KpiTile` reserves two 13px lines whatever the string does, which is what lets one `TILE_H` constant hold: measured on the running renderer, every tile is 112px in en/de/ja and both criterion lines are 26px in ru. The reservation is a floor, not a cap — Russian's delta caption (`↑+105.6k по сравнению с: 9 минут назад`) still runs to four lines and takes its row to 138px, which is a separate defect and not something `TILE_H` can absorb. |
+| A card grid responds by changing its column count, never its card width | `flex-wrap` + `flex: 1 1 132px` hands the leftover width to whichever cards landed in the last row: at a 1000px window five KPI tiles rendered at 137px and the sixth at 748px, all six carrying the same three lines. A card wider than its neighbour makes a claim the data is not making. Equal `minmax(0, 1fr)` tracks, and a count that **divides** the number of cards so no row is ever short (TRA-467). |
 | Narrow gives up the comparison, then the table, never the value | The number and the project name are the screen; the footnote and the metric columns are elaboration. Compact already renders a legible row at 420px. |
 | A view toggle with one usable option is hidden, not disabled | A disabled segment is a control with nothing to choose. The stored preference is untouched and returns with the width. |
 | Migrate a screen **whole**, one screen per PR | A half-migrated screen looks worse than the un-migrated one; a big-bang redesign PR never lands. |

--- a/packages/app/src/renderer/workspace/Workspace.tsx
+++ b/packages/app/src/renderer/workspace/Workspace.tsx
@@ -106,14 +106,38 @@ const MIN_SCROLL_WINDOW = 160;
 export const TABLE_MIN_PANE_W = PANE_PAD + FROZEN_COLS_W + MIN_SCROLL_WINDOW;
 
 /**
- * How tall the full-height KPI strip would be in a pane this wide. The tiles
- * flex-wrap, so width decides how many rows of 112px there are — at the app's
- * 640px minimum window that is three rows, 396px.
+ * How many tiles go in a row at this pane width — always a divisor of
+ * `KPI_COUNT`, so every row is full.
+ *
+ * The strip used to be a wrapping flexbox of `flex: 1 1 132px` tiles, which
+ * packs as many as fit and then stretches whatever landed in the last row
+ * across the leftover width. Measured in the Electron window at a 1000px window:
+ * five tiles at 137px and the sixth at 748px, carrying the same three lines of
+ * content (TRA-467). A dashboard card is one size; only the column count
+ * responds to width. Restricting the count to a divisor of six is what removes
+ * the ragged last row that the stretching existed to hide.
+ *
+ * `0` is an unmeasured pane on first paint. It falls through to one column —
+ * the same six-row answer the old `Math.max(1, …)` gave — so the first frame is
+ * unchanged.
+ */
+export function kpiColumns(paneW: number): number {
+  const inner = Math.max(0, paneW - PANE_PAD);
+  const fits = (n: number) => n * TILE_MIN_W + (n - 1) * TILE_GAP <= inner;
+  return [6, 3, 2].find(fits) ?? 1;
+}
+
+/**
+ * How tall the full-height KPI strip would be in a pane this wide. Width decides
+ * the column count and so how many rows of 112px there are — at the app's 640px
+ * minimum window that is three rows, 396px.
+ *
+ * This reads `kpiColumns()` rather than repeating the packing rule: a layout
+ * number written twice is how the top band ended up 3px out of true (DESIGN.md,
+ * "The top band").
  */
 export function kpiStripHeight(paneW: number): number {
-  const inner = Math.max(0, paneW - PANE_PAD);
-  const perRow = Math.max(1, Math.floor((inner + TILE_GAP) / (TILE_MIN_W + TILE_GAP)));
-  const rows = Math.ceil(KPI_COUNT / perRow);
+  const rows = KPI_COUNT / kpiColumns(paneW);
   return rows * TILE_H + (rows - 1) * TILE_GAP + STRIP_PAD;
 }
 
@@ -281,6 +305,7 @@ export function Workspace() {
 
   const narrow = isNarrowPane(pane.w);
   const dense = isDensePane(pane.w, pane.h);
+  const kpiCols = kpiColumns(pane.w);
   // The stored preference is never rewritten: widening the window has to bring
   // the user's own choice back, not whatever the narrow layout fell back to.
   const effectiveView: ViewMode = narrow ? 'compact' : view;
@@ -346,6 +371,7 @@ export function Workspace() {
         refreshing={data.refreshing}
         scrolled={scrolled}
         dense={dense}
+        kpiColumns={kpiCols}
         hideViewToggle={narrow}
         rightExtra={<AddProjectControl onAdd={(root) => data.addProject(root)} />}
         // Above the tiles, not below them: the line that says these numbers

--- a/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
@@ -74,6 +74,12 @@ export interface WorkspaceHeaderProps {
   scrolled?: boolean;
   /** Collapse the KPI tiles to one line each — see {@link KpiTileProps.dense}. */
   dense?: boolean;
+  /**
+   * How many tiles per row, from `kpiColumns()` in Workspace.tsx — always a
+   * divisor of six, so every row is full and every tile is the same width.
+   * Defaults to three for a standalone render with no pane to measure.
+   */
+  kpiColumns?: number;
   /** The pane is too narrow for the table, so Compact is the only view. */
   hideViewToggle?: boolean;
   /** Slot rendered at the end of the toolbar row (typically AddProjectControl). */
@@ -168,6 +174,7 @@ export function WorkspaceHeader({
   refreshing,
   scrolled = false,
   dense = false,
+  kpiColumns = 3,
   hideViewToggle = false,
   rightExtra,
   banner,
@@ -279,7 +286,14 @@ export function WorkspaceHeader({
       {banner}
 
       {/* ── KPI grid ───────────────────────────────────────────────── */}
-      <div className="flex items-stretch gap-4 px-4 pt-4 pb-3 flex-wrap">
+      {/* A grid, not a wrapping flexbox. Flex-wrap stretches the last row's
+          survivors across the leftover width, which at a 1000px window put one
+          748px tile next to five 137px ones (TRA-467). Equal tracks, and a
+          column count that divides six so no row is ever short. */}
+      <div
+        className="grid items-stretch gap-4 px-4 pt-4 pb-3"
+        style={{ gridTemplateColumns: `repeat(${kpiColumns}, minmax(0, 1fr))` }}
+      >
         <KpiTile
           label={t('kpiProjects')}
           value={kpis.totalProjects}

--- a/packages/app/src/renderer/workspace/__tests__/Workspace.pane.test.ts
+++ b/packages/app/src/renderer/workspace/__tests__/Workspace.pane.test.ts
@@ -11,10 +11,46 @@
  * much room this surface actually has.
  */
 import { describe, expect, it } from 'vitest';
-import { TABLE_MIN_PANE_W, isDensePane, isNarrowPane, kpiStripHeight } from '../Workspace';
+import {
+  TABLE_MIN_PANE_W,
+  isDensePane,
+  isNarrowPane,
+  kpiColumns,
+  kpiStripHeight,
+} from '../Workspace';
 
 /** Pane geometry for a window, with the default 220px sidebar and 44px header. */
 const pane = (winW: number, winH: number) => ({ w: winW - 220, h: winH - 44 });
+
+/**
+ * TRA-467: the strip was a wrapping flexbox of `flex: 1 1 132px` tiles, so the
+ * last row's survivors absorbed the leftover width. Measured in the Electron
+ * window at 1000px: five tiles at 137px and one at 748px. Uniform tile width is
+ * a property of the column count being a divisor of six, which is what these
+ * assert.
+ */
+describe('kpiColumns', () => {
+  it('only ever returns a divisor of six, so no row is short', () => {
+    for (let paneW = 0; paneW <= 2000; paneW += 1) {
+      expect([1, 2, 3, 6]).toContain(kpiColumns(paneW));
+    }
+  });
+
+  it('never packs a tile below its 132px minimum', () => {
+    for (let paneW = 280 + 32; paneW <= 2000; paneW += 1) {
+      const cols = kpiColumns(paneW);
+      const tileW = (paneW - 32 - (cols - 1) * 16) / cols;
+      expect(tileW).toBeGreaterThanOrEqual(132);
+    }
+  });
+
+  it('widens by whole columns rather than by stretching a tile', () => {
+    expect(kpiColumns(0)).toBe(1); // unmeasured first paint
+    expect(kpiColumns(420)).toBe(2); // 640px window, the app minimum
+    expect(kpiColumns(780)).toBe(3); // 1000px window — was 5 tiles + one 748px
+    expect(kpiColumns(904)).toBe(6);
+  });
+});
 
 describe('kpiStripHeight', () => {
   it('reproduces the strip measured at the minimum window', () => {

--- a/packages/app/src/renderer/workspace/components/KpiTile.tsx
+++ b/packages/app/src/renderer/workspace/components/KpiTile.tsx
@@ -125,8 +125,11 @@ export function KpiTile({
           : 'flex flex-col items-start gap-1 text-left transition-colors'
       }
       style={{
-        minWidth: 132,
-        flex: '1 1 132px',
+        // No `flex` basis: the strip is a grid whose track count already
+        // guarantees at least 132px per tile, and a flex-grow here is what let
+        // a last-row tile stretch to 5.5x its siblings (TRA-467). `minWidth: 0`
+        // so a long footnote sizes to its track instead of widening it.
+        minWidth: 0,
         padding: dense ? '8px 12px' : 16,
         borderRadius: 12,
         // A card is content: it stays opaque --surface in BOTH states. Tinting


### PR DESCRIPTION
Closes TRA-467.

## What renders today

The six KPI tiles on Workspace are a wrapping flexbox (`flex-wrap`) of
`flex: 1 1 132px` tiles. That packs as many as fit and then stretches whatever
landed in the last row across the entire leftover width. Measured on the running
Electron window with `getBoundingClientRect()`, 220px sidebar:

| Window | Tile widths (px) | Widest / narrowest |
|---|---|---|
| 640 (app minimum) | 186 × 6 | 1.0x |
| 760 | 159 × 6 | 1.0x |
| 900 | 150 150 150 150 **316 316** | 2.1x |
| **1000** | 137 137 137 137 137 **748** | **5.5x** |
| **1100** | 157 157 157 157 157 **848** | **5.4x** |
| 1200 | 145 × 6 | 1.0x |
| 1640 | 218 × 6 | 1.0x |

At a 1000px window — 40px off the app's own default — "Indexing / 0 / nothing
running" renders as a 748px card holding one digit, next to five 137px siblings
with identical anatomy (11px label, 28px value, 11px comparison line). The card's
width carries no information; it is a function of how many of its siblings
happened to fit on the row above.

## The change

The strip becomes a `grid` of equal `minmax(0, 1fr)` tracks, and the track count
is constrained to a **divisor of six** (6 / 3 / 2 / 1). Cards in a dashboard are
one size; only the column count reads the pane. Restricting the count to a
divisor also means every row is full — no ragged tail to stretch, and no trailing
dead space either.

`kpiColumns(paneW)` is the single source for that count. `kpiStripHeight()`
divides by it rather than re-deriving the packing rule, so it and `isDensePane()`
cannot drift apart the way the top band's two copies did (DESIGN.md, "The top
band"). Thresholds fall out of the constants already there — `TILE_MIN_W` 132,
`TILE_GAP` 16, `PANE_PAD` 32.

Row counts are **identical at every width**, so `kpiStripHeight()` and
`isDensePane()` return exactly what they returned before; the three existing
assertions in `Workspace.pane.test.ts` pass untouched, including the
unmeasured-pane first-paint case.

## After, measured the same way

```
 640 -> 186 186 186 186 186 186     1200 -> 145 × 6
 760 -> 159 × 6                     1300 -> 161 × 6
 900 -> 205 × 6   (3 cols × 2 rows) 1450 -> 186 × 6
1000 -> 239 × 6   (3 cols × 2 rows) 1640 -> 218 × 6
1100 -> 272 × 6   (3 cols × 2 rows)
```

Uniform at every width, and the 900–1100 band now gets *larger* tiles than
before rather than one giant and five small ones.

## Verification

Judged in the Electron window (`electron-cdp.mjs launch` + CDP), never in Chrome.
Screenshots before/after at 1000px in light and dark, plus Reduce Transparency,
Increase Contrast, the 640×420 window minimum (dense mode, 2 × 3, uniform) and
1640×900 (6 × 1). Screenshots are on TRA-467.

`pnpm typecheck` clean, 505 app tests pass, three new assertions cover the
divisor property, the 132px floor and the widths that used to stretch.

`DESIGN.md` gains the rule ("A card grid responds by changing its column count,
never its card width") in §6 and a decision-log row, per the house rule that a
run which changes a rule updates the document in the same PR.

Agent: Design/UX Agent
