### PR TITLE
fix(indexer): resolve Java imports, the next language after Go (TRA-483)

### DIFF
--- a/docs/language-matrix.md
+++ b/docs/language-matrix.md
@@ -14,7 +14,7 @@ extraction; call graphs and type edges are a much smaller set.
 
 - **indexed with the default config:** 78 (the rest need an `include` entry — see below)
 - **tree-sitter parser:** 29 · **regex parser:** 46 · **custom parser:** 6
-- **import edges:** 11
+- **import edges:** 12
 - **call edges (`get_call_graph`, call-aware `find_usages`):** 3
 - **type / inheritance edges:** 2
 - **covered by a plugin test:** 65
@@ -100,7 +100,7 @@ second thing, so it is much shorter than the language list — see
 | hcl | .tf .hcl .tfvars | custom | yes | yes | — | — | yes |
 | html | .html .htm | tree-sitter | yes | yes | — | — | yes |
 | ini | .ini .cfg .conf .properties | regex | — | — | — | — | — |
-| java | .java | tree-sitter | yes | — | — | — | yes |
+| java | .java | tree-sitter | yes | yes | — | — | yes |
 | json | .json .jsonc .json5 | tree-sitter | — | — | — | — | yes |
 | julia | .jl | regex | yes | — | — | — | yes |
 | kotlin | .kt .kts | tree-sitter | yes | — | — | — | yes |

--- a/src/indexer/edge-resolver.ts
+++ b/src/indexer/edge-resolver.ts
@@ -15,6 +15,7 @@ import {
 import { resolveTypeScriptHeritageEdges as _resolveHeritage } from './edge-resolvers/heritage.js';
 import { resolveIacImportEdges as _resolveIacImports } from './edge-resolvers/iac-imports.js';
 import { resolveGoImportEdges as _resolveGoImports } from './edge-resolvers/go-imports.js';
+import { resolveJavaImportEdges as _resolveJavaImports } from './edge-resolvers/java-imports.js';
 import { resolveEsmImportEdges as _resolveImports } from './edge-resolvers/imports.js';
 import { resolveMarkdownTagEdges as _resolveMarkdownTags } from './edge-resolvers/markdown-tags.js';
 import { resolveMarkdownWikilinkEdges as _resolveMarkdownLinks } from './edge-resolvers/markdown-wikilinks.js';
@@ -140,6 +141,11 @@ export class EdgeResolver {
   /** Pass 2e3: Go import edges (module path → package directory). */
   resolveGoImportEdges(scope?: ChangeScope): void {
     timed('go-imports', () => _resolveGoImports(this.state, scope));
+  }
+
+  /** Pass 2e4: Java import edges (package name → source directory). */
+  resolveJavaImportEdges(scope?: ChangeScope): void {
+    timed('java-imports', () => _resolveJavaImports(this.state, scope));
   }
 
   /** Pass 2e2: PHP import edges (PSR-4 use statements). */

--- a/src/indexer/edge-resolvers/import-capable-languages.ts
+++ b/src/indexer/edge-resolvers/import-capable-languages.ts
@@ -42,6 +42,7 @@ export const IMPORT_EDGE_LANGUAGES: ReadonlySet<string> = new Set([
   'python', // resolvePythonImportEdges
   'php', // resolvePhpImportEdges
   'go', // resolveGoImportEdges
+  'java', // resolveJavaImportEdges
   'yaml', // resolveIacImportEdges — kustomize / docker-compose refs
   'hcl', // resolveIacImportEdges — local terraform module sources
   'markdown', // resolveMarkdownWikilinkEdges

--- a/src/indexer/edge-resolvers/java-imports.ts
+++ b/src/indexer/edge-resolvers/java-imports.ts
@@ -1,0 +1,131 @@
+/**
+ * Pass 2e4: Resolve Java import specifiers to file→file graph edges (TRA-483).
+ *
+ * Java names a type, and the language forces the package to mirror the
+ * directory layout, so the specifier *is* the path:
+ *
+ *     import com.example.store.Repo;   // → .../com/example/store/Repo.java
+ *     import com.example.store.*;      // → every .java file in that directory
+ *     import static com.example.Ids.of;// → .../com/example/Ids.java
+ *
+ * The Java plugin already extracted these (`metadata.from`), but nothing
+ * consumed them — same gap TRA-449 closed for Go. Resolution is pure suffix
+ * matching against the indexed files: no build file is read, so Maven, Gradle
+ * and plain `src/` layouts all work, and a JDK or third-party import simply
+ * fails to match rather than inventing a node.
+ */
+import { logger } from '../../logger.js';
+import type { ChangeScope } from '../../plugin-api/types.js';
+import type { PipelineState } from '../pipeline-state.js';
+
+/** Every trailing `/`-aligned suffix of a path, longest first. */
+function suffixes(path: string): string[] {
+  const out = [path];
+  for (let i = path.indexOf('/'); i >= 0; i = path.indexOf('/', i + 1)) {
+    out.push(path.slice(i + 1));
+  }
+  return out;
+}
+
+function addTo(map: Map<string, number[]>, key: string, id: number): void {
+  const list = map.get(key);
+  if (list) list.push(id);
+  else map.set(key, [id]);
+}
+
+export function resolveJavaImportEdges(state: PipelineState, _scope?: ChangeScope): void {
+  // WHY: driven by `state.pendingImports`, already scoped to re-extracted files.
+  void _scope;
+  const { store } = state;
+  if (state.pendingImports.size === 0) return;
+
+  const pendingFileIds = Array.from(state.pendingImports.keys());
+  const fileMap = store.getFilesByIds(pendingFileIds);
+  const hasJava = pendingFileIds.some((id) => fileMap.get(id)?.language === 'java');
+  if (!hasJava) return;
+
+  // Suffix → file ids. `byType` keys end in `.java` (an import naming a type),
+  // `byPackage` keys are the directories (a wildcard import naming a package).
+  const byType = new Map<string, number[]>();
+  const byPackage = new Map<string, number[]>();
+  const allJavaIds: number[] = [];
+  for (const f of store.getAllFiles()) {
+    const p = f.path.split('\\').join('/');
+    if (!p.endsWith('.java')) continue;
+    allJavaIds.push(f.id);
+    for (const s of suffixes(p)) addTo(byType, s, f.id);
+    const dir = p.includes('/') ? p.slice(0, p.lastIndexOf('/')) : '';
+    if (dir) for (const s of suffixes(dir)) addTo(byPackage, s, f.id);
+  }
+  if (allJavaIds.length === 0) return;
+
+  const importsEdgeType = store.db
+    .prepare('SELECT id FROM edge_types WHERE name = ?')
+    .get('imports') as { id: number } | undefined;
+  if (!importsEdgeType) return;
+
+  const nodeIds = new Map<number, number>();
+  const lookupIds = allJavaIds.concat(pendingFileIds);
+  const CHUNK = 500;
+  for (let i = 0; i < lookupIds.length; i += CHUNK) {
+    for (const [k, v] of store.getNodeIdsBatch('file', lookupIds.slice(i, i + CHUNK))) {
+      nodeIds.set(k, v);
+    }
+  }
+
+  const insertStmt = store.db.prepare(
+    `INSERT INTO edges (source_node_id, target_node_id, edge_type_id, resolved, metadata, is_cross_ws)
+     VALUES (?, ?, ?, 1, ?, 0)
+     ON CONFLICT(source_node_id, target_node_id, edge_type_id)
+     DO UPDATE SET metadata = excluded.metadata`,
+  );
+
+  /**
+   * `com.example.store.Repo` → the files it can mean. Tried in order: the type
+   * itself, the package it would be as a wildcard, then the type one segment up
+   * — which covers both `import static ...Ids.of` and a nested class.
+   */
+  const resolve = (specifier: string): number[] => {
+    const bare = specifier.endsWith('.*') ? specifier.slice(0, -2) : specifier;
+    const path = bare.split('.').join('/');
+    const type = byType.get(`${path}.java`);
+    if (type) return type;
+    const pkg = byPackage.get(path);
+    if (pkg) return pkg;
+    const cut = path.lastIndexOf('/');
+    return (cut > 0 && byType.get(`${path.slice(0, cut)}.java`)) || [];
+  };
+
+  let created = 0;
+  let external = 0;
+
+  store.db.transaction(() => {
+    for (const [fileId, imports] of state.pendingImports) {
+      if (fileMap.get(fileId)?.language !== 'java') continue;
+      const sourceNodeId = nodeIds.get(fileId);
+      if (sourceNodeId == null) continue;
+
+      const seen = new Set<string>();
+      for (const { from } of imports) {
+        if (!from || seen.has(from)) continue;
+        seen.add(from);
+
+        const targets = resolve(from);
+        if (targets.length === 0) {
+          external++;
+          continue;
+        }
+        for (const targetId of targets) {
+          const targetNodeId = nodeIds.get(targetId);
+          if (targetNodeId == null || targetNodeId === sourceNodeId) continue;
+          insertStmt.run(sourceNodeId, targetNodeId, importsEdgeType.id, JSON.stringify({ from }));
+          created++;
+        }
+      }
+    }
+  })();
+
+  if (created > 0 || external > 0) {
+    logger.info({ edges: created, external }, 'Java import edges resolved');
+  }
+}

--- a/src/indexer/pipeline.ts
+++ b/src/indexer/pipeline.ts
@@ -897,6 +897,7 @@ export class IndexingPipeline {
       () => edgeResolver.resolvePythonImportEdges(scope),
       () => edgeResolver.resolvePhpImportEdges(scope),
       () => edgeResolver.resolveGoImportEdges(scope),
+      () => edgeResolver.resolveJavaImportEdges(scope),
       () => edgeResolver.resolvePhpCallEdges(scope),
       () => edgeResolver.resolveTypeScriptCallEdges(scope),
       () => edgeResolver.resolveTypeScriptTypeEdges(scope),

--- a/tests/integration/java-import-resolution-e2e.test.ts
+++ b/tests/integration/java-import-resolution-e2e.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Java cross-file import resolution E2E (TRA-483).
+ *
+ * Same gap TRA-449 closed for Go: the Java plugin extracted `import` specifiers
+ * into `metadata.from`, but no pipeline pass consumed them, so a Java repo
+ * indexed with zero import edges. These tests pin the four shapes a Java import
+ * comes in — plain type, wildcard package, static member, nested class — plus
+ * the rule that a JDK or third-party import resolves to nothing rather than to
+ * an invented node.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { TraceMcpConfig } from '../../src/config.js';
+import type { Store } from '../../src/db/store.js';
+import { IndexingPipeline } from '../../src/indexer/pipeline.js';
+import { JavaLanguagePlugin } from '../../src/indexer/plugins/language/java/index.js';
+import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import { createTestStore, createTmpFixture, removeTmpDir } from '../test-utils.js';
+
+const SRC = 'src/main/java/com/example/app';
+
+const FILES: Record<string, string> = {
+  [`${SRC}/Main.java`]: `package com.example.app;
+
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import com.example.app.store.Repo;
+import static com.example.app.util.Ids.next;
+
+public class Main {
+  public static void main(String[] args) {
+    List<String> all = new Repo().all();
+    StringUtils.trim(all.get(next()));
+  }
+}
+`,
+  [`${SRC}/Api.java`]: `package com.example.app;
+
+import com.example.app.store.*;
+
+public class Api {
+  Repo repo = new Repo();
+  Row row = new Row();
+}
+`,
+  [`${SRC}/Nested.java`]: `package com.example.app;
+
+import com.example.app.store.Repo.Cursor;
+
+public class Nested {
+  Cursor cursor;
+}
+`,
+  [`${SRC}/store/Repo.java`]: `package com.example.app.store;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Repo {
+  public static class Cursor {}
+  public List<String> all() { return new ArrayList<>(); }
+}
+`,
+  [`${SRC}/store/Row.java`]: `package com.example.app.store;
+
+public class Row {}
+`,
+  [`${SRC}/util/Ids.java`]: `package com.example.app.util;
+
+public final class Ids {
+  public static int next() { return 0; }
+}
+`,
+};
+
+function importTargets(store: Store, sourcePath: string): Set<string> {
+  const file = store.getFile(sourcePath);
+  if (!file) return new Set();
+  const nodeId = store.getNodeId('file', file.id);
+  if (nodeId == null) return new Set();
+  const targets = new Set<string>();
+  for (const edge of store.getOutgoingEdges(nodeId)) {
+    if (edge.edge_type_name !== 'imports') continue;
+    const ref = store.getNodeRef(edge.target_node_id);
+    if (ref?.nodeType === 'file') targets.add(store.getFileById(ref.refId)?.path ?? '');
+  }
+  return targets;
+}
+
+describe('Java import resolution E2E', () => {
+  let store: Store;
+  let fixtureDir: string;
+
+  beforeAll(async () => {
+    fixtureDir = createTmpFixture(FILES, 'trace-mcp-java-imports-');
+    store = createTestStore();
+    const registry = new PluginRegistry();
+    registry.registerLanguagePlugin(new JavaLanguagePlugin());
+
+    const config: TraceMcpConfig = {
+      root: fixtureDir,
+      include: ['**/*.java'],
+      exclude: ['node_modules/**'],
+      db: { path: ':memory:' },
+      plugins: [],
+    } as TraceMcpConfig;
+
+    await new IndexingPipeline(store, registry, config, fixtureDir).indexAll();
+  });
+
+  afterAll(() => {
+    removeTmpDir(fixtureDir);
+  });
+
+  it('resolves a plain type import to the file declaring it', () => {
+    expect(importTargets(store, `${SRC}/Main.java`)).toContain(`${SRC}/store/Repo.java`);
+  });
+
+  it('resolves a static member import to the class holding the member', () => {
+    expect(importTargets(store, `${SRC}/Main.java`)).toContain(`${SRC}/util/Ids.java`);
+  });
+
+  it('resolves a wildcard import to every file in that package', () => {
+    expect(importTargets(store, `${SRC}/Api.java`)).toEqual(
+      new Set([`${SRC}/store/Repo.java`, `${SRC}/store/Row.java`]),
+    );
+  });
+
+  it('resolves a nested-class import to its outer class file', () => {
+    expect(importTargets(store, `${SRC}/Nested.java`)).toEqual(new Set([`${SRC}/store/Repo.java`]));
+  });
+
+  it('skips JDK and third-party imports rather than inventing targets', () => {
+    // Main.java imports java.util.List and org.apache...StringUtils; neither is
+    // in the repo, so only the two first-party targets may appear.
+    expect(importTargets(store, `${SRC}/Main.java`).size).toBe(2);
+    // Repo.java imports only JDK types — it must end up with no import edges.
+    expect(importTargets(store, `${SRC}/store/Repo.java`).size).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Indexing `google/gson` produced 34 Java import edges and `square/retrofit` 3 — essentially nothing, in repos of 281 and 989 files. The Java plugin extracted every `import` into `metadata.from`, but no pipeline pass consumed it, so the specifier went nowhere.

Same gap TRA-449 closed for Go. Java was the largest of the 13 languages that commit explicitly left behind.

## How

Java forces the package to mirror the directory layout, so the specifier *is* the path. `resolveJavaImportEdges` matches it as a `/`-aligned suffix against the indexed files — no build file is read, so Maven, Gradle and plain `src/` layouts all work, and a JDK or third-party import simply fails to match rather than inventing a node.

All four import shapes resolve:

| Shape | Example | Target |
| --- | --- | --- |
| plain type | `import com.example.store.Repo;` | `.../com/example/store/Repo.java` |
| wildcard package | `import com.example.store.*;` | every `.java` in that directory |
| static member | `import static com.example.Ids.next;` | `.../com/example/Ids.java` |
| nested class | `import com.example.store.Repo.Cursor;` | `.../com/example/store/Repo.java` |

## Evidence

Measured before and after on real repos, not fixtures — first-party `java → java` file import edges:

| Repo | Before | After |
| --- | --- | --- |
| google/gson | 34 | 1030 |
| square/retrofit | 3 | 617 |

`tests/integration/java-import-resolution-e2e.test.ts` pins all four shapes plus the rule that JDK/third-party imports resolve to nothing.

Local: `pnpm run lint` clean, `biome ci` clean, `pnpm run test` — 9194 passed, 8 skipped, 0 failed.

`docs/language-matrix.md` regenerated: Imports 11 → 12. Remaining from the TRA-449 list — Ruby, Rust, C, C++, C#, Kotlin, Swift, Elixir, Lua, Astro, Svelte.