### PR TITLE
docs(design): a review run must isolate the daemon, not just the screen (TRA-502)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1242,6 +1242,18 @@ care whether the window is visible — and the person at the keyboard does (TRA-
 CDP client can attach to `http://127.0.0.1:9222` once it is up, including `chrome-devtools`
 MCP via `--browser-url`.
 
+**`launch` is isolated from the screen, not from the daemon — isolate that yourself.**
+The app supervises whatever is on `:3741`, and a dev build's version is almost never the
+installed daemon's: on the run that produced TRA-503 it logged `version mismatch —
+daemon=3.5.1 app=3.5.2, restarting daemon`, the restart failed, and the developer's daemon
+was left dead until it was kicked back by hand. Before `launch`, do what
+`capture-screenshots.mjs` does: point `TRACE_MCP_BIN` at a no-op shim so `ensureDaemon()`
+and `restartDaemon()` cannot reach launchd, start your own daemon on another port under its
+own `TRACE_MCP_DATA_DIR`, and rewrite the renderer's calls onto it from the same CDP session
+(`Fetch.enable` on `http://127.0.0.1:3741/*`, `Fetch.continueRequest` with the port
+swapped). A review then reads a seeded index instead of whatever the developer happens to be
+indexing, which is also the only way two runs a month apart compare.
+
 `launch --visible` puts it on screen for the one case that needs eyes on the running app,
 and then also sets `TRACE_MCP_DEV_ALWAYS_ON_TOP=1`: Chromium stops compositing a fully
 *occluded* window, and a CDP screenshot of one hands back the frame it painted minutes ago


### PR DESCRIPTION
`electron-cdp.mjs launch` keeps its window off screen, and DESIGN.md says so at length. Nothing said the app it launches also supervises whatever is on `:3741`.

A dev build's version is almost never the installed daemon's. Today's design run logged `version mismatch — daemon=3.5.1 app=3.5.2, restarting daemon`, the restart failed (an unpackaged build cannot manage the installed launchd agent), and the developer's daemon was left dead until it was kicked back by hand — on the machine somebody is working on, which is the case TRA-403 exists to protect.

This writes down the setup `scripts/capture-screenshots.mjs` already uses and that any review run needs: a no-op `TRACE_MCP_BIN` so `ensureDaemon()`/`restartDaemon()` cannot reach launchd, an own daemon on another port under its own `TRACE_MCP_DATA_DIR`, and the renderer's `:3741` calls rewritten onto it from the same CDP session. It is also what makes a review reproducible: reading whatever the developer happens to be indexing never was.

Docs only — one paragraph in DESIGN.md's review-harness section.