### PR TITLE
docs: pin /perf/ with a permalink, undoing a soft 404 from #635

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -1,6 +1,10 @@
 ---
 layout: default
 title: Desktop app performance baseline
+# Without this, Jekyll publishes this file at /perf/README.html and GitHub
+# Pages stops serving it as the directory index, so /perf/ — the URL that
+# already existed — starts returning the "Page not found" body under a 200.
+permalink: /perf/
 description: Internal working document. Measured performance history for the trace-mcp desktop app.
 noindex: true
 ---

--- a/tests/docs/internal-links.test.ts
+++ b/tests/docs/internal-links.test.ts
@@ -111,6 +111,32 @@ describe('docs footer nav covers every indexed page', () => {
     ).toEqual([]);
   });
 
+  /**
+   * GitHub Pages serves a directory's README as its index, so docs/perf/README.md
+   * was reachable at /perf/ with no front matter at all. Adding front matter hands
+   * the file to Jekyll, which publishes it at /perf/README.html instead — and /perf/
+   * then falls through to the "Page not found" body served under a 200, a soft 404
+   * on a URL that had been working. Shipped exactly that way in #635 and caught on
+   * the live site afterwards, not by CI.
+   *
+   * `permalink` pins the output URL back to the directory, so the two cannot diverge.
+   */
+  it('every README under docs/ pins its URL with a permalink', () => {
+    const readmes = readdirSync(DOCS, { recursive: true, encoding: 'utf-8' })
+      .map((f) => f.replace(/\\/g, '/'))
+      .filter((f) => !f.startsWith('_') && /(^|\/)README\.md$/.test(f));
+    const unpinned = readmes.filter((f) => {
+      const raw = readFileSync(join(DOCS, f), 'utf-8');
+      if (!raw.startsWith('---\n')) return false; // no front matter: Jekyll leaves the URL alone
+      const expected = `/${f.replace(/README\.md$/, '')}`;
+      return !new RegExp(`^permalink:\\s*${expected}/?\\s*$`, 'm').test(raw);
+    });
+    expect(
+      unpinned,
+      `READMEs with front matter but no \`permalink:\` pinning them to their directory URL: ${unpinned.join(', ')}`,
+    ).toEqual([]);
+  });
+
   it('the layout renders the nav from the data file, not a hardcoded list', () => {
     const layout = readFileSync(join(DOCS, '_layouts', 'default.html'), 'utf-8');
     expect(layout).toMatch(/site\.data\.docs_nav/);


### PR DESCRIPTION
Follow-up to #635, found by checking the deployed site rather than the diff.

## The regression

GitHub Pages serves a directory's `README` as its index, so `docs/perf/README.md` was reachable at `/perf/` with **no front matter at all**. #635 added front matter to mark it `noindex`, which handed the file to Jekyll. Jekyll publishes it at `/perf/README.html` instead, and `/perf/` now falls through to GitHub's "Page not found" body — served under HTTP **200**, i.e. a soft 404 on a URL that had been working.

Measured on the live site after the merge:

| URL | before #635 | after #635 |
|---|---|---|
| `/perf/` | 200, `<title>Desktop app performance baseline` | 200, `<title>Page not found · GitHub Pages` |
| `/perf/README.html` | 404 | 200, `noindex, follow` |

The rest of #635 deployed correctly and is verified live: the sitemap now carries 20 `<loc>` entries including `language-matrix` and `daemon-memory`, `/language-matrix.html` has exactly one `<h1>`, and `/ROADMAP.html` and `/DESIGN-WEB.html` both emit `<meta name="robots" content="noindex, follow">`.

## The fix

`permalink: /perf/` in the front matter pins the output URL back to the directory, so the noindex marking and the working URL stop fighting each other.

## Guard

New check in `tests/docs/internal-links.test.ts`: a `README.md` under `docs/` that has front matter must carry a `permalink:` matching its directory. Front-matter-less READMEs are left alone — Jekyll does not move those.

Proved it bites by deleting the `permalink:` line from `docs/perf/README.md` — the document, not a constant in the test — and watching it fail with `READMEs with front matter but no permalink: pinning them to their directory URL: perf/README.md`.

`pnpm exec vitest run tests/docs/` → 113 passed. `pnpm run lint` → clean. `pnpm exec biome ci .` → clean (running it this time; #635's CI went red on formatting because I only ran vitest and build).

Agent: SEO Agent
