### PR TITLE
fix(app): the sidebar file row leads with the filename, not the path (TRA-503)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -448,6 +448,13 @@ sidebar edges, `8px` internal padding, 8px gap, a 16px icon slot, a 13px label t
 truncates, and an optional trailing count in tabular figures. Label text starts at
 x=38 in every row.
 
+**A file row leads with the filename, not the path.** The name is what identifies
+the row, so it gets `--label` and the front of the line; the *leaf* directory follows
+it in `--label-secondary` and is the only part allowed to shorten. Never the reverse —
+a path-first row spends its width on `src/renderer/tabs/` and then eats the filename's
+extension, which is the one token the reader was looking for (TRA-503). Everything
+above the leaf belongs in the row's tooltip.
+
 **Anything that lives in the sidebar is a row.** Nav items are rows. Settings is a row.
 The idle update banner is a row. The footer was the last strip running its own
 geometry, and putting it on the row system is what made the sidebar read as one thing.
@@ -1431,6 +1438,7 @@ new evidence.
 | A surface that draws its own toolbar owns its whole pane | Wrapping it in the pane's `p-4` doubles every inset the surface already declares — the workspace KPI row started at x=32 with its first card at y=76. |
 | Paths truncate at the **head**, keeping the tail | The tail is the part that distinguishes siblings; tail-truncation hid the only useful segment. |
 | Sidebar file paths use a `dir`/`name` flex split, not `direction: rtl` | The rtl hack mangled any path containing `.` or `_` runs (`.idea/workspace.xml` → `idea/workspace.xml.`). |
+| A file row is **name first, location second** — and the location is the leaf directory, not the path (TRA-503) | A 180–320px row fits one of the two. Location-first spent up to 45% of the row on `src/renderer/tabs/` and truncated the filename anyway: `Settings.tsx` rendered as `src/render…Settings.t…`, losing the extension on every row that overflowed. Quick open already listed a file as name-then-directory; the sidebar and Ask now match it. |
 | Whitespace separates sidebar groups, not rules | Fewer lines, clearer grouping; matches the platform sidebar. |
 | Rows are windowed past 100 items | A thousand projects costs what a hundred does. |
 | A surface with extra columns collapses them with a **container query**, trailing column first | At the 640px window minimum the app sidebar already takes 220. Ask's chat rail + inspector left the conversation at zero width and painted the inspector over its own toolbar. The rules must be last in the file — a container query adds no specificity. |

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -27,6 +27,7 @@ import {
 } from './update-check.js';
 import {
   clampSidebarWidth,
+  parentDir,
   readSidebarCollapsed,
   readSidebarWidth,
   SIDEBAR_MAX,
@@ -416,7 +417,8 @@ function ProjectFileExplorer({
         <div role="tree" aria-label={t('projectFiles')} ref={listRef}>
           {files.map((f, i) => {
             const display = shortPath(f.path);
-            const { dir, name } = splitPath(display);
+            const { name } = splitPath(display);
+            const parent = parentDir(display);
             return (
               <SidebarRow
                 key={f.path}
@@ -425,9 +427,11 @@ function ProjectFileExplorer({
                 selected={selected === f.path}
                 glyph={<FileTypeGlyph ftype={fileKind(f.path).ftype} size={16} />}
                 label={
+                  /* Filename first, location after it — the row is 180–320px
+                     wide and only one of the two can survive that (TRA-503). */
                   <span className="ws-sb-path">
-                    {dir && <span className="dir">{dir}</span>}
                     <span className="name">{name}</span>
+                    {parent && <span className="dir">{parent}</span>}
                   </span>
                 }
                 count={sort === 'edges' ? f.edges : f.symbols}

--- a/packages/app/src/renderer/__tests__/sidebar-file-list.test.tsx
+++ b/packages/app/src/renderer/__tests__/sidebar-file-list.test.tsx
@@ -76,6 +76,40 @@ describe('sidebar file list, empty', () => {
   });
 });
 
+/* TRA-503. The row used to render `<dir>/<name>`, and at every sidebar width
+   from 180 to 320 the filename is what lost its tail:
+   `src/renderer/tabs/Settings.tsx` came out as `src/render…Settings.t…`. The
+   name leads now and only the location may be shortened — this pins the order
+   and the fact that the location is a leaf segment, not a path. */
+describe('sidebar file row', () => {
+  it('puts the filename before its location, and shows only the leaf directory', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              files: [
+                { path: 'src/renderer/tabs/Settings.tsx', symbols: 32, edges: 0 },
+                { path: 'README.md', symbols: 1, edges: 0 },
+              ],
+            }),
+            { status: 200 },
+          ),
+      ),
+    );
+    await renderProjectWindow();
+
+    const [settings, readme] = [...document.querySelectorAll('.ws-sb-path')];
+    expect(settings.querySelector('.name')?.textContent).toBe('Settings.tsx');
+    expect(settings.querySelector('.dir')?.textContent).toBe('tabs');
+    expect([...settings.children].map((c) => c.className)).toEqual(['name', 'dir']);
+    // A file at the project root has no location to show, so it renders none.
+    expect(readme.querySelector('.name')?.textContent).toBe('README.md');
+    expect(readme.querySelector('.dir')).toBeNull();
+  });
+});
+
 /* TRA-478. Every case above rejects immediately, which is the one shape of
    "daemon down" that was never broken. A wedged daemon still holds :3741 open,
    so the connect never completes and the promise never settles — and the list

--- a/packages/app/src/renderer/__tests__/sidebar-prefs.test.ts
+++ b/packages/app/src/renderer/__tests__/sidebar-prefs.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   clampSidebarWidth,
+  parentDir,
   readSidebarCollapsed,
   readSidebarWidth,
   SIDEBAR_DEFAULT,
@@ -62,5 +63,20 @@ describe('splitPath', () => {
   it('handles a bare filename and Windows separators', () => {
     expect(splitPath('README.md')).toEqual({ dir: '', name: 'README.md' });
     expect(splitPath('src\\main\\tray.ts')).toEqual({ dir: 'src\\main\\', name: 'tray.ts' });
+  });
+});
+
+describe('parentDir', () => {
+  // The row is 180–320px wide. `src/renderer/tabs/` ate 45% of it and the
+  // filename lost its extension anyway; the leaf is the segment that actually
+  // tells two siblings apart (TRA-503).
+  it('keeps only the leaf segment, without separators', () => {
+    expect(parentDir('src/renderer/tabs/Settings.tsx')).toBe('tabs');
+    expect(parentDir('src/renderer/lattice/ui/__tests__/primitives.test.tsx')).toBe('__tests__');
+    expect(parentDir('src\\main\\tray.ts')).toBe('main');
+  });
+
+  it('is empty for a file at the project root, so the row renders no location', () => {
+    expect(parentDir('README.md')).toBe('');
   });
 });

--- a/packages/app/src/renderer/sidebar-prefs.ts
+++ b/packages/app/src/renderer/sidebar-prefs.ts
@@ -53,15 +53,36 @@ export function writeSidebarCollapsed(collapsed: boolean): void {
  * Split a path into a truncatable directory part and the filename, which must
  * never be truncated.
  *
- * The previous implementation truncated with `direction: rtl`, which reorders
- * the trailing punctuation of a path under the bidi algorithm — that is why
- * `.idea/workspace.xml` rendered as `idea/workspace.xml.` and
- * `__external__/_root/php.synthetic` as `…l__/_root/php.synthetic__`. Splitting
- * here and ellipsising only `dir` in plain LTR gets head-truncation with no
- * bidi involvement at all.
+ * Splitting here rather than in CSS is what keeps the two parts independently
+ * styleable in plain LTR. It replaced a `direction: rtl` truncation that
+ * reordered a path's trailing punctuation under the bidi algorithm — that is
+ * why `.idea/workspace.xml` rendered as `idea/workspace.xml.` and
+ * `__external__/_root/php.synthetic` as `…l__/_root/php.synthetic__`.
+ *
+ * What a row actually shows is `name` followed by `parentDir()`, not `dir` —
+ * see that function for why.
  */
 export function splitPath(displayPath: string): { dir: string; name: string } {
   const idx = Math.max(displayPath.lastIndexOf('/'), displayPath.lastIndexOf('\\'));
   if (idx < 0) return { dir: '', name: displayPath };
   return { dir: displayPath.slice(0, idx + 1), name: displayPath.slice(idx + 1) };
+}
+
+/**
+ * The location a file row shows *after* its filename: the last path segment
+ * only, without separators.
+ *
+ * A sidebar row is 180–320px wide and a repo-relative path does not fit in it.
+ * Putting the whole directory first cost up to 45% of the row and then spent
+ * the remainder truncating the filename — the one token that identifies the
+ * file — so `src/renderer/tabs/Settings.tsx` rendered as `src/render…Settings.t…`
+ * (TRA-503). Quick open already showed the filename as the label and the
+ * directory as the detail; this is the same order, and the leaf segment is the
+ * part that distinguishes siblings (`types.ts` in `workspace/` from `types.ts`
+ * in `tabs/`). Everything above the leaf stays in the row's tooltip.
+ */
+export function parentDir(displayPath: string): string {
+  const { dir } = splitPath(displayPath);
+  const segments = dir.split(/[/\\]/).filter(Boolean);
+  return segments[segments.length - 1] ?? '';
 }

--- a/packages/app/src/renderer/styles/sidebar.css
+++ b/packages/app/src/renderer/styles/sidebar.css
@@ -173,8 +173,14 @@
    this rule actually reaches is .ws-sb-ico. A glyph's floor is 3:1, which the
    dimmed white already met — so this was a consistency fix, not the AA fix the
    original commit message claimed. .ws-sb-count is styled here and rendered by
-   no component in the app; see TRA-358 for build-or-delete. */
+   no component in the app; see TRA-358 for build-or-delete.
+
+   .ws-sb-path .dir joined it in TRA-503: the file row's location is
+   --label-secondary, which in light appearance is half-opacity black — it
+   rendered near-black on the accent fill, beside a white filename and a white
+   count. */
 .ws-sidebar:focus-within .ws-sb-row.is-selected .ws-sb-ico,
+.ws-sidebar:focus-within .ws-sb-row.is-selected .ws-sb-path .dir,
 .ws-sidebar:focus-within .ws-sb-row.is-selected .ws-sb-count {
   color: var(--on-accent);
 }
@@ -249,20 +255,24 @@
   -webkit-app-region: no-drag;
 }
 
-/* File-explorer row: <dir>/<name> where the DIRECTORY truncates and the
-   filename never does. Replaces the `direction: rtl` hack, which mangled
-   any path containing `.` or `_` runs. */
+/* File-explorer row: <name> then <parent dir>, the way quick open lists a file.
+   The name leads at --label and the location follows in secondary text, because
+   only one of the two survives a 180–320px row — and the reader needs the name.
+   Location-first spent up to 45% of the row on `src/renderer/tabs/` and still
+   truncated the filename's extension (TRA-503). */
 .ws-sb-path {
   display: flex;
   flex: 1;
   min-width: 0;
   align-items: baseline;
 }
-/* The directory absorbs essentially all of the shrink (999 vs 1), so the
-   filename only ever truncates once the directory is down to nothing. */
+/* The location absorbs essentially all of the shrink (999 vs 1), so the
+   filename only ever truncates once the location is down to nothing — and it
+   fades out to the RIGHT of the name, where a truncation reads as one. */
 .ws-sb-path .dir {
   flex: 0 999 auto;
   min-width: 0;
+  margin-left: 6px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/app/src/renderer/tabs/AskTab.tsx
+++ b/packages/app/src/renderer/tabs/AskTab.tsx
@@ -23,7 +23,7 @@ import {
   StatusDot,
   Toolbar,
 } from '../lattice/ui';
-import { splitPath } from '../sidebar-prefs.js';
+import { parentDir, splitPath } from '../sidebar-prefs.js';
 
 const BASE = 'http://127.0.0.1:3741';
 
@@ -946,18 +946,19 @@ function ContextInspector({
   );
 }
 
-/** One 28px row showing `<dir>/<name>`, where the directory truncates at the
-    head and the filename never does (DESIGN.md §4). */
+/** One 28px row showing the filename, then its parent directory in secondary
+    text — the location is what truncates, never the name (DESIGN.md §4). */
 function PathRow({ path, onClick }: { path: string; onClick: () => void }) {
-  const { dir, name } = splitPath(path);
+  const { name } = splitPath(path);
+  const parent = parentDir(path);
   return (
     <button type="button" className="ws-sb-row" title={path} onClick={onClick}>
       <span className="ws-sb-ico" aria-hidden="true">
         <Icon name="description" size={16} />
       </span>
       <span className="ws-sb-path">
-        <span className="dir">{dir}</span>
         <span className="name">{name}</span>
+        {parent && <span className="dir">{parent}</span>}
       </span>
     </button>
   );


### PR DESCRIPTION
Closes TRA-503.

A sidebar file row is 180–320px wide and a repo-relative path does not fit in it. The row put the directory first, so an overflowing row ellipsised **both** parts and the filename lost its tail — the one token that identifies the file.

Measured in the real Electron window (`packages/app/scripts/electron-cdp.mjs`, hidden window, CDP screenshot), sidebar at its 220px default:

| Path | Before | After |
|---|---|---|
| `src/renderer/tabs/Settings.tsx` | `src/render… Settings.t…` | `Settings.tsx  tabs` |
| `src/renderer/tabs/ToolActivity.tsx` | `src/ren… ToolActivity.t…` | `ToolActivity.tsx  tabs` |
| `src/main/guard-control.ts` | `src/m… guard-control.…` | `guard-control.ts  main` |
| `src/renderer/tabs/GraphExplorerGPU.tsx` | `s.GraphExplorerGPU.t…` | `GraphExplorerGPU.t…  t` |
| `src/renderer/workspace/types.ts` | `src/renderer/… types.…` | `types.ts  workspace` |

`Settings.tsx` needs ~76px; the directory kept 74.1px of the 145.5px path box and left the name 71.4px — even though `.dir` carries `flex: 0 999 auto` to stop exactly that, and `splitPath()`'s docstring says the filename "must never be truncated". At the 180px minimum it got worse: `guard-control.ts` rendered as `sguard-control.…`, a bare `s` with no ellipsis reading as part of the word.

## What changed

Quick open (⌘P) already lists a file as `label: name, detail: dir`. The sidebar file list and `AskTab`'s path rows now use the same order.

- `parentDir()` in `renderer/sidebar-prefs.ts` — the leaf path segment only. `src/renderer/tabs/` was up to 45% of the row, and head-truncation cut `tabs`, the segment that actually distinguishes siblings. The full path stays in the row's tooltip.
- `.name` moves before `.dir`; `.ws-sb-path .dir` gains `margin-left: 6px`. The 999:1 shrink split is unchanged — the location is still what shortens, but now it fades out to the *right* of the name.
- On a focused selected row the location joins `.ws-sb-ico`/`.ws-sb-count` at full `--on-accent`. `--label-secondary` is half-opacity black, which rendered near-black on the accent fill beside a white filename and a white count.

## Known remainder

When the filename alone fills the row, the location shrinks to a one-glyph sliver (`t`, `c`) rather than disappearing. Flexbox has no "whole or nothing", and both alternatives were measured on the running app and rejected: capping the location at `7ch` with `flex: 0 0 auto` removes the sliver but truncates short filenames to pay for it (`types.ts` → `type…`), and `direction: rtl` head-elision is a no-op under `unicode-bidi: plaintext`. The sliver sits after the name in secondary grey and no longer corrupts the filename.

## Verification

Screenshots in both appearances at 220px and at `SIDEBAR_MIN`, plus the selected-row state, are attached to TRA-503. Captured from the Electron window against a sandboxed daemon on :3799 with its own `TRACE_MCP_DATA_DIR` — the developer's daemon on :3741 was neither read nor restarted.

`parentDir` unit tests, plus a render test in `sidebar-file-list.test.tsx` pinning the child order and the "a root file shows no location" case. `pnpm test` 529/529, `typecheck` and `biome ci` clean. Rule recorded in `DESIGN.md` (row system + design-decisions table).
