### PR TITLE
fix(update): target the running bundle, reclaim orphaned staging

### DIFF
--- a/scripts/locate-app.mjs
+++ b/scripts/locate-app.mjs
@@ -179,6 +179,78 @@ export function locateInstalledApp(options = {}) {
 }
 
 /**
+ * The `.app` bundle a running trace-mcp process was launched from, or null.
+ *
+ * A machine can hold more than one installed bundle — dragged into
+ * `/Applications` once, re-installed into `~/Applications` later — and the two
+ * updaters then disagree about which one "the install" is: `postinstall-app.mjs`
+ * asks `locateInstalledApp()` (marker first), while Electron main derives its
+ * install dir from `process.execPath`. When they diverge, postinstall stages
+ * `.trace-mcp-pending.zip` next to a bundle nobody is running, the running copy
+ * never sees a pending update, and it stays behind forever while every
+ * `npm install -g` reports success — the TRA-357 shape one level up, observed
+ * with a 112 MB orphan zip beside a `/Applications` bundle two releases behind.
+ *
+ * The running bundle is the only copy the user can actually observe, so it is
+ * the honest target. `pgrep -f` alone cannot answer this — it matches on the
+ * bundle-relative path and returns pids, not paths — so we resolve each pid's
+ * executable through `ps -o comm=` and walk back up to the `.app`.
+ *
+ * Same two gates as every other resolver here: a build-tree path never counts
+ * as an install, and the bundle id must match.
+ *
+ * @param {LocateOptions & { pgrepBin?: string, psBin?: string }} [options]
+ * @returns {string | null}
+ */
+export function runningBundlePath(options = {}) {
+  const platform = options.platform ?? process.platform;
+  if (platform !== 'darwin') return null;
+
+  const appName = options.appName ?? APP_NAME;
+  const bundleId = options.bundleId ?? BUNDLE_ID;
+  const pgrepBin = options.pgrepBin ?? '/usr/bin/pgrep';
+  const psBin = options.psBin ?? '/bin/ps';
+  const plistBuddyBin = options.plistBuddyBin ?? '/usr/libexec/PlistBuddy';
+  const marker = `${appName}${path.sep}Contents${path.sep}MacOS${path.sep}`;
+
+  let pids;
+  try {
+    pids = execFileSync(pgrepBin, ['-f', marker], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf-8',
+      timeout: 5_000,
+    })
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => /^\d+$/.test(line));
+  } catch {
+    // Non-zero exit is pgrep's "no match" — indistinguishable from a failure
+    // here, and both mean the same thing to callers: no running bundle.
+    return null;
+  }
+
+  for (const pid of pids) {
+    let comm;
+    try {
+      comm = execFileSync(psBin, ['-p', pid, '-o', 'comm='], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        encoding: 'utf-8',
+        timeout: 5_000,
+      }).trim();
+    } catch {
+      continue;
+    }
+    const at = comm.indexOf(marker);
+    if (at === -1) continue;
+    const candidate = comm.slice(0, at + appName.length);
+    if (!isPlausibleInstallPath(candidate)) continue;
+    if (!isValidAppBundle(candidate, bundleId, plistBuddyBin)) continue;
+    return candidate;
+  }
+  return null;
+}
+
+/**
  * Repair an update swap that died halfway through.
  *
  * Both swap sites (`postinstall-app.mjs` and `apply-pending-update.mjs`) do:

--- a/scripts/postinstall-app.mjs
+++ b/scripts/postinstall-app.mjs
@@ -37,6 +37,7 @@ import {
   locateInstalledApp,
   readBundleVersion,
   recoverInterruptedSwap,
+  runningBundlePath,
 } from './locate-app.mjs';
 
 // Resolved at top-level after the platform/no-update gates run. `null` means
@@ -54,13 +55,23 @@ let PENDING_CHECKSUM = '';
 // scripts/app-dist-repo.mjs. Overridable via env.
 const GITHUB_REPO = getAppDistRepo();
 
-// Test seams. All three default to production values and are only ever set by
+// Test seams. All default to production values and are only ever set by
 // tests/scripts/postinstall-app.test.ts, which needs to point the release
 // lookup at a local HTTP server, make "is the app running" deterministic (the
 // real pgrep answers differently depending on whether the developer happens to
 // have trace-mcp.app open), and avoid bouncing the developer's real daemon.
 const API_BASE = process.env.TRACE_MCP_UPDATE_API_BASE || 'https://api.github.com';
 const PGREP_BIN = process.env.TRACE_MCP_PGREP_BIN || '/usr/bin/pgrep';
+const PS_BIN = process.env.TRACE_MCP_PS_BIN || '/bin/ps';
+// The directories a bundle conventionally lives in — same defaults as
+// locate-app.mjs. Only the orphan sweep below reads them, and only tests
+// override them: a test must never be able to delete files out of the real
+// /Applications on the machine running it.
+const CONVENTIONAL_APP_DIRS = (
+  process.env.TRACE_MCP_APP_DIRS || `${path.join(os.homedir(), 'Applications')}:/Applications`
+)
+  .split(':')
+  .filter(Boolean);
 const LAUNCHCTL_BIN = process.env.TRACE_MCP_LAUNCHCTL_BIN || '/bin/launchctl';
 
 if (process.env.TRACE_MCP_NO_AUTO_UPDATE === '1') process.exit(0);
@@ -114,14 +125,52 @@ for (const { action, path: target } of recoverInterruptedSwap()) {
   console.log(`  trace-mcp: ${action} ${target} (interrupted update)`);
 }
 
+// A running bundle outranks the marker. With two installed copies on one
+// machine the marker and the running app can name different bundles, and then
+// the pending zip is staged beside a bundle nobody launched: the running copy
+// never offers "restart to install" and silently stays behind while npm keeps
+// reporting success. Electron main already derives its install dir from
+// `process.execPath`, so targeting the running bundle is what makes the two
+// sides agree by construction. See runningBundlePath() in locate-app.mjs.
 const located = locateInstalledApp();
-if (!located) process.exit(0);
+const running = runningBundlePath({ pgrepBin: PGREP_BIN, psBin: PS_BIN });
+const target = running ?? located?.appPath;
+if (!target) process.exit(0);
+if (running && located && running !== located.appPath) {
+  console.log(
+    `  trace-mcp: updating the running bundle ${running} (location marker points at ${located.appPath})`,
+  );
+}
 
-APP_PATH = located.appPath;
+APP_PATH = target;
 INSTALL_DIR = path.dirname(APP_PATH);
 PENDING_ZIP = path.join(INSTALL_DIR, '.trace-mcp-pending.zip');
 PENDING_VERSION = path.join(INSTALL_DIR, '.trace-mcp-pending-version');
 PENDING_CHECKSUM = path.join(INSTALL_DIR, '.trace-mcp-pending.sha256');
+
+// Reclaim staging aimed at a bundle we are not going to swap. Both appliers
+// only ever look beside the bundle they resolved themselves, so a zip left in
+// any other directory is ~110 MB that nothing will apply and nothing will
+// delete — one was found sitting beside a `/Applications` copy two releases
+// behind while the marker and the running app both named `~/Applications`.
+for (const dir of new Set(
+  [...CONVENTIONAL_APP_DIRS, located ? path.dirname(located.appPath) : null].filter(
+    (d) => d && d !== INSTALL_DIR,
+  ),
+)) {
+  for (const name of [
+    '.trace-mcp-pending.zip',
+    '.trace-mcp-pending.sha256',
+    '.trace-mcp-pending-version',
+  ]) {
+    try {
+      fs.unlinkSync(path.join(dir, name));
+      console.log(`  trace-mcp: removed orphaned ${name} in ${dir}`);
+    } catch {
+      /* absent, or not ours to delete — best-effort like every path here */
+    }
+  }
+}
 
 /**
  * Returns true if the installed trace-mcp.app is currently running.

--- a/tests/scripts/locate-app.test.ts
+++ b/tests/scripts/locate-app.test.ts
@@ -337,3 +337,121 @@ describe.skipIf(process.platform === 'win32')('locateInstalledApp', () => {
     expect(result?.appPath).toBe(target);
   });
 });
+
+/**
+ * A `pgrep -f` stub printing the pids we hand it, and a `ps -p <pid> -o comm=`
+ * stub mapping each pid to an executable path. Together they stand in for a
+ * running Electron bundle without launching one.
+ */
+function createProcStubs(
+  home: string,
+  procs: Record<string, string>,
+): { pgrepBin: string; psBin: string } {
+  const pids = Object.keys(procs);
+  const pgrepBin = path.join(home, 'pgrep-stub.sh');
+  // pgrep exits 1 when nothing matches; the caller must treat that as "none".
+  fs.writeFileSync(
+    pgrepBin,
+    pids.length === 0
+      ? '#!/usr/bin/env bash\nexit 1\n'
+      : `#!/usr/bin/env bash\ncat <<'EOF'\n${pids.join('\n')}\nEOF\n`,
+    { mode: 0o755 },
+  );
+
+  const psBin = path.join(home, 'ps-stub.sh');
+  const cases = pids.map((pid) => `  ${pid}) echo ${JSON.stringify(procs[pid])} ;;`).join('\n');
+  // Args arrive as `-p <pid> -o comm=`, so $2 is the pid.
+  fs.writeFileSync(psBin, `#!/usr/bin/env bash\ncase "$2" in\n${cases}\n  *) exit 1 ;;\nesac\n`, {
+    mode: 0o755,
+  });
+  return { pgrepBin, psBin };
+}
+
+function runRunningBundlePath(opts: {
+  homeDir: string;
+  pgrepBin: string;
+  psBin: string;
+  platform?: NodeJS.Platform;
+}): string | null {
+  const harness = `
+import { runningBundlePath } from ${JSON.stringify(MODULE_PATH)};
+const opts = JSON.parse(process.argv[2]);
+process.stdout.write(JSON.stringify(runningBundlePath(opts)));
+`;
+  const harnessPath = path.join(opts.homeDir, 'running-harness.mjs');
+  fs.writeFileSync(harnessPath, harness);
+  const stdout = execFileSync(process.execPath, [harnessPath, JSON.stringify(opts)], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+    timeout: 15_000,
+  });
+  return JSON.parse(stdout) as string | null;
+}
+
+// TRA-506: with a bundle in /Applications and another in ~/Applications, the
+// location marker and the running app named different copies. postinstall
+// staged the pending zip beside the marker's bundle, the running one never saw
+// it, and the machine sat two releases behind while npm reported success — the
+// state this was written against had a 112 MB orphan zip to prove it.
+describe.skipIf(process.platform === 'win32')('runningBundlePath', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-running-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('resolves the .app of a running process', () => {
+    const dragged = createFakeBundle(path.join(home, 'Applications-system'));
+    const { pgrepBin, psBin } = createProcStubs(home, {
+      '4242': path.join(dragged, 'Contents', 'MacOS', 'trace-mcp'),
+    });
+
+    expect(runRunningBundlePath({ homeDir: home, pgrepBin, psBin, platform: 'darwin' })).toBe(
+      dragged,
+    );
+  });
+
+  it('returns null when nothing is running', () => {
+    const { pgrepBin, psBin } = createProcStubs(home, {});
+    expect(runRunningBundlePath({ homeDir: home, pgrepBin, psBin, platform: 'darwin' })).toBeNull();
+  });
+
+  it('ignores a bundle running out of a build tree', () => {
+    const built = createFakeBundle(
+      (() => {
+        const d = path.join(home, 'checkout', 'packages', 'app', 'release', 'mac-arm64');
+        fs.mkdirSync(d, { recursive: true });
+        return d;
+      })(),
+    );
+    const { pgrepBin, psBin } = createProcStubs(home, {
+      '77': path.join(built, 'Contents', 'MacOS', 'trace-mcp'),
+    });
+
+    expect(runRunningBundlePath({ homeDir: home, pgrepBin, psBin, platform: 'darwin' })).toBeNull();
+  });
+
+  it('skips a process whose bundle id does not match and takes the next one', () => {
+    const foreign = createFakeBundle(path.join(home, 'Other'), 'com.someone-else.app');
+    const real = createFakeBundle(path.join(home, 'Applications'));
+    const { pgrepBin, psBin } = createProcStubs(home, {
+      '1': path.join(foreign, 'Contents', 'MacOS', 'trace-mcp'),
+      '2': path.join(real, 'Contents', 'MacOS', 'trace-mcp'),
+    });
+
+    expect(runRunningBundlePath({ homeDir: home, pgrepBin, psBin, platform: 'darwin' })).toBe(real);
+  });
+
+  it('returns null on non-darwin platforms', () => {
+    const app = createFakeBundle(path.join(home, 'Applications'));
+    const { pgrepBin, psBin } = createProcStubs(home, {
+      '9': path.join(app, 'Contents', 'MacOS', 'trace-mcp'),
+    });
+
+    expect(runRunningBundlePath({ homeDir: home, pgrepBin, psBin, platform: 'linux' })).toBeNull();
+  });
+});

--- a/tests/scripts/postinstall-app.test.ts
+++ b/tests/scripts/postinstall-app.test.ts
@@ -91,6 +91,19 @@ function writePgrepStub(dir: string, running: boolean): string {
   return stub;
 }
 
+/** A stub for `/bin/ps -p <pid> -o comm=`, reporting `appPath`'s main binary. */
+function writePsStub(dir: string, appPath: string): string {
+  const stub = path.join(dir, 'ps-stub.sh');
+  fs.writeFileSync(
+    stub,
+    `#!/bin/sh\necho '${path.join(appPath, 'Contents', 'MacOS', 'trace-mcp')}'\n`,
+    {
+      mode: 0o755,
+    },
+  );
+  return stub;
+}
+
 describe.skipIf(process.platform !== 'darwin')('postinstall-app.mjs bundle swap', () => {
   let fx: Fixture;
   let tmp: string;
@@ -191,7 +204,7 @@ describe.skipIf(process.platform !== 'darwin')('postinstall-app.mjs bundle swap'
    * the child's own HTTP request.
    */
   function runPostinstall(
-    opts: { appRunning?: boolean; appRunningEnv?: boolean } = {},
+    opts: { appRunning?: boolean; appRunningEnv?: boolean; runningBundle?: string } = {},
   ): Promise<string> {
     const child = spawn(process.execPath, [SCRIPT_PATH], {
       env: {
@@ -201,6 +214,16 @@ describe.skipIf(process.platform !== 'darwin')('postinstall-app.mjs bundle swap'
         TRACE_MCP_UPDATE_API_BASE: fx.baseUrl,
         TRACE_MCP_APP_RUNNING: opts.appRunningEnv ? '1' : '',
         TRACE_MCP_PGREP_BIN: writePgrepStub(tmp, opts.appRunning ?? false),
+        // Left at a binary that reports no such pid unless a test names the
+        // bundle it wants "running"; that keeps every other case on the
+        // marker-resolved path they were written against.
+        TRACE_MCP_PS_BIN: opts.runningBundle
+          ? writePsStub(tmp, opts.runningBundle)
+          : '/usr/bin/false',
+        // Confine the orphan-staging sweep to this fixture. Without it the
+        // script would reach into the real /Applications of whatever machine
+        // runs the suite.
+        TRACE_MCP_APP_DIRS: [fx.installDir, path.join(tmp, 'Applications')].join(':'),
         // Never bounce the developer's real launchd daemon from a test run.
         TRACE_MCP_LAUNCHCTL_BIN: '/usr/bin/true',
         TRACE_MCP_NO_AUTO_UPDATE: '',
@@ -230,6 +253,69 @@ describe.skipIf(process.platform !== 'darwin')('postinstall-app.mjs bundle swap'
     expect(fs.readFileSync(path.join(fx.installDir, '.trace-mcp-version'), 'utf-8')).toBe('v3.1.1');
     // No half-finished swap left behind.
     expect(fs.readdirSync(fx.installDir).filter((f) => f.includes('.bak-'))).toEqual([]);
+  });
+
+  /* TRA-506: one machine, two installed bundles — one dragged into
+     /Applications, one re-installed into ~/Applications. The location marker
+     named the second, the user was running the first, and postinstall staged
+     the pending zip beside the bundle nobody had open. The running copy never
+     offered "restart to install" and sat two releases behind while every npm
+     install reported success; the orphan zip (110 MB) was never applied and
+     never reclaimed, because both appliers only look beside the bundle they
+     resolved themselves. Electron main targets `process.execPath`, so the
+     running bundle is the one postinstall has to agree with. */
+  it('targets the running bundle over the marker and reclaims the orphan staging', async () => {
+    // Marker + fx.appPath point at the ~/Applications copy...
+    installBundle('3.4.0');
+    // ...but the user is running the one in the system-wide directory.
+    const systemDir = path.join(tmp, 'Applications');
+    fs.mkdirSync(systemDir, { recursive: true });
+    const systemApp = path.join(systemDir, 'trace-mcp.app');
+    writeBundle(systemApp, '3.3.0');
+
+    // A previous run staged 3.5.2 next to the marker's bundle; nothing can
+    // ever apply it there once the running copy is the target.
+    for (const [name, body] of [
+      ['.trace-mcp-pending.zip', 'orphan'],
+      ['.trace-mcp-pending.sha256', 'f'.repeat(64)],
+      ['.trace-mcp-pending-version', '3.5.2'],
+    ] as const) {
+      fs.writeFileSync(path.join(fx.installDir, name), body);
+    }
+
+    publishRelease('3.5.2');
+
+    const stdout = await runPostinstall({ appRunning: true, runningBundle: systemApp });
+
+    expect(stdout).toContain(systemApp);
+    // Staged beside the bundle the user actually has open.
+    expect(fs.existsSync(path.join(systemDir, '.trace-mcp-pending.zip'))).toBe(true);
+    expect(fs.readFileSync(path.join(systemDir, '.trace-mcp-pending-version'), 'utf-8')).toBe(
+      '3.5.2',
+    );
+    // ...and the unreachable copy is gone rather than left on disk forever.
+    expect(fs.existsSync(path.join(fx.installDir, '.trace-mcp-pending.zip'))).toBe(false);
+    expect(fs.existsSync(path.join(fx.installDir, '.trace-mcp-pending.sha256'))).toBe(false);
+    expect(fs.existsSync(path.join(fx.installDir, '.trace-mcp-pending-version'))).toBe(false);
+  });
+
+  /* The state this was found in: marker and running app agreed on
+     ~/Applications, while a complete 112 MB staging for the current release sat
+     beside a /Applications copy left over from an earlier drag-install. Neither
+     applier looks there, so it was permanent. */
+  it('reclaims staging left in a conventional dir that is not the target', async () => {
+    installBundle('3.4.0');
+    const otherDir = path.join(tmp, 'Applications');
+    fs.mkdirSync(otherDir, { recursive: true });
+    fs.writeFileSync(path.join(otherDir, '.trace-mcp-pending.zip'), 'orphan');
+    fs.writeFileSync(path.join(otherDir, '.trace-mcp-pending-version'), '3.5.2');
+    publishRelease('3.5.2');
+
+    await runPostinstall();
+
+    expect(readBundleVersion(fx.appPath)).toBe('3.5.2');
+    expect(fs.existsSync(path.join(otherDir, '.trace-mcp-pending.zip'))).toBe(false);
+    expect(fs.existsSync(path.join(otherDir, '.trace-mcp-pending-version'))).toBe(false);
   });
 
   it('stages a pending zip instead of swapping while the app is running', async () => {


### PR DESCRIPTION
## The silent failure

A machine can hold more than one installed `trace-mcp.app` — dragged into `/Applications` once, re-installed into `~/Applications` later. The two updaters disagree about which one "the install" is:

- `scripts/postinstall-app.mjs` and `scripts/apply-pending-update.mjs` resolve it with `locateInstalledApp()` — **location marker first**.
- `packages/app/src/main/index.ts` derives `INSTALL_DIR` from `process.execPath` — **the running bundle** (deliberately, since TRA-357's `/Applications` drag-install case).

When those name different bundles, postinstall stages `.trace-mcp-pending.zip` beside a bundle nobody launched. The running copy looks for the zip beside itself, finds nothing, never offers "restart to install", and stays behind indefinitely — while every `npm install -g trace-mcp` exits 0 and the app reads green. Nothing complains, because from the user's side nothing looks wrong.

## Found live, not by reading

On the machine this was written on:

| | version |
|---|---|
| `~/Applications/trace-mcp.app` (running, marker target) | 3.4.0 |
| `/Applications/trace-mcp.app` | 3.3.0 |
| npm `latest` / GitHub Release | 3.5.2 |

…plus a complete staging for 3.5.2 (112 MB zip + `.sha256` + `-version`) sitting beside the `/Applications` copy since 06:28 that morning. Neither applier looks in that directory, so nothing would ever have applied it or reclaimed the space.

## Change

- **`scripts/locate-app.mjs`** — new `runningBundlePath()`. `pgrep -f` alone can't answer this (it matches a bundle-relative path and returns pids, not paths), so each pid is resolved through `ps -p <pid> -o comm=` and walked back up to the `.app`. Same two gates as every other resolver in the file: a build-tree path is never an install, and the bundle id must match.
- **`scripts/postinstall-app.mjs`** — a running bundle now outranks the marker, so postinstall and Electron main agree by construction. Staging left in any other conventional directory is deleted rather than leaking ~110 MB forever. The directory list is behind a `TRACE_MCP_APP_DIRS` test seam so the suite can never reach into the real `/Applications` of the machine running it.

No change to the MCP tool contract or the on-disk schema.

## Verification

Code review is exactly what missed the original incident, so the diff is not the evidence.

- `pnpm run test` — **9226 passed**, 8 skipped, 833 files. `build`, `lint`, `typecheck`, `format:check` clean.
- New regression tests fail on the pre-change script and pass after (checked by reverting `postinstall-app.mjs` alone): `targets the running bundle over the marker and reclaims the orphan staging`, `reclaims staging left in a conventional dir that is not the target`, plus 5 unit tests for `runningBundlePath`.
- **Real upgrade rehearsal, big gap.** A real `v1.30.0` release zip unpacked into an isolated `HOME`, marker planted, real `postinstall-app.mjs` run against the live GitHub API: swapped to **3.5.2**, version read back out of `Info.plist`, `.trace-mcp-version` written, no `.bak-` residue.
- **Real two-bundle rehearsal.** Two 1.30.0 bundles, marker on one, `ps` reporting the other as running: staging landed beside the running copy and the marker's directory was left clean.

Refs TRA-506.
