### PR TITLE
fix(app): remove broken native macOS tab bar under hiddenInset (TRA-587)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -837,54 +837,18 @@ Two things to know before touching the offset:
 `src/renderer/styles/__tests__/tokens.test.ts` fail if the constant, the token, the
 stylesheets and `tray.ts` ever drift apart again.
 
-### The second top band: the native tab bar is macOS's, not ours
+### macOS window chrome and multi-window architecture
 
-Opening a project opens a native macOS **tab**, so the normal state of this app is a
-tabbed window — not an edge case. AppKit then draws a tab bar, and because the window is
-`titleBarStyle: 'hiddenInset'` (full-size content view) it draws it **over** the web
-contents: `innerHeight` stays equal to `outerHeight`, nothing reflows, and the tab bar
-simply covers the top 20px of whatever the renderer painted. That is most of the
-band above, so the surface toolbar and the sidebar toggle went from "misaligned" to
-"gone" (TRA-399).
+In earlier versions, opening a project attached as a native macOS AppKit tab (`tabbingIdentifier`, `addTabbedWindow`).
+However, on `titleBarStyle: 'hiddenInset'` (full-size content view) windows, AppKit's native `NSTabBar` has no standard titlebar container allocated and renders squashed/clipped at the top border of the window, displacing traffic lights and causing layout distortion across tab switches and focus events (TRA-370, TRA-399, TRA-432, TRA-523, TRA-587).
 
-The rule that follows: **a band we do not draw still has to be reserved.** The tab bar is
-AppKit's, we cannot restyle it and we cannot ask whether it is up — so:
+Under TRA-587:
+- **macOS uses clean, independent windows**: Each window (Workspace + individual projects) is an independent window with standard `titleBarStyle: 'hiddenInset'` and native vibrancy sidebar.
+- **Top band baseline is unified**: The traffic lights always sit centered in the 44px top band at `{ x: 14, y: 15 }` (`TRAFFIC_LIGHT_X`, `TRAFFIC_LIGHT_Y`).
+- **Sidebar toggle stays stable**: A `78px` left pad on `.ws-sidebar-titlebar` consistently clears the traffic lights without shifting or recalculating.
+- **Non-macOS platforms**: Windows and Linux use `WindowTabBar` (a custom HTML tab strip broadcast via IPC).
 
-- `MAC_TAB_BAR_H` (20px, measured, `chrome-metrics.ts`) and `--mac-tabbar-h` are one
-  number, exactly like `TOP_BAND_H`. The stage reserves it with `padding-top` while
-  `data-tabbar="on"`, and the app's own band starts below it. Never draw into it.
-- **A geometry we do not draw is measured from two independent landmarks, never one.**
-  This constant shipped wrong twice off a single reading — 36 (TRA-370), then 28
-  (TRA-432) — because each time one landmark was found, believed, and shipped. Take
-  both: where the bar's own plate stops (the same row at every x across the window),
-  and where the control it carries is centred (the selected tab's pill). They have to
-  agree; when they do not, neither is the answer yet. Measured on macOS 26.5 /
-  Electron 41.10.6 at 2x: plate ends at 20.0, tab pill spans 0.5–17.5, centre 9.0.
-- **Every pixel of surplus in a reserved band is visible twice.** It renders as a dead
-  strip of window backdrop under the bar, and it drops the traffic lights by half its
-  height, because they are centred in what this number says. 36 put them 8px below the
-  tabs; 28 put them 4px below (TRA-523, reported twice before it was measured right).
-- **Assert chrome geometry against something outside the constant.** 28 went back to 36
-  on its own when an unrelated PR was squashed from a stale base (#659), and the suite
-  stayed green: the only assertion compared `MAC_TAB_BAR_H` with itself. A test written
-  against a measured AppKit landmark fails on both a bad re-measurement and a silent
-  revert; a test written against the constant fails on neither.
-- **The traffic lights belong to whichever band holds the top line**, not to a constant.
-  With no tab bar that is our 44px band (centre 22); with one it is AppKit's 20px tab bar
-  (centre 10, the tab pill's own centre line). `trafficLightYFor(tabBarVisible)` is the
-  only place that chooses, and `tab-chrome.test.ts` asserts the result against the
-  measured tab centre — not against `MAC_TAB_BAR_H`, which is the number under suspicion.
-- **`trafficLightPosition` is applied once, at window creation, and AppKit re-lays the
-  title bar out under it.** So every event that can change the tab count re-applies it —
-  `show`, `focus`, `closed`, `did-finish-load` — synchronously and again a frame later,
-  because the tab bar comes and goes asynchronously. Without that, closing back to one tab
-  left the lights 6px high until a window resize forced a layout pass, which is the "nudge
-  the window and it fixes itself" users report.
-- The 78px that clears the lights in `.ws-sidebar-titlebar` goes away with them: while the
-  tab bar holds the lights, reserving their width leaves the toggle floating in a gap.
-
-`src/main/__tests__/tab-chrome.test.ts` drives the real window events and fails if any of
-those stops firing.
+`src/main/__tests__/tab-chrome.test.ts` and `src/main/__tests__/chrome-metrics.test.ts` assert consistent traffic light placement and independent window management.
 
 ### Where a global action lives
 

--- a/packages/app/src/main/__tests__/tab-chrome.test.ts
+++ b/packages/app/src/main/__tests__/tab-chrome.test.ts
@@ -1,36 +1,22 @@
-/* TRA-399. Opening a project opens a native macOS tab, and AppKit answers with
-   a tab bar — a second top band, on top of the one the app draws. Two things
-   have to be re-derived every time the tab count crosses 1, and neither was:
+/* TRA-587. Native macOS tabs with titleBarStyle: 'hiddenInset' resulted in a
+   squashed, broken NSTabBar rendered at the top edge of the window, misaligned
+   traffic lights, and layout distortion. Each window (Workspace + individual
+   projects) opens as a clean independent window on macOS with consistent chrome. */
 
-   - the renderer has to reserve the tab bar's height, or the tab bar covers the
-     surface toolbar and the sidebar toggle outright;
-   - the traffic lights have to be re-placed for the band that now holds them,
-     because `trafficLightPosition` is applied once at window creation and
-     AppKit re-lays the title bar out underneath it. The window kept an offset
-     measured against a band that was no longer there until a resize forced a
-     layout pass — which is exactly the "nudge the window and it fixes itself"
-     the bug was reported as.
-
-   The old code fired only from `projectWindows.size === 0`, i.e. only when the
-   LAST project tab closed, and never touched the button position at all. These
-   tests drive the real window events. */
-
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
-  MAC_TAB_BAR_H,
   TOP_BAND_H,
+  TRAFFIC_LIGHT_D,
   TRAFFIC_LIGHT_X,
   TRAFFIC_LIGHT_Y,
-  TRAFFIC_LIGHT_Y_TABBED,
   trafficLightCentreY,
-  trafficLightYFor,
 } from '../../shared/chrome-metrics.js';
 
 /** A stand-in for one BrowserWindow, recording what the app does to its chrome. */
 class FakeWindow {
   static all: FakeWindow[] = [];
+  opts: Record<string, unknown>;
   handlers = new Map<string, Array<() => void>>();
-  buttonPositions: Array<{ x: number; y: number }> = [];
   sent: Array<{ channel: string; args: unknown[] }> = [];
   destroyed = false;
   wcHandlers = new Map<string, Array<() => void>>();
@@ -49,7 +35,8 @@ class FakeWindow {
     setWindowOpenHandler: vi.fn(),
   };
 
-  constructor() {
+  constructor(opts: Record<string, unknown> = {}) {
+    this.opts = opts;
     FakeWindow.all.push(this);
   }
 
@@ -65,23 +52,11 @@ class FakeWindow {
   }
 
   isDestroyed = () => this.destroyed;
-  setWindowButtonPosition = (p: { x: number; y: number }) => this.buttonPositions.push(p);
   loadURL = () => this.webContents.emit('did-finish-load');
-  // Real windows emit these; the events are how the app learns the tab count moved.
   show = () => this.emit('show');
   focus = () => this.emit('focus');
   setTitle = vi.fn();
   addTabbedWindow = vi.fn();
-
-  /** The last chrome state this window was told to adopt. */
-  get chrome() {
-    const tabbar = this.sent.filter((s) => s.channel === 'tabbar-changed').at(-1);
-    return {
-      lightY: this.buttonPositions.at(-1)?.y,
-      lightX: this.buttonPositions.at(-1)?.x,
-      tabBarVisible: tabbar?.args[0],
-    };
-  }
 }
 
 vi.mock('electron', () => ({
@@ -107,112 +82,63 @@ vi.mock('../api-client', () => ({
 vi.mock('../daemon-lifecycle', () => ({ ensureDaemon: vi.fn(), restartDaemon: vi.fn() }));
 vi.mock('../i18n', () => ({ t: (k: string) => k, startI18n: vi.fn() }));
 
-/**
- * A fresh tray module on a fresh set of windows, with the menu window and one
- * project tab open — the state the bug is reported in. `tray.ts` keeps its
- * windows in module scope, so each test needs its own copy of the module.
- */
-async function openMenuAndProject() {
-  FakeWindow.all.length = 0;
-  vi.resetModules();
-  const platform = process.platform;
-  Object.defineProperty(process, 'platform', { value: 'darwin' });
-  const { showMenuWindow } = await import('../tray.js');
-  const { ipcMain } = await import('electron');
-  try {
-    showMenuWindow();
-    const menu = FakeWindow.all[0];
-    menu.emit('ready-to-show');
-
-    // Newest registration first: the ipcMain mock outlives vi.resetModules(),
-    // so earlier tests' handlers — bound to their own module state — are still
-    // in the call list, and the oldest one would open nothing.
-    const calls = [...(ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls].reverse();
-    const openProject = calls.find((c: unknown[]) => c[0] === 'open-project-tab')?.[1] as (
-      event: unknown,
-      root: string,
-    ) => unknown;
-    openProject({}, '/tmp/demo');
-    const project = FakeWindow.all[1];
-    project.emit('ready-to-show');
-    return { menu, project };
-  } finally {
-    Object.defineProperty(process, 'platform', { value: platform });
-  }
-}
-
-describe('the traffic lights follow whichever band owns the top line', () => {
-  it('centres them in the app band when there is no tab bar', () => {
-    expect(trafficLightCentreY(trafficLightYFor(false))).toBe(TOP_BAND_H / 2);
-    expect(trafficLightYFor(false)).toBe(TRAFFIC_LIGHT_Y);
+describe('the traffic lights sit on the top band centre line', () => {
+  it('centres them in the 44px top band', () => {
+    expect(trafficLightCentreY()).toBe(TOP_BAND_H / 2);
+    expect(TRAFFIC_LIGHT_Y).toBe((TOP_BAND_H - TRAFFIC_LIGHT_D) / 2 - 1);
   });
 
-  it('centres them in the tab bar when AppKit is drawing one', () => {
-    expect(trafficLightCentreY(trafficLightYFor(true))).toBe(MAC_TAB_BAR_H / 2);
-    expect(trafficLightYFor(true)).toBe(TRAFFIC_LIGHT_Y_TABBED);
-  });
-
-  /* The one assertion the earlier attempts could not have passed. They compared
-     the lights against MAC_TAB_BAR_H, which is the number that was wrong, so
-     they agreed with themselves and shipped lights 8px (TRA-370) then 4px
-     (TRA-432) below the tabs — and stayed green when #659 silently put the
-     first value back. MAC_TAB_CENTRE_Y is measured off AppKit
-     instead: the selected tab's pill spans y=0.5..17.5 on a 2x capture of a
-     real two-tab window (macOS 26.5 / Electron 41.10.6), and the plate it sits
-     on ends at y=20.0 — 10 is the line the user sees the tabs on. Re-measure
-     it, do not derive it from MAC_TAB_BAR_H (TRA-523). */
-  it('puts them on the line the tabs are actually drawn on', () => {
-    const MAC_TAB_CENTRE_Y = 10;
-    expect(trafficLightCentreY(trafficLightYFor(true))).toBe(MAC_TAB_CENTRE_Y);
-  });
-
-  it('does not reuse one offset for both bands', () => {
-    expect(TRAFFIC_LIGHT_Y_TABBED).not.toBe(TRAFFIC_LIGHT_Y);
-  });
-});
-
-describe('window chrome is re-derived when the tab count crosses 1', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
-  it('reserves the tab bar and moves the lights into it when a tab opens', async () => {
-    const { menu, project } = await openMenuAndProject();
-    vi.runAllTimers();
-
-    for (const win of [menu, project]) {
-      expect(win.chrome.tabBarVisible).toBe(true);
-      expect(win.chrome.lightY).toBe(TRAFFIC_LIGHT_Y_TABBED);
-      expect(win.chrome.lightX).toBe(TRAFFIC_LIGHT_X);
+  it('sets consistent traffic light coordinates on window creation', async () => {
+    FakeWindow.all.length = 0;
+    vi.resetModules();
+    const platform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const { showMenuWindow } = await import('../tray.js');
+    try {
+      showMenuWindow();
+      const menu = FakeWindow.all[0];
+      expect(menu.opts.trafficLightPosition).toEqual({
+        x: TRAFFIC_LIGHT_X,
+        y: TRAFFIC_LIGHT_Y,
+      });
+      // No tabbingIdentifier on macOS — prevents broken native NSTabBar
+      expect(menu.opts.tabbingIdentifier).toBeUndefined();
+      expect(menu.addTabbedWindow).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, 'platform', { value: platform });
     }
   });
 
-  /* The reported bug: after closing back to one tab the lights kept the tabbed
-     offset until the window was resized. Nothing re-applied the position. */
-  it('puts the lights back on the app band when the tab closes — no resize', async () => {
-    const { menu, project } = await openMenuAndProject();
-    vi.runAllTimers();
+  it('opens project windows independently without attaching native tabs', async () => {
+    FakeWindow.all.length = 0;
+    vi.resetModules();
+    const platform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const { showMenuWindow } = await import('../tray.js');
+    const { ipcMain } = await import('electron');
+    try {
+      showMenuWindow();
+      const menu = FakeWindow.all[0];
+      menu.emit('ready-to-show');
 
-    project.destroyed = true;
-    project.emit('closed');
-    vi.runAllTimers();
+      const calls = [...(ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls].reverse();
+      const openProject = calls.find((c: unknown[]) => c[0] === 'open-project-tab')?.[1] as (
+        event: unknown,
+        root: string,
+      ) => unknown;
+      openProject({}, '/tmp/demo');
+      const project = FakeWindow.all[1];
+      project.emit('ready-to-show');
 
-    expect(menu.chrome.tabBarVisible).toBe(false);
-    expect(menu.chrome.lightY).toBe(TRAFFIC_LIGHT_Y);
-    expect(trafficLightCentreY(menu.chrome.lightY as number)).toBe(TOP_BAND_H / 2);
-  });
-
-  /* The old signal was `projectWindows.size === 0`, so closing the MENU tab —
-     leaving one project window, no tab bar — told nobody anything. */
-  it('reports the tab bar gone when the menu tab is the one that closes', async () => {
-    const { menu, project } = await openMenuAndProject();
-    vi.runAllTimers();
-
-    menu.destroyed = true;
-    menu.emit('closed');
-    vi.runAllTimers();
-
-    expect(project.chrome.tabBarVisible).toBe(false);
-    expect(project.chrome.lightY).toBe(TRAFFIC_LIGHT_Y);
+      expect(menu.addTabbedWindow).not.toHaveBeenCalled();
+      expect(project.opts.tabbingIdentifier).toBeUndefined();
+      expect(project.opts.trafficLightPosition).toEqual({
+        x: TRAFFIC_LIGHT_X,
+        y: TRAFFIC_LIGHT_Y,
+      });
+    } finally {
+      Object.defineProperty(process, 'platform', { value: platform });
+    }
   });
 });
+

--- a/packages/app/src/main/preload.ts
+++ b/packages/app/src/main/preload.ts
@@ -67,13 +67,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.removeListener('fullscreen-changed', handler);
     };
   },
-  onTabBarChanged: (callback: (visible: boolean) => void) => {
-    const handler = (_event: Electron.IpcRendererEvent, visible: boolean) => callback(visible);
-    ipcRenderer.on('tabbar-changed', handler);
-    return () => {
-      ipcRenderer.removeListener('tabbar-changed', handler);
-    };
-  },
   /** Mirror the renderer's appearance choice onto `nativeTheme`, so the
       sidebar's native vibrancy matches the theme the DOM is painting. */
   setAppearance: (appearance: 'auto' | 'light' | 'dark'): void => {

--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { app, BrowserWindow, ipcMain, Menu, nativeImage, nativeTheme, Tray } from 'electron';
-import { TRAFFIC_LIGHT_X, TRAFFIC_LIGHT_Y, trafficLightYFor } from '../shared/chrome-metrics.js';
+import { TRAFFIC_LIGHT_X, TRAFFIC_LIGHT_Y } from '../shared/chrome-metrics.js';
 import { parseWindowMode, shouldRunAsAccessory } from '../shared/window-mode.js';
 import { DaemonClient } from './api-client';
 import {
@@ -79,8 +79,6 @@ function getTrayIconPaths(): { active: string; inactive: string } {
     inactive: path.join(ASSETS, `tray-icon-dim-${theme}.png`),
   };
 }
-
-const TABBING_ID = 'trace-mcp-tabs';
 
 let tray: Tray;
 let menuWindow: BrowserWindow | null = null;
@@ -179,8 +177,6 @@ function createWindowOptions(
     ...extraOpts,
   };
   if (isMac) {
-    // tabbingIdentifier is macOS-only
-    opts.tabbingIdentifier = TABBING_ID;
     // Native NSVisualEffectView behind the whole window. The renderer paints
     // the content pane opaque and leaves the sidebar region transparent, so
     // only the sidebar reads as vibrant. `visualEffectState: 'followWindow'`
@@ -219,15 +215,6 @@ function safeSend(win: BrowserWindow | null, channel: string, ...args: unknown[]
 function setupWindowEvents(win: BrowserWindow): void {
   win.on('enter-full-screen', () => safeSend(win, 'fullscreen-changed', true));
   win.on('leave-full-screen', () => safeSend(win, 'fullscreen-changed', false));
-
-  /* Every event that can change how many tabs the group holds, or that gives a
-     renderer that missed the last broadcast a chance to catch up. 'closed' is
-     the one the bug was reported against; 'focus' also covers a tab dragged out
-     into its own window, which fires nothing else we can see. */
-  win.on('show', syncTabChromeSoon);
-  win.on('focus', syncTabChromeSoon);
-  win.on('closed', syncTabChromeSoon);
-  win.webContents.on('did-finish-load', syncTabChrome);
 
   // Auto-reload on renderer crash (GPU crash, OOM, etc.)
   win.webContents.on('render-process-gone', (_event, details) => {
@@ -271,64 +258,6 @@ function presentWindow(win: BrowserWindow): void {
   ensureDockVisible();
   win.show();
   win.focus();
-}
-
-/* ---- The native tab bar (macOS), and the two things it breaks (TRA-399) ----
-
-   Every window we open carries the same `tabbingIdentifier`, so a second window
-   is a second TAB, and AppKit answers with a tab bar. Two consequences, both of
-   which have to be re-derived whenever the tab count crosses 1:
-
-   1. The tab bar is painted over the top of the web contents (the window is
-      full-size content view, so the viewport never shrinks). The renderer has
-      to reserve MAC_TAB_BAR_H or the tab bar covers its whole top band — the
-      Files/Symbols control, Filter, Search, Fit, Live, ··· and the sidebar
-      toggle, all of them, unreachable. `tabbar-changed` is that signal.
-
-   2. The traffic lights are ours to place, and the band they belong to changes:
-      44px while we own the top line, 36px (the tab bar) while AppKit does.
-      `trafficLightPosition` is applied once at window creation, and AppKit
-      re-lays the title bar out when the tab bar comes and goes — so the custom
-      offset has to be re-applied, or the lights keep an offset measured against
-      a band that is no longer there until something else forces a layout pass.
-      A window resize was the "fix" users found. */
-
-/** Is AppKit drawing a tab bar? True exactly when the group holds >1 tab. */
-function tabBarVisible(): boolean {
-  return isMac && BrowserWindow.getAllWindows().filter((w) => !w.isDestroyed()).length > 1;
-}
-
-/**
- * Re-derive both, for every window, from the tab count that holds right now.
- * Idempotent and cheap, so it can be called from anything that might have
- * changed the answer rather than only from the one path we thought of.
- */
-function syncTabChrome(): void {
-  if (!isMac) return;
-  const visible = tabBarVisible();
-  const y = trafficLightYFor(visible);
-  for (const win of BrowserWindow.getAllWindows()) {
-    if (win.isDestroyed()) continue;
-    try {
-      win.setWindowButtonPosition({ x: TRAFFIC_LIGHT_X, y });
-    } catch {
-      /* window torn down between the guard and the call */
-    }
-    safeSend(win, 'tabbar-changed', visible);
-  }
-}
-
-/**
- * The same, once the run loop has caught up. AppKit adds and removes the tab
- * bar asynchronously around 'closed' and 'ready-to-show', so a position written
- * synchronously can be measured against the title bar we are leaving rather
- * than the one we are arriving at. Running it twice costs nothing and removes
- * the race — never rely on the synchronous pass alone.
- */
-function syncTabChromeSoon(): void {
-  if (!isMac) return;
-  syncTabChrome();
-  setTimeout(syncTabChrome, 120);
 }
 
 // ── Custom tab bar for Windows ─────────────────────────────────
@@ -439,14 +368,6 @@ export function showMenuWindow(tab?: string): void {
   menuWindow = new BrowserWindow(createWindowOptions());
   menuWindow.loadURL(getRendererUrl({ view: 'menu', ...(tab ? { tab } : {}) }));
 
-  // Attach to existing tab group if project windows are open (macOS only)
-  if (isMac) {
-    const existingTab = [...projectWindows.values()].find((w) => !w.isDestroyed());
-    if (existingTab) {
-      existingTab.addTabbedWindow(menuWindow);
-    }
-  }
-
   menuWindow.webContents.on('did-finish-load', () => {
     menuWindow?.setTitle(t('tray:menuWindow'));
   });
@@ -484,11 +405,6 @@ function openProjectTab(root: string): void {
   projectWindows.set(root, win);
 
   win.loadURL(getRendererUrl({ view: 'project', root }));
-
-  // Attach as a native macOS tab to the menu window
-  if (isMac && menuWindow && !menuWindow.isDestroyed()) {
-    menuWindow.addTabbedWindow(win);
-  }
 
   win.once('ready-to-show', () => {
     presentWindow(win);

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -721,7 +721,6 @@ export function App() {
   const [sidebarWidth, setSidebarWidth] = useState(readSidebarWidth);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(readSidebarCollapsed);
   const [_isFullscreen, setIsFullscreen] = useState(false);
-  const [tabBarVisible, setTabBarVisible] = useState(false);
   const [quickOpen, setQuickOpen] = useState(false);
   const [quickFiles, setQuickFiles] = useState<string[]>([]);
   /* The element surfaces portal their toolbar into. Callback ref rather than
@@ -988,14 +987,6 @@ export function App() {
       return api.onFullscreenChanged((fs: boolean) => setIsFullscreen(fs));
     }
   }, []);
-
-  /* Opening a project opens a native macOS tab, and AppKit then paints its tab
-     bar over the top of the web contents — the viewport does not shrink, so
-     everything we draw on the top line ends up underneath it (TRA-399). The
-     main process reports the tab bar's presence; the stage reserves its height.
-     Wired here rather than in the sidebar because the whole window shifts. */
-  useEffect(() => window.electronAPI?.onTabBarChanged?.(setTabBarVisible), []);
-
   const isGraph = isProject && projectTab === 'graph';
   const needsFlexLayout = isProject && (projectTab === 'graph' || projectTab === 'ask');
   /* Surfaces that draw their own toolbar own the whole pane: a 16px inset turns
@@ -1032,7 +1023,6 @@ export function App() {
       className="ws-stage flex flex-col h-screen"
       data-mode={theme}
       data-platform={hasInsetTitleBar() ? 'mac' : 'other'}
-      data-tabbar={tabBarVisible ? 'on' : undefined}
     >
       {showOnboarding && <GuardOnboarding onClose={() => setShowOnboarding(false)} />}
       {quickOpen && <QuickOpen items={quickOpenItems()} onClose={() => setQuickOpen(false)} />}

--- a/packages/app/src/renderer/electron.d.ts
+++ b/packages/app/src/renderer/electron.d.ts
@@ -53,7 +53,6 @@ declare global {
       openProjectTab: (root: string) => Promise<{ ok: boolean }>;
       closeCurrentTab: () => Promise<{ ok: boolean }>;
       onFullscreenChanged: (callback: (isFullscreen: boolean) => void) => () => void;
-      onTabBarChanged: (callback: (visible: boolean) => void) => () => void;
       setAppearance: (appearance: 'auto' | 'light' | 'dark') => void;
       setLocale: (locale: string) => void;
       syncSidebarWidth: (width: number) => void;

--- a/packages/app/src/renderer/styles/__tests__/tokens.test.ts
+++ b/packages/app/src/renderer/styles/__tests__/tokens.test.ts
@@ -2,7 +2,6 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
-  MAC_TAB_BAR_H,
   TOP_BAND_H,
   TRAFFIC_LIGHT_D,
   TRAFFIC_LIGHT_Y,
@@ -198,24 +197,6 @@ describe('design tokens', () => {
         expect(body, `${selector} not found`).toBeDefined();
         expect(body).toMatch(/height:\s*var\(--top-band-h\)/);
       }
-    });
-
-    /* TRA-399. The macOS tab bar is a SECOND band on the same line, drawn by
-       AppKit over the top of the web contents — the viewport never shrinks, so
-       without a reservation the tab bar simply covers the band above and every
-       control on it. Same discipline as --top-band-h: one owner, one token. */
-    it('generates --mac-tabbar-h from src/shared/chrome-metrics.ts', () => {
-      expect(tokensCss).toMatch(new RegExp(`--mac-tabbar-h:\\s*${MAC_TAB_BAR_H}px`));
-    });
-
-    it('reserves the tab bar on macOS instead of drawing under it', () => {
-      const sidebarCss = readFileSync(
-        fileURLToPath(new URL('../sidebar.css', import.meta.url)),
-        'utf8',
-      );
-      expect(sidebarCss).toMatch(
-        /\[data-platform="mac"\]\[data-tabbar="on"\]\s*\{[^}]*padding-top:\s*var\(--mac-tabbar-h\)/,
-      );
     });
 
     it('leaves no stylesheet writing a band height by hand', () => {

--- a/packages/app/src/renderer/styles/sidebar.css
+++ b/packages/app/src/renderer/styles/sidebar.css
@@ -17,16 +17,6 @@
   background: var(--surface-sunken, var(--surface));
 }
 
-/* The native macOS tab bar is AppKit's band, not ours, and it is painted OVER
-   the top of the web contents — `innerHeight` never shrinks, so without this
-   the tab bar simply covers the app's own top band and every control on it
-   (TRA-399). Reserve its height so our band starts below it instead of under
-   it. Only on macOS, and only while a tab bar is actually up: the main process
-   sets data-tabbar from the live tab count. */
-.ws-stage[data-platform="mac"][data-tabbar="on"] {
-  padding-top: var(--mac-tabbar-h);
-}
-
 .ws-shell {
   display: flex;
   flex: 1;
@@ -431,16 +421,6 @@
   padding-left: 78px;
 }
 
-/* …and the 78px that clears the traffic lights goes with them. With a tab bar
-   up the lights are in AppKit's band, not ours, so reserving their width here
-   would leave the sidebar toggle floating in a gap nothing occupies. 6px lines
-   its box up with the selection pills below it. */
-.ws-stage[data-platform="mac"][data-tabbar="on"] .ws-sidebar-titlebar {
-  padding-left: 6px;
-}
-.ws-stage[data-platform="mac"][data-tabbar="on"] .ws-shell.is-collapsed .ws-content-head {
-  padding-left: 12px;
-}
 .ws-content-body {
   flex: 1;
   min-height: 0;

--- a/packages/app/src/renderer/styles/tokens.css
+++ b/packages/app/src/renderer/styles/tokens.css
@@ -149,13 +149,6 @@
      and styles/__tests__/tokens.test.ts fails if these two drift apart. */
   --top-band-h: 44px;
 
-  /* The band we do NOT draw (TRA-399). A macOS tabbed window grows an AppKit
-     tab bar, painted over the top of the web contents — the viewport never
-     shrinks, because the window is full-size content view. Reserve it or it
-     covers the whole top band above. Same owner, same guard:
-     src/shared/chrome-metrics.ts (MAC_TAB_BAR_H) and tokens.test.ts. */
-  --mac-tabbar-h: 20px;
-
   /* ---- Motion */
   --dur-micro: 120ms;
   --dur-standard: 200ms;

--- a/packages/app/src/shared/chrome-metrics.ts
+++ b/packages/app/src/shared/chrome-metrics.ts
@@ -37,54 +37,10 @@ const centreLightsIn = (bandH: number): number =>
 /** Offset that centres the lights in the band. Never write this number down. */
 export const TRAFFIC_LIGHT_Y = centreLightsIn(TOP_BAND_H);
 
-/* ---- The second band, the one we do not draw (TRA-399) --------------------
-   A macOS tabbed window grows an AppKit tab bar. The window is
-   `titleBarStyle: 'hiddenInset'`, i.e. full-size content view, so the web
-   contents does NOT shrink — `innerHeight` stays equal to `outerHeight` and the
-   tab bar is painted OVER the top of the renderer. Reserve its height or it
-   swallows whatever the app drew on that line, which is the entire surface
-   toolbar plus the sidebar toggle.
-
-   Measured on macOS 26.5 / Electron 41.10.6 from a 2x capture of a real
-   two-tab window, by the two things that band actually contains:
-
-     the bar's PLATE runs y=0 to y=20.0 — the same row at every x across the
-     window, the fill below it being the window's own backdrop, not the bar;
-     the SELECTED TAB's pill runs y=0.5 to y=17.5, centre y=9.0.
-
-   Anything taller than 20 is not the bar. It is this constant over-reserving,
-   and the surplus renders in the window's backdrop as a dead strip that looks
-   exactly like a bar with nothing in it. Worse, the traffic lights are centred
-   in whatever this says, so every surplus pixel puts them half a pixel below
-   the tabs: at 36 they sat 8px low (TRA-370), at 28 they sat 4px low (TRA-432).
-   Both of those came from asking where the surrounding material resumes rather
-   than where the bar's own plate stops.
-
-   28 then went back to 36 on its own: #659, a telemetry change, was squashed
-   from a stale base and carried the old value in with it, along with several
-   other unrelated reverts. Nothing caught it, because the only assertion on
-   this constant compared it with itself. That is why the guard in
-   tab-chrome.test.ts is written against a number measured off AppKit.
-
-   If a future macOS changes the metric, this is the one constant that absorbs
-   it. Re-measure both numbers — the plate's bottom row AND the tab centre —
-   and update `MAC_TAB_CENTRE_Y` in tab-chrome.test.ts with them. A measurement
-   of one alone is what went wrong twice. */
-
-/** Height of the AppKit tab bar on a tabbed window, in CSS px. */
-export const MAC_TAB_BAR_H = 20;
-
-/** Offset that centres the lights in the TAB BAR, which owns the top band then. */
-export const TRAFFIC_LIGHT_Y_TABBED = centreLightsIn(MAC_TAB_BAR_H);
-
-/** The offset that holds right now. The lights belong to whichever band is on
-    the window's top line — ours at TOP_BAND_H, AppKit's at MAC_TAB_BAR_H. */
-export const trafficLightYFor = (tabBarVisible: boolean): number =>
-  tabBarVisible ? TRAFFIC_LIGHT_Y_TABBED : TRAFFIC_LIGHT_Y;
-
 /** Distance from the window's leading edge to the first light. */
 export const TRAFFIC_LIGHT_X = 14;
 
 /** Where the lights' centre lands, given an offset — that band's centre. */
 export const trafficLightCentreY = (y: number = TRAFFIC_LIGHT_Y): number =>
   y + TRAFFIC_LIGHT_FRAME_INSET + TRAFFIC_LIGHT_D / 2;
+


### PR DESCRIPTION
## Summary

Fixes TRA-587 (Issue 01a058dd-3140-7e58-8519-7474bd129d72).

### Root Cause
On macOS with `titleBarStyle: 'hiddenInset'` (full-size content view), attaching project windows as native AppKit tabs (`tabbingIdentifier`, `addTabbedWindow`) caused AppKit's native `NSTabBar` to render squashed and clipped against the top 0px of the window border, misaligning traffic light buttons and causing continuous layout battles on tab switches, closures, and focus events.

### Changes
- Removed `tabbingIdentifier` and `addTabbedWindow` on macOS window creation and project opening, switching to clean independent windows.
- Kept unified top band metrics (`TOP_BAND_H = 44px`, `TRAFFIC_LIGHT_Y = 15px`, `TRAFFIC_LIGHT_X = 14px`) so traffic lights and sidebar toggles stay perfectly aligned without band-shifting hackarounds.
- Removed dead `--mac-tabbar-h` token, `data-tabbar` attribute, and old tab chrome sync hacks.
- Updated `DESIGN.md`, `tokens.test.ts`, `chrome-metrics.ts`, and `tab-chrome.test.ts`.

### Test Evidence
- `pnpm test` in `packages/app`: 52 test files, 534 tests passed.
- `pnpm run build` in `packages/app`: renderer and main process compile cleanly.
- `pnpm run lint`: clean.
- Full repo `pnpm test`: 849 files, 9373 tests passed.