### PR TITLE
fix(app): the KPI strip stops half-blanking and half-shouting when the daemon drops (TRA-495)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -621,6 +621,31 @@ is for a number nobody has ever had, not for one that is a few minutes old. The 
 that line has to match the screen. Saying "these are the last indexed numbers" over a row of
 em dashes is the same lie in the other direction.
 
+**Readings off one source give one answer about whether they are knowable.** A strip
+whose tiles are all derived from a single call cannot half-blank: the tile that reports
+an array's *length* must not say "unknown" while four tiles beside it report *sums over
+that array's elements*. The KPI strip did exactly that with the daemon down — Projects
+`—`, Files `114.4k`, Symbols `767.3k` — and disproved itself two tiles further along,
+where Healthy's caption is `totalProjects === 0 ? "No projects yet" : "grade A or B…"`
+and rendered the criterion, so the same frame knew the count it had just refused to
+print (TRA-495). The cause is always the same shape: two `unavailable` flags left over
+from when the halves had two upstreams, still wired after the halves merged. When two
+sources become one, the flags derived from them merge too — otherwise the strip
+contradicts itself *and* the pane below it, which is promising that nothing was lost.
+The one tile that may still blank is one measuring a different quantity: activity, not
+stock. A daemon that is not running is not indexing, so a cached Indexing count would
+be the strip's only genuine lie.
+
+**A delta is a claim about now, and dies with the connection.** "↑ +21.4k vs 3 hours
+ago" asserts that 21,400 files appeared *since* the baseline — present tense, about a
+source the same screen is describing as unreachable 500px lower. Refusing to *write* a
+baseline while the daemon is down (§ the row on baselines below) does not cover this:
+the baseline that lies is the one rolled while the daemon was healthy, displayed on the
+frame after it drops, which is the frame every user sees. Suppress the comparison and
+fall back to the tile's footnote — a criterion ("grade A or B, no security findings")
+or a ratio ("1,787 per project") is a statement about the snapshot itself and stays true
+however old the snapshot is.
+
 **The placeholder is the whole statement. A card with no number explains nothing.**
 The em dash *is* the sentence "we don't have this" — give it an accessible name
 (`aria-label="Not available"`) and stop. The comparison slot underneath answers
@@ -1341,6 +1366,8 @@ new evidence.
 | Skeletons at final geometry instead of spinners or "Loading…" | Nothing shifts when the data lands, and the loading state shows the shape of what is coming. |
 | A failed fetch settles on an em dash | A skeleton that pulses forever promises data that is never coming. |
 | The em dash is the whole statement — no caption, no tooltip repeating it (TRA-488) | The tile's caption slot is a comparison line, and a failure sentence there is multiplied by the number of cards: six tiles said "Couldn't be measured" under a banner promising the numbers were on their way, and over a pane already headed "The daemon isn't running". |
+| Tiles fed by one source blank together or not at all (TRA-495) | Projects is `projects.length` and Files is a sum over that same array. With the daemon down the strip printed `—` for the length and `114.4k` for the sum, and two tiles further along rendered Healthy's non-empty-workspace caption — the frame knew the count it had just refused to print. Indexing is the exception: it measures activity, not stock, so a cached value there is the one real lie. |
+| No delta chip while the source is unreachable (TRA-495) | "↑ +21.4k vs 3 hours ago" is present tense about a daemon the same screen says isn't running. Refusing to *write* the baseline (TRA-458) doesn't help — the one that lies was rolled while the daemon was healthy. The footnote it falls back to is a criterion or a ratio, which stays true of a snapshot. |
 | `listPending` separates "daemon hasn't answered" from "never indexed" | `status ?? 'unknown'` blamed the project for the daemon's silence. |
 | Sidebar footer is `.ws-sb-row`, not its own geometry | One row system for the whole sidebar; the footer's labels started 26px left of every other label. |
 | Appearance is Auto / Light / Dark, with Auto clearing the key | The old `toggle` only ever wrote `light` or `dark`, so one click pinned the app forever and the system listener stopped mattering. |

--- a/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceHeader.tsx
@@ -218,8 +218,24 @@ export function WorkspaceHeader({
         : undefined,
     [baseline, t],
   );
+  // A delta is a claim about NOW — "21.4k files appeared since 3 hours ago".
+  // With the daemon unreachable nothing about now is available; that is the
+  // entire content of DaemonDownPane 500px below. TRA-458 stopped the baseline
+  // being WRITTEN while the daemon is down, which does not stop an
+  // already-rolled one being DISPLAYED on the frame after the connection drops
+  // — the frame every user actually sees. Each tile falls back to its footnote,
+  // which is a criterion or a ratio and stays true of a snapshot (TRA-495).
   const delta = (pick: (k: WorkspaceKpis) => number): number | null =>
-    baseline ? pick(kpis) - pick(baseline.kpis) : null;
+    baseline && !listFailed ? pick(kpis) - pick(baseline.kpis) : null;
+
+  // Projects counts the same array that Files, Symbols, Healthy and Needs
+  // attention sum over — one `deriveKpis(data.projects)` call, one array. A
+  // frame that can print 114.4k files can print 64 projects, so blanking the
+  // length while the sums report is the strip disagreeing with itself two tiles
+  // apart, and contradicting DaemonDownPane's own "nothing was lost" (TRA-495).
+  // The em dash belongs to a strip with nothing behind it — cold start with the
+  // daemon down, no snapshot restored — where the length really is unknown.
+  const noSnapshot = kpis.totalProjects === 0;
 
   const filterMenu = useMenuAnchor();
   const overflowMenu = useMenuAnchor();
@@ -299,7 +315,7 @@ export function WorkspaceHeader({
           value={kpis.totalProjects}
           dense={dense}
           pending={listLoading}
-          unavailable={listFailed}
+          unavailable={listFailed && noSnapshot}
           delta={delta((k) => k.totalProjects)}
           deltaCaption={deltaCaption}
           footnote={t('kpiTrackingFromToday')}
@@ -376,6 +392,10 @@ export function WorkspaceHeader({
           tone="busy"
           dense={dense}
           pending={listLoading}
+          // Plain `listFailed`, unlike Projects above: this is the one reading
+          // on the strip that measures activity rather than stock, and a daemon
+          // that is not running is not indexing. A cached count here would be
+          // the strip's only genuine lie (TRA-495).
           unavailable={listFailed}
           footnote={
             kpis.indexing === 0

--- a/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/WorkspaceHeader.test.tsx
@@ -118,8 +118,65 @@ describe('WorkspaceHeader KPI strip', () => {
 
   it('never turns a dead daemon into a negative delta', () => {
     renderHeader(false, { listFailed: true });
-    expect(kpiValue('Projects')).toBe('—');
     expect(kpiTile('Projects').textContent).not.toMatch(/[↑↓]/);
+  });
+
+  /* One `deriveKpis(data.projects)` call feeds all six tiles: Projects is that
+     array's LENGTH, Files and Symbols are sums over its ELEMENTS. Blanking the
+     length while the sums print is the strip contradicting itself two tiles
+     apart, and contradicting the pane below that promises "nothing was lost"
+     (TRA-495). */
+  it('keeps the stock tiles on their snapshot when the daemon drops', () => {
+    const kpis: WorkspaceKpis = {
+      totalProjects: 64,
+      totalFiles: 114_400,
+      totalSymbols: 767_300,
+      healthy: 39,
+      needsAttention: 54,
+      indexing: 0,
+    };
+    renderHeader(false, { listFailed: true, kpis });
+    expect(kpiValue('Projects')).toBe('64');
+    expect(kpiValue('Files')).toBe('114.4k');
+    expect(kpiValue('Healthy')).toBe('39');
+    // Activity, not stock: a daemon that is not running is not indexing, so a
+    // cached count here would be the one genuine lie on the strip.
+    expect(kpiValue('Indexing')).toBe('—');
+  });
+
+  /* A delta asserts something about NOW — "21.4k files appeared since 3 hours
+     ago" — 500px above a pane saying the daemon isn't running. TRA-458 stopped
+     the baseline being WRITTEN while the daemon is down; it does not stop an
+     already-rolled one being DISPLAYED on the frame the connection drops. */
+  it('shows no delta on any tile while the daemon is unreachable', () => {
+    localStorage.setItem(
+      LS_BASELINE_KEY,
+      JSON.stringify({
+        at: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+        kpis: { ...ZERO_KPIS, totalProjects: 57, totalFiles: 93_000 },
+      }),
+    );
+    const kpis: WorkspaceKpis = { ...ZERO_KPIS, totalProjects: 64, totalFiles: 114_400 };
+    renderHeader(false, { listFailed: true, kpis });
+    for (const label of ['Projects', 'Files']) {
+      const comparison = kpiTile(label).children[2]!.textContent!;
+      expect(comparison).not.toMatch(/[↑↓]/);
+      expect(comparison).not.toContain('hours ago');
+      // The slot falls back to the footnote — a ratio or a criterion, which
+      // stays true of a snapshot — rather than going blank.
+      expect(comparison).not.toBe('');
+    }
+  });
+
+  it('em-dashes every tile when the daemon is down with no snapshot behind it', () => {
+    renderHeader(true, {
+      listFailed: true,
+      metricsFailed: true,
+      kpis: { ...ZERO_KPIS, totalProjects: 0 },
+    });
+    for (const label of ['Projects', 'Files', 'Symbols', 'Healthy', 'Needs attention', 'Indexing']) {
+      expect(kpiValue(label)).toBe('—');
+    }
   });
 
   /* The baseline is what every delta chip is measured against, so a reading


### PR DESCRIPTION
Closes TRA-495.

## The defect

Every tile on the KPI strip is one `deriveKpis(data.projects)` call over one array. `totalProjects` is that array's **length**; `totalFiles` and `totalSymbols` are **sums over its elements**. With the daemon unreachable and a localStorage snapshot restored, the strip rendered:

```
Projects        :: —
Files           :: 114.4k  ↑ +21.4k  vs 4 hours ago
Symbols         :: 767.3k  ↑ +111.1k vs 4 hours ago
Healthy         :: 39      grade A or B, no security findings
Needs attention :: 54      low grade or any findings
Indexing        :: —
```

Two faults, one mistake seen from both sides.

**1. One array, two answers about whether it is knowable.** The tile reporting the array's length said the number could not be had, while four tiles reported sums over its contents. The strip disproves itself without any code being read: Healthy's caption is `totalProjects === 0 ? "No projects yet" : "grade A or B…"`, and it rendered the criterion — so on that exact frame the strip knew `totalProjects > 0`, two tiles left of the em dash saying it didn't. The cause is two `unavailable` flags (`listFailed` for Projects/Indexing, `metricsFailed` for the other four) left over from when the halves had two upstreams. They merge in `mergeIntoViewModel` before either flag is read.

**2. A growth claim from an app that just said it cannot measure.** `↑ +21.4k vs 4 hours ago` in `--status-green`, 500px above "The daemon isn't running". TRA-458 stopped the baseline being *written* while the daemon is down; it does not stop an already-rolled baseline being *displayed* on the frame after the connection drops — the frame every user sees.

## The change

- Projects blanks only when there is nothing behind the strip at all (`listFailed && kpis.totalProjects === 0`). With a snapshot it reads `64`, like Files reads `114.4k` — same array, same answer, and it substantiates the pane's own "nothing was lost".
- No tile draws a delta chip while `listFailed`. Each falls back to its footnote, which is a criterion or a ratio — a comparison that stays true of a snapshot however old it is.
- Indexing keeps its em dash unconditionally. It is the one reading on the strip that measures activity rather than stock, and a daemon that is not running is not indexing; a cached count there would be the strip's only genuine lie.
- Cold start with no snapshot is unchanged: both flags are true, all six tiles are em dashes.

`DESIGN.md` §5 gains the generalised rules ("Readings off one source give one answer about whether they are knowable" / "A delta is a claim about now, and dies with the connection") plus two review-checklist rows.

## Verification

Electron window over CDP (`scripts/electron-cdp.mjs shot --offline`), not a browser tab — on its own port and a throwaway profile so a concurrent run's window was never touched. Light, dark, Reduce Transparency, and the 640×420 window minimum.

| | Projects | Files | Symbols | Healthy | Needs attention | Indexing |
|---|---|---|---|---|---|---|
| before | `—` | `114.4k` ↑+21.4k vs 4 hours ago | `767.3k` ↑+111.1k vs 4 hours ago | `39` | `54` | `—` |
| after | `64` tracking from today | `114.4k` 1,788 per project | `767.3k` 7 per file | `39` grade A or B… | `54` low grade or any findings | `—` |
| after, no snapshot | `—` | `—` | `—` | `—` | `—` | `—` |

At 640×420 the strip is `dense` and reads `Projects 64 · Files 114.4k · Symbols 767.3k · Healthy 39 · Needs attention 54 · Indexing —`.

`pnpm test` in `packages/app`: 520 passed (47 files). `typecheck` clean, `check-i18n` clean. Three new tests cover the snapshot case, delta suppression, and the cold-start case; the old `never turns a dead daemon into a negative delta` test kept its delta assertion and dropped the `Projects === '—'` one, which is the behaviour this issue changes.

Agent: Design/UX Agent
