### PR TITLE
fix(app): one answer for an unreachable daemon on Project Overview (TRA-469)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -531,6 +531,17 @@ and "Couldn't be measured" are for a number nobody has ever had, not for one tha
 minutes old. The corollary: that line has to match the screen. Saying "these are the last
 indexed numbers" over a row of em dashes is the same lie in the other direction.
 
+**The surface decides reachability before any section is allowed to explain itself.** A
+shared error primitive states one diagnosis for every caller — `SectionError` says "the
+daemon may still be indexing" and cannot know whether that is true. So the surface has to
+ask first: with the service unreachable it takes the whole pane with the one statement and
+the one button, and never renders section-level errors at all. Otherwise every failed fetch
+on the screen repeats a guess the surface has already contradicted in its own toolbar, each
+with a Retry aimed at a socket that is refusing (TRA-469). Two callers of this now exist, so
+the pane is a shared component (`components/DaemonDownPane.tsx`) and the reachability test is
+one exported reducer (`deriveDaemonState`) — never a fresh `!connected`, which is true on
+mount and would flash the pane on every open.
+
 ---
 
 ## 6. Layout skeleton

--- a/packages/app/src/renderer/components/DaemonDownPane.tsx
+++ b/packages/app/src/renderer/components/DaemonDownPane.tsx
@@ -1,0 +1,42 @@
+/**
+ * DaemonDownPane — the one thing a surface says when the daemon is not
+ * answering at all (TRA-397, shared in TRA-469).
+ *
+ * "One condition gets one sentence" (DESIGN.md §5) is a rule about the whole
+ * screen, not about one component: it only holds if every surface reaches for
+ * the same answer. Workspace had this pane and Project Overview did not, so
+ * Project Overview said "the daemon may still be indexing" five times over a
+ * daemon it was simultaneously reporting unreachable — four Retry buttons
+ * firing at a refused socket, and a wait offered where there is a process to
+ * start.
+ *
+ * Copy is unchanged from where it was defined, so the ten locales keep the
+ * strings they already have. (Clients.tsx still carries its own near-duplicate
+ * under `clients:daemonDownTitle`; folding it in changes copy that ships today,
+ * so it is left for its own change.)
+ */
+import { useTranslation } from 'react-i18next';
+import { Button, EmptyState } from '../lattice/ui';
+
+export function DaemonDownPane({
+  restarting,
+  onRestart,
+}: {
+  restarting: boolean;
+  onRestart: () => void;
+}) {
+  const { t } = useTranslation('workspace');
+  return (
+    <EmptyState
+      icon="cable"
+      iconSize={32}
+      title={t('daemonDownTitle')}
+      subtitle={t('daemonDownSubtitle')}
+      action={
+        <Button variant="prominent" size="large" onClick={onRestart} disabled={restarting}>
+          {restarting ? t('startingDaemon') : t('startDaemon')}
+        </Button>
+      }
+    />
+  );
+}

--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -21,6 +21,7 @@
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { DaemonDownPane } from '../components/DaemonDownPane';
 import { GuardSection } from '../components/GuardSection';
 import { ProjectStatsModal } from '../components/ProjectStatsModal';
 import { useDaemon } from '../hooks/useDaemon';
@@ -47,6 +48,7 @@ import {
   useMenuAnchor,
   type Tone,
 } from '../lattice/ui';
+import { deriveDaemonState } from '../workspace/useWorkspaceProjects';
 
 interface ProjectStats {
   files: number;
@@ -227,7 +229,15 @@ export function ProjectOverview({
   onNavigateToService?: (serviceName: string) => void;
 }) {
   const { t } = useTranslation('overview');
-  const { projects, loading: daemonLoading, connected, reindexProject, addProject } = useDaemon();
+  const {
+    projects,
+    loading: daemonLoading,
+    connected,
+    restarting,
+    reindexProject,
+    addProject,
+    restartDaemon,
+  } = useDaemon();
   const project = projects.find((p) => p.root === root);
   const status = project?.status ?? 'unknown';
   const progress = project?.progress;
@@ -235,6 +245,19 @@ export function ProjectOverview({
      indexed". Without this the panel offered "Index project" for a project it
      was simultaneously reporting 78 files and 700 symbols for. */
   const listPending = !project && (daemonLoading || !connected);
+
+  /* The same reducer the Workspace reads, not a fresh `!connected` (TRA-469):
+     `connected` is false on mount, and a naive test flashes a daemon-down pane
+     on every project open. `deriveDaemonState` already encodes "has not
+     answered yet is not failing to". There is no metrics fetch on this surface,
+     so the only degraded reading it can produce is the one from the feed. */
+  const daemonDown =
+    deriveDaemonState({
+      loading: daemonLoading,
+      connected,
+      liveProjects: projects.length,
+      metricsErrorKind: null,
+    }) === 'unreachable';
 
   const [stats, setStats] = useState<ProjectStats | null>(null);
   const [statsLoad, setStatsLoad] = useState<Load>('loading');
@@ -462,13 +485,17 @@ export function ProjectOverview({
           </div>
         </div>
 
-        {listPending ? (
+        {daemonDown ? (
+          /* Nothing. DaemonDownPane below owns the diagnosis and carries the
+             one button that helps; a second "Daemon unreachable" chip up here
+             is the same sentence said twice (TRA-469). Every action this
+             toolbar can offer talks to the daemon that isn't there. */
+          null
+        ) : listPending ? (
           /* Offering "Index project" before the daemon has answered invites the
-             user to re-index something that may already be indexed. The toolbar
-             always renders, so the daemon-down wording lives here rather than in
-             the Status row, which is itself missing when the fetch failed. */
+             user to re-index something that may already be indexed. */
           <Button className="is-status" disabled>
-            {connected ? t('statusChecking') : t('statusDaemonUnreachable')}
+            {t('statusChecking')}
           </Button>
         ) : project ? (
           /* While indexing the action is unavailable, and a DISABLED prominent
@@ -560,6 +587,16 @@ export function ProjectOverview({
       )}
 
       {/* ── Content ──────────────────────────────────────────────────── */}
+      {/* One statement and one action, in place of five sections whose every
+          number came from the daemon that is not running. Each of those
+          sections would otherwise render a SectionError reading "the daemon may
+          still be indexing" — a wait, offered for a process that has stopped —
+          with a Retry that fires at a refused socket (TRA-469). */}
+      {daemonDown ? (
+        <div className="flex-1 min-h-0 flex flex-col">
+          <DaemonDownPane restarting={restarting} onRestart={() => void restartDaemon()} />
+        </div>
+      ) : (
       <div
         className="flex-1 overflow-auto"
         onScroll={(e) => setScrolled((e.target as HTMLElement).scrollTop > 0)}
@@ -984,6 +1021,7 @@ export function ProjectOverview({
           </Section>
         </div>
       </div>
+      )}
 
       {rowMenu.at && rowMenuFor && (
         <Menu

--- a/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
@@ -18,8 +18,10 @@ const daemon = {
   projects: [] as { root: string; status: string; progress?: { phase: string; percent: number } }[],
   loading: false,
   connected: true,
+  restarting: false,
   reindexProject: vi.fn(),
   addProject: vi.fn(),
+  restartDaemon: vi.fn(),
 };
 
 vi.mock('../../hooks/useDaemon', () => ({
@@ -57,8 +59,10 @@ beforeEach(() => {
   daemon.projects = [{ root: ROOT, status: 'ready' }];
   daemon.loading = false;
   daemon.connected = true;
+  daemon.restarting = false;
   daemon.reindexProject.mockClear();
   daemon.addProject.mockClear();
+  daemon.restartDaemon.mockClear();
 });
 
 afterEach(() => vi.unstubAllGlobals());
@@ -217,19 +221,39 @@ describe('ProjectOverview surface', () => {
     expect(screen.getByRole('button', { name: 'Re-add project' })).toBeTruthy();
   });
 
-  it('says the daemon is unreachable rather than blaming the project', async () => {
+  /* TRA-469. With the daemon actually stopped this surface said the same thing
+     six times, and four of those said "the daemon may still be indexing" — a
+     wait offered for a process that is not running, each with a Retry firing at
+     a refused socket. One statement, one action. */
+  it('answers an unreachable daemon once, with the button that starts it', async () => {
     daemon.projects = [];
     daemon.loading = false;
     daemon.connected = false;
     mockApi({ '/stats': null, '/coverage': null, '/subprojects': null, '/smells': null });
     render(<ProjectOverview root={ROOT} />);
 
-    /* The toolbar always renders, so it carries the diagnosis even when every
-       section fetch failed and the Status row never appeared. */
-    const action = await screen.findByRole('button', { name: 'Daemon unreachable' });
-    expect(action).toHaveProperty('disabled', true);
-    expect(action.className).toContain('is-status');
+    expect(await screen.findByText("The daemon isn't running")).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Start daemon' })).toBeTruthy();
+
+    /* Not one SectionError, and so not one Retry, and no second copy of the
+       diagnosis in the toolbar. */
+    expect(screen.queryByText(/may still be indexing/)).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Daemon unreachable' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Index project' })).toBeNull();
+  });
+
+  /* The reducer, not a bare `!connected`: the feed is closed on mount, and a
+     naive test flashes the daemon-down pane on every project open. */
+  it('does not show the daemon-down pane while the first read is in flight', async () => {
+    daemon.projects = [];
+    daemon.loading = true;
+    daemon.connected = false;
+    mockApi({ '/stats': STATS, '/coverage': COVERAGE, '/subprojects': {}, '/smells': NO_SMELLS });
+    render(<ProjectOverview root={ROOT} />);
+
+    expect(await screen.findByText('Checking…')).toBeTruthy();
+    expect(screen.queryByText("The daemon isn't running")).toBeNull();
   });
 
   it('keeps the chrome and offers a retry when a section fails', async () => {

--- a/packages/app/src/renderer/workspace/Workspace.tsx
+++ b/packages/app/src/renderer/workspace/Workspace.tsx
@@ -22,6 +22,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { DaemonDownPane } from '../components/DaemonDownPane';
 import { t } from '../i18n';
 import { formatNumber } from '../i18n/format';
 import { Button, EmptyState } from '../lattice/ui';
@@ -196,24 +197,6 @@ export function busyMessage(o: {
     });
   }
   return t(o.haveNumbers ? 'workspace:busyStale' : 'workspace:busyFresh');
-}
-
-/** The pane shown when the daemon is not answering at all. */
-function DaemonDownPane({ restarting, onRestart }: { restarting: boolean; onRestart: () => void }) {
-  const { t } = useTranslation('workspace');
-  return (
-    <EmptyState
-      icon="cable"
-      iconSize={32}
-      title={t('daemonDownTitle')}
-      subtitle={t('daemonDownSubtitle')}
-      action={
-        <Button variant="prominent" size="large" onClick={onRestart} disabled={restarting}>
-          {restarting ? t('startingDaemon') : t('startDaemon')}
-        </Button>
-      }
-    />
-  );
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes TRA-469.

## What renders today

With the daemon genuinely not answering, Project Overview says the same thing six times, and four of those say something that isn't true:

| Where | Text |
|---|---|
| Toolbar | `Daemon unreachable` |
| Index | `Couldn't load the index summary. The daemon may still be indexing.` + Retry |
| Guard | `trace-mcp server not running` |
| Coverage | `Couldn't load dependency coverage. The daemon may still be indexing.` + Retry |
| Quality | `Couldn't load the quality scan. The daemon may still be indexing.` + Retry |
| Services | `Couldn't load the service list. The daemon may still be indexing.` + Retry |

The app *knows* it is the second state — it prints "Daemon unreachable" in its own toolbar — and then tells the user four more times that the daemon "may still be indexing", which is a wait. There is nothing to wait for, and the four Retry buttons fire four requests at a socket that is refusing.

`DESIGN.md` §5 is explicit: *"Keep apart only what the user would act on differently — 'busy' and 'not running' are two states because one is a wait and the other is a button."* Workspace got that answer in TRA-397 (`DaemonDownPane` takes the pane, offers **Start daemon**, banner suppressed). Project Overview is the surface that never got the pass.

The wrong sentence is in the shared primitive, not in Project Overview: `SectionError` (`lattice/ui/Surface.tsx:199`) renders one catalogue string, `ui:sectionError`, with no knowledge of whether the daemon is reachable — it is hardcoded to the busy diagnosis in all ten locales. So the fix is at the surface, which is the only layer that can know.

## The change

- **`DaemonDownPane` moves out of `Workspace.tsx`** into `components/DaemonDownPane.tsx` — it now has two callers. Copy and keys unchanged, so no catalogue churn across the ten locales.
- **The unreachable test reuses `deriveDaemonState()`** from `useWorkspaceProjects.ts` — the existing, tested pure reducer — rather than a fresh `!connected` check. That distinction matters: `connected` is `false` on mount, so a naive check would flash a daemon-down pane on every project open. `deriveDaemonState` already encodes "has not answered *yet* is not failing to". There is no metrics fetch on this surface, so `metricsErrorKind` is `null` and the only degraded reading it can produce is the one from the feed.
- **Unreachable takes the content pane** with the one statement and the one button, in place of five sections of broken cards. The toolbar's duplicate `Daemon unreachable` chip is suppressed for the same reason the Workspace banner is: the pane owns the diagnosis, and every action that toolbar can offer talks to the daemon that isn't there.
- **`DESIGN.md` §5 gains the rule**, stated for the class rather than for this screen: a shared error primitive states one diagnosis for every caller and cannot verify it, so the surface has to settle reachability before any section is allowed to explain itself.

## Tests

Two, both in `ProjectOverview.test.tsx`:

- `answers an unreachable daemon once, with the button that starts it` — asserts the heading and **Start daemon** are there, and that there is no `may still be indexing` copy, no `Retry`, no `Daemon unreachable` chip and no `Index project`. This is the regression guard the issue asked for.
- `does not show the daemon-down pane while the first read is in flight` — `loading: true, connected: false, projects: []`, which is every project open. Fails if the reducer is ever swapped back for a bare `!connected`.

`pnpm test` (506 tests, 46 files), `typecheck`, `check:i18n` and `build` all pass locally.

## Verified in the running app

Not from reading the diff. Nikolai's daemon is live on this machine and was **not** stopped; instead the harness window (`scripts/electron-cdp.mjs launch`, offscreen, own user-data-dir) had every request to `127.0.0.1:3741` blocked at the network layer via CDP `Network.setBlockedURLs`, so both the fetches and the SSE feed fail exactly as they do against a refused socket. Captured after a 14s settle — past the 8s `DAEMON_FETCH_TIMEOUT_MS` — with the DOM asserted at capture time: `{busy: 0, retries: 0, indexingCopy: false, unreachableChip: false, heading: "The daemon isn't running", action: "Start daemon"}`.

Shot in light, dark, and dark with Reduce Transparency + Increase Contrast. Screenshots are on TRA-469.

## Deliberately not in this PR

- `Clients.tsx` carries a third near-duplicate of this pane under its own `clients:daemonDownTitle` / `daemonDownSubtitle`. Folding it into the shared component changes copy that ships today, on a surface this issue did not look at — it gets its own change.
- The project window's **sidebar** file list still says "No indexed files match this scope." with the daemon down, which is a different component (`App.tsx`) and a different wrong sentence. Filed separately rather than widened into here.
