### PR TITLE
docs(workspace): correct two comments TRA-467 left stale

### DIFF
--- a/packages/app/src/renderer/workspace/Workspace.tsx
+++ b/packages/app/src/renderer/workspace/Workspace.tsx
@@ -81,7 +81,7 @@ function loadFilter(): WorkspaceFilter {
 // thresholds are read off the pane itself.
 
 // Pane and strip geometry, all read off the rendered surface rather than guessed.
-const TILE_MIN_W = 132; // KpiTile's flex basis
+const TILE_MIN_W = 132; // narrowest a KpiTile may be before the column count drops
 const TILE_GAP = 16; // gap-4
 // A full-height tile: 16 + 13 + 4 + 32 + 4 + 26 + 16 + hairlines. The comparison
 // line reserves two 13px lines rather than one, because at 132–214px of tile a
@@ -118,9 +118,12 @@ export const TABLE_MIN_PANE_W = PANE_PAD + FROZEN_COLS_W + MIN_SCROLL_WINDOW;
  * responds to width. Restricting the count to a divisor of six is what removes
  * the ragged last row that the stretching existed to hide.
  *
- * `0` is an unmeasured pane on first paint. It falls through to one column —
- * the same six-row answer the old `Math.max(1, …)` gave — so the first frame is
- * unchanged.
+ * `0` falls through to one column. Nothing on screen reaches that any more —
+ * the pane is measured in a `useLayoutEffect` before the first paint, because
+ * once the column count reads `pane.w` a zero-width first frame is not a no-op
+ * but a 748px tile in a 780px strip. Keep it defined all the same:
+ * `kpiStripHeight(0)` is asserted, and a function that decides layout should
+ * answer for every width rather than trust its callers to screen one out.
  */
 export function kpiColumns(paneW: number): number {
   const inner = Math.max(0, paneW - PANE_PAD);


### PR DESCRIPTION
Two comments in `Workspace.tsx` describe the code as it was before the KPI strip became a grid. Both point the next reader at the bug rather than away from it.

- `TILE_MIN_W` is annotated "KpiTile's flex basis". KpiTile has no flex basis any more — it declares `minWidth: 0` and takes its width from its grid track (#608). The constant is now the width below which the column count drops.
- `kpiColumns()`'s doc ends "so the first frame is unchanged". That was true for exactly one commit: #612 measures the pane in a `useLayoutEffect`, so nothing on screen reaches the zero-width branch. Left as it stood it reads as permission to go back to observing the pane after the paint, which is the 748px-tile first frame #612 removed.

Comments only, no behaviour change. `pnpm run typecheck` and `pnpm run test` (46 files, 506 tests) pass locally.

Agent: Design/UX Agent