### PR TITLE
feat(server): tailor the advertised surface to the connected MCP client (TRA-513)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -439,6 +439,7 @@ The `tools.*` section controls what the MCP server injects into every session �
     "preset": "standard",                // "full" | "standard" | "minimal" | "review" | "architecture"
     "description_verbosity": "full",     // "full" | "minimal" | "none"
     "instructions_verbosity": "full",    // "full" | "minimal" | "none" — controls the tool-routing block
+    "client_profile": "auto",            // "auto" | "off" | "claude-code" | "codex" | "cursor" | "vscode" | "generic"
     "agent_behavior": "off",             // "strict" | "minimal" | "off" — see below
     "meta_fields": true,                 // true | false | ["_hints", "_budget_warning", ...]
     "compact_schemas": false             // strip advanced params from tool schemas (saves tokens)
@@ -453,6 +454,7 @@ The `tools.*` section controls what the MCP server injects into every session �
 | `tools.exclude` | — | Blacklist specific tools by name |
 | `tools.description_verbosity` | `"full"` | Per-tool description length. `minimal` = first sentence. `none` = empty |
 | `tools.instructions_verbosity` | `"full"` | Server-level instructions (the tool-routing block). `full` ~2K tokens, `minimal` ~200 |
+| `tools.client_profile` | `"auto"` | Tailors the advertised surface to the connected host — see [Client profiles](#client-profiles). `auto` detects it from the `initialize` handshake, a profile name pins it, `off` disables the layer. Env override: `TRACE_MCP_CLIENT_PROFILE` |
 | `tools.agent_behavior` | `"off"` | Behavior rules appended to instructions — see [Agent behavior rules](#agent-behavior-rules) |
 | `tools.meta_fields` | `true` | Meta fields in responses (`_hints`, `_budget_warning`, etc.). Set `false` or list to narrow |
 | `tools.compact_schemas` | `false` | Strip advanced/optional params from tool schemas. Cuts schema size ~42% (measured 2026-08-29) |
@@ -490,6 +492,47 @@ Measured `tools/list` cost of each preset on this repo (serialized chars,
 2026-08-29): `minimal` 34.0k, `review` 28.9k, `architecture` 33.6k, `standard`
 64.6k, `full` 157.1k. `load_tools` itself is 0.9k of that — the price of making
 the other 123k optional.
+
+### Client profiles
+
+The preset decides *how much* capability a session advertises. The client
+profile decides what that particular host does not need to be told about.
+
+The connected client names itself in the `initialize` handshake, so trace-mcp
+knows whether it is talking to Claude Code, Codex, Cursor, VS Code, or something
+it has never seen. Two things follow from that:
+
+- **Tools the host already has are not advertised.** A CLI coding agent arrives
+  with its own content search; offering ours alongside it costs schema tokens
+  and gives the model two ways to do one thing. Suppression lists are short and
+  deliberately conservative — `search_text` and `discover_hermes_sessions` today.
+- **The instructions name the host's own tools.** The routing block is written
+  for a host it cannot see, so it says "`read`, `content-match`, `glob` mean
+  whatever yours are called". Once the handshake identifies the host it says
+  `Read`/`Grep`/`Glob` on Claude Code and `shell` (cat/rg/find) with
+  `apply_patch` on Codex.
+
+The profile composes *after* the preset — it only removes names from whatever
+the preset already advertised — and it never removes capability. A suppressed
+tool stays callable by name, `load_tools({ tools: ["search_text"] })` puts it
+back on `tools/list`, and `"client_profile": "off"` (or
+`TRACE_MCP_CLIENT_PROFILE=off`) disables the layer entirely. An unrecognised
+host resolves to `generic`, which suppresses nothing.
+
+Measured on a live `initialize` + `tools/list` round-trip against the built
+server, default `minimal` preset (serialized chars, 2026-08-30):
+
+| Client | instructions | `tools/list` | advertised | handshake total |
+|---|---|---|---|---|
+| `generic` (or `client_profile: "off"`) | 7,669 | 36,523 | 28 | 44,192 |
+| `claude-code` | 7,933 | 34,621 | 27 | 42,554 (−3.7%) |
+| `codex` | 7,927 | 34,621 | 27 | 42,548 (−3.7%) |
+| `cursor` | 7,928 | 34,621 | 27 | 42,549 (−3.7%) |
+
+The instructions grow slightly because the profile appends one line naming what
+it hid and how to get it back — without it a suppressed tool is invisible, since
+`load_tools()` lists what the *preset* deferred and a suppressed tool is inside
+the preset.
 
 Every `tools.*` option works from a project-local config file (`.trace-mcp/.config.json`) as well as the global one — none of them are global-only. The tool surface is built once per MCP session, so a change takes effect on the next session (restart the MCP client); the daemon does not need restarting.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -231,6 +231,16 @@ const ToolsConfigSchema = z
     description_verbosity: z.enum(['full', 'minimal', 'none']).default('full'),
     /** Server instructions verbosity: full (default ~2K tokens), minimal (~200 tokens), none (empty) */
     instructions_verbosity: z.enum(['full', 'minimal', 'none']).default('full'),
+    /**
+     * Per-client tailoring of the advertised surface (TRA-513). "auto" resolves
+     * the profile from the `initialize` handshake's `clientInfo.name`; a profile
+     * name pins it for a host we guessed wrong about; "off" disables the layer
+     * and advertises the full preset surface to every client. Env override:
+     * TRACE_MCP_CLIENT_PROFILE.
+     */
+    client_profile: z
+      .enum(['auto', 'off', 'claude-code', 'codex', 'cursor', 'vscode', 'generic'])
+      .default('auto'),
     /** Agent behavior rules appended to server instructions. strict = full discipline rules (anti-sycophancy, goal-driven execution, 2-strike rule), minimal = anti-fabrication only, off = no behavior rules. Auto-set to "strict" by Max-tier init. */
     agent_behavior: z.enum(['strict', 'minimal', 'off']).default('off'),
     /** Control which meta fields appear in responses. true = all (default), false = none, or list specific fields to include */

--- a/src/daemon/router/session.ts
+++ b/src/daemon/router/session.ts
@@ -5,6 +5,7 @@ import type { TraceMcpConfig } from '../../config.js';
 import { logger } from '../../logger.js';
 import { checkVersionDrift, versionDriftMessage } from '../../init/version-stamp.js';
 import { stripRedundantSchemaKeyword } from '../../server/schema-shim.js';
+import { ClientProfileGate } from '../../server/client-profile.js';
 import { createToolFilter } from '../../server/tool-filter.js';
 import { disarmStdoutGuard } from '../../server/transport-hardening.js';
 import { tryAutoSpawnDaemon } from '../lifecycle.js';
@@ -84,12 +85,21 @@ export class StdioSession {
    * session-less and surfaces "Session expired, reinitialize required" (#209).
    */
   private cachedInitialize: JSONRPCMessage | null = null;
+  /**
+   * Tailors the advertised surface to the connected host (TRA-513). Applied on
+   * the wire because both backends build their tool surface and their
+   * instructions before `initialize` has been read — this is the only layer that
+   * sees the handshake and every frame going back to the client.
+   */
+  private readonly clientProfile: ClientProfileGate;
 
   constructor(opts: StdioSessionOptions) {
     this.opts = opts;
+    this.clientProfile = new ClientProfileGate(opts.config);
     this.stdio = stripRedundantSchemaKeyword(new StdioServerTransport());
     this.router = new MessageRouter({
-      sendToClient: (msg) => this.stdio.send(msg),
+      sendToClient: (msg) =>
+        this.stdio.send(this.clientProfile.applyToClient(msg) as JSONRPCMessage),
       drainTimeoutMs: opts.drainTimeoutMs ?? 5_000,
     });
     this.watcher = new PollingDaemonWatcher({
@@ -113,6 +123,10 @@ export class StdioSession {
       // Cache the handshake so a later swapped-in proxy backend can re-establish
       // the daemon session (the client only sends `initialize` once).
       if (isInitializeRequest(msg as JSONRPCMessage)) this.cachedInitialize = msg as JSONRPCMessage;
+      this.clientProfile.observeFromClient(msg);
+      if (isInitializeRequest(msg as JSONRPCMessage)) {
+        logger.info({ profile: this.clientProfile.name }, 'StdioSession: resolved client profile');
+      }
       void this.router.ingestFromClient(msg as JSONRPCMessage);
     };
     this.stdio.onerror = (err) => {

--- a/src/server/__tests__/client-profile.test.ts
+++ b/src/server/__tests__/client-profile.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Per-client tool surface + instructions (TRA-513).
+ *
+ * A profile's suppression list is a claim about a host — "this one already has
+ * a content search" — so it has to be checkable. There is one test per profile
+ * asserting the resolved surface against the real `minimal` preset, so a profile
+ * drifting into hiding something important fails here rather than in a user's
+ * session.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import type { TraceMcpConfig } from '../../config.js';
+import { captureAllTools } from '../../tools/register/__tests__/_capture-tools.js';
+import { TOOL_PRESETS } from '../../tools/project/presets.js';
+import {
+  CLIENT_PROFILE_NAMES,
+  type ClientProfileName,
+  ClientProfileGate,
+  detectClientProfile,
+  getClientProfile,
+  resolveClientProfile,
+  retargetInstructions,
+} from '../client-profile.js';
+import { HOST_TOOLS_GENERIC, buildInstructions, hostToolLines } from '../instructions.js';
+import { UNGATED_META_TOOLS } from '../tool-filter.js';
+
+const ALL_TOOLS = captureAllTools();
+
+/** The `tools/list` payload a `minimal`-preset session would receive. */
+function minimalPresetTools(): Array<{ name: string; description: string; inputSchema: unknown }> {
+  const allowed = new Set([...(TOOL_PRESETS.minimal as string[]), ...UNGATED_META_TOOLS]);
+  return ALL_TOOLS.filter((t) => allowed.has(t.name)).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: z.toJSONSchema(z.object(t.schemaShape)),
+  }));
+}
+
+function cfg(over: Record<string, unknown> = {}): TraceMcpConfig {
+  return { tools: over } as unknown as TraceMcpConfig;
+}
+
+/** Drive a gate through a handshake and one `tools/list`. */
+function runSession(
+  clientName: string | undefined,
+  config: TraceMcpConfig = cfg(),
+): { gate: ClientProfileGate; instructions: string; tools: string[] } {
+  const gate = new ClientProfileGate(config);
+  gate.observeFromClient({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: clientName === undefined ? {} : { clientInfo: { name: clientName, version: '1' } },
+  });
+  const init = gate.applyToClient({
+    jsonrpc: '2.0',
+    id: 1,
+    result: { instructions: buildInstructions('none', 'full', 'off'), serverInfo: {} },
+  }) as { result: { instructions: string } };
+  const list = gate.applyToClient({
+    jsonrpc: '2.0',
+    id: 2,
+    result: { tools: minimalPresetTools() },
+  }) as { result: { tools: Array<{ name: string }> } };
+  return {
+    gate,
+    instructions: init.result.instructions,
+    tools: list.result.tools.map((t) => t.name),
+  };
+}
+
+afterEach(() => {
+  delete process.env.TRACE_MCP_CLIENT_PROFILE;
+});
+
+describe('client detection', () => {
+  it.each([
+    ['claude-code', 'claude-code'],
+    ['Claude Code', 'claude-code'],
+    ['codex-cli', 'codex'],
+    ['Cursor', 'cursor'],
+    ['Visual Studio Code', 'vscode'],
+    ['vscode-copilot', 'vscode'],
+  ])('resolves %s to the %s profile', (clientName, expected) => {
+    expect(detectClientProfile(clientName)).toBe(expected);
+  });
+
+  it.each([
+    // Claude Desktop has no native file tools — it must not inherit Claude
+    // Code's suppression list just because the name starts the same way.
+    'claude-ai',
+    'mcp-inspector',
+    '',
+    undefined,
+  ])('falls back to generic for %s', (clientName) => {
+    expect(detectClientProfile(clientName)).toBe('generic');
+  });
+});
+
+describe('resolved tool surface, per profile', () => {
+  const baseline = minimalPresetTools().map((t) => t.name);
+
+  // One assertion per profile: exactly which tools this host stops being
+  // offered. Adding a name here is a claim that the host covers it natively.
+  const EXPECTED_HIDDEN: Record<ClientProfileName, string[]> = {
+    'claude-code': ['search_text'],
+    codex: ['search_text'],
+    cursor: ['search_text'],
+    vscode: ['search_text'],
+    generic: [],
+  };
+
+  for (const profile of CLIENT_PROFILE_NAMES) {
+    it(`"${profile}" hides exactly ${JSON.stringify(EXPECTED_HIDDEN[profile])} from the minimal preset`, () => {
+      process.env.TRACE_MCP_CLIENT_PROFILE = profile;
+      const { tools } = runSession(undefined);
+      expect(baseline.filter((n) => !tools.includes(n))).toEqual(EXPECTED_HIDDEN[profile]);
+      // Nothing may be *added* — a profile only ever removes.
+      expect(tools.filter((n) => !baseline.includes(n))).toEqual([]);
+    });
+  }
+
+  it('leaves every suppressed tool reachable through load_tools', () => {
+    process.env.TRACE_MCP_CLIENT_PROFILE = 'claude-code';
+    const gate = new ClientProfileGate(cfg());
+    gate.observeFromClient({ method: 'initialize', params: {} });
+    gate.observeFromClient({
+      method: 'tools/call',
+      params: { name: 'load_tools', arguments: { tools: ['search_text'] } },
+    });
+    const list = gate.applyToClient({
+      jsonrpc: '2.0',
+      id: 2,
+      result: { tools: minimalPresetTools() },
+    }) as { result: { tools: Array<{ name: string }> } };
+    expect(list.result.tools.map((t) => t.name)).toContain('search_text');
+  });
+
+  it('composes after the preset rather than replacing it', () => {
+    process.env.TRACE_MCP_CLIENT_PROFILE = 'claude-code';
+    // A surface the preset already narrowed to two tools stays narrowed; the
+    // profile only removes its own names from what it is handed.
+    const gate = new ClientProfileGate(cfg());
+    gate.observeFromClient({ method: 'initialize', params: {} });
+    const list = gate.applyToClient({
+      jsonrpc: '2.0',
+      id: 2,
+      result: { tools: [{ name: 'search' }, { name: 'search_text' }] },
+    }) as { result: { tools: Array<{ name: string }> } };
+    expect(list.result.tools.map((t) => t.name)).toEqual(['search']);
+  });
+});
+
+describe('overrides', () => {
+  it('pins the profile from config for a host we guessed wrong about', () => {
+    expect(resolveClientProfile('some-unknown-cli', cfg({ client_profile: 'codex' }))?.name).toBe(
+      'codex',
+    );
+  });
+
+  it('lets the env var beat config', () => {
+    process.env.TRACE_MCP_CLIENT_PROFILE = 'generic';
+    expect(resolveClientProfile('claude-code', cfg({ client_profile: 'codex' }))?.name).toBe(
+      'generic',
+    );
+  });
+
+  it('disables the layer entirely on "off"', () => {
+    expect(resolveClientProfile('claude-code', cfg({ client_profile: 'off' }))).toBeNull();
+    process.env.TRACE_MCP_CLIENT_PROFILE = 'off';
+    const { tools, instructions } = runSession('claude-code');
+    expect(tools).toContain('search_text');
+    expect(instructions).toBe(buildInstructions('none', 'full', 'off'));
+  });
+
+  it('falls back to detection on a nonsense override rather than failing', () => {
+    process.env.TRACE_MCP_CLIENT_PROFILE = 'not-a-profile';
+    expect(resolveClientProfile('cursor', cfg())?.name).toBe('cursor');
+  });
+});
+
+describe('instructions retargeting', () => {
+  it("names the host's own tools instead of the generic placeholders", () => {
+    const { instructions } = runSession('codex-cli');
+    expect(instructions).toContain('`shell` (rg)');
+    expect(instructions).toContain('apply_patch');
+    // The generic rubric exists because we did not know the host. We do now.
+    expect(instructions).not.toContain('host tool names vary');
+    expect(instructions).not.toContain('`content-match`');
+  });
+
+  it('retargets the minimal verbosity variant too', () => {
+    const minimal = buildInstructions('none', 'minimal', 'off');
+    const cursor = retargetInstructions(minimal, getClientProfile('cursor'));
+    expect(cursor).toContain('`grep_search`');
+    expect(cursor).not.toContain('`content-match`');
+  });
+
+  it('leaves an empty instructions block alone', () => {
+    expect(retargetInstructions('', getClientProfile('codex'))).toBe('');
+  });
+
+  it('tells the session what was hidden and how to get it back', () => {
+    const { instructions } = runSession('claude-code');
+    expect(instructions).toContain('search_text');
+    expect(instructions).toContain('load_tools');
+  });
+
+  // The retarget is a substring swap against the exact lines buildInstructions
+  // emitted. If the two drift apart the swap silently no-ops, so pin it here.
+  it('keeps every generic host-tool line present in the built instructions', () => {
+    const full = buildInstructions('none', 'full', 'off');
+    const minimal = buildInstructions('none', 'minimal', 'off');
+    for (const line of hostToolLines(HOST_TOOLS_GENERIC)) {
+      expect(
+        full.includes(line) || minimal.includes(line),
+        `hostToolLines() emitted a line no verbosity uses, so retargeting would no-op:\n${line}`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('wire payload', () => {
+  it('measurably shrinks the advertised surface for every non-generic profile', () => {
+    const baseline = JSON.stringify(minimalPresetTools()).length;
+    for (const profile of CLIENT_PROFILE_NAMES) {
+      if (profile === 'generic') continue;
+      process.env.TRACE_MCP_CLIENT_PROFILE = profile;
+      const gate = new ClientProfileGate(cfg());
+      gate.observeFromClient({ method: 'initialize', params: {} });
+      const list = gate.applyToClient({
+        jsonrpc: '2.0',
+        id: 2,
+        result: { tools: minimalPresetTools() },
+      }) as { result: { tools: unknown[] } };
+      const after = JSON.stringify(list.result.tools).length;
+      expect(after, `"${profile}" did not shrink the payload`).toBeLessThan(baseline);
+    }
+  });
+
+  it('passes non-result frames through untouched', () => {
+    process.env.TRACE_MCP_CLIENT_PROFILE = 'claude-code';
+    const gate = new ClientProfileGate(cfg());
+    gate.observeFromClient({ method: 'initialize', params: {} });
+    const err = { jsonrpc: '2.0', id: 3, error: { code: -32601, message: 'nope' } };
+    expect(gate.applyToClient(err)).toBe(err);
+    const notification = { jsonrpc: '2.0', method: 'notifications/tools/list_changed' };
+    expect(gate.applyToClient(notification)).toBe(notification);
+  });
+
+  it('does nothing at all before the handshake arrives', () => {
+    const gate = new ClientProfileGate(cfg());
+    const frame = { jsonrpc: '2.0', id: 2, result: { tools: [{ name: 'search_text' }] } };
+    expect(gate.applyToClient(frame)).toBe(frame);
+    expect(gate.name).toBeNull();
+  });
+});

--- a/src/server/client-profile.ts
+++ b/src/server/client-profile.ts
@@ -1,0 +1,288 @@
+/**
+ * Per-client tailoring of the advertised surface (TRA-513).
+ *
+ * The connected host tells us who it is in `initialize` (`clientInfo.name`) and
+ * until now we threw that away, so every host got the same `tools/list` and the
+ * same instructions. Two costs followed: we advertise tools the host already
+ * has natively — pure wire cost plus a mis-pick opportunity, since the model now
+ * has two ways to do one thing — and our routing table names host tools that
+ * only exist in some hosts.
+ *
+ * A profile is data, not code: a set of tool names this host already covers,
+ * plus the names its own file tools go by. It composes *after* the preset — the
+ * preset is the coarse "how much capability" knob, the profile only removes what
+ * this particular host duplicates. Nothing is renamed or removed: a suppressed
+ * tool is hidden from `tools/list` and stays one `load_tools` call away.
+ *
+ * Deliberately conservative. A suppression entry is a claim that this host
+ * genuinely covers that tool, and a wrong claim costs capability, so the lists
+ * stay short until a host has actually been surveyed. `generic` — the fallback
+ * for anything unrecognised — suppresses nothing at all.
+ */
+import type { TraceMcpConfig } from '../config.js';
+import { resolvePreset } from '../tools/project/presets.js';
+import { HOST_TOOLS_GENERIC, type HostToolNames, hostToolLines } from './instructions.js';
+
+export const CLIENT_PROFILE_NAMES = [
+  'claude-code',
+  'codex',
+  'cursor',
+  'vscode',
+  'generic',
+] as const;
+export type ClientProfileName = (typeof CLIENT_PROFILE_NAMES)[number];
+
+export interface ClientProfile {
+  name: ClientProfileName;
+  /** Tools this host already covers — hidden from `tools/list`, not removed. */
+  suppress: ReadonlySet<string>;
+  /** What this host's own file tools are called, for the instructions block. */
+  hostTools: HostToolNames;
+}
+
+/**
+ * `search_text` is a regex-over-indexed-files tool. Every host below ships an
+ * equivalent (Grep, `rg` through a shell, a workspace text search) that costs
+ * the session nothing, so advertising ours buys a second way to do one thing.
+ *
+ * `discover_hermes_sessions` enumerates session logs for the Hermes harness —
+ * inert on any of these hosts, which have their own log layout.
+ */
+const HOST_COVERED: ReadonlySet<string> = new Set(['search_text', 'discover_hermes_sessions']);
+
+const PROFILES: Record<ClientProfileName, ClientProfile> = {
+  'claude-code': {
+    name: 'claude-code',
+    suppress: HOST_COVERED,
+    hostTools: {
+      rubric: "your host's own tools are `Read`, `Grep`, `Glob`, `Edit`",
+      read: '`Read`',
+      grep: '`Grep`',
+      glob: '`Glob`',
+      edit: 'Edit/Write',
+    },
+  },
+  codex: {
+    name: 'codex',
+    suppress: HOST_COVERED,
+    hostTools: {
+      rubric:
+        'your host reads and searches through `shell` — cat, rg, find — and edits with `apply_patch`',
+      read: '`shell` (cat)',
+      grep: '`shell` (rg)',
+      glob: '`shell` (find)',
+      edit: 'apply_patch',
+    },
+  },
+  cursor: {
+    name: 'cursor',
+    suppress: HOST_COVERED,
+    hostTools: {
+      rubric: "your host's own tools are `read_file`, `grep_search`, `file_search`, `edit_file`",
+      read: '`read_file`',
+      grep: '`grep_search`',
+      glob: '`file_search`',
+      edit: 'edit_file',
+    },
+  },
+  vscode: {
+    name: 'vscode',
+    suppress: HOST_COVERED,
+    hostTools: {
+      rubric: "your host's own tools are `readFile`, `textSearch`, `fileSearch`, `editFile`",
+      read: '`readFile`',
+      grep: '`textSearch`',
+      glob: '`fileSearch`',
+      edit: 'editFile',
+    },
+  },
+  // The fallback has to be a no-op, not a guess: a host we don't recognise may
+  // have no file tools at all (Claude Desktop, a bare SDK client), and hiding
+  // `search_text` there would take away its only content search.
+  generic: { name: 'generic', suppress: new Set(), hostTools: HOST_TOOLS_GENERIC },
+};
+
+/** Substring → profile. Order matters: the first hit wins. */
+const DETECTION: ReadonlyArray<[string, ClientProfileName]> = [
+  // "claude-code" before "claude": Claude Desktop reports "claude-ai" and has
+  // no native file tools, so it must fall through to `generic`.
+  ['claude-code', 'claude-code'],
+  ['codex', 'codex'],
+  ['cursor', 'cursor'],
+  ['visual-studio-code', 'vscode'],
+  ['vscode', 'vscode'],
+  ['copilot', 'vscode'],
+];
+
+/**
+ * Resolve a host name from `initialize` to a profile name.
+ *
+ * Separators are normalised to `-` first: the same host reports itself as
+ * "claude-code" from the CLI and "Claude Code" from an SDK wrapper, and both
+ * have to land on the same profile.
+ */
+export function detectClientProfile(clientName: string | undefined): ClientProfileName {
+  const name = (clientName ?? '').toLowerCase().replace(/[\s_.]+/g, '-');
+  if (!name) return 'generic';
+  for (const [needle, profile] of DETECTION) if (name.includes(needle)) return profile;
+  return 'generic';
+}
+
+function isProfileName(v: string): v is ClientProfileName {
+  return (CLIENT_PROFILE_NAMES as readonly string[]).includes(v);
+}
+
+/**
+ * The profile this session runs with, or `null` when the layer is switched off.
+ *
+ * `TRACE_MCP_CLIENT_PROFILE` beats config, config beats detection — for users on
+ * a host we guessed wrong about, and for anyone who wants the full surface
+ * regardless (`off`). An unrecognised override value falls back to detection
+ * rather than failing the handshake.
+ */
+export function resolveClientProfile(
+  clientName: string | undefined,
+  config: TraceMcpConfig,
+): ClientProfile | null {
+  const override = process.env.TRACE_MCP_CLIENT_PROFILE ?? config.tools?.client_profile ?? 'auto';
+  if (override === 'off') return null;
+  if (override !== 'auto' && isProfileName(override)) return PROFILES[override];
+  return PROFILES[detectClientProfile(clientName)];
+}
+
+/** Read a profile by name. Exported for tests and `get_preset_info`-style reads. */
+export function getClientProfile(name: ClientProfileName): ClientProfile {
+  return PROFILES[name];
+}
+
+/**
+ * Rewrite the host-tool names in a built instructions string.
+ *
+ * The instructions are composed by the daemon (or the in-process server) before
+ * the client's `initialize` is even parsed, so this runs on the wire instead:
+ * a substring swap of the exact lines `hostToolLines` produced. Both sides build
+ * from that one function, so a drift makes the swap a no-op rather than a
+ * corruption — and client-profile.test.ts fails when it does.
+ */
+export function retargetInstructions(instructions: string, profile: ClientProfile): string {
+  if (!instructions || profile.hostTools === HOST_TOOLS_GENERIC) return instructions;
+  const from = hostToolLines(HOST_TOOLS_GENERIC);
+  const to = hostToolLines(profile.hostTools);
+  let out = instructions;
+  for (let i = 0; i < from.length; i++) {
+    if (from[i] !== to[i]) out = out.split(from[i]).join(to[i]);
+  }
+  return out;
+}
+
+/**
+ * One line telling the session what the profile took away and how to get it
+ * back. Without it a suppressed tool is invisible: `load_tools` with no
+ * arguments lists what the *preset* deferred, and a profile-suppressed tool is
+ * inside the preset, so it shows up in neither list.
+ */
+export function suppressionNotice(profile: ClientProfile, hidden: readonly string[]): string {
+  if (hidden.length === 0) return '';
+  return (
+    `Client profile "${profile.name}": ${hidden.length} tool(s) your host already covers ` +
+    `are hidden from tools/list — ${hidden.join(', ')}. ` +
+    `Call load_tools({ tools: ["${hidden[0]}"] }) to advertise them anyway, or set ` +
+    'tools.client_profile to "off" to disable this layer.'
+  );
+}
+
+/** A JSON-RPC frame, seen structurally — we never parse it into SDK types. */
+type Frame = Record<string, unknown>;
+
+/**
+ * The profile applied to a live stdio session's wire traffic.
+ *
+ * It sits at the session boundary rather than inside the tool gate for the same
+ * reason the preset filter does on the daemon path: one daemon serves many
+ * sessions, and both backends build their surface — and their instructions —
+ * before the client's `initialize` has been read. The session is the only place
+ * that sees both who the client is and every frame going back to it.
+ *
+ * Hiding is all it does: a suppressed tool stays callable if the client asks for
+ * it by name. That is deliberate — the token win is entirely in not advertising
+ * the tool, and rejecting the call would only break a client that cached an
+ * earlier `tools/list`.
+ */
+export class ClientProfileGate {
+  private profile: ClientProfile | null = null;
+  /** Suppressed tools this session pulled back in via `load_tools`. */
+  private readonly reinstated = new Set<string>();
+  /** Names actually withheld from the last `tools/list`, for logging/tests. */
+  private lastHidden: string[] = [];
+
+  constructor(private readonly config: TraceMcpConfig) {}
+
+  /** Profile name for logs, or null while the handshake hasn't arrived. */
+  get name(): ClientProfileName | null {
+    return this.profile?.name ?? null;
+  }
+
+  /** Tools withheld from the most recent `tools/list`. */
+  get hidden(): readonly string[] {
+    return this.lastHidden;
+  }
+
+  /** Inbound: learn who the client is, and honour explicit escalation. */
+  observeFromClient(msg: unknown): void {
+    const m = msg as Frame;
+    if (m.method === 'initialize') {
+      const info = (m.params as Frame | undefined)?.clientInfo as Frame | undefined;
+      const clientName = typeof info?.name === 'string' ? info.name : undefined;
+      this.profile = resolveClientProfile(clientName, this.config);
+      return;
+    }
+    if (m.method !== 'tools/call') return;
+    const params = m.params as Frame | undefined;
+    if (params?.name !== 'load_tools') return;
+    const args = params.arguments as { preset?: string; tools?: string[] } | undefined;
+    for (const t of args?.tools ?? []) this.reinstated.add(t);
+    if (!args?.preset) return;
+    const resolved = resolvePreset(args.preset);
+    if (resolved === 'all') for (const t of this.profile?.suppress ?? []) this.reinstated.add(t);
+    else if (resolved) for (const t of resolved) this.reinstated.add(t);
+  }
+
+  /** Outbound: retarget the instructions and thin the advertised surface. */
+  applyToClient(msg: unknown): unknown {
+    if (!this.profile) return msg;
+    const m = msg as Frame;
+    const result = m.result as Frame | undefined;
+    if (!result) return msg;
+    if (typeof result.instructions === 'string') return this.rewriteInitialize(m, result);
+    if (Array.isArray(result.tools)) return this.filterToolsList(m, result);
+    return msg;
+  }
+
+  // ── Internals ───────────────────────────────────────────────────────
+
+  private suppressed(): string[] {
+    return [...(this.profile?.suppress ?? [])].filter((t) => !this.reinstated.has(t));
+  }
+
+  private rewriteInitialize(msg: Frame, result: Frame): unknown {
+    let instructions = retargetInstructions(result.instructions as string, this.profile!);
+    // The notice needs the names, and at handshake time no tools/list has gone
+    // out yet — so it states what the profile *will* hide.
+    const notice = suppressionNotice(this.profile!, this.suppressed());
+    if (notice) instructions = instructions ? `${instructions}\n\n${notice}` : notice;
+    if (instructions === result.instructions) return msg;
+    return { ...msg, result: { ...result, instructions } };
+  }
+
+  private filterToolsList(msg: Frame, result: Frame): unknown {
+    const hide = new Set(this.suppressed());
+    if (hide.size === 0) return msg;
+    const advertised = result.tools as Array<{ name?: unknown }>;
+    const tools = advertised.filter((t) => typeof t?.name !== 'string' || !hide.has(t.name));
+    if (tools.length === advertised.length) return msg;
+    this.lastHidden = advertised
+      .map((t) => t?.name)
+      .filter((n): n is string => typeof n === 'string' && hide.has(n));
+    return { ...msg, result: { ...result, tools } };
+  }
+}

--- a/src/server/instructions.ts
+++ b/src/server/instructions.ts
@@ -1,3 +1,54 @@
+/**
+ * How the instructions refer to the host's own file tools.
+ *
+ * The routing table is written for a host we cannot see, so TRA-512 made it name
+ * tools generically — `read`, `content-match`, `glob` — rather than assume Claude
+ * Code's. When the `initialize` handshake tells us which host is actually
+ * connected we can do better than generic and name its real tools, so these are
+ * a per-profile value the client-profile layer swaps on the wire
+ * (server/client-profile.ts) rather than literals.
+ */
+export interface HostToolNames {
+  /** Parenthetical after "THE RULE", introducing the host's vocabulary. */
+  rubric: string;
+  /** File-read tool. */
+  read: string;
+  /** Content-match tool. */
+  grep: string;
+  /** File-glob tool. */
+  glob: string;
+  /** Line-edit tools, as one phrase. */
+  edit: string;
+}
+
+/** What `buildInstructions` emits, and what an unrecognised host keeps. */
+export const HOST_TOOLS_GENERIC: HostToolNames = {
+  rubric:
+    'host tool names vary — `read`, `content-match`/grep, `glob` mean whatever yours are called',
+  read: '`read`',
+  grep: '`content-match`',
+  glob: '`glob`',
+  edit: 'Edit/Write',
+};
+
+/**
+ * Every instructions line that names a host tool, in a fixed order.
+ *
+ * Retargeting is a substring swap of this array (generic → profile), so both
+ * sides must build from this one function or the swap silently no-ops. Kept
+ * honest by client-profile.test.ts.
+ */
+export function hostToolLines(h: HostToolNames): string[] {
+  return [
+    `THE RULE (${h.rubric}):`,
+    `- Full-file ${h.read} for discovery: not the move. Take \`get_outline\`, then pull the one symbol with \`get_symbol\`. Read the file directly only when you already have the outline and the span you want is a few lines — or the file is not code (.md/.json/.yaml/config), or you are about to edit it.`,
+    `- ${h.grep} or ${h.glob} over source: not the move. \`search\` and \`find_usages\` resolve symbol kinds, imports, and call sites; a text scan cannot rank its hits and misses re-exports, aliases, and dynamic dispatch.`,
+    `- After every ${h.edit} → \`register_edit\` { file_path } (reindexes one file; far lighter than \`reindex\`). If the reply carries \`_duplication_warnings\`, review them before continuing.`,
+    `Use trace-mcp tools instead of ${h.read}/${h.grep}/${h.glob} for source code.`,
+    `Use ${h.read}/${h.grep} only for non-code files (.md, .json, .yaml) or before ${h.edit}.`,
+  ];
+}
+
 /** Builds the MCP server instructions string based on verbosity level. */
 export function buildInstructions(
   detectedFrameworks: string,
@@ -5,16 +56,17 @@ export function buildInstructions(
   agentBehavior: 'strict' | 'minimal' | 'off' = 'off',
 ): string {
   const behaviorBlock = buildBehaviorBlock(agentBehavior);
+  const host = hostToolLines(HOST_TOOLS_GENERIC);
 
   if (verbosity === 'none') return behaviorBlock;
 
   if (verbosity === 'minimal') {
     const core = [
       `trace-mcp: framework-aware code intelligence. Detected: ${detectedFrameworks}.`,
-      'Use trace-mcp tools instead of Read/Grep/Glob for source code.',
+      host[4],
       'Key tools: search, get_outline, get_symbol, get_task_context, get_change_impact, find_usages, batch.',
       'Use batch for 2+ independent queries. Use get_task_context to start tasks.',
-      'Use Read/Grep only for non-code files (.md, .json, .yaml) or before Edit.',
+      host[5],
     ].join(' ');
     return behaviorBlock ? `${core}\n\n${behaviorBlock}` : core;
   }
@@ -22,9 +74,9 @@ export function buildInstructions(
   return [
     `trace-mcp is a framework-aware code intelligence server for this project. Detected frameworks: ${detectedFrameworks}.`,
     '',
-    'THE RULE (host tool names vary — `read`, `content-match`/grep, `glob` mean whatever yours are called):',
-    '- Full-file `read` for discovery: not the move. Take `get_outline`, then pull the one symbol with `get_symbol`. Read the file directly only when you already have the outline and the span you want is a few lines — or the file is not code (.md/.json/.yaml/config), or you are about to edit it.',
-    '- `content-match` or `glob` over source: not the move. `search` and `find_usages` resolve symbol kinds, imports, and call sites; a text scan cannot rank its hits and misses re-exports, aliases, and dynamic dispatch.',
+    host[0],
+    host[1],
+    host[2],
     '',
     'If you catch yourself thinking one of these, that is the signal to switch:',
     '- "I already know the path, so one read is cheaper than a lookup." — knowing the path does not shrink the file. The lookup returns the symbol; the read returns everything around it.',
@@ -61,7 +113,7 @@ export function buildInstructions(
     '- Check waste → `get_optimization_report`; track savings → `get_session_stats`, `get_real_savings`',
     '',
     'Editing:',
-    '- After every Edit/Write → `register_edit` { file_path } (reindexes one file; far lighter than `reindex`). If the reply carries `_duplication_warnings`, review them before continuing.',
+    host[3],
     '- Before writing a new function/class → `check_duplication` { name, kind }',
     '- Rename → `apply_rename`; move a symbol or file → `apply_move`; change params → `change_signature`; delete → `remove_dead_code`. All dry-run by default: review, then re-call with `dry_run: false` (`confirm_large: true` past 20 files). Preview any of them with `plan_refactoring`. `extract_function` is disabled.',
     '- Same mechanical change 2+ times → `apply_codemod` { pattern, replacement, file_pattern }, not a run of edits.',


### PR DESCRIPTION
Closes TRA-513.

The `initialize` handshake tells us which host is connected (`clientInfo.name`) and we threw it away, so every client got the same `tools/list` and the same instructions block.

## What this adds

A client-profile layer resolving to `claude-code`, `codex`, `cursor`, `vscode`, or `generic` (the fallback for anything unrecognised). A profile is data, not code: a set of tools this host already covers natively, plus what its own file tools are called.

- **Composes after the preset.** The preset stays the coarse "how much capability" knob; the profile only removes names from what the preset already advertised. There is a test for exactly this.
- **Additive and non-breaking.** No tool renamed, no schema changed. A suppressed tool is hidden from `tools/list` but stays callable by name, and `load_tools({ tools: ["search_text"] })` puts it back on the list — verified live, not just in unit tests.
- **Discoverable.** The handshake carries one line naming what the profile hid and how to undo it. Without it a suppressed tool is invisible: `load_tools()` lists what the *preset* deferred, and a profile-suppressed tool is inside the preset.
- **Overridable.** `tools.client_profile` (or `TRACE_MCP_CLIENT_PROFILE`) pins a profile for a host we guessed wrong about, or `off` disables the layer and restores the full preset surface byte-for-byte.

Applied at the stdio session boundary rather than in the tool gate, for the same reason the preset filter is: one daemon serves many sessions, and both backends build their surface *and* their instructions before `initialize` has been read. The session is the only layer that sees both the handshake and every frame going back to the client.

## Measurement

Real `initialize` + `tools/list` round-trip against the built server (`node dist/cli.js serve`), reading the wire payload. Serialized chars, default `minimal` preset:

| Client | instructions | `tools/list` | advertised | handshake total |
|---|---|---|---|---|
| `generic` (or `client_profile: "off"`) | 7,669 | 36,523 | 28 | 44,192 |
| `claude-code` | 7,933 | 34,621 | 27 | 42,554 (−3.7%) |
| `codex` | 7,927 | 34,621 | 27 | 42,548 (−3.7%) |
| `cursor` | 7,928 | 34,621 | 27 | 42,549 (−3.7%) |

On the `full` preset: 188,462 → 185,838 (−1.4%, two tools suppressed).

The instructions grow ~260 chars because of the suppression notice; the net is still negative, and `generic`/`off` reproduces the current payload exactly.

**Honest read on the size of the win.** ~3.7% on the shipped default is real but modest, and smaller than the issue implies. The reason is that the honest overlap is small: trace-mcp has no file-read and no glob tool, so the only genuine duplicate of a host native is `search_text` (Grep / `rg` / workspace text search). `discover_hermes_sessions` is the other entry — inert on all four hosts. I did not add `apply_codemod` (no host has cross-file regex replace) or `check_claudemd_drift` (it handles AGENTS.md and .cursorrules too). Each suppression entry is a claim about a host and a wrong claim costs capability, so the lists stay short until a host has actually been surveyed; the per-profile tests make growing them a deliberate, reviewed act.

The instructions half is a correctness win rather than a size win: the routing block now names `Read`/`Grep`/`Glob` on Claude Code and `shell` (cat/rg/find) + `apply_patch` on Codex, instead of the host-neutral placeholders it has to use when it does not know who is listening.

## Interaction with TRA-512

Rebased onto #647, as the issue asked. `full`-verbosity instructions for `generic` are byte-identical to what that PR shipped — verified by diffing both builds. The one text change is `minimal` verbosity, which still named Read/Grep/Glob; it now uses TRA-512's host-neutral vocabulary, so both verbosities are consistent and both retarget.

## Tests

`src/server/__tests__/client-profile.test.ts` — 29 tests: detection (including Claude Desktop's `claude-ai` correctly falling through to `generic` rather than inheriting Claude Code's list), one resolved-tool-set assertion per profile against the real `minimal` preset, preset composition, `load_tools` escalation, all three override paths, instructions retargeting per verbosity, and a drift guard that fails if `hostToolLines` stops matching what `buildInstructions` emits (which would make retargeting silently no-op).

Full suite: 9,266 passed / 5 skipped. Typecheck and `biome ci` clean.
