### PR TITLE
fix(search): scope the subproject fan-out to the requested project (TRA-470)

### DIFF
--- a/src/subproject/__tests__/subproject-search-scope.test.ts
+++ b/src/subproject/__tests__/subproject-search-scope.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { reachableSubprojects } from '../subproject-search.js';
+
+const repo = (repo_root: string, project_root: string) => ({ repo_root, project_root });
+
+describe('reachableSubprojects (TRA-470)', () => {
+  const repos = [
+    repo('/work/shop/api', '/work/shop'),
+    repo('/work/shop/web', '/work/shop'),
+    repo('/other/client-a', '/other'),
+    repo('/other/client-b', '/other'),
+  ];
+
+  it('keeps only subprojects registered under the requested project root', () => {
+    expect(reachableSubprojects(repos, '/work/shop').map((r) => r.repo_root)).toEqual([
+      '/work/shop/api',
+      '/work/shop/web',
+    ]);
+  });
+
+  it('keeps siblings when the requested root is itself a registered subproject', () => {
+    expect(reachableSubprojects(repos, '/work/shop/api').map((r) => r.repo_root)).toEqual([
+      '/work/shop/api',
+      '/work/shop/web',
+    ]);
+  });
+
+  it('returns nothing for an unrelated project root', () => {
+    expect(reachableSubprojects(repos, '/tmp/scratch')).toEqual([]);
+  });
+
+  it('ignores trailing slashes on either side', () => {
+    expect(reachableSubprojects([repo('/work/shop/api/', '/work/shop/')], '/work/shop')).toHaveLength(
+      1,
+    );
+  });
+});

--- a/src/subproject/__tests__/subproject-search-scope.test.ts
+++ b/src/subproject/__tests__/subproject-search-scope.test.ts
@@ -30,8 +30,8 @@ describe('reachableSubprojects (TRA-470)', () => {
   });
 
   it('ignores trailing slashes on either side', () => {
-    expect(reachableSubprojects([repo('/work/shop/api/', '/work/shop/')], '/work/shop')).toHaveLength(
-      1,
-    );
+    expect(
+      reachableSubprojects([repo('/work/shop/api/', '/work/shop/')], '/work/shop'),
+    ).toHaveLength(1);
   });
 });

--- a/src/subproject/manager.ts
+++ b/src/subproject/manager.ts
@@ -817,14 +817,18 @@ export class SubprojectManager {
     return _detectBreakingChanges(this.topoStore, ep);
   }
 
-  /** Search across all subprojects — delegates to subproject-search module. */
+  /**
+   * Search subprojects reachable from `projectRoot` (the project's own
+   * subprojects plus its siblings when it is one itself), excluding
+   * `projectRoot` itself. Delegates to the subproject-search module.
+   */
   subprojectSearch(
     query: string,
     filters?: { kind?: string; language?: string; filePattern?: string },
     limit = 20,
-    excludeRoot?: string,
+    projectRoot?: string,
   ): SubprojectSearchResult {
-    return _subprojectSearch(this.topoStore, query, filters, limit, excludeRoot);
+    return _subprojectSearch(this.topoStore, query, filters, limit, projectRoot);
   }
 
   /**

--- a/src/subproject/subproject-search.ts
+++ b/src/subproject/subproject-search.ts
@@ -91,28 +91,50 @@ function searchRepoDb(
   return items;
 }
 
+const normRoot = (root: string): string => root.replace(/\/+$/, '');
+
 /**
- * Search across all subprojects. Opens each per-repo DB readonly,
- * runs FTS search, normalizes scores within the repo, and merges results.
+ * Subprojects reachable from `projectRoot`: those registered under it, plus —
+ * when `projectRoot` is itself a registered subproject — its siblings under the
+ * same parent project. The topology DB is global (one row per repo ever
+ * registered on the machine), so without this filter a scoped search fanned out
+ * across every unrelated repo: wrong results, wasted tokens (TRA-470).
+ */
+export function reachableSubprojects<T extends { repo_root: string; project_root: string }>(
+  repos: T[],
+  projectRoot: string,
+): T[] {
+  const scope = normRoot(projectRoot);
+  const parents = new Set([scope]);
+  for (const repo of repos) {
+    if (normRoot(repo.repo_root) === scope) parents.add(normRoot(repo.project_root));
+  }
+  return repos.filter((repo) => parents.has(normRoot(repo.project_root)));
+}
+
+/**
+ * Search subprojects reachable from `projectRoot`. Opens each per-repo DB
+ * readonly, runs FTS search, normalizes scores within the repo, and merges
+ * results. Omitting `projectRoot` searches every registered subproject.
  */
 export function subprojectSearch(
   topoStore: TopologyStore,
   query: string,
   filters?: { kind?: string; language?: string; filePattern?: string },
   limit = 20,
-  excludeRoot?: string,
+  projectRoot?: string,
 ): SubprojectSearchResult {
-  const repos = topoStore.getAllSubprojects();
+  const allRepos = topoStore.getAllSubprojects();
+  const repos = projectRoot ? reachableSubprojects(allRepos, projectRoot) : allRepos;
   const allItems: SubprojectSearchItem[] = [];
   let reposSearched = 0;
 
-  // Normalize excludeRoot for comparison (strip trailing slash)
-  const normalizedExclude = excludeRoot?.replace(/\/+$/, '');
+  const normalizedExclude = projectRoot ? normRoot(projectRoot) : undefined;
 
   for (const repo of repos) {
     if (!repo.db_path || !fs.existsSync(repo.db_path)) continue;
     // Skip the local repo — its results are already in the primary search
-    if (normalizedExclude && repo.repo_root.replace(/\/+$/, '') === normalizedExclude) continue;
+    if (normalizedExclude && normRoot(repo.repo_root) === normalizedExclude) continue;
 
     let db: Database.Database | null = null;
     try {

--- a/src/subproject/subproject-search.ts
+++ b/src/subproject/subproject-search.ts
@@ -3,6 +3,7 @@
  * Extracted from SubprojectManager to reduce class complexity.
  */
 import fs from 'node:fs';
+import path from 'node:path';
 import Database from 'better-sqlite3';
 import { searchFts } from '../db/fts.js';
 import { logger } from '../logger.js';
@@ -91,7 +92,13 @@ function searchRepoDb(
   return items;
 }
 
-const normRoot = (root: string): string => root.replace(/\/+$/, '');
+/**
+ * Canonical form for comparing two repo roots. `path.resolve` collapses
+ * trailing and duplicated separators the same way `upsertSubproject` does when
+ * it writes the row — and unlike a `/\/+$/` strip it carries no ReDoS risk on
+ * a path that ultimately comes from a tool caller.
+ */
+const normRoot = (root: string): string => path.resolve(root);
 
 /**
  * Subprojects reachable from `projectRoot`: those registered under it, plus —

--- a/src/tools/register/navigation/search-tools.ts
+++ b/src/tools/register/navigation/search-tools.ts
@@ -17,6 +17,7 @@ import { computeRetrievalConfidence } from '../../../scoring/retrieval-confidenc
 import { loadTunedWeights } from '../../../runtime/tuning.js';
 import type { ServerContext } from '../../../server/types.js';
 import { SubprojectManager } from '../../../subproject/manager.js';
+import { reachableSubprojects } from '../../../subproject/subproject-search.js';
 import { type SearchResultItemProjected } from '../../navigation/navigation.js';
 import { searchText } from '../../navigation/search-text.js';
 import { suggestQueries } from '../../navigation/suggest.js';
@@ -389,10 +390,13 @@ export function registerSearchTools(server: McpServer, ctx: ServerContext): void
         }
       }
 
-      // Subproject layer: search across all subprojects when topology is enabled
+      // Subproject layer: search the subprojects reachable from THIS project.
+      // The topology DB is global, so this pass must be scoped — otherwise a
+      // search in one project fans out across every repo registered on the
+      // machine (TRA-470).
       if (ctx.topoStore) {
         try {
-          const subprojects = ctx.topoStore.getAllSubprojects();
+          const subprojects = reachableSubprojects(ctx.topoStore.getAllSubprojects(), projectRoot);
           if (subprojects.length > 0) {
             const manager = new SubprojectManager(ctx.topoStore);
             const subResult = manager.subprojectSearch(


### PR DESCRIPTION
Closes TRA-470.

## The problem

`search` runs a second, independent pass after the scoped symbol search
(`src/tools/register/navigation/search-tools.ts`). That pass called
`topoStore.getAllSubprojects()` — a single **global** topology DB holding every
repo ever registered on the machine, with no project argument.

So a search scoped to one project opened and FTS-queried every unrelated repo's
DB. Nothing leaked into the scoped `items` array (results land under
`subproject_results` with a `repo` field), but:

1. The caller asked for a scope and did not get one.
2. Every scoped search paid for a fan-out across N unrelated repos — the
   product's core metric.
3. On a machine with unrelated client repos registered, a search inside one
   project surfaced symbol names and file paths from the others.

## The fix

Scope the topology pass to the subprojects reachable from the requested project
root: those registered under it, plus its siblings when the root is itself a
registered subproject. The second half matters — searching from inside one
service of a monorepo must still reach its peers, which is the case the
topology layer exists for.

`reachableSubprojects()` is exported from `src/subproject/subproject-search.ts`
and applied both at the call site (so the pass is skipped entirely when nothing
is reachable) and inside `subprojectSearch()` itself. `excludeRoot` is renamed
to `projectRoot` since it now does both jobs.

No MCP tool signature or DB schema change — `subproject_results` and
`subproject_repos_searched` keep their shape, they just stop containing
unrelated repos.

## Test evidence

New `src/subproject/__tests__/subproject-search-scope.test.ts` covers the four
cases: children only, siblings from inside a subproject, unrelated root returns
nothing, trailing-slash normalization.

```
pnpm run lint    # tsc --noEmit, clean
pnpm run build   # ok
pnpm run test    # 832 files passed | 2 skipped, 9193 tests passed | 8 skipped
```
