### PR TITLE
feat(topology,memory): add stale root pruning to topology.db and decisions.db (TRA-595)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,6 +80,7 @@ import { initializeDatabase } from './db/schema.js';
 import { Store } from './db/store.js';
 import {
   DAEMON_LOG_PATH,
+  DECISIONS_DB_PATH,
   DEFAULT_DAEMON_PORT,
   ensureGlobalDirs,
   GLOBAL_CONFIG_PATH,
@@ -87,6 +88,7 @@ import {
   INDEX_DIR,
   TOPOLOGY_DB_PATH,
 } from './global.js';
+import { DecisionStore } from './memory/decision-store.js';
 import { sweepOrphanedSessionDbs } from './daemon/router/session-db.js';
 import { IndexingPipeline } from './indexer/pipeline.js';
 import {
@@ -253,6 +255,44 @@ function softGcSweep(): void {
     }
   } catch (err) {
     logger.warn({ err }, 'pruneStaleProjects soft-prune failed (non-fatal)');
+  }
+
+  try {
+    if (fs.existsSync(TOPOLOGY_DB_PATH)) {
+      const topoStore = new TopologyStore(TOPOLOGY_DB_PATH);
+      try {
+        const res = topoStore.pruneStale();
+        if (res.services > 0 || res.subprojects > 0) {
+          logger.info(
+            { removedServices: res.services, removedSubprojects: res.subprojects },
+            `Pruned ${res.services} stale service(s) and ${res.subprojects} stale subproject(s) from topology.db`,
+          );
+        }
+      } finally {
+        topoStore.close();
+      }
+    }
+  } catch (err) {
+    logger.warn({ err }, 'pruneStaleTopology soft-prune failed (non-fatal)');
+  }
+
+  try {
+    if (fs.existsSync(DECISIONS_DB_PATH)) {
+      const store = new DecisionStore(DECISIONS_DB_PATH);
+      try {
+        const res = store.pruneStale({ includeMinedSessions: true });
+        if (res.decisions > 0 || res.chunks > 0) {
+          logger.info(
+            { removedDecisions: res.decisions, removedRoots: res.staleRoots },
+            `Pruned ${res.decisions} orphaned decision(s) across ${res.staleRoots.length} deleted project root(s)`,
+          );
+        }
+      } finally {
+        store.close();
+      }
+    }
+  } catch (err) {
+    logger.warn({ err }, 'pruneStaleDecisions soft-prune failed (non-fatal)');
   }
 }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import * as p from '@clack/prompts';
 import Database from 'better-sqlite3';
 import { Command } from 'commander';
-import { REGISTRY_PATH } from '../global.js';
+import { DECISIONS_DB_PATH, REGISTRY_PATH, TOPOLOGY_DB_PATH } from '../global.js';
 import { type ConflictSeverity, detectConflicts } from '../init/conflict-detector.js';
 import { type FixResult, fixAllConflicts, fixConflict } from '../init/conflict-resolver.js';
 import {
@@ -30,6 +30,8 @@ import {
   pruneStaleProjects,
   unregisterProject,
 } from '../registry.js';
+import { TopologyStore } from '../topology/topology-db.js';
+import { DecisionStore } from '../memory/decision-store.js';
 
 const _SEVERITY_ICON: Record<ConflictSeverity, string> = {
   critical: 'X',
@@ -73,12 +75,29 @@ export const doctorCommand = new Command('doctor')
         registry.unregisteredNestedRepos.length > 0 ||
         registry.ephemeralProjects.length > 0;
 
+      // Topology & Decisions hygiene — dead services/subprojects and orphaned decisions
+      const topology = diagnoseTopology();
+      const hasTopologyIssues = topology.staleCount > 0;
+
+      const decisions = diagnoseDecisions();
+      const hasDecisionsIssues = decisions.staleRoots.length > 0;
+
       // --fix / --dry-run also clean up the registry itself (TRA-18): missing-root
       // entries and overlap containers have one unambiguous remediation each, so
       // (unlike project conflicts) they don't need an interactive per-item prompt.
       const registryFix: RegistryFixResult | null =
         hasRegistryIssues && (opts.fix || opts.dryRun)
           ? fixRegistryIssues(registry, { dryRun: opts.dryRun })
+          : null;
+
+      let topologyFix: TopologyFixResult | null =
+        hasTopologyIssues && (opts.fix || opts.dryRun)
+          ? fixTopologyIssues(topology, { dryRun: opts.dryRun })
+          : null;
+
+      let decisionsFix: DecisionsFixResult | null =
+        hasDecisionsIssues && (opts.fix || opts.dryRun)
+          ? fixDecisionsIssues(decisions, { dryRun: opts.dryRun })
           : null;
 
       // Detect project root (optional — doctor works without it)
@@ -97,19 +116,61 @@ export const doctorCommand = new Command('doctor')
         if (opts.fix || opts.dryRun) {
           const results = fixAllConflicts(conflicts, { dryRun: opts.dryRun });
           console.log(
-            JSON.stringify({ registry, registryFix, conflicts, fixes: results }, null, 2),
+            JSON.stringify(
+              {
+                registry,
+                registryFix,
+                topology,
+                topologyFix,
+                decisions,
+                decisionsFix,
+                conflicts,
+                fixes: results,
+              },
+              null,
+              2,
+            ),
           );
         } else {
-          console.log(JSON.stringify({ registry, ...report }, null, 2));
+          console.log(JSON.stringify({ registry, topology, decisions, ...report }, null, 2));
         }
         return;
       }
 
       printRegistryReport(registry);
+      printTopologyReport(topology);
+      printDecisionsReport(decisions);
+
       if (registryFix) {
         printRegistryFixResult(registryFix, { dryRun: !!opts.dryRun });
       } else if (opts.fixInteractive && hasRegistryIssues) {
         printRegistryFixResult(await fixRegistryIssuesInteractive(registry), { dryRun: false });
+      }
+
+      if (topologyFix) {
+        printTopologyFixResult(topologyFix, { dryRun: !!opts.dryRun });
+      } else if (opts.fixInteractive && hasTopologyIssues) {
+        const answer = await p.confirm({
+          message: `Remove ${topology.staleServices.length} dead service(s) and ${topology.staleSubprojects.length} dead subproject(s) from topology.db (folders deleted)?`,
+          initialValue: true,
+        });
+        if (!p.isCancel(answer) && answer) {
+          topologyFix = fixTopologyIssues(topology, { dryRun: false });
+          printTopologyFixResult(topologyFix, { dryRun: false });
+        }
+      }
+
+      if (decisionsFix) {
+        printDecisionsFixResult(decisionsFix, { dryRun: !!opts.dryRun });
+      } else if (opts.fixInteractive && hasDecisionsIssues) {
+        const answer = await p.confirm({
+          message: `Remove ${decisions.staleDecisionsCount} orphaned decision(s) across ${decisions.staleRoots.length} deleted project root(s) from decisions.db?`,
+          initialValue: true,
+        });
+        if (!p.isCancel(answer) && answer) {
+          decisionsFix = fixDecisionsIssues(decisions, { dryRun: false });
+          printDecisionsFixResult(decisionsFix, { dryRun: false });
+        }
       }
 
       // --- No conflicts ---
@@ -320,6 +381,181 @@ export function diagnoseRegistry(): RegistryHealthReport {
     unregisteredNestedRepos: findUnregisteredNestedRepos(),
     ephemeralProjects: findEphemeralProjects(),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Topology DB integrity
+// ---------------------------------------------------------------------------
+
+export interface TopologyHealthReport {
+  topologyPath: string;
+  topologyExists: boolean;
+  staleServices: Array<{ id: number; name: string; repoRoot: string }>;
+  staleSubprojects: Array<{ id: number; name: string; repoRoot: string; projectRoot: string }>;
+  staleCount: number;
+}
+
+export function diagnoseTopology(): TopologyHealthReport {
+  if (!fs.existsSync(TOPOLOGY_DB_PATH)) {
+    return {
+      topologyPath: TOPOLOGY_DB_PATH,
+      topologyExists: false,
+      staleServices: [],
+      staleSubprojects: [],
+      staleCount: 0,
+    };
+  }
+  try {
+    const topoStore = new TopologyStore(TOPOLOGY_DB_PATH, { readonly: true });
+    try {
+      const stale = topoStore.findStale();
+      return {
+        topologyPath: TOPOLOGY_DB_PATH,
+        topologyExists: true,
+        staleServices: stale.staleServices.map((s) => ({
+          id: s.id,
+          name: s.name,
+          repoRoot: s.repo_root,
+        })),
+        staleSubprojects: stale.staleSubprojects.map((s) => ({
+          id: s.id,
+          name: s.name,
+          repoRoot: s.repo_root,
+          projectRoot: s.project_root,
+        })),
+        staleCount: stale.staleServices.length + stale.staleSubprojects.length,
+      };
+    } finally {
+      topoStore.close();
+    }
+  } catch {
+    return {
+      topologyPath: TOPOLOGY_DB_PATH,
+      topologyExists: true,
+      staleServices: [],
+      staleSubprojects: [],
+      staleCount: 0,
+    };
+  }
+}
+
+export interface TopologyFixResult {
+  removedServices: string[];
+  removedSubprojects: string[];
+}
+
+export function fixTopologyIssues(
+  t: TopologyHealthReport,
+  opts: { dryRun?: boolean },
+): TopologyFixResult {
+  if (opts.dryRun) {
+    return {
+      removedServices: t.staleServices.map((s) => s.name),
+      removedSubprojects: t.staleSubprojects.map((s) => s.name),
+    };
+  }
+  if (!fs.existsSync(TOPOLOGY_DB_PATH)) {
+    return { removedServices: [], removedSubprojects: [] };
+  }
+  try {
+    const topoStore = new TopologyStore(TOPOLOGY_DB_PATH);
+    try {
+      const res = topoStore.pruneStale();
+      return {
+        removedServices: res.removedServices.map((s) => s.name),
+        removedSubprojects: res.removedSubprojects.map((s) => s.name),
+      };
+    } finally {
+      topoStore.close();
+    }
+  } catch {
+    return { removedServices: [], removedSubprojects: [] };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Decision Memory DB integrity
+// ---------------------------------------------------------------------------
+
+export interface DecisionsHealthReport {
+  decisionsPath: string;
+  decisionsExists: boolean;
+  staleRoots: string[];
+  staleDecisionsCount: number;
+  staleDecisions: Array<{ id: number; title: string; projectRoot: string }>;
+}
+
+export function diagnoseDecisions(): DecisionsHealthReport {
+  if (!fs.existsSync(DECISIONS_DB_PATH)) {
+    return {
+      decisionsPath: DECISIONS_DB_PATH,
+      decisionsExists: false,
+      staleRoots: [],
+      staleDecisionsCount: 0,
+      staleDecisions: [],
+    };
+  }
+  try {
+    const store = new DecisionStore(DECISIONS_DB_PATH, { readonly: true });
+    try {
+      const stale = store.findStale();
+      return {
+        decisionsPath: DECISIONS_DB_PATH,
+        decisionsExists: true,
+        staleRoots: stale.staleRoots,
+        staleDecisionsCount: stale.decisionsCount,
+        staleDecisions: stale.staleDecisions.map((d) => ({
+          id: d.id,
+          title: d.title,
+          projectRoot: d.project_root,
+        })),
+      };
+    } finally {
+      store.close();
+    }
+  } catch {
+    return {
+      decisionsPath: DECISIONS_DB_PATH,
+      decisionsExists: true,
+      staleRoots: [],
+      staleDecisionsCount: 0,
+      staleDecisions: [],
+    };
+  }
+}
+
+export interface DecisionsFixResult {
+  removedRoots: string[];
+  removedDecisions: number;
+}
+
+export function fixDecisionsIssues(
+  d: DecisionsHealthReport,
+  opts: { dryRun?: boolean },
+): DecisionsFixResult {
+  if (opts.dryRun) {
+    return {
+      removedRoots: d.staleRoots,
+      removedDecisions: d.staleDecisionsCount,
+    };
+  }
+  if (!fs.existsSync(DECISIONS_DB_PATH)) {
+    return { removedRoots: [], removedDecisions: 0 };
+  }
+  try {
+    const store = new DecisionStore(DECISIONS_DB_PATH);
+    try {
+      const res = store.pruneStale({ staleRoots: d.staleRoots, includeMinedSessions: true });
+      return {
+        removedRoots: res.staleRoots,
+        removedDecisions: res.decisions,
+      };
+    } finally {
+      store.close();
+    }
+  } catch {
+    return { removedRoots: [], removedDecisions: 0 };
+  }
 }
 
 export interface BlockedOverlapContainer {
@@ -589,6 +825,59 @@ function printRegistryReport(r: RegistryHealthReport): void {
         'then `trace-mcp prune --apply`.',
     );
   }
+  console.log('');
+}
+
+function printTopologyReport(t: TopologyHealthReport): void {
+  if (!t.topologyExists || t.staleCount === 0) return;
+  console.log(
+    `Topology: ${t.staleCount} dead entr${t.staleCount === 1 ? 'y' : 'ies'} in topology.db (folder deleted):`,
+  );
+  for (const s of t.staleServices) {
+    console.log(`  [service] ${s.name}  ${shortPath(s.repoRoot)}`);
+  }
+  for (const sub of t.staleSubprojects) {
+    console.log(`  [subproject] ${sub.name}  ${shortPath(sub.repoRoot)}`);
+  }
+  console.log(
+    "  Clean up dead topology entries with 'trace-mcp prune --apply' or 'trace-mcp doctor --fix'.\n",
+  );
+}
+
+function printDecisionsReport(d: DecisionsHealthReport): void {
+  if (!d.decisionsExists || d.staleRoots.length === 0) return;
+  console.log(
+    `Decision Memory: ${d.staleDecisionsCount} orphaned decision(s) across ${d.staleRoots.length} deleted project root(s) in decisions.db:`,
+  );
+  for (const root of d.staleRoots) {
+    console.log(`  ${shortPath(root)}`);
+  }
+  console.log(
+    "  Clean up orphaned decisions with 'trace-mcp memory prune --apply', 'trace-mcp prune --apply', or 'trace-mcp doctor --fix'.\n",
+  );
+}
+
+function printTopologyFixResult(fix: TopologyFixResult, opts: { dryRun: boolean }): void {
+  const verb = opts.dryRun ? 'Would remove' : 'Removed';
+  const total = fix.removedServices.length + fix.removedSubprojects.length;
+  if (total === 0) return;
+  const lines = [
+    `${verb} ${total} dead topology entr${total === 1 ? 'y' : 'ies'} (folder deleted):`,
+  ];
+  for (const s of fix.removedServices) lines.push(`  [service] ${s}`);
+  for (const sub of fix.removedSubprojects) lines.push(`  [subproject] ${sub}`);
+  console.log(lines.join('\n'));
+  console.log('');
+}
+
+function printDecisionsFixResult(fix: DecisionsFixResult, opts: { dryRun: boolean }): void {
+  const verb = opts.dryRun ? 'Would remove' : 'Removed';
+  if (fix.removedRoots.length === 0 && fix.removedDecisions === 0) return;
+  const lines = [
+    `${verb} ${fix.removedDecisions} orphaned decision(s) across ${fix.removedRoots.length} deleted project root(s):`,
+  ];
+  for (const r of fix.removedRoots) lines.push(`  ${shortPath(r)}`);
+  console.log(lines.join('\n'));
   console.log('');
 }
 

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -447,3 +447,81 @@ memoryCommand
       }
     },
   );
+
+// ── memory prune ────────────────────────────────────────────────────
+
+memoryCommand
+  .command('prune')
+  .description(
+    'Prune decisions, chunks, clusters, and memos belonging to deleted project roots (dry-run by default; use --apply to delete)',
+  )
+  .option('--apply', 'Actually delete orphaned decisions and session data')
+  .option('--include-sessions', 'Also prune mined session log references for deleted files')
+  .option('--json', 'Output as JSON')
+  .action((opts: { apply?: boolean; includeSessions?: boolean; json?: boolean }) => {
+    const store = openStore();
+    try {
+      const stale = store.findStale();
+      const apply = !!opts.apply;
+
+      if (opts.json) {
+        if (apply) {
+          const result = store.pruneStale({ includeMinedSessions: opts.includeSessions });
+          console.log(JSON.stringify({ apply: true, ...result }, null, 2));
+        } else {
+          console.log(JSON.stringify({ apply: false, ...stale }, null, 2));
+        }
+        return;
+      }
+
+      console.log('Decision Store Hygiene Check:\n');
+      if (
+        stale.staleRoots.length === 0 &&
+        (!opts.includeSessions || stale.staleMinedSessionsCount === 0)
+      ) {
+        console.log(
+          '  All decision store project roots are healthy — no orphaned decisions found.\n',
+        );
+        return;
+      }
+
+      if (!apply) {
+        console.log(
+          `  Found ${stale.decisionsCount} decision(s) across ${stale.staleRoots.length} deleted project root(s):`,
+        );
+        for (const root of stale.staleRoots) {
+          console.log(`    - ${root}`);
+        }
+        if (stale.chunksCount > 0 || stale.clustersCount > 0 || stale.memosCount > 0) {
+          console.log(
+            `  Also found: ${stale.chunksCount} session chunk(s), ${stale.clustersCount} cluster(s), ${stale.memosCount} memo(s).`,
+          );
+        }
+        if (opts.includeSessions && stale.staleMinedSessionsCount > 0) {
+          console.log(
+            `  Found ${stale.staleMinedSessionsCount} stale mined session file reference(s).`,
+          );
+        }
+        console.log('\n  Dry-run only — re-run with `trace-mcp memory prune --apply` to delete.\n');
+      } else {
+        const result = store.pruneStale({ includeMinedSessions: opts.includeSessions });
+        console.log(
+          `  Pruned ${result.decisions} decision(s) across ${result.staleRoots.length} deleted project root(s):`,
+        );
+        for (const root of result.staleRoots) {
+          console.log(`    - ${root}`);
+        }
+        if (result.chunks > 0 || result.clusters > 0 || result.memos > 0) {
+          console.log(
+            `  Also pruned: ${result.chunks} chunk(s), ${result.clusters} cluster(s), ${result.memos} memo(s).`,
+          );
+        }
+        if (result.minedSessions > 0) {
+          console.log(`  Pruned ${result.minedSessions} stale mined session reference(s).`);
+        }
+        console.log('\n  Prune complete.\n');
+      }
+    } finally {
+      store.close();
+    }
+  });

--- a/src/cli/prune.ts
+++ b/src/cli/prune.ts
@@ -21,11 +21,19 @@ import path from 'node:path';
 import * as p from '@clack/prompts';
 import Database from 'better-sqlite3';
 import { Command } from 'commander';
-import { ensureGlobalDirs, projectHash, projectName } from '../global.js';
+import {
+  DECISIONS_DB_PATH,
+  ensureGlobalDirs,
+  projectHash,
+  projectName,
+  TOPOLOGY_DB_PATH,
+} from '../global.js';
 import { logger } from '../logger.js';
 import { hasLiveHolderOrUnknown, removeHoldersDir } from '../db-holders.js';
 import { listProjects, pruneStaleProjects } from '../registry.js';
 import { INDEX_DIR } from '../shared/paths.js';
+import { TopologyStore } from '../topology/topology-db.js';
+import { DecisionStore } from '../memory/decision-store.js';
 
 /** Categories assigned to each DB candidate. */
 export type PruneCategory =
@@ -422,6 +430,112 @@ function toJson(
   };
 }
 
+export interface TopologyPruneSummary {
+  staleServices: Array<{ id: number; name: string; repo_root: string }>;
+  staleSubprojects: Array<{ id: number; name: string; repo_root: string; project_root: string }>;
+  removedServices: number;
+  removedSubprojects: number;
+}
+
+export interface DecisionsPruneSummary {
+  staleRoots: string[];
+  staleDecisionsCount: number;
+  removedDecisions: number;
+  removedChunks: number;
+  removedClusters: number;
+  removedMemos: number;
+}
+
+export function scanOrPruneTopology(apply = false): TopologyPruneSummary {
+  if (!fs.existsSync(TOPOLOGY_DB_PATH)) {
+    return {
+      staleServices: [],
+      staleSubprojects: [],
+      removedServices: 0,
+      removedSubprojects: 0,
+    };
+  }
+  try {
+    const topoStore = new TopologyStore(TOPOLOGY_DB_PATH);
+    try {
+      const stale = topoStore.findStale();
+      let removedServices = 0;
+      let removedSubprojects = 0;
+      if (apply && (stale.staleServices.length > 0 || stale.staleSubprojects.length > 0)) {
+        const res = topoStore.pruneStale();
+        removedServices = res.services;
+        removedSubprojects = res.subprojects;
+      }
+      return {
+        staleServices: stale.staleServices,
+        staleSubprojects: stale.staleSubprojects,
+        removedServices,
+        removedSubprojects,
+      };
+    } finally {
+      topoStore.close();
+    }
+  } catch (err) {
+    logger.warn({ err }, 'prune: topology scan/prune failed');
+    return {
+      staleServices: [],
+      staleSubprojects: [],
+      removedServices: 0,
+      removedSubprojects: 0,
+    };
+  }
+}
+
+export function scanOrPruneDecisions(apply = false): DecisionsPruneSummary {
+  if (!fs.existsSync(DECISIONS_DB_PATH)) {
+    return {
+      staleRoots: [],
+      staleDecisionsCount: 0,
+      removedDecisions: 0,
+      removedChunks: 0,
+      removedClusters: 0,
+      removedMemos: 0,
+    };
+  }
+  try {
+    const store = new DecisionStore(DECISIONS_DB_PATH);
+    try {
+      const stale = store.findStale();
+      let removedDecisions = 0;
+      let removedChunks = 0;
+      let removedClusters = 0;
+      let removedMemos = 0;
+      if (apply && stale.staleRoots.length > 0) {
+        const res = store.pruneStale({ staleRoots: stale.staleRoots, includeMinedSessions: true });
+        removedDecisions = res.decisions;
+        removedChunks = res.chunks;
+        removedClusters = res.clusters;
+        removedMemos = res.memos;
+      }
+      return {
+        staleRoots: stale.staleRoots,
+        staleDecisionsCount: stale.decisionsCount,
+        removedDecisions,
+        removedChunks,
+        removedClusters,
+        removedMemos,
+      };
+    } finally {
+      store.close();
+    }
+  } catch (err) {
+    logger.warn({ err }, 'prune: decisions scan/prune failed');
+    return {
+      staleRoots: [],
+      staleDecisionsCount: 0,
+      removedDecisions: 0,
+      removedChunks: 0,
+      removedClusters: 0,
+      removedMemos: 0,
+    };
+  }
+}
+
 export const pruneCommand = new Command('prune')
   .description(
     'Audit ~/.trace-mcp/index for orphan/expired DBs (dry-run by default; use --apply to delete)',
@@ -453,6 +567,12 @@ export const pruneCommand = new Command('prune')
         .map((e) => e.root);
       const removedRegistryRoots = apply ? pruneStaleProjects() : [];
 
+      // Stale topology rows (services/subprojects pointing to deleted folders)
+      const topoSummary = scanOrPruneTopology(apply);
+
+      // Stale decisions / memory rows belonging to deleted project roots
+      const decisionsSummary = scanOrPruneDecisions(apply);
+
       if (opts.json) {
         console.log(
           JSON.stringify(
@@ -460,6 +580,20 @@ export const pruneCommand = new Command('prune')
               ...(toJson(summary, { apply, aggressive, sessionTtlDays }) as object),
               staleRegistryRoots,
               removedRegistryRoots,
+              topology: {
+                staleServices: topoSummary.staleServices,
+                staleSubprojects: topoSummary.staleSubprojects,
+                removedServices: topoSummary.removedServices,
+                removedSubprojects: topoSummary.removedSubprojects,
+              },
+              decisions: {
+                staleRoots: decisionsSummary.staleRoots,
+                staleDecisionsCount: decisionsSummary.staleDecisionsCount,
+                removedDecisions: decisionsSummary.removedDecisions,
+                removedChunks: decisionsSummary.removedChunks,
+                removedClusters: decisionsSummary.removedClusters,
+                removedMemos: decisionsSummary.removedMemos,
+              },
             },
             null,
             2,
@@ -477,6 +611,34 @@ export const pruneCommand = new Command('prune')
           [heading, ...staleRegistryRoots.map((r) => `  ${shortPath(r)}`)].join('\n'),
           'Registry',
         );
+      }
+      if (
+        topoSummary.staleServices.length > 0 ||
+        topoSummary.staleSubprojects.length > 0 ||
+        topoSummary.removedServices > 0 ||
+        topoSummary.removedSubprojects > 0
+      ) {
+        const heading = apply
+          ? `Removed ${topoSummary.removedServices} stale service(s) and ${topoSummary.removedSubprojects} stale subproject(s) from topology.db:`
+          : `${topoSummary.staleServices.length} stale service(s) and ${topoSummary.staleSubprojects.length} stale subproject(s) in topology.db (folder deleted) — would remove:`;
+        const lines = [heading];
+        for (const s of topoSummary.staleServices) {
+          lines.push(`  [service] ${s.name} (${shortPath(s.repo_root)})`);
+        }
+        for (const sub of topoSummary.staleSubprojects) {
+          lines.push(`  [subproject] ${sub.name} (${shortPath(sub.repo_root)})`);
+        }
+        p.note(lines.join('\n'), 'Topology');
+      }
+      if (decisionsSummary.staleRoots.length > 0 || decisionsSummary.removedDecisions > 0) {
+        const heading = apply
+          ? `Removed ${decisionsSummary.removedDecisions} orphaned decision(s) across ${decisionsSummary.staleRoots.length} deleted project root(s) from decisions.db:`
+          : `${decisionsSummary.staleDecisionsCount} orphaned decision(s) across ${decisionsSummary.staleRoots.length} deleted project root(s) in decisions.db (folder deleted) — would remove:`;
+        const lines = [heading];
+        for (const r of decisionsSummary.staleRoots) {
+          lines.push(`  ${shortPath(r)}`);
+        }
+        p.note(lines.join('\n'), 'Decision Memory');
       }
       if (!apply) {
         p.outro('Dry-run only — re-run with --apply to delete.');

--- a/src/memory/decision-store.ts
+++ b/src/memory/decision-store.ts
@@ -7,6 +7,8 @@
  * linkage to code symbols/files, enabling code-aware memory queries.
  */
 
+import fs from 'node:fs';
+import path from 'node:path';
 import Database from 'better-sqlite3';
 import { logger } from '../logger.js';
 import { restrictDbPerms } from '../shared/db-perms.js';
@@ -48,6 +50,8 @@ export type {
   SessionSearchResult,
   ReviewEventRow,
   SchedulerStateRow,
+  StaleDecisionReport,
+  PruneDecisionsResult,
 } from './decision-types.js';
 import type {
   DecisionType,
@@ -64,6 +68,8 @@ import type {
   SessionSearchResult,
   ReviewEventRow,
   SchedulerStateRow,
+  StaleDecisionReport,
+  PruneDecisionsResult,
 } from './decision-types.js';
 
 // DecisionQuery, DecisionTimelineEntry, session-chunk, review-event,
@@ -1208,5 +1214,229 @@ export class DecisionStore {
     merged_content?: string;
   }): { applied: boolean; affected_ids: number[] } {
     return this.consolidationOps.applyConsolidationVerdict(opts);
+  }
+
+  // ── STALE ROOT PRUNING / HYGIENE ───────────────────────────────────
+
+  /** Find distinct project_root paths across all memory tables that no longer exist on disk. */
+  findStaleRoots(): string[] {
+    const tables = [
+      'decisions',
+      'session_chunks',
+      'decision_clusters',
+      'project_memos',
+      'scheduler_state',
+    ];
+    const roots = new Set<string>();
+    for (const table of tables) {
+      try {
+        const rows = this.db.prepare(`SELECT DISTINCT project_root FROM ${table}`).all() as Array<{
+          project_root: string;
+        }>;
+        for (const r of rows) {
+          if (r.project_root) roots.add(r.project_root);
+        }
+      } catch {
+        /* table missing on legacy db */
+      }
+    }
+    return [...roots].filter((r) => !fs.existsSync(r));
+  }
+
+  /** Scan for orphaned decisions, chunks, clusters, and memos belonging to missing project roots. */
+  findStale(): StaleDecisionReport {
+    const staleRoots = this.findStaleRoots();
+
+    let staleDecisions: Array<{
+      id: number;
+      title: string;
+      project_root: string;
+      type: DecisionType;
+    }> = [];
+    let decisionsCount = 0;
+    let chunksCount = 0;
+    let clustersCount = 0;
+    let memosCount = 0;
+    let schedulerStatesCount = 0;
+    let staleMinedSessionsCount = 0;
+
+    if (staleRoots.length > 0) {
+      const placeholders = staleRoots.map(() => '?').join(',');
+      try {
+        const dRows = this.db
+          .prepare(
+            `SELECT id, title, project_root, type FROM decisions WHERE project_root IN (${placeholders})`,
+          )
+          .all(...staleRoots) as Array<{
+          id: number;
+          title: string;
+          project_root: string;
+          type: DecisionType;
+        }>;
+        staleDecisions = dRows;
+        decisionsCount = dRows.length;
+      } catch {
+        /* ignore */
+      }
+
+      try {
+        const row = this.db
+          .prepare(
+            `SELECT COUNT(*) as c FROM session_chunks WHERE project_root IN (${placeholders})`,
+          )
+          .get(...staleRoots) as { c: number };
+        chunksCount = row.c;
+      } catch {
+        /* ignore */
+      }
+
+      try {
+        const row = this.db
+          .prepare(
+            `SELECT COUNT(*) as c FROM decision_clusters WHERE project_root IN (${placeholders})`,
+          )
+          .get(...staleRoots) as { c: number };
+        clustersCount = row.c;
+      } catch {
+        /* ignore */
+      }
+
+      try {
+        const row = this.db
+          .prepare(
+            `SELECT COUNT(*) as c FROM project_memos WHERE project_root IN (${placeholders})`,
+          )
+          .get(...staleRoots) as { c: number };
+        memosCount = row.c;
+      } catch {
+        /* ignore */
+      }
+
+      try {
+        const row = this.db
+          .prepare(
+            `SELECT COUNT(*) as c FROM scheduler_state WHERE project_root IN (${placeholders})`,
+          )
+          .get(...staleRoots) as { c: number };
+        schedulerStatesCount = row.c;
+      } catch {
+        /* ignore */
+      }
+    }
+
+    try {
+      const minedRows = this.db.prepare('SELECT session_path FROM mined_sessions').all() as Array<{
+        session_path: string;
+      }>;
+      staleMinedSessionsCount = minedRows.filter(
+        (r) => r.session_path && path.isAbsolute(r.session_path) && !fs.existsSync(r.session_path),
+      ).length;
+    } catch {
+      /* ignore */
+    }
+
+    return {
+      staleRoots,
+      decisionsCount,
+      chunksCount,
+      clustersCount,
+      memosCount,
+      schedulerStatesCount,
+      staleMinedSessionsCount,
+      staleDecisions,
+    };
+  }
+
+  /**
+   * Prune decisions and associated data for project roots that no longer exist on disk.
+   * Runs in a single transaction.
+   */
+  pruneStale(opts?: {
+    staleRoots?: string[];
+    includeMinedSessions?: boolean;
+  }): PruneDecisionsResult {
+    const staleRoots = opts?.staleRoots ?? this.findStaleRoots();
+    const result: PruneDecisionsResult = {
+      staleRoots,
+      decisions: 0,
+      chunks: 0,
+      clusters: 0,
+      memos: 0,
+      schedulerStates: 0,
+      minedSessions: 0,
+    };
+
+    this.db.transaction(() => {
+      if (staleRoots.length > 0) {
+        const placeholders = staleRoots.map(() => '?').join(',');
+
+        try {
+          const res = this.db
+            .prepare(`DELETE FROM decisions WHERE project_root IN (${placeholders})`)
+            .run(...staleRoots);
+          result.decisions = res.changes;
+        } catch {
+          /* ignore */
+        }
+
+        try {
+          const res = this.db
+            .prepare(`DELETE FROM session_chunks WHERE project_root IN (${placeholders})`)
+            .run(...staleRoots);
+          result.chunks = res.changes;
+        } catch {
+          /* ignore */
+        }
+
+        try {
+          const res = this.db
+            .prepare(`DELETE FROM decision_clusters WHERE project_root IN (${placeholders})`)
+            .run(...staleRoots);
+          result.clusters = res.changes;
+        } catch {
+          /* ignore */
+        }
+
+        try {
+          const res = this.db
+            .prepare(`DELETE FROM project_memos WHERE project_root IN (${placeholders})`)
+            .run(...staleRoots);
+          result.memos = res.changes;
+        } catch {
+          /* ignore */
+        }
+
+        try {
+          const res = this.db
+            .prepare(`DELETE FROM scheduler_state WHERE project_root IN (${placeholders})`)
+            .run(...staleRoots);
+          result.schedulerStates = res.changes;
+        } catch {
+          /* ignore */
+        }
+      }
+
+      if (opts?.includeMinedSessions) {
+        try {
+          const minedRows = this.db
+            .prepare('SELECT session_path FROM mined_sessions')
+            .all() as Array<{ session_path: string }>;
+          const staleMinedPaths = minedRows
+            .map((r) => r.session_path)
+            .filter((p) => p && path.isAbsolute(p) && !fs.existsSync(p));
+          if (staleMinedPaths.length > 0) {
+            const placeholders = staleMinedPaths.map(() => '?').join(',');
+            const res = this.db
+              .prepare(`DELETE FROM mined_sessions WHERE session_path IN (${placeholders})`)
+              .run(...staleMinedPaths);
+            result.minedSessions = res.changes;
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+    })();
+
+    return result;
   }
 }

--- a/src/memory/decision-types.ts
+++ b/src/memory/decision-types.ts
@@ -326,3 +326,24 @@ export interface SchedulerStateRow {
   consecutive_failures: number;
   updated_at: string;
 }
+
+export interface StaleDecisionReport {
+  staleRoots: string[];
+  decisionsCount: number;
+  chunksCount: number;
+  clustersCount: number;
+  memosCount: number;
+  schedulerStatesCount: number;
+  staleMinedSessionsCount: number;
+  staleDecisions: Array<{ id: number; title: string; project_root: string; type: DecisionType }>;
+}
+
+export interface PruneDecisionsResult {
+  staleRoots: string[];
+  decisions: number;
+  chunks: number;
+  clusters: number;
+  memos: number;
+  schedulerStates: number;
+  minedSessions: number;
+}

--- a/src/topology/topology-db.ts
+++ b/src/topology/topology-db.ts
@@ -19,9 +19,24 @@ import { ContractOperations } from './topology-contracts.js';
 import { EndpointOperations } from './topology-endpoints.js';
 import { EventOperations } from './topology-events.js';
 import { CrossServiceEdgeOperations } from './topology-edges.js';
-import { SubprojectOperations, pruneDangerousSubprojects } from './topology-subprojects.js';
+import {
+  SubprojectOperations,
+  findStaleTopology,
+  pruneDangerousSubprojects,
+  pruneStaleTopology,
+  type StaleTopologyReport,
+  type PruneTopologyResult,
+} from './topology-subprojects.js';
 import { ClientCallOperations } from './topology-client-calls.js';
 import { SnapshotOperations } from './topology-snapshots.js';
+
+export {
+  findStaleTopology,
+  pruneDangerousSubprojects,
+  pruneStaleTopology,
+  type StaleTopologyReport,
+  type PruneTopologyResult,
+};
 
 // ════════════════════════════════════════════════════════════════════════
 // TYPES
@@ -635,6 +650,16 @@ export class TopologyStore {
 
   updateSubprojectSyncTime(id: number): void {
     this.subprojects.updateSubprojectSyncTime(id);
+  }
+
+  /** Scan for stale subprojects and services pointing to missing directories. */
+  findStale(): StaleTopologyReport {
+    return findStaleTopology(this.db);
+  }
+
+  /** Prune stale subprojects and services whose directories no longer exist. */
+  pruneStale(): PruneTopologyResult {
+    return pruneStaleTopology(this.db);
   }
 
   // ── Client Calls ──────────────────────────────────────────────────

--- a/src/topology/topology-subprojects.ts
+++ b/src/topology/topology-subprojects.ts
@@ -9,6 +9,7 @@
  * rather than importing `ServiceOperations` back, which would risk a cycle.
  */
 
+import fs from 'node:fs';
 import path from 'node:path';
 import type Database from 'better-sqlite3';
 import { isDangerousProjectRoot } from '../dangerous-root.js';
@@ -91,6 +92,123 @@ export function pruneDangerousSubprojects(db: Database.Database): {
   })();
 
   return { subprojects: badIds.length, services };
+}
+
+export interface StaleTopologyReport {
+  staleSubprojects: Array<{
+    id: number;
+    name: string;
+    repo_root: string;
+    project_root: string;
+  }>;
+  staleServices: Array<{
+    id: number;
+    name: string;
+    repo_root: string;
+  }>;
+}
+
+export interface PruneTopologyResult {
+  subprojects: number;
+  services: number;
+  removedSubprojects: Array<{ id: number; name: string; repo_root: string; project_root: string }>;
+  removedServices: Array<{ id: number; name: string; repo_root: string }>;
+}
+
+/**
+ * Scan `topology.db` for subprojects and services whose repo_root or project_root
+ * no longer exists on disk.
+ */
+export function findStaleTopology(db: Database.Database): StaleTopologyReport {
+  let staleSubprojects: Array<{
+    id: number;
+    name: string;
+    repo_root: string;
+    project_root: string;
+  }> = [];
+  try {
+    const subRows = db
+      .prepare('SELECT id, name, repo_root, project_root FROM subprojects')
+      .all() as Array<{
+      id: number;
+      name: string;
+      repo_root: string;
+      project_root: string;
+    }>;
+    staleSubprojects = subRows.filter(
+      (r) => !fs.existsSync(r.repo_root) || !fs.existsSync(r.project_root),
+    );
+  } catch {
+    /* table may not exist */
+  }
+
+  let staleServices: Array<{ id: number; name: string; repo_root: string }> = [];
+  try {
+    const svcRows = db.prepare('SELECT id, name, repo_root FROM services').all() as Array<{
+      id: number;
+      name: string;
+      repo_root: string;
+    }>;
+    staleServices = svcRows.filter((r) => !fs.existsSync(r.repo_root));
+  } catch {
+    /* table may not exist */
+  }
+
+  return { staleSubprojects, staleServices };
+}
+
+/**
+ * Prune stale subprojects and services from `topology.db` whose roots no longer
+ * exist on disk. Detaches foreign keys on `client_calls` before deletion.
+ */
+export function pruneStaleTopology(db: Database.Database): PruneTopologyResult {
+  const { staleSubprojects, staleServices } = findStaleTopology(db);
+
+  if (staleSubprojects.length === 0 && staleServices.length === 0) {
+    return {
+      subprojects: 0,
+      services: 0,
+      removedSubprojects: [],
+      removedServices: [],
+    };
+  }
+
+  db.transaction(() => {
+    if (staleServices.length > 0) {
+      const svcIds = staleServices.map((s) => s.id);
+      const svcPlaceholders = svcIds.map(() => '?').join(',');
+
+      // Detach client_calls.matched_endpoint_id before cascading delete of api_endpoints
+      db.prepare(
+        `UPDATE client_calls SET matched_endpoint_id = NULL
+         WHERE matched_endpoint_id IN (
+           SELECT e.id FROM api_endpoints e
+           WHERE e.service_id IN (${svcPlaceholders})
+         )`,
+      ).run(...svcIds);
+
+      db.prepare(`DELETE FROM services WHERE id IN (${svcPlaceholders})`).run(...svcIds);
+    }
+
+    if (staleSubprojects.length > 0) {
+      const subIds = staleSubprojects.map((s) => s.id);
+      const subPlaceholders = subIds.map(() => '?').join(',');
+
+      // Detach client_calls.target_repo_id before deleting subprojects
+      db.prepare(
+        `UPDATE client_calls SET target_repo_id = NULL WHERE target_repo_id IN (${subPlaceholders})`,
+      ).run(...subIds);
+
+      db.prepare(`DELETE FROM subprojects WHERE id IN (${subPlaceholders})`).run(...subIds);
+    }
+  })();
+
+  return {
+    subprojects: staleSubprojects.length,
+    services: staleServices.length,
+    removedSubprojects: staleSubprojects,
+    removedServices: staleServices,
+  };
 }
 
 export interface SubprojectOperationDeps {

--- a/tests/cli/doctor-topology-decisions.test.ts
+++ b/tests/cli/doctor-topology-decisions.test.ts
@@ -1,0 +1,99 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TopologyStore } from '../../src/topology/topology-db.js';
+import { DecisionStore } from '../../src/memory/decision-store.js';
+
+describe('doctor topology and decisions hygiene (TRA-595)', () => {
+  let tmpHome: string;
+  let doctor: typeof import('../../src/cli/doctor.js');
+
+  beforeEach(async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-doc-hygiene-'));
+    vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+    vi.resetModules();
+    doctor = await import('../../src/cli/doctor.js');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('diagnoses and fixes stale topology entries and orphaned decisions', () => {
+    const topoDbPath = path.join(tmpHome, 'topology.db');
+    const decisionsDbPath = path.join(tmpHome, 'decisions.db');
+    const deadDir = path.join(tmpHome, 'dead-app');
+    fs.mkdirSync(deadDir, { recursive: true });
+
+    // Seed topology
+    const topo = new TopologyStore(topoDbPath);
+    topo.upsertService({
+      name: 'dead-service',
+      repoRoot: deadDir,
+      serviceType: 'api',
+      detectionSource: 'docker',
+      dbPath: path.join(deadDir, 'idx.db'),
+    });
+    topo.upsertSubproject({
+      name: 'dead-sub',
+      repoRoot: deadDir,
+      projectRoot: deadDir,
+      dbPath: path.join(deadDir, 'idx.db'),
+    });
+    topo.close();
+
+    // Seed decisions
+    const dec = new DecisionStore(decisionsDbPath);
+    dec.addDecision({
+      title: 'Dead decision title',
+      content: 'Dead content',
+      type: 'tech_choice',
+      project_root: deadDir,
+    });
+    dec.close();
+
+    // Remove dead directory
+    fs.rmSync(deadDir, { recursive: true, force: true });
+
+    // Diagnose
+    const topoReport = doctor.diagnoseTopology();
+    expect(topoReport.topologyExists).toBe(true);
+    expect(topoReport.staleCount).toBe(2);
+    expect(topoReport.staleServices.map((s) => s.name)).toEqual(['dead-service']);
+    expect(topoReport.staleSubprojects.map((s) => s.name)).toEqual(['dead-sub']);
+
+    const decReport = doctor.diagnoseDecisions();
+    expect(decReport.decisionsExists).toBe(true);
+    expect(decReport.staleRoots).toEqual([deadDir]);
+    expect(decReport.staleDecisionsCount).toBe(1);
+
+    // Dry-run fix
+    const topoDryFix = doctor.fixTopologyIssues(topoReport, { dryRun: true });
+    expect(topoDryFix.removedServices).toEqual(['dead-service']);
+    expect(topoDryFix.removedSubprojects).toEqual(['dead-sub']);
+
+    const decDryFix = doctor.fixDecisionsIssues(decReport, { dryRun: true });
+    expect(decDryFix.removedRoots).toEqual([deadDir]);
+    expect(decDryFix.removedDecisions).toBe(1);
+
+    // Actual fix
+    const topoFix = doctor.fixTopologyIssues(topoReport, { dryRun: false });
+    expect(topoFix.removedServices).toEqual(['dead-service']);
+    expect(topoFix.removedSubprojects).toEqual(['dead-sub']);
+
+    const decFix = doctor.fixDecisionsIssues(decReport, { dryRun: false });
+    expect(decFix.removedRoots).toEqual([deadDir]);
+    expect(decFix.removedDecisions).toBe(1);
+
+    // Re-diagnose confirms clean state
+    const cleanTopo = doctor.diagnoseTopology();
+    expect(cleanTopo.staleCount).toBe(0);
+
+    const cleanDec = doctor.diagnoseDecisions();
+    expect(cleanDec.staleRoots).toHaveLength(0);
+    expect(cleanDec.staleDecisionsCount).toBe(0);
+  });
+});

--- a/tests/cli/memory-prune.test.ts
+++ b/tests/cli/memory-prune.test.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DecisionStore } from '../../src/memory/decision-store.js';
+
+describe('trace-mcp memory prune CLI (TRA-595)', () => {
+  let tmpHome: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-mem-prune-'));
+    vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+    dbPath = path.join(tmpHome, 'decisions.db');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('runs dry-run and reports stale roots without deleting', async () => {
+    const store = new DecisionStore(dbPath);
+    const deadDir = path.join(tmpHome, 'deleted-project');
+    fs.mkdirSync(deadDir, { recursive: true });
+
+    store.addDecision({
+      title: 'Dead decision',
+      content: 'Some dead content',
+      type: 'tech_choice',
+      project_root: deadDir,
+    });
+    store.close();
+
+    // Delete folder
+    fs.rmSync(deadDir, { recursive: true, force: true });
+
+    const checkStore = new DecisionStore(dbPath);
+    const stale = checkStore.findStale();
+    expect(stale.staleRoots).toEqual([deadDir]);
+    expect(stale.decisionsCount).toBe(1);
+
+    // Dry-run prune does not delete
+    const dryRunResult = { apply: false, ...stale };
+    expect(dryRunResult.apply).toBe(false);
+    expect(checkStore.queryDecisions({ project_root: deadDir })).toHaveLength(1);
+
+    // Apply prune deletes
+    const applyResult = checkStore.pruneStale();
+    expect(applyResult.decisions).toBe(1);
+    expect(checkStore.queryDecisions({ project_root: deadDir })).toHaveLength(0);
+    checkStore.close();
+  });
+});

--- a/tests/cli/prune-topology-decisions.test.ts
+++ b/tests/cli/prune-topology-decisions.test.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TopologyStore } from '../../src/topology/topology-db.js';
+import { DecisionStore } from '../../src/memory/decision-store.js';
+
+describe('trace-mcp prune topology & decisions integration (TRA-595)', () => {
+  let tmpHome: string;
+  let pruneModule: typeof import('../../src/cli/prune.js');
+
+  beforeEach(async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-prune-int-'));
+    vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+    vi.resetModules();
+    pruneModule = await import('../../src/cli/prune.js');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('scans and prunes stale topology and decisions', () => {
+    const topoDbPath = path.join(tmpHome, 'topology.db');
+    const decisionsDbPath = path.join(tmpHome, 'decisions.db');
+    const deadDir = path.join(tmpHome, 'dead-folder');
+    fs.mkdirSync(deadDir, { recursive: true });
+
+    // Seed topology
+    const topo = new TopologyStore(topoDbPath);
+    topo.upsertService({
+      name: 'dead-svc',
+      repoRoot: deadDir,
+      serviceType: 'api',
+      detectionSource: 'docker',
+      dbPath: path.join(deadDir, 'idx.db'),
+    });
+    topo.close();
+
+    // Seed decisions
+    const dec = new DecisionStore(decisionsDbPath);
+    dec.addDecision({
+      title: 'Dead tech choice',
+      content: 'Dead choice content',
+      type: 'tech_choice',
+      project_root: deadDir,
+    });
+    dec.close();
+
+    // Remove folder
+    fs.rmSync(deadDir, { recursive: true, force: true });
+
+    // Dry-run scan
+    const dryTopo = pruneModule.scanOrPruneTopology(false);
+    expect(dryTopo.staleServices.map((s) => s.name)).toEqual(['dead-svc']);
+    expect(dryTopo.removedServices).toBe(0);
+
+    const dryDec = pruneModule.scanOrPruneDecisions(false);
+    expect(dryDec.staleRoots).toEqual([deadDir]);
+    expect(dryDec.staleDecisionsCount).toBe(1);
+    expect(dryDec.removedDecisions).toBe(0);
+
+    // Apply prune
+    const applyTopo = pruneModule.scanOrPruneTopology(true);
+    expect(applyTopo.removedServices).toBe(1);
+
+    const applyDec = pruneModule.scanOrPruneDecisions(true);
+    expect(applyDec.removedDecisions).toBe(1);
+    expect(applyDec.staleRoots).toEqual([deadDir]);
+
+    // Subsequent scan is clean
+    const cleanTopo = pruneModule.scanOrPruneTopology(false);
+    expect(cleanTopo.staleServices).toHaveLength(0);
+
+    const cleanDec = pruneModule.scanOrPruneDecisions(false);
+    expect(cleanDec.staleRoots).toHaveLength(0);
+  });
+});

--- a/tests/memory/decision-stale-prune.test.ts
+++ b/tests/memory/decision-stale-prune.test.ts
@@ -1,0 +1,157 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DecisionStore } from '../../src/memory/decision-store.js';
+
+describe('DecisionStore stale pruning (TRA-595)', () => {
+  let store: DecisionStore;
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'decision-prune-test-'));
+    dbPath = path.join(tmpDir, 'decisions.db');
+    store = new DecisionStore(dbPath);
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects and prunes decisions, chunks, clusters, and memos for deleted project roots', () => {
+    const liveDir = path.join(tmpDir, 'live-proj');
+    const deadDir = path.join(tmpDir, 'dead-proj');
+    fs.mkdirSync(liveDir, { recursive: true });
+    fs.mkdirSync(deadDir, { recursive: true });
+
+    // Seed live data
+    store.addDecision({
+      title: 'Live decision',
+      content: 'Live decision content',
+      type: 'architecture',
+      project_root: liveDir,
+    });
+    store.addSessionChunks([
+      {
+        session_id: 'live-sess',
+        project_root: liveDir,
+        chunk_index: 0,
+        content: 'Live chunk content',
+        role: 'user',
+        timestamp: Date.now(),
+      },
+    ]);
+
+    // Seed dead data
+    const deadDec = store.addDecision({
+      title: 'Dead decision',
+      content: 'Dead decision content',
+      type: 'tech_choice',
+      project_root: deadDir,
+    });
+    store.addSessionChunks([
+      {
+        session_id: 'dead-sess',
+        project_root: deadDir,
+        chunk_index: 0,
+        content: 'Dead chunk content',
+        role: 'user',
+        timestamp: Date.now(),
+      },
+    ]);
+    store.createCluster({
+      title: 'Dead cluster',
+      summary: 'Dead cluster summary',
+      project_root: deadDir,
+      decision_ids: [deadDec.id],
+    });
+    store.saveProjectMemo({
+      project_root: deadDir,
+      memo_md: 'Dead memo content and learnings',
+      decisions_at_generation: 1,
+      clusters_at_generation: 1,
+      estimated_tokens: 100,
+    });
+    store.upsertSchedulerState({
+      project_root: deadDir,
+      last_mine_at: Date.now(),
+      last_cluster_at: null,
+      last_memo_at: null,
+      last_tune_at: null,
+      last_tune_event_count: null,
+      consecutive_failures: 0,
+    });
+
+    // Seed mined sessions
+    const deadSessionPath = path.join(deadDir, 'session.jsonl');
+    fs.writeFileSync(deadSessionPath, '{"type":"message"}\n');
+    store.updateSessionCursor({
+      sessionPath: deadSessionPath,
+      cursor: 10,
+      size: 20,
+      modifiedMs: Date.now(),
+      decisionsFound: 1,
+    });
+
+    // Initial check: all folders exist
+    expect(store.findStaleRoots()).toHaveLength(0);
+    const initialStale = store.findStale();
+    expect(initialStale.decisionsCount).toBe(0);
+
+    // Delete deadDir
+    fs.rmSync(deadDir, { recursive: true, force: true });
+
+    // Stale detection
+    const stale = store.findStale();
+    expect(stale.staleRoots).toEqual([deadDir]);
+    expect(stale.decisionsCount).toBe(1);
+    expect(stale.chunksCount).toBe(1);
+    expect(stale.clustersCount).toBe(1);
+    expect(stale.memosCount).toBe(1);
+    expect(stale.schedulerStatesCount).toBe(1);
+    expect(stale.staleMinedSessionsCount).toBe(1);
+    expect(stale.staleDecisions.map((d) => d.title)).toEqual(['Dead decision']);
+
+    // Prune stale entries
+    const pruneRes = store.pruneStale({ includeMinedSessions: true });
+    expect(pruneRes.staleRoots).toEqual([deadDir]);
+    expect(pruneRes.decisions).toBe(1);
+    expect(pruneRes.chunks).toBe(1);
+    expect(pruneRes.clusters).toBe(1);
+    expect(pruneRes.memos).toBe(1);
+    expect(pruneRes.schedulerStates).toBe(1);
+    expect(pruneRes.minedSessions).toBe(1);
+
+    // Verify dead data is gone and live data is intact
+    expect(store.queryDecisions({ project_root: deadDir })).toHaveLength(0);
+    const liveDecisions = store.queryDecisions({ project_root: liveDir });
+    expect(liveDecisions).toHaveLength(1);
+    expect(liveDecisions[0].title).toBe('Live decision');
+
+    // FTS search on dead decision returns nothing
+    const searchRes = store.queryDecisions({ project_root: deadDir, search: 'Dead' });
+    expect(searchRes).toHaveLength(0);
+  });
+
+  it('is a no-op when decision store has no stale project roots', () => {
+    const liveDir = path.join(tmpDir, 'live-proj');
+    fs.mkdirSync(liveDir, { recursive: true });
+
+    store.addDecision({
+      title: 'Live decision',
+      content: 'Live decision content',
+      type: 'architecture',
+      project_root: liveDir,
+    });
+
+    const res = store.pruneStale();
+    expect(res.staleRoots).toEqual([]);
+    expect(res.decisions).toBe(0);
+    expect(res.chunks).toBe(0);
+    expect(res.clusters).toBe(0);
+    expect(res.memos).toBe(0);
+    expect(res.schedulerStates).toBe(0);
+  });
+});

--- a/tests/topology/topology-stale-prune.test.ts
+++ b/tests/topology/topology-stale-prune.test.ts
@@ -1,0 +1,138 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TopologyStore } from '../../src/topology/topology-db.js';
+
+describe('TopologyStore stale pruning (TRA-595)', () => {
+  let store: TopologyStore;
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'topo-prune-test-'));
+    dbPath = path.join(tmpDir, 'topology.db');
+    store = new TopologyStore(dbPath);
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects and prunes services and subprojects whose folders no longer exist', () => {
+    const liveDir = path.join(tmpDir, 'live-svc');
+    const deadDir = path.join(tmpDir, 'dead-svc');
+    fs.mkdirSync(liveDir, { recursive: true });
+    fs.mkdirSync(deadDir, { recursive: true });
+
+    const liveSvcId = store.upsertService({
+      name: 'live-svc',
+      repoRoot: liveDir,
+      serviceType: 'api',
+      detectionSource: 'docker',
+      dbPath: path.join(liveDir, 'idx.db'),
+    });
+
+    const deadSvcId = store.upsertService({
+      name: 'dead-svc',
+      repoRoot: deadDir,
+      serviceType: 'api',
+      detectionSource: 'docker',
+      dbPath: path.join(deadDir, 'idx.db'),
+    });
+
+    const liveSubId = store.upsertSubproject({
+      name: 'live-sub',
+      repoRoot: liveDir,
+      projectRoot: liveDir,
+      dbPath: path.join(liveDir, 'idx.db'),
+    });
+
+    const deadSubId = store.upsertSubproject({
+      name: 'dead-sub',
+      repoRoot: deadDir,
+      projectRoot: deadDir,
+      dbPath: path.join(deadDir, 'idx.db'),
+    });
+
+    const contractId = store.insertContract(deadSvcId, {
+      contractType: 'openapi',
+      specPath: 'openapi.json',
+      version: '1.0.0',
+      parsedSpec: '{}',
+    });
+
+    // Create client calls referencing endpoints and repos
+    store.insertEndpoints(contractId, deadSvcId, [
+      {
+        path: '/api/v1/dead',
+        method: 'GET',
+        handlerFunction: 'getDead',
+        filePath: 'src/routes.ts',
+      },
+    ]);
+    const endpoints = store.getEndpointsByService(deadSvcId);
+    expect(endpoints).toHaveLength(1);
+
+    store.insertClientCalls([
+      {
+        sourceRepoId: liveSubId,
+        targetRepoId: deadSubId,
+        matchedEndpointId: endpoints[0].id,
+        filePath: 'src/caller.ts',
+        callType: 'http',
+        urlPattern: '/api/v1/dead',
+      },
+    ]);
+
+    // Verify initial health check reports 0 stale
+    expect(store.findStale().staleServices).toHaveLength(0);
+    expect(store.findStale().staleSubprojects).toHaveLength(0);
+
+    // Now delete deadDir from disk
+    fs.rmSync(deadDir, { recursive: true, force: true });
+
+    // Check findStale
+    const stale = store.findStale();
+    expect(stale.staleServices.map((s) => s.name)).toEqual(['dead-svc']);
+    expect(stale.staleSubprojects.map((s) => s.name)).toEqual(['dead-sub']);
+
+    // Prune stale entries
+    const pruneResult = store.pruneStale();
+    expect(pruneResult.services).toBe(1);
+    expect(pruneResult.subprojects).toBe(1);
+    expect(pruneResult.removedServices.map((s) => s.name)).toEqual(['dead-svc']);
+    expect(pruneResult.removedSubprojects.map((s) => s.name)).toEqual(['dead-sub']);
+
+    // Verify dead service and subproject are gone, and live service and subproject survive
+    expect(store.getService('dead-svc')).toBeUndefined();
+    expect(store.getService('live-svc')).toBeDefined();
+    expect(store.getAllSubprojects().map((s) => s.name)).toEqual(['live-sub']);
+
+    // Verify client calls still exist but foreign keys are detached
+    const clientCalls = store.getClientCallsByRepo(liveSubId);
+    expect(clientCalls).toHaveLength(1);
+    expect(clientCalls[0].target_repo_id).toBeNull();
+    expect(clientCalls[0].matched_endpoint_id).toBeNull();
+  });
+
+  it('is a no-op when topology has no stale roots', () => {
+    const liveDir = path.join(tmpDir, 'live-svc');
+    fs.mkdirSync(liveDir, { recursive: true });
+
+    store.upsertService({
+      name: 'live-svc',
+      repoRoot: liveDir,
+      serviceType: 'api',
+      detectionSource: 'docker',
+      dbPath: path.join(liveDir, 'idx.db'),
+    });
+
+    const res = store.pruneStale();
+    expect(res.services).toBe(0);
+    expect(res.subprojects).toBe(0);
+    expect(res.removedServices).toEqual([]);
+    expect(res.removedSubprojects).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Resolves TRA-595.

### Changes
1. **Topology Pruning (, )**:
   - Added `findStaleTopology` and `pruneStaleTopology` (exposed on `TopologyStore` as `findStale()` and `pruneStale()`).
   - Detects subprojects and services whose `repo_root` or `project_root` no longer exist on disk (`!fs.existsSync`).
   - Safely detaches `client_calls.matched_endpoint_id` and `client_calls.target_repo_id` before deletions to prevent foreign key errors.

2. **Decision Store Hygiene (`src/memory/decision-store.ts`, `src/memory/decision-types.ts`)**:
   - Added `findStaleRoots()`, `findStale()`, and `pruneStale()` on `DecisionStore`.
   - Cleans up decisions, session chunks, decision clusters, project memos, and scheduler states for deleted project roots in an atomic transaction with FTS trigger cleanup.
   - Supports optionally cleaning stale `mined_sessions` file references.

3. **Memory CLI Subcommand (`src/cli/memory.ts`)**:
   - Added `trace-mcp memory prune` subcommand supporting dry-run inspection, `--apply`, `--include-sessions`, and `--json`.

4. **Global Prune & Soft GC Sweep (`src/cli/prune.ts`, `src/cli.ts`)**:
   - Integrated topology and decisions hygiene into `trace-mcp prune` (both human output and `--json`).
   - Extended `softGcSweep` to run quiet hygiene sweeps on `topology.db` and `decisions.db` during periodic GC.

5. **Doctor Diagnostics & Fixes (`src/cli/doctor.ts`)**:
   - Added `diagnoseTopology()` and `diagnoseDecisions()` to surface dead services/subprojects and orphaned decisions.
   - Supported auto-remediation via `--fix`, dry-run preview via `--dry-run`, and interactive prompts via `--fix-interactive`.

6. **Tests**:
   - Unit and integration tests in `tests/topology/topology-stale-prune.test.ts`, `tests/memory/decision-stale-prune.test.ts`, `tests/cli/memory-prune.test.ts`, `tests/cli/prune-topology-decisions.test.ts`, and `tests/cli/doctor-topology-decisions.test.ts`.