### PR TITLE
fix(workspace): a dead daemon gets one verdict from the KPI strip, not two (TRA-495)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -634,6 +634,36 @@ holding the daemon state says it; the cards inside it go quiet. A tooltip repeat
 the sentence when the tile is too short for a caption is the same defect with a
 smaller audience.
 
+**One source gets one verdict on whether it is knowable.** Two readings off the same
+array must not disagree about whether the array is there. The Workspace strip is a
+single `deriveKpis(projects)` call — `totalProjects` is that array's length,
+`totalFiles` a sum over its elements — but Projects and Indexing were gated on
+`listFailed` while Files, Symbols, Healthy and Needs attention were gated on
+`metricsFailed`. The split was true when the two halves had two upstreams; they merge
+in `mergeIntoViewModel` before either flag is read. So with the daemon down the tile
+that *counts* the array printed an em dash beside four tiles that *summed* it, over a
+pane promising "nothing was lost" — and the strip disproved itself two tiles along,
+where Healthy's comparison line ("grade A or B, no security findings" rather than "no
+projects yet") is chosen by `totalProjects > 0` (TRA-495). When flags multiply,
+re-derive them from what the values actually read, not from what they used to read.
+
+**A delta is a statement about now; a snapshot has no now.** Stale values stay
+(paragraph above), but every comparison that asserts *change* goes: `↑ +21.4k vs 3
+hours ago` in `--status-green` is a claim to have measured 21,400 new files, made by
+an app whose next paragraph is that it cannot reach the thing that measures. Not
+storing a baseline in that state is not enough — the baseline that was already rolled
+gets displayed on the frame *after* the connection drops, which is the frame every
+user sees. Fall back to the comparisons that survive a snapshot: a criterion ("grade
+A or B, no security findings") or a ratio ("1,787 per project"). The slot is never
+left empty.
+
+**A stock survives the source dying; an activity reading does not.** Files, symbols
+and project counts sit on disk whether or not the daemon answers, so they go stale.
+"Indexing" is a count of what is happening right now, and nothing is: it keeps its em
+dash while the tiles beside it keep their numbers. That is not the inconsistency the
+paragraph above forbids — it is the one distinction on the strip that is real, and
+each tile follows from what it measures.
+
 ---
 
 ## 6. Layout skeleton

--- a/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
@@ -218,8 +218,29 @@ export function WorkspaceHeader({
         : undefined,
     [baseline, t],
   );
+  /**
+   * The daemon is unreachable and what is on screen is the restored snapshot.
+   *
+   * Every tile here is one `deriveKpis(data.projects)` call over one array:
+   * `totalProjects` is its length, `totalFiles` a sum over its elements
+   * (`types.ts`). Wiring the first pair to `listFailed` and the second to
+   * `metricsFailed` made sense while they had two upstreams; they merge in
+   * `mergeIntoViewModel` before either flag is read. So the strip blanked the
+   * tile that counts the array and printed four that sum it — one array, two
+   * answers about whether it was knowable, over a pane promising "nothing was
+   * lost" (TRA-495). The stocks keep their last reading instead.
+   */
+  const snapshotOnly = listFailed && kpis.totalProjects > 0;
+
+  /* No delta while the strip is a snapshot. A delta is a statement about now,
+     and the whole content of the pane below is that there is no now to read:
+     "↑ +21.4k vs 3 hours ago" in --status-green, 500px above "The daemon isn't
+     running". TRA-458 stopped the baseline being WRITTEN in this state; this
+     stops an already-rolled one being displayed on the frame after the
+     connection drops, which is the frame every user sees. Each tile falls back
+     to its footnote — a criterion or a ratio, still true of a snapshot. */
   const delta = (pick: (k: WorkspaceKpis) => number): number | null =>
-    baseline ? pick(kpis) - pick(baseline.kpis) : null;
+    baseline && !snapshotOnly ? pick(kpis) - pick(baseline.kpis) : null;
 
   const filterMenu = useMenuAnchor();
   const overflowMenu = useMenuAnchor();
@@ -299,7 +320,10 @@ export function WorkspaceHeader({
           value={kpis.totalProjects}
           dense={dense}
           pending={listLoading}
-          unavailable={listFailed}
+          /* Only when there is nothing to fall back on — a cold start against a
+             daemon that never answered, where `metricsFailed` blanks the other
+             four too and the strip is six em dashes, uniformly. */
+          unavailable={listFailed && !snapshotOnly}
           delta={delta((k) => k.totalProjects)}
           deltaCaption={deltaCaption}
           footnote={t('kpiTrackingFromToday')}
@@ -376,6 +400,10 @@ export function WorkspaceHeader({
           tone="busy"
           dense={dense}
           pending={listLoading}
+          /* Unconditionally, unlike the five tiles beside it: Indexing is the
+             only reading here that measures activity rather than stock, and a
+             daemon that is not running is indexing nothing. Carrying a cached
+             count through would be the one genuine lie on a stale strip. */
           unavailable={listFailed}
           footnote={
             kpis.indexing === 0

--- a/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
@@ -18,19 +18,18 @@ const ZERO_KPIS: WorkspaceKpis = {
 
 let strip: HTMLElement;
 
-function renderHeader(
-  metricsLoading: boolean,
-  extra: Partial<{
-    listLoading: boolean;
-    metricsFailed: boolean;
-    listFailed: boolean;
-    dense: boolean;
-    hideViewToggle: boolean;
-    kpis: WorkspaceKpis;
-    filter: WorkspaceFilter;
-  }> = {},
-) {
-  const { container } = render(
+type HeaderExtra = Partial<{
+  listLoading: boolean;
+  metricsFailed: boolean;
+  listFailed: boolean;
+  dense: boolean;
+  hideViewToggle: boolean;
+  kpis: WorkspaceKpis;
+  filter: WorkspaceFilter;
+}>;
+
+function header(metricsLoading: boolean, extra: HeaderExtra) {
+  return (
     <WorkspaceHeader
       kpis={ZERO_KPIS}
       metricsLoading={metricsLoading}
@@ -41,9 +40,22 @@ function renderHeader(
       onRefresh={() => {}}
       refreshing={false}
       {...extra}
-    />,
+    />
   );
+}
+
+/**
+ * Renders the strip and returns a re-render for the same header with new props.
+ * The daemon-down cases need it: `listFailed` is never true on the first frame
+ * of a real launch — the snapshot restores, the baseline rolls off it, and the
+ * connection is only pronounced dead {@link DEGRADED_GRACE_MS} later. Mounting
+ * straight into the failed state skips the frame everybody actually sees.
+ */
+function renderHeader(metricsLoading: boolean, extra: HeaderExtra = {}) {
+  const { container, rerender } = render(header(metricsLoading, extra));
   strip = container;
+  return (nextLoading: boolean, nextExtra: HeaderExtra) =>
+    rerender(header(nextLoading, nextExtra));
 }
 
 /** The KPI tile whose label is `label`. */
@@ -118,7 +130,6 @@ describe('WorkspaceHeader KPI strip', () => {
 
   it('never turns a dead daemon into a negative delta', () => {
     renderHeader(false, { listFailed: true });
-    expect(kpiValue('Projects')).toBe('—');
     expect(kpiTile('Projects').textContent).not.toMatch(/[↑↓]/);
   });
 
@@ -223,6 +234,79 @@ describe('WorkspaceHeader KPI strip', () => {
     }
     // Indexing really is a subset of the workspace, so it keeps its share.
     expect(kpiTile('Indexing').children[2]!.textContent).toBe('8% of 53 projects');
+  });
+});
+
+/* Every tile on this strip is one `deriveKpis(data.projects)` call over one
+   array: `totalProjects` is that array's length, `totalFiles` a sum over its
+   elements. With the daemon unreachable the array is the restored localStorage
+   snapshot, and the strip used to blank the tile reporting the length while
+   four tiles reported sums over the contents — one array, two answers about
+   whether it was knowable, over a pane headed "The daemon isn't running" and
+   promising "nothing was lost" (TRA-495). */
+describe('WorkspaceHeader with the daemon down', () => {
+  const SNAPSHOT: WorkspaceKpis = {
+    totalProjects: 64,
+    totalFiles: 114_400,
+    totalSymbols: 767_300,
+    healthy: 39,
+    needsAttention: 54,
+    indexing: 0,
+  };
+
+  /** Mount alive so the baseline rolls, then lose the daemon — the real order. */
+  function loseTheDaemon(kpis: WorkspaceKpis = SNAPSHOT) {
+    const rerender = renderHeader(false, { kpis });
+    rerender(false, { kpis, listFailed: true });
+  }
+
+  beforeEach(() => localStorage.clear());
+
+  it('keeps every stock reading the snapshot still holds', () => {
+    loseTheDaemon();
+    expect(kpiValue('Projects')).toBe('64');
+    expect(kpiValue('Files')).toBe('114.4k');
+    expect(kpiValue('Symbols')).toBe('767.3k');
+    expect(kpiValue('Healthy')).toBe('39');
+    expect(kpiValue('Needs attention')).toBe('54');
+  });
+
+  it('claims no delta, because a delta is a statement about now', () => {
+    // The baseline is real and five hours old, so every tile would otherwise
+    // print "↑ +114.4k vs 5 hours ago" — growth measured by an app that has
+    // just said it cannot reach the thing that measures.
+    localStorage.setItem(
+      LS_BASELINE_KEY,
+      JSON.stringify({
+        at: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
+        kpis: { ...SNAPSHOT, totalFiles: 93_000, totalSymbols: 656_200, totalProjects: 53 },
+      }),
+    );
+    loseTheDaemon();
+    for (const label of ['Projects', 'Files', 'Symbols', 'Healthy', 'Needs attention']) {
+      expect(kpiTile(label).textContent).not.toMatch(/[↑↓]/);
+      // …and the comparison slot is not left empty either: each falls back to
+      // its footnote, which stays true of a snapshot.
+      expect(kpiTile(label).children[2]!.textContent).not.toBe('');
+    }
+  });
+
+  it('leaves Indexing unknown — a daemon that is not running is indexing nothing', () => {
+    // The one reading on the strip that measures activity rather than stock.
+    // A cached count here would be the single genuine lie.
+    loseTheDaemon();
+    expect(kpiValue('Indexing')).toBe('—');
+    expect(kpiTile('Indexing').querySelector('[aria-label="Not available"]')).not.toBeNull();
+  });
+
+  it('falls back to six em dashes when there is no snapshot to hold', () => {
+    // Cold start against a daemon that never answered: nothing was restored,
+    // so the strip has nothing to be stale about and says so uniformly.
+    const empty: WorkspaceKpis = { ...SNAPSHOT, totalProjects: 0, totalFiles: 0, totalSymbols: 0, healthy: 0, needsAttention: 0 };
+    renderHeader(true, { kpis: empty, listFailed: true, metricsFailed: true });
+    for (const label of ['Projects', 'Files', 'Symbols', 'Healthy', 'Needs attention', 'Indexing']) {
+      expect(kpiValue(label)).toBe('—');
+    }
   });
 });
 


### PR DESCRIPTION
Closes TRA-495.

## Before

With the daemon unreachable, read off `document.querySelectorAll('[data-kpi]')` in the
Electron window:

```
Projects        :: —
Files           :: 114.4k  ↑ +21.4k  vs 3 hours ago
Symbols         :: 767.3k  ↑ +111.1k vs 3 hours ago
Healthy         :: 39      grade A or B, no security findings
Needs attention :: 54      low grade or any findings
Indexing        :: —
```

…directly above `DaemonDownPane`: "The daemon isn't running / trace-mcp indexes your
projects in a local background service. Start it to see them again — nothing was lost."

Two defects, one mistake seen from two sides.

**One array, six tiles, two answers about whether it is knowable.** Every tile is a
single `deriveKpis(data.projects)` call (`Workspace.tsx:241`). `totalProjects` is that
array's length (`types.ts:319`); `totalFiles` is a sum over its elements (`:306`). The
tile that *counts* the array claimed the number could not be had, beside four tiles
reporting sums over its *contents*. The strip disproves itself two tiles along: Healthy's
comparison line is `kpis.totalProjects === 0 ? kpiNoProjectsYet : kpiHealthyCriteria`, and
it rendered the criterion — so on that frame the strip knew `totalProjects > 0`.

The cause is two flags for one source. Projects and Indexing took `listFailed`; the other
four took `metricsFailed`, which is false whenever the localStorage snapshot restored
(`useWorkspaceProjects.ts:212`). The split was true while the halves had two upstreams;
they merge in `mergeIntoViewModel` before either flag is read.

**A growth claim from an app that just said it cannot measure.** `↑ +21.4k vs 3 hours ago`
in `--status-green`, 500px above "The daemon isn't running". TRA-458 stopped the baseline
being *written* in this state (`WorkspaceHeader.tsx:207`); it does not stop an
already-rolled one being *displayed* on the frame after the connection drops — which is
the frame every user sees, because the snapshot restores and the baseline rolls before
`DEGRADED_GRACE_MS` elapses.

## After

```
Projects        :: 64      tracking from today
Files           :: 114.4k  1,788 per project
Symbols         :: 767.3k  7 per file
Healthy         :: 39      grade A or B, no security findings
Needs attention :: 54      low grade or any findings
Indexing        :: —
```

- Every stock tile keeps its last reading — which is what substantiates the pane's own
  "nothing was lost".
- No tile shows a delta. Each falls back to its footnote: a criterion or a ratio, still
  true of a snapshot. The comparison slot is never left empty.
- Indexing keeps its em dash unconditionally. It is the one reading here that measures
  activity rather than stock, and a daemon that is not running is indexing nothing.
- With no snapshot at all — cold start against a daemon that never answered —
  `metricsFailed` and `listFailed` are both true and the strip is six em dashes,
  uniformly.

No new catalogue strings, no geometry change: `kpiStripHeight()` and every tile dimension
are untouched in every language.

## Verified

`packages/app/scripts/electron-cdp.mjs shot --offline` against the real Electron window
(`titleBarStyle: 'hiddenInset'`, native vibrancy) — not a browser tab — before and after,
in light and dark, at the 640×420 window minimum, and under Reduce Transparency +
Increase Contrast. Four new tests in `WorkspaceHeader.test.tsx` mount alive and then lose
the daemon, because mounting straight into the failed state skips the frame the defect
lives on. 519 tests, typecheck, `check:i18n` and build all pass locally.

## DESIGN.md

Three rules added to §5 "One condition gets one sentence, and stale beats empty":

- **One source gets one verdict on whether it is knowable.** When flags multiply,
  re-derive them from what the values actually read, not from what they used to read.
- **A delta is a statement about now; a snapshot has no now.** Stale values stay; every
  comparison asserting *change* goes, falling back to one that survives a snapshot.
- **A stock survives the source dying; an activity reading does not.**

Agent: Design/UX Agent
