### PR TITLE
fix(app): the sidebar file list stops blaming the scope for a dead daemon (TRA-471)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -546,6 +546,18 @@ is not one that is failing to. `connected` is false for the first moments of eve
 mount, so a surface that invents its own check flashes a daemon-down pane on every
 open.
 
+**An empty list and no list are two different facts, and a `catch` that writes `[]`
+destroys the difference.** The empty state is then free to explain a result that
+was never received: the sidebar's file list told the user "No indexed files match
+this scope" about a fetch that had been refused by a socket, four inches from the
+pane that was correctly saying the daemon was not running (TRA-471). A list keeps
+whether it was answered, and asserts a cause only for the empty answer it actually
+got. What it does when it was not answered is *nothing* — the surface holding the
+daemon state has already said it once, and a second sentence would only compete.
+Its refresh affordance stays, though: a control that re-fetches is the list's own
+way back when the daemon returns, and hiding it would trade a wrong sentence for a
+dead end.
+
 **Values that were true a minute ago outrank no values at all.** A refresh that fails must
 leave the last good ones on screen, cache them across launches, and say once — above them,
 where they are read before the numbers are — that they are the last indexed ones. Em dashes
@@ -1276,6 +1288,7 @@ new evidence.
 | A comparison line reserves its height, it does not measure it | The catalogue runs +30% longer in German and Russian and a tile is 132–214px wide, so whether the line wraps is not a property of the design. `KpiTile` reserves two 13px lines whatever the string does, which is what lets one `TILE_H` constant hold: measured on the running renderer, every tile is 112px in en/de/ja and both criterion lines are 26px in ru. The reservation is a floor, not a cap — Russian's delta caption (`↑+105.6k по сравнению с: 9 минут назад`) still runs to four lines and takes its row to 138px, which is a separate defect and not something `TILE_H` can absorb. |
 | A card grid responds by changing its column count, never its card width | `flex-wrap` + `flex: 1 1 132px` hands the leftover width to whichever cards landed in the last row: at a 1000px window five KPI tiles rendered at 137px and the sixth at 748px, all six carrying the same three lines. A card wider than its neighbour makes a claim the data is not making. Equal `minmax(0, 1fr)` tracks, and a count that **divides** the number of cards so no row is ever short (TRA-467). |
 | A surface whose every section reads one source states its failure once, at surface level | Project Overview said one dead daemon six times — the toolbar chip, Guard's line, and four `SectionError`s each claiming "the daemon may still be indexing" with a Retry aimed at a refusing socket. "Busy" is a wait, "not running" is a button; the app knew which one it was and printed the other four times. `DaemonDownPane` is now shared, and the test for down is `deriveDaemonState()` rather than a fresh `!connected` that would flash on every mount (TRA-469). |
+| An empty list and no list are two different facts | A `.catch(() => setFiles([]))` makes a refused socket indistinguishable from a filter that matched nothing, and the empty state then explains a result it never received — the sidebar's file list blamed the scope filter while the pane beside it correctly said the daemon was not running (TRA-471). Keep whether the list was answered; assert a cause only for the empty answer you actually got, render nothing for the one you did not, and leave the re-fetching control in place as the way back. |
 | Narrow gives up the comparison, then the table, never the value | The number and the project name are the screen; the footnote and the metric columns are elaboration. Compact already renders a legible row at 420px. |
 | A view toggle with one usable option is hidden, not disabled | A disabled segment is a control with nothing to choose. The stored preference is untouched and returns with the width. |
 | Migrate a screen **whole**, one screen per PR | A half-migrated screen looks worse than the un-migrated one; a big-bang redesign PR never lands. |

--- a/packages/app/scripts/electron-cdp.mjs
+++ b/packages/app/scripts/electron-cdp.mjs
@@ -12,6 +12,7 @@
  *   node scripts/electron-cdp.mjs shot out.png      # screenshot the current page
  *   node scripts/electron-cdp.mjs shot out.png --view=project --tab=graph --dark
  *   node scripts/electron-cdp.mjs shot out.png --locale=zh --size=640x420
+ *   node scripts/electron-cdp.mjs shot out.png --offline   # daemon-down states
  *
  * `launch` uses its own --user-data-dir so it does not fight the installed
  * trace-mcp.app for Electron's single-instance lock. Once it is up, an external
@@ -114,6 +115,19 @@ function launch(visible) {
 async function shot(outFile, opts) {
   const page = await waitForPage();
   const cdp = await connect(page.webSocketDebuggerUrl);
+  /* `--offline` reviews the daemon-down states without stopping the daemon —
+     which, on a machine somebody else is working on, is not ours to stop. The
+     renderer's fetches are refused at the network layer, so it sees exactly what
+     a dead socket gives it; nothing is monkey-patched and nothing survives the
+     run. Blocked before the first paint, so a mount-time fetch is caught too. */
+  if (opts.offline) {
+    await cdp.send('Network.enable');
+    await cdp.send('Network.setBlockedURLs', { urls: ['*127.0.0.1:3741*'] });
+    if (!opts.url) {
+      await cdp.send('Runtime.evaluate', { expression: 'location.reload()' });
+      await sleep(opts.settleMs);
+    }
+  }
   if (opts.url) {
     await cdp.send('Page.enable');
     await cdp.send('Page.navigate', { url: opts.url });
@@ -204,10 +218,11 @@ if (cmd === 'launch') {
     settleMs: Number(flag('settle') ?? 1500),
     click: flag('click'),
     evaluate: flag('eval'),
+    offline: rest.includes('--offline'),
   });
 } else {
   console.error(
-    'usage: electron-cdp.mjs launch [--visible] | shot <out.png> [--url=…] [--dark|--light]',
+    'usage: electron-cdp.mjs launch [--visible] | shot <out.png> [--url=…] [--dark|--light] [--offline]',
   );
   process.exit(1);
 }

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -271,6 +271,10 @@ function ProjectFileExplorer({
   const [sort, setSort] = useState<FileSort>('symbols');
   const [files, setFiles] = useState<FileEntry[]>([]);
   const [loading, setLoading] = useState(true);
+  /* Did a list actually come back? An empty list and no list at all are two
+     different facts, and `setFiles([])` on failure collapsed them into one —
+     which is how a refused socket ended up blaming the scope filter (TRA-471). */
+  const [answered, setAnswered] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
   const [ctx, setCtx] = useState<{ x: number; y: number; path: string } | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -297,10 +301,14 @@ function ProjectFileExplorer({
     fetch(`${BASE}/api/projects/files?${params}`)
       .then((r) => (r.ok ? r.json() : Promise.reject()))
       .then((data) => {
-        if (!cancelled) setFiles(data.files ?? []);
+        if (cancelled) return;
+        setFiles(data.files ?? []);
+        setAnswered(true);
       })
       .catch(() => {
-        if (!cancelled) setFiles([]);
+        if (cancelled) return;
+        setFiles([]);
+        setAnswered(false);
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -383,10 +391,18 @@ function ProjectFileExplorer({
           ))}
         </div>
       ) : files.length === 0 ? (
-        <div className="ws-sb-empty">
-          <Icon name="description" size={20} className="gi" />
-          <span>{t('noFilesMatchScope')}</span>
-        </div>
+        /* Only a list that came back empty can be blamed on the scope. With the
+           daemon down nothing was ever fetched, and the content pane already
+           carries that diagnosis and its Start daemon button — the sidebar does
+           not name a cause it cannot know, and does not say the same thing twice
+           (DESIGN.md §5). The sort pop-up above stays: changing it re-fetches,
+           which is the sidebar's own way back once the daemon answers again. */
+        answered ? (
+          <div className="ws-sb-empty">
+            <Icon name="description" size={20} className="gi" />
+            <span>{t('noFilesMatchScope')}</span>
+          </div>
+        ) : null
       ) : (
         <div role="tree" aria-label={t('projectFiles')} ref={listRef}>
           {files.map((f, i) => {

--- a/packages/app/src/renderer/__tests__/sidebar-file-list.test.tsx
+++ b/packages/app/src/renderer/__tests__/sidebar-file-list.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+/* TRA-471. The sidebar's file list has its own state, so the daemon-down answer
+   TRA-469 gave the content pane never reached it: a refused socket left
+   `files` empty and the list blamed the scope filter for it. An empty list and
+   no list are two different facts. */
+
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { App } from '../App';
+
+const SCOPE_LINE = 'No indexed files match this scope.';
+
+beforeEach(() => {
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    setWindowSections: vi.fn(),
+    onAppCommand: vi.fn(() => () => {}),
+    openProjectTab: vi.fn(),
+    openSettings: vi.fn(),
+    selectFolder: vi.fn(async () => null),
+    syncSidebarWidth: vi.fn(),
+    checkForUpdate: vi.fn(async () => ({ available: false })),
+    checkPendingUpdate: vi.fn(async () => ({ pending: false })),
+    openInEditor: vi.fn(),
+  };
+  localStorage.clear();
+  localStorage.setItem('trace-mcp.onboarded.v1', '1');
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function renderProjectWindow(): Promise<void> {
+  window.history.replaceState({}, '', '/?view=project&root=/tmp/proj');
+  await act(async () => {
+    render(<App />);
+  });
+}
+
+describe('sidebar file list, empty', () => {
+  it('blames the scope when the daemon answered with no files', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ files: [] }), { status: 200 })),
+    );
+    await renderProjectWindow();
+    expect(document.body.textContent).toContain(SCOPE_LINE);
+  });
+
+  it('says nothing when the daemon never answered', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => Promise.reject(new TypeError('fetch failed'))));
+    await renderProjectWindow();
+    expect(document.body.textContent).not.toContain(SCOPE_LINE);
+  });
+
+  /* A 500 is not a scope filter either — the list is missing for a reason the
+     sidebar cannot name, same as a refused connection. */
+  it('says nothing when the daemon answered with an error', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('nope', { status: 500 })));
+    await renderProjectWindow();
+    expect(document.body.textContent).not.toContain(SCOPE_LINE);
+  });
+});


### PR DESCRIPTION
Closes TRA-471.

## What renders today

With the daemon unreachable, Project Overview says one thing and the sidebar says another — four inches apart, in the same window:

| Where | Text |
|---|---|
| Content pane | **The daemon isn't running** · Start daemon |
| Sidebar file list | No indexed files match this scope. |

The second one is wrong. No list was ever fetched, so the scope filter has nothing to do with it, and changing the scope will not produce one. This is the defect TRA-469 fixed on the content pane, surviving in the sidebar because the sidebar holds its own state.

The mechanism is one line — `.catch(() => setFiles([]))` in `ProjectFileExplorer` collapsed *answered with no files* and *never answered* into the same state, and the empty state was then free to explain a result it had not received.

## The fix

`ProjectFileExplorer` keeps whether a list actually came back, and asserts the scope only for the empty answer it really got. When it was not answered — a refused socket, a 500, anything — it renders nothing: the surface that holds the daemon state has already said it once, and a second sentence would only compete with it (`DESIGN.md` §5).

No new catalogue string, so no churn across ten locales.

**The sort pop-up above the list stays.** Changing it re-runs the fetch, which is the sidebar's own way back once the daemon answers again. Hiding it would trade a wrong sentence for a dead end, which is a worse deal than the one being fixed.

**Ask's chat rail** was the other sidebar list the issue asked about. It is not reachable in this state: a daemon that does not answer `/api/ask/provider` puts `AskTab` on its no-provider screen before the rail renders. Untouched here.

## Reviewed with `--offline`, not by stopping the daemon

`electron-cdp.mjs shot --offline` blocks the renderer's requests to `127.0.0.1:3741` over CDP, so the daemon-down states can be shot without stopping a daemon on a machine somebody else is working on.

Before and after, light and dark, in the Electron window at 1180×760 — screenshots on TRA-471.

| | Before | After |
|---|---|---|
| Content pane | The daemon isn't running · Start daemon | unchanged |
| Sidebar | No indexed files match this scope. | *(nothing)* |

## Tests

`sidebar-file-list.test.tsx` pins all three cases: answered-with-no-files keeps the sentence, a rejected fetch drops it, a 500 drops it. Reverting `App.tsx` fails two of the three.

The daemon-up empty list is pinned by that test rather than by a screenshot: this environment has no reachable daemon on 3741 to render it with, so I am not claiming a render I did not see.

Local: `pnpm run test` 509 passed (47 files), `pnpm run typecheck` clean, `pnpm run check:i18n` clean, `pnpm run build` clean.
