### PR TITLE
fix(app): one focus ring per control, on the control's own boundary (TRA-521)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -839,6 +839,20 @@ Not a pass at the end. These are floors.
 - **Focus ring**: one ring, house-wide. `--focus-ring` on `:focus-visible` globally;
   primitives use `outline: 2px solid var(--accent); outline-offset: 2px`. Keyboard
   only — `*:focus { outline: none }`. Every focusable element must show it.
+- **One control, one ring.** A composite control — a search capsule, a composer card, a
+  segmented track — rings its whole outer box on `:focus-within`. The thing inside it
+  that actually takes DOM focus is a *part*, not a control, so it must be silenced:
+  the shared `:where(.lx-search, .ask-input) :is(input, textarea):focus-visible
+  { box-shadow: none }` rule in `app.css`, or a local one for parts that are buttons.
+  Skip it and the universal `*:focus-visible` rule draws a second ring inside the
+  first — sized to the part and, because that rule also sets `border-radius: inherit`,
+  shaped like the parent: a blue pill struck through the placeholder and across the
+  field's own boundary (TRA-521). Every new `:focus-within` ring adds a wrapper to
+  that list; `tokens.test.ts` fails if one is missed.
+- **A part of a control is not a tab stop.** The clear button inside a search field
+  follows `NSSearchField`'s cancel button: `tabIndex={-1}`, clickable, in the
+  accessibility tree, out of the Tab order. Esc from the field is the keyboard path.
+  The alternative is a stop whose ring can only duplicate the wrapper's.
 - **Hit targets**: ≥24×24 for anything focusable (§4).
 - **Icon-only controls carry a label and a tooltip.** The `Button` type enforces both
   for the `icon` variant.

--- a/packages/app/src/renderer/app.css
+++ b/packages/app/src/renderer/app.css
@@ -72,6 +72,20 @@ body {
   box-shadow: var(--focus-ring);
   border-radius: inherit;
 }
+/* …except the text field inside a composite control, which already rings its
+   whole outer box on `:focus-within` — the search field's capsule, the
+   composer's card. That box IS the control; its <input> is a part of it, so
+   the rule above drew a second ring inside the first, sized to the part and
+   (via `border-radius: inherit`) shaped like the parent — the blue pill
+   struck through "Search projects" and across the field's own boundary
+   (TRA-521). One control, one ring.
+   Buttons nested in these wrappers (the clear button, the composer's send)
+   keep theirs: they are separate controls, and the wrapper's ring cannot say
+   which of them holds focus. Keep this list in step with every
+   `:focus-within { box-shadow: var(--focus-ring) }` rule in styles/. */
+:where(.lx-search, .ask-input) :is(input, textarea):focus-visible {
+  box-shadow: none;
+}
 
 /* ── Loading skeletons ──────────────────────────────────────────── */
 /* Blocks at the exact geometry of the value they stand in for, so nothing

--- a/packages/app/src/renderer/lattice/ui/SearchField.tsx
+++ b/packages/app/src/renderer/lattice/ui/SearchField.tsx
@@ -67,6 +67,12 @@ export function SearchField({
         <button
           type="button"
           className="lx-btn v-icon sz-regular"
+          /* Not a tab stop, like NSSearchField's cancel button. The capsule
+             rings as one control on `:focus-within`, so a focused clear button
+             drew a second ring inside — and bulging past — the first
+             (TRA-521). Esc from the field clears, which is the keyboard path;
+             this stays clickable and in the accessibility tree. */
+          tabIndex={-1}
           aria-label={t('clearSearch')}
           title={t('clearSearch')}
           onClick={() => {

--- a/packages/app/src/renderer/styles/__tests__/tokens.test.ts
+++ b/packages/app/src/renderer/styles/__tests__/tokens.test.ts
@@ -235,6 +235,56 @@ describe('design tokens', () => {
     });
   });
 
+  /* TRA-521. A composite control rings its whole outer box on `:focus-within`,
+     and the universal `*:focus-visible` rule in app.css then rings the part
+     inside it a second time — sized to the part, and shaped like the parent
+     because that rule also sets `border-radius: inherit`. On the Workspace
+     toolbar that painted a blue pill straight through the "Search projects"
+     placeholder and across the capsule's own boundary; the Ask composer had
+     the same double ring on its textarea.
+
+     Two wrappers had already been patched one at a time (quick open's field,
+     the context row's segmented track) without anyone noticing it was one bug
+     with three sites, which is exactly how the next wrapper acquires it. So
+     assert the invariant instead of the fix: every wrapper that paints the
+     ring on itself must also silence the ring on the parts inside it —
+     either through the shared `:where(...)` rule in app.css, or with a local
+     `:focus-visible { box-shadow: none }` of its own. */
+  it('never rings a composite control twice', () => {
+    const dir = fileURLToPath(new URL('..', import.meta.url));
+    const sheets: Array<[string, string]> = [
+      ['app.css', appCss],
+      ...readdirSync(dir)
+        .filter((f) => f.endsWith('.css'))
+        .map((f) => [f, readFileSync(`${dir}/${f}`, 'utf8')] as [string, string]),
+    ];
+    const all = sheets.map(([, css]) => css).join('\n');
+
+    // Wrappers that paint the focus ring on themselves: the ring rule must sit
+    // ON the `:focus-within` element, not on a descendant of it (which is how
+    // the sidebar styles its selected row and is not a focus ring at all).
+    const wrappers = new Set<string>();
+    for (const [, selector, body] of all.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+      if (!/box-shadow:[^;]*(--focus-ring|--accent)/.test(body)) continue;
+      for (const part of selector.split(',')) {
+        const m = /\.([\w-]+):focus-within\s*$/.exec(part.trim());
+        if (m) wrappers.add(m[1]);
+      }
+    }
+    // If this ever empties, the regex above stopped matching and the guard
+    // silently passes on everything.
+    expect(wrappers.size).toBeGreaterThanOrEqual(3);
+
+    const unguarded = [...wrappers].filter((cls) => {
+      const escaped = cls.replace(/[-]/g, '\\-');
+      const silenced = new RegExp(
+        `\\.${escaped}\\b[^{}]*:focus-visible[^{}]*\\{[^{}]*box-shadow:\\s*none`,
+      );
+      return !silenced.test(all);
+    });
+    expect(unguarded).toEqual([]);
+  });
+
   /* TRA-297: `user-select: none` on body used to be the last word, so no path,
      id, metric or error message anywhere in the app could be selected — let
      alone copied. Content opts back in; chrome inside it opts back out. */

--- a/packages/app/src/renderer/styles/controls.css
+++ b/packages/app/src/renderer/styles/controls.css
@@ -250,11 +250,15 @@
 .lx-search:hover {
   background: var(--fill-quaternary);
 }
+/* The house ring, not a hand-rolled copy of half of it. The copy dropped the
+   token's `inset 0 0 0 1px var(--accent)`, so the only crisp edge on a focused
+   field was the second ring the universal `*:focus-visible` rule drew on the
+   <input> — inset, text-sized, and across the capsule's own boundary
+   (TRA-521) — and the field ignored the Increase Contrast variant of the
+   token (4px at 60%) entirely. */
 .lx-search:focus-within {
   background: var(--surface);
-  box-shadow:
-    inset 0 0 0 0.5px var(--separator),
-    0 0 0 3px color-mix(in oklab, var(--accent) 35%, transparent);
+  box-shadow: var(--focus-ring);
 }
 .lx-search .lx-search-glyph {
   flex: none;


### PR DESCRIPTION
Closes TRA-521.

## The bug

The **Search projects** field drew two focus rings. One belongs there; the other was
inset, text-sized, and painted across the field's own boundary and over the magnifier.

Measured in the running Electron window, field focused by Tab:

| | before | after |
|---|---|---|
| `.lx-search` (the control) | `inset 0 0 0 .5px --separator, 0 0 0 3px accent/35%` | `var(--focus-ring)` |
| `.lx-search input` (a part of it) | `0 0 0 3px accent/35%, inset 0 0 0 1px accent` | `none` |

Two things combined:

1. `.lx-search:focus-within` hand-rolled **half** of `--focus-ring` — the 3px halo without
   the token's `inset 0 0 0 1px var(--accent)`. So the field had no crisp edge of its own,
   and it silently ignored the Increase Contrast variant of the token (4px at 60%).
2. The universal `*:focus-visible` rule in `app.css` then painted the **whole** token a
   second time on the `<input>`, sized to the input and — because that rule also sets
   `border-radius: inherit` — shaped like the capsule. That is the pill through the
   placeholder.

## The fix

The wrapper is the control; the input is a part of it. One control, one ring.

- **`app.css`** silences the house ring on the text field of a composite control:
  `:where(.lx-search, .ask-input) :is(input, textarea):focus-visible { box-shadow: none }`.
  Buttons nested in those wrappers keep theirs — they are separate controls, and the
  wrapper's ring cannot say which of them holds focus.
- **`controls.css`** — `.lx-search:focus-within` now uses `var(--focus-ring)` rather than
  half of it. Ring geometry is the token, both variants:
  `0 0 0 3px color-mix(in oklab, var(--accent) 35%, transparent)` + `inset 0 0 0 1px var(--accent)`,
  and `0 0 0 4px accent/60%` + the same inset under `prefers-contrast: more`
  (`tokens.css` L170 and L433).
- **`SearchField.tsx`** — the clear button is `tabIndex={-1}`, like `NSSearchField`'s cancel
  button. Focused, it drew its own ring inside and bulging past the capsule. Esc from the
  field already clears; it stays clickable and in the accessibility tree.

## Audited across the app, as the issue asked

This was a shared bug, not a one-off. Every wrapper that rings itself on `:focus-within`:

| wrapper | before | now |
|---|---|---|
| `.lx-search` | double ring | fixed here |
| `.ask-input` (Ask composer textarea) | double ring — measured, same shadow at both levels | fixed here |
| `.ws-ctx-seg` (segmented track) | already silenced locally (island.css) | unchanged |
| `.lx-qo-field` (quick open) | deliberately ringless | unchanged |

Two of these had been patched one at a time, each with a local rule, without anyone
noticing it was one bug with three sites — which is how the next wrapper acquires it. So
the new test in `tokens.test.ts` asserts the **invariant**, not the fix: every wrapper that
paints the ring on itself must silence the ring on its parts, via the shared rule or a
local one. Reverting the `app.css` rule fails it with
`expected [ 'ask-input', 'lx-search' ] to deeply equal []`.

## Spacing budget

`.lx-search` sits at x 232 to 413.5 in the Workspace toolbar; the ring's 3px outset reaches
416.5 and the Filter button starts at 421.5. Nothing overlaps and nothing is clipped —
with the second ring gone the row's existing 8px gap is enough, so no spacing change was
needed. Measured, not assumed.

## Verification

Real Electron window over CDP (`electron-cdp.mjs launch` — unmapped, never on screen;
`:3741` blocked at the network layer so the developer's daemon was not touched). Before and
after screenshots in dark and light, plus Increase Contrast and Reduce Transparency, are on
TRA-521.

Keyboard pass on the Workspace surface: **17 tab stops, exactly one ring each** (scripted,
real `Input.dispatchKeyEvent` Tab presses — `:focus-visible` is a keyboard heuristic, and a
programmatic focus call never reproduces the bug). Before the fix the same pass reported
2 rings on "Clear search".

`typecheck`, `test` (529 passed), `check:i18n` and `build` all green in the app package.

Agent: Design/UX Agent
