### PR TITLE
ci: fail a PR that duplicates an open PR on the same issue (TRA-476)

### DIFF
--- a/.github/workflows/duplicate-pr.yml
+++ b/.github/workflows/duplicate-pr.yml
@@ -40,10 +40,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: node scripts/check-duplicate-pr.mjs "$PR_NUMBER" report.md
+        run: |
+          # The base ref predates the guard on the PR that introduces it, and
+          # on any PR branched before it landed. Nothing to check yet.
+          if [ ! -f scripts/check-duplicate-pr.mjs ]; then
+            echo "Guard not present on the base ref; skipping."
+            exit 0
+          fi
+          node scripts/check-duplicate-pr.mjs "$PR_NUMBER" report.md
 
       - name: Report duplicates
-        if: failure() && steps.check.outcome == 'failure'
+        if: failure() && hashFiles('report.md') != ''
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: duplicate-pr

--- a/.github/workflows/duplicate-pr.yml
+++ b/.github/workflows/duplicate-pr.yml
@@ -1,0 +1,57 @@
+name: Duplicate PR Check
+
+# TRA-476: #598 duplicated #597 (TRA-448) and #613 duplicated #611 (TRA-469).
+# In both cases the duplicating run was working a *different* issue, so each
+# issue had exactly one run — no dispatcher lock or issue-level claim protocol
+# would have fired. The PR list is the only place both pieces of work are
+# visible at once, so the guard lives here and fails the check rather than
+# asking every run to remember to look.
+#
+# Security: no checkout, no build, no code from the PR is executed. The job
+# reads PR titles and bodies through the GitHub API and skips fork PRs, whose
+# token cannot comment anyway.
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # base ref, not the PR head: the guard must not run a version of
+          # itself that the PR being checked is allowed to edit.
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: scripts/check-duplicate-pr.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Check for an open PR on the same issue
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/check-duplicate-pr.mjs "$PR_NUMBER" report.md
+
+      - name: Report duplicates
+        if: failure() && steps.check.outcome == 'failure'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: duplicate-pr
+          path: report.md
+
+      - name: Clear a stale report
+        if: success()
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: duplicate-pr
+          delete: true

--- a/scripts/check-duplicate-pr.mjs
+++ b/scripts/check-duplicate-pr.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// Fails a PR that duplicates another OPEN PR on the same TRA issue.
+//
+// TRA-476: two agents shipped the same issue twice (#598 duplicating #597 on
+// TRA-448, #613 duplicating #611 on TRA-469).  Neither was a second run
+// dispatched against the issue — in both cases a run working a *different*
+// issue implemented the same fix — so no issue-level claim protocol or
+// dispatcher lock would have fired.  The only place the two pieces of work
+// are ever both visible is the PR list, so the guard lives there.
+//
+// A PR that cites the other one in its body is a follow-up, not a duplicate
+// (#614 → #611, the healthy version), and passes.
+
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/** Distinct TRA issue keys mentioned in a blob of text, uppercased. */
+export function issueKeys(text) {
+  return [...new Set((text ?? '').match(/\bTRA-\d+\b/gi)?.map((k) => k.toUpperCase()) ?? [])];
+}
+
+/**
+ * Open PRs that claim the same TRA issue as `pr` and that `pr` does not cite.
+ *
+ * @param {{number: number, title: string, body?: string}} pr
+ * @param {Array<{number: number, title: string, body?: string}>} openPrs
+ */
+export function findDuplicatePrs(pr, openPrs) {
+  const keys = issueKeys(`${pr.title}\n${pr.body ?? ''}`);
+  if (keys.length === 0) return [];
+  const cited = new Set(
+    [...`${pr.body ?? ''}`.matchAll(/#(\d+)/g)].map((m) => Number.parseInt(m[1], 10)),
+  );
+  return openPrs.filter(
+    (other) =>
+      other.number !== pr.number &&
+      !cited.has(other.number) &&
+      issueKeys(`${other.title}\n${other.body ?? ''}`).some((k) => keys.includes(k)),
+  );
+}
+
+export function formatReport(duplicates) {
+  const lines = duplicates.map((d) => `- #${d.number} — ${d.title}`);
+  return [
+    '### Duplicate work check',
+    '',
+    'This PR claims the same TRA issue as an open PR:',
+    '',
+    ...lines,
+    '',
+    'Two agents have implemented the same issue twice before (#598/#597, #613/#611):',
+    'both were complete, tested, CI-green work thrown away. Reconcile before merging.',
+    '',
+    'If this is a follow-up rather than a duplicate, cite the PR it follows',
+    '(`Follow-up to #NNN`) in the description — the check passes once you do.',
+  ].join('\n');
+}
+
+function gh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
+}
+
+function main() {
+  const number = Number.parseInt(process.argv[2] ?? '', 10);
+  if (!Number.isInteger(number) || number <= 0) {
+    console.error('usage: check-duplicate-pr.mjs <pr-number>');
+    process.exit(2);
+  }
+  const pr = JSON.parse(gh(['pr', 'view', String(number), '--json', 'number,title,body']));
+  const openPrs = JSON.parse(
+    gh(['pr', 'list', '--state', 'open', '--limit', '100', '--json', 'number,title,body']),
+  );
+  const duplicates = findDuplicatePrs(pr, openPrs);
+  if (duplicates.length === 0) {
+    console.log('No open PR claims the same TRA issue.');
+    return;
+  }
+  const report = formatReport(duplicates);
+  console.error(report);
+  writeFileSync(process.argv[3] ?? 'duplicate-pr-report.md', `${report}\n`);
+  process.exit(1);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/tests/ci/duplicate-pr.test.ts
+++ b/tests/ci/duplicate-pr.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — plain .mjs script, no type declarations
+import { findDuplicatePrs, formatReport, issueKeys } from '../../scripts/check-duplicate-pr.mjs';
+
+// Fixtures are the real PRs from the TRA-476 incident, trimmed to the fields
+// the check reads. Two of these pairs are duplicates that cost a full
+// implementation each; two are healthy follow-ups that must still pass.
+const PR_597 = {
+  number: 597,
+  title: 'docs: price the default tool surface on one basis everywhere (TRA-448)',
+  body: 'Closes TRA-448.',
+};
+const PR_598 = {
+  number: 598,
+  title: 'docs: say which basis prices the default tool surface (TRA-448)',
+  body: 'Closes TRA-448.\n\nThree pages priced the shipped default tool surface at three numbers.',
+};
+const PR_611 = {
+  number: 611,
+  title: 'fix(app): Project Overview says a dead daemon once, not six times (TRA-469)',
+  body: 'Closes TRA-469.',
+};
+const PR_613 = {
+  number: 613,
+  title: 'fix(app): one answer for an unreachable daemon on Project Overview (TRA-469)',
+  body: 'Closes TRA-469.',
+};
+const PR_614 = {
+  number: 614,
+  title: 'fix(app): centre the daemon-down pane on Project Overview (TRA-469)',
+  body: 'Follow-up to #611 (TRA-469), found by looking at the shipped render.',
+};
+const PR_612 = {
+  number: 612,
+  title: 'fix(workspace): measure the pane before the first paint, not after it',
+  body: 'Follow-up to #608.',
+};
+
+describe('issueKeys', () => {
+  it('collects distinct keys case-insensitively', () => {
+    expect(issueKeys('Closes TRA-448, supersedes tra-448 and TRA-455')).toEqual([
+      'TRA-448',
+      'TRA-455',
+    ]);
+  });
+
+  it('is empty for a PR that names no issue', () => {
+    expect(issueKeys(PR_612.title)).toEqual([]);
+  });
+});
+
+describe('findDuplicatePrs', () => {
+  it('flags the second PR on an issue another open PR already claims', () => {
+    expect(findDuplicatePrs(PR_598, [PR_597]).map((p) => p.number)).toEqual([597]);
+    expect(findDuplicatePrs(PR_613, [PR_611]).map((p) => p.number)).toEqual([611]);
+  });
+
+  it('passes a follow-up that cites the PR it builds on', () => {
+    expect(findDuplicatePrs(PR_614, [PR_611])).toEqual([]);
+  });
+
+  it('passes a PR whose sibling has already merged and left the open list', () => {
+    expect(findDuplicatePrs(PR_614, [])).toEqual([]);
+  });
+
+  it('passes a PR that names no issue', () => {
+    expect(findDuplicatePrs(PR_612, [PR_611])).toEqual([]);
+  });
+
+  it('ignores itself and unrelated issues', () => {
+    expect(findDuplicatePrs(PR_597, [PR_597, PR_611])).toEqual([]);
+  });
+});
+
+describe('formatReport', () => {
+  it('names the clashing PR and the way out', () => {
+    const report = formatReport(findDuplicatePrs(PR_598, [PR_597]));
+    expect(report).toContain('- #597 — docs: price the default tool surface');
+    expect(report).toContain('Follow-up to #NNN');
+  });
+});


### PR DESCRIPTION
Closes TRA-476.

## What the measurement said

The issue proposed a dispatcher guard: refuse a second run against an issue already `in_progress`. The run history says that guard would have fired zero times, because **each issue had exactly one run**:

| Issue | Runs on the issue | Duplicate PR came from |
|---|---|---|
| TRA-448 | 1 (Lead Engineer, 01:32:51 → #597) | an Implementation Engineer run working another issue → #598 |
| TRA-469 | 1 (Design/UX, 03:25:35 → #613) | the same agent's TRA-465 autopilot run → #611 |

Answering the three questions in the issue:

1. **Did the duplicating run see an `## Active sibling runs` block?** For TRA-448, it could not have — the two runs belonged to different agents and that block only lists the current agent's own runs. For TRA-469 it did, and said so in its own summary ("a sibling run of mine, the TRA-465 autopilot"). The block was not the gap; what it points at is — it says to check *this issue's* comment history, and the sibling was working a different issue.
2. **Was a claim comment posted?** No. TRA-448's first comment is the completion note at 02:06:59, after both PRs existed; TRA-469's is at 03:40:41, after #613 was already open. Nothing was there to read.
3. **Is `in_progress` visible to a second dispatch?** Moot — there was never a second dispatch.

So every issue-keyed guard fails against the actual data. The two pieces of work were only ever both visible in one place: the PR list.

## The guard

`.github/workflows/duplicate-pr.yml` runs on PR `opened`/`reopened`/`edited` and fails when another **open** PR names the same `TRA-###`. Failing rather than commenting is the point — "never merge with red CI" is already a hard rule, so it cannot be silently skipped the way a protocol can.

The escape hatch is the same signal the issue named as the healthy version: a PR whose body **cites** the other PR (`Follow-up to #611`) passes. That is exactly what distinguishes #614 → #611 from #613 → #611.

Replayed against the incident (`tests/ci/duplicate-pr.test.ts`, real PR titles and bodies as fixtures):

- #598 vs open #597 → **caught**
- #613 vs open #611 → **caught**
- #614 (cites #611) → passes
- #612 (no issue key) → passes

## Not solved

The guard fires at PR-open, so it saves the review and CI cycles, not the implementation. Catching it earlier needs a signal at dispatch time, and there is none: for TRA-469 the colliding run was legitimately assigned to a different issue, and no issue-level lock can see that. Tightening the read-side protocol was considered and rejected — a protocol that depends on every run remembering to look is what already failed here twice.

## Security

No checkout of PR head and no PR code executed: the job checks out the script from `pull_request.base.sha`, reads titles and bodies through the API, and skips fork PRs.

## Tests

`pnpm run build`, `pnpm exec biome check`, `pnpm run test` — 9188 passed. One unrelated timing flake, `tests/perf/stress.test.ts` "getAllFiles on 10K files returns in <100ms" (109ms vs a 100ms bound on a loaded machine); passes in isolation and touches nothing in this diff. The CLI path was also run live against open PR #617 (exit 0, no clash).

Agent: Lead Engineer
