### PR TITLE
fix(app): the KPI strip stops arguing with the banner above it (TRA-488)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -530,8 +530,9 @@ Every data surface owes four states, and each has a house form:
   tall, 20px glyph, 13px title). An empty section is not a hero.
 - **Error** — the chrome stays put; the sentence and its Retry action sit together.
   Each section tracks its own load state. A failed fetch must not pulse a skeleton
-  forever promising data that is never coming — settle on an em dash and
-  "Couldn't be measured". A fetch only *fails* if it can: every request to the
+  forever promising data that is never coming — settle on an em dash, and leave the
+  sentence to the surface that knows why (see the next section). A fetch only
+  *fails* if it can: every request to the
   daemon carries `AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS)`, because a wedged
   daemon still holds its port open and a connect that never completes leaves the
   loading state with nothing to leave it (TRA-478).
@@ -589,10 +590,23 @@ dead end.
 
 **Values that were true a minute ago outrank no values at all.** A refresh that fails must
 leave the last good ones on screen, cache them across launches, and say once — above them,
-where they are read before the numbers are — that they are the last indexed ones. Em dashes
-and "Couldn't be measured" are for a number nobody has ever had, not for one that is a few
-minutes old. The corollary: that line has to match the screen. Saying "these are the last
-indexed numbers" over a row of em dashes is the same lie in the other direction.
+where they are read before the numbers are — that they are the last indexed ones. An em dash
+is for a number nobody has ever had, not for one that is a few minutes old. The corollary:
+that line has to match the screen. Saying "these are the last indexed numbers" over a row of
+em dashes is the same lie in the other direction.
+
+**The placeholder is the whole statement. A card with no number explains nothing.**
+The em dash *is* the sentence "we don't have this" — give it an accessible name
+(`aria-label="Not available"`) and stop. The comparison slot underneath answers
+"compared to what?", and a failure message is not a comparison; putting one there
+multiplies the diagnosis by the number of cards on the strip. Six KPI tiles each
+captioned "Couldn't be measured" said it four times *under a banner promising the
+numbers were on their way*, and six times *over a pane already headed "The daemon
+isn't running"* — the two states in which the caption could appear at all (TRA-488).
+This is the same rule as the paragraph above, applied one level down: the surface
+holding the daemon state says it; the cards inside it go quiet. A tooltip repeating
+the sentence when the tile is too short for a caption is the same defect with a
+smaller audience.
 
 ---
 
@@ -1299,7 +1313,8 @@ new evidence.
 | Cards are opaque with a hairline, no shadow, no glass | Cards are content. The active KPI tile painted on accent measured 3.28:1 and pushed its footnote to 4.45:1. |
 | `.lx-btn.is-status:disabled` keeps full opacity | A disabled button whose label is the status readout is information, not an inert control; dimming put it at 2.3:1. |
 | Skeletons at final geometry instead of spinners or "Loading…" | Nothing shifts when the data lands, and the loading state shows the shape of what is coming. |
-| A failed fetch settles on an em dash + "Couldn't be measured" | A skeleton that pulses forever promises data that is never coming. |
+| A failed fetch settles on an em dash | A skeleton that pulses forever promises data that is never coming. |
+| The em dash is the whole statement — no caption, no tooltip repeating it (TRA-488) | The tile's caption slot is a comparison line, and a failure sentence there is multiplied by the number of cards: six tiles said "Couldn't be measured" under a banner promising the numbers were on their way, and over a pane already headed "The daemon isn't running". |
 | `listPending` separates "daemon hasn't answered" from "never indexed" | `status ?? 'unknown'` blamed the project for the daemon's silence. |
 | Sidebar footer is `.ws-sb-row`, not its own geometry | One row system for the whole sidebar; the footer's labels started 26px left of every other label. |
 | Appearance is Auto / Light / Dark, with Auto clearing the key | The old `toggle` only ever wrote `light` or `dark`, so one click pinned the app forever and the system listener stopped mattering. |

--- a/packages/app/src/renderer/workspace/__tests__/Workspace.degraded.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/Workspace.degraded.test.tsx
@@ -110,7 +110,10 @@ describe('a slow daemon', () => {
     // …and the line above them must not claim otherwise.
     expect(banners()[0]).toContain("The numbers arrive when it's done.");
     expect(kpi('Files')).toBe('—');
-    expect(screen.getAllByText("Couldn't be measured").length).toBeGreaterThan(0);
+    /* The banner owns the sentence. Four tiles each captioned "Couldn't be
+       measured" under a banner promising the numbers are on their way said the
+       opposite thing four times in the same 200px (TRA-488). */
+    expect(screen.queryByText("Couldn't be measured")).toBeNull();
   });
 
   it('offers the retry that matches, and never a restart', () => {
@@ -131,6 +134,26 @@ describe('an unreachable daemon', () => {
     expect(screen.getByText("The daemon isn't running")).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Start daemon' })).toBeTruthy();
     expect(banners()).toHaveLength(0);
+  });
+
+  /* …nor six more sentences in the strip above it. The KPI tiles stay on screen
+     when DaemonDownPane takes the pane, and each used to caption its em dash
+     "Couldn't be measured" — one dead daemon, announced seven times in one
+     window (TRA-488, the defect TRA-469 fixed on Project Overview). */
+  it('leaves the sentence to the pane and keeps the tiles to em dashes', () => {
+    data = {
+      ...OK,
+      projects: [],
+      metricsLoading: true,
+      errorKind: 'offline',
+      daemonState: 'unreachable',
+      connected: false,
+    };
+    render(<Workspace />);
+
+    expect(screen.getByText("The daemon isn't running")).toBeTruthy();
+    expect(kpi('Files')).toBe('—');
+    expect(screen.queryByText("Couldn't be measured")).toBeNull();
   });
 });
 

--- a/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
@@ -108,7 +108,11 @@ describe('WorkspaceHeader KPI strip', () => {
       // finished and failed, so it must settle on an em dash instead.
       expect(kpiTile(label).querySelector('.ws-skel')).toBeNull();
       expect(kpiValue(label)).toBe('—');
-      expect(kpiTile(label).textContent).toContain("Couldn't be measured");
+      // The em dash is the whole statement. The caption slot is for a
+      // comparison, and four cards repeating one failure sentence is not one
+      // — the banner or the daemon-down pane says it, once (TRA-488).
+      expect(kpiTile(label).textContent).not.toContain("Couldn't be measured");
+      expect(kpiTile(label).querySelector('[aria-label="Not available"]')).not.toBeNull();
     }
   });
 
@@ -259,11 +263,15 @@ describe('WorkspaceHeader at a pane that cannot afford the full layout', () => {
     }
   });
 
-  it('keeps "couldn\'t be measured" reachable when dense drops the caption', () => {
+  it('says "unknown" once when dense, on the em dash itself', () => {
     renderHeader(true, { dense: true, metricsFailed: true });
     const tile = kpiTile('Files');
     expect(kpiValue('Files')).toBe('—');
-    expect(tile.getAttribute('title')).toBe("Couldn't be measured");
+    // The dense tile carried a `title` tooltip repeating the failure sentence,
+    // which is the same sentence the banner above it already holds. The em
+    // dash's own accessible name is what a reader needs here (TRA-488).
+    expect(tile.getAttribute('title')).toBeNull();
+    expect(tile.querySelector('[aria-label="Not available"]')).not.toBeNull();
   });
 
   it('hides the view toggle when Compact is the only view that fits', () => {

--- a/packages/app/src/renderer/workspace/components/KpiTile.tsx
+++ b/packages/app/src/renderer/workspace/components/KpiTile.tsx
@@ -111,9 +111,6 @@ export function KpiTile({
   const shell = {
     'data-kpi': label,
     'data-dense': dense ? '' : undefined,
-    // Dense drops the comparison line, so the one sentence that explains an
-    // em dash has to survive somewhere the user can still reach it.
-    title: dense && unavailable ? t('kpiUnavailable') : undefined,
     className: dense
       ? 'flex flex-row items-baseline justify-between gap-2 text-left transition-colors'
       : 'flex flex-col items-start gap-1 text-left transition-colors',
@@ -197,12 +194,23 @@ export function KpiTile({
         >
           {/* `unavailable` outranks `pending`: a fetch that finished and failed
               is not still loading, so the skeleton must not win when both are
-              set. */}
+              set. And an unavailable tile says nothing here at all — the em
+              dash above already reads as "unknown" and carries that as its
+              accessible name, while this slot is for a comparison and a failure
+              sentence is not one.
+
+              Whenever a tile is unavailable, a surface that knows WHY is
+              already on screen: the busy banner above the strip, or
+              DaemonDownPane in the pane below. (`unavailable` is only reached
+              through `metricsFailed`/`listFailed`, and both imply a non-`ok`
+              daemonState — see `deriveDaemonState`.) Captioning each tile
+              "Couldn't be measured" put four of those under a banner promising
+              the numbers were on their way, and six over a pane already headed
+              "The daemon isn't running" (TRA-488). One condition, one sentence
+              — the rule TRA-469 and TRA-471 settled for the other surfaces. */}
           {pending && !unavailable ? (
             <Skeleton width={92} height={11} />
-          ) : unavailable ? (
-            t('kpiUnavailable')
-          ) : delta !== null ? (
+          ) : unavailable ? null : delta !== null ? (
             <DeltaChip delta={delta} caption={deltaCaption} />
           ) : (
             footnote

--- a/packages/app/src/shared/i18n/catalog/de/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/de/workspace.ts
@@ -70,7 +70,6 @@ export const workspace = {
   kpiNoChange: 'Keine Änderung',
   kpiNoChangeVs: 'Keine Änderung {{caption}}',
   kpiNotAvailable: 'Nicht verfügbar',
-  kpiUnavailable: 'Konnte nicht gemessen werden',
 
   // ── Table ───────────────────────────────────────────────────────────────
   projectsGrid: 'Projekte',

--- a/packages/app/src/shared/i18n/catalog/en/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/en/workspace.ts
@@ -87,7 +87,6 @@ export const workspace = {
   kpiNoChange: 'No change',
   kpiNoChangeVs: 'No change {{caption}}',
   kpiNotAvailable: 'Not available',
-  kpiUnavailable: "Couldn't be measured",
 
   // ── Table ───────────────────────────────────────────────────────────────
   projectsGrid: 'Projects',

--- a/packages/app/src/shared/i18n/catalog/es/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/es/workspace.ts
@@ -69,7 +69,6 @@ export const workspace = {
   kpiNoChange: 'Sin cambios',
   kpiNoChangeVs: 'Sin cambios {{caption}}',
   kpiNotAvailable: 'No disponible',
-  kpiUnavailable: 'No se pudo medir',
 
   projectsGrid: 'Proyectos',
   loadingProjects: 'Cargando los proyectos',

--- a/packages/app/src/shared/i18n/catalog/fr/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/fr/workspace.ts
@@ -71,7 +71,6 @@ export const workspace = {
   kpiNoChange: 'Aucun changement',
   kpiNoChangeVs: 'Aucun changement {{caption}}',
   kpiNotAvailable: 'Indisponible',
-  kpiUnavailable: 'Impossible à mesurer',
 
   projectsGrid: 'Projets',
   loadingProjects: 'Chargement des projets',

--- a/packages/app/src/shared/i18n/catalog/hi/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/hi/workspace.ts
@@ -66,7 +66,6 @@ export const workspace = {
   kpiNoChange: 'कोई बदलाव नहीं',
   kpiNoChangeVs: 'कोई बदलाव नहीं {{caption}}',
   kpiNotAvailable: 'उपलब्ध नहीं',
-  kpiUnavailable: 'माप नहीं सके',
 
   projectsGrid: 'प्रोजेक्ट',
   loadingProjects: 'प्रोजेक्ट लोड हो रहे हैं',

--- a/packages/app/src/shared/i18n/catalog/ja/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/ja/workspace.ts
@@ -61,7 +61,6 @@ export const workspace = {
   kpiNoChange: '変化なし',
   kpiNoChangeVs: '変化なし（{{caption}}）',
   kpiNotAvailable: '利用できません',
-  kpiUnavailable: '計測できませんでした',
 
   projectsGrid: 'プロジェクト',
   loadingProjects: 'プロジェクトを読み込み中',

--- a/packages/app/src/shared/i18n/catalog/ko/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/ko/workspace.ts
@@ -61,7 +61,6 @@ export const workspace = {
   kpiNoChange: '변화 없음',
   kpiNoChangeVs: '{{caption}} 변화 없음',
   kpiNotAvailable: '해당 없음',
-  kpiUnavailable: '측정할 수 없음',
 
   projectsGrid: '프로젝트',
   loadingProjects: '프로젝트 불러오는 중',

--- a/packages/app/src/shared/i18n/catalog/pt-BR/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/pt-BR/workspace.ts
@@ -71,7 +71,6 @@ export const workspace = {
   kpiNoChange: 'Sem mudança',
   kpiNoChangeVs: 'Sem mudança {{caption}}',
   kpiNotAvailable: 'Indisponível',
-  kpiUnavailable: 'Não foi possível medir',
 
   projectsGrid: 'Projetos',
   loadingProjects: 'Carregando projetos',

--- a/packages/app/src/shared/i18n/catalog/ru/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/workspace.ts
@@ -83,7 +83,6 @@ export const workspace = {
   kpiNoChange: 'Без изменений',
   kpiNoChangeVs: 'Без изменений {{caption}}',
   kpiNotAvailable: 'Нет данных',
-  kpiUnavailable: 'Не удалось измерить',
 
   projectsGrid: 'Проекты',
   loadingProjects: 'Загрузка проектов',

--- a/packages/app/src/shared/i18n/catalog/zh/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/workspace.ts
@@ -60,7 +60,6 @@ export const workspace = {
   kpiNoChange: '无变化',
   kpiNoChangeVs: '无变化，{{caption}}',
   kpiNotAvailable: '不可用',
-  kpiUnavailable: '无法测量',
 
   projectsGrid: '项目',
   loadingProjects: '正在加载项目',


### PR DESCRIPTION
Closes TRA-488.

## The defect

Every KPI tile whose fetch failed captioned its em dash **"Couldn't be measured"**.
There are exactly two states in which that caption can reach the screen, and in
both of them another surface on the same screen is already saying what happened —
better, and with the action attached.

**1. The daemon is busy.** Read off the running Electron window:

```
Indexing 4 of 8 projects. The numbers arrive when it's done.   [Try again]
Projects           8   tracking from today
Files              —   Couldn't be measured
Symbols            —   Couldn't be measured
Healthy            —   Couldn't be measured
Needs attention    —   Couldn't be measured
```

The banner and the four cards 16px below it describe the same four numbers at the
same instant and disagree about them. The banner is future tense and transient —
*the numbers arrive when it's done*. The caption is past tense and terminal.

Not a race, guaranteed by construction: `metricsFailed` is
`metricsLoading && errorKind !== null` (`Workspace.tsx:366`), and the `haveNumbers`
that picks the banner's wording is `!metricsLoading` (`:338`). So the caption
*implies* the "numbers arrive when it's done" branch of `busyMessage`.

**2. The daemon is not running.** `DaemonDownPane` holds the pane — "The daemon
isn't running" with a **Start daemon** button — and the strip above it repeats the
caption six more times. One dead daemon, announced seven times in one window. That
is the defect TRA-469 fixed on Project Overview, surviving on Workspace because
the strip has its own state.

## The fix

An `unavailable` tile renders the em dash and nothing else.

`DESIGN.md` gives the tile three slots — label, value, **comparison**. The
comparison answers "compared to what?"; a failure message is not a comparison, and
putting one there multiplies the diagnosis by the number of cards on the strip. The
em dash is already the whole statement and already carries it to assistive
technology (`aria-label="Not available"` on the value). The dense tile had the same
problem with a smaller audience — it moved the sentence into a `title` tooltip —
and that goes too.

`workspace:kpiUnavailable` is now dead and is deleted from all ten catalogues.
`kpiNotAvailable` stays: it is the dash's accessible name and the one place this
belongs.

## Geometry is untouched

The reserved 26px caption box stays, so `kpiStripHeight()`, `isDensePane()` and
every tile dimension are unchanged in every language. Measured on the running
window at the 640x420 minimum, the six dense tiles are still 186x37 with no
`title` attribute; at full width the table header sits at the same y before and
after.

## Verified

Electron window (`packages/app/scripts/electron-cdp.mjs`, CDP-driven, window never
shown), both appearances, before and after; plus the CDP sweep at the window
minimum. 514 app tests pass; `typecheck` and `check:i18n` clean.

Three regression pins, one per state: the busy banner is now the only sentence,
the daemon-down pane is now the only sentence, and the dense tile carries no
tooltip repeating either. The rule is written into `DESIGN.md` §5 in the same
commit, generalised — the surface holding the daemon state says it once, the cards
inside it go quiet.

Agent: Design/UX Agent
