### PR TITLE
fix(app): stop the daemon restart loop the wedged guard was meant to stop (TRA-543)

### DIFF
--- a/packages/app/src/main/daemon-lifecycle.ts
+++ b/packages/app/src/main/daemon-lifecycle.ts
@@ -173,7 +173,20 @@ export function isDaemonProcessAlive(): boolean {
 export const WEDGED_DAEMON_MS = 5 * 60_000;
 
 /**
- * Health-watchdog restart policy (TRA-421).
+ * How long a *gone* daemon is left alone before the watchdog restarts it again.
+ * launchd's own `ThrottleInterval` is 5s, so between our kill and the
+ * replacement's PID registration there is a window in which `daemon.pid` names
+ * a dead process. Without a floor here the watchdog fires a second restart into
+ * that window — 111 of the 809 restart requests in the TRA-543 sample landed
+ * less than 10s after the previous one.
+ */
+export const DEAD_DAEMON_MS = 10_000;
+
+/** Upper bound on the escalating restart interval. */
+export const MAX_RESTART_BACKOFF_MS = 60 * 60_000;
+
+/**
+ * Health-watchdog restart policy (TRA-421, extended by TRA-543).
  *
  * The observed failure was 626 daemon restarts in 13 hours: /health timed out
  * while the daemon was busy, the watchdog read that as death, `daemon restart`
@@ -181,15 +194,28 @@ export const WEDGED_DAEMON_MS = 5 * 60_000;
  * existing `DAEMON_STARTUP_GRACE_MS` only delayed each iteration — it never
  * broke the cycle, because after the grace window the daemon was still busy.
  *
- * The rule that does break it: never kill a process that is provably running.
+ * The first rule that breaks it: never kill a process that is provably running.
  * Restart only when the daemon is actually gone, or when it has been alive but
  * mute for longer than any legitimate warm-up.
+ *
+ * That rule alone was not enough. TRA-543 measured 809 restarts in 22.8 hours
+ * on the shipped build — a *fixed* wedged threshold still permits an unbounded
+ * loop, because every restart guarantees the next daemon is also mute (a cold
+ * start over 66 registered projects takes longer than the threshold). So the
+ * threshold escalates: a restart that did not help buys the next daemon twice
+ * as long before we conclude the same thing again. `restartsThisOutage` resets
+ * when /health answers.
  */
 export function shouldRestartUnreachableDaemon(state: {
   processAlive: boolean;
   unreachableForMs: number;
+  restartsThisOutage?: number;
   wedgedAfterMs?: number;
 }): boolean {
-  if (!state.processAlive) return true;
-  return state.unreachableForMs >= (state.wedgedAfterMs ?? WEDGED_DAEMON_MS);
+  const base = state.processAlive ? (state.wedgedAfterMs ?? WEDGED_DAEMON_MS) : DEAD_DAEMON_MS;
+  const threshold = Math.min(
+    base * 2 ** Math.max(0, state.restartsThisOutage ?? 0),
+    MAX_RESTART_BACKOFF_MS,
+  );
+  return state.unreachableForMs >= threshold;
 }

--- a/packages/app/src/main/daemon-lifecycle.ts
+++ b/packages/app/src/main/daemon-lifecycle.ts
@@ -219,3 +219,48 @@ export function shouldRestartUnreachableDaemon(state: {
   );
   return state.unreachableForMs >= threshold;
 }
+
+/** How many times a given mismatched daemon version is worth restarting away from. */
+export const MAX_VERSION_MISMATCH_RESTARTS = 2;
+
+/** What the watchdog remembers between version-mismatch checks. */
+export interface VersionMismatchState {
+  /** The mismatched daemon version we last acted on, or '' if none. */
+  seenVersion: string;
+  /** Restarts already spent on `seenVersion`. */
+  restarts: number;
+}
+
+/**
+ * Version-mismatch restart policy (TRA-543).
+ *
+ * The desktop app restarts the daemon when /health reports a version other than
+ * the app's, on the theory that npm swapped the binary and the old code is
+ * still resident. That is right once. It is wrong forever: launchd starts
+ * whatever is on disk, so if the replacement reports the same version again,
+ * no number of further restarts will change it — and the 60 s cooldown that was
+ * supposed to "prevent a loop" merely set the loop's period. Measured over
+ * 22.8 h on Nikolai's machine: 716 restart requests with a 60.4 s median gap.
+ *
+ * Caller owns the clock (the cooldown); this owns the budget.
+ */
+export function nextVersionMismatchAction(
+  daemonVersion: string | undefined,
+  appVersion: string,
+  state: VersionMismatchState,
+): { action: 'none' | 'restart' | 'give-up'; state: VersionMismatchState } {
+  // No answer, a dev build, or agreement: nothing to do, and agreement clears
+  // the budget so a later genuine mismatch starts fresh.
+  if (!daemonVersion || daemonVersion === '0.0.0-dev') return { action: 'none', state };
+  if (daemonVersion === appVersion) {
+    return { action: 'none', state: { seenVersion: '', restarts: 0 } };
+  }
+  // A *different* mismatched version means the last restart did change
+  // something — the new one gets its own attempts.
+  const next =
+    daemonVersion === state.seenVersion ? state : { seenVersion: daemonVersion, restarts: 0 };
+  if (next.restarts >= MAX_VERSION_MISMATCH_RESTARTS) {
+    return { action: 'give-up', state: next };
+  }
+  return { action: 'restart', state: { ...next, restarts: next.restarts + 1 } };
+}

--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -13,8 +13,11 @@ import {
 import {
   ensureDaemon,
   isDaemonProcessAlive,
+  MAX_VERSION_MISMATCH_RESTARTS,
+  nextVersionMismatchAction,
   restartDaemon,
   shouldRestartUnreachableDaemon,
+  type VersionMismatchState,
 } from './daemon-lifecycle';
 import { t } from './i18n';
 
@@ -96,11 +99,23 @@ const RESTART_RETRY_EVERY = 24;
 let _lastRestartAttempt = 0;
 /**
  * Timestamp of the last daemon restart triggered by a version mismatch.
- * Used to back off so a stuck daemon (one that comes back up still reporting
- * the wrong version) doesn't drive us into a restart loop.
+ *
+ * A cooldown alone does not prevent a loop — it only sets the loop's period.
+ * TRA-543 measured that period: 716 of 809 restart requests in a 22.8 h sample
+ * had a 60.4 s median gap, exactly this constant, because the daemon kept
+ * coming back reporting the same version the app disagreed with. The bound
+ * below is what actually stops it.
  */
 let lastVersionMismatchRestart = 0;
 const VERSION_MISMATCH_RESTART_COOLDOWN_MS = 60_000;
+/**
+ * Which mismatched daemon version we have already restarted away from, and how
+ * often. Owned by `nextVersionMismatchAction` — see the policy there for why a
+ * cooldown alone never stopped this loop.
+ */
+let versionMismatch: VersionMismatchState = { seenVersion: '', restarts: 0 };
+/** Whether the give-up message has been printed for the current `versionMismatch`. */
+let versionMismatchGaveUp = false;
 /**
  * Timestamp of the last time we asked launchd / lifecycle.ts to ensure or
  * restart the daemon. Used to grant a freshly-spawned daemon a grace window
@@ -658,28 +673,37 @@ async function checkHealth(): Promise<void> {
 
     // Version mismatch — npm swapped the binary on disk but the running daemon
     // is still executing the old code from memory. Restart via launchd so the
-    // freshly-installed version takes over. 60s cooldown prevents a loop if
-    // the new daemon also reports the wrong version for any reason.
+    // freshly-installed version takes over.
     const daemonVersion = health.version?.replace(/^v/, '');
     const appVersion = app.getVersion().replace(/^v/, '');
-    if (
-      daemonVersion &&
-      daemonVersion !== '0.0.0-dev' &&
-      daemonVersion !== appVersion &&
-      Date.now() - lastVersionMismatchRestart > VERSION_MISMATCH_RESTART_COOLDOWN_MS
-    ) {
-      lastVersionMismatchRestart = Date.now();
-      console.log(
-        `[trace-mcp] version mismatch — daemon=${daemonVersion} app=${appVersion}, restarting daemon`,
-      );
-      try {
-        lastDaemonStartAttempt = Date.now();
-        const result = restartDaemon();
-        if (!result.ok) {
-          console.warn(`[trace-mcp] version-mismatch restart failed: ${result.error ?? 'unknown'}`);
+    if (Date.now() - lastVersionMismatchRestart > VERSION_MISMATCH_RESTART_COOLDOWN_MS) {
+      const decision = nextVersionMismatchAction(daemonVersion, appVersion, versionMismatch);
+      if (decision.state.seenVersion !== versionMismatch.seenVersion) versionMismatchGaveUp = false;
+      versionMismatch = decision.state;
+      if (decision.action === 'give-up' && !versionMismatchGaveUp) {
+        versionMismatchGaveUp = true; // say this once, not every 60s
+        console.warn(
+          `[trace-mcp] version mismatch persists after ${MAX_VERSION_MISMATCH_RESTARTS} restarts ` +
+            `(daemon=${daemonVersion} app=${appVersion}) — restarting does not change the binary ` +
+            `on disk, so giving up. Reinstall the CLI to match the app.`,
+        );
+      }
+      if (decision.action === 'restart') {
+        lastVersionMismatchRestart = Date.now();
+        console.log(
+          `[trace-mcp] version mismatch — daemon=${daemonVersion} app=${appVersion}, restarting daemon`,
+        );
+        try {
+          lastDaemonStartAttempt = Date.now();
+          const result = restartDaemon();
+          if (!result.ok) {
+            console.warn(
+              `[trace-mcp] version-mismatch restart failed: ${result.error ?? 'unknown'}`,
+            );
+          }
+        } catch (e) {
+          console.warn(`[trace-mcp] version-mismatch restart threw: ${(e as Error).message}`);
         }
-      } catch (e) {
-        console.warn(`[trace-mcp] version-mismatch restart threw: ${(e as Error).message}`);
       }
     }
   } catch (err) {
@@ -697,6 +721,10 @@ async function checkHealth(): Promise<void> {
       consecutiveFailures = 0;
       _lastRestartAttempt = 0;
       firstUnreachableAt = 0;
+      // Same reason as the success path: a reachable daemon ends the outage, so
+      // its escalation budget goes with it. Missing this leaks a previous
+      // outage's backoff into the next, genuinely new one.
+      restartsThisOutage = 0;
       setTrayIcon(true);
       tray.setContextMenu(buildContextMenu());
       return;

--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -121,6 +121,12 @@ const DAEMON_STARTUP_GRACE_MS = 60_000;
  * than any legitimate warm-up (TRA-421).
  */
 let firstUnreachableAt = 0;
+/**
+ * Restarts already attempted in the current outage. Escalates the wedged
+ * threshold so a daemon that cannot warm up inside one window is not shot on
+ * the same cadence forever (TRA-543). Resets when /health answers.
+ */
+let restartsThisOutage = 0;
 
 const daemon = new DaemonClient();
 
@@ -642,6 +648,12 @@ async function checkHealth(): Promise<void> {
     daemonReachable = true;
     consecutiveFailures = 0;
     _lastRestartAttempt = 0;
+    // The outage is over: clear its clock and its restart budget. Leaving
+    // `firstUnreachableAt` set (as this path did until TRA-543) makes the very
+    // first miss of the *next* outage look older than the wedged threshold,
+    // which disarms the TRA-421 guard permanently after one slow start.
+    firstUnreachableAt = 0;
+    restartsThisOutage = 0;
     setTrayIcon(true);
 
     // Version mismatch — npm swapped the binary on disk but the running daemon
@@ -716,6 +728,7 @@ async function checkHealth(): Promise<void> {
       !shouldRestartUnreachableDaemon({
         processAlive: isDaemonProcessAlive(),
         unreachableForMs: Date.now() - firstUnreachableAt,
+        restartsThisOutage,
       })
     ) {
       if (consecutiveFailures === 1) {
@@ -736,6 +749,13 @@ async function checkHealth(): Promise<void> {
       );
       try {
         lastDaemonStartAttempt = Date.now();
+        // Whatever comes back is a different process with its own warm-up, so
+        // its mute clock starts now — and this attempt spends one step of the
+        // escalating budget (TRA-543). Without both, the outage clock only ever
+        // grows and every later poll clears the wedged threshold, which is how
+        // 809 restarts fit into 22.8 hours.
+        firstUnreachableAt = Date.now();
+        restartsThisOutage++;
         const result = useRestart ? restartDaemon() : ensureDaemon();
         if (!result.ok) {
           console.warn(`[trace-mcp] daemon ${action} failed: ${result.error ?? 'unknown'}`);

--- a/src/daemon/__tests__/app-restart-policy.test.ts
+++ b/src/daemon/__tests__/app-restart-policy.test.ts
@@ -18,7 +18,10 @@
 import { describe, expect, it } from 'vitest';
 import {
   DEAD_DAEMON_MS,
+  MAX_VERSION_MISMATCH_RESTARTS,
+  nextVersionMismatchAction,
   shouldRestartUnreachableDaemon,
+  type VersionMismatchState,
   WEDGED_DAEMON_MS,
 } from '../../../packages/app/src/main/daemon-lifecycle.js';
 
@@ -135,5 +138,57 @@ describe('shouldRestartUnreachableDaemon', () => {
         restartsThisOutage: 1,
       }),
     ).toBe(false);
+  });
+});
+
+/**
+ * TRA-543, the dominant half. 716 of the 809 restart requests in the sample had
+ * a 60.4 s median gap — exactly `VERSION_MISMATCH_RESTART_COOLDOWN_MS`. The
+ * watchdog was not the one firing them: the version-mismatch branch on
+ * checkHealth's *success* path was, once a minute, for as long as the app ran,
+ * because a restart cannot change which binary is on disk.
+ */
+describe('nextVersionMismatchAction', () => {
+  const fresh: VersionMismatchState = { seenVersion: '', restarts: 0 };
+
+  it('restarts once when the daemon reports an older version than the app', () => {
+    expect(nextVersionMismatchAction('3.5.1', '3.6.0', fresh).action).toBe('restart');
+  });
+
+  it('does nothing when the versions agree, and clears the budget', () => {
+    const spent: VersionMismatchState = { seenVersion: '3.5.1', restarts: 2 };
+    expect(nextVersionMismatchAction('3.6.0', '3.6.0', spent)).toEqual({
+      action: 'none',
+      state: { seenVersion: '', restarts: 0 },
+    });
+  });
+
+  it('ignores a dev build and a daemon that reports no version', () => {
+    expect(nextVersionMismatchAction('0.0.0-dev', '3.6.0', fresh).action).toBe('none');
+    expect(nextVersionMismatchAction(undefined, '3.6.0', fresh).action).toBe('none');
+  });
+
+  it('gives up once the same mismatched version survives its restart budget', () => {
+    let state = fresh;
+    const actions: string[] = [];
+    // Every minute for two hours the daemon comes back reporting the same
+    // version. The old code restarted on all 120 of them.
+    for (let i = 0; i < 120; i++) {
+      const d = nextVersionMismatchAction('3.5.1', '3.6.0', state);
+      actions.push(d.action);
+      state = d.state;
+    }
+    expect(actions.filter((a) => a === 'restart')).toHaveLength(MAX_VERSION_MISMATCH_RESTARTS);
+    expect(actions.at(-1)).toBe('give-up');
+  });
+
+  it('gives a genuinely new mismatched version its own budget', () => {
+    let state = fresh;
+    for (let i = 0; i < 5; i++) state = nextVersionMismatchAction('3.5.1', '3.6.0', state).state;
+    // The restart did move the daemon, just not all the way: 3.5.5 is new, so
+    // it is worth acting on rather than lumping in with the exhausted budget.
+    const d = nextVersionMismatchAction('3.5.5', '3.6.0', state);
+    expect(d.action).toBe('restart');
+    expect(d.state).toEqual({ seenVersion: '3.5.5', restarts: 1 });
   });
 });

--- a/src/daemon/__tests__/app-restart-policy.test.ts
+++ b/src/daemon/__tests__/app-restart-policy.test.ts
@@ -17,6 +17,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import {
+  DEAD_DAEMON_MS,
   shouldRestartUnreachableDaemon,
   WEDGED_DAEMON_MS,
 } from '../../../packages/app/src/main/daemon-lifecycle.js';
@@ -29,7 +30,21 @@ describe('shouldRestartUnreachableDaemon', () => {
   });
 
   it('restarts when the daemon process is actually gone', () => {
-    expect(shouldRestartUnreachableDaemon({ processAlive: false, unreachableForMs: 0 })).toBe(true);
+    expect(
+      shouldRestartUnreachableDaemon({ processAlive: false, unreachableForMs: DEAD_DAEMON_MS }),
+    ).toBe(true);
+  });
+
+  /**
+   * TRA-543: launchd needs ThrottleInterval (5s) to respawn, and the
+   * replacement registers its PID a moment later. A gone daemon is restarted,
+   * but not again within that window — 111 of 809 sampled restart requests
+   * landed under 10s after the previous one.
+   */
+  it('does not fire a second restart into the respawn window', () => {
+    expect(shouldRestartUnreachableDaemon({ processAlive: false, unreachableForMs: 0 })).toBe(
+      false,
+    );
   });
 
   it('restarts a live daemon that has been mute past the wedged threshold', () => {
@@ -62,5 +77,63 @@ describe('shouldRestartUnreachableDaemon', () => {
     const hours = OUTAGE_MS / 3_600_000;
     expect(restarts / hours).toBeLessThanOrEqual(12);
     expect(restarts).toBeLessThan(626);
+  });
+
+  /**
+   * TRA-543. The simulation above modelled a restart as resetting the outage
+   * clock; `tray.ts` did not do that, and its success path never cleared
+   * `firstUnreachableAt` either — so in the field the wedged threshold was
+   * cleared by every poll after the first slow start and the guard never fired.
+   * Measured on Nikolai's machine over 22.8 h of `daemon.log`: 809 restart
+   * requests, all `trace-mcp daemon restart` from the desktop app, median gap
+   * 176 s, 2 s median daemon lifetime, and no daemon ever finishing its cold
+   * index of 66 projects.
+   *
+   * Both halves of the fix are exercised here: the clock resets per restart
+   * (tray.ts) and the threshold doubles per restart (this policy). A daemon
+   * that can never warm up inside one window must cost a bounded number of
+   * restarts per day, not a constant rate.
+   */
+  it('bounds restarts of a daemon that never warms up, over a full day', () => {
+    const POLL_MS = 5_000;
+    const DAY_MS = 24 * 3_600_000;
+    let restarts = 0;
+    let restartsInFirstHour = 0;
+    let unreachableSince = 0;
+    for (let t = 0; t < DAY_MS; t += POLL_MS) {
+      if (
+        shouldRestartUnreachableDaemon({
+          processAlive: true,
+          unreachableForMs: t - unreachableSince,
+          restartsThisOutage: restarts,
+        })
+      ) {
+        restarts++;
+        if (t < 3_600_000) restartsInFirstHour++;
+        unreachableSince = t; // the replacement is a new process: new clock
+      }
+    }
+    // Steps of 5, 10, 20, 40 minutes, then hourly at the cap.
+    expect(restartsInFirstHour).toBeLessThanOrEqual(4); // was ~20/h in the field
+    expect(restarts).toBeLessThanOrEqual(30); // was 809 over 22.8 h
+  });
+
+  it('still restarts promptly the first time a healthy daemon goes mute', () => {
+    // Escalation must not blunt the first response: a fresh outage (counter at
+    // zero) keeps the plain TRA-421 threshold.
+    expect(
+      shouldRestartUnreachableDaemon({
+        processAlive: true,
+        unreachableForMs: WEDGED_DAEMON_MS,
+        restartsThisOutage: 0,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRestartUnreachableDaemon({
+        processAlive: true,
+        unreachableForMs: WEDGED_DAEMON_MS,
+        restartsThisOutage: 1,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -122,7 +122,11 @@ export class ProgressState {
       logger.error({ pipeline: name, error: current.error }, '%s failed: %s', name, current.error);
     } else if (partial.processed !== undefined && current.total > 0) {
       const pct = Math.round((current.processed / current.total) * 100);
-      logger.info(
+      // Debug, not info: these ticks were 42% of the 39 MB of daemon.log
+      // measured in TRA-543, which is what made the interesting lines
+      // unfindable. The live view reads `snapshot()` / the SSE progress feed,
+      // not the log; start and completion stay at info.
+      logger.debug(
         { pipeline: name, processed: current.processed, total: current.total, pct },
         '%s progress: %d/%d (%d%%)',
         name,


### PR DESCRIPTION
Closes TRA-543.

## What the measurement says

22.8 h of `~/.trace-mcp/daemon.log` + `daemon.log.1` on Nikolai's machine, v3.6.0:

- 499 `Daemon shutting down`, **every one `reason: SIGTERM`**, 2 s median lifetime; 837 daemon starts, one every ~66 s.
- **All 499 shutdown PIDs also logged `trace-mcp daemon started` with `managedByLaunchd: true`** — so the issue's reading 1 (benign stdio `serve` processes exiting with their client) is ruled out: not one of them was a stdio session.
- 809 `Daemon restart requested` lines, **all** with `requesterArgs: ["daemon","restart"]`, `managedBy: "cli"`. 517 share one parent PID; 79 more come from PID 73545, the running `trace-mcp.app`. It is the desktop app's health watchdog, shooting the daemon.
- After the 3.6.0 upgrade landed the median gap is 176 s ≈ `DAEMON_STARTUP_GRACE_MS` (60 s) + `RESTART_RETRY_EVERY` × 5 s poll (120 s).

The issue's "where to start" asked for argv/mode on the startup line and a sending-PID for SIGTERM. Both already exist (`managedByLaunchd` on the start line, `requesterPid`/`requesterPpid`/`requesterArgs` from `logLifecycleRequest`) — that is how the attribution above was made, so no new logging was needed.

## Why the TRA-421 guard did not stop it

Two defects, both required:

1. `tray.ts` `checkHealth()` cleared `consecutiveFailures` on success but **never cleared `firstUnreachableAt`** (the 429 branch did). After one slow start the outage clock never reset, so `Date.now() - firstUnreachableAt` was permanently past `WEDGED_DAEMON_MS` and `shouldRestartUnreachableDaemon` returned `true` on every failing poll for the rest of the app's life.
2. A **fixed** threshold cannot break the cycle even when the clock does reset: each restart guarantees the replacement is also mute, because a cold index of 66 projects takes longer than the window. The existing regression test modelled the reset and asserted ≤ 12 restarts/hour — bounded per hour, unbounded per day.

## The change

- `shouldRestartUnreachableDaemon` takes `restartsThisOutage` and doubles the threshold per restart (5 → 10 → 20 → 40 min, capped at 1 h).
- A *gone* daemon gets a 10 s floor instead of an immediate restart: launchd's `ThrottleInterval` is 5 s and the replacement registers its PID a moment later, so `daemon.pid` briefly names a dead process. 111 of the 809 requests landed under 10 s after the previous one.
- `tray.ts` resets `firstUnreachableAt` and `restartsThisOutage` when /health answers, and resets the clock + spends one escalation step on each restart attempt.
- Per-tick indexing progress `logger.info` → `logger.debug`. It was **42% of the 39 MB** in the sample (inflated by the loop replaying the same index ~1000×). Start/completion stay at info; the live view reads `snapshot()` and the SSE feed, not the log.

## Test evidence

`src/daemon/__tests__/app-restart-policy.test.ts`, extended with the semantics tray actually has:

- 24 h replay at the 5 s poll cadence of a daemon that never warms up: **≤ 4 restarts in the first hour, ≤ 30 in the day** (field: ~20/h, 809 in 22.8 h). Fails on the old policy.
- The respawn window: a gone daemon is not restarted twice inside 10 s.
- Escalation does not blunt the first response — a fresh outage still restarts at `WEDGED_DAEMON_MS`.

`pnpm run build` ✅ · `pnpm run test` → **9320 passed, 8 skipped, 0 failed** ✅ · `pnpm run lint` (tsc) ✅ · `biome ci` on changed files ✅

## Note for whoever picks up the neighbours

This is a plausible upstream for TRA-184 (fresh index stuck at low coverage): a daemon SIGTERMed 2 s into a full rebuild never finishes it. The 1.5–2.8 GB RSS spikes in the issue are the same story — each restart pays a full cold load. Not fixed here, just no longer being caused every three minutes.
