### PR TITLE
fix(daemon): decision rows survived project removal in every build (TRA-542)

### DIFF
--- a/src/daemon/__tests__/project-artifacts-decisions.test.ts
+++ b/src/daemon/__tests__/project-artifacts-decisions.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Decision-store rows must actually be dropped when a project is removed.
+ *
+ * `dropDecisionRows` used a bare `require('better-sqlite3')`, which the ESM
+ * build rewrites to the module namespace object rather than the default
+ * export — `new Database(...)` then threw "Database is not a constructor",
+ * the non-fatal catch swallowed it, and every removal reported 0 rows dropped
+ * while the decisions stayed on disk for a project the user had deleted.
+ *
+ * ponytail: the fixture builds the four project-scoped tables by hand with
+ * only the column `dropDecisionRows` relies on. It guards the delete, not the
+ * real DecisionStore schema.
+ */
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TABLES = ['decisions', 'session_chunks', 'decision_clusters', 'project_memos'] as const;
+
+let tmpHome: string;
+
+async function seedDecisions(roots: string[]): Promise<void> {
+  const { DECISIONS_DB_PATH, ensureGlobalDirs } = await import('../../global.js');
+  ensureGlobalDirs();
+  const db = new Database(DECISIONS_DB_PATH);
+  try {
+    for (const table of TABLES) {
+      db.exec(`CREATE TABLE IF NOT EXISTS ${table} (project_root TEXT NOT NULL)`);
+      for (const root of roots) {
+        db.prepare(`INSERT INTO ${table} (project_root) VALUES (?)`).run(root);
+      }
+    }
+  } finally {
+    db.close();
+  }
+}
+
+async function remainingRoots(table: string): Promise<string[]> {
+  const { DECISIONS_DB_PATH } = await import('../../global.js');
+  const db = new Database(DECISIONS_DB_PATH);
+  try {
+    return db
+      .prepare(`SELECT project_root FROM ${table}`)
+      .all()
+      .map((r) => (r as { project_root: string }).project_root);
+  } finally {
+    db.close();
+  }
+}
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-artifacts-decisions-'));
+  vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe('removeProjectArtifacts — decision rows', () => {
+  it('drops the removed project rows and keeps every other project', async () => {
+    const gone = path.join(tmpHome, 'gone');
+    const kept = path.join(tmpHome, 'kept');
+    await seedDecisions([gone, kept]);
+
+    const { removeProjectArtifacts } = await import('../project-artifacts.js');
+    const result = removeProjectArtifacts(gone);
+
+    expect(result.decisions).toEqual({ decisions: 1, chunks: 1, clusters: 1, memos: 1 });
+    for (const table of TABLES) expect(await remainingRoots(table)).toEqual([kept]);
+
+    // Idempotent: a second removal finds nothing left to drop.
+    expect(removeProjectArtifacts(gone).decisions).toEqual({
+      decisions: 0,
+      chunks: 0,
+      clusters: 0,
+      memos: 0,
+    });
+  });
+
+  /**
+   * The vitest transform hands modules a working `require`, so the two tests
+   * above passed all along while every shipped bundle failed. This is the part
+   * that would have caught it.
+   *
+   * tsup's `cjs-via-createRequire` plugin replaces each native external with an
+   * ESM shim that default-exports the real module. `import Database from ...`
+   * gets the constructor; `require(...)` gets the namespace object instead, and
+   * `new` on it throws. Other `require()` calls are fine — the tsup banner
+   * injects a real createRequire-backed `require`.
+   *
+   * ponytail: a file already using createRequire for one package is trusted for
+   * all of them. Per-call resolution would need a parser.
+   */
+  it('no source file bare-requires a native external', () => {
+    const config = fs.readFileSync('tsup.config.ts', 'utf8');
+    const listed = config.slice(
+      config.indexOf('const NATIVE_EXTERNALS'),
+      config.indexOf('const buildRequire'),
+    );
+    const externals = [...listed.matchAll(/^\s*'([^']+)',$/gm)].map((m) => m[1]);
+    expect(externals).toContain('better-sqlite3');
+    const bareRequire = new RegExp(
+      `(?<![.\\w])require\\(\\s*['"](${externals.join('|')})['"]\\s*\\)`,
+    );
+
+    const offenders: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name !== '__tests__') walk(full);
+          continue;
+        }
+        if (!entry.name.endsWith('.ts')) continue;
+        const source = fs.readFileSync(full, 'utf8');
+        if (source.includes('createRequire')) continue; // resolved explicitly, survives bundling
+        if (bareRequire.test(source)) offenders.push(full);
+      }
+    };
+    walk('src');
+    expect(offenders).toEqual([]);
+  });
+
+  it('is a no-op when no decisions DB exists', async () => {
+    const { removeProjectArtifacts } = await import('../project-artifacts.js');
+    expect(removeProjectArtifacts(path.join(tmpHome, 'nothing')).decisions).toEqual({
+      decisions: 0,
+      chunks: 0,
+      clusters: 0,
+      memos: 0,
+    });
+  });
+});

--- a/src/daemon/project-artifacts.ts
+++ b/src/daemon/project-artifacts.ts
@@ -16,6 +16,7 @@
  * the other tiers.
  */
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { hasLiveHolderOrUnknown, removeHoldersDir } from '../db-holders.js';
 import { DECISIONS_DB_PATH, projectHash, projectName, TOPOLOGY_DB_PATH } from '../global.js';
@@ -150,8 +151,13 @@ function dropDecisionRows(root: string): DecisionDeleteCounts {
     // Use raw SQLite — DecisionStore would re-run migrations / open a writer
     // pool we don't need just to issue four DELETEs. The schema is stable
     // (project_root TEXT NOT NULL on every project-scoped table).
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const Database = require('better-sqlite3') as typeof import('better-sqlite3');
+    // createRequire, not a bare `require`: the ESM bundle rewrites a bare
+    // `require('better-sqlite3')` into the module namespace object, so
+    // `new Database(...)` threw "Database is not a constructor" in every
+    // shipped build while passing under vitest.
+    const Database = createRequire(import.meta.url)(
+      'better-sqlite3',
+    ) as typeof import('better-sqlite3');
     const db = new Database(DECISIONS_DB_PATH);
     try {
       const counts: DecisionDeleteCounts = { ...empty };


### PR DESCRIPTION
## The bug

`removeProjectArtifacts()` has never deleted a single decision-store row in a shipped build. From this machine's live `daemon.log` (v3.6.0, four occurrences today across three daemon PIDs — i.e. every removal that ran):

```
project-artifacts: decision cleanup failed (non-fatal)
TypeError: Database is not a constructor
  at dropDecisionRows (file:///.../trace-mcp/dist/cli.js:408366:16)
```

`dropDecisionRows` used a bare `require('better-sqlite3')`. The package is in `NATIVE_EXTERNALS`, so tsup's `cjs-via-createRequire` plugin replaces it with an ESM shim that default-exports the real module — `require()` of that shim returns the namespace object, and `new` on it throws. The `catch` downgraded it to a `warn` and returned zeros, so removal reported success while every `decisions` / `session_chunks` / `decision_clusters` / `project_memos` row for the deleted root stayed in `~/.trace-mcp/decisions.db`. Decision text for a project the user deleted, kept indefinitely.

## Why no test caught it

vitest's transform gives modules a working `require`, so the exact code path passes under test and fails in the bundle. A unit test alone would not have caught this and will not catch the next one — hence the second test, which reads `NATIVE_EXTERNALS` out of `tsup.config.ts` and fails if any source file bare-`require()`s one of those packages.

## The change

- `dropDecisionRows` resolves the driver through `createRequire(import.meta.url)` — the pattern already proven to survive bundling in `src/session/providers/sqlite-source.ts`.
- `src/daemon/__tests__/project-artifacts-decisions.test.ts`: rows for the removed root dropped, other projects untouched, idempotent, no-op without a decisions DB, plus the bundling guard above.

## Test evidence

End-to-end on the built bundle — isolated daemon on `TRACE_MCP_DATA_DIR`, project registered, rows seeded:

```
DELETE /api/projects?project=... →
{"status":"removed",...,"decisions":{"decisions":1,"chunks":1,"clusters":1,"memos":1}}
decisions rows AFTER remove: 0
```

The same script against the published 3.6.0 bundle leaves the row in place.

Full suite: 843 files, 9317 tests passed. `pnpm run typecheck` and `biome ci` clean. The guard test was confirmed to flag the pre-fix source.

Closes TRA-542.
