### PR TITLE
fix(app): centre the daemon-down pane on Project Overview (TRA-469)

### DIFF
--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -602,8 +602,16 @@ export function ProjectOverview({
              down all five render the same failure. Five broken cards is not
              five pieces of information — it is one, said five times, and four
              of those said "may still be indexing" about a process that is not
-             running (TRA-469). One statement, one button. */
-          <DaemonDownPane restarting={restarting} onRestart={() => void restartDaemon()} />
+             running (TRA-469). One statement, one button.
+
+             The flex column is load-bearing: `.ws-center-empty` centres itself
+             with `flex: 1`, which does nothing inside this scroll container's
+             block formatting context. Without it the pane hugged the top edge
+             and left ~900px of empty content below it, while the same component
+             on Workspace — which does have a flex parent — sat centred. */
+          <div className="h-full flex flex-col">
+            <DaemonDownPane restarting={restarting} onRestart={() => void restartDaemon()} />
+          </div>
         ) : (
         <div className="flex flex-col gap-6 px-4 py-4 mx-auto w-full" style={{ maxWidth: 720 }}>
           {/* Indexing caption — the phase in words, next to the bar above. */}


### PR DESCRIPTION
Follow-up to #611 (TRA-469), found by looking at the shipped render rather than at the diff.

#611 is correct about what the surface *says* — one statement, one button, zero "may still be indexing", zero Retry. It is wrong about where the statement sits.

`DaemonDownPane` is `.ws-center-empty`, which centres itself with `flex: 1`. #611 renders it directly inside Project Overview's content container:

```tsx
<div className="flex-1 overflow-auto" onScroll={…}>
  {daemonDown ? <DaemonDownPane … /> : <div className="flex flex-col gap-6 …">…</div>}
```

That container is a block formatting context, so `flex: 1` does nothing and the block hugs the top edge. Measured in the Electron window at 960×700: the glyph starts ~90px below the toolbar and the pane ends around a third of the way down, leaving roughly 900px of empty content below it. The *same component* on Workspace sits centred, because `Workspace.tsx` gives it `flex-1 min-h-0 flex flex-col`. One component, two vertical positions, on the two surfaces that share it — which is the thing extracting it into `components/` was supposed to stop.

The fix is the flex column Workspace already provides:

```tsx
<div className="h-full flex flex-col">
  <DaemonDownPane … />
</div>
```

No test: this is a class change with no logic, and a jsdom assertion on vertical centring would be brittle theatre. Verified by screenshot instead — the check that actually catches it, and the one that would have caught it the first time.

**Verified** offscreen in the Electron window (`scripts/electron-cdp.mjs launch`, hidden, own user-data-dir), light and dark, with every request to `127.0.0.1:3741` blocked at the network layer via CDP `Network.setBlockedURLs` so the renderer reads the daemon as unreachable exactly as it would against a refused socket. Nikolai's own daemon was not stopped. Captured after a 14s settle, past `DAEMON_FETCH_TIMEOUT_MS`; DOM at capture time: `{busy: 0, retries: 0, indexingCopy: false, unreachableChip: false, heading: "The daemon isn't running", action: "Start daemon"}`. Before/after screenshots are on TRA-469.

`pnpm test` (506 tests, 46 files), `typecheck` and `build` pass locally.
