### PR TITLE
test(update): verify the upgrade path against real releases (TRA-562)

### DIFF
--- a/scripts/verify-upgrade-path.mjs
+++ b/scripts/verify-upgrade-path.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+/**
+ * Does an old install actually reach the current version?
+ *
+ * Everything else that guards the updater asserts against a mock: the GitHub
+ * API is stubbed, the "bundle" is a fixture directory. That is what let TRA-357
+ * through — the code read correctly and shipped, and five real upgrades in a row
+ * ended `npm-only` while the app kept showing "Up to date". A silent update
+ * failure produces no complaint, so it has to be caught by running the real
+ * thing, not by reading it.
+ *
+ * So this downloads a real published release, installs it as a real `.app`, runs
+ * the real postinstall hook against it, and asserts the bundle on disk moved to
+ * this checkout's version and still passes Gatekeeper.
+ *
+ * Manual / autopilot only — not wired into CI. It downloads two ~110 MB zips per
+ * run, which is not a per-PR cost worth paying; the Update Health autopilot runs
+ * it and records the starting version it covered.
+ *
+ *   node scripts/verify-upgrade-path.mjs                # 10 releases back
+ *   node scripts/verify-upgrade-path.mjs --from v1.50.0 # a specific one
+ *   node scripts/verify-upgrade-path.mjs --arch x64
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REPO = 'nikolai-vysotskyi/trace-mcp';
+const BUNDLE_ID = 'com.trace-mcp.app';
+
+if (process.platform !== 'darwin') {
+  console.log('skip: macOS only');
+  process.exit(0);
+}
+
+const args = process.argv.slice(2);
+const argOf = (name) => {
+  const i = args.indexOf(name);
+  return i === -1 ? null : args[i + 1];
+};
+const arch = argOf('--arch') ?? 'arm64';
+const zipSuffix = arch === 'arm64' ? '-arm64-mac.zip' : '-mac.zip';
+
+const repoRoot = path.resolve(new URL('..', import.meta.url).pathname);
+const expected = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf-8')).version;
+
+const gh = (...a) => execFileSync('gh', a, { encoding: 'utf-8', maxBuffer: 32 << 20 });
+
+const from =
+  argOf('--from') ??
+  gh(
+    'release',
+    'list',
+    '--repo',
+    REPO,
+    '--limit',
+    '10',
+    '--json',
+    'tagName',
+    '--jq',
+    '.[-1].tagName',
+  ).trim();
+
+console.log(`upgrade path: ${from} (${arch}) -> ${expected}`);
+
+// `/private/tmp`, not `/tmp`: locate-app.mjs rejects install paths under a
+// `workdir`/`build`/... segment as local builds, and the applier's own
+// is-this-the-entrypoint check compares argv[1] against a realpath'd
+// import.meta.url. A symlinked or implausible sandbox makes this script pass
+// while testing nothing.
+const sandbox = fs.mkdtempSync(path.join('/private/tmp', 'trace-mcp-upgrade-'));
+const apps = path.join(sandbox, 'Applications');
+const home = path.join(sandbox, 'home');
+fs.mkdirSync(apps);
+fs.mkdirSync(path.join(home, '.trace-mcp'), { recursive: true });
+
+// ponytail: a stub that reports "nothing running" rather than a fake process
+// tree. pgrep answers for the whole machine, so without this the developer's own
+// running copy becomes the update target — the postinstall would report success
+// having swapped a bundle this script never created.
+const pgrepStub = path.join(sandbox, 'pgrep-none');
+fs.writeFileSync(pgrepStub, '#!/bin/sh\nexit 1\n');
+fs.chmodSync(pgrepStub, 0o755);
+
+let failure = null;
+try {
+  gh('release', 'download', from, '--repo', REPO, '--pattern', `*${zipSuffix}`, '--dir', sandbox);
+  const zip = fs.readdirSync(sandbox).find((n) => n.endsWith(zipSuffix));
+  if (!zip) throw new Error(`${from} publishes no ${zipSuffix} asset`);
+  execFileSync('/usr/bin/ditto', ['-x', '-k', path.join(sandbox, zip), apps]);
+
+  const appPath = path.join(apps, 'trace-mcp.app');
+  const versionOf = (p) =>
+    execFileSync(
+      '/usr/libexec/PlistBuddy',
+      ['-c', 'Print :CFBundleShortVersionString', path.join(p, 'Contents', 'Info.plist')],
+      { encoding: 'utf-8' },
+    ).trim();
+
+  const before = versionOf(appPath);
+  if (before === expected) throw new Error(`${from} is already ${expected} — nothing to verify`);
+  console.log(`  installed ${before}`);
+
+  fs.writeFileSync(
+    path.join(home, '.trace-mcp', 'app-location.json'),
+    JSON.stringify({ appPath, bundleId: BUNDLE_ID, version: before, writtenAt: Date.now() }),
+  );
+
+  execFileSync('node', [path.join(repoRoot, 'scripts', 'postinstall-app.mjs')], {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      HOME: home,
+      TRACE_MCP_APP_DIRS: apps,
+      TRACE_MCP_PGREP_BIN: pgrepStub,
+    },
+  });
+
+  const after = versionOf(appPath);
+  if (after !== expected) {
+    throw new Error(`bundle is ${after}, expected ${expected} — the update did not land`);
+  }
+  console.log(`  bundle is now ${after}`);
+
+  // An unsigned or broken bundle launches to a Gatekeeper refusal, which is the
+  // same dead end as not updating at all.
+  execFileSync('/usr/sbin/spctl', ['-a', '-t', 'exec', appPath], { stdio: 'pipe' });
+  console.log('  gatekeeper: accepted');
+} catch (err) {
+  failure = err;
+} finally {
+  fs.rmSync(sandbox, { recursive: true, force: true });
+}
+
+if (failure) {
+  console.error(`FAIL ${from} -> ${expected}: ${failure.message}`);
+  process.exit(1);
+}
+console.log(`PASS ${from} -> ${expected}`);


### PR DESCRIPTION
## What

`scripts/verify-upgrade-path.mjs` — a check that answers "does an old install actually reach the current version" by running the real thing instead of reading it.

It downloads a real published release, installs it as a real `.app` at a path `locate-app.mjs` accepts, runs the real `scripts/postinstall-app.mjs` against it, and asserts the bundle on disk moved to this checkout's version and still passes Gatekeeper.

## Why

Every existing guard on the macOS updater asserts against a mock: the GitHub API is stubbed and the "bundle" is a fixture directory. That is the shape of test that let TRA-357 through — the code read correctly, shipped, and five real upgrades in a row ended `npm-only` while the app kept showing "Up to date". A silent update failure produces no complaint from the user, so it has to be caught here.

## Deliberately not in CI

It downloads ~110 MB per run. That is not a per-PR cost worth paying to re-answer a question that only changes when a release cuts. The Update Health autopilot (TRA-562) runs it and records which starting version it covered.

## Evidence

Three starting versions, all landing on 3.8.0, notarized and Gatekeeper-accepted:

```
PASS v1.50.0 -> 3.8.0   # two majors back — the version the reported incident was stuck on
PASS v2.0.0  -> 3.8.0
PASS v3.1.1  -> 3.8.0
```

Negative control — the assertion is live, not vacuous:

```
$ TRACE_MCP_NO_AUTO_UPDATE=1 node scripts/verify-upgrade-path.mjs --from v3.1.1
FAIL v3.1.1 -> 3.8.0: bundle is 3.1.1, expected 3.8.0 — the update did not land
```

Local gate: `pnpm run typecheck`, `pnpm run build`, `pnpm run biome:ci` clean; `pnpm run test` — 9353 passed, 8 skipped, 0 failed.

## Note on #689

#689 rewrites this area (macOS → electron-updater) and is open. No file overlap — this adds one new script. It reads `postinstall-app.mjs` only through the env seams (`TRACE_MCP_APP_DIRS`, `TRACE_MCP_PGREP_BIN`) that exist on both `master` and that branch, so it keeps working after #689 lands, where it will then be verifying the legacy→self-updating bridge.

Closes TRA-562 for this run.
