### PR TITLE
fix(indexer): reconcile scope on full reindex, keep git-ignored files out of the index

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,7 +95,11 @@ You can place a config file at `.trace-mcp/.config.json` in your project root to
   "exclude": ["node_modules/**", "dist/**", "coverage/**"],
   "ignore": {
     "directories": ["generated", "proto"],
-    "patterns": ["**/fixtures/**", "**/*.generated.ts"]
+    "patterns": ["**/fixtures/**", "**/*.generated.ts"],
+    // Respect the project's root .gitignore when walking (default: true).
+    // Set false to index git-ignored trees too — vendored and generated code
+    // then competes with your own in every search result.
+    "gitignore": true
   }
 }
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -358,6 +358,14 @@ const IgnoreConfigSchema = z
     directories: z.array(z.string()).default([]),
     /** Extra gitignore-style patterns to exclude from indexing. */
     patterns: z.array(z.string()).default([]),
+    /**
+     * Respect the project's root `.gitignore` when walking the tree. On by
+     * default: git-ignored trees are vendored/generated content that poisons
+     * search precision (TRA-468). Set false to index them anyway — they are
+     * then flagged `files.gitignored = 1` and their content is still not
+     * served to AI.
+     */
+    gitignore: z.boolean().default(true),
   })
   .prefault({});
 

--- a/src/indexer/__tests__/scope-reconcile.test.ts
+++ b/src/indexer/__tests__/scope-reconcile.test.ts
@@ -1,0 +1,142 @@
+/**
+ * TRA-468 — a full reindex used to be purely additive. `insertFile` upserts
+ * and nothing ever deleted, so every path any past version once walked stayed
+ * in `files` / `symbols` and in search results forever, even after the walker
+ * stopped visiting it. One real project carried 1650 rows from May–July under a
+ * `lastIndexed` stamp from a run that wrote 183 of them; 93% of its symbols
+ * came from git-ignored vendored trees the current indexer walks right past.
+ *
+ * Two halves, tested here:
+ *   - `selectOutOfScopeFiles` — which rows a full walk may delete;
+ *   - end to end — a poisoned index converges on the next `indexAll`, and
+ *     git-ignored files never enter it in the first place.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { initializeDatabase } from '../../db/schema.js';
+import { Store } from '../../db/store.js';
+import { TraceMcpConfigSchema } from '../../config.js';
+import { PluginRegistry } from '../../plugin-api/registry.js';
+import { TypeScriptLanguagePlugin } from '../plugins/language/typescript/index.js';
+import { IndexingPipeline, selectOutOfScopeFiles } from '../pipeline.js';
+
+function row(over: Partial<Parameters<typeof selectOutOfScopeFiles>[0]['files'][0]> = {}) {
+  return {
+    id: 1,
+    path: 'src/a.ts',
+    language: 'typescript',
+    content_hash: 'h1',
+    ...over,
+  };
+}
+
+describe('selectOutOfScopeFiles', () => {
+  it('drops rows the current walk no longer owns', () => {
+    const files = [row({ id: 1, path: 'src/a.ts' }), row({ id: 2, path: 'vendored/b.ts' })];
+    expect(selectOutOfScopeFiles({ files, inScope: ['src/a.ts'], truncated: false })).toEqual([2]);
+  });
+
+  it('keeps every row the walk still owns', () => {
+    const files = [row({ id: 1, path: 'src/a.ts' }), row({ id: 2, path: 'src/b.ts' })];
+    expect(
+      selectOutOfScopeFiles({ files, inScope: ['src/a.ts', 'src/b.ts'], truncated: false }),
+    ).toEqual([]);
+  });
+
+  it('keeps phantom rows for external packages — they have no path on disk', () => {
+    const files = [
+      row({ id: 2, path: 'node_modules/lodash/index.js', content_hash: '__phantom__' }),
+      row({ id: 3, path: 'react', content_hash: '__phantom_pkg__' }),
+    ];
+    expect(selectOutOfScopeFiles({ files, inScope: ['src/a.ts'], truncated: false })).toEqual([]);
+  });
+
+  it('keeps .env rows — EnvIndexer writes those on a separate pass', () => {
+    const files = [row({ id: 2, path: '.env.local', language: 'env' })];
+    expect(selectOutOfScopeFiles({ files, inScope: ['src/a.ts'], truncated: false })).toEqual([]);
+  });
+
+  it('refuses to act on an empty walk (glob failure must not wipe the index)', () => {
+    const files = [row({ id: 1 }), row({ id: 2, path: 'src/b.ts' })];
+    expect(selectOutOfScopeFiles({ files, inScope: [], truncated: false })).toEqual([]);
+  });
+
+  it('refuses to act on a truncated walk — "not in scope" only means "past the cap"', () => {
+    const files = [row({ id: 1 }), row({ id: 2, path: 'src/b.ts' })];
+    expect(selectOutOfScopeFiles({ files, inScope: ['src/a.ts'], truncated: true })).toEqual([]);
+  });
+});
+
+describe('indexAll — scope reconcile and .gitignore (end to end)', () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'scope-reconcile-'));
+    mkdirSync(join(workDir, 'src'), { recursive: true });
+    mkdirSync(join(workDir, 'vendored', 'deep'), { recursive: true });
+    writeFileSync(join(workDir, '.gitignore'), 'vendored/\n');
+    writeFileSync(join(workDir, 'src', 'a.ts'), 'export function realOne() { return 1; }\n');
+    writeFileSync(join(workDir, 'vendored', 'b.ts'), 'export function ghostOne() { return 2; }\n');
+    writeFileSync(
+      join(workDir, 'vendored', 'deep', 'c.ts'),
+      'export function ghostTwo() { return 3; }\n',
+    );
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function makePipeline(store: Store) {
+    const registry = new PluginRegistry();
+    registry.registerLanguagePlugin(new TypeScriptLanguagePlugin());
+    const config = TraceMcpConfigSchema.parse({
+      root: workDir,
+      include: ['**/*.ts'],
+      exclude: [],
+      db: { path: ':memory:' },
+    });
+    return new IndexingPipeline(store, registry, config, workDir);
+  }
+
+  it('never indexes git-ignored files', async () => {
+    const store = new Store(initializeDatabase(':memory:'));
+    await makePipeline(store).indexAll();
+
+    const paths = store.getAllFiles().map((f) => f.path);
+    expect(paths).toContain('src/a.ts');
+    expect(paths).not.toContain('vendored/b.ts');
+    expect(paths).not.toContain('vendored/deep/c.ts');
+  });
+
+  it('deletes rows a previous version left behind for out-of-scope files', async () => {
+    const store = new Store(initializeDatabase(':memory:'));
+
+    // Stand in for what an older indexer wrote: a vendored tree that the
+    // current walk excludes, plus a file since deleted from disk.
+    const stale = store.insertFile('vendored/b.ts', 'typescript', 'old', 40, null, null);
+    store.insertSymbol(stale, {
+      symbolId: 'vendored/b.ts::ghostOne#function',
+      name: 'ghostOne',
+      kind: 'function',
+      byteStart: 0,
+      byteEnd: 10,
+      lineStart: 1,
+      lineEnd: 1,
+    });
+    store.insertFile('src/gone.ts', 'typescript', 'old', 40, null, null);
+    expect(store.getAllFiles()).toHaveLength(2);
+
+    await makePipeline(store).indexAll();
+
+    const paths = store.getAllFiles().map((f) => f.path);
+    expect(paths).toEqual(['src/a.ts']);
+    // The stale row's symbols went with it — they are what search was serving.
+    const names = store
+      .getAllFiles()
+      .flatMap((f) => store.getSymbolsByFile(f.id).map((s) => s.name));
+    expect(names).toEqual(['realOne']);
+  });
+});

--- a/src/indexer/file-collector.ts
+++ b/src/indexer/file-collector.ts
@@ -3,6 +3,7 @@ import picomatch from 'picomatch';
 import type { TraceMcpConfig } from '../config.js';
 import { logger } from '../logger.js';
 import { descendantExcludeGlobs } from '../registry.js';
+import type { GitignoreMatcher } from '../utils/gitignore.js';
 import type { TraceignoreMatcher } from '../utils/traceignore.js';
 import type { WorkspaceInfo } from './monorepo.js';
 
@@ -14,6 +15,13 @@ export interface FileCollectorParams {
   rootPath: string;
   workspaces: WorkspaceInfo[];
   traceignore: TraceignoreMatcher | undefined;
+  /**
+   * Root `.gitignore` matcher, or undefined when `ignore.gitignore` is off.
+   * The watcher has always dropped git-ignored events; the full walk did not,
+   * so vendored/generated trees landed in the index and in search results
+   * (TRA-468). Same matcher, same stack, one behavior.
+   */
+  gitignore?: GitignoreMatcher | undefined;
   /** Overridable for tests; defaults to 10_000 (IndexingPipeline.DEFAULT_MAX_FILES). */
   maxFiles: number;
 }
@@ -27,7 +35,7 @@ export interface FileCollectorParams {
  * private method; only `this.*` field reads became explicit parameters.
  */
 export async function collectFiles(params: FileCollectorParams): Promise<string[]> {
-  const { config, rootPath, workspaces, traceignore, maxFiles } = params;
+  const { config, rootPath, workspaces, traceignore, gitignore, maxFiles } = params;
   const traceignoreIgnore = traceignore?.toFastGlobIgnore() ?? [];
   // Most-specific registered project owns a path: skip files that live under a
   // registered descendant so an umbrella root doesn't index its child repos
@@ -116,6 +124,14 @@ export async function collectFiles(params: FileCollectorParams): Promise<string[
 
   if (traceignore) {
     entries = entries.filter((e) => !traceignore.isIgnored(e));
+  }
+
+  // Applied after the deep/workspace fallbacks so those can't smuggle a
+  // git-ignored tree back in. ponytail: root .gitignore only — nested
+  // .gitignore files are not read, matching GitignoreMatcher's existing
+  // contract and the watcher's. Upgrade both together if it ever matters.
+  if (gitignore) {
+    entries = entries.filter((e) => !gitignore.isIgnored(e));
   }
 
   if (entries.length > maxFiles) {

--- a/src/indexer/file-persister.ts
+++ b/src/indexer/file-persister.ts
@@ -121,7 +121,7 @@ export class FilePersister {
       if (this.tryFastSymbolUpdate(fileId, ext)) {
         this.state.changedFileIds.add(fileId);
         store.updateFileHash(fileId, ext.hash, ext.contentSize, ext.mtimeMs);
-        if (ext.gitignored) store.updateFileGitignored(fileId, true);
+        store.updateFileGitignored(fileId, ext.gitignored);
         // Workspace may change between indexing runs (e.g., after monorepo
         // detection logic was fixed). Update even on fast path.
         if (ext.workspace) store.updateFileWorkspace(fileId, ext.workspace);
@@ -168,10 +168,11 @@ export class FilePersister {
       }
     }
 
-    // Flag gitignored files — indexed for graph metadata, content not served to AI
-    if (ext.gitignored) {
-      store.updateFileGitignored(fileId, true);
-    }
+    // Flag gitignored files — indexed for graph metadata, content not served to
+    // AI. Written unconditionally: the flag used to be set-only, so a file that
+    // stopped being ignored kept `gitignored = 1` forever and every consumer
+    // that filters on the column (summaries, source-reader) silently dropped it.
+    store.updateFileGitignored(fileId, ext.gitignored);
 
     // Persist base extraction symbols, edges, and entities
     this.persistSymbolsAndEntities(fileId, ext.relPath, ext.symbols, ext.otherEdges, ext);

--- a/src/indexer/pipeline.ts
+++ b/src/indexer/pipeline.ts
@@ -182,6 +182,60 @@ export function canSkipFullPostprocess(args: {
   return currentHead === storedHead;
 }
 
+/** Content hashes that mark synthetic `files` rows minted by edge resolution
+ *  for external packages. They have no path on disk, so a scope reconcile must
+ *  never mistake them for stale rows. */
+const PHANTOM_CONTENT_HASHES = new Set(['__phantom__', '__phantom_pkg__']);
+
+/** The subset of a `FileRow` the scope reconcile needs to judge a row. */
+export interface ReconcilableFileRow {
+  id: number;
+  path: string;
+  language: string | null;
+  content_hash: string | null;
+}
+
+/**
+ * Pick the `files` rows a full reindex must delete: those the current walk no
+ * longer considers in scope.
+ *
+ * Indexing is otherwise upsert-only — `insertFile` does `ON CONFLICT DO UPDATE`
+ * and nothing ever removes what a previous run wrote. So every path any past
+ * version once walked stays in the index and in search results forever, even
+ * after the walker stopped visiting it: excluded dirs, vendored trees, a
+ * `.gitignore` rule added later. TRA-468 found a project where 93% of the
+ * symbol index came from git-ignored vendored code the current indexer walks
+ * right past, with a `lastIndexed` timestamp from the run that touched 10% of
+ * the rows.
+ *
+ * Rows kept regardless of scope:
+ *   - phantom/external package rows (no on-disk path by construction);
+ *   - `.env` rows, which `EnvIndexer` writes on its own pass after this one.
+ *
+ * Refuses to act on a scope it cannot trust — an empty walk (glob failure,
+ * unreadable root) or one truncated at `security.max_files`, where "not in
+ * scope" only means "past the cap".
+ */
+export function selectOutOfScopeFiles(args: {
+  files: ReconcilableFileRow[];
+  /** Repo-relative POSIX paths the current walk found. */
+  inScope: string[];
+  /** True when the walk hit `security.max_files` and was cut short. */
+  truncated: boolean;
+}): number[] {
+  const { files, inScope, truncated } = args;
+  if (truncated || inScope.length === 0) return [];
+  const keep = new Set(inScope.map((p) => p.split(path.sep).join('/')));
+  return files
+    .filter(
+      (f) =>
+        !keep.has(f.path.split(path.sep).join('/')) &&
+        f.language !== 'env' &&
+        !PHANTOM_CONTENT_HASHES.has(f.content_hash ?? ''),
+    )
+    .map((f) => f.id);
+}
+
 export interface IndexingPipelineDeps {
   /** Inject a daemon-shared ExtractPool. When provided, the pipeline never
    *  creates its own pool and dispose() does NOT terminate the shared one. */
@@ -341,7 +395,6 @@ export class IndexingPipeline {
       //     would be a false positive that automated quality gates would
       //     misinterpret as a regression.
       const skipShrinkCheck = force === true || this._postprocessLevel === 'none';
-      const before = skipShrinkCheck ? null : this.captureSizeSnapshot();
       if (this.config.children?.length) {
         this.workspaces = buildMultiRootWorkspaces(this.rootPath, this.config.children);
         logger.info({ workspaces: this.workspaces.map((w) => w.name) }, 'Multi-root workspaces');
@@ -359,6 +412,8 @@ export class IndexingPipeline {
       // The "from-scratch" signal is `totalSymbols === 0` — this works even
       // when `force=true` is passed (which would otherwise skip the shrink
       // check signal).
+      // Read BEFORE reconcileScope: an index whose every row went out of scope
+      // is still a live DB other connections may be reading, not a fresh one.
       const isFromScratch = (() => {
         try {
           return this.store.getStats().totalSymbols === 0;
@@ -366,6 +421,12 @@ export class IndexingPipeline {
           return false;
         }
       })();
+      // Reconcile before snapshotting: dropping rows the walk no longer owns is
+      // the intended outcome here, not the parser regression `checkShrink`
+      // hunts for. Repairing an index that was 93% stale would otherwise raise
+      // a shrink warning on the very run that fixed it.
+      this.reconcileScope(filePaths);
+      const before = skipShrinkCheck ? null : this.captureSizeSnapshot();
       if (isFromScratch) {
         logger.info('Engaging bulk-load mode for from-scratch index');
         enableBulkMode(this.store.db);
@@ -449,6 +510,39 @@ export class IndexingPipeline {
     }
   }
 
+  /** Rows dropped by the last `reconcileScope` — see its use in `runPipeline`. */
+  private _scopeRowsRemoved = 0;
+
+  /**
+   * Delete `files` rows (and their symbols/edges/entities) that the current
+   * walk no longer owns. Full reindex only — the incremental path is handed a
+   * few paths and knows nothing about the rest of the tree.
+   *
+   * This is also the repair path for an index poisoned by an older version:
+   * the daemon runs `indexAll` per project on start, so a stale index converges
+   * without any explicit `trace-mcp doctor --fix` step.
+   */
+  private reconcileScope(inScope: string[]): number {
+    const maxFiles = this.config.security?.max_files ?? IndexingPipeline.DEFAULT_MAX_FILES;
+    const staleIds = selectOutOfScopeFiles({
+      files: this.store.getAllFiles(),
+      inScope,
+      // ponytail: collectFiles truncates silently, so infer it from the count
+      // rather than widening its return type for one boolean.
+      truncated: inScope.length >= maxFiles,
+    });
+    this._scopeRowsRemoved = staleIds.length;
+    if (staleIds.length === 0) return 0;
+    this.store.db.transaction(() => {
+      for (const id of staleIds) this.store.deleteFile(id);
+    })();
+    logger.info(
+      { root: this.rootPath, removed: staleIds.length, inScope: inScope.length },
+      'Dropped index rows for files no longer in scope',
+    );
+    return staleIds.length;
+  }
+
   deleteFiles(filePaths: string[]): void {
     if (filePaths.length === 0) return;
     this.store.db.transaction(() => {
@@ -469,6 +563,9 @@ export class IndexingPipeline {
   ): Promise<IndexingResult> {
     const result = this._lock.then(async () => {
       this._isIncremental = true;
+      // Incremental runs never reconcile scope; clear the flag a prior
+      // indexAll left behind so it can't force a postprocess here.
+      this._scopeRowsRemoved = 0;
       // Default to 'minimal' for incremental runs. Watcher/hook/register_edit
       // callers don't override; full postprocess (LSP + env + snapshots) was
       // the source of 3-11s outliers visible in daemon.log on single-file
@@ -488,6 +585,11 @@ export class IndexingPipeline {
       const ownedByDescendant = descendantGlobs.length
         ? picomatch(descendantGlobs, { dot: true })
         : undefined;
+      // Same gate collectFiles() now applies. The watcher already dropped
+      // git-ignored events, but hooks, `register_edit` and the HTTP reindex
+      // endpoint reach here directly and would otherwise re-add rows the full
+      // walk excludes — putting the index straight back out of sync (TRA-468).
+      const gitignore = this.gitignoreMatcher();
       const relPaths: string[] = [];
       for (const fp of filePaths) {
         const rel = path.isAbsolute(fp) ? path.relative(this.rootPath, fp) : fp;
@@ -503,6 +605,10 @@ export class IndexingPipeline {
         }
         if (ownedByDescendant?.(relPosix)) {
           logger.debug({ file: rel }, 'Skipped: owned by a more-specific registered project');
+          continue;
+        }
+        if (gitignore?.isIgnored(relPosix)) {
+          logger.debug({ file: rel }, 'Git-ignored path skipped in indexFiles');
           continue;
         }
         relPaths.push(rel);
@@ -558,6 +664,9 @@ export class IndexingPipeline {
     this.registry.clearCaches();
     this._changedFileIds.clear();
     this._gitignore = new GitignoreMatcher(this.rootPath);
+    // Note: `_scopeRowsRemoved` is deliberately NOT reset here — indexAll sets
+    // it just before calling us and the postprocess gate below reads it. It is
+    // reset by `indexFiles`, which never reconciles.
     this._traceignore = new TraceignoreMatcher(this.rootPath, this.config.ignore);
     this.registerFrameworkEdgeTypes();
 
@@ -578,7 +687,10 @@ export class IndexingPipeline {
       const skipPostprocess =
         this._postprocessLevel !== 'none' &&
         canSkipFullPostprocess({
-          force,
+          // A scope reconcile just deleted files (and their edges): HEAD may be
+          // unchanged and extraction may have hash-skipped everything, but the
+          // graph is not the one we stamped. Re-resolve.
+          force: force || this._scopeRowsRemoved > 0,
           indexed: result.indexed,
           errors: result.errors,
           totalEdges: this.store.getStats().totalEdges,
@@ -1175,12 +1287,29 @@ export class IndexingPipeline {
     }
   }
 
+  /** The active `.gitignore` matcher, or undefined when `ignore.gitignore` is
+   *  off. Built on demand — `collectFiles()` runs before `runPipeline()`
+   *  refreshes the matchers, and on a first index there is nothing to refresh. */
+  private gitignoreMatcher(): GitignoreMatcher | undefined {
+    if (this.config.ignore?.gitignore === false) return undefined;
+    this._gitignore ??= new GitignoreMatcher(this.rootPath);
+    return this._gitignore;
+  }
+
   private async collectFiles(): Promise<string[]> {
+    // Built here rather than read from the field: on a first index
+    // `runPipeline` has not run yet, so `_traceignore` was undefined and the
+    // opening walk silently ignored .traceignore entirely.
+    this._traceignore = new TraceignoreMatcher(this.rootPath, this.config.ignore);
+    // Rebuilt per walk so an edit to .gitignore takes effect on this run, not
+    // the next one.
+    this._gitignore = new GitignoreMatcher(this.rootPath);
     return collectFilesImpl({
       config: this.config,
       rootPath: this.rootPath,
       workspaces: this.workspaces,
       traceignore: this._traceignore,
+      gitignore: this.gitignoreMatcher(),
       maxFiles: this.config.security?.max_files ?? IndexingPipeline.DEFAULT_MAX_FILES,
     });
   }

--- a/tests/indexer/rename-detection.test.ts
+++ b/tests/indexer/rename-detection.test.ts
@@ -99,7 +99,7 @@ describe('IndexingPipeline — rename detection by content hash', () => {
     fs.writeFileSync(path.join(tmpRoot, oldRel), 'export const x = 1;\n');
     await pipeline.indexAll();
 
-    const oldId = store.getFile(oldRel)!.id;
+    expect(store.getFile(oldRel)).toBeDefined();
 
     fs.unlinkSync(path.join(tmpRoot, oldRel));
     // Content differs slightly — must not be treated as a rename.
@@ -107,7 +107,13 @@ describe('IndexingPipeline — rename detection by content hash', () => {
 
     await pipeline.indexAll();
 
-    expect(store.getFile(newRel)).toBeDefined();
-    expect(store.getFile(newRel)!.id).not.toBe(oldId);
+    // Asserted by content rather than by row id: the scope reconcile (TRA-468)
+    // drops the vanished path before extraction, so SQLite is free to hand the
+    // freed rowid straight back to the new file. A carried-over rename would
+    // show up as the OLD symbol surviving under the new path.
+    expect(store.getFile(oldRel)).toBeUndefined();
+    const after = store.getFile(newRel);
+    expect(after).toBeDefined();
+    expect(store.getSymbolsByFile(after!.id).map((s) => s.name)).toEqual(['y']);
   });
 });


### PR DESCRIPTION
Fixes the two defects in TRA-468.

## Defect 1 — reindex was additive

`insertFile` upserts and nothing ever deleted, so every path any past version once walked stayed in `files` / `symbols` — and live in search — forever. Not deleted-file drift: the current walker correctly skips those trees, it just never removed what an older one wrote.

`indexAll` now calls `reconcileScope(filePaths)`. The decision is a pure function, `selectOutOfScopeFiles`, so the guards are exhaustively testable:

- keeps **phantom rows** (`content_hash` `__phantom__` / `__phantom_pkg__`) — external packages have no on-disk path by construction;
- keeps **`.env` rows** — `EnvIndexer` writes those on a later pass in the same run;
- **refuses an empty walk** (glob failure must never wipe an index) and a walk **truncated at `security.max_files`**, where "not in scope" only means "past the cap".

Two ordering details that matter:

- reconcile runs **before** `captureSizeSnapshot`, so repairing a 93%-stale index doesn't raise a `shrinkWarning` on the very run that fixed it;
- `isFromScratch` is read **before** reconcile — an index whose every row went out of scope is still a live DB other connections may be reading, not a fresh one, and bulk mode (`synchronous=OFF`) must not engage on it.

When reconcile removed anything, the postprocess short-circuit is bypassed so edges re-resolve against the smaller graph.

**This is also the repair path.** The daemon runs `indexAll` per project on start, so poisoned indexes converge without a `doctor --fix` step or any new command.

## Defect 2 — git-ignored files were indexed

Policy chosen: **git-ignored content stays out of the index**, `ignore.gitignore: false` to opt out.

This isn't a product reversal — it's the behavior the codebase already claimed. `watcher.ts` drops git-ignored events with the comment *"Mirrors the full scan's ignore stack (IndexingPipeline.runPipeline) so a gitignored file never reaches pipeline.indexFiles() on a watcher event either"*. The full scan was the one place that never got the gate. `indexFiles` gets it too, since hooks / `register_edit` / the HTTP reindex endpoint reach it without passing the watcher.

Two related repairs found on the way:

- **`files.gitignored` was set-only** (`if (ext.gitignored) update(..., true)` at both persist sites). A file that stopped being ignored kept `gitignored = 1` forever, and every consumer filtering on that column silently dropped it. Written unconditionally now. This also explains the issue's "5 of 1356 flagged": once the hash/mtime fast-path skips an unchanged file, its flag is never revisited, so a `.gitignore` rule added after a file was first indexed never lands on it.
- **`collectFiles` used `this._traceignore`, which `runPipeline` builds *after* the walk.** On a first index it was `undefined`, so the opening walk ignored `.traceignore` entirely. Both matchers are now built by `collectFiles` itself, per walk, so a `.gitignore` edit takes effect on the current run rather than the next.

## Secondary lead — dismissed

Not a scoping leak. `subproject_repos_searched` / `subproject_results` come from the topology layer (`search-tools.ts:392-412`), which reads a single global `TopologyStore` at `TOPOLOGY_DB_PATH` and calls `getAllSubprojects()` — unscoped by design, returned under a separate key with a `repo` field rather than mixed into `items`. Scoped `items` were correct. That the topology layer ignores `?project=` at all is arguable but a separate question; filed as TRA-470 rather than widened into this PR.

## Test evidence

`src/indexer/__tests__/scope-reconcile.test.ts` — six cases pinning the `selectOutOfScopeFiles` truth table (out-of-scope, in-scope, phantom, env, empty walk, truncated walk), plus two end-to-end against a real pipeline on the issue's exact 3-file repro:

- git-ignored `vendored/b.ts` and `vendored/deep/c.ts` never enter the index;
- pre-seeded stale rows (a vendored file plus one deleted from disk) and their symbols are gone after one `indexAll`.

`tests/indexer/rename-detection.test.ts` — one assertion updated. It proved "not treated as a rename" via row-id inequality; reconcile now drops the vanished path first, so SQLite hands the freed rowid back to the new file. Asserted by content instead (a carried-over rename would show the old symbol under the new path), which is what the test was actually about.

Local: `pnpm test` 9180 passed / 9 skipped, 0 failed. `pnpm typecheck`, `pnpm build`, `biome check` clean.

## Contract

No MCP tool signature changed. No schema migration — `files.gitignored` keeps its meaning, it just becomes accurate. Existing indexes shrink on their next full reindex; that is the fix.

Closes TRA-468.

Agent: Lead Engineer (Multica)

