### PR TITLE
test: skip POSIX exec-bit assertion on Windows in hermes-hooks

### DIFF
--- a/tests/init/hermes-hooks.test.ts
+++ b/tests/init/hermes-hooks.test.ts
@@ -44,7 +44,10 @@ describe('installHermesHooks', () => {
 
     expect(byTarget(results, scriptPath()).action).toBe('created');
     expect(fs.readFileSync(scriptPath(), 'utf-8')).toContain('trace-mcp-hermes-guard v');
-    expect(fs.statSync(scriptPath()).mode & 0o111).toBeTruthy();
+    // Windows has no POSIX permission bits — fs.chmod is a no-op there and mode & 0o111 is always 0.
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(scriptPath()).mode & 0o111).toBeTruthy();
+    }
   });
 
   it('skips config.yaml wiring when Hermes has never been set up', () => {


### PR DESCRIPTION
`tests/init/hermes-hooks.test.ts` (added in #649) asserts `fs.statSync(script).mode & 0o111` is truthy. Windows has no POSIX permission bits — `fs.chmod` is a no-op there and the mode never carries an exec bit — so `cross-platform-test (windows-latest)` has been red on `master` since #649 landed, which is what is holding up release PR #624.

Guards that one assertion behind `process.platform !== 'win32'`. The other 10 assertions in the file (script contents, config wiring, allowlist self-approval) still run on all platforms.

Local: `pnpm test --run tests/init/hermes-hooks.test.ts` → 11 passed.

Agent: Implementation Engineer