### PR TITLE
fix(tools): get_untested_symbols reports the actionable tier by default (TRA-515)

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -101,7 +101,7 @@ Tools are registered dynamically based on detected frameworks — you only see t
 | `get_implementations` | Find all classes that implement or extend a given interface/base class |
 | `get_type_hierarchy` | Walk TypeScript class/interface hierarchy: ancestors and descendants |
 | `get_api_surface` | List all exported symbols (public API) of a file or matching files |
-| `get_untested_symbols` | Find ALL symbols (not just exports) lacking test coverage. Classifies as "unreached" (no test imports the source) or "imported_not_called" (test imports file but never references symbol). Pass `scope: "exports_only"` for the fast exports-only scan |
+| `get_untested_symbols` | Find ALL symbols (not just exports) lacking test coverage. Returns the "unreached" tier (no test imports the source) by default; `level: "imported_not_called"` / `"all"` opt into the weaker tier, where transitively-exercised symbols also land. Pass `scope: "exports_only"` for the fast exports-only scan |
 | `self_audit` | One-shot project health: dead exports, untested code, dependency hotspots, heritage metrics |
 
 ## Quality & security

--- a/ops/test-coverage-ledger.md
+++ b/ops/test-coverage-ledger.md
@@ -4,7 +4,9 @@ What the Test & Quality Health runs have actually covered, so the next run
 starts where the last one stopped instead of re-deriving the same list.
 
 Candidates come from dogfooding `get_untested_symbols` against this repo's own
-index, filtered to `src/**`, `level: "unreached"`, functions and classes only.
+index, filtered to `src/**`, functions and classes only. Since TRA-515 the tool
+defaults to `level: "unreached"`, so no manual level filtering is needed —
+`level: "all"` restores the old combined output.
 Priority is not the headline percentage — it is the surface that can damage a
 user's machine or break the tool contract: disk paths, shell, DB/schema,
 parsing, the MCP tool surface.

--- a/src/api/dashboard-routes.ts
+++ b/src/api/dashboard-routes.ts
@@ -145,12 +145,11 @@ function queryProjectHealth(entry: RegistryEntry): ProjectHealth {
     }
 
     // ── Untested symbols (real implementation) ────────────────────────────────
-    // getUntestedSymbols classifies 'unreached' + 'imported_not_called'; sum both.
+    // Count only 'unreached' (TRA-515): 'imported_not_called' is a direct-call-edge
+    // artefact that inflates the figure to ~95% of the codebase on any real repo.
     let untestedSymbols = 0;
     try {
-      const untestedResult = getUntestedSymbols(store);
-      untestedSymbols =
-        untestedResult.by_level.unreached + untestedResult.by_level.imported_not_called;
+      untestedSymbols = getUntestedSymbols(store).by_level.unreached;
     } catch {
       // fallback: leave 0
     }

--- a/src/server/compact-params.ts
+++ b/src/server/compact-params.ts
@@ -37,7 +37,7 @@ export const COMPACT_CORE_PARAMS: Record<string, string[]> = {
   get_control_flow: ['symbol_id', 'fqn'],
   graph_query: ['query', 'depth'],
   check_duplication: ['name', 'kind', 'symbol_id'],
-  get_untested_symbols: ['file_pattern', 'scope', 'max_results'],
+  get_untested_symbols: ['file_pattern', 'scope', 'level', 'max_results'],
   get_complexity_trend: ['file_path'],
   get_coupling_trend: ['file_path', 'since_days'],
   get_symbol_complexity_trend: ['symbol_id'],

--- a/src/tools/analysis/introspect.ts
+++ b/src/tools/analysis/introspect.ts
@@ -804,10 +804,16 @@ interface UntestedSymbolItem {
   level: TestReachLevel;
 }
 
+/** Requested classification tier — `all` restores the pre-TRA-515 combined output. */
+type TestReachFilter = TestReachLevel | 'all';
+
 interface GetUntestedSymbolsResult {
   file_pattern: string | null;
+  /** Which tier the `untested` list and `total_untested` count cover. */
+  level: TestReachFilter;
   untested: UntestedSymbolItem[];
   total_symbols: number;
+  /** Count of symbols at the requested `level` — NOT the sum of both tiers. */
   total_untested: number;
   by_level: { unreached: number; imported_not_called: number };
 }
@@ -849,14 +855,22 @@ const CODE_LANGUAGES = new Set([
  *
  * Uses import-graph test_covers edges + test file name matching + symbol name matching.
  *
+ * `imported_not_called` is a weak signal: `test_covers` records direct edges only,
+ * so a helper exercised transitively through a covered caller still lands there.
+ * It therefore dominates the raw count (on this repo: 4558 of 5209) and is excluded
+ * from the default output — the default headline is the actionable `unreached` set.
+ *
  * @param includeNonCode  When true, restores legacy behaviour and includes symbols
  *                        from non-code files (markdown, json, yaml, …). Default false.
+ * @param level           Which tier to report. Default 'unreached'; 'all' restores
+ *                        the pre-TRA-515 combined list.
  */
 export function getUntestedSymbols(
   store: Store,
   filePattern?: string,
   maxResults?: number,
   includeNonCode = false,
+  level: TestReachFilter = 'unreached',
 ): GetUntestedSymbolsResult {
   // ── 1. Query all symbols with file paths ──────────────────────────────────
   const likeClause = filePattern
@@ -1017,14 +1031,16 @@ export function getUntestedSymbols(
     return a.file.localeCompare(b.file) || a.name.localeCompare(b.name);
   });
 
-  const limited = maxResults ? untested.slice(0, maxResults) : untested;
   const unreachedCount = untested.filter((u) => u.level === 'unreached').length;
+  const selected = level === 'all' ? untested : untested.filter((u) => u.level === level);
+  const limited = maxResults ? selected.slice(0, maxResults) : selected;
 
   return {
     file_pattern: filePattern ?? null,
+    level,
     untested: limited,
     total_symbols: candidates.length,
-    total_untested: untested.length,
+    total_untested: selected.length,
     by_level: {
       unreached: unreachedCount,
       imported_not_called: untested.length - unreachedCount,

--- a/src/tools/register/analysis.ts
+++ b/src/tools/register/analysis.ts
@@ -188,7 +188,7 @@ export function registerAnalysisTools(server: McpServer, ctx: ServerContext): vo
 
   server.tool(
     'get_untested_symbols',
-    'Find symbols lacking test coverage. scope="all_symbols" (default) classifies each as "unreached" (no test file imports the source) or "imported_not_called" (test imports file but never references this symbol) — by default only source-code languages (TypeScript, Python, Go, Ruby, …) are considered, use include_non_code=true to restore the legacy noisy behaviour. scope="exports_only" is the fast export-keyword-only scan. Read-only. Returns JSON: { untested: [{ symbol_id, name, kind, file, classification }], total }. Supports `output_format: "toon"`.',
+    'Find symbols lacking test coverage. scope="all_symbols" (default) returns only "unreached" symbols (no test file imports the source) — the weaker "imported_not_called" tier is opt-in via `level`. `total_untested` counts the requested level only; `by_level` always carries both. Only source-code languages are considered unless include_non_code=true. scope="exports_only" is the fast export-keyword-only scan. Read-only. Returns JSON: { level, untested: [{ symbol_id, name, kind, file, level }], total_symbols, total_untested, by_level }. Supports `output_format: "toon"`.',
     {
       file_pattern: z
         .string()
@@ -214,18 +214,24 @@ export function registerAnalysisTools(server: McpServer, ctx: ServerContext): vo
         .describe(
           'all_symbols (default): full classification. exports_only: fast export-only scan.',
         ),
+      level: z
+        .enum(['unreached', 'imported_not_called', 'all'])
+        .optional()
+        .describe(
+          'Which tier to return. unreached (default): source files no test reaches — the actionable set. imported_not_called: test imports the file but never references the symbol by name — a weak signal, since test_covers records direct call edges only, so anything exercised transitively lands here and swamps the count. all: both tiers (pre-TRA-515 behaviour). Ignored when scope="exports_only".',
+        ),
       // Inherited from the retired `get_untested_exports` alias (TRA-240) so
       // its TOON support survives the migration — the exports_only payload is
       // the flat-scalar-row shape TOON measurably wins on.
       output_format: OutputFormatSchema,
     },
-    async ({ file_pattern, max_results, include_non_code, scope, output_format }) => {
+    async ({ file_pattern, max_results, include_non_code, scope, level, output_format }) => {
       if (scope === 'exports_only') {
         const result = getUntestedExports(store, file_pattern);
         const fmt = output_format === 'markdown' ? 'json' : output_format;
         return { content: [{ type: 'text', text: encodeResponse(result, fmt) }] };
       }
-      const result = getUntestedSymbols(store, file_pattern, max_results, include_non_code);
+      const result = getUntestedSymbols(store, file_pattern, max_results, include_non_code, level);
       const fmt = output_format === 'markdown' ? 'json' : output_format;
       return { content: [{ type: 'text', text: encodeResponse(result, fmt) }] };
     },

--- a/tests/tools/behavioural/get-untested-symbols.behavioural.test.ts
+++ b/tests/tools/behavioural/get-untested-symbols.behavioural.test.ts
@@ -79,7 +79,7 @@ describe('get_untested_symbols — behavioural contract', () => {
     // testFileSymbolNames map for "covered" gets populated.
     store.insertEdge(testFileNid, srcFileNid, 'imports', true, undefined, false, 'ast_resolved');
 
-    const result = getUntestedSymbols(store);
+    const result = getUntestedSymbols(store, undefined, undefined, false, 'all');
     const item = result.untested.find((u) => u.name === 'neverCalled');
     expect(item).toBeDefined();
     expect(item!.level).toBe('imported_not_called');
@@ -284,7 +284,7 @@ describe('get_untested_symbols — behavioural contract', () => {
       byteEnd: 40,
     });
 
-    const result = getUntestedSymbols(store);
+    const result = getUntestedSymbols(store, undefined, undefined, false, 'all');
     const orphan = result.untested.find((u) => u.name === 'orphanFn');
     const covered = result.untested.find((u) => u.name === 'neverCalled');
     expect(orphan?.level).toBe('unreached');
@@ -293,5 +293,73 @@ describe('get_untested_symbols — behavioural contract', () => {
     expect(result.by_level.unreached).toBeGreaterThanOrEqual(1);
     expect(result.by_level.imported_not_called).toBeGreaterThanOrEqual(1);
     expect(result.untested.some((u) => u.name === '[1.10.0]')).toBe(false);
+  });
+  // ─── TRA-515: default headline is the actionable `unreached` set ──────────
+  // `imported_not_called` is a direct-call-edge artefact and dominated the raw
+  // count (4558 of 5209 on this repo), making `total_untested` read as "95% of
+  // the codebase is untested". It is now opt-in.
+
+  it('defaults to level="unreached" and omits imported_not_called from the count', () => {
+    const orphanId = store.insertFile('src/orphan.ts', 'typescript', 'h1', 100);
+    store.insertSymbol(orphanId, {
+      symbolId: 'src/orphan.ts::orphanFn#function',
+      name: 'orphanFn',
+      kind: 'function',
+      byteStart: 0,
+      byteEnd: 40,
+    });
+
+    const srcFileId = store.insertFile('src/covered.ts', 'typescript', 'h2', 100);
+    const symId = store.insertSymbol(srcFileId, {
+      symbolId: 'src/covered.ts::neverCalled#function',
+      name: 'neverCalled',
+      kind: 'function',
+      byteStart: 0,
+      byteEnd: 40,
+    });
+    const testFileId = store.insertFile('tests/covered.test.ts', 'typescript', 'h3', 100);
+    store.insertSymbol(testFileId, {
+      symbolId: 'tests/covered.test.ts::otherTest#function',
+      name: 'otherTest',
+      kind: 'function',
+      byteStart: 0,
+      byteEnd: 30,
+    });
+    const testFileNid = store.getNodeId('file', testFileId)!;
+    store.insertEdge(
+      testFileNid,
+      store.getNodeId('symbol', symId)!,
+      'test_covers',
+      true,
+      undefined,
+      false,
+      'ast_resolved',
+    );
+    store.insertEdge(
+      testFileNid,
+      store.getNodeId('file', srcFileId)!,
+      'imports',
+      true,
+      undefined,
+      false,
+      'ast_resolved',
+    );
+
+    const def = getUntestedSymbols(store);
+    expect(def.level).toBe('unreached');
+    expect(def.untested.map((u) => u.name)).toEqual(['orphanFn']);
+    expect(def.total_untested).toBe(1);
+    // by_level still reports both tiers, so the fuller picture is not lost.
+    expect(def.by_level.unreached).toBe(1);
+    expect(def.by_level.imported_not_called).toBe(1);
+
+    // Opt-in tiers.
+    const all = getUntestedSymbols(store, undefined, undefined, false, 'all');
+    expect(all.total_untested).toBe(2);
+    expect(all.untested.map((u) => u.name).sort()).toEqual(['neverCalled', 'orphanFn']);
+
+    const weak = getUntestedSymbols(store, undefined, undefined, false, 'imported_not_called');
+    expect(weak.total_untested).toBe(1);
+    expect(weak.untested.map((u) => u.name)).toEqual(['neverCalled']);
   });
 });

--- a/tests/tools/introspect.test.ts
+++ b/tests/tools/introspect.test.ts
@@ -393,7 +393,7 @@ describe('getUntestedExports', () => {
 
 describe('getUntestedSymbols', () => {
   it('returns untested symbol analysis with level classification', () => {
-    const result = getUntestedSymbols(store);
+    const result = getUntestedSymbols(store, undefined, undefined, false, 'all');
     expect(result.total_symbols).toBeGreaterThan(0);
     expect(typeof result.total_untested).toBe('number');
     expect(Array.isArray(result.untested)).toBe(true);
@@ -433,7 +433,7 @@ describe('getUntestedSymbols', () => {
   });
 
   it('sorts unreached before imported_not_called', () => {
-    const result = getUntestedSymbols(store);
+    const result = getUntestedSymbols(store, undefined, undefined, false, 'all');
     const levels = result.untested.map((u) => u.level);
     const firstImported = levels.indexOf('imported_not_called');
     const lastUnreached = levels.lastIndexOf('unreached');


### PR DESCRIPTION
Closes TRA-515.

## The number was wrong

Dogfooding `get_untested_symbols` on this repo's own index — 9248 passing tests across 837 files — reported **5219 of 5487 symbols (95%) untested**. 4589 of those were `imported_not_called`: `test_covers` records direct call edges from a test, so every symbol reached transitively through a covered caller lands in that tier. To see real gaps a user had to know to discard 94% of the output, which makes the tool useless for the prioritisation it exists for.

## Decision

Of the four options in the issue I took **1 + 2**: `unreached` becomes the headline, `imported_not_called` becomes opt-in, and `total_untested` is scoped to the requested tier instead of silently summing both. Transitive propagation (option 3) changes what the graph means and risks a perf regression on large indexes for a signal that would still be an approximation; "document the recipe" (option 4) leaves the misleading default in place.

## Measured on this repo's index (2017 files)

| | before | after |
|---|---|---|
| `total_untested`, no filters | 5219 | **630** |
| `total_untested`, `src/**` | — | 373 |

`by_level` still reports both tiers (`{ unreached: 630, imported_not_called: 4589 }`), so nothing is hidden.

## Migration

Contract-visible, no schema change:

- Response gains `level` (the tier the list and count cover).
- The default `untested` list and `total_untested` now cover `unreached` only.
- `level: "all"` restores the previous combined output; `level: "imported_not_called"` isolates the weak tier.
- The dashboard's untested-symbol metric now counts `unreached` only, for the same reason.

The `imported_not_called` caveat moved into the `level` param's `describe()` rather than the top-level description, to stay under the 800-char per-tool schema budget guardrail (TRA-186).

## Tests

- New regression test pins the default tier, the `by_level` totals, and both opt-in tiers.
- Existing tests that asserted the combined default now pass `level: "all"` explicitly.
- Full suite: 9275 passed, 8 skipped, 0 failed. `pnpm run build` and `tsc --noEmit` clean.

Agent: Lead Engineer
