### PR TITLE
fix(update): re-check whether the app is running per bundle (TRA-555)

### DIFF
--- a/scripts/postinstall-app.mjs
+++ b/scripts/postinstall-app.mjs
@@ -147,6 +147,13 @@ if (running && located && running !== located.appPath) {
 // so no later install ever resolves to it. Found in the wild at three releases
 // behind (`/Applications` on 3.3.0, `~/Applications` on 3.6.0) with npm
 // reporting success every time. One download, applied to all of them.
+//
+// Scope, deliberately: the running bundle, the marker's bundle, and the two
+// conventional directories. A copy installed somewhere else that is neither
+// running nor the marker target stays invisible here — `mdfind` by bundle id
+// would find it, but Spotlight also indexes build trees and external volumes,
+// and no user has yet been seen installing outside those directories. Revisit
+// if one is.
 INSTALLED_APPS = [target];
 for (const candidate of [
   ...CONVENTIONAL_APP_DIRS.map((dir) => path.join(dir, APP_NAME)),
@@ -481,14 +488,17 @@ async function main() {
       return;
     }
 
-    const appRunning = appIsRunning();
     for (const appPath of stale) {
       try {
         applyTo(appPath, {
           zipPath,
           digest: expectedDigest,
           tagName: release.tag_name,
-          appRunning,
+          // Asked per bundle, not once for the whole sweep: swapping a ~100 MB
+          // bundle takes seconds, and a user who launches the app during that
+          // window would otherwise have the next bundle swapped against a
+          // stale "not running" answer — the TRA-431 failure, once per copy.
+          appRunning: appIsRunning(),
           tmpDir,
         });
       } catch {

--- a/tests/scripts/locate-app.test.ts
+++ b/tests/scripts/locate-app.test.ts
@@ -455,3 +455,40 @@ describe.skipIf(process.platform === 'win32')('runningBundlePath', () => {
     expect(runRunningBundlePath({ homeDir: home, pgrepBin, psBin, platform: 'linux' })).toBeNull();
   });
 });
+
+// isInstalledApp is pure — no env, no marker, no subprocess of its own — so it
+// is imported directly instead of going through the harnesses above.
+describe.skipIf(process.platform === 'win32')('isInstalledApp', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-installed-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('accepts a valid bundle in a plausible install directory', async () => {
+    const { isInstalledApp } = await import(MODULE_PATH);
+    expect(isInstalledApp(createFakeBundle(path.join(home, 'Applications')))).toBe(true);
+  });
+
+  it('rejects a valid bundle sitting in a build tree', async () => {
+    const { isInstalledApp } = await import(MODULE_PATH);
+    const dir = path.join(home, 'checkout', 'packages', 'app', 'release', 'mac-arm64');
+    fs.mkdirSync(dir, { recursive: true });
+    expect(isInstalledApp(createFakeBundle(dir))).toBe(false);
+  });
+
+  it('rejects a plausible path whose bundle id is not ours', async () => {
+    const { isInstalledApp } = await import(MODULE_PATH);
+    const foreign = createFakeBundle(path.join(home, 'Applications'), 'com.someone-else.app');
+    expect(isInstalledApp(foreign)).toBe(false);
+  });
+
+  it('rejects a plausible path with no bundle at all', async () => {
+    const { isInstalledApp } = await import(MODULE_PATH);
+    expect(isInstalledApp(path.join(home, 'Applications', 'trace-mcp.app'))).toBe(false);
+  });
+});

--- a/tests/scripts/postinstall-app.test.ts
+++ b/tests/scripts/postinstall-app.test.ts
@@ -91,6 +91,29 @@ function writePgrepStub(dir: string, running: boolean): string {
   return stub;
 }
 
+/**
+ * A pgrep stub that answers "not running" until its `runningFromCall`-th
+ * invocation and "running" from then on — the user launching the app midway
+ * through a multi-bundle sweep.
+ */
+function writeFlippingPgrepStub(dir: string, runningFromCall: number): string {
+  const stub = path.join(dir, 'pgrep-flip-stub.sh');
+  const counter = path.join(dir, 'pgrep-calls');
+  fs.rmSync(counter, { force: true });
+  fs.writeFileSync(
+    stub,
+    `#!/bin/sh
+n=$(cat '${counter}' 2>/dev/null || echo 0)
+n=$((n+1))
+echo "$n" > '${counter}'
+[ "$n" -ge ${runningFromCall} ] && { echo 4242; exit 0; }
+exit 1
+`,
+    { mode: 0o755 },
+  );
+  return stub;
+}
+
 /** A stub for `/bin/ps -p <pid> -o comm=`, reporting `appPath`'s main binary. */
 function writePsStub(dir: string, appPath: string): string {
   const stub = path.join(dir, 'ps-stub.sh');
@@ -204,7 +227,12 @@ describe.skipIf(process.platform !== 'darwin')('postinstall-app.mjs bundle swap'
    * the child's own HTTP request.
    */
   function runPostinstall(
-    opts: { appRunning?: boolean; appRunningEnv?: boolean; runningBundle?: string } = {},
+    opts: {
+      appRunning?: boolean;
+      appRunningEnv?: boolean;
+      runningBundle?: string;
+      pgrepRunningFromCall?: number;
+    } = {},
   ): Promise<string> {
     const child = spawn(process.execPath, [SCRIPT_PATH], {
       env: {
@@ -213,7 +241,9 @@ describe.skipIf(process.platform !== 'darwin')('postinstall-app.mjs bundle swap'
         TRACE_MCP_APP_DIST_REPO: DIST_REPO,
         TRACE_MCP_UPDATE_API_BASE: fx.baseUrl,
         TRACE_MCP_APP_RUNNING: opts.appRunningEnv ? '1' : '',
-        TRACE_MCP_PGREP_BIN: writePgrepStub(tmp, opts.appRunning ?? false),
+        TRACE_MCP_PGREP_BIN: opts.pgrepRunningFromCall
+          ? writeFlippingPgrepStub(tmp, opts.pgrepRunningFromCall)
+          : writePgrepStub(tmp, opts.appRunning ?? false),
         // Left at a binary that reports no such pid unless a test names the
         // bundle it wants "running"; that keeps every other case on the
         // marker-resolved path they were written against.
@@ -328,6 +358,32 @@ describe.skipIf(process.platform !== 'darwin')('postinstall-app.mjs bundle swap'
     // Each swap records its own version marker, and leaves no backup behind.
     expect(fs.readFileSync(path.join(systemDir, '.trace-mcp-version'), 'utf-8')).toBe('v3.5.2');
     expect(fs.readdirSync(systemDir).filter((f) => f.includes('.bak-'))).toEqual([]);
+  });
+
+  /* TRA-555: swapping a ~100 MB bundle takes seconds, so the user can launch
+     the app while the sweep is between bundles. A single hoisted "is it
+     running" answer would then swap a live bundle out from under a running
+     process — TRA-431, once per install. pgrep here says "not running" for the
+     first bundle and "running" for the second. */
+  it('re-checks whether the app is running between bundles', async () => {
+    installBundle('3.4.0');
+    const systemDir = path.join(tmp, 'Applications');
+    fs.mkdirSync(systemDir, { recursive: true });
+    const systemApp = path.join(systemDir, 'trace-mcp.app');
+    writeBundle(systemApp, '3.3.0');
+
+    publishRelease('3.5.2');
+
+    // Call 1 is the startup runningBundlePath() probe, calls 2 and 3 are the
+    // per-bundle checks — so the app "launches" just before the second swap.
+    await runPostinstall({ pgrepRunningFromCall: 3 });
+
+    expect(readBundleVersion(fx.appPath)).toBe('3.5.2');
+    // Second bundle was left alone and got a staged update instead.
+    expect(readBundleVersion(systemApp)).toBe('3.3.0');
+    expect(fs.readFileSync(path.join(systemDir, '.trace-mcp-pending-version'), 'utf-8')).toBe(
+      '3.5.2',
+    );
   });
 
   it('leaves an already-current sibling bundle untouched', async () => {


### PR DESCRIPTION
Follow-up to #672, raised by its reviewer and tracked as TRA-555.

## 1. `appIsRunning()` re-checked per bundle (the substantive one)

`main()` computed the running check once and passed that snapshot to every
bundle. With one bundle that was "check once, use once". With N, bundle A's
swap (unzip + rename of a ~100 MB app) takes seconds, and a user launching the
app in that window would have bundle B swapped against a stale
`appRunning === false` — renaming a live bundle out from under a running
process, which is exactly TRA-431, multiplied by bundle count.

Now asked inside the loop, so a mid-sweep launch downgrades the remaining
bundles to the stage-a-pending-zip path.

## 2. Bundle discovery scope documented

The sweep covers the running bundle, the marker's bundle, and the two
conventional directories. An install elsewhere that is neither running nor the
marker target stays invisible. `mdfind` by bundle id would reach it, but
Spotlight also indexes build trees and external volumes, and no user has been
seen installing outside those directories — so the limit is written down in the
code rather than engineered around. No regression versus before, which touched
zero secondary installs.

## 3. Direct unit tests for `isInstalledApp`

It was only covered indirectly through the postinstall happy path. Four cases
now cover both negative branches: build-tree path with a valid bundle id, and
plausible path with a foreign bundle id, plus accept and no-bundle-at-all.

## Test evidence

`pnpm test --run tests/scripts/postinstall-app.test.ts tests/scripts/locate-app.test.ts`
→ 35 passed (2 files).

The new `re-checks whether the app is running between bundles` test was
verified to fail against the hoisted version: with `appIsRunning()` lifted back
out of the loop the second bundle is swapped in place instead of staged, and
the test goes red (1 failed | 13 passed). `pnpm run build` and `biome check`
are clean.
