### PR TITLE
fix(app): shorten the Russian KPI delta caption to one line (TRA-464)

### DIFF
--- a/packages/app/src/shared/i18n/__tests__/catalog-parity.test.ts
+++ b/packages/app/src/shared/i18n/__tests__/catalog-parity.test.ts
@@ -62,6 +62,24 @@ describe('translation catalogues', () => {
     });
   }
 
+  /* `kpiDeltaCaption` shares one 26px, two-line box with the arrow and the
+     value ("↑+105.6k ") and with whatever `relativeTime` returns ("59 минут
+     назад"), in a tile 145–225px wide. Only the wording around `{{when}}` is
+     ours to spend, and Russian spent 16 characters of it on "по сравнению с: "
+     — four lines of caption under a one-line number, and a 138px tile where
+     `TILE_H` says 112 (TRA-464).
+
+     ponytail: a character budget, not a rendered measurement — jsdom cannot
+     wrap text. Measured on the running Electron window at 1280×800, where the
+     tile is 158px: 22 characters of caption fit two lines, 38 need three. */
+  it('keeps the KPI delta caption short enough for two lines', () => {
+    for (const [code, catalog] of Object.entries(CATALOGS)) {
+      const affix = catalog.workspace.kpiDeltaCaption.replace('{{when}}', '');
+      const label = `${code}/workspace:kpiDeltaCaption ${JSON.stringify(affix)}`;
+      expect([...affix].length, label).toBeLessThanOrEqual(14);
+    }
+  });
+
   it('leaves no string empty', () => {
     for (const [code, catalog] of Object.entries(CATALOGS)) {
       for (const [ns, strings] of Object.entries(catalog)) {

--- a/packages/app/src/shared/i18n/catalog/ru/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/workspace.ts
@@ -79,7 +79,12 @@ export const workspace = {
   kpiShare_few: '{{percent}}% из {{total}} проектов',
   kpiShare_many: '{{percent}}% из {{total}} проектов',
   kpiShare_other: '{{percent}}% из {{total}} проектов',
-  kpiDeltaCaption: 'по сравнению с: {{when}}',
+  /* Bare timestamp, no preposition: `{{when}}` is already a full clause
+     ("9 минут назад"), and every Russian way of prefixing it — "по сравнению
+     с: 9 минут назад" — is 16 characters that wrapped the caption to four
+     lines in a 158px tile and pushed the card past TILE_H (TRA-464). The
+     arrow carries the comparison. */
+  kpiDeltaCaption: '{{when}}',
   kpiNoChange: 'Без изменений',
   kpiNoChangeVs: 'Без изменений {{caption}}',
   kpiNotAvailable: 'Нет данных',


### PR DESCRIPTION
Fixes TRA-464.

`kpiDeltaCaption` in the Russian catalogue reads `по сравнению с: {{when}}`, and
`{{when}}` is already a complete clause — `relativeTime` gives `9 минут назад`.
With the arrow and the value in front of it that is 38 characters in an 11px,
two-line box that a 158px tile fits 33 characters of. The caption took four
lines, the card measured 138px where `TILE_H` says 112, and `kpiStripHeight()`
under-reported a row by 26px — so `isDensePane()` declined to collapse a strip
that does not fit, which is the class of bug TRA-325 was.

The fix is the one the issue recommends: drop the preposition and let the arrow
carry the comparison, the way the shorter locales already do. One catalogue
string, no code.

## Evidence

Measured on the running Electron window over CDP with
`getBoundingClientRect().height` — not eyeballed, not from the diff. All ten
locales, seeded metrics, both required window sizes plus the width where the
overflow actually bites:

| Window | Tile width | Before | After |
|---|---|---|---|
| 960×700 | 225px | every locale 112 | every locale 112 |
| 1440×900 | 185px | every locale 112 | every locale 112 |
| 1280×800 | 158px | **ru 138**, en 112 | **ru 112**, en 112 |

Russian caption before: `↑+105.6k по сравнению с: 9 минут назад`.
After: `↑+105.6k 9 минут назад`.

`packages/app`: 47 files / 514 tests pass, `tsc --noEmit` clean, `check-i18n`
clean.

## The guard

`catalog-parity.test.ts` gains a character budget on the wording around
`{{when}}` (≤14). It is a budget rather than a rendered measurement because
jsdom cannot wrap text; the number comes from the Electron measurement above
(22 characters of caption fit two lines at 158px, 38 need three). Verified to
fail on the old string: `expected 16 to be less than or equal to 14`.

## Out of scope, found while measuring

At 145–158px tiles several locales still exceed `TILE_H` for reasons that are
not the Russian caption: de/es/pt-BR reach 125px because the tile **label**
wraps (`Benötigt Aufmerksamkeit`), and at 145px English reaches 125 because the
delta caption needs three lines on its own. Filed separately rather than folded
in here.
