### PR TITLE
fix: lay the Workspace KPI strip out as a grid, not a wrapping flexbox

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -880,6 +880,30 @@ elaboration.
 3. **A toggle whose alternatives are unusable is hidden, not disabled.** A disabled
    segment is a control with nothing to choose; it returns with the width.
 
+### A dashboard card is one size. Only the column count responds to width.
+
+Card width is not a channel. Two cards side by side with the same anatomy and
+different widths tell the reader the wider one carries more, and in a wrapping
+flexbox it carries nothing — it is just what landed last.
+
+- **A strip of cards is a `grid`, never `flex-wrap`.** `flex-wrap` stretches whatever
+  ends up in the short last row across all the leftover width. The Workspace KPI strip
+  was `flex-wrap` with `flex: 1 1 132px` per tile: at a 1000px window five tiles fit on
+  the first row and Indexing rendered **748px wide holding one digit**, 5.5x its five
+  137px siblings (TRA-467). Nothing about the number was different — only the wrap
+  boundary.
+- **The column count divides the card count.** Six cards go 6 / 3 / 2 / 1, never 4 or 5.
+  A full last row is what makes the stretch impossible in the first place, and it also
+  removes the trailing dead space a partial row leaves behind.
+- **One function decides it, and the height helper reads the same one.**
+  `kpiColumns(paneW)` in `Workspace.tsx` is what the strip renders with *and* what
+  `kpiStripHeight()` counts rows from. A second copy of the breakpoints is how the two
+  drift and the pane reserves a height the strip does not occupy — the same failure
+  §6's top band records.
+- **Cards declare no width of their own.** No `flex`, no `min-width` fighting the
+  column. `grid-template-columns: repeat(n, minmax(0, 1fr))` and nothing else; the
+  minimum card width lives in the breakpoints, not on the card.
+
 ---
 
 ## 7. Accessibility

--- a/packages/app/src/renderer/workspace/Workspace.tsx
+++ b/packages/app/src/renderer/workspace/Workspace.tsx
@@ -80,7 +80,7 @@ function loadFilter(): WorkspaceFilter {
 // thresholds are read off the pane itself.
 
 // Pane and strip geometry, all read off the rendered surface rather than guessed.
-const TILE_MIN_W = 132; // KpiTile's flex basis
+const TILE_MIN_W = 132; // narrowest a KpiTile may be before the column count drops
 const TILE_GAP = 16; // gap-4
 // A full-height tile: 16 + 13 + 4 + 32 + 4 + 26 + 16 + hairlines. The comparison
 // line reserves two 13px lines rather than one, because at 132–214px of tile a
@@ -106,14 +106,32 @@ const MIN_SCROLL_WINDOW = 160;
 export const TABLE_MIN_PANE_W = PANE_PAD + FROZEN_COLS_W + MIN_SCROLL_WINDOW;
 
 /**
- * How tall the full-height KPI strip would be in a pane this wide. The tiles
- * flex-wrap, so width decides how many rows of 112px there are — at the app's
- * 640px minimum window that is three rows, 396px.
+ * How many KPI tiles sit on one row in a pane this wide.
+ *
+ * Always a divisor of six, so every row is full. A wrapping flexbox instead
+ * packs what fits and then stretches the remainder across the leftover width:
+ * at a 1000px window that rendered Indexing as a 748px card holding one digit
+ * next to five 137px siblings, 5.5x wide for no reason a reader can see
+ * (TRA-467). Card width is not a channel — only the column count responds to
+ * the pane (DESIGN.md §7).
+ *
+ * `0` means "not measured yet"; callers that paint decide what to assume.
+ */
+export function kpiColumns(paneW: number): number {
+  const inner = paneW - PANE_PAD;
+  for (const n of [6, 3, 2]) {
+    if (inner >= n * TILE_MIN_W + (n - 1) * TILE_GAP) return n;
+  }
+  return 1;
+}
+
+/**
+ * How tall the full-height KPI strip would be in a pane this wide — the same
+ * column count the strip actually renders with, never a second copy of the
+ * rule. At the app's 640px minimum window that is three rows, 396px.
  */
 export function kpiStripHeight(paneW: number): number {
-  const inner = Math.max(0, paneW - PANE_PAD);
-  const perRow = Math.max(1, Math.floor((inner + TILE_GAP) / (TILE_MIN_W + TILE_GAP)));
-  const rows = Math.ceil(KPI_COUNT / perRow);
+  const rows = Math.ceil(KPI_COUNT / kpiColumns(paneW));
   return rows * TILE_H + (rows - 1) * TILE_GAP + STRIP_PAD;
 }
 
@@ -281,6 +299,10 @@ export function Workspace() {
 
   const narrow = isNarrowPane(pane.w);
   const dense = isDensePane(pane.w, pane.h);
+  // Unmeasured means wide, as it does for `narrow`: the first paint runs before
+  // ResizeObserver reports, and guessing one column there would stack all six
+  // tiles for a frame on every launch of a full-size window.
+  const kpiCols = pane.w > 0 ? kpiColumns(pane.w) : KPI_COUNT;
   // The stored preference is never rewritten: widening the window has to bring
   // the user's own choice back, not whatever the narrow layout fell back to.
   const effectiveView: ViewMode = narrow ? 'compact' : view;
@@ -346,6 +368,7 @@ export function Workspace() {
         refreshing={data.refreshing}
         scrolled={scrolled}
         dense={dense}
+        kpiColumns={kpiCols}
         hideViewToggle={narrow}
         rightExtra={<AddProjectControl onAdd={(root) => data.addProject(root)} />}
         // Above the tiles, not below them: the line that says these numbers

--- a/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
@@ -74,6 +74,13 @@ export interface WorkspaceHeaderProps {
   scrolled?: boolean;
   /** Collapse the KPI tiles to one line each — see {@link KpiTileProps.dense}. */
   dense?: boolean;
+  /**
+   * Tiles per row, from `kpiColumns()` in Workspace.tsx — always a divisor of
+   * six so every row is full and no tile is stretched by a wrap boundary. The
+   * strip must not re-derive this: `kpiStripHeight()` sizes the pane off the
+   * same function, and two copies of the rule is how the top band drifted.
+   */
+  kpiColumns?: number;
   /** The pane is too narrow for the table, so Compact is the only view. */
   hideViewToggle?: boolean;
   /** Slot rendered at the end of the toolbar row (typically AddProjectControl). */
@@ -168,6 +175,7 @@ export function WorkspaceHeader({
   refreshing,
   scrolled = false,
   dense = false,
+  kpiColumns = 6,
   hideViewToggle = false,
   rightExtra,
   banner,
@@ -279,7 +287,10 @@ export function WorkspaceHeader({
       {banner}
 
       {/* ── KPI grid ───────────────────────────────────────────────── */}
-      <div className="flex items-stretch gap-4 px-4 pt-4 pb-3 flex-wrap">
+      <div
+        className="grid items-stretch gap-4 px-4 pt-4 pb-3"
+        style={{ gridTemplateColumns: `repeat(${kpiColumns}, minmax(0, 1fr))` }}
+      >
         <KpiTile
           label={t('kpiProjects')}
           value={kpis.totalProjects}

--- a/packages/app/src/renderer/workspace/__tests__/Workspace.pane.test.ts
+++ b/packages/app/src/renderer/workspace/__tests__/Workspace.pane.test.ts
@@ -11,10 +11,38 @@
  * much room this surface actually has.
  */
 import { describe, expect, it } from 'vitest';
-import { TABLE_MIN_PANE_W, isDensePane, isNarrowPane, kpiStripHeight } from '../Workspace';
+import { TABLE_MIN_PANE_W, isDensePane, isNarrowPane, kpiColumns, kpiStripHeight } from '../Workspace';
 
 /** Pane geometry for a window, with the default 220px sidebar and 44px header. */
 const pane = (winW: number, winH: number) => ({ w: winW - 220, h: winH - 44 });
+
+describe('kpiColumns', () => {
+  it('is always a divisor of six, so no row is ever short', () => {
+    // A short last row is what the old flex-wrap stretched: at a 1000px window
+    // five tiles fit above and the sixth took all 748px left over (TRA-467).
+    for (let paneW = 0; paneW <= 2000; paneW += 4) {
+      expect([1, 2, 3, 6]).toContain(kpiColumns(paneW));
+    }
+  });
+
+  it('never asks a column to be narrower than a tile can be', () => {
+    for (let paneW = 320; paneW <= 2000; paneW += 4) {
+      const n = kpiColumns(paneW);
+      if (n === 1) continue; // below 280px of inner width there is no choice
+      expect(paneW - 32).toBeGreaterThanOrEqual(n * 132 + (n - 1) * 16);
+    }
+  });
+
+  it('keeps the row count the flex-wrap layout produced at every width', () => {
+    // kpiStripHeight() and isDensePane() are sized off these rows, so the fix
+    // must not move a single pane from three rows to four.
+    for (let paneW = 0; paneW <= 2000; paneW += 4) {
+      const inner = Math.max(0, paneW - 32);
+      const perRow = Math.max(1, Math.floor((inner + 16) / (132 + 16)));
+      expect(Math.ceil(6 / kpiColumns(paneW))).toBe(Math.ceil(6 / perRow));
+    }
+  });
+});
 
 describe('kpiStripHeight', () => {
   it('reproduces the strip measured at the minimum window', () => {

--- a/packages/app/src/renderer/workspace/components/KpiTile.tsx
+++ b/packages/app/src/renderer/workspace/components/KpiTile.tsx
@@ -125,8 +125,10 @@ export function KpiTile({
           : 'flex flex-col items-start gap-1 text-left transition-colors'
       }
       style={{
-        minWidth: 132,
-        flex: '1 1 132px',
+        // No width of its own: the strip is a grid whose column count comes
+        // from `kpiColumns()`, and a tile that also declared a flex basis was
+        // what let the last row stretch its survivors to 5.5x the rest
+        // (TRA-467). Every tile is one column wide, always.
         padding: dense ? '8px 12px' : 16,
         borderRadius: 12,
         // A card is content: it stays opaque --surface in BOTH states. Tinting


### PR DESCRIPTION
Closes TRA-467.

## What was wrong

The six KPI tiles on Workspace were a wrapping flexbox (`flex items-stretch gap-4 flex-wrap`) of items that each declared `flex: 1 1 132px`. A `flex-wrap` row packs what fits and then stretches whatever landed in the short last row across all the leftover width, so the strip's card widths were an artifact of where the wrap boundary fell.

Measured in the Electron window over CDP (not a browser), at a 220px sidebar:

| Window width | Tile widths (px) | Widest / narrowest |
|---|---|---|
| 640 (app minimum) | 186 × 6 | 1.0x |
| 760 | 159 × 6 | 1.0x |
| 900 | 150 150 150 150 **316 316** | 2.1x |
| **1000** | 137 137 137 137 137 **748** | **5.5x** |
| **1100** | 157 157 157 157 157 **848** | **5.4x** |
| 1200 | 145 × 6 | 1.0x |
| 1640 | 218 × 6 | 1.0x |

At 1000px — 40px off the app's own default window — "Indexing / 0 / nothing running" was a 748px card holding one digit, next to five 137px siblings with identical anatomy (11px label, 28px value, 11px comparison line). Card width is not a channel: two cards with the same anatomy and different widths tell the reader the wider one carries more, and here it carried nothing.

## The fix

The strip is a real grid whose column count is a **divisor of six** — 6 / 3 / 2 / 1 — so every row is full and there is no ragged tail to stretch and no trailing dead space either. Thresholds fall out of the existing constants (`TILE_MIN_W` 132, `TILE_GAP` 16, `PANE_PAD` 32): 6 columns at inner ≥ 872, 3 at ≥ 428, 2 at ≥ 280, else 1.

`kpiColumns()` is the single place that rule lives, and `kpiStripHeight()` counts its rows from the same function instead of re-deriving the breakpoints — two copies of one layout rule is the drift DESIGN.md §6 already records for the top band. Tiles no longer declare a width of their own (`flex` and `min-width` both gone); the minimum card width lives in the breakpoints.

Row counts are unchanged at every width, so `kpiStripHeight()` and `isDensePane()` return exactly what they returned before, and the three existing assertions in `Workspace.pane.test.ts` pass untouched. A new property test asserts that directly: the column count is always in {1,2,3,6}, never asks a column to be narrower than a tile can be, and reproduces the old flex-wrap row count at every width from 0 to 2000.

## After

Re-ran the same CDP sweep in the Electron window:

| Window width | Pane | Tile widths (px) | Widest / narrowest | Rows |
|---|---|---|---|---|
| 640 | 420 | 186 × 6 | 1.00x | 3 |
| 760 | 540 | 159 × 6 | 1.00x | 2 |
| 900 | 680 | 205 × 6 | 1.00x | 2 |
| 1000 | 780 | 239 × 6 | 1.00x | 2 |
| 1100 | 880 | 272 × 6 | 1.00x | 2 |
| 1200 | 980 | 145 × 6 | 1.00x | 1 |
| 1440 | 1220 | 185 × 6 | 1.00x | 1 |
| 1640 | 1420 | 218 × 6 | 1.00x | 1 |

Uniform at all 51 widths from 640 to 1640 in steps of 20, not just the eight above. Screenshots taken in the Electron window in both appearances at 1000×800, plus the 640×420 window minimum (dense tiles, 2 × 3, nothing clipped) — attached to TRA-467.

The rule is written into `DESIGN.md` §6 in this PR: *A dashboard card is one size. Only the column count responds to width.*

## Checks

`pnpm run typecheck`, `pnpm run build`, `pnpm run test` (46 files, 505 tests) all pass locally.

Agent: Design/UX Agent
