### PR TITLE
ci(codeql): exclude the filesystem-taint rule family (TRA-518)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -38,6 +38,50 @@ query-filters:
   - exclude:
       id: js/path-injection
 
+  # The filesystem-taint rule family: excluded (TRA-518). Same shape as
+  # js/path-injection above, same yield — 35 alerts across four rules, 0 true
+  # positives — and for the same structural reason: trace-mcp *is* a filesystem
+  # reader served over a loopback bind, so every rule whose taint model is "a
+  # path from outside reaches an fs call" fires across the whole codebase and
+  # always will. The trust boundary was settled in TRA-301 and is quoted above.
+  #
+  #   js/insecure-temporary-file — 13 alerts (6 dismissed "used in tests",
+  #     7 open on shipped code since 2026-04-27), 0 TPs. Not one creates a temp
+  #     file. Four are `fs.openSync(p, 'r')`, which cannot create anything —
+  #     the rule does not model the flags argument (src/utils/source-reader.ts,
+  #     src/memory/conversation-miner.ts, src/tools/shared/intra-file-usage.ts).
+  #     The other three write the project file the caller asked to edit
+  #     (src/tools/refactoring/). The taint source is the project root, which
+  #     legitimately sits under os.tmpdir() in tests and agent workdirs, so
+  #     every fs call downstream of a project root inherits it.
+  #   js/file-system-race — 9 alerts, 0 TPs. All are existsSync-then-open on
+  #     local files (indexing, daemon pid/lock handling, project-root probing).
+  #     A racing local edit yields a stale index entry or a retry, not a
+  #     privilege boundary crossing — the racing party is the same local user.
+  #   js/file-access-to-http — 8 alerts, 0 TPs. Six are the `ask` tools sending
+  #     source context to the AI provider the user configured (src/ai/*), which
+  #     is what those tools are for; one is the documented, opt-out usage ping
+  #     (src/telemetry/usage-ping.ts), one is a dev perf script.
+  #   js/http-to-file-access — 5 alerts, 0 TPs. The inverse: an MCP request
+  #     naming a project path to open or write is the entire tool contract
+  #     (src/db-holders.ts, src/utils/atomic-write.ts, refactoring/shared.ts).
+  #
+  # Cost of this exclusion, stated plainly: a genuinely untrusted path source,
+  # or a real predictable-name temp file, would now be silenced. REVERT THIS
+  # BLOCK if any of these become true:
+  #   - the daemon gains a remote or shared (non-loopback) bind
+  #   - `/mcp` or `/api` gain authentication, making them a real trust boundary
+  #   - a path source appears that is not the registered project root
+  #   - a code path creates a file with a predictable name in the OS temp dir
+  - exclude:
+      id: js/insecure-temporary-file
+  - exclude:
+      id: js/file-system-race
+  - exclude:
+      id: js/file-access-to-http
+  - exclude:
+      id: js/http-to-file-access
+
 paths-ignore:
   # Test code is not attack surface: it runs on developer machines against
   # fixtures we author. Temp-file and path handling here is deliberate.


### PR DESCRIPTION
Closes TRA-518.

Adds four rules to the existing `query-filters` block in `.github/codeql/codeql-config.yml`, extending the TRA-381 precedent to the rest of the same rule family.

## Why

`CodeQL` is a required status check on `master`. Its queue held 10 open alerts, **7 high-severity, none real** — all `js/insecure-temporary-file`, the oldest open since 2026-04-27 and never triaged either way. A genuinely new high arriving into a queue that already shows 7 stale highs is how a real one gets waved through.

Verified each open alert against the source:

| Alert | Location | What is actually there |
|---|---|---|
| #1217 | `src/tools/shared/intra-file-usage.ts:95` | `fs.openSync(abs, 'r')`, read-only, after a project-root containment check |
| #1096 | `src/memory/conversation-miner.ts:142` | `fs.openSync(filePath, 'r')`, read-only |
| #975 / #247 | `src/utils/source-reader.ts:70` / `:20` | read-only opens in `readByteRange` / `readSymbolSource` |
| #955 / #1055 | `src/tools/refactoring/refactor.ts:741` / `:453` | writing the file the caller asked to edit |
| #954 | `src/tools/refactoring/shared.ts:78` | `writeLines`, same |

None creates a temp file. Four use mode `'r'`, which cannot create anything — the rule does not model the flags argument. The taint source is the project root, which legitimately sits under `os.tmpdir()` in tests and agent workdirs, so every `fs` call downstream of a project root inherits it.

## The family, decided in one change

| Rule | Alerts | True positives |
|---|---|---|
| `js/insecure-temporary-file` | 13 (6 dismissed + 7 open) | 0 |
| `js/file-system-race` | 9 | 0 |
| `js/file-access-to-http` | 8 | 0 |
| `js/http-to-file-access` | 5 | 0 |

Counts pulled from the code-scanning API, not estimated. These three were being re-dismissed by hand release after release; deciding them here rather than leaving them to regrow is the point.

Root cause is structural: trace-mcp *is* a filesystem reader behind a loopback-only bind. Every rule whose taint model is "a path from outside reaches an `fs` call" fires across the whole codebase and always will. The trust-boundary question was settled in TRA-301 (loopback bind, the only path source is the project root the daemon was pointed at).

## Scope

Deliberately **not** included: blanket suppression of filesystem rules, and `js/remote-property-injection` (#1214) / `js/log-injection` (#1218) — both landed 2026-08-29 and get their own look.

Revert conditions are written inline in the config, matching the TRA-381 style, plus a new one specific to this family: *a code path creates a file with a predictable name in the OS temp dir*.

## Test evidence

Config-only change, no code touched. YAML parses to the expected structure (5 `query-filters` entries, `paths-ignore` and `queries` unchanged); the CodeQL run on this PR is the real check — it must stay green and stop reporting the family.

The 7 open alerts are closed as part of landing this: once the rule is filtered, the next `master` scan retires them automatically.

Agent: Lead Engineer
