### PR TITLE
fix(app): the sidebar file list can no longer pulse a skeleton forever (TRA-478)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -531,7 +531,10 @@ Every data surface owes four states, and each has a house form:
 - **Error** — the chrome stays put; the sentence and its Retry action sit together.
   Each section tracks its own load state. A failed fetch must not pulse a skeleton
   forever promising data that is never coming — settle on an em dash and
-  "Couldn't be measured".
+  "Couldn't be measured". A fetch only *fails* if it can: every request to the
+  daemon carries `AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS)`, because a wedged
+  daemon still holds its port open and a connect that never completes leaves the
+  loading state with nothing to leave it (TRA-478).
 - **Unknown ≠ empty ≠ zero.** "The daemon has not answered yet" and "this project was
   never indexed" are different sentences. "0 of 0 dependencies covered" is an empty
   state, not a full green meter.
@@ -1340,6 +1343,7 @@ new evidence.
 | A card grid responds by changing its column count, never its card width | `flex-wrap` + `flex: 1 1 132px` hands the leftover width to whichever cards landed in the last row: at a 1000px window five KPI tiles rendered at 137px and the sixth at 748px, all six carrying the same three lines. A card wider than its neighbour makes a claim the data is not making. Equal `minmax(0, 1fr)` tracks, and a count that **divides** the number of cards so no row is ever short (TRA-467). |
 | A surface whose every section reads one source states its failure once, at surface level | Project Overview said one dead daemon six times — the toolbar chip, Guard's line, and four `SectionError`s each claiming "the daemon may still be indexing" with a Retry aimed at a refusing socket. "Busy" is a wait, "not running" is a button; the app knew which one it was and printed the other four times. `DaemonDownPane` is now shared, and the test for down is `deriveDaemonState()` rather than a fresh `!connected` that would flash on every mount (TRA-469). |
 | An empty list and no list are two different facts | A `.catch(() => setFiles([]))` makes a refused socket indistinguishable from a filter that matched nothing, and the empty state then explains a result it never received — the sidebar's file list blamed the scope filter while the pane beside it correctly said the daemon was not running (TRA-471). Keep whether the list was answered; assert a cause only for the empty answer you actually got, render nothing for the one you did not, and leave the re-fetching control in place as the way back. |
+| A request with no deadline has no failure state, so the skeleton wins forever | "Daemon down" is not always a refused socket: a wedged daemon still holds :3741 open, the connect sits in `SYN_SENT`, and `fetch` neither resolves nor rejects. The sidebar's file list was the one daemon fetch in the app without `AbortSignal.timeout` — measured on the running renderer, 2 of 6 navigations left six skeletons pulsing and `aria-busy="true"` set indefinitely, four inches from a pane correctly saying the daemon was not running (TRA-478). Give every request a deadline, and derive the render from the request's own terminal state (`'loading' | 'answered' | 'failed'`), never from a boolean a cancelled run can strand. A fixture that rejects immediately — which is every daemon-down test we had — cannot see this class of bug. |
 | Narrow gives up the comparison, then the table, never the value | The number and the project name are the screen; the footnote and the metric columns are elaboration. Compact already renders a legible row at 420px. |
 | A view toggle with one usable option is hidden, not disabled | A disabled segment is a control with nothing to choose. The stored preference is untouched and returns with the width. |
 | Migrate a screen **whole**, one screen per PR | A half-migrated screen looks worse than the un-migrated one; a big-bang redesign PR never lands. |

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -6,6 +6,7 @@ import { GuardOnboarding, isOnboardingDone } from './components/GuardOnboarding'
 import { QuickOpen, type QuickOpenItem } from './components/QuickOpen';
 import { SidebarRow } from './components/SidebarRow';
 import { WindowTabBar } from './components/WindowTabBar';
+import { DAEMON_FETCH_TIMEOUT_MS } from './hooks/useDaemon';
 import { t } from './i18n';
 import { formatNumber } from './i18n/format';
 import { fileKind, FileTypeGlyph, Icon } from './lattice/icons';
@@ -270,11 +271,14 @@ function ProjectFileExplorer({
   const { t } = useTranslation('shell');
   const [sort, setSort] = useState<FileSort>('symbols');
   const [files, setFiles] = useState<FileEntry[]>([]);
-  const [loading, setLoading] = useState(true);
-  /* Did a list actually come back? An empty list and no list at all are two
-     different facts, and `setFiles([])` on failure collapsed them into one —
-     which is how a refused socket ended up blaming the scope filter (TRA-471). */
-  const [answered, setAnswered] = useState(false);
+  /* One state, three terminal facts, written only by the request that owns it.
+     It was two booleans — `loading`, cleared in a `.finally` any cancelled run
+     could skip, and `answered`, because an empty list and no list at all are
+     different facts (TRA-471). A skeleton then outranked both, so a request
+     that never settled pulsed six rows forever (TRA-478). `unavailable`
+     outranks `pending` here for the same reason it does in `KpiTile`: a fetch
+     that finished and failed is not still loading. */
+  const [status, setStatus] = useState<'loading' | 'answered' | 'failed'>('loading');
   const [selected, setSelected] = useState<string | null>(null);
   const [ctx, setCtx] = useState<{ x: number; y: number; path: string } | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -291,27 +295,32 @@ function ProjectFileExplorer({
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
+    setStatus('loading');
     const params = new URLSearchParams({ project: root, sort, limit: String(LIMIT) });
     // Pass scope to API if it's a custom path filter (not 'project' or empty)
     const effectiveScope = debouncedScope?.trim();
     if (effectiveScope && effectiveScope !== 'project') {
       params.set('scope', effectiveScope);
     }
-    fetch(`${BASE}/api/projects/files?${params}`)
+    /* The deadline every other daemon fetch already carries (`useDaemon`), and
+       the one this list was missing. A daemon that is down is not always a
+       refused socket: a wedged process still holds :3741 open, so the connect
+       sits in SYN_SENT and `fetch` neither resolves nor rejects — which is how
+       the skeletons outlived the request (TRA-478). Without a deadline there is
+       no terminal state to render. */
+    fetch(`${BASE}/api/projects/files?${params}`, {
+      signal: AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS),
+    })
       .then((r) => (r.ok ? r.json() : Promise.reject()))
       .then((data) => {
         if (cancelled) return;
         setFiles(data.files ?? []);
-        setAnswered(true);
+        setStatus('answered');
       })
       .catch(() => {
         if (cancelled) return;
         setFiles([]);
-        setAnswered(false);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
+        setStatus('failed');
       });
     return () => {
       cancelled = true;
@@ -382,7 +391,7 @@ function ProjectFileExplorer({
         aria-label={t('sortFilesBy')}
       />
 
-      {loading ? (
+      {status === 'loading' ? (
         // Skeletons at the final 28px geometry — nothing shifts on load.
         <div aria-busy="true" aria-label={t('loadingFiles')}>
           {Array.from({ length: 6 }, (_, i) => (
@@ -397,7 +406,7 @@ function ProjectFileExplorer({
            not name a cause it cannot know, and does not say the same thing twice
            (DESIGN.md §5). The sort pop-up above stays: changing it re-fetches,
            which is the sidebar's own way back once the daemon answers again. */
-        answered ? (
+        status === 'answered' ? (
           <div className="ws-sb-empty">
             <Icon name="description" size={20} className="gi" />
             <span>{t('noFilesMatchScope')}</span>

--- a/packages/app/src/renderer/__tests__/sidebar-file-list.test.tsx
+++ b/packages/app/src/renderer/__tests__/sidebar-file-list.test.tsx
@@ -7,6 +7,7 @@
 import { act, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { App } from '../App';
+import { DAEMON_FETCH_TIMEOUT_MS } from '../hooks/useDaemon';
 
 const SCOPE_LINE = 'No indexed files match this scope.';
 
@@ -71,6 +72,57 @@ describe('sidebar file list, empty', () => {
   it('says nothing when the daemon answered with an error', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response('nope', { status: 500 })));
     await renderProjectWindow();
+    expect(document.body.textContent).not.toContain(SCOPE_LINE);
+  });
+});
+
+/* TRA-478. Every case above rejects immediately, which is the one shape of
+   "daemon down" that was never broken. A wedged daemon still holds :3741 open,
+   so the connect never completes and the promise never settles — and the list
+   pulsed six skeletons forever, telling a screen reader it was still loading.
+   The request needs a deadline; the render needs a terminal state to reach. */
+describe('sidebar file list, daemon reachable but never answering', () => {
+  it('leaves the loading state when the request hits its deadline', async () => {
+    /* The deadline is driven by hand rather than by advancing timers:
+       `AbortSignal.timeout` schedules inside the platform, where a fake clock
+       does not reach it. Standing in for it also proves the component asked for
+       one at all — on the code this test pins, it never did. */
+    const deadlines: number[] = [];
+    /* Every deadline in the window, not just the last one: the daemon poll asks
+       for its own, and the file list's is not reliably the most recent. */
+    const expire: (() => void)[] = [];
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockImplementation((ms: number) => {
+      deadlines.push(ms);
+      const controller = new AbortController();
+      expire.push(() => controller.abort(new DOMException('timed out', 'TimeoutError')));
+      return controller.signal;
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_url: unknown, init?: { signal?: AbortSignal }) =>
+          // A wedged daemon: the socket is open, so nothing but the deadline ends this.
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => reject(init.signal?.reason));
+          }),
+      ),
+    );
+    try {
+      await renderProjectWindow();
+      expect(deadlines).toContain(DAEMON_FETCH_TIMEOUT_MS);
+      // Still in flight, so the skeletons are right to be up.
+      expect(document.querySelectorAll('.ws-sb-skeleton').length).toBeGreaterThan(0);
+
+      await act(async () => {
+        for (const fire of expire) fire();
+      });
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+
+    expect(document.querySelectorAll('.ws-sb-skeleton')).toHaveLength(0);
+    expect(document.querySelectorAll('[aria-busy="true"]')).toHaveLength(0);
+    // Still not the scope's fault — nothing ever came back.
     expect(document.body.textContent).not.toContain(SCOPE_LINE);
   });
 });


### PR DESCRIPTION
Fixes TRA-478.

TRA-471 stopped the sidebar file list blaming the scope filter for a dead daemon. Going back to look at the shipped render rather than the diff turned up what replaced it: with the daemon down, **2 of 6 navigations left six skeleton rows pulsing indefinitely** and `aria-busy="true"` set on the region permanently — four inches left of a pane correctly saying "The daemon isn't running".

## Root cause, measured rather than guessed

"Daemon down" is not always a refused socket. A **wedged** daemon still holds `:3741` open:

```
$ lsof -nP -iTCP:3741
node      71110  ...  TCP 127.0.0.1:3741 (LISTEN)
node       1459  ...  TCP 127.0.0.1:57161->127.0.0.1:3741 (SYN_SENT)
trace-mcp 37791  ...  TCP 127.0.0.1:57169->127.0.0.1:3741 (SYN_SENT)
...
$ curl -m 3 http://127.0.0.1:3741/api/health
* Connection timed out after 3010 milliseconds
```

The connect never completes, so `fetch` neither resolves nor rejects. `ProjectFileExplorer` was **the one daemon fetch in the app without a deadline** — `useDaemon`, `useWorkspaceProjects` and Settings all already pass `AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS)`. Without one there is no terminal state for the render to reach, so `loading` stayed `true` forever and the skeleton branch (which sits above the `answered` check) meant TRA-471's new logic was never reached.

The intermittency is why it got through: Chromium fails the connect fast once a previous attempt in the same profile has already timed out, so a single check easily sees the good path. It is also why the TRA-471 tests pass — a fixture that rejects immediately is the one shape of "down" that was never broken.

## The change

Two edits, both smaller than what they replace:

- The request carries the deadline every sibling already carries.
- `loading` + `answered` collapse into one `status: 'loading' | 'answered' | 'failed'`, written only by the request that owns it. The `.finally(() => { if (!cancelled) setLoading(false) })` that a cancelled run could skip is gone entirely. `unavailable` outranks `pending`, the same rule `KpiTile` already states.

TRA-471's behaviour is unchanged: daemon down → the list renders nothing (the pane carries the diagnosis); daemon answered with an empty list → "No indexed files match this scope".

## Verification

Same machine, same wedged socket, before and after, in the real Electron window (`electron-cdp.mjs launch`, window never shown). Sampled at +12s and again at +18s per trial:

| | stuck |
|---|---|
| before | **2 of 6** navigations (`sk=6 busy=1`, stable) |
| after | **0 of 10** navigations (`sk=0 busy=0`) |

Screenshots of both are on TRA-478.

New test drives the deadline by hand rather than with a fake clock — `AbortSignal.timeout` schedules inside the platform, where `vi.useFakeTimers` does not reach — and standing in for it also proves the component asked for a deadline at all. It fails on the pre-fix component (verified by stashing `App.tsx`).

`pnpm test` 513 passed / 47 files, `typecheck`, `check:i18n`, `build` all clean locally.

`DESIGN.md` gets the rule as a class rule, in §5 and in the decision log: a request with no deadline has no failure state, so the skeleton wins forever.

Agent: Design/UX Agent
