### PR TITLE
fix(ci): stop compiling better-sqlite3 — use its bundled prebuilds (TRA-567)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,11 @@ concurrency:
 
 env:
   # Skip OUR three postinstall scripts. We do NOT use --ignore-scripts on the
-  # build install because that would also block pnpm from compiling native
-  # bindings (better-sqlite3, @parcel/watcher) — listed in the package.json
-  # `pnpm.onlyBuiltDependencies`. Without the .node binary, 67 tests that hit
-  # SQLite fail with "Could not locate the bindings file". These env vars let
-  # our own scripts opt out cleanly while pnpm's native compile still runs.
+  # build install because that would also block the install scripts pnpm is
+  # allowed to run via `pnpm.onlyBuiltDependencies` (@parcel/watcher, esbuild).
+  # These env vars let our own scripts opt out cleanly while those still run.
+  # better-sqlite3 is deliberately NOT on that list — it ships N-API prebuilds
+  # and must never be compiled here (TRA-567).
   TRACE_MCP_NO_POSTINSTALL: '1'
   TRACE_MCP_NO_AUTO_UPDATE: '1'
   # Preflight (codesign warm-up) intentionally left enabled — it's a no-op on
@@ -101,7 +101,14 @@ jobs:
             # `apply_move` does path arithmetic on `path.relative` output, so
             # its separator handling is Windows-shaped by construction — #527
             # was all-green here and broke the release PR on Windows.
+            # TRA-567: fourth Windows-shaped hole, and the first one that came
+            # from a dependency rather than our code — a better-sqlite3 bump
+            # made pnpm compile it from source, which only fails on Windows.
+            # Any lockfile change can move a native binding, so dep bumps now
+            # pay the cross-platform run instead of the release job doing it.
             platform:
+              - 'pnpm-lock.yaml'
+              - 'tests/db/native-prebuild.test.ts'
               - 'src/tools/refactoring/**'
               - 'tests/refactoring/**'
               - 'src/dangerous-root.ts'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
             # pay the cross-platform run instead of the release job doing it.
             platform:
               - 'pnpm-lock.yaml'
+              - 'package.json'
               - 'tests/db/native-prebuild.test.ts'
               - 'src/tools/refactoring/**'
               - 'tests/refactoring/**'

--- a/package.json
+++ b/package.json
@@ -160,7 +160,6 @@
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",
-      "better-sqlite3",
       "esbuild",
       "simple-git-hooks"
     ],

--- a/tests/db/native-prebuild.test.ts
+++ b/tests/db/native-prebuild.test.ts
@@ -10,14 +10,19 @@ import { describe, expect, it } from 'vitest';
 // v3.9.0 Windows release once the runner image moved to Visual Studio 18 and
 // pnpm's bundled node-gyp read it as version "undefined".
 //
-// This asserts the property that has to hold, not the config line: the module
-// loads from a prebuilt binary and no node-gyp output exists. It fails if a
-// future bump drops prebuilds for a platform we build on.
+// This asserts the property that has to hold, not the config line: a prebuilt
+// binary exists for the platform running the test. `lib/binding.js` checks
+// `prebuilds/` before `build/Release`, so its presence is what decides whether
+// a toolchain is ever needed. It fails if a future bump drops prebuilds for a
+// platform we build on.
+//
+// Deliberately NOT asserting the absence of `build/` — pnpm's side-effects
+// cache can restore a previously compiled directory into the store without
+// running node-gyp at all, so its presence proves nothing either way.
 describe('better-sqlite3 native binding', () => {
-  it('loads a bundled prebuild without a node-gyp build', () => {
+  it('ships a prebuild for this platform', () => {
     const pkgRoot = path.dirname(require.resolve('better-sqlite3/package.json'));
 
-    expect(fs.existsSync(path.join(pkgRoot, 'build'))).toBe(false);
     expect(
       fs.existsSync(path.join(pkgRoot, 'prebuilds', `${process.platform}-${process.arch}.node`)) ||
         // musl linux gets its own prebuild name

--- a/tests/db/native-prebuild.test.ts
+++ b/tests/db/native-prebuild.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// TRA-567: better-sqlite3 13.x ships N-API prebuilds for every platform we
+// support inside its npm tarball, so it is deliberately NOT in the root
+// package.json `pnpm.onlyBuiltDependencies` — we never compile it. The 12.x
+// line downloaded per-ABI prebuilds from a GitHub release and fell through to
+// `node-gyp rebuild` when one was missing; that fallthrough is what killed the
+// v3.9.0 Windows release once the runner image moved to Visual Studio 18 and
+// pnpm's bundled node-gyp read it as version "undefined".
+//
+// This asserts the property that has to hold, not the config line: the module
+// loads from a prebuilt binary and no node-gyp output exists. It fails if a
+// future bump drops prebuilds for a platform we build on.
+describe('better-sqlite3 native binding', () => {
+  it('loads a bundled prebuild without a node-gyp build', () => {
+    const pkgRoot = path.dirname(require.resolve('better-sqlite3/package.json'));
+
+    expect(fs.existsSync(path.join(pkgRoot, 'build'))).toBe(false);
+    expect(
+      fs.existsSync(path.join(pkgRoot, 'prebuilds', `${process.platform}-${process.arch}.node`)) ||
+        // musl linux gets its own prebuild name
+        fs.existsSync(path.join(pkgRoot, 'prebuilds', `linuxmusl-${process.arch}.node`)),
+    ).toBe(true);
+  });
+
+  it('opens a database', async () => {
+    const Database = (await import('better-sqlite3')).default;
+    const db = new Database(':memory:');
+    try {
+      expect(db.prepare('select 1 as n').get()).toEqual({ n: 1 });
+    } finally {
+      db.close();
+    }
+  });
+});


### PR DESCRIPTION
Closes TRA-567.

## What broke

The v3.9.0 Windows release job ([run 33334309537](https://github.com/nikolai-vysotskyi/trace-mcp/actions/runs/33334309537)) died inside `pnpm install --frozen-lockfile`:

```
better-sqlite3 install$ node-gyp rebuild
gyp ERR! find VS unknown version "undefined" found at "C:\Program Files\Microsoft Visual Studio\18\Enterprise"
gyp ERR! find VS could not find a version of Visual Studio 2017 or newer to use
```

`windows-latest` moved to Visual Studio 18; pnpm 10.33's bundled node-gyp 11.5.0 doesn't know that version, reads it as `undefined`, then rejects VS2017 as unsupported on Node 22.

## Why the fix is neither of the three options in the issue

The compile should never have run. better-sqlite3 13.x switched to **N-API prebuilds bundled in the npm tarball**:

```
$ npm pack better-sqlite3@13.0.3 && tar tzf … | grep prebuilds
package/prebuilds/darwin-arm64.node   package/prebuilds/linux-x64.node
package/prebuilds/win32-x64.node      package/prebuilds/win32-arm64.node   …
```

That's also why every 13.x GitHub release has **zero** assets, while 12.11.1 has 138 per-ABI tarballs — the delivery mechanism moved into the package. `lib/binding.js` prefers `prebuilds/` and only falls back to `build/Release`.

We were compiling on top of a binary we already had. `binding.gyp` still exists in the tarball, and better-sqlite3 was still listed in `pnpm.onlyBuiltDependencies` from the 12.x days, so pnpm ran the implicit `node-gyp rebuild` on every platform. On macOS/Linux it silently wasted ~40s; on Windows it needed a toolchain that no longer resolves.

Removing it from the list:

- fixes the release job **and** the CI matrix,
- fixes `npm install -g trace-mcp` on any Windows machine without Build Tools — pinning `windows-2022` or forcing a newer node-gyp would have fixed only our runners and left users compiling,
- makes installs faster everywhere,
- needs no version pin and starts no deprecation clock.

Prebuild coverage is linux/darwin/win32 × x64/arm64 plus musl — a superset of what we build and ship.

## Also here

Dep bumps now run the cross-platform matrix (`pnpm-lock.yaml` added to the `changes` platform filter). This failure arrived via a green dependabot PR (#657); the release job was the first thing in the repo to run an install on Windows. That's the fourth Windows-shaped hole this filter has been widened for.

## Test evidence

`tests/db/native-prebuild.test.ts` asserts the property rather than the config line — the module loads from `prebuilds/` and no `build/` directory exists — so a future bump that drops prebuilds for a platform we build on fails here instead of at release time.

```
$ rm -rf node_modules && pnpm install --frozen-lockfile
Ignored build scripts: better-sqlite3@13.0.3, onnxruntime-node@1.24.3.

$ node -e '…' 
sqlite: 3.53.4 row: 42
no build dir: true

$ pnpm exec vitest run …
Test Files  754 passed | 2 skipped
      Tests  8801 passed | 5 skipped
```

(one unrelated flake, `tests/init/launcher-integration.test.ts`, spawn timeout under full-suite load — passes in isolation on this branch and on master.)

Windows verification: cross-platform matrix on this PR — it now runs, because the lockfile filter above matches.

## Release follow-up (TRA-566)

v3.9.0's tag doesn't contain this fix, so the `workflow_dispatch` republish path can't produce its Windows assets. Once this merges, the next release-please cut ships complete on both platforms and becomes `Latest`; v3.9.0 stays a pre-release, and `/releases/latest` keeps resolving to a complete release throughout.