### PR TITLE
fix(app): Project Overview says a dead daemon once, not six times (TRA-469)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -524,6 +524,28 @@ does not blink a banner with it, while recovery publishes immediately. Escalatin
 makes a working app look broken. Keep apart only what the user would act on differently —
 "busy" and "not running" are two states because one is a wait and the other is a button.
 
+**A surface whose every section reads one source states its failure once, at
+surface level.** Five sections that each fetch from the daemon do not produce five
+pieces of information when the daemon is down — they produce one, said five times.
+Project Overview said it six: the toolbar chip, Guard's own line, and four
+`SectionError`s that each claimed "the daemon may still be indexing", the *wait*
+diagnosis, about a process that was not running, each with a Retry aimed at a
+socket that was refusing (TRA-469). The pane takes the one statement and the one
+button; whatever else was going to say it steps aside, the same way the Workspace
+banner steps aside for `DaemonDownPane`.
+
+The corollary, and the reason this is a rule rather than a fix: **the shared error
+primitive must not name a cause it cannot know.** `SectionError` renders one
+catalogue string in all ten locales; a section that cannot tell "busy" from "not
+running" must not pick one. Deciding that is the surface's job, because the
+surface is what holds the daemon state.
+
+**The test for "down" is a shared reducer, not a fresh `!connected`.**
+`deriveDaemonState()` already encodes that a daemon which has not answered *yet*
+is not one that is failing to. `connected` is false for the first moments of every
+mount, so a surface that invents its own check flashes a daemon-down pane on every
+open.
+
 **Values that were true a minute ago outrank no values at all.** A refresh that fails must
 leave the last good ones on screen, cache them across launches, and say once — above them,
 where they are read before the numbers are — that they are the last indexed ones. Em dashes
@@ -1239,6 +1261,7 @@ new evidence.
 | A share of a total is only for a set that really is a **part of that total** | Healthy and Needs attention are overlapping predicates — a grade-B project with 15 dead exports is in both — so "57% of 53 projects" beside "83% of 53 projects" is the grammar of a partition on numbers that do not partition anything. Two shares of one denominator get added by every reader who sees them side by side. A comparison line for an overlapping set names its criterion instead. |
 | A comparison line reserves its height, it does not measure it | The catalogue runs +30% longer in German and Russian and a tile is 132–214px wide, so whether the line wraps is not a property of the design. `KpiTile` reserves two 13px lines whatever the string does, which is what lets one `TILE_H` constant hold: measured on the running renderer, every tile is 112px in en/de/ja and both criterion lines are 26px in ru. The reservation is a floor, not a cap — Russian's delta caption (`↑+105.6k по сравнению с: 9 минут назад`) still runs to four lines and takes its row to 138px, which is a separate defect and not something `TILE_H` can absorb. |
 | A card grid responds by changing its column count, never its card width | `flex-wrap` + `flex: 1 1 132px` hands the leftover width to whichever cards landed in the last row: at a 1000px window five KPI tiles rendered at 137px and the sixth at 748px, all six carrying the same three lines. A card wider than its neighbour makes a claim the data is not making. Equal `minmax(0, 1fr)` tracks, and a count that **divides** the number of cards so no row is ever short (TRA-467). |
+| A surface whose every section reads one source states its failure once, at surface level | Project Overview said one dead daemon six times — the toolbar chip, Guard's line, and four `SectionError`s each claiming "the daemon may still be indexing" with a Retry aimed at a refusing socket. "Busy" is a wait, "not running" is a button; the app knew which one it was and printed the other four times. `DaemonDownPane` is now shared, and the test for down is `deriveDaemonState()` rather than a fresh `!connected` that would flash on every mount (TRA-469). |
 | Narrow gives up the comparison, then the table, never the value | The number and the project name are the screen; the footnote and the metric columns are elaboration. Compact already renders a legible row at 420px. |
 | A view toggle with one usable option is hidden, not disabled | A disabled segment is a control with nothing to choose. The stored preference is untouched and returns with the width. |
 | Migrate a screen **whole**, one screen per PR | A half-migrated screen looks worse than the un-migrated one; a big-bang redesign PR never lands. |

--- a/packages/app/src/renderer/components/DaemonDownPane.tsx
+++ b/packages/app/src/renderer/components/DaemonDownPane.tsx
@@ -1,0 +1,36 @@
+/* DaemonDownPane — the pane a surface shows when the daemon never answered.
+
+   One condition gets one sentence (DESIGN.md §5). An unreachable daemon is not a
+   wait, it is a button: every surface that depends on the daemon says the same
+   thing and offers the same action, rather than each inventing its own wording
+   for the same dead process.
+
+   Lifted out of Workspace.tsx when Project Overview became the second caller
+   (TRA-469). The strings stay in the `workspace` namespace they were written in —
+   moving them would churn ten locale files to say what they already say. */
+
+import { useTranslation } from 'react-i18next';
+import { Button, EmptyState } from '../lattice/ui';
+
+export function DaemonDownPane({
+  restarting,
+  onRestart,
+}: {
+  restarting: boolean;
+  onRestart: () => void;
+}) {
+  const { t } = useTranslation('workspace');
+  return (
+    <EmptyState
+      icon="cable"
+      iconSize={32}
+      title={t('daemonDownTitle')}
+      subtitle={t('daemonDownSubtitle')}
+      action={
+        <Button variant="prominent" size="large" onClick={onRestart} disabled={restarting}>
+          {restarting ? t('startingDaemon') : t('startDaemon')}
+        </Button>
+      }
+    />
+  );
+}

--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -21,9 +21,11 @@
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { DaemonDownPane } from '../components/DaemonDownPane';
 import { GuardSection } from '../components/GuardSection';
 import { ProjectStatsModal } from '../components/ProjectStatsModal';
 import { useDaemon } from '../hooks/useDaemon';
+import { deriveDaemonState } from '../workspace/useWorkspaceProjects';
 import { t } from '../i18n';
 import { formatDate, formatNumber, relativeTime } from '../i18n/format';
 import { Icon } from '../lattice/icons';
@@ -227,7 +229,15 @@ export function ProjectOverview({
   onNavigateToService?: (serviceName: string) => void;
 }) {
   const { t } = useTranslation('overview');
-  const { projects, loading: daemonLoading, connected, reindexProject, addProject } = useDaemon();
+  const {
+    projects,
+    loading: daemonLoading,
+    connected,
+    restarting,
+    restartDaemon,
+    reindexProject,
+    addProject,
+  } = useDaemon();
   const project = projects.find((p) => p.root === root);
   const status = project?.status ?? 'unknown';
   const progress = project?.progress;
@@ -235,6 +245,23 @@ export function ProjectOverview({
      indexed". Without this the panel offered "Index project" for a project it
      was simultaneously reporting 78 files and 700 symbols for. */
   const listPending = !project && (daemonLoading || !connected);
+
+  /* One condition gets one sentence (DESIGN.md §5). With the daemon down this
+     surface used to say so six times — the toolbar chip, Guard's own line, and
+     four section errors that each claimed "the daemon may still be indexing",
+     which is the *wait* state for a process that is not running (TRA-469).
+
+     `deriveDaemonState` rather than a fresh `!connected`: `connected` is false
+     for the first moments of every mount, and a naive test would flash a
+     daemon-down pane on every project open. Reusing the reducer is also what
+     keeps the two surfaces from drifting into two definitions of "down". */
+  const daemonDown =
+    deriveDaemonState({
+      loading: daemonLoading,
+      connected,
+      liveProjects: projects.length,
+      metricsErrorKind: null,
+    }) === 'unreachable';
 
   const [stats, setStats] = useState<ProjectStats | null>(null);
   const [statsLoad, setStatsLoad] = useState<Load>('loading');
@@ -462,13 +489,19 @@ export function ProjectOverview({
           </div>
         </div>
 
-        {listPending ? (
+        {daemonDown ? (
+          /* The pane below owns this diagnosis and offers the button that fixes
+             it, so the toolbar does not repeat it — the same reason the
+             Workspace banner steps aside for DaemonDownPane (TRA-397, TRA-469). */
+          null
+        ) : listPending ? (
           /* Offering "Index project" before the daemon has answered invites the
              user to re-index something that may already be indexed. The toolbar
-             always renders, so the daemon-down wording lives here rather than in
-             the Status row, which is itself missing when the fetch failed. */
+             always renders, so the "still checking" wording lives here rather
+             than in the Status row, which is itself missing when the fetch
+             failed. */
           <Button className="is-status" disabled>
-            {connected ? t('statusChecking') : t('statusDaemonUnreachable')}
+            {t('statusChecking')}
           </Button>
         ) : project ? (
           /* While indexing the action is unavailable, and a DISABLED prominent
@@ -564,6 +597,14 @@ export function ProjectOverview({
         className="flex-1 overflow-auto"
         onScroll={(e) => setScrolled((e.target as HTMLElement).scrollTop > 0)}
       >
+        {daemonDown ? (
+          /* Every section on this surface reads the daemon, so with the daemon
+             down all five render the same failure. Five broken cards is not
+             five pieces of information — it is one, said five times, and four
+             of those said "may still be indexing" about a process that is not
+             running (TRA-469). One statement, one button. */
+          <DaemonDownPane restarting={restarting} onRestart={() => void restartDaemon()} />
+        ) : (
         <div className="flex flex-col gap-6 px-4 py-4 mx-auto w-full" style={{ maxWidth: 720 }}>
           {/* Indexing caption — the phase in words, next to the bar above. */}
           {status === 'indexing' && progress?.phase && (
@@ -983,6 +1024,7 @@ export function ProjectOverview({
             )}
           </Section>
         </div>
+        )}
       </div>
 
       {rowMenu.at && rowMenuFor && (

--- a/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
@@ -18,6 +18,8 @@ const daemon = {
   projects: [] as { root: string; status: string; progress?: { phase: string; percent: number } }[],
   loading: false,
   connected: true,
+  restarting: false,
+  restartDaemon: vi.fn(),
   reindexProject: vi.fn(),
   addProject: vi.fn(),
 };
@@ -57,6 +59,8 @@ beforeEach(() => {
   daemon.projects = [{ root: ROOT, status: 'ready' }];
   daemon.loading = false;
   daemon.connected = true;
+  daemon.restarting = false;
+  daemon.restartDaemon.mockClear();
   daemon.reindexProject.mockClear();
   daemon.addProject.mockClear();
 });
@@ -217,19 +221,41 @@ describe('ProjectOverview surface', () => {
     expect(screen.getByRole('button', { name: 'Re-add project' })).toBeTruthy();
   });
 
-  it('says the daemon is unreachable rather than blaming the project', async () => {
+  /* TRA-469. Every section here reads the daemon, so a daemon that never
+     answered used to fail all five at once: the toolbar chip, Guard's own line
+     and four section errors, six statements about one dead process. Four of
+     them said "the daemon may still be indexing" — the *wait* state — and
+     offered a Retry against a socket that was refusing. One condition gets one
+     sentence (DESIGN.md §5), and this one is a button, not a wait. */
+  it('says an unreachable daemon once, with the process to start', async () => {
     daemon.projects = [];
     daemon.loading = false;
     daemon.connected = false;
     mockApi({ '/stats': null, '/coverage': null, '/subprojects': null, '/smells': null });
     render(<ProjectOverview root={ROOT} />);
 
-    /* The toolbar always renders, so it carries the diagnosis even when every
-       section fetch failed and the Status row never appeared. */
-    const action = await screen.findByRole('button', { name: 'Daemon unreachable' });
-    expect(action).toHaveProperty('disabled', true);
-    expect(action.className).toContain('is-status');
+    expect(await screen.findByText("The daemon isn't running")).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Start daemon' })).toBeTruthy();
+
+    // Not the five broken cards, and not a second copy of the diagnosis.
+    expect(screen.queryByText(/may still be indexing/)).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Daemon unreachable' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Index project' })).toBeNull();
+  });
+
+  /* The pane is for a daemon that never answered, NOT for the first moments of
+     a mount — `connected` is false there too, and a naive test would flash it
+     on every project open. */
+  it('does not show the daemon-down pane while the daemon is still answering', async () => {
+    daemon.projects = [];
+    daemon.loading = true;
+    daemon.connected = false;
+    mockApi({ '/stats': STATS, '/coverage': COVERAGE, '/subprojects': {}, '/smells': NO_SMELLS });
+    render(<ProjectOverview root={ROOT} />);
+
+    expect(await screen.findByRole('button', { name: 'Checking…' })).toBeTruthy();
+    expect(screen.queryByText("The daemon isn't running")).toBeNull();
   });
 
   it('keeps the chrome and offers a retry when a section fails', async () => {

--- a/packages/app/src/renderer/workspace/Workspace.tsx
+++ b/packages/app/src/renderer/workspace/Workspace.tsx
@@ -26,6 +26,7 @@ import { t } from '../i18n';
 import { formatNumber } from '../i18n/format';
 import { Button, EmptyState } from '../lattice/ui';
 import { addRecentProject, removeRecentProject } from '../recent-projects';
+import { DaemonDownPane } from '../components/DaemonDownPane';
 import { AddProjectControl } from './AddProjectControl';
 import { BulkActionsBar } from './BulkActionsBar';
 import { WorkspaceCompactView } from './WorkspaceCompactView';
@@ -196,24 +197,6 @@ export function busyMessage(o: {
     });
   }
   return t(o.haveNumbers ? 'workspace:busyStale' : 'workspace:busyFresh');
-}
-
-/** The pane shown when the daemon is not answering at all. */
-function DaemonDownPane({ restarting, onRestart }: { restarting: boolean; onRestart: () => void }) {
-  const { t } = useTranslation('workspace');
-  return (
-    <EmptyState
-      icon="cable"
-      iconSize={32}
-      title={t('daemonDownTitle')}
-      subtitle={t('daemonDownSubtitle')}
-      action={
-        <Button variant="prominent" size="large" onClick={onRestart} disabled={restarting}>
-          {restarting ? t('startingDaemon') : t('startDaemon')}
-        </Button>
-      }
-    />
-  );
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes TRA-469.

## What renders today

With the daemon unreachable (`curl 127.0.0.1:3741` refuses the connection),
Project Overview says so **six times**, and four of them say something untrue.
Settled state, not a mid-load frame — re-shot after a 12s settle, zero skeleton
nodes and zero `aria-busy` left on the page:

| Where | Text |
|---|---|
| Toolbar | `Daemon unreachable` |
| Index | `Couldn't load the index summary. The daemon may still be indexing.` + Retry |
| Guard | `trace-mcp server not running` |
| Coverage | `Couldn't load dependency coverage. The daemon may still be indexing.` + Retry |
| Quality | `Couldn't load the quality scan. The daemon may still be indexing.` + Retry |
| Services | `Couldn't load the service list. The daemon may still be indexing.` + Retry |

`DESIGN.md` §5, "One condition gets one sentence, and stale beats empty":

> Keep apart only what the user would act on differently — **"busy" and "not
> running" are two states because one is a wait and the other is a button.**

The app knew which state it was in — it printed "Daemon unreachable" in its own
toolbar — and then told the user four times to wait for an indexing pass that
was not happening, offering four Retry buttons aimed at a socket that was
refusing the connection.

The wrong sentence comes from the shared primitive: `SectionError`
(`lattice/ui/Surface.tsx`) renders one catalogue string, `ui:sectionError`,
hardcoded to the busy diagnosis in all ten locales, with no knowledge of whether
the daemon is reachable. Deciding that is the surface's job, because the surface
is what holds the daemon state.

## The change

Every section here reads the daemon, so all five fail together. Project Overview
adopts the answer Workspace already had in TRA-397 rather than inventing a
second one: the pane takes the one statement and the one button, and the
toolbar chip steps aside instead of repeating it.

- `DaemonDownPane` moves out of `Workspace.tsx` — it has two callers now. Copy
  and strings are unchanged, so no catalogue churn across ten locales.
- The unreachable test is `deriveDaemonState()`, the existing tested pure
  reducer, **not** a fresh `!connected`. That distinction is the whole reason it
  is worth a line of comment: `connected` is `false` for the first moments of
  every mount, so a naive check would flash a daemon-down pane on every project
  open. `deriveDaemonState` already encodes "has not answered *yet* is not
  failing to", and reusing it keeps the two surfaces from drifting into two
  definitions of "down".

## Verification

Judged in the Electron window with the daemon genuinely stopped, light and dark.
Measured on the running renderer after the change:

```
title "The daemon isn't running"  true
"may still be indexing"           false
Retry buttons                     0
"Daemon unreachable" chip         false
```

Before/after screenshots in both appearances are on TRA-469.

Tests: the old test pinned the six-sentence behaviour, so it is rewritten to pin
the new one, plus a second test for the mount case that must **not** show the
pane. 506 app tests pass, `typecheck` clean, `check:i18n` clean.

`DESIGN.md` §5 gains the rule and §11 a decision-log row, per the house rule that
a run which changes a rule updates the document in the same PR.

## Left out, deliberately

With the daemon down the sidebar's file list still reads "No indexed files match
this scope" — the same class of wrong diagnosis (it blames the scope filter), in
a different component with its own state. It is pre-existing, not a regression
from this change, and it belongs to the sidebar rather than this surface; filed
separately rather than widening this diff.

Agent: Design/UX Agent
