### PR TITLE
fix(workspace): the dashboard is a readout, not six half-broken controls

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -492,6 +492,40 @@ this one was declared in TRA-265 and never rendered a pixel. Tables that pin col
 `border-collapse: separate` with `border-spacing: 0`, which also moves the row hairline
 from the `<tr>` (ignored in the separated model) onto the cells.
 
+### A readout is content. A selection mark belongs to the thing selected.
+
+Two rules for any strip where some cards act and some only report, broken together on
+the Workspace dashboard's opening frame (TRA-475).
+
+**A card with no action renders as a `<div>`, never as a disabled `<button>`.** A
+component that wraps every card in a `<button>` and switches off the ones without an
+`onClick` is not being defensive — it is announcing a control to VoiceOver and then
+telling the user they may not use it, where there was never a control. Three of the six
+KPI tiles shipped that way. Whatever the card needs to keep — the test hook, the
+anatomy, the `title` — it keeps on a `<div>`, and it leaves the accessibility tree.
+
+**A tile lights when its own filter is on, and at no other time.** `Projects` lit when
+*no* filter was on, so the accent border — the app's one mark for "this filter is
+active" — sat on a tile whose filter was not, directly above a list showing everything,
+on every launch. An affordance for clearing belongs where clearing belongs (the Filter
+menu, the overflow menu, clicking the lit tile again), not on a neighbour whose lit
+state then means the opposite of everyone else's. The resting dashboard has no accent
+in it.
+
+The corollary that closes the loop: **the cards that ARE controls have to look like it
+under the pointer.** With the disabled `<button>` gone, `button.ws-kpi:hover` is exactly
+the clickable set. Use `--fill-quaternary` for a card's hover, not `--fill-tertiary`:
+the footnote is `--label-secondary`, which measures 4.64:1 (light) / 5.37:1 (dark) over
+the former and 4.45:1 over the latter. A card's own hover must not push its text under
+AA.
+
+And layer that tint, do not swap the fill for it. Every `--fill-*` token is
+translucent, so `background: var(--fill-quaternary)` on a card throws away the card's
+own `--surface` and composites the tint against the pane behind it — the hovered tile
+measured (234,234,236) on the rendered frame instead of an opaque (244,244,244). A
+`background-image: linear-gradient(var(--fill-quaternary), var(--fill-quaternary))`
+paints the tint *on* the surface, and leaves `box-shadow` free for the focus ring.
+
 ### States are part of the component, not an afterthought
 
 Every data surface owes four states, and each has a house form:

--- a/packages/app/src/renderer/styles/island.css
+++ b/packages/app/src/renderer/styles/island.css
@@ -982,3 +982,38 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
 .ws-table td[colspan] {
   border-bottom: 0;
 }
+
+/* ============================================================================
+   KPI TILE — .ws-kpi  (workspace/components/KpiTile.tsx, TRA-475)
+
+   Geometry, type and the selection border stay inline in the component; this
+   file owns the FILL, because that is the one property that has to change on
+   hover and an inline background outranks any rule here.
+
+   Only the tiles that carry a filter render as `<button>`, so `button.ws-kpi`
+   is exactly the set that should respond to the pointer. Before this there was
+   no `[data-kpi]` rule anywhere in the renderer: a clickable card and a static
+   one were indistinguishable under the cursor.
+
+   --fill-quaternary, not --fill-tertiary: the footnote is --label-secondary,
+   which measures 4.64:1 in light and 5.37:1 in dark over this fill, and 4.45:1
+   over --fill-tertiary. A card's own hover must not push its text under AA.
+
+   The tint is a background-IMAGE layered on the opaque surface, not a
+   background-color replacing it. Every fill token is translucent, so setting
+   `background: var(--fill-quaternary)` drops the card's own --surface and
+   composites the tint against whatever is behind the card instead: measured on
+   the rendered frame, the hovered card came back (234,234,236) — the tint over
+   the --surface-sunken pane — where an opaque card is (244,244,244). A card
+   is content and stays opaque in every state. Leaving `box-shadow` alone also keeps the
+   `*:focus-visible` ring intact on a tile that is hovered and focused at once.
+
+   No `:active` rule — --fill-pressed takes that footnote to 4.37:1, and the
+   press already has feedback: the accent border arrives on release.
+   ============================================================================ */
+.ws-kpi {
+  background: var(--surface);
+}
+button.ws-kpi:hover {
+  background-image: linear-gradient(var(--fill-quaternary), var(--fill-quaternary));
+}

--- a/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
@@ -303,8 +303,11 @@ export function WorkspaceHeader({
           delta={delta((k) => k.totalProjects)}
           deltaCaption={deltaCaption}
           footnote={t('kpiTrackingFromToday')}
-          active={isDefaultFilter(filter)}
-          onClick={() => onFilterChange(EMPTY_FILTER)}
+          /* No `active`, no `onClick`. Projects is the workspace total, not a
+             filter: lighting it when NO filter is on put the one mark that
+             means "this filter is active" on a tile whose filter is not, above
+             a list showing everything (TRA-475). Clearing stays reachable from
+             the Filter menu, the overflow menu, and the lit preset tile. */
         />
         <KpiTile
           label={t('kpiFiles')}

--- a/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
@@ -27,6 +27,7 @@ function renderHeader(
     dense: boolean;
     hideViewToggle: boolean;
     kpis: WorkspaceKpis;
+    filter: WorkspaceFilter;
   }> = {},
 ) {
   const { container } = render(
@@ -183,6 +184,58 @@ describe('WorkspaceHeader KPI strip', () => {
     }
     // Indexing really is a subset of the workspace, so it keeps its share.
     expect(kpiTile('Indexing').children[2]!.textContent).toBe('8% of 53 projects');
+  });
+});
+
+describe('WorkspaceHeader KPI tiles: which of them are controls', () => {
+  beforeEach(() => localStorage.clear());
+
+  const READOUTS = ['Projects', 'Files', 'Symbols'];
+  const FILTERS = ['Healthy', 'Needs attention', 'Indexing'];
+
+  it('marks nothing selected while nothing is filtered', () => {
+    // Projects used to light when NO filter was on, so the one mark meaning
+    // "this filter is active" sat, on every launch, above a list showing
+    // everything (TRA-475).
+    renderHeader(false);
+    for (const label of [...READOUTS, ...FILTERS]) {
+      const tile = kpiTile(label);
+      expect(tile.getAttribute('aria-pressed')).not.toBe('true');
+      expect(tile.style.border).toContain('var(--separator)');
+    }
+  });
+
+  it('renders a tile with no filter behind it as content, not a dead control', () => {
+    // `<button disabled>` told VoiceOver there was a control here and that the
+    // user may not use it — a broken control where there was never one.
+    renderHeader(false);
+    for (const label of READOUTS) {
+      const tile = kpiTile(label);
+      expect(tile.tagName).toBe('DIV');
+      expect(tile.getAttribute('aria-pressed')).toBeNull();
+      // Still a card: same anatomy, same hook, same class.
+      expect(tile.children).toHaveLength(3);
+      expect(tile.className).toContain('ws-kpi');
+    }
+  });
+
+  it('keeps the three filter presets as real buttons', () => {
+    renderHeader(false);
+    for (const label of FILTERS) {
+      const tile = kpiTile(label);
+      expect(tile.tagName).toBe('BUTTON');
+      expect(tile).not.toHaveProperty('disabled', true);
+      expect(tile.getAttribute('aria-pressed')).toBe('false');
+    }
+  });
+
+  it('lights exactly the tile whose filter is on', () => {
+    renderHeader(false, { filter: { ...EMPTY_FILTER, preset: 'healthy' } });
+    expect(kpiTile('Healthy').getAttribute('aria-pressed')).toBe('true');
+    expect(kpiTile('Healthy').style.border).toContain('var(--accent)');
+    for (const label of ['Projects', 'Files', 'Symbols', 'Needs attention', 'Indexing']) {
+      expect(kpiTile(label).style.border).toContain('var(--separator)');
+    }
   });
 });
 

--- a/packages/app/src/renderer/workspace/components/KpiTile.tsx
+++ b/packages/app/src/renderer/workspace/components/KpiTile.tsx
@@ -108,39 +108,38 @@ export function KpiTile({
   const interactive = onClick !== undefined;
   const valueColor = unavailable ? 'var(--label-secondary)' : tone ? TONE_COLOR[tone] : 'var(--label)';
 
-  return (
-    <button
-      type="button"
-      disabled={!interactive}
-      aria-pressed={interactive ? active : undefined}
-      data-kpi={label}
-      data-dense={dense ? '' : undefined}
-      // Dense drops the comparison line, so the one sentence that explains an
-      // em dash has to survive somewhere the user can still reach it.
-      title={dense && unavailable ? t('kpiUnavailable') : undefined}
-      onClick={onClick}
-      className={
-        dense
-          ? 'flex flex-row items-baseline justify-between gap-2 text-left transition-colors'
-          : 'flex flex-col items-start gap-1 text-left transition-colors'
-      }
-      style={{
-        // No `flex` basis: the strip is a grid whose track count already
-        // guarantees at least 132px per tile, and a flex-grow here is what let
-        // a last-row tile stretch to 5.5x its siblings (TRA-467). `minWidth: 0`
-        // so a long footnote sizes to its track instead of widening it.
-        minWidth: 0,
-        padding: dense ? '8px 12px' : 16,
-        borderRadius: 12,
-        // A card is content: it stays opaque --surface in BOTH states. Tinting
-        // the active tile pushed --label-secondary to 4.45:1 on its footnote —
-        // that token only clears 4.5 over an untinted surface. Selection is the
-        // accent border + aria-pressed, which as a UI boundary needs only 3:1.
-        background: 'var(--surface)',
-        border: `0.5px solid ${active ? 'var(--accent)' : 'var(--separator)'}`,
-        cursor: interactive ? 'pointer' : 'default',
-      }}
-    >
+  const shared = {
+    'data-kpi': label,
+    'data-dense': dense ? '' : undefined,
+    // Dense drops the comparison line, so the one sentence that explains an
+    // em dash has to survive somewhere the user can still reach it.
+    title: dense && unavailable ? t('kpiUnavailable') : undefined,
+    className: `ws-kpi ${
+      dense
+        ? 'flex flex-row items-baseline justify-between gap-2 text-left transition-colors'
+        : 'flex flex-col items-start gap-1 text-left transition-colors'
+    }`,
+    style: {
+      // No `flex` basis: the strip is a grid whose track count already
+      // guarantees at least 132px per tile, and a flex-grow here is what let
+      // a last-row tile stretch to 5.5x its siblings (TRA-467). `minWidth: 0`
+      // so a long footnote sizes to its track instead of widening it.
+      minWidth: 0,
+      padding: dense ? '8px 12px' : 16,
+      borderRadius: 12,
+      // The resting fill lives in island.css (`.ws-kpi`), not here: an inline
+      // background outranks every stylesheet rule, and the hover response the
+      // clickable tiles need is a stylesheet rule. A card is content, so it
+      // stays opaque in BOTH states — tinting the active tile pushed
+      // --label-secondary to 4.45:1 on its footnote, and that token only clears
+      // 4.5 over an untinted surface. Selection is the accent border +
+      // aria-pressed, which as a UI boundary needs only 3:1.
+      border: `0.5px solid ${active ? 'var(--accent)' : 'var(--separator)'}`,
+    },
+  } as const;
+
+  const body = (
+    <>
       {/* Active is signalled by the accent BORDER + aria-pressed, not by an
           accent label: --accent on the active tile's --fill-tertiary tint
           measures 3.28:1, and --badge-accent-fg only reaches 4.29:1. Promoting
@@ -212,6 +211,19 @@ export function KpiTile({
           )}
         </span>
       )}
+    </>
+  );
+
+  // A tile with no `onClick` is a readout, and a readout is content. Rendering
+  // it as `<button disabled>` told VoiceOver there was a control here and that
+  // the user may not use it — a broken control where there was never one
+  // (TRA-475). A `<div>` keeps the anatomy, the hook and the dense `title`, and
+  // leaves the accessibility tree.
+  if (!interactive) return <div {...shared}>{body}</div>;
+
+  return (
+    <button type="button" aria-pressed={active} onClick={onClick} {...shared}>
+      {body}
     </button>
   );
 }


### PR DESCRIPTION
Closes TRA-475.

## What was wrong

Measured on the running Electron window (CDP, `getComputedStyle` on `[data-kpi]`), the Workspace dashboard's opening frame:

| Tile | `aria-pressed` | `disabled` | border |
|---|---|---|---|
| Projects | **`true`** | false | **`rgb(10, 132, 255)`** (`--accent`) |
| Files | — | **true** | `--separator` |
| Symbols | — | **true** | `--separator` |
| Healthy / Needs attention / Indexing | `false` | false | `--separator` |

Two defects.

**1. The resting dashboard said something was selected.** Five of the six tiles are filter toggles that light their border when their filter is on. `Projects` lit when *no* filter was on (`active={isDefaultFilter(filter)}`), so the app's one mark for "this filter is active" sat on a tile whose filter was not — directly above a list showing everything. Its click was a no-op in that state, and clearing is already reachable from the Filter menu, the overflow menu, and clicking the lit preset tile.

**2. Three stat cards were `<button disabled>`.** `KpiTile` wrapped every tile in a `<button>` and switched off the ones with no `onClick`. VoiceOver announced a control and then said the user may not use it, where there was never a control.

## What changed

- `Projects` drops `active`/`onClick` — a readout beside Files and Symbols.
- A `KpiTile` with no `onClick` renders as a `<div>`: same three-line anatomy, same `data-kpi` hook, same dense `title`, out of the accessibility tree.
- The three real controls get a hover response. There was no `[data-kpi]` rule in any renderer stylesheet, so a clickable card was indistinguishable from a static one under the pointer. With the dead buttons gone, `button.ws-kpi` is exactly the clickable set.
- `DESIGN.md` §5 gains the rule ("A readout is content. A selection mark belongs to the thing selected.").

## On the hover fill

`--fill-quaternary`, not `--fill-tertiary`: the footnote is `--label-secondary`, which measures 4.64:1 (light) / 5.37:1 (dark) over the former and 4.45:1 over the latter. A card's own hover must not push its own text under AA.

It is layered as a `background-image` on the opaque surface rather than set as `background`. Every `--fill-*` token is translucent, so swapping the fill throws away the card's `--surface` and composites the tint against the pane behind it — the first cut rendered the hovered card at (234,234,236) instead of (244,244,244). Caught by sampling the pixel, not by reading the CSS. Leaving `box-shadow` untouched also keeps the `*:focus-visible` ring on a tile that is hovered and focused at once.

No `:active` rule: `--fill-pressed` takes that footnote to 4.37:1, and the press already has feedback — the accent border arrives on release.

## Verification

Re-measured on the running renderer after the change:

- At rest: `Projects` / `Files` / `Symbols` are `DIV`, no `aria-pressed`; `Healthy` / `Needs attention` / `Indexing` are `BUTTON`, `disabled: false`, `aria-pressed="false"`. All six borders `--separator`.
- Selecting Healthy: `aria-pressed="true"` and `rgb(0, 105, 217)` on that tile alone; every other tile stays `--separator`.
- Forced `:hover` on Healthy: `rgba(255, 255, 255, 0.06)` in dark; rendered pixels (244,244,244) light / (43,43,43) dark, against resting (255,255,255) / (30,30,30) — the card stays opaque. `Projects` does not respond.

Screenshots in both appearances are on TRA-475. The KPI cards are opaque content with no material, so there is nothing for Reduce Transparency to change; Increase Contrast only darkens `--separator`, which all six tiles share.

`pnpm run typecheck`, `pnpm run test` (510 passed), `pnpm run check:i18n` and `pnpm run build` all pass in `packages/app`.

Agent: Design/UX Agent
