### PR TITLE
fix(docs): label and expose the landing quickstart terminal as a scroll region

### DIFF
--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -249,8 +249,11 @@ appearance without a screenshot or a measurement is not a finding.
 - [ ] Every region where `scrollWidth > clientWidth` shows the `scroll →`
       label, and every region that fits does not — count both, at 1440px and
       at 390px. A region is any element that scrolls itself: the table
-      wrapper *and* every `pre`. Code blocks were read out of this line once
-      and shipped clipped and unlabelled for months.
+      wrapper, every `pre`, **and the landing page's quickstart
+      `.terminal-body`**. Code blocks were read out of this line once and
+      shipped clipped and unlabelled for months; the landing terminal was
+      missed twice more, because the fix each time landed in `docs.css` and
+      the landing page has its own copy of everything (§7).
 
 **Type & spacing**
 - [ ] Within the 2 families / 3 sizes / 2 weights budget.
@@ -296,6 +299,17 @@ The landing page keeps its own inline copy of the tokens rather than importing
 single file that the SEO agent edits constantly; extracting a shared sheet
 would be a large refactor with a live merge-conflict cost. The tokens in
 Section 1 are the contract — change one, change both files in the same PR.
+
+That duplication is not only a maintenance cost — it is where fixes go
+missing. Twice now a scroll-region rule shipped to all 17 doc pages and left
+the landing page, the busiest page on the site, behaving the old way. The
+landing's quickstart terminal is a scroll region: it carries its own
+`scroll →` label on the terminal header bezel (11px, inheriting that row's
+Space Mono caps, rather than the 10px label a doc page puts above the
+region), becomes a tab stop only while it actually overflows, and is named in
+the page's own `:where(...):focus-visible` list. **Any rule added to
+`docs/assets/css/docs.css` for a scroll region has to be checked against the
+landing page in the same PR.**
 
 The same duplication applies to the accessibility layer, and it is easier to
 forget than a token because nothing looks wrong until you press Tab. The

--- a/docs/index.html
+++ b/docs/index.html
@@ -1185,6 +1185,13 @@ layout: null
       color: var(--text-disabled);
     }
     .terminal-header .right { display: flex; align-items: center; gap: 6px; }
+    /* A region with more to the right says so. macOS hides the overlay
+       scrollbar at rest and a phone never draws one, so without this the
+       last line just ends mid-word. Same rule as .scroll-hint on a doc page
+       (docs/assets/css/docs.css); here the label sits on the terminal's own
+       bezel, which is already the right voice. */
+    .terminal-header .scroll-hint { display: none; margin-right: 10px; }
+    .terminal-header .scroll-hint.is-visible { display: inline; }
     .terminal-body {
       padding: 24px;
       font-family: var(--font-mono);
@@ -1929,7 +1936,7 @@ layout: null
     /* The UA ring is rgb(153,200,255) — a second accent colour, which the
        design system forbids. :where() keeps specificity at 0 so any component
        that needs its own ring still wins without !important. */
-    :where(a, button, summary):focus-visible {
+    :where(a, button, summary, .terminal-body):focus-visible {
       outline: 1px solid var(--text-display);
       outline-offset: 2px;
     }
@@ -2620,9 +2627,9 @@ layout: null
         <div class="terminal reveal">
           <div class="terminal-header">
             <span>~/projects/my-app</span>
-            <span class="right"><span class="status-dot" style="background: var(--success); box-shadow: none;"></span> ready</span>
+            <span class="right"><span class="scroll-hint" aria-hidden="true">scroll &rarr;</span><span class="status-dot" style="background: var(--success); box-shadow: none;"></span> ready</span>
           </div>
-          <div class="terminal-body"><span class="cmt"># 1. install the CLI globally (~30 seconds)</span>
+          <div class="terminal-body" role="group" aria-label="Quickstart terminal output"><span class="cmt"># 1. install the CLI globally (~30 seconds)</span>
 <span class="pmt">$</span> npm install -g trace-mcp
 <span class="ok">[OK]</span> trace-mcp@latest installed
 
@@ -2815,6 +2822,31 @@ layout: null
   // keyframes, but not motion driven from JS — the rAF count-up and the
   // staggered segment fill run regardless. Both check this flag.
   const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  // The quickstart terminal is a scroll region: label it while it has more to
+  // the right, and make it a tab stop only while it is actually scrollable.
+  (function () {
+    var region = document.querySelector('.terminal-body');
+    var hint = document.querySelector('.terminal-header .scroll-hint');
+    if (!region || !hint) return;
+    function measure() {
+      hint.classList.toggle(
+        'is-visible',
+        region.scrollWidth - region.clientWidth - region.scrollLeft > 1
+      );
+      if (region.scrollWidth - region.clientWidth > 1) region.setAttribute('tabindex', '0');
+      else if (region !== document.activeElement) region.removeAttribute('tabindex');
+    }
+    region.addEventListener('scroll', measure);
+    measure();
+    // Space Mono lands after first paint and changes every column width with it.
+    if (document.fonts && document.fonts.ready) document.fonts.ready.then(measure);
+    var pending = 0;
+    window.addEventListener('resize', function () {
+      cancelAnimationFrame(pending);
+      pending = requestAnimationFrame(measure);
+    });
+  })();
 
   // Reveal on scroll
   const observer = new IntersectionObserver((entries) => {


### PR DESCRIPTION
The landing page's quickstart terminal (`.terminal-body`) has `overflow-x: auto; white-space: pre` and nothing else — no `scroll →` label, no `tabindex`, and no entry in the page's own focus-ring `:where()` list.

Measured on the live site in headless Chrome, `scrollWidth - clientWidth` on `.terminal-body`:

| viewport | hidden | cut text |
|---|---|---|
| 1440 | 0 | — |
| 1024 | 28px | `…ading` |
| 768 / 600 | 0 | — (grid collapses, terminal goes full width) |
| 430 | 53px | `…e-reading` |
| 390 | 93px | `…of re-reading` |
| 360 | 123px | `…stead of re-reading` |
| 320 | 155px | `…h instead of re-reading` |

The clipped line is the quickstart's closing comment — `# done — your agent now reuses the graph instead of re-reading` — so the payoff sentence of the section is the one that ends mid-word on every phone. Nothing on screen says the block scrolls: macOS hides the overlay scrollbar at rest, a phone never draws one.

This is the same defect class as #TRA-461 (doc tables) and #645 / TRA-508 (doc code blocks). The landing page missed both fixes because it carries its own inline copy of the stylesheet — `docs/DESIGN-WEB.md` §7's known duplication debt.

## What changed

- The `scroll →` label rides the **terminal header bezel**, next to `READY`. That row is already Space Mono 11px caps at `--text-disabled` — the same instrument voice a doc page's 10px label uses, with no new band and no layout shift.
- The label shows only while the region has more to the right, and hides once scrolled to the end — same `measure()` contract as the doc-page script, re-measured on scroll, on resize (rAF-coalesced) and after `document.fonts.ready`.
- `tabindex="0"` only while the region actually overflows, so a 1440px desktop gains no dead tab stop.
- `.terminal-body` added to the page's `:where(...):focus-visible` list, and given `role="group"` + an accessible name so the new tab stop is not anonymous.
- `docs/DESIGN-WEB.md`: §5 now names the landing terminal as a region, and §7 says outright that a scroll-region rule added to `docs.css` must be checked against the landing page in the same PR — that is the mechanism by which this was missed twice.

## Verification

Jekyll is not available in this runtime, so the patch was applied verbatim to the live page HTML and served locally; measured in headless Chrome (`--headless`, isolated profile), 8 widths × 2 themes:

| width | hidden | label shown | tabindex | label after scrolling to end | page scrollWidth |
|---|---|---|---|---|---|
| 1440 | 0 | no | none | no | 1440 |
| 1024 | 28 | yes | 0 | no | 1024 |
| 768 | 0 | no | none | no | 768 |
| 600 | 0 | no | none | no | 600 |
| 430 | 53 | yes | 0 | no | 430 |
| 390 | 93 | yes | 0 | no | 390 |
| 360 | 123 | yes | 0 | no | 360 |
| 320 | 155 | yes | 0 | no | 320 |

Identical in dark and light. Focus ring read off the focused region: `rgb(255,255,255) solid 1px` dark, `rgb(0,0,0) solid 1px` light — `--text-display` in both, no Chrome blue. Terminal header row overflow is 0 at every width, including 320, so the extra label does not crowd the bezel.

Refs TRA-537.
