### PR TITLE
fix(init): update tool routing table and stale hint references (TRA-579)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,13 @@ IMPORTANT: For ANY code exploration task, ALWAYS use trace-mcp tools first. NEVE
 | Read one symbol's source | `get_symbol` | Read (full file) |
 | What breaks if I change X | `get_change_impact` | guessing |
 | All usages of a symbol | `find_usages` | Grep |
-| All implementations of an interface | `get_type_hierarchy` | ls/find on directories |
+| All implementations of an interface | `get_implementations` | ls/find on directories |
 | All classes implementing X | `search` with `implements` filter | Grep |
 | Project health / coverage gaps | `self_audit` | manual inspection |
 | Dead code / dead exports | `get_dead_code` (`mode: "exports_only"`) | Grep for unused |
 | Context for a task | `get_feature_context` | reading 15 files |
 | Tests for a symbol | `get_tests_for` | Glob + Grep |
-| Untested symbols (deep) | `get_untested_symbols` (classifies "unreached" vs "imported_not_called") | manual audit |
+| Untested symbols (deep) | `get_untested_symbols` (deferred — load via `load_tools`) | manual audit |
 | Circular dependencies | `get_circular_imports` | manual tracing |
 
 Use Read/Grep/Glob ONLY for non-code files (.md, .json, .yaml, config) or before Edit.

--- a/skills/trace-mcp/SKILL.md
+++ b/skills/trace-mcp/SKILL.md
@@ -34,7 +34,7 @@ Activate this skill whenever you need to:
 | What breaks if I change X | `get_change_impact` | guessing |
 | Who calls this / what does it call | `get_call_graph` | Grep |
 | All usages of a symbol | `find_usages` | Grep |
-| Implementations of an interface | `get_type_hierarchy` | Grep / ls |
+| Implementations of an interface | `get_implementations` | Grep / ls |
 | Classes implementing X | `search` with `implements` filter | Grep |
 | Tests for a symbol or file | `get_tests_for` | Glob + Grep |
 | Project overview | `get_project_map` (summary_only) | Bash ls/find |

--- a/src/init/ide-rules.ts
+++ b/src/init/ide-rules.ts
@@ -23,15 +23,15 @@ const TOOL_ROUTING_POLICY = `IMPORTANT: For ANY code exploration task, ALWAYS us
 | Read one symbol's source | \`get_symbol\` | reading full file |
 | What breaks if I change X | \`get_change_impact\` | guessing |
 | All usages of a symbol | \`find_usages\` | grep / find references |
-| All implementations of an interface | \`get_type_hierarchy\` | listing directories |
+| All implementations of an interface | \`get_implementations\` | listing directories |
 | All classes implementing X | \`search\` with \`implements\` filter | grep |
 | Project health / coverage gaps | \`self_audit\` | manual inspection |
 | Dead code / dead exports | \`get_dead_code\` (\`mode: "exports_only"\`) | grep for unused |
 | Context for a task | \`get_feature_context\` | reading many files |
 | Tests for a symbol | \`get_tests_for\` | searching test files |
-| HTTP request flow | \`get_request_flow\` | reading route files |
-| DB model relationships | \`get_model_context\` | reading model + migration files |
-| Component tree | \`get_component_tree\` | reading component files |
+| HTTP request flow | \`get_request_flow\` (framework-gated) | reading route files |
+| DB model relationships | \`get_model_context\` (framework-gated) | reading model + migration files |
+| Component tree | \`get_component_tree\` (framework-gated) | reading component files |
 | Circular dependencies | \`get_circular_imports\` | manual tracing |
 
 Start sessions with \`get_project_map\` (summary_only=true) to get project overview.

--- a/src/init/md-block.ts
+++ b/src/init/md-block.ts
@@ -42,16 +42,16 @@ IMPORTANT: For ANY code exploration task, ALWAYS use trace-mcp tools first. NEVE
 | Read one symbol's source | \`get_symbol\` | Read (full file) |
 | What breaks if I change X | \`get_change_impact\` | guessing |
 | All usages of a symbol | \`find_usages\` | Grep |
-| All implementations of an interface | \`get_type_hierarchy\` | ls/find on directories |
+| All implementations of an interface | \`get_implementations\` | ls/find on directories |
 | All classes implementing X | \`search\` with \`implements\` filter | Grep |
 | Project health / coverage gaps | \`self_audit\` | manual inspection |
 | Dead code / dead exports | \`get_dead_code\` (\`mode: "exports_only"\`) | Grep for unused |
 | Context for a task | \`get_feature_context\` | reading 15 files |
 | Tests for a symbol | \`get_tests_for\` | Glob + Grep |
-| Untested symbols (deep) | \`get_untested_symbols\` (classifies "unreached" vs "imported_not_called") | manual audit |
-| HTTP request flow | \`get_request_flow\` | reading route files |
-| DB model relationships | \`get_model_context\` | reading model + migrations |
-| Component tree | \`get_component_tree\` | reading component files |
+| Untested symbols (deep) | \`get_untested_symbols\` (deferred — load via \`load_tools\`) | manual audit |
+| HTTP request flow | \`get_request_flow\` (framework-gated) | reading route files |
+| DB model relationships | \`get_model_context\` (framework-gated) | reading model + migrations |
+| Component tree | \`get_component_tree\` (framework-gated) | reading component files |
 | Circular dependencies | \`get_circular_imports\` | manual tracing |
 
 Use Read/Grep/Glob ONLY for non-code files (.md, .json, .yaml, config) or before Edit.

--- a/src/server/instructions.ts
+++ b/src/server/instructions.ts
@@ -100,7 +100,7 @@ export function buildInstructions(
     '- Tests for a symbol/file → `get_tests_for`',
     '',
     'Architecture & meta-analysis:',
-    '- Implementations of an interface → `get_type_hierarchy`',
+    '- Implementations of an interface → `get_implementations`',
     '- Health, dead exports, hotspots → `self_audit`; untested symbols → `get_untested_symbols`',
     '- Dead code → `get_dead_code` (`mode: "exports_only"` for exports)',
     '- Imports → `get_import_graph` (`get_module_graph` on NestJS); cycles → `get_circular_imports`; coupling → `get_coupling`',

--- a/src/tools/register/analysis.ts
+++ b/src/tools/register/analysis.ts
@@ -302,7 +302,7 @@ export function registerAnalysisTools(server: McpServer, ctx: ServerContext): vo
         content: [
           {
             type: 'text',
-            text: jh('get_dependency_cycles', {
+            text: jh('get_circular_imports', {
               total_cycles: cycles.length,
               cycles,
               ...(cycles.length === 0
@@ -422,7 +422,7 @@ export function registerAnalysisTools(server: McpServer, ctx: ServerContext): vo
         content: [
           {
             type: 'text',
-            text: jh('get_repo_health', { ...result, hotspots: hotspots.slice(0, 10) }),
+            text: jh('get_project_health', { ...result, hotspots: hotspots.slice(0, 10) }),
           },
         ],
       };

--- a/src/tools/register/git.ts
+++ b/src/tools/register/git.ts
@@ -656,7 +656,7 @@ export function registerGitTools(server: McpServer, ctx: ServerContext): void {
     },
     async ({ symbol_id, target_name }) => {
       const result = checkRenameSafe(store, symbol_id, target_name);
-      return { content: [{ type: 'text', text: jh('check_rename_safe', result) }] };
+      return { content: [{ type: 'text', text: jh('check_rename', result) }] };
     },
   );
 }

--- a/src/tools/shared/hints.ts
+++ b/src/tools/shared/hints.ts
@@ -117,7 +117,7 @@ const hintGenerators: Record<string, HintGenerator> = {
       });
     }
     hints.push({
-      tool: 'check_rename_safe',
+      tool: 'check_rename',
       args: { symbol_id: '<symbol>' },
       why: 'Verify rename is safe across all usages',
     });
@@ -134,7 +134,7 @@ const hintGenerators: Record<string, HintGenerator> = {
     const callers = arr(dig(r, 'callers'));
     if (callers.length > 5) {
       hints.push({
-        tool: 'get_extraction_candidates',
+        tool: 'get_refactor_candidates',
         args: {},
         why: 'High fan-in — check if this is an extraction candidate',
       });
@@ -249,7 +249,7 @@ const hintGenerators: Record<string, HintGenerator> = {
   get_project_map(r) {
     const hints: Hint[] = [];
     hints.push({ tool: 'suggest_queries', why: 'Get example queries tailored to this project' });
-    hints.push({ tool: 'get_repo_health', why: 'Check code quality metrics and hotspots' });
+    hints.push({ tool: 'get_project_health', why: 'Check code quality metrics and hotspots' });
     return hints;
   },
 
@@ -314,20 +314,20 @@ const hintGenerators: Record<string, HintGenerator> = {
     return hints;
   },
 
-  get_coupling_metrics(r) {
+  get_coupling(r) {
     const hints: Hint[] = [];
-    hints.push({ tool: 'get_dependency_cycles', why: 'Find circular dependency chains' });
+    hints.push({ tool: 'get_circular_imports', why: 'Find circular dependency chains' });
     hints.push({
-      tool: 'get_extraction_candidates',
+      tool: 'get_refactor_candidates',
       why: 'Find functions worth extracting to reduce coupling',
     });
     return hints;
   },
 
-  get_dependency_cycles(r) {
+  get_circular_imports(r) {
     const hints: Hint[] = [];
     hints.push({
-      tool: 'get_layer_violations',
+      tool: 'check_architecture',
       why: 'Check if cycles violate architectural layers',
     });
     return hints;
@@ -343,7 +343,7 @@ const hintGenerators: Record<string, HintGenerator> = {
     return hints;
   },
 
-  check_rename_safe(r) {
+  check_rename(r) {
     const hints: Hint[] = [];
     const safe = dig(r, 'safe');
     if (safe === true) {
@@ -420,14 +420,14 @@ const hintGenerators: Record<string, HintGenerator> = {
     return hints;
   },
 
-  get_repo_health(r) {
+  get_project_health(r) {
     const hints: Hint[] = [];
-    hints.push({ tool: 'get_hotspots', why: 'Find files with highest churn + complexity' });
+    hints.push({ tool: 'get_risk_hotspots', why: 'Find files with highest churn + complexity' });
     hints.push({ tool: 'get_dead_code', why: 'Find and clean up unreachable code' });
     return hints;
   },
 
-  get_hotspots(r) {
+  get_risk_hotspots(r) {
     const hints: Hint[] = [];
     const files = arr(r);
     if (files.length > 0) {
@@ -533,7 +533,7 @@ const hintGenerators: Record<string, HintGenerator> = {
     return hints;
   },
 
-  get_page_rank(r) {
+  get_pagerank(r) {
     const hints: Hint[] = [];
     const ranked = arr(r);
     if (ranked.length > 0) {

--- a/tests/tools/hints.test.ts
+++ b/tests/tools/hints.test.ts
@@ -94,18 +94,18 @@ describe('Next-step hints', () => {
       const hints = getHints('get_call_graph', {
         callers: Array(6).fill({ symbol_id: 'x' }),
       });
-      const extractHint = hints.find((h) => h.tool === 'get_extraction_candidates');
+      const extractHint = hints.find((h) => h.tool === 'get_refactor_candidates');
       expect(extractHint).toBeDefined();
     });
 
-    test('check_rename_safe suggests apply_rename when safe', () => {
-      const hints = getHints('check_rename_safe', { safe: true, conflicts: [] });
+    test('check_rename suggests apply_rename when safe', () => {
+      const hints = getHints('check_rename', { safe: true, conflicts: [] });
       const applyHint = hints.find((h) => h.tool === 'apply_rename');
       expect(applyHint).toBeDefined();
     });
 
-    test('check_rename_safe returns empty when not safe', () => {
-      const hints = getHints('check_rename_safe', { safe: false, conflicts: ['x'] });
+    test('check_rename returns empty when not safe', () => {
+      const hints = getHints('check_rename', { safe: false, conflicts: ['x'] });
       const applyHint = hints.find((h) => h.tool === 'apply_rename');
       expect(applyHint).toBeUndefined();
     });
@@ -116,16 +116,16 @@ describe('Next-step hints', () => {
       expect(removeHint).toBeDefined();
     });
 
-    test('get_coupling_metrics suggests dependency_cycles', () => {
-      const hints = getHints('get_coupling_metrics', []);
+    test('get_coupling suggests circular_imports', () => {
+      const hints = getHints('get_coupling', []);
       const toolNames = hints.map((h) => h.tool);
-      expect(toolNames).toContain('get_dependency_cycles');
+      expect(toolNames).toContain('get_circular_imports');
     });
 
-    test('get_dependency_cycles suggests layer_violations', () => {
-      const hints = getHints('get_dependency_cycles', {});
+    test('get_circular_imports suggests check_architecture', () => {
+      const hints = getHints('get_circular_imports', {});
       const toolNames = hints.map((h) => h.tool);
-      expect(toolNames).toContain('get_layer_violations');
+      expect(toolNames).toContain('check_architecture');
     });
 
     test('get_schema suggests model_context', () => {
@@ -134,10 +134,10 @@ describe('Next-step hints', () => {
       expect(toolNames).toContain('get_model_context');
     });
 
-    test('get_repo_health suggests hotspots and dead_code', () => {
-      const hints = getHints('get_repo_health', {});
+    test('get_project_health suggests risk_hotspots and dead_code', () => {
+      const hints = getHints('get_project_health', {});
       const toolNames = hints.map((h) => h.tool);
-      expect(toolNames).toContain('get_hotspots');
+      expect(toolNames).toContain('get_risk_hotspots');
       expect(toolNames).toContain('get_dead_code');
     });
 

--- a/tests/tools/tool-references-integrity.test.ts
+++ b/tests/tools/tool-references-integrity.test.ts
@@ -1,0 +1,135 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { TRACE_MCP_ROUTING_BLOCK } from '../../src/init/md-block.js';
+import { buildInstructions } from '../../src/server/instructions.js';
+import { allToolNames } from '../docs/tool-surface.js';
+
+const ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+/**
+ * TRA-579 / GitHub #706:
+ * Ensure that all MCP tool names referenced in user/agent facing entry points
+ * (routing blocks, response hints, and server instructions) match real,
+ * registered tool names. Stale aliases or unregistered tool references cause
+ * agents to call tools that do not exist or are impossible to route.
+ */
+describe('tool references integrity', () => {
+  const registered = new Set(allToolNames());
+
+  describe('src/init/md-block.ts', () => {
+    it('every tool in the routing table matches a registered tool name', () => {
+      // Parse markdown table rows: | Task | trace-mcp tool | Instead of |
+      const lines = TRACE_MCP_ROUTING_BLOCK.split('\n');
+      const tableLines = lines.filter(
+        (l) => l.startsWith('|') && !l.includes('---') && !l.includes('Task |'),
+      );
+      const referencedTools: string[] = [];
+
+      for (const line of tableLines) {
+        const cols = line.split('|').map((c) => c.trim());
+        if (cols.length >= 3) {
+          const toolCol = cols[2]; // column 2 is "trace-mcp tool"
+          // Find backticked tool names
+          const matches = [...toolCol.matchAll(/`([a-z0-9_]+)`/g)].map((m) => m[1]);
+          for (const match of matches) {
+            // Skip non-tool keywords like mode / filter params
+            if (['implements', 'exports_only'].includes(match)) continue;
+            referencedTools.push(match);
+          }
+        }
+      }
+
+      // Also check footer tools (e.g. get_project_map)
+      const footerMatches = [...TRACE_MCP_ROUTING_BLOCK.matchAll(/`([a-z0-9_]+)`/g)].map(
+        (m) => m[1],
+      );
+      for (const match of footerMatches) {
+        if (registered.has(match)) {
+          referencedTools.push(match);
+        }
+      }
+
+      expect(referencedTools.length).toBeGreaterThan(10);
+      const invalid = referencedTools.filter((name) => !registered.has(name));
+      expect(invalid, `md-block.ts references invalid tool names: ${invalid.join(', ')}`).toEqual(
+        [],
+      );
+    });
+  });
+
+  describe('src/tools/shared/hints.ts', () => {
+    const hintsSource = readFileSync(join(ROOT, 'src/tools/shared/hints.ts'), 'utf8');
+
+    it('every hintGenerator key matches a registered tool name', () => {
+      // hintGenerators: Record<string, HintGenerator> = { ... }
+      // Match generator keys: '  tool_name(r) {'
+      const generatorKeys = [...hintsSource.matchAll(/^\s{2}([a-z0-9_]+)\(r\)\s*\{/gm)].map(
+        (m) => m[1],
+      );
+
+      expect(generatorKeys.length).toBeGreaterThan(15);
+      const invalid = generatorKeys.filter((name) => !registered.has(name));
+      expect(invalid, `hints.ts generator keys not registered: ${invalid.join(', ')}`).toEqual([]);
+    });
+
+    it('every suggested tool in hints matches a registered tool name', () => {
+      // Match: tool: 'tool_name'
+      const suggestedTools = [...hintsSource.matchAll(/tool:\s*['"]([a-z0-9_]+)['"]/g)].map(
+        (m) => m[1],
+      );
+
+      expect(suggestedTools.length).toBeGreaterThan(20);
+      const invalid = [...new Set(suggestedTools)].filter((name) => !registered.has(name));
+      expect(invalid, `hints.ts suggests invalid tool names: ${invalid.join(', ')}`).toEqual([]);
+    });
+  });
+
+  describe('src/server/instructions.ts', () => {
+    it('every tool name referenced in instructions matches a registered tool name', () => {
+      const fullInstructions = buildInstructions('TypeScript, React', 'full', 'strict');
+      const minimalInstructions = buildInstructions('TypeScript, React', 'minimal', 'minimal');
+      const combined = `${fullInstructions}\n${minimalInstructions}`;
+
+      // Extract all backticked identifiers and check if any look like tool names
+      // Tool names follow snake_case convention (or single words like search, batch, reindex, pin)
+      const backticked = [...new Set([...combined.matchAll(/`([a-z0-9_]+)`/g)].map((m) => m[1]))];
+
+      // Known non-tool backticked terms in instructions (e.g. options, args, concepts)
+      const nonToolKeywords = new Set([
+        'read',
+        'content-match',
+        'glob',
+        'fusion',
+        'implements',
+        'extends',
+        'exports_only',
+        'dry_run',
+        'confirm_large',
+        'file_path',
+        'true',
+        'false',
+        'today',
+      ]);
+
+      const toolCandidates = backticked.filter(
+        (w) => !nonToolKeywords.has(w) && !w.startsWith('_'),
+      );
+      const toolsFound = toolCandidates.filter((w) => registered.has(w));
+
+      expect(toolsFound.length).toBeGreaterThan(20);
+
+      // Any candidate that looks like a tool name (contains '_' or is a known registered tool) must be registered
+      const unknownTools = toolCandidates.filter(
+        (w) =>
+          (w.includes('_') || ['search', 'batch', 'reindex', 'pin'].includes(w)) &&
+          !registered.has(w),
+      );
+      expect(
+        unknownTools,
+        `instructions.ts references unregistered tools: ${unknownTools.join(', ')}`,
+      ).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Closes #706. Fixes TRA-579.

- In `src/init/md-block.ts` and `src/init/ide-rules.ts`, update the routing table to use `get_implementations` (which is registered in standard preset) for interface implementations instead of `get_type_hierarchy` (which is deferred).
- Clearly annotate deferred (`get_untested_symbols`) and framework-gated (`get_request_flow`, `get_model_context`, `get_component_tree`) tools in the generated routing table so sessions know when/how they are available.
- Audit and fix all stale tool name references in `src/tools/shared/hints.ts`, `src/tools/register/analysis.ts`, `src/tools/register/git.ts`, and `src/server/instructions.ts`:
  - `get_repo_health` -> `get_project_health`
  - `get_dependency_cycles` -> `get_circular_imports`
  - `get_layer_violations` -> `check_architecture`
  - `get_extraction_candidates` -> `get_refactor_candidates`
  - `get_coupling_metrics` -> `get_coupling`
  - `check_rename_safe` -> `check_rename`
  - `get_page_rank` -> `get_pagerank`
  - `get_hotspots` -> `get_risk_hotspots`
  - `get_type_hierarchy` -> `get_implementations` in `instructions.ts`
- Add `tests/tools/tool-references-integrity.test.ts` unit test ensuring all user/agent-facing tool references in `md-block.ts`, `hints.ts`, and `instructions.ts` match registered tool names.
- Update `tests/tools/hints.test.ts` expectations.

## Test Evidence
- `pnpm typecheck` passed cleanly.
- `pnpm biome:ci` passed cleanly.
- `pnpm test` passed all 852 test files (9,379 tests).