### PR TITLE
fix(app): MCP clients — the row actions never ran, and six drifted rows took six clicks (TRA-497)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -518,6 +518,44 @@ border rather than a tint. The background therefore lives in `controls.css`, not
 component's `style` prop: an inline `background:` shorthand also writes
 `background-image: none` inline, which no stylesheet rule can outrank.
 
+### A row action reports its own result, and the same click is not asked N times
+
+Three rules, all broken at once on MCP clients (TRA-497), all about a list whose rows
+carry an action.
+
+**A control that ran reports what happened, on the row.** Connect and Update spawned
+`trace-mcp init` with `--mcp-client cursor` as one argv entry — `execFile` takes an
+array, so that is a single unknown option, and commander exits 1 before doing anything.
+The renderer read `result?.ok` and, when it was false, *did nothing*: no refresh, no
+sentence, no changed state. So every action on that screen had been inert since the
+screen shipped in April, and looked exactly like an action with nothing to do. Four
+months of nobody noticing is what a swallowed result buys. A write that failed says so
+in the row's caption slot, in `--status-red`, with a glyph beside it — the failure
+outranks whatever the caption held before, because it is the only thing on the row the
+user can act on. The row keeps its button: a report is not a dead end.
+
+**An action offered on N rows that are one bucket is offered once for the bucket.** If
+the list already sorts those rows together — MCP clients ranks `stale` to the top —
+then the screen has already decided they are one thing, and making the user click N
+times is the screen refusing to act on what it knows. The action goes in the **section
+header**, not the toolbar: the toolbar speaks for the surface, and a surface with two
+lists has no business putting one list's action there. `Section` takes an `action` slot
+for exactly this. It appears from **two** rows up; at one row the row's own button is
+the shorter path and a second control is only more to read. Its label carries the size
+of what it will do (`Update all · 6`), it runs the items one at a time so a row that
+fails names itself, and it counts up while it works. Its right edge lines up with the
+column of row buttons under it (12px in), not with the caption beside it (4px) — the
+edge the eye compares is the one directly below.
+
+**Setup asks; repair does not.** The same handler drove Connect and Update, so
+repairing a config that had drifted re-opened the enforcement-level menu — a setup
+question, asked about a config whose answer was already on disk, with no indication of
+which level it was on. Whatever the user picked silently became the new level. A repair
+reconciles what drifted and touches nothing else; if the only available call cannot
+promise that, the call is wrong, not the rule. `trace-mcp clients update` exists because
+`init` could not make that promise: every flag combination it has either installs hooks
+and tweakcc or writes `tools.agent_behavior = "off"`.
+
 ### States are part of the component, not an afterthought
 
 Every data surface owes four states, and each has a house form:

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -428,19 +428,20 @@ ipcMain.handle(
       return { ok: false, error: 'JetBrains AI Assistant must be configured manually in the IDE.' };
     }
 
-    // Compose CLI flags based on enforcement level
-    const flags = [`--mcp-client ${clientName}`, '--yes'];
+    // Compose CLI flags based on enforcement level.
+    // `--mcp-client` and its value are two argv entries: execFile passes the
+    // array straight to the process without a shell, so a single
+    // `--mcp-client cursor` string is one unknown option and commander exits 1
+    // before doing anything. That shipped with this screen (2026-04) and left
+    // every Connect and Update button on it silently inert (TRA-497).
+    const flags = ['--mcp-client', clientName, '--yes'];
 
-    if (level === 'base') {
-      flags.push('--skip-hooks');
-    }
     // 'standard' and 'max' both install hooks (no --skip-hooks)
     // 'max' also installs tweakcc, but that's handled automatically by init
-    // when no --skip-hooks is passed and tweakcc prompts are available
-
-    // Non-Claude clients don't use hooks/tweakcc, always skip
+    // when no --skip-hooks is passed and tweakcc prompts are available.
+    // Non-Claude clients don't use hooks/tweakcc, so they always skip.
     const claudeClients = new Set(['claude-code', 'claw-code', 'claude-desktop']);
-    if (!claudeClients.has(clientName)) {
+    if (level === 'base' || !claudeClients.has(clientName)) {
       flags.push('--skip-hooks');
     }
 
@@ -464,6 +465,57 @@ ipcMain.handle(
     });
   },
 );
+
+// IPC: repair the trace-mcp entry in one or more client configs.
+//
+// Not `init`: what drifts after an upgrade is the MCP entry, and reconciling it
+// is not setup. `init` asks — or, with --yes, decides — which enforcement level
+// to run at, so routing Update through it would answer a question the user has
+// already answered, in whichever direction the flags happened to fall
+// (`--skip-hooks` writes agent_behavior "off"; omitting it installs hooks and
+// tweakcc). `clients update` writes the entry and nothing else, which is what
+// the button says it does.
+ipcMain.handle('update-mcp-clients', async (_event, clientNames: string[]) => {
+  return new Promise<{ ok: boolean; error?: string }>((resolve) => {
+    execFile(
+      'trace-mcp',
+      ['clients', 'update', ...clientNames, '--json'],
+      { timeout: 60_000, maxBuffer: 1024 * 1024 },
+      (error, stdout, stderr) => {
+        if (error) {
+          resolve({ ok: false, error: describeCliFailure(error.message, stdout, stderr) });
+          return;
+        }
+        resolve({ ok: true });
+      },
+    );
+  });
+});
+
+/**
+ * The one write that failed, rather than the exit code that followed it.
+ *
+ * The app can self-update ahead of the CLI it shells out to (TRA-180), so
+ * "this CLI predates the command" is a state a user can reach, and
+ * `unknown command 'update'` is not a sentence to show them.
+ *
+ * Deliberately not in the catalogue: it lands in the row's caption slot beside
+ * the CLI's own error text, which is English wherever it comes from. Half a
+ * translated sentence next to an untranslated one reads worse than neither.
+ */
+function describeCliFailure(message: string, stdout: string, stderr: string): string {
+  if (/unknown command|unknown option/.test(stderr + message)) {
+    return 'The installed trace-mcp CLI is older than this app. Run `npm i -g trace-mcp` to update it.';
+  }
+  try {
+    const steps: { action: string; detail?: string }[] = JSON.parse(stdout).steps ?? [];
+    const failed = steps.find((s) => s.detail?.startsWith('Error:'));
+    if (failed?.detail) return failed.detail;
+  } catch {
+    /* not JSON — fall through to the raw message */
+  }
+  return message;
+}
 
 // IPC: check for app update.
 // Primary source is the npm registry (no auth, no practical rate limit — the package

--- a/packages/app/src/main/preload.ts
+++ b/packages/app/src/main/preload.ts
@@ -40,6 +40,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     level: string,
   ): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('configure-mcp-client', clientName, level),
+  /** Repair drifted entries. Setup asks for an enforcement level; this never does. */
+  updateMcpClients: (clientNames: string[]): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke('update-mcp-clients', clientNames),
   openProjectTab: (root: string): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('open-project-tab', root),
   closeCurrentTab: (): Promise<{ ok: boolean }> => ipcRenderer.invoke('close-current-tab'),

--- a/packages/app/src/renderer/electron.d.ts
+++ b/packages/app/src/renderer/electron.d.ts
@@ -33,6 +33,8 @@ declare global {
         clientName: string,
         level: string,
       ) => Promise<{ ok: boolean; error?: string }>;
+      /** Repair drifted entries. Setup asks for an enforcement level; this never does. */
+      updateMcpClients: (clientNames: string[]) => Promise<{ ok: boolean; error?: string }>;
       openProjectTab: (root: string) => Promise<{ ok: boolean }>;
       closeCurrentTab: () => Promise<{ ok: boolean }>;
       onFullscreenChanged: (callback: (isFullscreen: boolean) => void) => () => void;

--- a/packages/app/src/renderer/tabs/Clients.tsx
+++ b/packages/app/src/renderer/tabs/Clients.tsx
@@ -23,10 +23,24 @@
  *     discloses the actual steps.
  *   - `401b97c5 http` as a session's primary label: a raw id where the name
  *     goes. The project leads, the id is a monospace caption.
+ *
+ * TRA-497 then found what the rewrite had not: the row actions did not work.
+ * Every Connect and Update button spawned `trace-mcp init` with
+ * `--mcp-client cursor` as ONE argv entry, which commander rejects as an
+ * unknown option, and the renderer discarded the failed result — so the button
+ * that had shipped with this screen in April had never configured anything, and
+ * looked no different from one that had. Three rules came out of it and are
+ * enforced below: a write reports its failure on the row; Update repairs the
+ * entry (`clients update`) rather than re-running setup, so it never re-asks
+ * the enforcement level; and the drifted rows, which after any upgrade are
+ * every configured client at once, get one action for the bucket the list
+ * already sorts them into.
  */
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { relativeTime } from '../i18n/format';
+import { DaemonDownPane } from '../components/DaemonDownPane';
+import { Icon } from '../lattice/icons';
 import {
   Badge,
   Button,
@@ -143,25 +157,37 @@ function shortPath(p: string): string {
 
 // ── Section scaffolding (same idiom as Project Overview) ──────────
 
-/** A titled group. Grouping is whitespace and a caption, never a rule. */
+/** A titled group. Grouping is whitespace and a caption, never a rule.
+ *
+ *  The header carries the list's own action, if it has one. An action that
+ *  operates on every row of ONE list belongs to that list, not to the surface:
+ *  the toolbar speaks for the screen, and this screen holds two lists. */
 function Section({
   title,
   count,
+  action,
   children,
 }: {
   title: string;
   count?: number;
+  action?: React.ReactNode;
   children: React.ReactNode;
 }) {
   return (
     <section className="flex flex-col gap-2">
-      <h3
-        className="flex items-baseline gap-1.5 px-1 min-h-6 text-[11px] leading-[13px] font-semibold"
-        style={{ color: 'var(--label-secondary)' }}
-      >
-        {title}
-        {count !== undefined && count > 0 && <span className="tabular-nums">{count}</span>}
-      </h3>
+      {/* The caption keeps the 4px inset a group caption has; the action takes
+          the rows' 12px, because the edge the eye compares it to is the column
+          of row buttons underneath, not the caption beside it. */}
+      <div className="flex items-center gap-1.5 pl-1 pr-3 min-h-6">
+        <h3
+          className="flex items-baseline gap-1.5 flex-1 min-w-0 text-[11px] leading-[13px] font-semibold"
+          style={{ color: 'var(--label-secondary)' }}
+        >
+          {title}
+          {count !== undefined && count > 0 && <span className="tabular-nums">{count}</span>}
+        </h3>
+        {action}
+      </div>
       {children}
     </section>
   );
@@ -258,10 +284,12 @@ function SupportedClientRow({
   status,
   configPath,
   staleReason,
+  error,
   configuring,
   last,
   onConnect,
   onConnectWithLevel,
+  onUpdate,
 }: {
   name: ClientName;
   label: string;
@@ -276,10 +304,13 @@ function SupportedClientRow({
   status: ClientConfigStatus;
   configPath?: string | null;
   staleReason?: string;
+  /** What the last write for this row said when it failed. */
+  error?: string;
   configuring: boolean;
   last: boolean;
   onConnect: () => void;
   onConnectWithLevel: (level: EnforcementLevel) => void;
+  onUpdate: () => void;
 }) {
   const { t } = useTranslation('clients');
   const isManual = MANUAL_CLIENTS.has(name) || status === 'unmanageable';
@@ -288,15 +319,21 @@ function SupportedClientRow({
   const [showSteps, setShowSteps] = useState(false);
 
   const connected = status === 'up_to_date' || status === 'unknown';
+  /* Connect asks; Update does not. Setting trace-mcp up for the first time is
+     the moment the enforcement level is chosen — repairing a config that
+     drifted on the next upgrade is not, and re-asking could only overwrite the
+     answer already in the file with a fresh guess. */
   const handleConnect = () => {
     if (hasLevels) levelMenu.open();
     else onConnect();
   };
 
-  /* One caption slot, and only when there is something to say: where the entry
-     lives, or the manual steps the user asked to see. */
-  const caption =
-    isManual && showSteps
+  /* One caption slot, and only when there is something to say. A failed write
+     outranks the path: the path is where the entry lives, which the row also
+     implies, and the error is the only thing here the user can act on. */
+  const caption = error
+    ? error
+    : isManual && showSteps
       ? MANUAL_HINTS[name]
       : (connected || status === 'stale') && configPath
         ? shortPath(configPath)
@@ -317,12 +354,16 @@ function SupportedClientRow({
           {label}
         </div>
         {caption && (
+          /* Never colour alone: the failure carries a glyph and reads as a
+             sentence, so Increase Contrast and a colour-blind reader both get
+             the same information as everyone else. */
           <div
-            className="text-[11px] leading-[13px] truncate"
-            style={{ color: 'var(--label-secondary)' }}
+            className="flex items-center gap-1 text-[11px] leading-[13px] min-w-0"
+            style={{ color: error ? 'var(--status-red)' : 'var(--label-secondary)' }}
             title={caption}
           >
-            {caption}
+            {error && <Icon name="warning" size={12} className="shrink-0" />}
+            <span className="truncate">{caption}</span>
           </div>
         )}
       </div>
@@ -344,7 +385,7 @@ function SupportedClientRow({
           >
             {t('updateAvailable')}
           </Badge>
-          <Button disabled={configuring} onClick={handleConnect}>
+          <Button disabled={configuring} onClick={onUpdate}>
             {configuring ? t('updating') : t('update')}
           </Button>
         </>
@@ -397,6 +438,9 @@ export function Clients() {
   const [statuses, setStatuses] = useState<RichClientStatus[]>([]);
   const [detecting, setDetecting] = useState(true);
   const [configuringClient, setConfiguringClient] = useState<string | null>(null);
+  /** Client name → what its last write said when it failed. */
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [bulk, setBulk] = useState<{ done: number; total: number } | null>(null);
   const [scrolled, setScrolled] = useState(false);
 
   const detectClients = useCallback(async () => {
@@ -436,15 +480,52 @@ export function Clients() {
     detectClients();
   }, [detectClients]);
 
+  /* A write that failed says so on its row until the next attempt clears it.
+     Swallowing the result is how a Connect button that could not run for four
+     months looked exactly like one that had nothing to do (TRA-497). */
+  const recordResult = (clientName: string, result?: { ok: boolean; error?: string }) => {
+    setErrors((prev) => {
+      const next = { ...prev };
+      if (result?.ok) delete next[clientName];
+      else next[clientName] = result?.error ?? t('writeFailed');
+      return next;
+    });
+    return result?.ok === true;
+  };
+
   const handleConnect = async (clientName: string, level: EnforcementLevel = 'max') => {
     setConfiguringClient(clientName);
     try {
       const result = await window.electronAPI?.configureMcpClient(clientName, level);
-      if (result?.ok) {
-        await detectClients();
-      }
+      if (recordResult(clientName, result)) await detectClients();
     } finally {
       setConfiguringClient(null);
+    }
+  };
+
+  const handleUpdate = async (clientName: string) => {
+    setConfiguringClient(clientName);
+    try {
+      const result = await window.electronAPI?.updateMcpClients?.([clientName]);
+      if (recordResult(clientName, result)) await detectClients();
+    } finally {
+      setConfiguringClient(null);
+    }
+  };
+
+  /* One config at a time, so a row that cannot be written names itself instead
+     of failing the whole batch anonymously — and so the count moves while the
+     work happens. */
+  const handleUpdateAll = async (names: string[]) => {
+    setBulk({ done: 0, total: names.length });
+    try {
+      for (const [i, name] of names.entries()) {
+        setBulk({ done: i, total: names.length });
+        recordResult(name, await window.electronAPI?.updateMcpClients?.([name]));
+      }
+    } finally {
+      setBulk(null);
+      await detectClients();
     }
   };
 
@@ -507,6 +588,14 @@ export function Clients() {
     (a, b) => sortRank(resolveStatus(a.name).status) - sortRank(resolveStatus(b.name).status),
   );
 
+  /* The list already knows the drifted rows are one bucket — it sorts them to
+     the top. After an upgrade they are every configured client at once, because
+     what drifted is the entry trace-mcp writes, so the common path through this
+     screen is N identical clicks. */
+  const stale = sortedClients
+    .filter((c) => resolveStatus(c.name).status === 'stale')
+    .map((c) => c.name);
+
   const sessions = [...clients].sort(
     (a, b) => new Date(b.connectedAt).getTime() - new Date(a.connectedAt).getTime(),
   );
@@ -536,21 +625,30 @@ export function Clients() {
         onScroll={(e) => setScrolled((e.target as HTMLElement).scrollTop > 0)}
       >
         {daemonDown ? (
+          /* Three surfaces now depend on the daemon, and one condition gets one
+             sentence (DESIGN.md §5) — this screen had been saying it in its own
+             words two tabs away from Workspace saying it in Workspace's. */
           <div className="flex items-center justify-center h-full">
-            <EmptyState
-              icon="cable"
-              title={t('daemonDownTitle')}
-              subtitle={t('daemonDownSubtitle')}
-              action={
-                <Button variant="prominent" disabled={restarting} onClick={() => restartDaemon()}>
-                  {restarting ? t('starting') : t('startDaemon')}
-                </Button>
-              }
-            />
+            <DaemonDownPane restarting={restarting} onRestart={() => restartDaemon()} />
           </div>
         ) : (
         <div className="flex flex-col gap-6 px-4 py-4 mx-auto w-full" style={{ maxWidth: 720 }}>
-          <Section title={t('supported')}>
+          <Section
+            title={t('supported')}
+            action={
+              stale.length > 1 && (
+                <Button
+                  size="small"
+                  disabled={bulk !== null || configuringClient !== null}
+                  onClick={() => handleUpdateAll(stale)}
+                >
+                  {bulk
+                    ? t('updatingProgress', { done: bulk.done + 1, total: bulk.total })
+                    : `${t('updateAll')} · ${stale.length}`}
+                </Button>
+              )
+            }
+          >
             <Card>
               {detecting && !statuses.length && !detected.length ? (
                 <SkeletonRows rows={6} label={t('detecting')} />
@@ -565,10 +663,14 @@ export function Clients() {
                       status={s.status}
                       configPath={s.configPath}
                       staleReason={s.staleReason}
-                      configuring={configuringClient === c.name}
+                      error={errors[c.name]}
+                      configuring={
+                        configuringClient === c.name || (bulk !== null && stale.includes(c.name))
+                      }
                       last={i === sortedClients.length - 1}
                       onConnect={() => handleConnect(c.name)}
                       onConnectWithLevel={(level) => handleConnect(c.name, level)}
+                      onUpdate={() => handleUpdate(c.name)}
                     />
                   );
                 })

--- a/packages/app/src/renderer/tabs/__tests__/Clients.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/Clients.test.tsx
@@ -23,6 +23,15 @@ const STATUSES = [
   },
 ];
 
+/* What every configured client looks like the moment after a trace-mcp
+   upgrade — the entry that drifted is the one trace-mcp writes, so drift is
+   never one row. This is the common state of this screen, not an edge case. */
+const ALL_DRIFTED = [
+  { client: 'claude-code', configPath: '/Users/x/.claude.json', status: 'stale', staleReason: 'cwd' },
+  { client: 'cursor', configPath: '/Users/x/.cursor/mcp.json', status: 'stale', staleReason: 'cwd' },
+  { client: 'amp', configPath: '/Users/x/.config/amp/settings.json', status: 'stale', staleReason: 'fields' },
+];
+
 const CLIENTS = [
   {
     id: '401b97c5aaaa',
@@ -45,11 +54,20 @@ vi.mock('../../hooks/useDaemon', () => ({
   }),
 }));
 
+function api(): {
+  getMcpClientStatuses: ReturnType<typeof vi.fn>;
+  configureMcpClient: ReturnType<typeof vi.fn>;
+  updateMcpClients: ReturnType<typeof vi.fn>;
+} {
+  return (window as unknown as { electronAPI: never }).electronAPI;
+}
+
 beforeEach(() => {
   (window as unknown as { electronAPI: unknown }).electronAPI = {
     getMcpClientStatuses: vi.fn().mockResolvedValue({ ok: true, statuses: STATUSES }),
     detectMcpClients: vi.fn().mockResolvedValue([]),
     configureMcpClient: vi.fn().mockResolvedValue({ ok: true }),
+    updateMcpClients: vi.fn().mockResolvedValue({ ok: true }),
   };
 });
 
@@ -133,4 +151,77 @@ it('opens the enforcement-level menu from the Claude row', async () => {
   fireEvent.click(claude as HTMLElement);
   const menu = await screen.findByRole('menu');
   expect(within(menu).getByRole('menuitem', { name: 'Max' })).toBeTruthy();
+});
+
+// ── TRA-497 ──────────────────────────────────────────────────────────────
+
+/* Connect asks which enforcement level to set up at. Update repairs an entry
+   that drifted on an upgrade — the level is already in the file, and the only
+   thing re-asking can do is overwrite the user's answer with a fresh guess. */
+it('repairs a drifted config without asking for an enforcement level', async () => {
+  render(<Clients />);
+  fireEvent.click(await screen.findByRole('button', { name: 'Update' }));
+
+  await waitFor(() => expect(api().updateMcpClients).toHaveBeenCalledWith(['windsurf']));
+  expect(api().configureMcpClient).not.toHaveBeenCalled();
+  expect(screen.queryByRole('menu')).toBeNull();
+});
+
+/* Six identical clicks is what this screen costs after every upgrade, and the
+   list already sorts the drifted rows into one bucket at the top of it. */
+it('offers one action for the whole drifted bucket, and names its size', async () => {
+  api().getMcpClientStatuses.mockResolvedValue({ ok: true, statuses: ALL_DRIFTED });
+  render(<Clients />);
+
+  const all = await screen.findByRole('button', { name: 'Update all · 3' });
+  fireEvent.click(all);
+
+  await waitFor(() => expect(api().updateMcpClients).toHaveBeenCalledTimes(3));
+  expect(api().updateMcpClients.mock.calls.map(([names]) => names[0])).toEqual([
+    'claude-code',
+    'cursor',
+    'amp',
+  ]);
+});
+
+/* One drifted row is not a bucket — the row's own button is the shorter path,
+   and a second control that does the same thing is just more to read. */
+it('offers no bulk action when a single row has drifted', async () => {
+  render(<Clients />);
+  await screen.findByRole('button', { name: 'Update' });
+  expect(screen.queryByRole('button', { name: /Update all/ })).toBeNull();
+});
+
+/* The whole defect this screen shipped with: `configureMcpClient` returned
+   `{ ok: false }` for four months and the renderer dropped it on the floor, so
+   a button that could not run looked exactly like one with nothing to do. */
+it('says on the row when a write failed, and keeps the row actionable', async () => {
+  api().updateMcpClients.mockResolvedValue({ ok: false, error: 'Error: EACCES' });
+  render(<Clients />);
+  fireEvent.click(await screen.findByRole('button', { name: 'Update' }));
+
+  expect(await screen.findByText('Error: EACCES')).toBeTruthy();
+  expect(screen.getByRole('button', { name: 'Update' })).toBeTruthy();
+});
+
+/* One condition gets one sentence (DESIGN.md §5): this screen used to phrase
+   the dead daemon in its own words, two tabs from Workspace phrasing it in
+   Workspace's. Both read DaemonDownPane now. */
+it('states an unreachable daemon in the same words as every other surface', async () => {
+  vi.resetModules();
+  vi.doMock('../../hooks/useDaemon', () => ({
+    useDaemon: () => ({
+      clients: [],
+      loading: false,
+      connected: false,
+      restarting: false,
+      restartDaemon: vi.fn(),
+      fetchClients: vi.fn(),
+    }),
+  }));
+  const { Clients: Down } = await import('../Clients');
+  render(<Down />);
+
+  expect(await screen.findByText("The daemon isn't running")).toBeTruthy();
+  expect(screen.queryByText('Daemon not reachable')).toBeNull();
 });

--- a/packages/app/src/shared/i18n/catalog/de/clients.ts
+++ b/packages/app/src/shared/i18n/catalog/de/clients.ts
@@ -7,12 +7,6 @@ export const clients = {
   detecting: 'Clients werden erkannt',
   loadingSessions: 'Sitzungen werden geladen',
 
-  daemonDownTitle: 'Daemon nicht erreichbar',
-  daemonDownSubtitle:
-    'trace-mcp-Clients verbinden sich über den lokalen Daemon. Starte ihn, um sie zu sehen und einzurichten.',
-  startDaemon: 'Daemon starten',
-  starting: 'Wird gestartet…',
-
   noSessionsTitle: 'Keine aktiven Sitzungen',
   noSessionsSubtitle: 'Eine Sitzung erscheint hier, sobald sich ein Client mit dem Daemon verbindet.',
   unnamedSession: 'Unbenannte Sitzung',
@@ -27,6 +21,9 @@ export const clients = {
   updateAvailable: 'Update verfügbar',
   update: 'Aktualisieren',
   updating: 'Wird aktualisiert…',
+  updateAll: 'Alle aktualisieren',
+  updatingProgress: '{{done}} von {{total}} werden aktualisiert',
+  writeFailed: 'Die Konfiguration konnte nicht geschrieben werden.',
   driftedField: 'Abweichendes Feld: {{field}}',
   setUpManually: 'Manuell einrichten…',
   hideSteps: 'Schritte ausblenden',

--- a/packages/app/src/shared/i18n/catalog/en/clients.ts
+++ b/packages/app/src/shared/i18n/catalog/en/clients.ts
@@ -14,12 +14,6 @@ export const clients = {
   detecting: 'Detecting clients',
   loadingSessions: 'Loading sessions',
 
-  daemonDownTitle: 'Daemon not reachable',
-  daemonDownSubtitle:
-    'trace-mcp clients connect through the local daemon. Start it to see and configure them.',
-  startDaemon: 'Start daemon',
-  starting: 'Starting…',
-
   noSessionsTitle: 'No active sessions',
   noSessionsSubtitle: 'A session appears here when a client connects to the daemon.',
   unnamedSession: 'Unnamed session',
@@ -34,6 +28,9 @@ export const clients = {
   updateAvailable: 'Update available',
   update: 'Update',
   updating: 'Updating…',
+  updateAll: 'Update all',
+  updatingProgress: 'Updating {{done}} of {{total}}',
+  writeFailed: 'The config could not be written.',
   driftedField: 'Drifted field: {{field}}',
   setUpManually: 'Set up manually…',
   hideSteps: 'Hide steps',

--- a/packages/app/src/shared/i18n/catalog/es/clients.ts
+++ b/packages/app/src/shared/i18n/catalog/es/clients.ts
@@ -7,12 +7,6 @@ export const clients = {
   detecting: 'Detectando clientes',
   loadingSessions: 'Cargando las sesiones',
 
-  daemonDownTitle: 'Daemon inaccesible',
-  daemonDownSubtitle:
-    'Los clientes de trace-mcp se conectan a través del daemon local. Arráncalo para verlos y configurarlos.',
-  startDaemon: 'Arrancar el daemon',
-  starting: 'Arrancando…',
-
   noSessionsTitle: 'No hay sesiones activas',
   noSessionsSubtitle: 'Aquí aparece una sesión cuando un cliente se conecta al daemon.',
   unnamedSession: 'Sesión sin nombre',
@@ -27,6 +21,9 @@ export const clients = {
   updateAvailable: 'Actualización disponible',
   update: 'Actualizar',
   updating: 'Actualizando…',
+  updateAll: 'Actualizar todo',
+  updatingProgress: 'Actualizando {{done}} de {{total}}',
+  writeFailed: 'No se pudo escribir la configuración.',
   driftedField: 'Campo desviado: {{field}}',
   setUpManually: 'Configurar a mano…',
   hideSteps: 'Ocultar los pasos',

--- a/packages/app/src/shared/i18n/catalog/fr/clients.ts
+++ b/packages/app/src/shared/i18n/catalog/fr/clients.ts
@@ -7,12 +7,6 @@ export const clients = {
   detecting: 'Détection des clients',
   loadingSessions: 'Chargement des sessions',
 
-  daemonDownTitle: 'Démon injoignable',
-  daemonDownSubtitle:
-    'Les clients trace-mcp se connectent via le démon local. Démarrez-le pour les voir et les configurer.',
-  startDaemon: 'Démarrer le démon',
-  starting: 'Démarrage…',
-
   noSessionsTitle: 'Aucune session active',
   noSessionsSubtitle: 'Une session apparaît ici quand un client se connecte au démon.',
   unnamedSession: 'Session sans nom',
@@ -27,6 +21,9 @@ export const clients = {
   updateAvailable: 'Mise à jour disponible',
   update: 'Mettre à jour',
   updating: 'Mise à jour…',
+  updateAll: 'Tout mettre à jour',
+  updatingProgress: 'Mise à jour de {{done}} sur {{total}}',
+  writeFailed: 'La configuration n’a pas pu être écrite.',
   driftedField: 'Champ modifié : {{field}}',
   setUpManually: 'Configurer manuellement…',
   hideSteps: 'Masquer les étapes',

--- a/packages/app/src/shared/i18n/catalog/hi/clients.ts
+++ b/packages/app/src/shared/i18n/catalog/hi/clients.ts
@@ -7,12 +7,6 @@ export const clients = {
   detecting: 'क्लाइंट खोजे जा रहे हैं',
   loadingSessions: 'सेशन लोड हो रहे हैं',
 
-  daemonDownTitle: 'डेमन उपलब्ध नहीं',
-  daemonDownSubtitle:
-    'trace-mcp क्लाइंट लोकल डेमन से जुड़ते हैं। उन्हें देखने और सेट करने के लिए इसे चालू करें।',
-  startDaemon: 'डेमन चालू करें',
-  starting: 'शुरू हो रहा है…',
-
   noSessionsTitle: 'कोई सक्रिय सेशन नहीं',
   noSessionsSubtitle: 'जब कोई क्लाइंट डेमन से जुड़ता है, सेशन यहाँ दिखता है।',
   unnamedSession: 'बिना नाम का सेशन',
@@ -27,6 +21,9 @@ export const clients = {
   updateAvailable: 'अपडेट उपलब्ध',
   update: 'अपडेट',
   updating: 'अपडेट हो रहा है…',
+  updateAll: 'सभी अपडेट करें',
+  updatingProgress: '{{total}} में से {{done}} अपडेट हो रहे हैं',
+  writeFailed: 'कॉन्फ़िगरेशन नहीं लिखा जा सका।',
   driftedField: 'बदला हुआ फ़ील्ड: {{field}}',
   setUpManually: 'खुद सेट करें…',
   hideSteps: 'चरण छिपाएँ',

--- a/packages/app/src/shared/i18n/catalog/ja/clients.ts
+++ b/packages/app/src/shared/i18n/catalog/ja/clients.ts
@@ -7,12 +7,6 @@ export const clients = {
   detecting: 'クライアントを検出中',
   loadingSessions: 'セッションを読み込み中',
 
-  daemonDownTitle: 'デーモンに接続できません',
-  daemonDownSubtitle:
-    'trace-mcp のクライアントはローカルのデーモン経由で接続します。デーモンを起動すると表示・設定できます。',
-  startDaemon: 'デーモンを起動',
-  starting: '起動中…',
-
   noSessionsTitle: 'アクティブなセッションはありません',
   noSessionsSubtitle: 'クライアントがデーモンに接続すると、ここにセッションが表示されます。',
   unnamedSession: '名前のないセッション',
@@ -27,6 +21,9 @@ export const clients = {
   updateAvailable: 'アップデートあり',
   update: 'アップデート',
   updating: 'アップデート中…',
+  updateAll: 'すべて更新',
+  updatingProgress: '{{total}} 件中 {{done}} 件を更新中',
+  writeFailed: '設定を書き込めませんでした。',
   driftedField: '差異のある項目: {{field}}',
   setUpManually: '手動で設定…',
   hideSteps: '手順を隠す',

--- a/packages/app/src/shared/i18n/catalog/ko/clients.ts
+++ b/packages/app/src/shared/i18n/catalog/ko/clients.ts
@@ -7,12 +7,6 @@ export const clients = {
   detecting: '클라이언트 탐지 중',
   loadingSessions: '세션 불러오는 중',
 
-  daemonDownTitle: '데몬에 연결할 수 없음',
-  daemonDownSubtitle:
-    'trace-mcp 클라이언트는 로컬 데몬을 통해 연결됩니다. 데몬을 시작하면 확인하고 설정할 수 있습니다.',
-  startDaemon: '데몬 시작',
-  starting: '시작하는 중…',
-
   noSessionsTitle: '활성 세션 없음',
   noSessionsSubtitle: '클라이언트가 데몬에 연결하면 세션이 여기에 표시됩니다.',
   unnamedSession: '이름 없는 세션',
@@ -27,6 +21,9 @@ export const clients = {
   updateAvailable: '업데이트 있음',
   update: '업데이트',
   updating: '업데이트 중…',
+  updateAll: '모두 업데이트',
+  updatingProgress: '{{total}}개 중 {{done}}개 업데이트 중',
+  writeFailed: '설정을 저장하지 못했습니다.',
   driftedField: '어긋난 필드: {{field}}',
   setUpManually: '수동으로 설정…',
   hideSteps: '단계 숨기기',

--- a/packages/app/src/shared/i18n/catalog/pt-BR/clients.ts
+++ b/packages/app/src/shared/i18n/catalog/pt-BR/clients.ts
@@ -7,12 +7,6 @@ export const clients = {
   detecting: 'Detectando clientes',
   loadingSessions: 'Carregando sessões',
 
-  daemonDownTitle: 'Daemon inacessível',
-  daemonDownSubtitle:
-    'Os clientes do trace-mcp se conectam pelo daemon local. Inicie-o para vê-los e configurá-los.',
-  startDaemon: 'Iniciar daemon',
-  starting: 'Iniciando…',
-
   noSessionsTitle: 'Nenhuma sessão ativa',
   noSessionsSubtitle: 'Uma sessão aparece aqui quando um cliente se conecta ao daemon.',
   unnamedSession: 'Sessão sem nome',
@@ -27,6 +21,9 @@ export const clients = {
   updateAvailable: 'Atualização disponível',
   update: 'Atualizar',
   updating: 'Atualizando…',
+  updateAll: 'Atualizar tudo',
+  updatingProgress: 'Atualizando {{done}} de {{total}}',
+  writeFailed: 'Não foi possível gravar a configuração.',
   driftedField: 'Campo divergente: {{field}}',
   setUpManually: 'Configurar manualmente…',
   hideSteps: 'Ocultar os passos',

--- a/packages/app/src/shared/i18n/catalog/ru/clients.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/clients.ts
@@ -7,12 +7,6 @@ export const clients = {
   detecting: 'Ищем клиентов',
   loadingSessions: 'Загружаем сессии',
 
-  daemonDownTitle: 'Сервис недоступен',
-  daemonDownSubtitle:
-    'Клиенты trace-mcp подключаются через локальный сервис. Запустите его, чтобы увидеть и настроить их.',
-  startDaemon: 'Запустить сервис',
-  starting: 'Запускаем…',
-
   noSessionsTitle: 'Активных сессий нет',
   noSessionsSubtitle: 'Сессия появится здесь, когда клиент подключится к сервису.',
   unnamedSession: 'Сессия без имени',
@@ -27,6 +21,9 @@ export const clients = {
   updateAvailable: 'Есть обновление',
   update: 'Обновить',
   updating: 'Обновляем…',
+  updateAll: 'Обновить все',
+  updatingProgress: 'Обновляем {{done}} из {{total}}',
+  writeFailed: 'Не удалось записать конфигурацию.',
   driftedField: 'Разошлось поле: {{field}}',
   setUpManually: 'Настроить вручную…',
   hideSteps: 'Скрыть шаги',

--- a/packages/app/src/shared/i18n/catalog/zh/clients.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/clients.ts
@@ -7,11 +7,6 @@ export const clients = {
   detecting: '正在检测客户端',
   loadingSessions: '正在加载会话',
 
-  daemonDownTitle: '无法连接守护进程',
-  daemonDownSubtitle: 'trace-mcp 的客户端通过本地守护进程连接。启动它才能查看和配置。',
-  startDaemon: '启动守护进程',
-  starting: '启动中…',
-
   noSessionsTitle: '没有活跃会话',
   noSessionsSubtitle: '当有客户端连接到守护进程时，会话会出现在这里。',
   unnamedSession: '未命名会话',
@@ -26,6 +21,9 @@ export const clients = {
   updateAvailable: '有可用更新',
   update: '更新',
   updating: '更新中…',
+  updateAll: '全部更新',
+  updatingProgress: '正在更新 {{done}}/{{total}}',
+  writeFailed: '无法写入配置。',
   driftedField: '偏移字段：{{field}}',
   setUpManually: '手动配置…',
   hideSteps: '隐藏步骤',

--- a/src/cli/clients.ts
+++ b/src/cli/clients.ts
@@ -7,10 +7,27 @@
  * what `init` would write now — including a stale `alwaysLoad: true` left
  * by a pre-#354 `init` run — the row should prompt the user to refresh the
  * config rather than pretend the integration is healthy.
+ *
+ * `trace-mcp clients update` is the repair half of the same pair, and exists
+ * because `init` could not be it. What drifts is the MCP server entry —
+ * `command`, `cwd`, a leftover `alwaysLoad` — and repairing it is a different
+ * operation from setting trace-mcp up: setup asks which enforcement level to
+ * run at, repair must not, because the answer is already in the user's config
+ * and re-asking it can only change what the user already chose. `init` is a
+ * setup command through and through: `--skip-hooks` writes
+ * `tools.agent_behavior = "off"`, and omitting it installs hooks and tweakcc.
+ * There is no flag combination that means "reconcile the entry and touch
+ * nothing else", so the desktop app's Update button had no safe call to make.
+ * This command is that call.
  */
 
 import { Command } from 'commander';
-import { getMcpClientStatuses, type McpClientStatus } from '../init/mcp-client.js';
+import {
+  configureMcpClients,
+  getMcpClientStatuses,
+  type McpClientStatus,
+} from '../init/mcp-client.js';
+import type { DetectedMcpClient, InitStepResult } from '../init/types.js';
 import { findProjectRoot } from '../project-root.js';
 
 export const clientsCommand = new Command('clients').description(
@@ -47,6 +64,65 @@ clientsCommand
 
     printHumanReport(scope, statuses);
   });
+
+clientsCommand
+  .command('update')
+  .description(
+    'Rewrite the trace-mcp entry in one or more client configs. Never touches hooks, tweakcc or agent_behavior.',
+  )
+  .argument(
+    '[clients...]',
+    'Clients to repair (e.g. cursor amp). Omit to repair every client whose config has drifted.',
+  )
+  .option('--json', 'Output machine-readable JSON')
+  .option('--scope <scope>', 'Config scope: global | project', 'global')
+  .option('--dry-run', 'Report what would be written without writing it')
+  .action(
+    (
+      clients: string[],
+      opts: { json?: boolean; scope?: 'global' | 'project'; dryRun?: boolean },
+    ) => {
+      const scope = opts.scope === 'project' ? 'project' : 'global';
+      const projectRoot = findProjectRoot(process.cwd());
+
+      const targets = (
+        clients.length > 0
+          ? (clients as DetectedMcpClient['name'][])
+          : getMcpClientStatuses(projectRoot, scope)
+              .filter((s) => s.status === 'stale')
+              .map((s) => s.client)
+      ) as DetectedMcpClient['name'][];
+
+      const steps =
+        targets.length > 0
+          ? configureMcpClients(targets, projectRoot, { scope, dryRun: opts.dryRun })
+          : [];
+
+      if (opts.json) {
+        console.log(JSON.stringify({ scope, projectRoot, clients: targets, steps }, null, 2));
+      } else {
+        printUpdateReport(targets, steps);
+      }
+
+      /* A repair that wrote nothing because every write failed is not a success.
+       `skipped` is also how configureMcpClients reports an unknown client name
+       and the manual-only pair, so the app can tell "nothing to do" from
+       "asked for something impossible" by the exit code alone. */
+      if (steps.some((s) => s.action === 'skipped' && s.detail?.startsWith('Error:'))) {
+        process.exitCode = 1;
+      }
+    },
+  );
+
+function printUpdateReport(targets: string[], steps: InitStepResult[]): void {
+  if (targets.length === 0) {
+    console.log('Every MCP client config already matches what trace-mcp writes.');
+    return;
+  }
+  for (const s of steps) {
+    console.log(`  ${s.action.padEnd(18)}  ${s.target}${s.detail ? `  (${s.detail})` : ''}`);
+  }
+}
 
 function printHumanReport(scope: string, statuses: McpClientStatus[]): void {
   console.log(`MCP client configurations (scope: ${scope})\n`);

--- a/tests/cli/clients.test.ts
+++ b/tests/cli/clients.test.ts
@@ -10,6 +10,7 @@ import type { McpClientStatus } from '../../src/init/mcp-client.js';
 
 vi.mock('../../src/init/mcp-client.js', () => ({
   getMcpClientStatuses: vi.fn(),
+  configureMcpClients: vi.fn(() => []),
 }));
 
 vi.mock('../../src/project-root.js', () => ({
@@ -17,10 +18,11 @@ vi.mock('../../src/project-root.js', () => ({
 }));
 
 const { clientsCommand } = await import('../../src/cli/clients.js');
-const { getMcpClientStatuses } = await import('../../src/init/mcp-client.js');
+const { configureMcpClients, getMcpClientStatuses } = await import('../../src/init/mcp-client.js');
 const { findProjectRoot } = await import('../../src/project-root.js');
 
 const mockGetMcpClientStatuses = vi.mocked(getMcpClientStatuses);
+const mockConfigureMcpClients = vi.mocked(configureMcpClients);
 const mockFindProjectRoot = vi.mocked(findProjectRoot);
 
 async function run(args: string[]): Promise<void> {
@@ -36,6 +38,8 @@ function printed(): string {
 beforeEach(() => {
   vi.clearAllMocks();
   mockFindProjectRoot.mockReturnValue('/proj/current');
+  mockConfigureMcpClients.mockReturnValue([]);
+  process.exitCode = undefined;
   logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 });
 
@@ -112,6 +116,96 @@ describe('clients status — human output', () => {
       'cursor',
       'windsurf',
     ]);
+  });
+});
+
+describe('clients update', () => {
+  it('repairs every stale client when no names are given', async () => {
+    mockGetMcpClientStatuses.mockReturnValue(SAMPLE_STATUSES);
+
+    await run(['update']);
+
+    expect(mockConfigureMcpClients).toHaveBeenCalledWith(['windsurf'], '/proj/current', {
+      scope: 'global',
+      dryRun: undefined,
+    });
+  });
+
+  it('repairs exactly the named clients, drifted or not', async () => {
+    await run(['update', 'cursor', 'amp']);
+
+    expect(mockGetMcpClientStatuses).not.toHaveBeenCalled();
+    expect(mockConfigureMcpClients).toHaveBeenCalledWith(['cursor', 'amp'], '/proj/current', {
+      scope: 'global',
+      dryRun: undefined,
+    });
+  });
+
+  /* The whole reason this command exists rather than another `init` flag: an
+     update must not re-open the enforcement-level question the user already
+     answered. configureMcpClients writes the MCP entry and nothing else. */
+  it('does not write hooks, tweakcc or agent_behavior', async () => {
+    await run(['update', 'cursor']);
+
+    const [, , opts] = mockConfigureMcpClients.mock.calls[0];
+    expect(Object.keys(opts).sort()).toEqual(['dryRun', 'scope']);
+  });
+
+  it('says so and calls nothing when every config already matches', async () => {
+    mockGetMcpClientStatuses.mockReturnValue([
+      { client: 'cursor', configPath: '/home/.cursor/mcp.json', status: 'up_to_date' },
+    ]);
+
+    await run(['update']);
+
+    expect(mockConfigureMcpClients).not.toHaveBeenCalled();
+    expect(printed()).toContain('already matches');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('passes project scope and --dry-run through', async () => {
+    await run(['update', 'cursor', '--scope', 'project', '--dry-run']);
+
+    expect(mockConfigureMcpClients).toHaveBeenCalledWith(['cursor'], '/proj/current', {
+      scope: 'project',
+      dryRun: true,
+    });
+  });
+
+  it('exits non-zero when a write failed', async () => {
+    mockConfigureMcpClients.mockReturnValue([
+      { target: '/home/.cursor/mcp.json', action: 'skipped', detail: 'Error: EACCES' },
+    ]);
+
+    await run(['update', 'cursor']);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('stays zero for a dry run, which also reports every row as skipped', async () => {
+    mockConfigureMcpClients.mockReturnValue([
+      { target: '/home/.cursor/mcp.json', action: 'skipped', detail: 'Would configure cursor' },
+    ]);
+
+    await run(['update', 'cursor', '--dry-run']);
+
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('emits scope, projectRoot, clients and steps as JSON', async () => {
+    mockConfigureMcpClients.mockReturnValue([
+      { target: '/home/.cursor/mcp.json', action: 'updated', detail: 'cursor (global)' },
+    ]);
+
+    await run(['update', 'cursor', '--json']);
+
+    const parsed = JSON.parse(printed());
+    expect(parsed).toMatchObject({
+      scope: 'global',
+      projectRoot: '/proj/current',
+      clients: ['cursor'],
+    });
+    expect(parsed.steps[0].action).toBe('updated');
   });
 });
 


### PR DESCRIPTION
## What was actually wrong

Every `Connect` and `Update` button on the MCP Clients screen has been inert since the screen
shipped (2026-04-12, `92320665`). `configure-mcp-client` built its flags as:

```ts
const flags = [`--mcp-client ${clientName}`, '--yes'];
execFile('trace-mcp', ['init', ...flags], …)
```

`execFile` passes the array to the process without a shell, so `--mcp-client cursor` is a single
unknown option. Measured on the running renderer, before this change:

```
> window.electronAPI.configureMcpClient('cursor','base')
{ ok: false,
  error: "Command failed: trace-mcp init --mcp-client cursor --yes --skip-hooks --skip-hooks\n
          error: unknown option '--mcp-client cursor'\n" }
```

The renderer read `result?.ok`, found it false, and did nothing — no refresh, no message, no
changed state. A button that could not run rendered identically to one with nothing to do.

## Changes

**The argv is two entries**, and a failed write now says so on its row: `--status-red` caption
with a glyph, replacing the config path, and the row keeps its button.

**`Update` repairs; it no longer re-runs setup.** It shared `handleConnect` with `Connect`, so
repairing a drifted config re-opened the enforcement-level menu — a setup question, asked about a
config whose answer was already on disk, with no indication which level it was on, and whatever
the user picked silently became the new level.

`init` cannot answer it either. Every flag combination it has either installs hooks and tweakcc,
or (`--skip-hooks`) writes `tools.agent_behavior = "off"` — `applyAgentBehavior` in `cli/init.ts`
downgrades `strict` → `off` rather than leaving it alone. There is no "reconcile the entry and
touch nothing else" call, so this adds one:

```
trace-mcp clients update [clients...] [--scope] [--dry-run] [--json]
```

It calls `configureMcpClients()` and nothing else; with no arguments it repairs every client
`clients status` reports as `stale`. The app shells out to it. When the app has self-updated ahead
of the CLI (TRA-180 makes that reachable), the row says so in a sentence rather than showing
`unknown command 'update'`.

**The drifted rows are one bucket.** After any trace-mcp upgrade they are every configured client
at once — what drifts is the entry trace-mcp itself writes — and `sortRank` already sorts them
together. `Section` grows an `action` slot; the bucket gets `Update all · 6`. One client at a time
so a row that fails names itself, counting up while it runs, and it appears only from two rows up
(at one row the row's own button is the shorter path). Its right edge is aligned to the column of
row buttons underneath (measured: both at 922px), not to the caption beside it.

**Folded in:** the daemon-down state reads `DaemonDownPane` like Workspace and Project Overview,
instead of phrasing the same condition in its own words two tabs away (DESIGN.md §5). Four
now-unused keys leave ten catalogues.

## Verification

Screenshots taken on the real Electron window via `packages/app/scripts/electron-cdp.mjs`
(hidden window, own profile — never on screen), light + dark + `--size=640x420`, with six clients
genuinely drifted. End-to-end repair driven through the app's own IPC:

```
> window.electronAPI.updateMcpClients(['cursor'])
{ ok: true }        # and ~/.cursor/mcp.json was rewritten
```

`pnpm --dir packages/app test` 526 passed · `tests/cli tests/init tests/scripts` 397 passed ·
typecheck clean in both packages · `check:i18n` clean · `biome ci` clean.

Five new renderer tests and seven new CLI tests cover: Update never opens the level menu, the
bulk action's size and per-client sequencing, the single-row case having no bulk action, a failed
write appearing on its row, the shared daemon-down sentence, and that `clients update` passes
`configureMcpClients` no option beyond `scope`/`dryRun`.

## Relationship to #637

Follow-up to #637, which is the other half of this thread and reached the same defect from the
daemon side: it adds `level` to `McpClientStatus` so the app can know which enforcement level a
config is on. It deliberately stops short of the UI ("Not in this PR: Update reusing the level").

This PR does not consume that field, and the reason is worth stating rather than leaving as a
silent divergence: **a repair does not need to know the level, because it must not write one.**
`clients update` calls `configureMcpClients()`, which touches the MCP entry only — hooks, tweakcc
and `agent_behavior` are all untouched, so there is nothing to preserve and nothing to re-ask.
Reusing a reported level would still be a write of the level, and a level read back from installed
artifacts is an inference; not writing it at all is the stronger guarantee.

`level` remains worth having for what #637 measures it for — **showing** a configured client's
level on its row, which the screen cannot do today. That is a separate, purely additive change and
I am happy to take it once #637 lands. The two PRs overlap textually in `Clients.tsx`,
`main/index.ts`, `preload.ts`, `electron.d.ts` and `cli/clients.ts` but not semantically; whichever
merges second rebases, and I will rebase this one if #637 goes first.

## Known limitation, filed separately

`clients status` and `clients update` both derive the expected entry's `cwd` from
`findProjectRoot(process.cwd())`, so a **global** registration carries whatever directory the CLI
was invoked from. The desktop app invokes it from the Electron bundle, which is why four of the
six rows above report `drift: cwd`. That is a CLI-contract question, not a visual one, and it does
not block anything here — `Update all` does exactly what six `Update` clicks do — but the badge
count on this screen is only fully trustworthy once it is settled.

Closes TRA-497. The `cwd` limitation below is TRA-501.

Agent: Design/UX Agent
