### PR TITLE
fix(app): enable custom WindowTabBar across all platforms including macOS

### DIFF
--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -296,7 +296,6 @@ function getTabList(focusedWebContentsId?: number): TabInfo[] {
 }
 
 function broadcastTabList(): void {
-  if (isMac) return; // macOS uses native tabs
   const allWindows = [menuWindow, ...projectWindows.values()];
   const focusedWin = BrowserWindow.getFocusedWindow();
   const tabs = getTabList(focusedWin?.webContents.id);

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -1029,15 +1029,23 @@ export function App() {
   );
   const toggleLivesInSidebar = !sidebarCollapsed && hasInsetTitleBar();
 
+  const [tabCount, setTabCount] = useState<number>(0);
+
+  useEffect(() => {
+    const api = window.electronAPI;
+    if (!api?.onTabListChanged) return;
+    return api.onTabListChanged((tabs) => setTabCount(tabs.length));
+  }, []);
+
   return (
     <div
       className="ws-stage flex flex-col h-screen"
       data-mode={theme}
       data-platform={hasInsetTitleBar() ? 'mac' : 'other'}
+      data-tabbar={tabCount > 1 ? 'on' : 'off'}
     >
       {showOnboarding && <GuardOnboarding onClose={() => setShowOnboarding(false)} />}
       {quickOpen && <QuickOpen items={quickOpenItems()} onClose={() => setQuickOpen(false)} />}
-      {/* Windows custom tab bar (hidden on macOS — native tabs handle it) */}
       <WindowTabBar />
 
       <div className={`ws-shell${sidebarCollapsed ? ' is-collapsed' : ''}`}>

--- a/packages/app/src/renderer/components/WindowTabBar.tsx
+++ b/packages/app/src/renderer/components/WindowTabBar.tsx
@@ -1,13 +1,20 @@
 /**
- * Custom tab bar for Windows (and Linux).
- * On macOS, native tabs handle this — this component renders nothing.
+ * Custom tab bar for every platform, macOS included (the native AppKit tabs
+ * were removed in PR 708).
  *
  * Displays a horizontal strip of tabs at the top of each window.
  * Each tab represents an open window (Menu + project windows).
  * Clicking a tab sends IPC to focus that window.
+ *
+ * On macOS this strip is the topmost band, so the system traffic lights are
+ * drawn INSIDE it. Its height is therefore TOP_BAND_H — the same number the
+ * main process derives `trafficLightPosition.y` from — and never a literal of
+ * its own. A 36px strip centres at 18 while the lights centre at 22, which is
+ * exactly the drift chrome-metrics.ts exists to prevent (TRA-370).
  */
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { TOP_BAND_H } from '../../shared/chrome-metrics.js';
 
 interface TabInfo {
   id: string;
@@ -58,10 +65,10 @@ export function WindowTabBar() {
       style={
         {
           display: 'flex',
-          alignItems: 'stretch',
-          height: 36,
+          alignItems: 'center',
+          height: TOP_BAND_H,
           background: 'var(--surface-sunken)',
-          borderBottom: '1px solid var(--separator)',
+          borderBottom: '0.5px solid var(--separator)',
           WebkitAppRegion: 'drag',
           paddingLeft: platform === 'darwin' ? 78 : 4,
           paddingRight: 4,
@@ -81,13 +88,14 @@ export function WindowTabBar() {
               display: 'flex',
               alignItems: 'center',
               gap: 6,
+              height: 28,
               padding: '0 12px',
               fontSize: 11,
               fontWeight: tab.active ? 600 : 400,
               color: tab.active ? 'var(--label)' : 'var(--label-secondary)',
               background: tab.active ? 'var(--fill-tertiary)' : 'transparent',
               border: 'none',
-              borderRadius: '6px 6px 0 0',
+              borderRadius: 6,
               cursor: 'pointer',
               maxWidth: 180,
               minWidth: 0,
@@ -95,7 +103,6 @@ export function WindowTabBar() {
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               WebkitAppRegion: 'no-drag',
-              marginTop: 4,
               transition: 'background 0.15s, color 0.15s',
             } as React.CSSProperties
           }

--- a/packages/app/src/renderer/components/WindowTabBar.tsx
+++ b/packages/app/src/renderer/components/WindowTabBar.tsx
@@ -33,8 +33,8 @@ export function WindowTabBar() {
     return api.onTabListChanged((newTabs: TabInfo[]) => setTabs(newTabs));
   }, []);
 
-  // Don't render on macOS (native tabs) or if only 1 tab (no strip needed)
-  if (platform === 'darwin' || tabs.length <= 1) return null;
+  // Don't render if only 1 tab (no strip needed)
+  if (tabs.length <= 1) return null;
 
   const handleTabClick = (tabId: string) => {
     const api = window.electronAPI;
@@ -63,7 +63,7 @@ export function WindowTabBar() {
           background: 'var(--surface-sunken)',
           borderBottom: '1px solid var(--separator)',
           WebkitAppRegion: 'drag',
-          paddingLeft: 4,
+          paddingLeft: platform === 'darwin' ? 78 : 4,
           paddingRight: 4,
           gap: 1,
           flexShrink: 0,

--- a/packages/app/src/renderer/components/__tests__/WindowTabBar.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/WindowTabBar.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TOP_BAND_H, trafficLightCentreY } from '../../../shared/chrome-metrics.js';
 import { WindowTabBar } from '../WindowTabBar';
 
 interface TabInfo {
@@ -64,6 +65,26 @@ describe('WindowTabBar', () => {
 
     const bar = container.firstChild as HTMLElement;
     expect(bar.style.paddingLeft).toBe('78px');
+  });
+
+  /* TRA-370 / PR 716. Under `hiddenInset` this strip is the topmost band, so the
+     system draws the traffic lights inside it. The first version hard-coded
+     36px while `trafficLightPosition.y` stayed derived from the 44px
+     TOP_BAND_H — lights centred at 22 in a strip centred at 18. Assert the tie,
+     not the number: if either side moves alone, this fails. */
+  it('sizes the strip so the traffic lights land on its centre line', async () => {
+    const tabs: TabInfo[] = [
+      { id: 'menu', title: 'Workspace', type: 'menu', active: true },
+      { id: '/projects/assetfeed', title: 'assetfeed', type: 'project', active: false },
+    ];
+    stubElectronAPI('darwin', tabs);
+
+    const { container } = render(<WindowTabBar />);
+    await screen.findByText('Workspace');
+
+    const bar = container.firstChild as HTMLElement;
+    expect(bar.style.height).toBe(`${TOP_BAND_H}px`);
+    expect(trafficLightCentreY()).toBe(Number.parseFloat(bar.style.height) / 2);
   });
 
   it('renders tab strip on Windows/Linux with 4px padding', async () => {

--- a/packages/app/src/renderer/components/__tests__/WindowTabBar.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/WindowTabBar.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WindowTabBar } from '../WindowTabBar';
+
+interface TabInfo {
+  id: string;
+  title: string;
+  type: string;
+  active: boolean;
+}
+
+function stubElectronAPI(platform = 'darwin', initialTabs: TabInfo[] = []) {
+  let tabCallback: ((tabs: TabInfo[]) => void) | null = null;
+
+  const api = {
+    getPlatform: vi.fn(async () => platform),
+    onTabListChanged: vi.fn((cb: (tabs: TabInfo[]) => void) => {
+      tabCallback = cb;
+      cb(initialTabs);
+      return () => {
+        tabCallback = null;
+      };
+    }),
+    focusTab: vi.fn(async (_id: string) => ({ ok: true })),
+    closeCurrentTab: vi.fn(async () => ({ ok: true })),
+  };
+
+  (window as unknown as { electronAPI: typeof api }).electronAPI = api;
+  return {
+    api,
+    emitTabs: (tabs: TabInfo[]) => tabCallback?.(tabs),
+  };
+}
+
+afterEach(() => {
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  vi.restoreAllMocks();
+});
+
+describe('WindowTabBar', () => {
+  it('renders nothing when only 1 tab exists', async () => {
+    const { container } = render(<WindowTabBar />);
+    stubElectronAPI('darwin', [
+      { id: 'menu', title: 'Workspace', type: 'menu', active: true },
+    ]);
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it('renders tab strip on macOS with 78px padding for traffic lights', async () => {
+    const tabs: TabInfo[] = [
+      { id: 'menu', title: 'Workspace', type: 'menu', active: true },
+      { id: '/projects/assetfeed', title: 'assetfeed', type: 'project', active: false },
+    ];
+    stubElectronAPI('darwin', tabs);
+
+    const { container } = render(<WindowTabBar />);
+
+    await screen.findByText('Workspace');
+    expect(screen.getByText('assetfeed')).toBeTruthy();
+
+    const bar = container.firstChild as HTMLElement;
+    expect(bar.style.paddingLeft).toBe('78px');
+  });
+
+  it('renders tab strip on Windows/Linux with 4px padding', async () => {
+    const tabs: TabInfo[] = [
+      { id: 'menu', title: 'Workspace', type: 'menu', active: true },
+      { id: '/projects/thewed', title: 'thewed', type: 'project', active: false },
+    ];
+    stubElectronAPI('win32', tabs);
+
+    const { container } = render(<WindowTabBar />);
+
+    await screen.findByText('Workspace');
+    const bar = container.firstChild as HTMLElement;
+    expect(bar.style.paddingLeft).toBe('4px');
+  });
+
+  it('switches tab on click', async () => {
+    const tabs: TabInfo[] = [
+      { id: 'menu', title: 'Workspace', type: 'menu', active: true },
+      { id: '/projects/assetfeed', title: 'assetfeed', type: 'project', active: false },
+    ];
+    const { api } = stubElectronAPI('darwin', tabs);
+
+    render(<WindowTabBar />);
+
+    const projectTab = await screen.findByText('assetfeed');
+    fireEvent.click(projectTab);
+
+    expect(api.focusTab).toHaveBeenCalledWith('/projects/assetfeed');
+  });
+
+  it('closes a project tab on close button click', async () => {
+    const tabs: TabInfo[] = [
+      { id: 'menu', title: 'Workspace', type: 'menu', active: true },
+      { id: '/projects/assetfeed', title: 'assetfeed', type: 'project', active: false },
+    ];
+    const { api } = stubElectronAPI('darwin', tabs);
+
+    render(<WindowTabBar />);
+
+    const closeBtn = await screen.findByRole('button', { name: /close/i });
+    fireEvent.click(closeBtn);
+
+    expect(api.focusTab).toHaveBeenCalledWith('/projects/assetfeed');
+    await waitFor(() => {
+      expect(api.closeCurrentTab).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/app/src/renderer/styles/sidebar.css
+++ b/packages/app/src/renderer/styles/sidebar.css
@@ -64,6 +64,9 @@
   padding-left: 78px;
   -webkit-app-region: drag;
 }
+.ws-stage[data-platform="mac"][data-tabbar="on"] .ws-sidebar-titlebar {
+  padding-left: 12px;
+}
 .ws-sidebar-titlebar > * {
   -webkit-app-region: no-drag;
 }
@@ -428,6 +431,9 @@
 /* Collapsed sidebar on macOS: the traffic lights land on this header instead. */
 .ws-stage[data-platform="mac"] .ws-shell.is-collapsed .ws-content-head {
   padding-left: 78px;
+}
+.ws-stage[data-platform="mac"][data-tabbar="on"] .ws-shell.is-collapsed .ws-content-head {
+  padding-left: 12px;
 }
 
 .ws-content-body {

--- a/scripts/postinstall-app.mjs
+++ b/scripts/postinstall-app.mjs
@@ -73,6 +73,7 @@ const GITHUB_REPO = getAppDistRepo();
 const API_BASE = process.env.TRACE_MCP_UPDATE_API_BASE || 'https://api.github.com';
 const PGREP_BIN = process.env.TRACE_MCP_PGREP_BIN || '/usr/bin/pgrep';
 const PS_BIN = process.env.TRACE_MCP_PS_BIN || '/bin/ps';
+const MDFIND_BIN = process.env.TRACE_MCP_MDFIND_BIN || '/usr/bin/mdfind';
 // The directories a bundle conventionally lives in — same defaults as
 // locate-app.mjs. The multi-bundle scan and the orphan sweep below read them,
 // and only tests override them: a test must never be able to swap or delete
@@ -142,7 +143,10 @@ if (process.platform !== 'darwin') process.exit(0);
 // script exits below, leaving the user permanently without an app. This is
 // the recovery path that actually fires in practice: the daemon's self-update
 // re-runs the postinstall even when the .app cannot be launched at all.
-for (const { action, path: target } of recoverInterruptedSwap()) {
+for (const { action, path: target } of recoverInterruptedSwap({
+  fallbackDirs: CONVENTIONAL_APP_DIRS,
+  mdfindBin: MDFIND_BIN,
+})) {
   console.log(`  trace-mcp: ${action} ${target} (interrupted update)`);
 }
 
@@ -153,7 +157,10 @@ for (const { action, path: target } of recoverInterruptedSwap()) {
 // reporting success. Electron main already derives its install dir from
 // `process.execPath`, so targeting the running bundle is what makes the two
 // sides agree by construction. See runningBundlePath() in locate-app.mjs.
-const located = locateInstalledApp();
+const located = locateInstalledApp({
+  fallbackDirs: CONVENTIONAL_APP_DIRS,
+  mdfindBin: MDFIND_BIN,
+});
 const running = runningBundlePath({ pgrepBin: PGREP_BIN, psBin: PS_BIN });
 const target = running ?? located?.appPath;
 if (!target) process.exit(0);

--- a/tests/scripts/postinstall-app.test.ts
+++ b/tests/scripts/postinstall-app.test.ts
@@ -263,6 +263,8 @@ describe.skipIf(process.platform !== 'darwin')('postinstall-app.mjs bundle swap'
         TRACE_MCP_PS_BIN: opts.runningBundle
           ? writePsStub(tmp, opts.runningBundle)
           : '/usr/bin/false',
+        // Silence Spotlight queries so tests never resolve bundles on the host.
+        TRACE_MCP_MDFIND_BIN: '/usr/bin/false',
         // Confine the orphan-staging sweep to this fixture. Without it the
         // script would reach into the real /Applications of whatever machine
         // runs the suite.


### PR DESCRIPTION
## Summary
- Enables the custom `WindowTabBar` on macOS (removing the `isMac` early return in `broadcastTabList` and platform restriction in `WindowTabBar.tsx`).
- Replaces the fragile native AppKit tabs under `hiddenInset` with the unified, fully controllable `WindowTabBar` that is already proven on Windows/Linux.
- Adds `paddingLeft: 78px` on macOS to cleanly clear the traffic lights.
- Adds `data-tabbar="on"` on `.ws-stage` to align the sidebar title bar when tabs are open.
- Isolates Spotlight search (`MDFIND_BIN`) in postinstall scripts and test suites.
- Adds comprehensive unit test suite in `WindowTabBar.test.tsx`.

## Verification
- 854 test files (9380 tests) passing in core.
- 54 test files (545 tests) passing in `packages/app`.
- Typecheck, `biome ci`, and renderer build passing.