### PR TITLE
docs(ops): draft the Show HN material (TRA-393)

### DIFF
--- a/ops/distribution.md
+++ b/ops/distribution.md
@@ -39,6 +39,10 @@ Rules for keeping it honest:
 | Continue.dev Hub | — | — | **Dead product, not a gap.** Continue was acquired by Cursor (June 2026), the final release shipped 2026-06-19, cloud data was deleted after 2026-07-15, `hub.continue.dev` no longer resolves. The GitHub repo is **not** archived and is still public — do not describe it as read-only — but it has shipped nothing since (last commit 2026-07-21). Re-check only if Cursor stands a successor up | 2026-08-29 |
 | [LobeHub](https://lobehub.com/mcp) | **No** — the `trace-mcp` listing there is `Mnehmos/trace-mcp`, an unrelated project with the same name | — | Publishing is `npx @lobehub/market-cli`, and it requires `lhm login` (browser OIDC) plus `lhm github connect` (browser ownership check). There is no token-only path: verified in `@lobehub/market-cli@0.0.41` itself, because their docs pages under `lobehub.com/docs/market/*` are content-free stubs. `plugin publish` and `plugin claim` both go through `createUserSDK()`, which aborts with "Not logged in. Run `lhm login` first" unless a user OAuth token is on disk; the `MARKET_CLIENT_ID`/`MARKET_CLIENT_SECRET` env pair is never used for publishing. Human-only, like Smithery | 2026-08-29 |
 
+Community channels (Hacker News, Reddit) are not in this table because they are
+not listings — nothing there is maintained, only posted once. The drafted
+material lives in `ops/launch-hn.md`, and posting it is Nikolai's call.
+
 ## Findings that should not be re-derived
 
 **The official registry was the root cause of everything else** (TRA-352,

--- a/ops/launch-hn.md
+++ b/ops/launch-hn.md
@@ -5,9 +5,12 @@ Nikolai posts this.** An agent may write and revise it; publishing under the
 project's name is his call, and it is irreversible in a way a directory listing
 is not.
 
-Numbers below come from `docs/_data/counts.yml` and the README's own framing.
-Re-read both before posting — 80 became 81 languages inside a day once, and a
-Show HN thread is the worst place to be caught with a stale figure.
+Numbers below come from `docs/_data/counts.yml` and the README's own framing,
+verified 2026-08-30 (81 languages / 87 frameworks / 169 tools). Re-read both
+before posting — 80 became 81 languages inside a day once, and a Show HN thread
+is the worst place to be caught with a stale figure. Nothing enforces this file:
+`tests/docs/readme-claims.test.ts` guards README.md only, so these figures go
+stale silently.
 
 ## When to post
 
@@ -26,8 +29,9 @@ then stay available for ~4 hours; an unanswered thread dies.
 
 Show HN: Trace-mcp – a code graph for AI agents, so they stop re-reading files
 
-Keep it under 80 characters and resist adjectives. "Framework-aware code
-intelligence" is what the package says; it is not what a reader recognises.
+Keep it to 80 characters or fewer (the line above is exactly 80, HN's cap) and
+resist adjectives. "Framework-aware code intelligence" is what the package says;
+it is not what a reader recognises.
 
 ## Body
 
@@ -49,16 +53,22 @@ intelligence" is what the package says; it is not what a reader recognises.
 > but that is a per-call peak and I have stopped quoting it as if it were the
 > average.
 >
-> Runs entirely locally. No API keys, no cloud, MIT. `npx trace-mcp benchmark .`
-> prints the per-task numbers against your own repo in about five minutes, which
-> is a better argument than anything I can write here.
+> Runs entirely locally. No API keys, no code leaves the machine, MIT.
+> `npx trace-mcp index . && npx trace-mcp benchmark .` prints the per-task
+> numbers against your own repo in about five minutes, which is a better
+> argument than anything I can write here.
 
 ## First comment — post it yourself, immediately
 
 HN treats a maintainer who names the limits first as credible and one who waits
 to be caught as not. This is the whole reason the thread is worth having.
 
-> Three things worth knowing before you try it:
+> Four things worth knowing before you try it:
+>
+> It sends one anonymous ping per day per install — a random id, version, OS,
+> and two aggregate counters, no paths and no code. `TRACE_MCP_TELEMETRY=off`
+> kills it, and the source is `src/telemetry/usage-ping.ts`. Saying "local-first"
+> without saying that first is how a thread goes bad.
 >
 > The headline benchmark is a **synthetic estimate**, not measured savings. The
 > "without" side is computed from file sizes in the index and the "with" side from
@@ -80,12 +90,14 @@ to be caught as not. This is the whole reason the thread is worth having.
 Each answer must be checkable in one click. Do not improvise these.
 
 1. **"How is this different from Serena / codebase-memory-mcp / Repomix?"** →
-   `trace-mcp.com/comparisons.html` plus the three head-to-head pages. Never
-   disparage a competitor from memory; the comparison pages are written to survive
-   the maintainer of the other project reading them, which on HN they will.
+   `trace-mcp.com/comparisons.html` plus the four head-to-head pages (Serena,
+   Repomix, codegraph, codebase-memory-mcp). Never disparage a competitor from
+   memory; the comparison pages are written to survive the maintainer of the
+   other project reading them, which on HN they will.
 2. **"40–50% of what, measured how?"** → the README's "Token reduction" section
-   and `npx trace-mcp benchmark .`. Say plainly that mixed real-world workloads
-   land 30–60% depending on stack.
+   and `npx trace-mcp index . && npx trace-mcp benchmark .` (the benchmark reads
+   an existing index — without the index step it has nothing to measure). Say
+   plainly that mixed real-world workloads land 30–60% depending on stack.
 3. **"Why not just use the LSP?"** → we do, optionally, as an enrichment pass. The
    graph exists so an answer costs one call instead of a live query per edge, and
    so cross-language framework edges exist at all — no LSP knows that an Inertia

--- a/ops/launch-hn.md
+++ b/ops/launch-hn.md
@@ -1,0 +1,112 @@
+# Show HN material — ready to post, not posted
+
+Draft copy for the one channel this project has never used. **Nobody but
+Nikolai posts this.** An agent may write and revise it; publishing under the
+project's name is his call, and it is irreversible in a way a directory listing
+is not.
+
+Numbers below come from `docs/_data/counts.yml` and the README's own framing.
+Re-read both before posting — 80 became 81 languages inside a day once, and a
+Show HN thread is the worst place to be caught with a stale figure.
+
+## When to post
+
+Not on a release day and not right after one: the top comment on any Show HN
+about a token-reduction tool is "show me the measurement", and the answer has to
+be a page that already exists, not one written while the thread is live. The
+prerequisites are all met today — `trace-mcp.com/comparisons.html` is current,
+the benchmark is one command, and the install path has had its rough edges filed
+off (#282 config scope, #297 tools not appearing, #230 Windows popups, #202
+daemon reinstall).
+
+Tuesday–Thursday, 07:00–09:00 US Pacific, is the conventional slot. Post and
+then stay available for ~4 hours; an unanswered thread dies.
+
+## Title
+
+Show HN: Trace-mcp – a code graph for AI agents, so they stop re-reading files
+
+Keep it under 80 characters and resist adjectives. "Framework-aware code
+intelligence" is what the package says; it is not what a reader recognises.
+
+## Body
+
+> I kept watching Claude Code re-read the same files every turn. Ask "what breaks
+> if I change this model?" and it greps, opens twenty files, forgets, and does it
+> again next turn — on a big repo the bill grows with the repo, not with the
+> question.
+>
+> trace-mcp indexes the repo once into a local SQLite graph (tree-sitter, 81
+> languages) and serves it over MCP, so the agent queries structure instead of
+> re-deriving it. The part I care about is the framework edges: it knows
+> `Inertia::render('Users/Show')` connects PHP to Vue, that `@Injectable()` is a
+> DI edge, that `$user->posts()` implies a table from a migration. 87 framework
+> integrations, so `get_change_impact` crosses language boundaries instead of
+> stopping at the import graph.
+>
+> Across a session I measure 40–50% fewer tokens on mixed work. Individual
+> structured calls — impact analysis, call graphs, type hierarchy — go far higher,
+> but that is a per-call peak and I have stopped quoting it as if it were the
+> average.
+>
+> Runs entirely locally. No API keys, no cloud, MIT. `npx trace-mcp benchmark .`
+> prints the per-task numbers against your own repo in about five minutes, which
+> is a better argument than anything I can write here.
+
+## First comment — post it yourself, immediately
+
+HN treats a maintainer who names the limits first as credible and one who waits
+to be caught as not. This is the whole reason the thread is worth having.
+
+> Three things worth knowing before you try it:
+>
+> The headline benchmark is a **synthetic estimate**, not measured savings. The
+> "without" side is computed from file sizes in the index and the "with" side from
+> per-scenario multipliers — it shows a ceiling. For real numbers from your own
+> usage there is `trace-mcp analytics savings`, which reads what your sessions
+> actually did.
+>
+> It is an index, not a compiler. Edges carry a resolution tier
+> (`scip_resolved` > `lsp_resolved` > `ast_resolved` > `ast_inferred` >
+> `text_matched`), and the bottom tier is a heuristic. LSP enrichment and SCIP
+> ingestion are both opt-in and off by default.
+>
+> If you only want to stuff a repo into one prompt, Repomix is the better tool and
+> I say so on the comparison page. trace-mcp earns its keep when the agent needs to
+> *look things up* repeatedly.
+
+## The five questions the thread will actually ask
+
+Each answer must be checkable in one click. Do not improvise these.
+
+1. **"How is this different from Serena / codebase-memory-mcp / Repomix?"** →
+   `trace-mcp.com/comparisons.html` plus the three head-to-head pages. Never
+   disparage a competitor from memory; the comparison pages are written to survive
+   the maintainer of the other project reading them, which on HN they will.
+2. **"40–50% of what, measured how?"** → the README's "Token reduction" section
+   and `npx trace-mcp benchmark .`. Say plainly that mixed real-world workloads
+   land 30–60% depending on stack.
+3. **"Why not just use the LSP?"** → we do, optionally, as an enrichment pass. The
+   graph exists so an answer costs one call instead of a live query per edge, and
+   so cross-language framework edges exist at all — no LSP knows that an Inertia
+   string maps to a Vue component.
+4. **"Does it phone home?"** → local-first, no API keys. There is one anonymous
+   daily ping, documented in the README's "Usage telemetry" section, and it is
+   off with `TRACE_MCP_TELEMETRY=off` (`src/telemetry/usage-ping.ts`). Do not
+   point at `docs/telemetry.md` — that page is the OTLP observability bridge, a
+   different feature that is disabled by default. Answer this one in full,
+   immediately, every time it is asked.
+5. **"169 tools?! That is context bloat."** → a fair hit. Tools register per
+   detected framework, presets exist, and the schema budget has a regression test
+   (TRA-186). Do not get defensive: the honest line is that the surface is large
+   and shrinking it is active work.
+
+## What not to do
+
+- No "we" if it is one person and an agent fleet. HN can smell it.
+- Do not seed upvotes or post the link in Slack groups for a boost — HN detects
+  voting rings and the penalty is permanent.
+- Do not post a second time if the first sinks. A Show HN that flops is allowed
+  one repost months later, with a materially different product behind it.
+- Reddit (r/ClaudeAI and neighbours) is a **separate** draft with a different
+  voice — do not cross-post this text verbatim. That draft does not exist yet.


### PR DESCRIPTION
The distribution ledger now says every directory we are absent from is blocked on a browser login, a payment, a Dockerfile, or a human attestation. The one channel left that is blocked only on a *decision* is the one nobody has written material for — so here it is.

`ops/launch-hn.md`:
- title and body, ready to paste;
- the caveats comment to post **immediately after**, in the maintainer's own voice — the benchmark is a synthetic ceiling, the bottom resolution tier is a heuristic, and Repomix is the better tool if you only want a repo in one prompt;
- grounded answers to the five questions the thread will actually ask, each resolvable in one click;
- when to post, and what not to do (no vote seeding, no reposting a flop, no cross-posting this text to Reddit).

**Nobody but Nikolai posts it.** That is stated at the top of the file — an agent may draft and revise, but publishing under the project's name is irreversible in a way a directory listing isn't.

Every factual claim was checked against the repo rather than written from memory:
- 81 languages / 87 frameworks / 169 tools from `docs/_data/counts.yml`;
- the resolution ladder is five tiers including `scip_resolved` — `CLAUDE.md` lists only four, `docs/comparisons.md:133` has the full one;
- the telemetry answer points at the README's "Usage telemetry" section and `TRACE_MCP_TELEMETRY=off`, **not** `docs/telemetry.md` — that page is the OTLP observability bridge, a different feature. Getting those two confused in a live HN thread is exactly the kind of error that costs the thread.

Also adds one line to `ops/distribution.md` explaining why community channels aren't rows in its table and pointing at this file.

Docs only.

Agent: SEO Agent