### PR TITLE
fix(app): Project Overview reads all three daemon states, not one (TRA-489)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -576,6 +576,32 @@ is not one that is failing to. `connected` is false for the first moments of eve
 mount, so a surface that invents its own check flashes a daemon-down pane on every
 open.
 
+**Reading one of the reducer's three values is not reading the reducer, and `stale`
+means nothing on a surface that caches nothing.** `deriveDaemonState()` returns
+`ok`, `stale` and `unreachable`; a surface that tests `=== 'unreachable'` has left
+the other two rendering as if the daemon were fine. Workspace can afford `stale`
+because it has the last KPI numbers to keep on screen under a line that qualifies
+them. Project Overview has no cached section data, so `stale` there is not "last
+known values" — it is every section failing at once, which is the state the pane
+exists to replace. A surface with nothing to keep on screen has two states, not
+three (TRA-489).
+
+Two corollaries, both of which shipped broken behind the first version of that test:
+
+- **`ok` is also returned while the daemon is still loading, and a surface that
+  fires its own fetches under that answer will render their failures before the
+  reducer concedes.** Four local fetches against a refused socket fail in
+  milliseconds; `useDaemon` takes up to `DAEMON_FETCH_TIMEOUT_MS`. Don't ask a
+  daemon that has not answered yet — hold the fetches, and the sections stay on
+  their skeletons instead of racing to an error. This is what makes such a bug look
+  intermittent: whether you see it depends on which finished first, so a harness
+  that samples once, late, will report it fixed.
+- **A cached status indicator has to step aside too.** A `stale` daemon still holds
+  `status: 'ready'` from its last answer, and a green dot over a pane reading "The
+  daemon isn't running" is the second statement the rule above forbids — and the
+  wrong one. Whatever renders the last snapshot goes neutral when the surface has
+  declared the source gone.
+
 **An empty list and no list are two different facts, and a `catch` that writes `[]`
 destroys the difference.** The empty state is then free to explain a result that
 was never received: the sidebar's file list told the user "No indexed files match

--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -254,14 +254,19 @@ export function ProjectOverview({
      `deriveDaemonState` rather than a fresh `!connected`: `connected` is false
      for the first moments of every mount, and a naive test would flash a
      daemon-down pane on every project open. Reusing the reducer is also what
-     keeps the two surfaces from drifting into two definitions of "down". */
+     keeps the two surfaces from drifting into two definitions of "down".
+
+     Anything but `ok`, not just `unreachable` (TRA-489). Workspace can afford
+     `stale` because it has cached KPI numbers to keep on screen under a banner
+     that qualifies them; this surface caches nothing, so `stale` here is not
+     "last known values" — it is five sections failing at once. */
   const daemonDown =
     deriveDaemonState({
       loading: daemonLoading,
       connected,
       liveProjects: projects.length,
       metricsErrorKind: null,
-    }) === 'unreachable';
+    }) !== 'ok';
 
   const [stats, setStats] = useState<ProjectStats | null>(null);
   const [statsLoad, setStatsLoad] = useState<Load>('loading');
@@ -345,11 +350,27 @@ export function ProjectOverview({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: status is an intentional trigger — refetches after the project leaves 'indexing' so the panel reflects the new totals.
   useEffect(() => {
+    /* Not before the daemon has answered (TRA-489). `deriveDaemonState` reduces
+       `loading` to 'ok', so the sections render during that window — and four
+       fetches against a refused local socket fail in milliseconds, well before
+       `useDaemon` concedes. That painted the four section errors the pane above
+       exists to replace, which is why the bug looked intermittent: whether you
+       saw it depended on which finished first. There is nothing to ask a daemon
+       that has not answered yet; the sections stay on their skeletons. */
+    if (daemonLoading) return;
     fetchStats();
     fetchCoverage();
     fetchServices();
     fetchSmells(smellsCategory);
-  }, [fetchStats, fetchCoverage, fetchServices, fetchSmells, smellsCategory, status]);
+  }, [
+    daemonLoading,
+    fetchStats,
+    fetchCoverage,
+    fetchServices,
+    fetchSmells,
+    smellsCategory,
+    status,
+  ]);
 
   const handleAddService = async () => {
     const api = window.electronAPI;
@@ -405,8 +426,13 @@ export function ProjectOverview({
 
   const projectName = root.split(/[/\\]/).filter(Boolean).pop() ?? root;
 
-  const statusTone: Tone =
-    status === 'indexing'
+  /* Neutral once the daemon has stopped talking, whatever the last snapshot
+     said. A 'stale' daemon still has 'ready' cached from its last answer, and
+     a green dot over a pane reading "The daemon isn't running" is a second
+     statement about the same condition — and the wrong one (TRA-489). */
+  const statusTone: Tone = daemonDown
+    ? 'neutral'
+    : status === 'indexing'
       ? 'orange'
       : status === 'error'
         ? 'red'

--- a/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
@@ -258,6 +258,48 @@ describe('ProjectOverview surface', () => {
     expect(screen.queryByText("The daemon isn't running")).toBeNull();
   });
 
+  /* TRA-489. `deriveDaemonState` returns three values and the pane above only
+     tested one of them. 'stale' — a feed that dropped after the daemon had
+     already named some projects — left all five sections rendering, and with
+     nothing behind them all five failed: the six-statement pane, back in full.
+     Workspace can afford 'stale' because it has cached KPI numbers to keep on
+     screen; this surface caches nothing, so 'stale' here IS down. */
+  it('says a stale daemon once too, not five times', async () => {
+    daemon.projects = [{ root: ROOT, status: 'ready' }];
+    daemon.loading = false;
+    daemon.connected = false;
+    mockApi({ '/stats': null, '/coverage': null, '/subprojects': null, '/smells': null });
+    render(<ProjectOverview root={ROOT} />);
+
+    expect(await screen.findByText("The daemon isn't running")).toBeTruthy();
+    expect(screen.queryByText(/may still be indexing/)).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+
+    /* And the toolbar dot does not keep the last snapshot's green over a pane
+       that says the daemon is gone — measured on the render, where 'stale'
+       still had `status: 'ready'` cached and showed one. */
+    expect(document.querySelector('.ws-statusdot.t-green')).toBeNull();
+    expect(document.querySelector('.ws-statusdot.t-neutral')).toBeTruthy();
+  });
+
+  /* The other uncovered branch, and the one that made the bug intermittent:
+     `loading` reduces to 'ok', so the sections render — and four local fetches
+     against a refused socket lose to no one. They finished failing before the
+     daemon conceded, painting the same four errors under a toolbar that said
+     "Checking…". Until the daemon has answered there is nothing to fetch. */
+  it('does not paint section failures before the daemon has answered', async () => {
+    daemon.projects = [];
+    daemon.loading = true;
+    daemon.connected = false;
+    mockApi({ '/stats': null, '/coverage': null, '/subprojects': null, '/smells': null });
+    render(<ProjectOverview root={ROOT} />);
+
+    expect(await screen.findByRole('button', { name: 'Checking…' })).toBeTruthy();
+    await waitFor(() => expect(screen.queryByText(/may still be indexing/)).toBeNull());
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+    expect(screen.queryByText("The daemon isn't running")).toBeNull();
+  });
+
   it('keeps the chrome and offers a retry when a section fails', async () => {
     mockApi({ '/stats': null, '/coverage': COVERAGE, '/subprojects': {}, '/smells': NO_SMELLS });
     render(<ProjectOverview root={ROOT} />);


### PR DESCRIPTION
TRA-489. Incompleteness in my own TRA-469 fix (#611), found while running the 10-trial
gate on TRA-478.

## What was wrong

`deriveDaemonState()` returns three values. `ProjectOverview.tsx` tested one:

```ts
const daemonDown = deriveDaemonState({ … }) === 'unreachable';
```

`'stale'` and `'ok'`-while-still-loading both fell through to "render all five sections",
and with the daemon down all five fail — the six-statement pane TRA-469 removed, back in
full.

Workspace can afford `'stale'` because it has cached KPI numbers to keep on screen under a
line that qualifies them. Project Overview caches nothing, so `'stale'` there is not "last
known values" — it is four `SectionError`s saying "the daemon may still be indexing" about
a process that is not running, each with a Retry aimed at a refusing socket.

## The change

1. **`daemonDown` is `!== 'ok'`, not `=== 'unreachable'`.** A surface with nothing to keep
   on screen has two states, not three.
2. **The sections do not fetch until the daemon has answered.** `'ok'` is also what the
   reducer returns while `useDaemon` is still loading, and four fetches against a refused
   local socket finish failing in milliseconds — long before a read capped at
   `DAEMON_FETCH_TIMEOUT_MS` concedes. That race is what made the bug intermittent. They
   now hold their skeletons instead.
3. **The toolbar dot goes neutral when the surface has declared the daemon gone.** A
   `'stale'` daemon still holds `status: 'ready'` from its last answer, and a green dot
   over "The daemon isn't running" is a second statement about one condition, and the
   wrong one. Caught on the render after (1) and (2) were already passing their unit
   tests — see below.

`DESIGN.md` §5 gets the rule this is an instance of, plus both corollaries.

## Measured

Built renderer loaded in an offscreen Electron window (`show: false` + `capturePage`, port
3741 refused for that session's partition only, so the machine's own daemon was untouched),
20 loads across three daemon scenarios, each sampled eight times through the load rather
than once at the end:

| scenario | daemon behaviour | before | after |
|---|---|---|---|
| A (×8) | every read refused instantly | pass | pass |
| B (×6) | sections refused instantly, `/api/projects` + `/api/events` 400ms late | **fail** — 4 errors / 4 Retries for the first ~450ms | pass — 0 at every sample |
| C (×6) | `/api/projects` answers, feed and all sections refused | **fail** — 4 errors / 4 Retries at every sample out to 6s, never recovers | pass — resolves to one statement, one button |

**8/20 → 20/20.**

Sampling matters here: the first cut of this harness read the DOM once, late, and passed
20/20 on the broken build. A transient wrong frame is still a wrong frame.

Scenario C's first ~3s still shows the four section errors, and that is left alone
deliberately — until the feed drop registers, the app has a daemon that just answered and
a Retry that would work, so the sections are entitled to say so. What C proves is that the
surface now *resolves*; before, it sat there permanently.

## Tests

Two new cases in `ProjectOverview.test.tsx` — one per uncovered branch — plus a dot
assertion on the existing unreachable case. Both new ones fail on `master`. Full app
suite: 517 passed. Typecheck, `check:i18n`, build all clean.

Agent: Design/UX Agent
