### PR TITLE
fix(svelte): $props() destructuring extracted zero props

### DIFF
--- a/docs/language-matrix.md
+++ b/docs/language-matrix.md
@@ -21,7 +21,7 @@ below, see [configuration](configuration.md).
 - **import edges:** 12
 - **call edges (`get_call_graph`, call-aware `find_usages`):** 3
 - **type / inheritance edges:** 2
-- **covered by a plugin test:** 65
+- **covered by a plugin test:** 66
 
 ## What the columns mean
 
@@ -133,7 +133,7 @@ second thing, so it is much shorter than the language list — see
 | scala | .scala .sc | tree-sitter | yes | — | — | — | yes |
 | solidity | .sol | tree-sitter | yes | — | — | — | yes |
 | sql | .sql | regex | yes | — | — | — | yes |
-| svelte | .svelte | regex | yes | — | — | — | — |
+| svelte | .svelte | regex | yes | — | — | — | yes |
 | swift | .swift | tree-sitter | yes | — | — | — | yes |
 | tcl | .tcl .tk .itcl .itk | regex (multi-pass) | yes | — | — | — | yes |
 | toml | .toml | tree-sitter | yes | — | — | — | yes |

--- a/src/indexer/plugins/language/svelte/index.ts
+++ b/src/indexer/plugins/language/svelte/index.ts
@@ -1,12 +1,14 @@
 /**
  * Svelte Language Plugin — regex-based symbol extraction.
  *
- * Extracts: script-level exports, component props ($props), reactive declarations,
- * stores, event dispatchers, actions, and import edges.
+ * Extracts: script-level exports, component props (`export let` and Svelte 5
+ * `$props()` destructuring), reactive declarations, stores, runes, snippets,
+ * and import edges.
  */
 
-import type { LanguagePlugin } from '../../../../plugin-api/types.js';
-import { createRegexLanguagePlugin } from '../regex-base.js';
+import type { FileParseResult, LanguagePlugin, RawSymbol } from '../../../../plugin-api/types.js';
+import type { TraceMcpResult } from '../../../../errors.js';
+import { createRegexLanguagePlugin, lineAt, makeSymbolId } from '../regex-base.js';
 
 const _plugin = createRegexLanguagePlugin({
   name: 'svelte',
@@ -19,8 +21,6 @@ const _plugin = createRegexLanguagePlugin({
     { kind: 'constant', pattern: /^\s*export\s+const\s+(\w+)/gm },
     // export function name
     { kind: 'function', pattern: /^\s*export\s+(?:async\s+)?function\s+(\w+)/gm },
-    // let { ... } = $props() — Svelte 5 runes
-    { kind: 'property', pattern: /\$props\(\)/gm },
     // $: name = (reactive declarations - Svelte 4)
     { kind: 'variable', pattern: /^\s*\$:\s+(\w+)\s*=/gm, meta: { reactive: true } },
     // $derived / $state / $effect (Svelte 5 runes)
@@ -33,7 +33,7 @@ const _plugin = createRegexLanguagePlugin({
     { kind: 'function', pattern: /^\s*(?:async\s+)?function\s+(\w+)/gm },
     // const name = (non-exported)
     { kind: 'variable', pattern: /^\s*(?:const|let)\s+(\w+)\s*=/gm },
-    // {#each}, {#if}, {#await} — template blocks (named via expression)
+    // {#snippet name} — template blocks
     { kind: 'variable', pattern: /\{#snippet\s+(\w+)/gm, meta: { snippet: true } },
   ],
   importPatterns: [
@@ -44,9 +44,99 @@ const _plugin = createRegexLanguagePlugin({
   ],
 });
 
+/**
+ * `let { a, b = 1, ...rest }: Props = $props()` — Svelte 5's declaration of a
+ * component's public API. Each destructured binding is a prop. The regex-base
+ * one-capture-group model can't express "N names from one match", so props are
+ * extracted here instead.
+ */
+const PROPS_DESTRUCTURE = /(?:let|const)\s*\{([^}]*)\}\s*(?::[^=]*?)?=\s*\$props\s*\(/g;
+
+/** Split on commas that are not nested inside (), [], {} or a string. */
+function splitTopLevel(source: string): Array<{ text: string; offset: number }> {
+  const parts: Array<{ text: string; offset: number }> = [];
+  let depth = 0;
+  let quote: string | null = null;
+  let start = 0;
+  for (let i = 0; i < source.length; i++) {
+    const c = source[i];
+    if (quote) {
+      if (c === quote && source[i - 1] !== '\\') quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') quote = c;
+    else if (c === '(' || c === '[' || c === '{') depth++;
+    else if (c === ')' || c === ']' || c === '}') depth--;
+    else if (c === ',' && depth === 0) {
+      parts.push({ text: source.slice(start, i), offset: start });
+      start = i + 1;
+    }
+  }
+  parts.push({ text: source.slice(start), offset: start });
+  return parts;
+}
+
+/**
+ * Local binding name of one destructured entry:
+ *   `children` → children · `open = false` → open · `...rest` → rest
+ *   `class: className` → className (the local name is what the code uses)
+ */
+function bindingName(part: string): string | undefined {
+  // Drop the default value; `=>` inside a default must not be mistaken for it.
+  let head = part;
+  const eq = head.search(/=(?!>)/);
+  if (eq !== -1) head = head.slice(0, eq);
+  const alias = head.split(':');
+  const name = alias[alias.length - 1].replace(/\.\.\./, '').trim();
+  return /^\w+$/.test(name) ? name : undefined;
+}
+
+function extractRuneProps(filePath: string, source: string): RawSymbol[] {
+  const symbols: RawSymbol[] = [];
+  const seen = new Set<string>();
+  PROPS_DESTRUCTURE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = PROPS_DESTRUCTURE.exec(source)) !== null) {
+    const blockOffset = m.index + m[0].indexOf('{') + 1;
+    for (const part of splitTopLevel(m[1])) {
+      const name = bindingName(part.text);
+      if (!name) continue;
+      const symbolId = makeSymbolId(filePath, name, 'property');
+      if (seen.has(symbolId)) continue;
+      seen.add(symbolId);
+      const nameOffset = blockOffset + part.offset + part.text.indexOf(name);
+      const line = lineAt(source, nameOffset);
+      symbols.push({
+        symbolId,
+        name,
+        kind: 'property',
+        fqn: name,
+        signature: part.text.trim(),
+        byteStart: nameOffset,
+        byteEnd: nameOffset + name.length,
+        lineStart: line,
+        lineEnd: line,
+        metadata: { prop: true, rune: true },
+      });
+    }
+  }
+  return symbols;
+}
+
 export const SvelteLanguagePlugin = class implements LanguagePlugin {
   manifest = _plugin.manifest;
   supportedExtensions = _plugin.supportedExtensions;
   supportedVersions = _plugin.supportedVersions;
-  extractSymbols = _plugin.extractSymbols;
+
+  extractSymbols(filePath: string, content: Buffer): TraceMcpResult<FileParseResult> {
+    // regex-base is synchronous, so the union's Promise arm is unreachable here.
+    const base = _plugin.extractSymbols(filePath, content) as TraceMcpResult<FileParseResult>;
+    return base.map((parsed) => {
+      const existing = new Set(parsed.symbols.map((s) => s.symbolId));
+      const props = extractRuneProps(filePath, content.toString('utf-8')).filter(
+        (s) => !existing.has(s.symbolId),
+      );
+      return props.length > 0 ? { ...parsed, symbols: [...parsed.symbols, ...props] } : parsed;
+    });
+  }
 };

--- a/tests/languages/svelte.test.ts
+++ b/tests/languages/svelte.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { SvelteLanguagePlugin } from '../../src/indexer/plugins/language/svelte/index.js';
+
+const plugin = new SvelteLanguagePlugin();
+
+async function parse(source: string, filePath = 'Component.svelte') {
+  const result = await plugin.extractSymbols(filePath, Buffer.from(source));
+  expect(result.isOk()).toBe(true);
+  return result._unsafeUnwrap();
+}
+
+const names = (r: Awaited<ReturnType<typeof parse>>) => r.symbols.map((s) => s.name);
+
+describe('SvelteLanguagePlugin', () => {
+  it('has correct manifest', () => {
+    expect(plugin.manifest.name).toBe('svelte-language');
+    expect(plugin.supportedExtensions).toContain('.svelte');
+  });
+
+  it('extracts Svelte 4 props, exports and reactive declarations', async () => {
+    const r = await parse(`<script>
+  export let title;
+  export const VERSION = 2;
+  export function focus() {}
+  $: upper = title.toUpperCase();
+</script>
+<h1>{upper}</h1>`);
+    expect(names(r)).toEqual(expect.arrayContaining(['title', 'VERSION', 'focus', 'upper']));
+    expect(r.symbols.find((s) => s.name === 'title')?.metadata).toMatchObject({ prop: true });
+  });
+
+  it('extracts runes and snippets', async () => {
+    const r = await parse(`<script>
+  let count = $state(0);
+  const doubled = $derived(count * 2);
+</script>
+{#snippet row(item)}<li>{item}</li>{/snippet}`);
+    expect(names(r)).toEqual(expect.arrayContaining(['count', 'doubled', 'row']));
+  });
+
+  it('produces import edges', async () => {
+    const r = await parse(`<script>
+  import Button from './Button.svelte';
+  import './styles.css';
+</script>`);
+    const modules = (r.edges ?? []).map((e) => e.metadata?.module);
+    expect(modules).toEqual(expect.arrayContaining(['./Button.svelte', './styles.css']));
+  });
+
+  // Svelte 5's $props() destructuring IS the component's public API. Before
+  // TRA-531 the plugin matched `$props()` with a pattern that had no capture
+  // group, so every prop of every Svelte 5 component extracted as nothing.
+  it('extracts every binding of a $props() destructure', async () => {
+    const r = await parse(`<script>
+  let { open = false, items = [1, 2, 3], onclick, ...rest } = $props();
+</script>`);
+    expect(names(r)).toEqual(expect.arrayContaining(['open', 'items', 'onclick', 'rest']));
+    expect(r.symbols.find((s) => s.name === 'onclick')?.metadata).toMatchObject({ prop: true });
+  });
+
+  it('handles renamed bindings and arrow-function defaults', async () => {
+    const r = await parse(`<script>
+  let { class: className, onselect = (a, b) => a + b } = $props();
+</script>`);
+    expect(names(r)).toEqual(expect.arrayContaining(['className', 'onselect']));
+    expect(names(r)).not.toContain('class');
+  });
+
+  // Verbatim from bits-ui (huntabyte/bits-ui, accordion-trigger.svelte) — a
+  // real Svelte 5 library component, not a hand-shaped fixture.
+  it('extracts the props of a real-world Svelte 5 component', async () => {
+    const r = await parse(`<script lang="ts">
+	import { boxWith, mergeProps } from "svelte-toolbelt";
+	import type { AccordionTriggerProps } from "../types.js";
+	import { AccordionTriggerState } from "../accordion.svelte.js";
+	import { createId } from "$lib/internal/create-id.js";
+
+	const uid = $props.id();
+
+	let {
+		disabled = false,
+		ref = $bindable(null),
+		id = createId(uid),
+		tabindex = 0,
+		children,
+		child,
+		...restProps
+	}: AccordionTriggerProps = $props();
+
+	const mergedProps = $derived(mergeProps(restProps, triggerState.props));
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{/if}`);
+    expect(names(r)).toEqual(
+      expect.arrayContaining([
+        'disabled',
+        'ref',
+        'id',
+        'tabindex',
+        'children',
+        'child',
+        'restProps',
+        'uid',
+        'mergedProps',
+      ]),
+    );
+    // Line numbers must point into the destructure, not at the match start.
+    expect(r.symbols.find((s) => s.name === 'tabindex')?.lineStart).toBe(13);
+  });
+});


### PR DESCRIPTION
## What

`svelte` was one of 16 language plugins with no test, and it had a real bug behind that gap.

The Svelte 5 props pattern was `{ kind: 'property', pattern: /\$props\(\)/gm }` — **no capture group**, so `regex-base`'s `if (!name) continue` dropped every match. Verified against a real component (`huntabyte/bits-ui`, `accordion-trigger.svelte`), not a fixture:

| | before | after |
|---|---|---|
| symbols extracted | 3 (`uid`, `triggerState`, `mergedProps`) | 12 |
| props extracted | **0 of 7** | 7 |

A Svelte 5 component's `$props()` destructure *is* its public API. It was invisible to `search`, `get_outline` and `get_symbol` for every Svelte 5 component in every indexed repo.

## Change

Props are parsed from the destructuring block — `regex-base`'s one-name-per-match model can't express "N names from one match". Handles defaults, rest elements, renames (`class: className`), and commas nested inside arrow-function/array/call defaults.

`tests/languages/svelte.test.ts` — 7 tests; 3 of them fail against the old plugin (verified by stashing the fix).

## Unrelated churn, flagged

19 doc files show an `updated:`/`lastmod` date bump. That is `pnpm run docs:sitemap` output — `tests/docs/internal-links.test.ts` was **already failing on a clean `main` checkout** because the sitemap dates lag today's commits. Regenerated so this branch is green; dates only, no content.

## Verification

```
pnpm run lint     ✅ tsc --noEmit clean
pnpm run build    ✅
pnpm run test     ✅ 827 files, 9151 passed, 8 skipped, 0 failed
```

Matrix regenerated: svelte Tests column `—` → `yes`, tested-plugin count 65 → 66.

Refs TRA-531.
