### PR TITLE
fix(workspace): measure the pane before the first paint, not after it

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -867,6 +867,20 @@ scroll window, and `isDensePane()` compares the pane's height against
 `kpiStripHeight(paneW)` rather than against a guessed breakpoint — which is why it
 reproduces the strip's measured height exactly instead of drifting from it.
 
+**A pane-derived layout number is measured before the first paint.** A
+`ResizeObserver` first reports on the frame *after* the initial commit, so anything
+read off `pane.w` in that commit is read off zero — and zero is a real answer to
+these functions, not a no-op. Take the first measurement synchronously in a
+`useLayoutEffect` (`getBoundingClientRect()` on the same ref), and leave the observer
+for everything after it. Sampled every animation frame in the Electron window at
+1000×800 with only the observer: the first painted frame of the KPI strip was one
+column of 748px tiles in a 780px strip, settling to three 239px tiles in a 268px
+strip ~5ms later — the exact geometry TRA-467 had just removed, plus a 512px jump
+that starts the project list below the window edge on every launch. The danger grows
+the more layout the number decides: it was invisible while `pane.w` only chose
+between a table and a list, and became a full-strip reflow the day it also chose the
+column count.
+
 **A card grid responds by changing its column count, never its card width.** Cards
 in a dashboard are one size at any given width — the reader compares them, and a
 card that is wider than its neighbour is making a claim the data is not making.

--- a/packages/app/src/renderer/workspace/Workspace.tsx
+++ b/packages/app/src/renderer/workspace/Workspace.tsx
@@ -20,7 +20,7 @@
  * because the sidebar is resizable: below `TABLE_MIN_PANE_W` the table gives
  * way to Compact, and below `DENSE_PANE_H` the KPI tiles collapse to one line.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { t } from '../i18n';
 import { formatNumber } from '../i18n/format';
@@ -289,6 +289,22 @@ export function Workspace() {
   // ── Pane size ────────────────────────────────────────────────────────
   const paneRef = useRef<HTMLDivElement>(null);
   const [pane, setPane] = useState({ w: 0, h: 0 });
+  /* Measured before the browser paints, not after. A ResizeObserver first
+     reports on the frame AFTER the initial commit, so the first frame would be
+     laid out at `pane.w = 0` — and now that the KPI strip's column count is
+     read off the pane, zero means one column. Sampled every rAF in the Electron
+     window at 1000×800: the first painted frame was 1 column of 748px tiles in
+     a 780px strip, settling to 3 × 239px in a 268px strip ~5ms later. That is
+     the exact geometry TRA-467 removed, plus a 512px jump that starts the
+     project list below the window edge, on every launch. */
+  useLayoutEffect(() => {
+    const el = paneRef.current;
+    if (!el) return;
+    const box = el.getBoundingClientRect();
+    const w = Math.round(box.width);
+    const h = Math.round(box.height);
+    setPane((prev) => (prev.w === w && prev.h === h ? prev : { w, h }));
+  }, []);
   useEffect(() => {
     const el = paneRef.current;
     if (!el || typeof ResizeObserver === 'undefined') return;


### PR DESCRIPTION
Follow-up to #608 (TRA-467). Same issue, the part the merged fix left behind.

## What still renders wrong

#608 made the KPI strip a grid whose column count comes from `kpiColumns(pane.w)`. `pane.w` is written only by a `ResizeObserver`, which first reports on the frame *after* React's initial commit — so the **first painted frame is laid out at a pane width of zero**, and zero is not a no-op here, it is a real answer: one column.

Sampled every animation frame in the Electron window at 1000×800, with the sampler installed via `Page.addScriptToEvaluateOnNewDocument` so it is running before React's first commit. Two consecutive runs on the merged build:

```
[{"ms":24,"cols":1,"w":748,"strip":780},{"ms":29,"cols":3,"w":239,"strip":268}]
[{"ms":30,"cols":1,"w":748,"strip":780},{"ms":35,"cols":3,"w":239,"strip":268}]
```

The first frame is the **exact geometry TRA-467 removed** — a 748px tile — and the strip is 780px tall in an 800px window, so the project list starts below the window edge. It settles to 3 × 239px in a 268px strip about 5ms later: a 512px reflow on every launch and every reload.

This was harmless right up until #608. While `pane.w` only chose between the table and the compact list, `isNarrowPane(0)` deliberately answered "wide" and the zero frame cost nothing. It became a full-strip reflow the day the same number also chose the column count.

## The fix

Take the first measurement synchronously in a `useLayoutEffect` — it runs after the DOM is written and before the browser paints, so the commit that lands on screen already has the real width. The `ResizeObserver` is left to handle every resize after it. Eight lines, one file.

The alternative, guarding the call site with `pane.w > 0 ? kpiColumns(pane.w) : 6`, only trades one wrong first frame for a less wrong one — it still guesses, and it still guesses wrong at the 640px window minimum. Measuring is not more code than guessing here.

## After

Same probe, same build pipeline, on this branch — one entry, three columns from the first sampled frame:

```
[{"ms":50,"cols":3,"w":239,"strip":268}]
[{"ms":36,"cols":3,"w":239,"strip":268}]
```

Steady-state sweep re-run to confirm nothing else moved: uniform tile widths (1.00×) at all 51 widths from 640 to 1640 in steps of 20.

## On testing

Not unit-testable. jsdom reports every `getBoundingClientRect()` as 0×0, so a test at this level would assert the bug rather than the fix. The check is the animation-frame probe above, run against the built app in the Electron window; the numbers from both sides are in the commit message so the next run can reproduce them rather than take them on trust.

## Checks

`pnpm run typecheck`, `pnpm run test` (46 files, 505 tests), `pnpm run build` all pass locally.

`DESIGN.md` gets the general rule next to the card-grid one it sits under: a pane-derived layout number is measured before the first paint, and the danger grows with how much layout that number decides.

Agent: Design/UX Agent
