### PR TITLE
fix(app): the tab bar is 20px, not 36 — lights back on the tab centre line (TRA-523)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -598,19 +598,37 @@ Opening a project opens a native macOS **tab**, so the normal state of this app 
 tabbed window — not an edge case. AppKit then draws a tab bar, and because the window is
 `titleBarStyle: 'hiddenInset'` (full-size content view) it draws it **over** the web
 contents: `innerHeight` stays equal to `outerHeight`, nothing reflows, and the tab bar
-simply covers the top 36px of whatever the renderer painted. That is the whole of the
+simply covers the top 20px of whatever the renderer painted. That is most of the
 band above, so the surface toolbar and the sidebar toggle went from "misaligned" to
 "gone" (TRA-399).
 
 The rule that follows: **a band we do not draw still has to be reserved.** The tab bar is
 AppKit's, we cannot restyle it and we cannot ask whether it is up — so:
 
-- `MAC_TAB_BAR_H` (36px, measured, `chrome-metrics.ts`) and `--mac-tabbar-h` are one
+- `MAC_TAB_BAR_H` (20px, measured, `chrome-metrics.ts`) and `--mac-tabbar-h` are one
   number, exactly like `TOP_BAND_H`. The stage reserves it with `padding-top` while
   `data-tabbar="on"`, and the app's own band starts below it. Never draw into it.
+- **A geometry we do not draw is measured from two independent landmarks, never one.**
+  This constant shipped wrong twice off a single reading — 36 (TRA-370), then 28
+  (TRA-432) — because each time one landmark was found, believed, and shipped. Take
+  both: where the bar's own plate stops (the same row at every x across the window),
+  and where the control it carries is centred (the selected tab's pill). They have to
+  agree; when they do not, neither is the answer yet. Measured on macOS 26.5 /
+  Electron 41.10.6 at 2x: plate ends at 20.0, tab pill spans 0.5–17.5, centre 9.0.
+- **Every pixel of surplus in a reserved band is visible twice.** It renders as a dead
+  strip of window backdrop under the bar, and it drops the traffic lights by half its
+  height, because they are centred in what this number says. 36 put them 8px below the
+  tabs; 28 put them 4px below (TRA-523, reported twice before it was measured right).
+- **Assert chrome geometry against something outside the constant.** 28 went back to 36
+  on its own when an unrelated PR was squashed from a stale base (#659), and the suite
+  stayed green: the only assertion compared `MAC_TAB_BAR_H` with itself. A test written
+  against a measured AppKit landmark fails on both a bad re-measurement and a silent
+  revert; a test written against the constant fails on neither.
 - **The traffic lights belong to whichever band holds the top line**, not to a constant.
-  With no tab bar that is our 44px band (centre 22); with one it is AppKit's 36px tab bar
-  (centre 18). `trafficLightYFor(tabBarVisible)` is the only place that chooses.
+  With no tab bar that is our 44px band (centre 22); with one it is AppKit's 20px tab bar
+  (centre 10, the tab pill's own centre line). `trafficLightYFor(tabBarVisible)` is the
+  only place that chooses, and `tab-chrome.test.ts` asserts the result against the
+  measured tab centre — not against `MAC_TAB_BAR_H`, which is the number under suspicion.
 - **`trafficLightPosition` is applied once, at window creation, and AppKit re-lays the
   title bar out under it.** So every event that can change the tab count re-applies it —
   `show`, `focus`, `closed`, `did-finish-load` — synchronously and again a frame later,

--- a/packages/app/src/main/__tests__/tab-chrome.test.ts
+++ b/packages/app/src/main/__tests__/tab-chrome.test.ts
@@ -152,6 +152,20 @@ describe('the traffic lights follow whichever band owns the top line', () => {
     expect(trafficLightYFor(true)).toBe(TRAFFIC_LIGHT_Y_TABBED);
   });
 
+  /* The one assertion the earlier attempts could not have passed. They compared
+     the lights against MAC_TAB_BAR_H, which is the number that was wrong, so
+     they agreed with themselves and shipped lights 8px (TRA-370) then 4px
+     (TRA-432) below the tabs — and stayed green when #659 silently put the
+     first value back. MAC_TAB_CENTRE_Y is measured off AppKit
+     instead: the selected tab's pill spans y=0.5..17.5 on a 2x capture of a
+     real two-tab window (macOS 26.5 / Electron 41.10.6), and the plate it sits
+     on ends at y=20.0 — 10 is the line the user sees the tabs on. Re-measure
+     it, do not derive it from MAC_TAB_BAR_H (TRA-523). */
+  it('puts them on the line the tabs are actually drawn on', () => {
+    const MAC_TAB_CENTRE_Y = 10;
+    expect(trafficLightCentreY(trafficLightYFor(true))).toBe(MAC_TAB_CENTRE_Y);
+  });
+
   it('does not reuse one offset for both bands', () => {
     expect(TRAFFIC_LIGHT_Y_TABBED).not.toBe(TRAFFIC_LIGHT_Y);
   });

--- a/packages/app/src/renderer/styles/tokens.css
+++ b/packages/app/src/renderer/styles/tokens.css
@@ -154,7 +154,7 @@
      shrinks, because the window is full-size content view. Reserve it or it
      covers the whole top band above. Same owner, same guard:
      src/shared/chrome-metrics.ts (MAC_TAB_BAR_H) and tokens.test.ts. */
-  --mac-tabbar-h: 36px;
+  --mac-tabbar-h: 20px;
 
   /* ---- Motion */
   --dur-micro: 120ms;

--- a/packages/app/src/shared/chrome-metrics.ts
+++ b/packages/app/src/shared/chrome-metrics.ts
@@ -15,7 +15,11 @@
 /** Height of every top band in the app, in CSS px. Mirrored by `--top-band-h`. */
 export const TOP_BAND_H = 44;
 
-/** The macOS traffic lights are 12pt circles. */
+/** The macOS traffic lights are 12pt circles.
+    macOS 26 draws them at 14pt; the pair below absorbs the difference, because
+    what `centreLightsIn` needs is the centre offset (bandH / 2 - 7), and 12
+    with a 1pt frame inset and 14 with none give the same number. Change one
+    without the other and every band moves. */
 export const TRAFFIC_LIGHT_D = 12;
 
 /* `trafficLightPosition.y` is NOT the top edge of the circle — the button's
@@ -41,20 +45,40 @@ export const TRAFFIC_LIGHT_Y = centreLightsIn(TOP_BAND_H);
    swallows whatever the app drew on that line, which is the entire surface
    toolbar plus the sidebar toggle.
 
-   Measured on macOS 26.5 / Electron 41.10.6 by photographing the window
-   (`screencapture -l<CGWindowID>`) with two tabs open and reading the column
-   profile down the sidebar: the tab bar's plate runs from y=0 to y=36.0, and
-   the sidebar's own material resumes at 36.0. If a future macOS changes the
-   metric, this is the one constant that absorbs it. */
+   Measured on macOS 26.5 / Electron 41.10.6 from a 2x capture of a real
+   two-tab window, by the two things that band actually contains:
+
+     the bar's PLATE runs y=0 to y=20.0 — the same row at every x across the
+     window, the fill below it being the window's own backdrop, not the bar;
+     the SELECTED TAB's pill runs y=0.5 to y=17.5, centre y=9.0.
+
+   Anything taller than 20 is not the bar. It is this constant over-reserving,
+   and the surplus renders in the window's backdrop as a dead strip that looks
+   exactly like a bar with nothing in it. Worse, the traffic lights are centred
+   in whatever this says, so every surplus pixel puts them half a pixel below
+   the tabs: at 36 they sat 8px low (TRA-370), at 28 they sat 4px low (TRA-432).
+   Both of those came from asking where the surrounding material resumes rather
+   than where the bar's own plate stops.
+
+   28 then went back to 36 on its own: #659, a telemetry change, was squashed
+   from a stale base and carried the old value in with it, along with several
+   other unrelated reverts. Nothing caught it, because the only assertion on
+   this constant compared it with itself. That is why the guard in
+   tab-chrome.test.ts is written against a number measured off AppKit.
+
+   If a future macOS changes the metric, this is the one constant that absorbs
+   it. Re-measure both numbers — the plate's bottom row AND the tab centre —
+   and update `MAC_TAB_CENTRE_Y` in tab-chrome.test.ts with them. A measurement
+   of one alone is what went wrong twice. */
 
 /** Height of the AppKit tab bar on a tabbed window, in CSS px. */
-export const MAC_TAB_BAR_H = 36;
+export const MAC_TAB_BAR_H = 20;
 
 /** Offset that centres the lights in the TAB BAR, which owns the top band then. */
 export const TRAFFIC_LIGHT_Y_TABBED = centreLightsIn(MAC_TAB_BAR_H);
 
 /** The offset that holds right now. The lights belong to whichever band is on
-    the window's top line — ours at 44px, AppKit's tab bar at 36px. */
+    the window's top line — ours at TOP_BAND_H, AppKit's at MAC_TAB_BAR_H. */
 export const trafficLightYFor = (tabBarVisible: boolean): number =>
   tabBarVisible ? TRAFFIC_LIGHT_Y_TABBED : TRAFFIC_LIGHT_Y;
 


### PR DESCRIPTION
## What was wrong

`MAC_TAB_BAR_H` reserves the AppKit tab bar that a tabbed macOS window grows, and
`trafficLightYFor` centres the traffic lights in whatever that number says. Every surplus
pixel in it is visible twice: once as a dead strip of window backdrop under the bar, and
once as half a pixel of drop on the lights.

Measured at 2x from the reported window capture (macOS 26.5 / Electron 41.10.6, two tabs
open), window-relative CSS px:

| landmark | measured | at `28` (build in the report) | at `36` (master today) | at `20` |
|---|---|---|---|---|
| tab bar plate, bottom row — identical at every x | **20.0** | — | — | — |
| selected tab pill | 0.5 – 17.5, centre **9.0** | — | — | — |
| traffic-light centre | **13.75** | 14 | 18 | **10** |
| renderer's first painted row | **28.0** | 28 | 36 | **20** |
| top band's topmost control | — | 37.75 | 45.75 | **29.75** |

Tabs centred on y=9.0, lights on y=13.75 — 4.75px apart — and the 8px between the plate's
bottom (20.0) and the renderer's first painted row (28.0) was ours, not the bar's.
At 20 the lights land on 10.0 and the band's topmost control starts 9.75px clear of the
bar, so nothing is covered.

## Why the previous report didn't land — both halves of it

**It under-corrected, and then it was reverted.**

1. TRA-432 moved the constant 36 → 28 and merged (#583). That removed 8px of a 16px
   error; the same 8px remained, which is what the reported screenshot shows.
2. **#659 (`feat(telemetry)`) put 36 back.** It was squashed from a stale base, so its
   diff reverted `chrome-metrics.ts` to 36 along with several other unrelated changes —
   `.github/codeql/codeql-config.yml`, `.github/dependabot.yml`, part of `ci.yml`,
   `.github/workflows/duplicate-pr.yml` (deleted), `CHANGELOG.md`, the release manifest
   and package versions (3.6.0 → 3.3.0), and the tests that came with #658. Filed
   separately — that is build/release mechanics, not a visual fix, and this PR only
   restores its own constant.

Both earlier numbers were read the same way: "where does the surrounding material
resume?" That answer is our own reserved band's bottom edge, not the bar's. The rule
this adds is to take **two** independent landmarks — where the bar's plate stops, and
where the control it carries is centred — and treat disagreement between them as "not
measured yet".

## Guard

`tab-chrome.test.ts` gains an assertion against the **measured tab centre** (10) rather
than against `MAC_TAB_BAR_H`. The existing test compared the constant with itself, so it
passed at 36, passed at 28, and stayed green through the silent revert. The new one
fails at 28 (`expected 14 to be 10`) and at 36 (`18`) — verified by reverting the
constant and re-running. `tokens.test.ts` already couples `--mac-tabbar-h` to the TS
constant, so the CSS token moves with it.

## Widths and states

The reservation is a `padding-top` on `.ws-stage`, so the centring is width-independent
by construction. Measured live in the running renderer with `data-tabbar="on"`:
`.ws-content-head` 20–64, sidebar titlebar 20–64, sidebar toggle 30–54, and every
toolbar control — Files/Symbols, Filter, Search, Fit, Live, ⋯ — centred on 41.75. One
line, and it holds at the 640×420 window minimum, where the toolbar wraps and grows the
band rather than clipping (`Toolbar` is `min-height` + `flex-wrap`, TRA-347).

## What I could not verify in this run

The "after" screenshot of the **native** chrome. `screencapture -l<id>` on a tab's own
window omits the shared tab bar, and native tabs would not form in an offscreen harness
on this machine, so photographing a tabbed window would have meant putting it on the
user's active Space — out of bounds. The before-values above are measured from a real
render; the after-values for the lights and the reserved band are the arithmetic of the
constant plus the live renderer measurement. The tab-centre assertion is what holds it.

Closes TRA-523.
