### PR TITLE
fix(site): light-mode disabled text was measured against the wrong background

### DIFF
--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -33,18 +33,27 @@ Two surfaces implement these: `docs/index.html` (landing, inline `<style>`) and
 | `--surface-raised` | `#1A1A1A` | `#F0F0F0` |
 | `--border` | `#222222` | `#E8E8E8` |
 | `--border-visible` | `#333333` | `#CCCCCC` |
-| `--text-disabled` | `#666666` | `#767676` |
+| `--text-disabled` | `#666666` | `#6D6D6D` |
 | `--text-secondary` | `#999999` | `#595959` |
 | `--text-primary` | `#E8E8E8` | `#1A1A1A` |
 | `--text-display` | `#FFFFFF` | `#000000` |
 | `--accent` | `#D71921` | `#B3151C` |
 
-Two light-mode values intentionally diverge from the landing page's inline
-copy, both for contrast on `#F5F5F5`:
+**Compute a light-mode ratio against the surface the text actually sits on.**
+Light mode has three of them — the page is `#F5F5F5`, a card or table or code
+block is `#FFFFFF`, and a raised cell is `#F0F0F0`. `#FFFFFF` is the most
+forgiving of the three and the one a colour picker defaults to, so a value
+checked only against white lands ~0.4 short on the page it ships on. That is
+how `--text-disabled` shipped at `#767676`: recorded here as "4.54:1", which
+is its ratio on `#FFFFFF` — on the `#F5F5F5` page it is 4.166:1, and every
+`scroll →` and `SEE ALSO` label on all 17 doc pages sat under AA for months
+while this file said they passed. `#6D6D6D` clears 4.5:1 on all three
+(4.75 / 5.17 / 4.54). Quote the worst of the three, not the best.
 
-- `--text-disabled` is `#767676` (4.54:1), not `#999999` (2.8:1).
-- `--accent` is `#B3151C` (6.1:1) for body-size link text; `#D71921` is 4.3:1,
-  which passes for large text but not for a 16px inline link.
+One light value still diverges on purpose: `--accent` is `#B3151C` on doc
+pages and `#D71921` on the landing. Both pass at body size (6.3:1 and 4.76:1
+on `#F5F5F5`); the docs run the darker one because a doc page is a wall of
+inline links, the landing runs the brand red because it is the brand.
 
 Dark mode is the default. Light is opt-in and equally first-class — never
 ship a change checked in one mode only.
@@ -239,7 +248,12 @@ appearance without a screenshot or a measurement is not a finding.
 - [ ] Exactly one image of a light/dark pair has computed `display: block` —
       read it off the element, in each theme.
 - [ ] Theme choice survives landing → doc page navigation.
-- [ ] Body text ≥ 4.5:1, large text ≥ 3:1, in both.
+- [ ] Body text ≥ 4.5:1, large text ≥ 3:1, in both — measured by walking the
+      rendered page and reading each element's own computed `color` against
+      its nearest opaque ancestor background, not by checking the token table
+      against one assumed surface. The token table has been wrong twice; the
+      DOM has not. Sweep the landing separately from a doc page: it carries
+      its own copy of the tokens (§7) and has drifted from this table before.
 
 **Widths**
 - [ ] Desktop (1440px) and narrow (≤500px) both screenshotted.

--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -88,11 +88,11 @@
   --surface-raised: #f0f0f0;
   --border: #e8e8e8;
   --border-visible: #cccccc;
-  --text-disabled: #767676; /* 4.54:1 on #F5F5F5 — Primer's #999 was 2.8:1 */
+  --text-disabled: #6d6d6d; /* 4.75:1 on #F5F5F5, 4.54:1 on #F0F0F0 — #767676 was 4.17:1 */
   --text-secondary: #595959;
   --text-primary: #1a1a1a;
   --text-display: #000000;
-  --accent: #b3151c; /* 6.1:1 on #F5F5F5; #D71921 is only 4.3:1 for body-size link text */
+  --accent: #b3151c; /* 6.3:1 on #F5F5F5, 6.9:1 on #FFFFFF — the landing keeps #D71921 */
   --accent-subtle: rgba(215, 25, 33, 0.12);
 
   --nav-bg: rgba(245, 245, 245, 0.85);

--- a/docs/index.html
+++ b/docs/index.html
@@ -295,8 +295,8 @@ layout: null
       --surface-raised: #F0F0F0;
       --border: #E8E8E8;
       --border-visible: #CCCCCC;
-      --text-disabled: #999999;
-      --text-secondary: #666666;
+      --text-disabled: #6D6D6D; /* 4.75:1 on #F5F5F5, 4.54:1 on #F0F0F0 — #999999 was 2.6:1 */
+      --text-secondary: #595959;
       --text-primary: #1A1A1A;
       --text-display: #000000;
       --accent: #D71921;


### PR DESCRIPTION
## What was wrong

`--text-disabled` in light mode fails WCAG AA for small text on both surfaces of the site, for two different reasons — and `docs/DESIGN-WEB.md` recorded both as passing.

**The landing page never got the fix.** Its inline copy still carried `--text-disabled: #999999` — **2.61:1** on the `#F5F5F5` page. Eleven distinct kinds of text render in it: every stat label, every service label, the app-screenshot caption, the footer headings, the version strip, the terminal's `scroll →` hint. Its `--text-secondary` had also drifted to `#666666` against the `#595959` the token table declares, so the landing's whole light ramp sat one step lighter than the contract.

**The doc pages got a fix computed against the wrong background.** `#767676` is 4.54:1 on `#FFFFFF` — which is what the CSS comment and DESIGN-WEB both recorded — but the page it ships on is `#F5F5F5`, where it is **4.166:1**. Every `scroll →` and `SEE ALSO` label on all 17 doc pages has been under AA since, while the standard said they passed.

## The fix

Light mode has three surfaces: `#F5F5F5` (page), `#FFFFFF` (card / table / code block), `#F0F0F0` (raised cell). `#6D6D6D` clears 4.5:1 on all three — **4.75 / 5.17 / 4.54**.

Both edits are inside `:root[data-theme="light"]`. **Dark mode is untouched.**

## Verification

Not the diff — the rendered DOM. Walked 7 pages in the browser at 1440px, reading each element's own computed `color` against its nearest opaque ancestor background:

| Page | light-mode AA failures before | after |
|---|---|---|
| `/` | 11 | 0 |
| `/comparisons.html` | 2 | 0 |
| `/vs/serena.html` | 2 | 0 |
| `/tools-index.html` | 2 | 0 |
| `/analytics.html` | 2 | 0 |
| `/configuration.html` | 2 | 0 |
| `/perf/` | 2 | 0 |

The two remaining sub-threshold marks on the landing are the ghost `94%` numeral (`#EBEBEB`, 1.09:1) and the YC badge glyph (white on `#FF6600`, 2.94:1). Both carry `aria-hidden="true"` and both are decorative — the YC badge has a real text label beside it. Correctly exempt.

Also swept in the same pass and found clean, so recorded rather than changed: all 23 pages have exactly one `h1`, zero page-level horizontal overflow at 1440px and 390px, zero emoji, every table wrapped and `scope`d, every `img` with `alt`, a skip link, and — on every page at both widths — the count of scroll regions that actually overflow exactly equals the count that are tab stops and the count that show the `scroll →` label. Focus rings are `--text-display` on every kind of tab stop across 8 pages. The scroll-region and focus work from #645/#676 is holding.

## Standard

`DESIGN-WEB.md` §1 now says to quote the ratio against the **worst** of the three light surfaces, not the most forgiving, and explains how this one got through. The review checklist's contrast line now says to measure the rendered DOM rather than check the token table against one assumed surface, and to sweep the landing separately because it carries its own copy of the tokens.

## Known, not fixed here

Dark mode's `--text-disabled: #666666` is **3.66:1** on `#000000` and 3.03:1 on `--surface-raised`. Raising it to clear 4.5:1 needs roughly `#858585`, which collapses it into `--text-secondary: #999999` and flattens the dark ramp. That is a design trade-off, not an arithmetic error — separate issue, not smuggled into this one.
