### PR TITLE
fix(app): clamp KpiTile label and comparison spans to preserve TILE_H (TRA-492)

### DIFF
--- a/packages/app/src/renderer/workspace/__tests__/KpiTile.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/KpiTile.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { KpiTile } from '../components/KpiTile';
+
+describe('KpiTile (TRA-492)', () => {
+  it('clamps the label to 1 line (13px) with truncation to preserve TILE_H', () => {
+    const { container } = render(
+      <KpiTile
+        label="Benötigt Aufmerksamkeit"
+        value={42}
+        tone="warn"
+        footnote="36% of 116 projects"
+      />,
+    );
+
+    const labelContainer = container.querySelector('span.inline-flex');
+    expect(labelContainer).not.toBeNull();
+    expect(labelContainer?.getAttribute('style')).toContain('height: 13px');
+    expect(labelContainer?.getAttribute('style')).toContain('min-height: 13px');
+    expect(labelContainer?.getAttribute('style')).toContain('max-height: 13px');
+    expect(labelContainer?.className).toContain('max-w-full');
+
+    const labelText = labelContainer?.querySelector('.truncate');
+    expect(labelText).not.toBeNull();
+    expect(labelText?.textContent).toBe('Benötigt Aufmerksamkeit');
+  });
+
+  it('clamps the comparison slot to 2 lines (26px) with -webkit-line-clamp to preserve TILE_H', () => {
+    const { container } = render(
+      <KpiTile
+        label="Files"
+        value={105600}
+        delta={105600}
+        deltaCaption="vs 9 minutes ago"
+      />,
+    );
+
+    const comparison = container.querySelector('span.line-clamp-2');
+    expect(comparison).not.toBeNull();
+    const style = comparison?.getAttribute('style') ?? '';
+    expect(style).toContain('height: 26px');
+    expect(style).toContain('min-height: 26px');
+    expect(style).toContain('max-height: 26px');
+    expect(style).toContain('overflow: hidden');
+    expect(comparison?.className).toContain('line-clamp-2');
+  });
+
+  it('reserves 26px even when footnote or delta is absent', () => {
+    const { container } = render(
+      <KpiTile
+        label="Projects"
+        value={10}
+      />,
+    );
+
+    const comparison = container.querySelector('span.line-clamp-2');
+    expect(comparison).not.toBeNull();
+    const style = comparison?.getAttribute('style') ?? '';
+    expect(style).toContain('height: 26px');
+  });
+
+  it('omits comparison slot in dense mode', () => {
+    const { container } = render(
+      <KpiTile
+        label="Projects"
+        value={10}
+        dense
+        footnote="footnote text"
+      />,
+    );
+
+    const comparison = container.querySelector('span.line-clamp-2');
+    expect(comparison).toBeNull();
+  });
+});

--- a/packages/app/src/renderer/workspace/components/KpiTile.tsx
+++ b/packages/app/src/renderer/workspace/components/KpiTile.tsx
@@ -140,11 +140,16 @@ export function KpiTile({
           measures 3.28:1, and --badge-accent-fg only reaches 4.29:1. Promoting
           the label to --label instead is 10.02:1 and reads as selected. */}
       <span
-        className="inline-flex items-center gap-1 text-[11px] leading-[13px] font-medium"
-        style={{ color: active ? 'var(--label)' : 'var(--label-secondary)' }}
+        className="inline-flex items-center gap-1 text-[11px] leading-[13px] font-medium max-w-full"
+        style={{
+          color: active ? 'var(--label)' : 'var(--label-secondary)',
+          height: 13,
+          minHeight: 13,
+          maxHeight: 13,
+        }}
       >
-        {tone ? <Icon name={TONE_ICON[tone]} size={11} /> : null}
-        {label}
+        {tone ? <Icon name={TONE_ICON[tone]} size={11} className="shrink-0" /> : null}
+        <span className="truncate min-w-0">{label}</span>
       </span>
 
       {/* `unavailable` outranks `pending`: a fetch that finished and failed is
@@ -181,16 +186,27 @@ export function KpiTile({
           it is the tallest part of the tile and the only part a user can
           reconstruct by widening the window. The value never goes.
 
-          Two lines are reserved whatever the string does. A tile is 132–214px
-          wide and the catalogue runs +30% longer than English in German and
-          Russian, so whether this wraps is not something the layout gets to
-          assume — and `kpiStripHeight()` in Workspace.tsx sizes the whole strip
-          off one constant tile height. Reserving the second line keeps that
-          constant true in every language instead of only in English. */}
+          Two lines are reserved and clamped whatever the string does. A tile
+          is 132–225px wide and the catalogue runs +30% longer than English in
+          German and Russian, while English's own delta captions can exceed two
+          lines at narrow widths. Clamping to two lines on the comparison (and one
+          line on the label) keeps TILE_H = 112 true by construction in every
+          language at every width instead of depending on translator discipline
+          (TRA-492). */}
       {dense ? null : (
         <span
-          className="text-[11px] leading-[13px]"
-          style={{ color: 'var(--label-secondary)', minHeight: 26, display: 'block' }}
+          className="text-[11px] leading-[13px] line-clamp-2"
+          style={{
+            color: 'var(--label-secondary)',
+            height: 26,
+            minHeight: 26,
+            maxHeight: 26,
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+            wordBreak: 'break-word',
+          }}
         >
           {/* `unavailable` outranks `pending`: a fetch that finished and failed
               is not still loading, so the skeleton must not win when both are


### PR DESCRIPTION
Closes TRA-492

## Summary
At narrow tile widths (145–158px), `KpiTile` broke the constant `TILE_H = 112` because:
1. Long labels in languages like German (`Benötigt Aufmerksamkeit`), Spanish (`Requiere atención`), Portuguese (`Precisa de atenção`), and Russian (`Требуют внимания`) wrapped onto two lines.
2. The English delta caption (`↑+105.6k vs 9 minutes ago`) wrapped onto three lines because the 2-line reservation was a `minHeight: 26` instead of a clamp.

## Changes
- **Label clamping**: Clamped label span to 1 line (`height: 13px`, `minHeight: 13px`, `maxHeight: 13px`, `max-w-full`) with `<span className="truncate min-w-0">{label}</span>` and `shrink-0` on icon.
- **Comparison clamping**: Clamped comparison span to 2 lines with `line-clamp-2`, `display: -webkit-box`, `-webkit-line-clamp: 2`, `overflow: hidden`, `word-break: break-word`, and fixed height reservation (`height: 26px`, `minHeight: 26px`, `maxHeight: 26px`).
- **Tests**: Added `packages/app/src/renderer/workspace/__tests__/KpiTile.test.tsx` verifying label & comparison clamping in normal and dense modes.
- **CDP Verification**: Verified via Chrome DevTools Protocol on running Electron instance across all 10 locales (`en`, `de`, `es`, `fr`, `hi`, `ja`, `ko`, `pt-BR`, `ru`, `zh`) and window sizes (960×700, 1440×900, 1280×800, 1200×900, 820×700). Every locale measured exactly 112px on all cards.