### PR TITLE
fix(app): resolve autoUpdater dynamic export and wrap long menu header status text

### DIFF
--- a/packages/app/src/main/__tests__/packaged-deps.test.ts
+++ b/packages/app/src/main/__tests__/packaged-deps.test.ts
@@ -30,4 +30,10 @@ describe('packaged production dependencies', () => {
     expect(pkg.dependencies?.['react-i18next']).toBeUndefined();
     expect(pkg.devDependencies?.['react-i18next']).toBeDefined();
   });
+
+  it('exports autoUpdater on default namespace for dynamic import interop', async () => {
+    const mod = await import('electron-updater');
+    const hasAutoUpdater = 'autoUpdater' in (mod.default ?? mod) || 'autoUpdater' in mod;
+    expect(hasAutoUpdater).toBe(true);
+  });
 });

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -710,7 +710,11 @@ async function getAutoUpdater() {
   if (UPDATE_CHANNEL !== 'electron-updater') {
     throw new Error(`electron-updater is not the update channel on ${process.platform}`);
   }
-  const { autoUpdater } = await import('electron-updater');
+  const mod = await import('electron-updater');
+  const autoUpdater = mod.autoUpdater ?? mod.default?.autoUpdater;
+  if (!autoUpdater) {
+    throw new Error('electron-updater did not export autoUpdater');
+  }
   // Download only when the user asks: the renderer's Update button drives the
   // whole flow, so a silent background download would fight the UI's state.
   autoUpdater.autoDownload = false;

--- a/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
@@ -104,6 +104,19 @@ describe('sidebar app menu', () => {
     expect(header?.querySelector('.status')?.className).toContain('is-info');
   });
 
+  it('renders long status text cleanly in the header without breaking structure', () => {
+    const longError =
+      'Cannot set properties of undefined (setting autoDownload) — long status message that wraps across multiple lines';
+    const { trigger } = renderMenu({
+      update: { available: false, current: '3.10.0', error: longError },
+    });
+    const header = openMenu(trigger).querySelector('.ws-ctx-header');
+    const statusText = header?.querySelector('.status .text');
+    expect(statusText?.textContent).toBe(longError);
+    expect(statusText?.getAttribute('title')).toBe(longError);
+    expect(header?.querySelector('.status')?.className).toContain('is-warn');
+  });
+
   /* Nikolai on the four-row APPEARANCE group: "это оч плохо во всплывашке".
      One labelled row with the switcher inline — and the segments are icon-only,
      so each one's accessible NAME is what has to carry Auto / Light / Dark. */

--- a/packages/app/src/renderer/styles/island.css
+++ b/packages/app/src/renderer/styles/island.css
@@ -555,6 +555,7 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
   position: fixed;
   z-index: 91;
   min-width: 220px;
+  max-width: 280px;
   padding: 5px;
   border-radius: var(--radius-popover);
   background: var(--surface-raised);
@@ -768,17 +769,18 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
 }
 .ws-ctx-header .status {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 6px;
   margin-top: 1px;
   font-size: 11px;
+  line-height: 14px;
   color: var(--label-secondary);
 }
 .ws-ctx-header .status .text {
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  white-space: normal;
 }
 /* Never colour alone: the dot repeats what the sentence beside it already
    says, it does not replace it. */
@@ -786,6 +788,7 @@ body.ws-resizing [data-lattice-claude] { pointer-events: none !important; }
   width: 6px;
   height: 6px;
   flex: none;
+  margin-top: 4px;
   border-radius: 50%;
   background: var(--label-secondary);
   box-shadow: 0 0 0 0.5px color-mix(in srgb, var(--label-secondary) 60%, black 40%);


### PR DESCRIPTION
Fixes TRA-586 (issue 01a058dc-6a4e-748d-b920-61c6bfb5a018)

### Changes
1. **Fix  undefined error**: When dynamic importing , CJS getter exports are exposed under . Safely fall back to  to prevent `TypeError: Cannot set properties of undefined (setting 'autoDownload')`.
2. **Prevent popover width expansion**:
   - Set `max-width: 280px` on `.ws-ctx-menu` to cap menu width.
   - Set `white-space: normal`, `word-break: break-word`, and `overflow-wrap: break-word` on `.ws-ctx-header .status .text` so that long error messages or long translated strings wrap to subsequent lines instead of blowing out popover width.
   - Adjust status dot alignment (`align-items: flex-start`, `margin-top: 4px`) so it stays centered with the first line of text.
3. **Tests**: Added tests for long status wrapping in `AppMenu.test.tsx` and dynamic import export resolution in `packaged-deps.test.ts`.