### PR TITLE
fix(app): an unmeasured KPI tile says it with the em dash alone (TRA-488)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -587,12 +587,26 @@ Its refresh affordance stays, though: a control that re-fetches is the list's ow
 way back when the daemon returns, and hiding it would trade a wrong sentence for a
 dead end.
 
+**The surface says it once; the cards inside it go quiet.** The rule above is about
+sections that each fetch; this one is about the repeating element — a KPI strip, a
+grid of tiles, a row of meters — where the multiplier is the layout itself. Every
+tile in it fails for the same one reason, so a per-tile failure caption is one
+sentence printed once per tile: six of "Couldn't be measured" sat above a
+`DaemonDownPane` that had already said it, with the button (TRA-488). A tile's
+third slot is the **comparison** — it answers "compared to what?" — and a diagnosis
+is not a comparison. The unknown value renders as an em dash and nothing else, with
+its accessible name (`kpiNotAvailable`, "Not available") on the dash itself; the
+caption box stays reserved so the strip's height constant holds in every language.
+A `title` tooltip is not the exception — it is the same sentence again, for fewer
+people.
+
 **Values that were true a minute ago outrank no values at all.** A refresh that fails must
 leave the last good ones on screen, cache them across launches, and say once — above them,
-where they are read before the numbers are — that they are the last indexed ones. Em dashes
-and "Couldn't be measured" are for a number nobody has ever had, not for one that is a few
-minutes old. The corollary: that line has to match the screen. Saying "these are the last
-indexed numbers" over a row of em dashes is the same lie in the other direction.
+where they are read before the numbers are — that they are the last indexed ones. An em dash
+is for a number nobody has ever had, not for one that is a few minutes old. The corollary:
+that line has to match the screen. Saying "these are the last indexed numbers" over a row of
+em dashes is the same lie in the other direction — as is captioning those dashes "couldn't
+be measured", past tense and terminal, under a banner promising the numbers are on their way.
 
 ---
 
@@ -1342,6 +1356,7 @@ new evidence.
 | A settled screenshot is not the only frame; sample the first one and sample repeatedly | TRA-467 verified a width sweep of settled sizes and asserted in a comment that the first frame was unchanged — reasoning from the height math, which was unchanged, while the render had gained a new input. The first painted frame was one 748px tile in a 780px strip, the exact geometry that PR removed, on every launch (#612). TRA-471 then left the sidebar file list stuck in `aria-busy` on 2 of 3 navigations, where a clean reload is one of the clean paths (TRA-478). Verify the property you changed, not the one you reasoned about. |
 | A card grid responds by changing its column count, never its card width | `flex-wrap` + `flex: 1 1 132px` hands the leftover width to whichever cards landed in the last row: at a 1000px window five KPI tiles rendered at 137px and the sixth at 748px, all six carrying the same three lines. A card wider than its neighbour makes a claim the data is not making. Equal `minmax(0, 1fr)` tracks, and a count that **divides** the number of cards so no row is ever short (TRA-467). |
 | A surface whose every section reads one source states its failure once, at surface level | Project Overview said one dead daemon six times — the toolbar chip, Guard's line, and four `SectionError`s each claiming "the daemon may still be indexing" with a Retry aimed at a refusing socket. "Busy" is a wait, "not running" is a button; the app knew which one it was and printed the other four times. `DaemonDownPane` is now shared, and the test for down is `deriveDaemonState()` rather than a fresh `!connected` that would flash on every mount (TRA-469). |
+| The surface says the failure once; the repeating cards inside it go quiet | Every tile in a KPI strip fails for the same one reason, so a per-tile caption is one sentence printed once per tile — six of "Couldn't be measured" above a `DaemonDownPane` that had already said it with the button, and, in the busy state, four more under a banner promising the numbers were on their way (TRA-488). The tile's third slot is the comparison, and a diagnosis is not a comparison. The em dash is the whole statement and already carries "Not available" to assistive technology; the reserved caption box stays so `kpiStripHeight()` holds in every language. A `title` tooltip is the same sentence for fewer people, not an exception. |
 | An empty list and no list are two different facts | A `.catch(() => setFiles([]))` makes a refused socket indistinguishable from a filter that matched nothing, and the empty state then explains a result it never received — the sidebar's file list blamed the scope filter while the pane beside it correctly said the daemon was not running (TRA-471). Keep whether the list was answered; assert a cause only for the empty answer you actually got, render nothing for the one you did not, and leave the re-fetching control in place as the way back. |
 | A request with no deadline has no failure state, so the skeleton wins forever | "Daemon down" is not always a refused socket: a wedged daemon still holds :3741 open, the connect sits in `SYN_SENT`, and `fetch` neither resolves nor rejects. The sidebar's file list was the one daemon fetch in the app without `AbortSignal.timeout` — measured on the running renderer, 2 of 6 navigations left six skeletons pulsing and `aria-busy="true"` set indefinitely, four inches from a pane correctly saying the daemon was not running (TRA-478). Give every request a deadline, and derive the render from the request's own terminal state (`'loading' | 'answered' | 'failed'`), never from a boolean a cancelled run can strand. A fixture that rejects immediately — which is every daemon-down test we had — cannot see this class of bug. |
 | Narrow gives up the comparison, then the table, never the value | The number and the project name are the screen; the footnote and the metric columns are elaboration. Compact already renders a legible row at 420px. |

--- a/packages/app/src/renderer/workspace/__tests__/Workspace.degraded.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/Workspace.degraded.test.tsx
@@ -110,7 +110,11 @@ describe('a slow daemon', () => {
     // …and the line above them must not claim otherwise.
     expect(banners()[0]).toContain("The numbers arrive when it's done.");
     expect(kpi('Files')).toBe('—');
-    expect(screen.getAllByText("Couldn't be measured").length).toBeGreaterThan(0);
+    // The banner is the only thing on screen that explains the em dashes. The
+    // tiles used to caption every one of them "Couldn't be measured" — past
+    // tense and terminal, under a banner that is future tense and transient,
+    // about the same four numbers at the same instant (TRA-488).
+    expect(screen.queryByText("Couldn't be measured")).toBeNull();
   });
 
   it('offers the retry that matches, and never a restart', () => {
@@ -131,6 +135,17 @@ describe('an unreachable daemon', () => {
     expect(screen.getByText("The daemon isn't running")).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Start daemon' })).toBeTruthy();
     expect(banners()).toHaveLength(0);
+  });
+
+  /* One dead daemon used to be announced seven times in one window: the pane
+     said it once with a Start daemon button, and the strip above it repeated
+     "Couldn't be measured" on all six tiles (TRA-488). */
+  it('is not repeated once per tile by the strip above it', () => {
+    data = { ...OK, projects: [], daemonState: 'unreachable', connected: false };
+    render(<Workspace />);
+
+    expect(screen.queryByText("Couldn't be measured")).toBeNull();
+    expect(kpi('Projects')).toBe('—');
   });
 });
 

--- a/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
@@ -30,7 +30,7 @@ function renderHeader(
     filter: WorkspaceFilter;
   }> = {},
 ) {
-  const { container } = render(
+  const result = render(
     <WorkspaceHeader
       kpis={ZERO_KPIS}
       metricsLoading={metricsLoading}
@@ -43,7 +43,8 @@ function renderHeader(
       {...extra}
     />,
   );
-  strip = container;
+  strip = result.container;
+  return result;
 }
 
 /** The KPI tile whose label is `label`. */
@@ -108,7 +109,10 @@ describe('WorkspaceHeader KPI strip', () => {
       // finished and failed, so it must settle on an em dash instead.
       expect(kpiTile(label).querySelector('.ws-skel')).toBeNull();
       expect(kpiValue(label)).toBe('—');
-      expect(kpiTile(label).textContent).toContain("Couldn't be measured");
+      // …and says it once. The em dash is the whole statement: the surface
+      // holding the daemon state already explains it, with the action next to
+      // it, and a per-card caption is that sentence printed six times (TRA-488).
+      expect(kpiTile(label).textContent).toBe(label + '—');
     }
   });
 
@@ -259,11 +263,18 @@ describe('WorkspaceHeader at a pane that cannot afford the full layout', () => {
     }
   });
 
-  it('keeps "couldn\'t be measured" reachable when dense drops the caption', () => {
-    renderHeader(true, { dense: true, metricsFailed: true });
-    const tile = kpiTile('Files');
-    expect(kpiValue('Files')).toBe('—');
-    expect(tile.getAttribute('title')).toBe("Couldn't be measured");
+  it('carries an unmeasured tile with the em dash alone, in either density', () => {
+    // No caption and no `title` tooltip: a tooltip is a second copy of the
+    // diagnosis with a smaller audience, and the diagnosis belongs to the
+    // surface holding the daemon state, not to each card in it (TRA-488).
+    for (const dense of [false, true]) {
+      const { unmount } = renderHeader(true, { dense, metricsFailed: true });
+      const tile = kpiTile('Files');
+      expect(kpiValue('Files')).toBe('—');
+      expect(tile.getAttribute('title')).toBeNull();
+      expect(tile.textContent).toBe('Files—');
+      unmount();
+    }
   });
 
   it('hides the view toggle when Compact is the only view that fits', () => {

--- a/packages/app/src/renderer/workspace/components/KpiTile.tsx
+++ b/packages/app/src/renderer/workspace/components/KpiTile.tsx
@@ -111,9 +111,6 @@ export function KpiTile({
   const shell = {
     'data-kpi': label,
     'data-dense': dense ? '' : undefined,
-    // Dense drops the comparison line, so the one sentence that explains an
-    // em dash has to survive somewhere the user can still reach it.
-    title: dense && unavailable ? t('kpiUnavailable') : undefined,
     className: dense
       ? 'flex flex-row items-baseline justify-between gap-2 text-left transition-colors'
       : 'flex flex-col items-start gap-1 text-left transition-colors',
@@ -197,12 +194,15 @@ export function KpiTile({
         >
           {/* `unavailable` outranks `pending`: a fetch that finished and failed
               is not still loading, so the skeleton must not win when both are
-              set. */}
+              set — and it renders nothing at all. This slot is the comparison,
+              which answers "compared to what?"; a diagnosis is not a comparison,
+              and the surface holding the daemon state already gives it once,
+              with the action attached. Six cards repeating it is six copies of
+              one sentence. The em dash is the whole statement, and it already
+              carries `kpiNotAvailable` to assistive technology. */}
           {pending && !unavailable ? (
             <Skeleton width={92} height={11} />
-          ) : unavailable ? (
-            t('kpiUnavailable')
-          ) : delta !== null ? (
+          ) : unavailable ? null : delta !== null ? (
             <DeltaChip delta={delta} caption={deltaCaption} />
           ) : (
             footnote

--- a/packages/app/src/shared/i18n/catalog/de/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/de/workspace.ts
@@ -70,7 +70,6 @@ export const workspace = {
   kpiNoChange: 'Keine Änderung',
   kpiNoChangeVs: 'Keine Änderung {{caption}}',
   kpiNotAvailable: 'Nicht verfügbar',
-  kpiUnavailable: 'Konnte nicht gemessen werden',
 
   // ── Table ───────────────────────────────────────────────────────────────
   projectsGrid: 'Projekte',

--- a/packages/app/src/shared/i18n/catalog/en/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/en/workspace.ts
@@ -87,7 +87,6 @@ export const workspace = {
   kpiNoChange: 'No change',
   kpiNoChangeVs: 'No change {{caption}}',
   kpiNotAvailable: 'Not available',
-  kpiUnavailable: "Couldn't be measured",
 
   // ── Table ───────────────────────────────────────────────────────────────
   projectsGrid: 'Projects',

--- a/packages/app/src/shared/i18n/catalog/es/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/es/workspace.ts
@@ -69,7 +69,6 @@ export const workspace = {
   kpiNoChange: 'Sin cambios',
   kpiNoChangeVs: 'Sin cambios {{caption}}',
   kpiNotAvailable: 'No disponible',
-  kpiUnavailable: 'No se pudo medir',
 
   projectsGrid: 'Proyectos',
   loadingProjects: 'Cargando los proyectos',

--- a/packages/app/src/shared/i18n/catalog/fr/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/fr/workspace.ts
@@ -71,7 +71,6 @@ export const workspace = {
   kpiNoChange: 'Aucun changement',
   kpiNoChangeVs: 'Aucun changement {{caption}}',
   kpiNotAvailable: 'Indisponible',
-  kpiUnavailable: 'Impossible à mesurer',
 
   projectsGrid: 'Projets',
   loadingProjects: 'Chargement des projets',

--- a/packages/app/src/shared/i18n/catalog/hi/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/hi/workspace.ts
@@ -66,7 +66,6 @@ export const workspace = {
   kpiNoChange: 'कोई बदलाव नहीं',
   kpiNoChangeVs: 'कोई बदलाव नहीं {{caption}}',
   kpiNotAvailable: 'उपलब्ध नहीं',
-  kpiUnavailable: 'माप नहीं सके',
 
   projectsGrid: 'प्रोजेक्ट',
   loadingProjects: 'प्रोजेक्ट लोड हो रहे हैं',

--- a/packages/app/src/shared/i18n/catalog/ja/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/ja/workspace.ts
@@ -61,7 +61,6 @@ export const workspace = {
   kpiNoChange: '変化なし',
   kpiNoChangeVs: '変化なし（{{caption}}）',
   kpiNotAvailable: '利用できません',
-  kpiUnavailable: '計測できませんでした',
 
   projectsGrid: 'プロジェクト',
   loadingProjects: 'プロジェクトを読み込み中',

--- a/packages/app/src/shared/i18n/catalog/ko/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/ko/workspace.ts
@@ -61,7 +61,6 @@ export const workspace = {
   kpiNoChange: '변화 없음',
   kpiNoChangeVs: '{{caption}} 변화 없음',
   kpiNotAvailable: '해당 없음',
-  kpiUnavailable: '측정할 수 없음',
 
   projectsGrid: '프로젝트',
   loadingProjects: '프로젝트 불러오는 중',

--- a/packages/app/src/shared/i18n/catalog/pt-BR/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/pt-BR/workspace.ts
@@ -71,7 +71,6 @@ export const workspace = {
   kpiNoChange: 'Sem mudança',
   kpiNoChangeVs: 'Sem mudança {{caption}}',
   kpiNotAvailable: 'Indisponível',
-  kpiUnavailable: 'Não foi possível medir',
 
   projectsGrid: 'Projetos',
   loadingProjects: 'Carregando projetos',

--- a/packages/app/src/shared/i18n/catalog/ru/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/workspace.ts
@@ -83,7 +83,6 @@ export const workspace = {
   kpiNoChange: 'Без изменений',
   kpiNoChangeVs: 'Без изменений {{caption}}',
   kpiNotAvailable: 'Нет данных',
-  kpiUnavailable: 'Не удалось измерить',
 
   projectsGrid: 'Проекты',
   loadingProjects: 'Загрузка проектов',

--- a/packages/app/src/shared/i18n/catalog/zh/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/workspace.ts
@@ -60,7 +60,6 @@ export const workspace = {
   kpiNoChange: '无变化',
   kpiNoChangeVs: '无变化，{{caption}}',
   kpiNotAvailable: '不可用',
-  kpiUnavailable: '无法测量',
 
   projectsGrid: '项目',
   loadingProjects: '正在加载项目',


### PR DESCRIPTION
Closes TRA-488.

## What renders today

Every KPI tile whose fetch failed captions its em dash `Couldn't be measured`. There are exactly two states in which that caption can appear, and in both of them another surface on the same screen is already saying what happened — better, and with the action attached.

**1. The daemon is busy.**

```
Indexing 4 of 8 projects. The numbers arrive when it's done.   [Try again]
Projects           8   tracking from today
Files              —   Couldn't be measured
Symbols            —   Couldn't be measured
Healthy            —   Couldn't be measured
Needs attention    —   Couldn't be measured
```

The banner and the four cards 16px below it describe the same four numbers at the same instant and disagree about them. The banner is future tense and transient; the caption is past tense and terminal. One of them is wrong on its face, and the wrong one is repeated four times.

This is not a race. `metricsFailed` is `metricsLoading && errorKind !== null` (`Workspace.tsx:366`), and the `haveNumbers` passed to `busyMessage` is `!metricsLoading` (`:338`), so `metricsFailed === true` *implies* `haveNumbers === false` — which is exactly the branch producing "The numbers arrive when it's done." Whenever the caption is on screen, that banner is on screen, guaranteed by construction.

**2. The daemon is not running.** `DaemonDownPane` holds the pane — "The daemon isn't running… Start it to see them again — nothing was lost." with a **Start daemon** button — and the strip above it repeats `Couldn't be measured` six more times. One dead daemon, announced seven times in one window. That is the defect TRA-469 fixed on Project Overview, surviving on Workspace because the strip has its own state.

## Why the caption is wrong in principle

`DESIGN.md` gives the tile three slots — label, value, **comparison**. The comparison answers "compared to what?" A failure message is not a comparison, and putting one there multiplies the diagnosis by the number of cards on the strip. The em dash is already the whole statement, and it already carries it to assistive technology: `<span aria-label="Not available">—</span>`.

The dense tile had the same problem with a smaller audience — it dropped the caption and moved the sentence into a `title` tooltip.

## The change

- An `unavailable` tile renders the em dash and nothing else. No caption, no `title`.
- The reserved 26px caption box stays, so `kpiStripHeight()` and every tile dimension are unchanged in every language.
- `workspace:kpiUnavailable` is now dead and is deleted from all ten catalogues. `kpiNotAvailable` ("Not available") stays — it is the em dash's accessible name and the one place this belongs.
- `DESIGN.md` gets the rule, generalised: the surface that holds the daemon state says it once; the repeating cards inside it go quiet.

## Verified

Measured on the running Electron renderer (`packages/app/scripts/electron-cdp.mjs`, CDP-driven, offline), light and dark, at the default window and at the 640×420 minimum. Geometry is identical either side of the change — only the text differs:

| | before | after |
|---|---|---|
| tile (default window) | 112 × 225px, caption box 26px | 112 × 225px, caption box 26px |
| tile (640×420, dense) | 37 × 186px, `title="Couldn't be measured"` | 37 × 186px, `title` absent |
| tile text | `Files—Couldn't be measured` | `Files—` |

Tests: 514 passed (47 files). `typecheck`, `check:i18n` (88 files clean) and `design-tokens.mjs` all pass. Three tests updated to assert the new copy, plus one new test that a dead daemon is not repeated once per tile by the strip above it.
