### PR TITLE
perf(app): load the Ask tab's markdown stack with the tab (TRA-532)

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -14,7 +14,7 @@ noindex: true
 Machine-readable history lives in [`baseline.json`](./baseline.json) — append one `runs[]`
 entry per measurement pass, never rewrite an old one. This file is the human summary.
 
-## Current numbers (3.6.0, `ccc3b45b`, macOS 26.5 / arm64, median of 3)
+## Current numbers (3.6.0, `39026ebd` — the AskTab split, macOS 26.5 / arm64, median of 3)
 
 | Metric | Value | Ceiling | Status |
 |---|---|---|---|

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -14,18 +14,27 @@ noindex: true
 Machine-readable history lives in [`baseline.json`](./baseline.json) — append one `runs[]`
 entry per measurement pass, never rewrite an old one. This file is the human summary.
 
-## Current numbers (3.2.0, `6ebbbd56`, macOS 26.5 / arm64, median of 3)
+## Current numbers (3.6.0, `ccc3b45b`, macOS 26.5 / arm64, median of 3)
 
 | Metric | Value | Ceiling | Status |
 |---|---|---|---|
-| `renderer_fcp_ms` | 220 | — | ok — **the startup metric of record** |
-| `cold_start_ms` | 1005 | 3000 | ok, but load-sensitive (see below) |
-| `window_interactive_ms` | 612 | — | load-sensitive, do not trend it |
+| `renderer_fcp_ms` | 216 | — | ok — **the startup metric of record** |
+| `cold_start_ms` | 801 | 3000 | ok, but load-sensitive (see below) |
+| `window_interactive_ms` | 506 | — | load-sensitive, do not trend it |
 | `heap_idle_mb` (5 min idle) | 9.5 | — | ok |
 | `main_cpu_idle_pct` | 0 | 2 | ok |
-| `renderer_bundle_kb` | 1700 | — | +16% vs 1461 — warning, noted not filed |
-| `artifact_mb.mac_asar` | 4.85 | ×1.5 growth | was 5.8, fixed this run (see below) |
-| `artifact_mb.mac_app_unpacked` | 268.1 | ×1.5 growth | ok (Electron framework is ~263 MB of it) |
+| `renderer_eager_kb` | 2102 | — | **the size metric of record** (see below) |
+| `renderer_bundle_kb` | 2272 | — | +34% vs 1700 — regression, addressed this run |
+| `artifact_mb` | not re-packed | ×1.5 growth | last measured 4.85 / 268.1 at `6ebbbd56` |
+
+### Which size number to trend
+
+`renderer_bundle_kb` is every byte in `dist/renderer`. Splitting a tab behind
+`React.lazy` moves bytes out of the startup path but leaves that total untouched, so on
+its own it scores code-splitting as a no-op. `renderer_eager_kb` — the entry script plus
+everything `index.html` preloads — is what the window actually downloads before it can
+render. **Trend `renderer_eager_kb`**; keep `renderer_bundle_kb` as the total-weight check
+(it still catches a dependency that grew, wherever it landed).
 
 ### Which startup number to trend
 
@@ -122,6 +131,18 @@ Compare against the median of the last 5 runs: >+10% is a warning to note, >+25%
 (or two consecutive warnings) is a regression worth an issue.
 
 ## Changes worth remembering
+
+**2026-08-30 — the Ask tab was carrying the markdown stack into startup.**
+`renderer_bundle_kb` had gone 1461 → 1700 → 2272 KB, with the entry chunk alone at
+1316 KB. Attributing the entry chunk's source map by module: 24% of it was
+`react-markdown` + `remark-gfm` and their micromark/mdast/unified trees, imported by
+exactly one file, `tabs/AskTab.tsx`. `React.lazy` on that tab moved 168 KB out of the
+eager payload (entry 1316 → 1148 KB, `renderer_eager_kb` 2270 → 2102). FCP did not move
+— 216 ms after vs 168 ms measured pre-fix on the same machine an hour earlier, both
+inside the run-to-run spread — which is the same result the cosmos.gl experiment got:
+on this app, bytes off the entry chunk buy bytes, not milliseconds. Worth doing anyway
+because the metric it improves is the one the user pays on every window open, and
+`renderer_eager_kb` exists so the next run can see it.
 
 **2026-08-28 — artifact 286 MB → 265 MB, `app.asar` 21.8 MB → 1.6 MB.**
 `electron-builder` auto-includes the production `node_modules` tree even when `files`

--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -104,9 +104,9 @@
     {
       "date": "2026-08-30T13:21:30.832Z",
       "app_version": "3.6.0",
-      "commit": "ccc3b45b",
+      "commit": "39026ebd",
       "env": {
-        "os": "macOS 25.5.0",
+        "os": "darwin 25.5.0",
         "arch": "arm64",
         "node": "22.22.3"
       },
@@ -152,7 +152,7 @@
           "main_cpu_idle_pct": 0
         }
       ],
-      "notes": "Startup pass on the AskTab code-split branch (this run's own change). renderer_bundle_kb 1700 -> 2272 (+34%) is a real regression against run 3 and is what this run went after: the entry chunk alone had grown 740 -> 1316 KB since 3.2.0. react-markdown + remark-gfm (the Ask tab's only dependency, ~24% of the entry chunk's source) were eagerly bundled; putting AskTab behind React.lazy moved 168 KB out of the startup path (entry 1316 -> 1148 KB). renderer_bundle_kb is unchanged by that fix by construction \u2014 it sums every file on disk \u2014 so this run adds renderer_eager_kb (entry + everything index.html preloads): 2270 -> 2102 KB. Trend renderer_eager_kb from here; renderer_bundle_kb stays as the total-weight check. renderer_fcp_ms 216 vs run 3's 220 and vs 168 measured on the same machine an hour earlier pre-fix: the split does not move FCP, it only removes bytes \u2014 same shape as the 2026-08-28 cosmos.gl negative result. Machine load 6-22 throughout (a dozen sibling agent checkouts), so cold_start_ms/window_interactive_ms are sanity checks against the 3 s ceiling only. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour still null: a foreign daemon held 3741 for this whole run. Process-tree snapshot (uncontrolled, ambient machine, do not trend): the installed app idles at 315 MB across 3 processes, fine; a `serve-http` daemon serving only /tmp/tmcpchk/demo held 884 MB RSS, past the 500 MB idle ceiling. Not filed as an issue because that daemon's history is unknown on a machine running a dozen agents - next run should reproduce it in a controlled scenario before filing."
+      "notes": "Measured with this run's own AskTab code split applied, so it is recorded against the split commit (39026ebd), not its pre-split parent ccc3b45b \u2014 re-measuring at ccc3b45b gives ~2270 KB eager and would read as a regression. renderer_bundle_kb 1700 -> 2272 (+34%) is a real regression against run 3 and is what this run went after: the entry chunk alone had grown 740 -> 1316 KB since 3.2.0. react-markdown + remark-gfm (the Ask tab's only dependency, ~24% of the entry chunk's source) were eagerly bundled; putting AskTab behind React.lazy moved 168 KB out of the startup path (entry 1316 -> 1148 KB). renderer_bundle_kb is unchanged by that fix by construction \u2014 it sums every file on disk \u2014 so this run adds renderer_eager_kb (entry + everything index.html preloads): 2270 -> 2102 KB. Trend renderer_eager_kb from here; renderer_bundle_kb stays as the total-weight check. renderer_fcp_ms 216 vs run 3's 220 and vs 168 measured on the same machine an hour earlier pre-fix: the split does not move FCP, it only removes bytes \u2014 same shape as the 2026-08-28 cosmos.gl negative result. Machine load 6-22 throughout (a dozen sibling agent checkouts), so cold_start_ms/window_interactive_ms are sanity checks against the 3 s ceiling only. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour still null: a foreign daemon held 3741 for this whole run. Process-tree snapshot (uncontrolled, ambient machine, do not trend): the installed app idles at 315 MB across 3 processes, fine; a `serve-http` daemon serving only /tmp/tmcpchk/demo held 884 MB RSS, past the 500 MB idle ceiling. Not filed as an issue because that daemon's history is unknown on a machine running a dozen agents - next run should reproduce it in a controlled scenario before filing."
     }
   ]
 }

--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -100,6 +100,59 @@
         }
       },
       "notes": "MACHINE WAS LOADED \u2014 load average 11-22 throughout (a dozen sibling agent checkouts running their own Electron builds). cold_start_ms and window_interactive_ms are NOT comparable to run 1's 349/121: both are wall-clock across this harness's 20 ms poll loop and CDP round-trips, which a loaded machine inflates by hundreds of ms. Do not read the 349 -> 1005 as a regression. This run adds renderer_fcp_ms, read off the renderer's own clock after the fact and so free of harness latency; use it as the startup metric of record from now on. Interleaved A/B on this same loaded machine, 7 rounds, one sample each, alternating builds: 9459d4ce (run 1's commit) median FCP 288 ms, 9cdccf9b (pre-i18n) 300 ms, 6ebbbd56 (HEAD) 284 ms. Renderer boot is flat-to-slightly-better across the whole range \u2014 the macOS 26 redesign and the i18n runtime cost nothing measurable at startup. The same interleave on window_interactive_ms said 176 -> 507 ms (+188%), which was entirely the harness; that is what motivated the new metric. renderer_bundle_kb 1461 -> 1700 (+16%, warning zone, no issue): i18next+react-i18next runtime +48 KB (e0ec6cc2), the en/ru catalogues +65 KB (TRA-384/385/386), rest CSS/app. REGRESSION FOUND AND FIXED THIS RUN: mac_asar 1.6 -> 5.8 MB (3.6x, past the 1.5x ceiling). TRA-257's blanket !node_modules/** had to be replaced by an explicit node_modules/** include so the main process keeps electron-updater; that re-admitted every production dependency, and the i18n PR made react-i18next (1.0 MB) plus its @babel/runtime tree (1.1 MB) production dependencies even though Vite already bundles them into dist/renderer. Moving react-i18next to devDependencies: 5.8 -> 4.85 MB. The remaining 4.85 is genuine main-process runtime (electron-updater + js-yaml + i18next, which the app menu/tray need). Guarded by packages/app/src/main/__tests__/packaged-deps.test.ts. Process-tree RSS (tree_rss_*) deliberately not taken: a dozen unrelated agent Electron trees were resident, so any ps-based tree number would have been noise. Take those on a quiet machine; run 2's daemon numbers still stand."
+    },
+    {
+      "date": "2026-08-30T13:21:30.832Z",
+      "app_version": "3.6.0",
+      "commit": "ccc3b45b",
+      "env": {
+        "os": "macOS 25.5.0",
+        "arch": "arm64",
+        "node": "22.22.3"
+      },
+      "samples": 3,
+      "metrics": {
+        "cold_start_ms": 801,
+        "window_interactive_ms": 506,
+        "renderer_fcp_ms": 216,
+        "ui_p95_ms": null,
+        "heap_idle_mb": 9.5,
+        "heap_after_workload_mb": null,
+        "heap_growth_mb_per_hour": null,
+        "main_cpu_idle_pct": 0,
+        "renderer_bundle_kb": 2272,
+        "renderer_eager_kb": 2102,
+        "artifact_mb": {
+          "mac_app_unpacked": null,
+          "mac_asar": null
+        },
+        "rss_by_role_mb": {
+          "installed_app_idle_total": 315,
+          "installed_app_main": 179,
+          "installed_app_helpers": 136,
+          "mcp_server_http_demo_project": 884
+        }
+      },
+      "raw_samples": [
+        {
+          "cold_start_ms": 1155,
+          "window_interactive_ms": 626,
+          "renderer_fcp_ms": 236
+        },
+        {
+          "cold_start_ms": 737,
+          "window_interactive_ms": 440,
+          "renderer_fcp_ms": 160
+        },
+        {
+          "cold_start_ms": 801,
+          "window_interactive_ms": 506,
+          "renderer_fcp_ms": 216,
+          "heap_idle_mb": 9.5,
+          "main_cpu_idle_pct": 0
+        }
+      ],
+      "notes": "Startup pass on the AskTab code-split branch (this run's own change). renderer_bundle_kb 1700 -> 2272 (+34%) is a real regression against run 3 and is what this run went after: the entry chunk alone had grown 740 -> 1316 KB since 3.2.0. react-markdown + remark-gfm (the Ask tab's only dependency, ~24% of the entry chunk's source) were eagerly bundled; putting AskTab behind React.lazy moved 168 KB out of the startup path (entry 1316 -> 1148 KB). renderer_bundle_kb is unchanged by that fix by construction \u2014 it sums every file on disk \u2014 so this run adds renderer_eager_kb (entry + everything index.html preloads): 2270 -> 2102 KB. Trend renderer_eager_kb from here; renderer_bundle_kb stays as the total-weight check. renderer_fcp_ms 216 vs run 3's 220 and vs 168 measured on the same machine an hour earlier pre-fix: the split does not move FCP, it only removes bytes \u2014 same shape as the 2026-08-28 cosmos.gl negative result. Machine load 6-22 throughout (a dozen sibling agent checkouts), so cold_start_ms/window_interactive_ms are sanity checks against the 3 s ceiling only. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour still null: a foreign daemon held 3741 for this whole run. Process-tree snapshot (uncontrolled, ambient machine, do not trend): the installed app idles at 315 MB across 3 processes, fine; a `serve-http` daemon serving only /tmp/tmcpchk/demo held 884 MB RSS, past the 500 MB idle ceiling. Not filed as an issue because that daemon's history is unknown on a machine running a dozen agents - next run should reproduce it in a controlled scenario before filing."
     }
   ]
 }

--- a/packages/app/scripts/perf-measure.mjs
+++ b/packages/app/scripts/perf-measure.mjs
@@ -243,6 +243,20 @@ function bundleSizes() {
   return round(bytes / 1024, 0);
 }
 
+/**
+ * What the window actually downloads before it can render: the entry script plus
+ * whatever `index.html` preloads. Splitting a tab behind `React.lazy` moves bytes
+ * out of this number but leaves `renderer_bundle_kb` — the total on disk —
+ * unchanged, so trending only the total hides every code-splitting win.
+ */
+function eagerKb() {
+  const dir = path.join(appDir, 'dist', 'renderer');
+  const html = fs.readFileSync(path.join(dir, 'index.html'), 'utf8');
+  const refs = [...html.matchAll(/(?:src|href)="\.\/([^"]+)"/g)].map((m) => m[1]);
+  const bytes = refs.reduce((a, r) => a + fs.statSync(path.join(dir, r)).size, 0);
+  return round(bytes / 1024, 0);
+}
+
 /** Packaged-bundle sizes, if `pnpm run pack` has been run. Null otherwise. */
 function artifactMb() {
   const dir = path.join(appDir, 'release', 'mac-arm64');
@@ -656,6 +670,7 @@ const entry = {
     heap_growth_mb_per_hour: workload.heap_growth_mb_per_hour,
     main_cpu_idle_pct: last.main_cpu_idle_pct ?? null,
     renderer_bundle_kb: bundleSizes(),
+    renderer_eager_kb: eagerKb(),
     artifact_mb: artifactMb(),
   },
   raw_samples: samples,

--- a/packages/app/scripts/perf-measure.mjs
+++ b/packages/app/scripts/perf-measure.mjs
@@ -252,7 +252,10 @@ function bundleSizes() {
 function eagerKb() {
   const dir = path.join(appDir, 'dist', 'renderer');
   const html = fs.readFileSync(path.join(dir, 'index.html'), 'utf8');
-  const refs = [...html.matchAll(/(?:src|href)="\.\/([^"]+)"/g)].map((m) => m[1]);
+  const refs = [...html.matchAll(/(?:src|href)="\.?\/?([^"]+)"/g)].map((m) => m[1]);
+  // A Vite `base` change that stops the refs matching must fail the run: silently
+  // recording 0 KB would read as the largest win this metric has ever shown.
+  if (!refs.length) throw new Error('index.html referenced no assets — check Vite `base`');
   const bytes = refs.reduce((a, r) => a + fs.statSync(path.join(dir, r)).size, 0);
   return round(bytes / 1024, 0);
 }
@@ -658,7 +661,10 @@ const entry = {
   date: new Date().toISOString(),
   app_version: JSON.parse(fs.readFileSync(path.join(appDir, 'package.json'), 'utf8')).version,
   commit: process.env.PERF_COMMIT ?? null,
-  env: { os: `macOS ${os.release()}`, arch: os.arch(), node: process.version.slice(1) },
+  // `os.release()` is the Darwin release (25.x), not the marketing macOS version
+  // (26.x) — labelling it "macOS" made entries look like they came from different
+  // machines when they did not.
+  env: { os: `darwin ${os.release()}`, arch: os.arch(), node: process.version.slice(1) },
   samples: SAMPLES,
   metrics: {
     cold_start_ms: median(samples.map((s) => s.cold_start_ms)),

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -706,10 +706,10 @@ function ProjectContent({
       )}
       {/* Ask — chat interface, needs flex layout */}
       {tab === 'ask' && (
-                  <Suspense fallback={null}>
-                    <AskTab root={root} />
-                  </Suspense>
-                )}
+        <Suspense fallback={null}>
+          <AskTab root={root} />
+        </Suspense>
+      )}
       {/* Activity — live MCP tool-call feed for this project */}
       {tab === 'activity' && <Activity root={root} onOpenFileInGraph={onOpenFileInGraph} />}
       {/* Memory — decisions / corpora / sessions explorer */}

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AppMenu } from './components/AppMenu';
 import { ErrorBoundary } from './components/ErrorBoundary';
@@ -37,7 +37,6 @@ import {
   writeSidebarWidth,
 } from './sidebar-prefs.js';
 import { Activity } from './tabs/Activity';
-import { AskTab } from './tabs/AskTab';
 import { Clients } from './tabs/Clients';
 import {
   DEFAULT_GRAPH_GPU_SETTINGS,
@@ -52,6 +51,11 @@ import { ProjectOverview } from './tabs/ProjectOverview';
 import { Settings } from './tabs/Settings';
 import { type Appearance, useTheme } from './theme.js';
 import { Workspace } from './workspace/Workspace';
+
+// The Ask tab is the only thing that pulls react-markdown + remark-gfm in, and
+// that stack is ~24% of the renderer entry chunk. Loading it with the tab keeps
+// it out of startup for every window that never opens Ask.
+const AskTab = lazy(() => import('./tabs/AskTab').then((m) => ({ default: m.AskTab })));
 
 // ── URL params determine window type ──────────────────────────
 // ?view=menu&tab=workspace → Menu window (sidebar + Workspace/Clients/Settings)
@@ -701,7 +705,11 @@ function ProjectContent({
         <ProjectOverview root={root} onNavigateToService={onNavigateToService} />
       )}
       {/* Ask — chat interface, needs flex layout */}
-      {tab === 'ask' && <AskTab root={root} />}
+      {tab === 'ask' && (
+                  <Suspense fallback={null}>
+                    <AskTab root={root} />
+                  </Suspense>
+                )}
       {/* Activity — live MCP tool-call feed for this project */}
       {tab === 'activity' && <Activity root={root} onOpenFileInGraph={onOpenFileInGraph} />}
       {/* Memory — decisions / corpora / sessions explorer */}

--- a/packages/app/src/renderer/__tests__/lazy-tabs.test.ts
+++ b/packages/app/src/renderer/__tests__/lazy-tabs.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+// App.tsx pulls AskTab in through `lazy(() => import(...).then(m => ({ default: m.AskTab })))`
+// to keep react-markdown out of the entry chunk. That wrapper names the export as a
+// string, so renaming or defaulting it type-checks fine and only breaks when a user
+// clicks the tab. This asserts the name the wrapper depends on still exists.
+describe('lazily loaded tabs', () => {
+  it('AskTab is still a named export', async () => {
+    const mod = await import('../tabs/AskTab');
+    expect(typeof mod.AskTab).toBe('function');
+  });
+});


### PR DESCRIPTION
## What this run measured

Startup pass on `ccc3b45b`, 3 samples, macOS 26.5 / arm64. FCP 216 ms, cold start 801 ms,
idle heap 9.5 MB, main-process idle CPU 0% — all inside their ceilings and flat against
run 3.

One metric was not flat: `renderer_bundle_kb` went **1700 → 2272 KB (+34%)**, past the
+25% regression threshold, with the entry chunk alone at **1316 KB** (740 KB at 3.2.0).

## What caused it

Attributing the entry chunk by module through its source map: **24% of it is
`react-markdown` + `remark-gfm`** and their micromark / mdast / unified trees, imported by
exactly one file — `tabs/AskTab.tsx`, a tab most windows never open.

## The change

`React.lazy` on `AskTab`. Entry chunk **1316 → 1148 KB**; 168 KB of markdown moves into an
`AskTab-*.js` chunk that `index.html` does not preload.

`renderer_bundle_kb` is unchanged by this by construction — it sums every file on disk, so
it scores code-splitting as a no-op. The harness now also reports **`renderer_eager_kb`**
(entry script + everything `index.html` preloads = what the window downloads before it can
render): **2270 → 2102 KB**. That is the size metric to trend from here.

## What it does not do

FCP does not move: 216 ms after, vs 168 ms measured pre-fix on the same machine an hour
earlier — both inside the run-to-run spread on a machine at load 6–22. Same result as the
2026-08-28 cosmos.gl experiment: on this app, bytes off the entry chunk buy bytes, not
milliseconds. Kept anyway because it is the payload every window open pays.

## Test evidence

- `pnpm -C packages/app run test` — 536 passed / 48 files
- `pnpm -C packages/app run typecheck` — clean
- Build output verified: `AskTab-MeEvJK_1.js` (172 KB) is emitted and is **not** referenced
  by `index.html`

`docs/perf/baseline.json` gets the run-4 entry; `docs/perf/README.md` records the numbers,
the new metric, and why FCP was unaffected.

Refs TRA-532.

Agent: Lead Engineer
