### PR TITLE
fix(clients): a global MCP registration no longer carries the caller's cwd (TRA-501)

### DIFF
--- a/src/cli/clients.ts
+++ b/src/cli/clients.ts
@@ -34,6 +34,20 @@ export const clientsCommand = new Command('clients').description(
   'Inspect MCP client configurations',
 );
 
+/**
+ * Project root for the scope-dependent parts of a client config. Global-scope
+ * entries no longer use it at all (TRA-501), so a cwd with no root marker is
+ * not a reason to fail: `findProjectRoot` throws there, which is exactly what
+ * the desktop app hits when it shells out from inside a packaged bundle.
+ */
+function resolveProjectRoot(): string {
+  try {
+    return findProjectRoot(process.cwd());
+  } catch {
+    return process.cwd();
+  }
+}
+
 clientsCommand
   .command('status')
   .description(
@@ -47,7 +61,7 @@ clientsCommand
   )
   .action((opts: { json?: boolean; scope?: 'global' | 'project'; client?: string }) => {
     const scope = opts.scope === 'project' ? 'project' : 'global';
-    const projectRoot = findProjectRoot(process.cwd());
+    const projectRoot = resolveProjectRoot();
     const clientNames = opts.client
       ? // biome-ignore lint/suspicious/noExplicitAny: validated downstream by getMcpClientStatuses
         (opts.client
@@ -83,7 +97,7 @@ clientsCommand
       opts: { json?: boolean; scope?: 'global' | 'project'; dryRun?: boolean },
     ) => {
       const scope = opts.scope === 'project' ? 'project' : 'global';
-      const projectRoot = findProjectRoot(process.cwd());
+      const projectRoot = resolveProjectRoot();
 
       const targets = (
         clients.length > 0

--- a/src/init/mcp-client.ts
+++ b/src/init/mcp-client.ts
@@ -125,9 +125,12 @@ export function configureMcpClients(
     if (name === 'warp') {
       const hasClaudeCode = clientNames.includes('claude-code');
       const launcher = getLauncherPath();
+      // No working_directory: Warp's MCP config is cloud-synced and user-level,
+      // so pinning it to the directory `init` ran in would be wrong everywhere
+      // else (TRA-501). Warp launches the server in the session's own directory.
       const snippet = JSON.stringify({
         mcpServers: {
-          'trace-mcp': { command: launcher, args: ['serve'], working_directory: projectRoot },
+          'trace-mcp': { command: launcher, args: ['serve'] },
         },
       });
       results.push({
@@ -150,7 +153,7 @@ export function configureMcpClients(
         results.push({ target: name, action: 'skipped', detail: 'Unknown client' });
         continue;
       }
-      const entry = { ...buildMcpEntry(), args: ['serve'], cwd: projectRoot };
+      const entry = buildExpectedEntry(name, projectRoot, opts.scope);
 
       if (fs.existsSync(configPath) && ampEntryMatches(configPath, entry)) {
         results.push({ target: configPath, action: 'already_configured', detail: name });
@@ -184,11 +187,8 @@ export function configureMcpClients(
         results.push({ target: name, action: 'skipped', detail: 'Unknown client' });
         continue;
       }
-      const entry: McpServerEntry & { type: 'stdio' } = {
-        type: 'stdio',
-        ...buildMcpEntry(),
-        args: ['serve'],
-        cwd: projectRoot,
+      const entry = buildExpectedEntry(name, projectRoot, opts.scope) as McpServerEntry & {
+        type: 'stdio';
       };
 
       if (fs.existsSync(configPath) && factoryEntryMatches(configPath, entry)) {
@@ -224,7 +224,7 @@ export function configureMcpClients(
         continue;
       }
 
-      const entry = { ...buildMcpEntry(), args: ['serve'], cwd: projectRoot };
+      const entry = buildExpectedEntry(name, projectRoot, opts.scope);
 
       if (fs.existsSync(configPath) && hermesEntryMatches(configPath, entry)) {
         results.push({ target: configPath, action: 'already_configured', detail: name });
@@ -284,11 +284,10 @@ export function configureMcpClients(
       }
 
       try {
-        const action = writeCodexTomlEntry(configPath, {
-          ...buildMcpEntry(),
-          args: ['serve'],
-          cwd: projectRoot,
-        });
+        const action = writeCodexTomlEntry(
+          configPath,
+          buildExpectedEntry(name, projectRoot, opts.scope),
+        );
         results.push({ target: configPath, action, detail: `${name} (${opts.scope})` });
       } catch (err) {
         results.push({
@@ -729,9 +728,33 @@ const ALL_MCP_CLIENT_NAMES: ReadonlyArray<DetectedMcpClient['name']> = [
 ];
 
 /**
+ * Clients whose config file is user-level no matter which scope was asked
+ * for — `getConfigPath` ignores `projectRoot` for these, so a project-scoped
+ * run would otherwise pin one project's path into a shared global file.
+ */
+const ALWAYS_GLOBAL_CLIENTS: ReadonlySet<DetectedMcpClient['name']> = new Set([
+  'claude-desktop',
+  'hermes',
+  'cline',
+  'kilocode',
+  'antigravity',
+  'kimi',
+]);
+
+/**
  * Build the entry we'd write for `name` right now. Single source of truth
  * shared by configureMcpClients() and getMcpClientStatuses() so drift
  * detection can never disagree with what init actually writes.
+ *
+ * A global registration deliberately carries NO `cwd` (TRA-501). `cwd` is the
+ * working directory the client spawns `trace-mcp serve` in, and `serve` takes
+ * whatever it is handed — so pinning it to `findProjectRoot(process.cwd())`
+ * made the "correct" contents of a user-level entry depend on the directory
+ * the CLI happened to run in: `clients status` reported `drift: cwd` from any
+ * other directory, and a repair driven by the desktop app (which shells out
+ * from the Electron bundle) wrote the app's own package directory into every
+ * client. Without it the client's own working directory wins, which for an
+ * editor is the project the user actually has open.
  */
 function buildExpectedEntry(
   name: DetectedMcpClient['name'],
@@ -739,7 +762,10 @@ function buildExpectedEntry(
   scope: McpScope,
 ): McpServerEntry & { type?: 'stdio' } {
   const base: McpServerEntry = { ...buildMcpEntry(), args: ['serve'] };
-  if (scope === 'global' || (name !== 'claude-code' && name !== 'claw-code')) {
+  const effectiveScope: McpScope = ALWAYS_GLOBAL_CLIENTS.has(name) ? 'global' : scope;
+  // claude-code/claw-code read a project-scoped config from the project root
+  // itself, so they already run there — no cwd needed.
+  if (effectiveScope === 'project' && name !== 'claude-code' && name !== 'claw-code') {
     base.cwd = projectRoot;
   }
   // alwaysLoad is intentionally never set here — see McpServerEntry.alwaysLoad.

--- a/tests/cli/clients.test.ts
+++ b/tests/cli/clients.test.ts
@@ -106,6 +106,20 @@ describe('clients status — human output', () => {
     expect(mockGetMcpClientStatuses).toHaveBeenCalledWith('/proj/current', 'global', undefined);
   });
 
+  /* A packaged desktop app shells out from inside its bundle, where no root
+     marker exists and findProjectRoot throws. Global scope no longer needs a
+     project root (TRA-501), so that must not take the command down. */
+  it('falls back to cwd when no project root can be found', async () => {
+    mockFindProjectRoot.mockImplementation(() => {
+      throw new Error('Could not find project root');
+    });
+    mockGetMcpClientStatuses.mockReturnValue([]);
+
+    await run(['status']);
+
+    expect(mockGetMcpClientStatuses).toHaveBeenCalledWith(process.cwd(), 'global', undefined);
+  });
+
   it('parses --client into a trimmed, filtered array', async () => {
     mockGetMcpClientStatuses.mockReturnValue([]);
 

--- a/tests/init/mcp-client-status.test.ts
+++ b/tests/init/mcp-client-status.test.ts
@@ -66,6 +66,45 @@ describe('getMcpClientStatuses', () => {
     expect(s.staleReason).toBeUndefined();
   });
 
+  // TRA-501: a global registration must not depend on the directory the CLI
+  // ran in. Before the fix, writing from one directory and asking for status
+  // from another reported `drift: cwd` forever — and a repair run from the
+  // wrong directory (the desktop app always is) wrote that directory back.
+  it('keeps a global entry directory-independent across writer and status', () => {
+    const otherRoot = path.join(sandbox, 'somewhere-else');
+    fs.mkdirSync(otherRoot, { recursive: true });
+
+    configureMcpClients(['cursor', 'factory-droid', 'amp'], projectRoot, { scope: 'global' });
+
+    // Written from projectRoot, asked about from an unrelated root.
+    const statuses = getMcpClientStatuses(otherRoot, 'global', ['cursor', 'factory-droid', 'amp']);
+    expect(statuses.map((s) => s.status)).toEqual(['up_to_date', 'up_to_date', 'up_to_date']);
+
+    const cursorEntry = JSON.parse(
+      fs.readFileSync(path.join(fakeHome, '.cursor', 'mcp.json'), 'utf-8'),
+    ).mcpServers['trace-mcp'];
+    expect(cursorEntry.cwd).toBeUndefined();
+  });
+
+  it('flags an existing global entry that still carries a cwd as stale, and repairs it (TRA-501)', () => {
+    configureMcpClients(['cursor'], projectRoot, { scope: 'global' });
+    const configPath = path.join(fakeHome, '.cursor', 'mcp.json');
+    const c = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    c.mcpServers['trace-mcp'].cwd = '/some/stale/path';
+    fs.writeFileSync(configPath, JSON.stringify(c, null, 2));
+
+    const [before] = getMcpClientStatuses(projectRoot, 'global', ['cursor']);
+    expect(before.status).toBe('stale');
+    expect(before.staleReason).toBe('cwd');
+
+    configureMcpClients(['cursor'], projectRoot, { scope: 'global' });
+    const [after] = getMcpClientStatuses(projectRoot, 'global', ['cursor']);
+    expect(after.status).toBe('up_to_date');
+    expect(
+      JSON.parse(fs.readFileSync(configPath, 'utf-8')).mcpServers['trace-mcp'].cwd,
+    ).toBeUndefined();
+  });
+
   it('flags `stale` with reason="alwaysLoad" when the on-disk entry carries a stale flag (GH #354)', () => {
     // Simulate an installation done by a pre-#354 `init`, which used to
     // write `alwaysLoad: true`. init no longer writes it, so an entry that

--- a/tests/init/mcp-clients-extra.test.ts
+++ b/tests/init/mcp-clients-extra.test.ts
@@ -180,7 +180,15 @@ describe('Factory Droid writer', () => {
     const entry = parsed.mcpServers['trace-mcp'];
     expect(entry.type).toBe('stdio');
     expect(entry.args).toEqual(['serve']);
-    expect(entry.cwd).toBe(projectRoot);
+    // Global scope carries no cwd — see TRA-501.
+    expect(entry.cwd).toBeUndefined();
+  });
+
+  it('writes cwd only for a project-scoped entry', () => {
+    configureMcpClients(['factory-droid'], projectRoot, { scope: 'project' });
+    const file = path.join(projectRoot, '.factory', 'mcp.json');
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(parsed.mcpServers['trace-mcp'].cwd).toBe(projectRoot);
   });
 
   it('preserves existing servers when adding trace-mcp', () => {
@@ -299,7 +307,8 @@ describe('Cline / KiloCode / Antigravity / Kimi writers (standard mcpServers)', 
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
     const entry = parsed.mcpServers['trace-mcp'];
     expect(entry.args).toEqual(['serve']);
-    expect(entry.cwd).toBe(projectRoot);
+    // Cline's config is global-only, so it never carries a project cwd (TRA-501).
+    expect(entry.cwd).toBeUndefined();
     // Standard shape clients must not carry the Claude-only alwaysLoad flag.
     expect(entry.alwaysLoad).toBeUndefined();
   });


### PR DESCRIPTION
Fixes TRA-501. Found while fixing the MCP Clients screen (TRA-497, #638).

## The bug

`buildExpectedEntry` (`src/init/mcp-client.ts`) put `cwd = projectRoot` on every global-scope entry, and `projectRoot` is `findProjectRoot(process.cwd())`. So the "correct" contents of a **user-level** registration depended on the directory the CLI happened to run in:

- `clients status` run from a different directory than the write reported `drift: cwd`, and clicking Update from that same directory wrote the same wrong value back — a permanent, unfixable drifted row.
- The desktop app shells out from the Electron bundle, so an app-driven repair wrote the app's own package directory as every client's `cwd`.

## The fix

A global entry carries no `cwd`. `serve` uses `process.cwd()` as-is and already tolerates a non-project directory (`src/cli.ts:312`, the `findProjectRoot` failure is caught), so the client spawns the server in its own working directory — for an editor, the project the user actually has open. That is what a global registration should mean; pinning it to one project was the accident.

Project-scoped entries still carry `cwd`, minus `claude-code`/`claw-code`, which read `.mcp.json` from the project root and therefore already run there.

Two things fixed alongside, same defect:

- The `amp` / `factory-droid` / `hermes` / `codex` writers hardcoded `cwd: projectRoot` while `detectClientStatus` compared against `buildExpectedEntry` — they agreed only by coincidence. All four now go through `buildExpectedEntry`, so writer and status can't diverge.
- Clients whose config file is user-level regardless of the requested scope (`claude-desktop`, `hermes`, `cline`, `kilocode`, `antigravity`, `kimi`) are treated as global here, so a project-scoped run stops pinning one project's path into a shared file. The pasteable Warp snippet drops `working_directory` for the same reason.

## Migration

Entries written by an older `init` still have a `cwd`. They report `stale` with `staleReason: 'cwd'` once, and the next `init` / Update strips it. No schema or MCP tool-signature change.

## Tests

`tests/init/mcp-client-status.test.ts`:
- write a global entry from `projectRoot`, ask for status from an unrelated directory → `up_to_date` for cursor / factory-droid / amp. Fails on `main`.
- an entry carrying a stale `cwd` → `stale` / `cwd`, and a repair run removes it.

`tests/init/mcp-clients-extra.test.ts`: global factory-droid and cline entries have no `cwd`; a project-scoped factory-droid entry still does.

```
pnpm run lint     clean
pnpm run build    success
pnpm run test     833 files, 9203 passed | 8 skipped
```
