### PR TITLE
fix(app): the dashboard at rest marks nothing selected (TRA-475)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -492,6 +492,32 @@ this one was declared in TRA-265 and never rendered a pixel. Tables that pin col
 `border-collapse: separate` with `border-spacing: 0`, which also moves the row hairline
 from the `<tr>` (ignored in the separated model) onto the cells.
 
+### A card is a control or it is a readout, and the resting screen shows no selection
+
+Three rules for any strip that mixes numbers with filters — the workspace KPI grid is
+the one we have, and it broke all three at once (TRA-475).
+
+**A mark that means "on" never sits on a tile that is off.** The accent border on the
+KPI strip means "this tile's filter is narrowing the list below". Projects carried it
+whenever *no* filter was on, which is the state every launch opens to: one tile ringed
+in accent, `aria-pressed="true"`, directly above a list showing everything. "Nothing is
+filtered" is drawn by six identical `--separator` hairlines, not by electing a tile to
+stand for *all*. A chip row may have an explicit **All** chip; a row of counts may not,
+because there the mark is the only thing distinguishing a control from a number.
+
+**A readout is content, so it is a `<div>`.** `<button disabled>` puts a number into the
+accessibility tree as a control the user is told they may not operate, when there was
+never a control. Dimming is for an action that exists and is unavailable now.
+
+**A card that is a control answers the pointer.** `cursor: pointer` — a `<button>` in
+Chromium defaults to `default` — plus a `--fill-quaternary` hover, applied as a second
+background *layer* so the card stays opaque `--surface`. That keeps `--label-secondary`
+on the footnote at 4.64:1 light / 5.37:1 dark; `--fill-tertiary`, which is what a chip
+hovers to, puts it at 4.45:1, and that measurement is why the *selected* tile is a
+border rather than a tint. The background therefore lives in `controls.css`, not in the
+component's `style` prop: an inline `background:` shorthand also writes
+`background-image: none` inline, which no stylesheet rule can outrank.
+
 ### States are part of the component, not an afterthought
 
 Every data surface owes four states, and each has a house form:

--- a/packages/app/src/renderer/styles/controls.css
+++ b/packages/app/src/renderer/styles/controls.css
@@ -612,6 +612,28 @@ input[type='checkbox']:focus-visible {
   inset: -4px 0;
 }
 
+/* ── KPI tile (workspace/components/KpiTile.tsx) ──────────────────────────
+   The card's opaque background lives here rather than inline, because the
+   hover tint has to compose with it: an inline `background:` shorthand also
+   writes `background-image: none` inline, and no stylesheet rule outranks an
+   inline declaration.
+
+   A tile that filters the list answers the pointer; a tile that only reports a
+   number (a `<div>`, not a `<button>`) does not. Before TRA-475 neither did,
+   and the accent border was the only thing on the strip that said "clickable"
+   — which is the same mark that means "selected".
+
+   The tint is a second background LAYER, so the card stays opaque --surface
+   and its footnote keeps --label-secondary at 4.64:1 in light and 5.37:1 in
+   dark. --fill-tertiary, which is what a chip hovers to, would put it at
+   4.45:1 — the measurement that already ruled a tint out for the ACTIVE tile. */
+[data-kpi] {
+  background: var(--surface);
+}
+button[data-kpi]:hover {
+  background-image: linear-gradient(var(--fill-quaternary), var(--fill-quaternary));
+}
+
 @media (prefers-reduced-motion: reduce) {
   .lx-btn,
   .lx-seg .lx-seg-item,

--- a/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
@@ -303,8 +303,14 @@ export function WorkspaceHeader({
           delta={delta((k) => k.totalProjects)}
           deltaCaption={deltaCaption}
           footnote={t('kpiTrackingFromToday')}
-          active={isDefaultFilter(filter)}
-          onClick={() => onFilterChange(EMPTY_FILTER)}
+          /* No `active`, and no click. The accent border on this strip means
+             "this tile's filter is on", and Projects had it whenever no filter
+             was on — so the resting dashboard, which is what every launch
+             opens to, marked one tile selected above a list showing everything
+             (TRA-475). The click it carried cleared an already-empty filter;
+             clearing is still on the Filter menu, the overflow menu, and the
+             lit preset tile itself. Projects is a readout, like Files and
+             Symbols beside it. */
         />
         <KpiTile
           label={t('kpiFiles')}

--- a/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
@@ -27,6 +27,7 @@ function renderHeader(
     dense: boolean;
     hideViewToggle: boolean;
     kpis: WorkspaceKpis;
+    filter: WorkspaceFilter;
   }> = {},
 ) {
   const { container } = render(
@@ -164,6 +165,41 @@ describe('WorkspaceHeader KPI strip', () => {
       const lines = [...kpiTile(label).children].map((c) => c.textContent?.trim() ?? '');
       expect(lines).toHaveLength(3);
       expect(lines[2]).not.toBe('');
+    }
+  });
+
+  /* The accent border on this strip means "this tile's filter is on". Projects
+     carried it whenever NO filter was on, so every launch opened with one tile
+     marked selected above a list showing everything (TRA-475). */
+  it('marks nothing selected while nothing is filtered', () => {
+    renderHeader(false);
+    for (const label of ['Projects', 'Files', 'Symbols', 'Healthy', 'Needs attention', 'Indexing']) {
+      expect(kpiTile(label).getAttribute('aria-pressed')).not.toBe('true');
+      expect(kpiTile(label).getAttribute('style')).toContain('var(--separator)');
+    }
+  });
+
+  it('lights only the tile whose own filter is on', () => {
+    renderHeader(false, { filter: { ...EMPTY_FILTER, preset: 'healthy' } });
+    expect(kpiTile('Healthy').getAttribute('aria-pressed')).toBe('true');
+    expect(kpiTile('Healthy').getAttribute('style')).toContain('var(--accent)');
+    for (const label of ['Projects', 'Needs attention', 'Indexing']) {
+      expect(kpiTile(label).getAttribute('style')).toContain('var(--separator)');
+    }
+  });
+
+  /* A readout is content. As `<button disabled>` a number went into the
+     accessibility tree as a control the user is told they may not operate,
+     when there was never a control to operate. */
+  it('renders a tile with no filter behind it as content, not a disabled button', () => {
+    renderHeader(false);
+    for (const label of ['Projects', 'Files', 'Symbols']) {
+      expect(kpiTile(label).tagName).toBe('DIV');
+    }
+    for (const label of ['Healthy', 'Needs attention', 'Indexing']) {
+      const tile = kpiTile(label);
+      expect(tile.tagName).toBe('BUTTON');
+      expect((tile as HTMLButtonElement).disabled).toBe(false);
     }
   });
 

--- a/packages/app/src/renderer/workspace/components/KpiTile.tsx
+++ b/packages/app/src/renderer/workspace/components/KpiTile.tsx
@@ -107,40 +107,37 @@ export function KpiTile({
   const { t } = useTranslation('workspace');
   const interactive = onClick !== undefined;
   const valueColor = unavailable ? 'var(--label-secondary)' : tone ? TONE_COLOR[tone] : 'var(--label)';
+  // Same card either way — only the wrapper differs.
+  const shell = {
+    'data-kpi': label,
+    'data-dense': dense ? '' : undefined,
+    // Dense drops the comparison line, so the one sentence that explains an
+    // em dash has to survive somewhere the user can still reach it.
+    title: dense && unavailable ? t('kpiUnavailable') : undefined,
+    className: dense
+      ? 'flex flex-row items-baseline justify-between gap-2 text-left transition-colors'
+      : 'flex flex-col items-start gap-1 text-left transition-colors',
+    style: {
+      // No `flex` basis: the strip is a grid whose track count already
+      // guarantees at least 132px per tile, and a flex-grow here is what let
+      // a last-row tile stretch to 5.5x its siblings (TRA-467). `minWidth: 0`
+      // so a long footnote sizes to its track instead of widening it.
+      minWidth: 0,
+      padding: dense ? '8px 12px' : 16,
+      borderRadius: 12,
+      // `background` and the hover tint live in controls.css (`[data-kpi]`):
+      // an inline shorthand here would set `background-image: none` inline,
+      // which no stylesheet rule can then override. A card is content and
+      // stays opaque --surface in both states — tinting the ACTIVE tile
+      // pushed --label-secondary to 4.45:1 on its footnote, and that token
+      // only clears 4.5 over an untinted surface. Selection is the accent
+      // border + aria-pressed, which as a UI boundary needs only 3:1.
+      border: `0.5px solid ${active ? 'var(--accent)' : 'var(--separator)'}`,
+    },
+  };
 
-  return (
-    <button
-      type="button"
-      disabled={!interactive}
-      aria-pressed={interactive ? active : undefined}
-      data-kpi={label}
-      data-dense={dense ? '' : undefined}
-      // Dense drops the comparison line, so the one sentence that explains an
-      // em dash has to survive somewhere the user can still reach it.
-      title={dense && unavailable ? t('kpiUnavailable') : undefined}
-      onClick={onClick}
-      className={
-        dense
-          ? 'flex flex-row items-baseline justify-between gap-2 text-left transition-colors'
-          : 'flex flex-col items-start gap-1 text-left transition-colors'
-      }
-      style={{
-        // No `flex` basis: the strip is a grid whose track count already
-        // guarantees at least 132px per tile, and a flex-grow here is what let
-        // a last-row tile stretch to 5.5x its siblings (TRA-467). `minWidth: 0`
-        // so a long footnote sizes to its track instead of widening it.
-        minWidth: 0,
-        padding: dense ? '8px 12px' : 16,
-        borderRadius: 12,
-        // A card is content: it stays opaque --surface in BOTH states. Tinting
-        // the active tile pushed --label-secondary to 4.45:1 on its footnote —
-        // that token only clears 4.5 over an untinted surface. Selection is the
-        // accent border + aria-pressed, which as a UI boundary needs only 3:1.
-        background: 'var(--surface)',
-        border: `0.5px solid ${active ? 'var(--accent)' : 'var(--separator)'}`,
-        cursor: interactive ? 'pointer' : 'default',
-      }}
-    >
+  const content = (
+    <>
       {/* Active is signalled by the accent BORDER + aria-pressed, not by an
           accent label: --accent on the active tile's --fill-tertiary tint
           measures 3.28:1, and --badge-accent-fg only reaches 4.29:1. Promoting
@@ -212,6 +209,27 @@ export function KpiTile({
           )}
         </span>
       )}
+    </>
+  );
+
+  /* A tile with no filter behind it is a readout, and a readout is content. It
+     rendered as `<button disabled>` until TRA-475, which puts a number in the
+     accessibility tree as a control the user is told they may not operate —
+     there was never a control. Only a tile that filters the list is a button;
+     everything else is a `<div>` and leaves the tree entirely. */
+  return interactive ? (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      {...shell}
+      // A `<button>` in Chromium is `cursor: default`; a card the size of this
+      // one has to say it is clickable before the pointer is over it.
+      className={`${shell.className} cursor-pointer`}
+    >
+      {content}
     </button>
+  ) : (
+    <div {...shell}>{content}</div>
   );
 }


### PR DESCRIPTION
Closes TRA-475.

## Before

The Workspace dashboard opened, on every launch with nothing filtered, with the
**Projects** tile ringed in `--accent` and reported to assistive technology as
`aria-pressed="true"`. Measured on the running Electron window over CDP,
`getComputedStyle` on `[data-kpi]`:

| Tile | tag | `aria-pressed` | `disabled` | border-color |
|---|---|---|---|---|
| Projects | button | **`true`** | false | **`rgb(10,132,255)`** |
| Files | button | — | **true** | `--separator` |
| Symbols | button | — | **true** | `--separator` |
| Healthy | button | `false` | false | `--separator` |
| Needs attention | button | `false` | false | `--separator` |
| Indexing | button | `false` | false | `--separator` |

Three defects in that table.

**The accent border means "this tile's filter is on".** Projects had
`active={isDefaultFilter(filter)}` — it lit when *no* filter was on. So the resting
dashboard, which is what the app opens to, marked one tile selected directly above a
list showing everything.

**Three stat cards were `<button disabled>`.** A number went into the accessibility
tree as a control the user is told they may not operate, when there was never a
control.

**No `[data-kpi]` rule existed in any renderer stylesheet**, so a clickable card was
indistinguishable from a static one under the pointer — no hover, and `<button>` in
Chromium is `cursor: default`. The accent border was the only thing that said
"clickable", which is the same mark that means "selected".

## After

| Tile | tag | `aria-pressed` | border-color | cursor |
|---|---|---|---|---|
| Projects / Files / Symbols | **div** | — | `--separator` | auto |
| Healthy / Needs attention / Indexing | button | `false` | `--separator` | pointer |

- Projects loses the border and the click. That click cleared an already-empty filter;
  clearing is still on the Filter menu, the overflow menu, and the lit preset tile.
- A tile with no `onClick` renders as a `<div>` and leaves the accessibility tree.
- Hover is `--fill-quaternary` applied as a second background **layer**, so the card
  stays opaque `--surface` and `--label-secondary` on the footnote holds **4.64:1**
  light / **5.37:1** dark. `--fill-tertiary` — what a chip hovers to — would put it at
  4.45:1, which is the measurement that already ruled a tint out for the *selected*
  tile. The background therefore moved from the `style` prop into `controls.css`: an
  inline `background:` shorthand also writes `background-image: none` inline, and no
  stylesheet rule outranks an inline declaration.

## Verification

Built app, `electron-cdp.mjs launch`, measured over CDP in both appearances:

```
after (rest):   Projects DIV --separator / Files DIV --separator / Symbols DIV --separator
                Healthy BUTTON --separator / Needs attention BUTTON --separator / Indexing BUTTON --separator
hover Healthy:  backgroundColor rgb(30,30,30)  (opaque)
                backgroundImage linear-gradient(rgba(255,255,255,.06), rgba(255,255,255,.06))
click Healthy:  Healthy rgb(10,132,255) pressed=true — every other tile --separator
```

509 tests pass, typecheck clean, `check:i18n` clean. Three new tests in
`WorkspaceHeader.test.tsx` cover the resting state, the single-tile selection, and the
`div`/`button` split.

`DESIGN.md` §5 gains the rule: *a card is a control or it is a readout, and the resting
screen shows no selection.*
