### PR TITLE
docs: add the scip_resolved tier to the stale resolution-tier tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ Other tools are NOT TOON-enabled — they regressed in measurements (heterogeneo
   - `src/lsp/mappers.ts` — symbol ↔ LSP position mapping
   - `src/lsp/config.ts` — auto-detection of available servers (tsserver, pyright, gopls, rust-analyzer)
   - `src/lsp/protocol.ts` — hand-written LSP type definitions (zero external deps)
-- Edges have a `resolution_tier` column (a field value, not a tool) with possible values ranked `lsp_resolved` > `ast_resolved` > `ast_inferred` > `text_matched`
+- Edges have a `resolution_tier` column (a field value, not a tool) with possible values ranked `scip_resolved` > `lsp_resolved` > `ast_resolved` > `ast_inferred` > `text_matched`
 - Config schema: `lsp` section in `TraceMcpConfigSchema` (`src/config.ts`)
 
 ## Workflow Checklists — MANDATORY

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -518,7 +518,8 @@ Every edge in the call graph carries a `resolution_tier` indicating how it was r
 
 | Tier | Source | Confidence |
 |---|---|---|
-| `lsp_resolved` | LSP call hierarchy | Compiler-grade (highest) |
+| `scip_resolved` | Offline SCIP index ingestion (opt-in) | Compiler-grade (highest) |
+| `lsp_resolved` | LSP call hierarchy | Compiler-grade |
 | `ast_resolved` | Tree-sitter + module resolution | Static AST (default) |
 | `ast_inferred` | Heuristic inference from imports | Medium |
 | `text_matched` | Name/text similarity matching | Lowest |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -892,7 +892,8 @@ Every edge in the call graph carries a `resolution_tier` indicating how it was r
 
 | Tier | Source | Confidence |
 |---|---|---|
-| `lsp_resolved` | LSP call hierarchy | Compiler-grade (highest) |
+| `scip_resolved` | Offline SCIP index ingestion (opt-in) | Compiler-grade (highest) |
+| `lsp_resolved` | LSP call hierarchy | Compiler-grade |
 | `ast_resolved` | Tree-sitter + module resolution | Static AST (default) |
 | `ast_inferred` | Heuristic inference from imports | Medium |
 | `text_matched` | Name/text similarity matching | Lowest |


### PR DESCRIPTION
`EdgeResolution` (`src/plugin-api/types.ts:63`) and `CONFIDENCE_BY_TIER` (`src/db/confidence.ts:35`) have five tiers; `CLAUDE.md`, `docs/configuration.md` and `docs/llms-full.txt` still documented four, omitting `scip_resolved`.

Found while fact-checking the Show HN draft in #625 — the draft quoted the five-tier ladder from `docs/comparisons.md` and it looked wrong against `CLAUDE.md`. The draft was right; these three pages were stale.

Docs only, no code change.

Agent: Lead Engineer