### PR TITLE
feat(web): cut the hero to one download and one command (TRA-609)

### DIFF
--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -338,3 +338,47 @@ motion driven from JavaScript. The landing page animates a stat count-up over
 1400ms and staggers a segmented bar at 30ms per cell from `setTimeout`; both
 read a `reduceMotion` flag off `matchMedia`. Any new JS-driven motion has to
 read it too — the media query alone will not catch it.
+
+---
+
+## 8. The landing hero
+
+Numbered last because §1–§7 were written before this section existed; renumbering
+would break the `§` references inside this file and the one in `docs/index.html`.
+Read it as the landing-page counterpart to §2.
+
+**Two actions. Never three** (TRA-609). The hero carries the DMG button and the
+install command, and nothing else. It shipped with four competing elements —
+`Download for macOS`, `Analyze your AI system`, `View on GitHub`, and the install
+line — which is not a hierarchy, it is a row. Both of the removed buttons already
+had a home: the header links to the repo and to `#install`, on desktop and on a
+phone. Check that before adding a fifth thing back.
+
+**The two actions do not look alike.** The DMG is `.btn .btn-primary .btn-lg` — a
+red pill, the one red on the screen. The install line is `.hero-install` — a
+technical 8px box on `--surface` with a `$` prompt, the command, and a `COPY`
+label behind a hairline. A pill next to a pill reads as two buttons of equal
+weight; that is what the dashed pill it replaced did.
+
+**`.hero-install` is a `<button>`.** It was a `<span onclick>`, so the only way to
+copy the command was a mouse — no tab stop, no focus ring, nothing for a screen
+reader. The `$` is `aria-hidden`; the `copy` label is `aria-live="polite"` so the
+`copied` state is announced.
+
+**It is visible on a phone.** It used to be `display: none` under 700px, which
+left a phone visitor with a DMG button and no copyable command at all. Below
+700px the row becomes one column, both actions go full width, and `.copy` pins
+right on `margin-left: auto`.
+
+**Off macOS the DMG button is removed** (TRA-440) and `.hero-install` gains
+`.is-primary`, which raises its border to `--text-display`. Without that the
+hero has no primary action anywhere outside a Mac. When you read that border
+back in the browser, wait out the 200ms `border-color` transition — a
+`getComputedStyle` fired in the same tick as the `classList.add` returns the
+*start* colour and looks like the rule never matched.
+
+**The headline is measured, not guessed.** `clamp(36px, 5.2vw, 60px)` over
+`max-width: 900px` is the pair that breaks the current wording after
+"intelligence" and nowhere else; at `72px/820px` it ran to three lines and split
+"AI coding agents" across two of them. Change the wording, re-measure the line
+count at 1440px and at 390px.

--- a/docs/index.html
+++ b/docs/index.html
@@ -507,6 +507,9 @@ layout: null
       border: 1px solid var(--border-visible);
     }
     .btn-secondary:hover { border-color: var(--text-display); }
+    /* The hero's single primary action. Bigger box, same type scale — a new
+       font size would cost the page a slot in the 3-size budget for nothing. */
+    .btn-lg { padding: 18px 34px; min-height: 56px; }
     .btn .arrow { display: inline-block; transition: transform 200ms ease-out; }
     .btn:hover .arrow { transform: translateX(3px); }
 
@@ -522,77 +525,69 @@ layout: null
     .hero-meta .divider { flex: 1; height: 1px; background: var(--border-visible); }
     .hero-headline {
       font-family: var(--font-body);
-      font-size: clamp(36px, 6vw, 72px);
+      /* 60/900 is the pair that breaks this headline after "intelligence" and
+         nowhere else. At 72/820 it ran to three lines and split "AI coding
+         agents" across two of them; measure again if the wording changes. */
+      font-size: clamp(36px, 5.2vw, 60px);
       font-weight: 400;
       line-height: 1.05;
       letter-spacing: -0.025em;
       color: var(--text-display);
-      max-width: 820px;
+      max-width: 900px;
       overflow-wrap: break-word;
     }
-    .hero-headline .em { font-weight: 700; }
     .hero-desc {
-      margin-top: 48px;
-      max-width: 720px;
+      margin-top: 28px;
+      max-width: 660px;
       font-size: 19px;
       line-height: 1.55;
       color: var(--text-primary);
       font-weight: 400;
     }
-    .hero-desc .accent-text { color: var(--text-display); font-weight: 500; }
-    .hero-bullets {
-      list-style: none;
-      margin-top: 28px;
-      display: flex;
-      flex-direction: column;
-      gap: 10px;
-      font-size: 17px;
-      color: var(--text-primary);
-      font-weight: 400;
-    }
-    .hero-bullets li {
-      display: flex;
-      align-items: baseline;
-      gap: 10px;
-    }
-    .hero-bullets li::before {
-      content: '●';
-      font-size: 9px;
-      color: var(--success);
-      flex-shrink: 0;
-      line-height: 1.9;
-    }
-    .bullet-accent {
-      color: var(--text-display);
-      font-weight: 600;
-    }
-    @media (max-width: 700px) {
-      .hero-bullets { font-size: 15px; margin-top: 20px; gap: 8px; }
-    }
+    /* The payoff half of the subtitle separates on colour, not weight — a second
+       weight here would spend a budget slot on what one shade already says. */
+    .hero-desc .accent-text { color: var(--text-display); }
     .hero-cta {
       margin-top: 56px;
       display: flex; gap: 12px; flex-wrap: wrap;
       align-items: center;
     }
+    /* The second install path, and the only one off macOS. A technical 8px box,
+       not a pill: it reads as a terminal line, and the pill next to it is the
+       one thing on this row that should read as a button. */
     .hero-install {
-      display: inline-flex; align-items: center; gap: 12px;
-      padding: 14px 24px;
-      border: 1px dashed var(--border-visible);
-      border-radius: 999px;
+      display: inline-flex; align-items: center; gap: 14px;
+      min-height: 56px;
+      padding: 0 20px;
+      background: var(--surface);
+      border: 1px solid var(--border-visible);
+      border-radius: 8px;
       font-family: var(--font-mono);
       font-size: 13px;
-      color: var(--text-secondary);
+      color: var(--text-display);
+      text-align: left;
       cursor: pointer;
-      transition: all 200ms ease-out;
+      transition: border-color 200ms cubic-bezier(0.25, 0.1, 0.25, 1);
     }
-    .hero-install:hover { border-color: var(--text-display); color: var(--text-display); border-style: solid; }
-    .hero-install code { color: var(--text-display); }
+    .hero-install:hover { border-color: var(--text-display); }
+    /* Off macOS the DMG button is removed and this is the hero's only action. */
+    .hero-install.is-primary { border-color: var(--text-display); }
+    .hero-install .prompt { color: var(--text-secondary); }
+    .hero-install code { color: var(--text-display); font-size: inherit; }
     .hero-install .copy {
+      align-self: stretch;
+      display: flex; align-items: center;
+      /* Pins the label to the right edge once the box goes full-width on a phone;
+         no effect while the box sizes to its content on desktop. */
+      margin-left: auto;
+      padding-left: 14px;
+      border-left: 1px solid var(--border);
       font-size: 10px;
       letter-spacing: 0.1em;
       text-transform: uppercase;
-      color: var(--text-disabled);
+      color: var(--text-secondary);
     }
+    .hero-install:hover .copy { color: var(--text-display); }
     .hero-alt-arch {
       margin-top: 14px;
       font-family: var(--font-mono);
@@ -608,7 +603,9 @@ layout: null
     }
     .hero-alt-arch a:hover { color: var(--text-display); border-color: var(--text-display); }
     .hero-trust {
-      margin-top: 18px;
+      /* Far enough from the architecture link above that the two mono caps rows
+         do not read as one paragraph. */
+      margin-top: 28px;
       font-family: var(--font-mono);
       font-size: 12px;
       letter-spacing: 0.08em;
@@ -630,10 +627,13 @@ layout: null
       .hero { padding: 88px 0 40px; }
       .hero-meta { margin-bottom: 28px; }
       .hero-headline { font-size: clamp(30px, 8vw, 44px); max-width: 100%; }
-      .hero-desc { margin-top: 24px; font-size: 16px; }
-      .hero-cta { margin-top: 24px; gap: 8px; }
-      .hero-cta .btn { padding: 12px 22px; font-size: 11px; }
-      .hero-install { display: none; }
+      .hero-desc { margin-top: 20px; font-size: 16px; }
+      /* One column, both full width: on a phone the two actions stack rather
+         than compete for a row 390px wide. The install line used to be
+         display:none here, which left a phone with no copyable command at all. */
+      .hero-cta { margin-top: 28px; gap: 10px; flex-direction: column; align-items: stretch; }
+      .hero-cta .btn { padding: 14px 22px; font-size: 11px; justify-content: center; }
+      .hero-install { font-size: 12px; min-height: 52px; padding: 0 14px; gap: 10px; }
       .hero-alt-arch { font-size: 11px; margin-top: 12px; }
       .hero-trust { font-size: 11px; gap: 8px; margin-top: 14px; }
     }
@@ -2011,38 +2011,34 @@ layout: null
       </div>
 
       <h1 class="hero-headline">
-        Your agent re-reads the same code every turn. <span class="em">trace-mcp indexes it once.</span>
+        Precomputed code intelligence for AI coding agents
       </h1>
 
       <p class="hero-desc">
-        trace-mcp is a framework-aware MCP server that serves precomputed code intelligence &mdash; a dependency graph, full-text search, impact analysis, and decision memory &mdash; to cut token usage for AI coding agents. It indexes your repo once and serves it through MCP, so agents query a precomputed graph instead of re-reading the same files on every turn.
+        trace-mcp indexes your repository once so agents stop re-reading the same files every turn.
+        <span class="accent-text">40&ndash;50% fewer tokens, 100% local.</span>
       </p>
 
-      <ul class="hero-bullets">
-        <li><span class="bullet-accent">~40&ndash;50%</span> fewer tokens on average</li>
-        <li><span class="bullet-accent">Faster responses</span> as the codebase grows</li>
-        <li><span class="bullet-accent">More reliable</span> results at scale</li>
-      </ul>
-
+      <!-- Two actions, no more (TRA-609): the DMG and the command that installs the
+           same thing without one. The two buttons that used to sit here both had a
+           second home already — the header links to the repo and to #install, which
+           is where "Analyze your AI system" pointed. Both survive on a phone. -->
       <div class="hero-cta">
         <!-- Rendered for everyone and pointed at the releases page, not hidden behind
              JS (TRA-440): a visitor without JavaScript gets a button that works, one
              click further from the file. detectMac() below removes it off macOS and
              rewrites the href to the DMG for the architecture it detects. -->
         <a href="https://github.com/nikolai-vysotskyi/trace-mcp/releases/latest"
-           rel="noopener" class="btn btn-primary" data-dmg>
+           rel="noopener" class="btn btn-primary btn-lg" data-dmg>
           Download for macOS <span class="arrow">&darr;</span>
         </a>
-        <a href="#install" class="btn btn-secondary" data-analyze-cta>
-          Analyze your AI system <span class="arrow">&rarr;</span>
-        </a>
-        <a href="https://github.com/nikolai-vysotskyi/trace-mcp" target="_blank" rel="noopener" class="btn btn-secondary">
-          View on GitHub
-        </a>
-        <span class="hero-install" onclick="copyInstall(this)">
+        <!-- A real <button>, not the <span onclick> this used to be: the only way to
+             copy the install command was a mouse click, and it took no focus ring. -->
+        <button type="button" class="hero-install" onclick="copyInstall(this)">
+          <span class="prompt" aria-hidden="true">$</span>
           <code>npm install -g trace-mcp</code>
-          <span class="copy">copy</span>
-        </span>
+          <span class="copy" aria-live="polite">copy</span>
+        </button>
       </div>
 
       <!-- The other architecture stays a quiet link, never a question the visitor has
@@ -2052,13 +2048,11 @@ layout: null
       </p>
 
       <p class="hero-trust">
-        <span class="ok">Open source</span>
+        <span class="ok">Open source (MIT)</span>
         <span class="dot"></span>
-        <span>MIT licensed</span>
+        <span>Local-first</span>
         <span class="dot"></span>
-        <span>Works with Claude Code, Cursor, Windsurf</span>
-        <span class="dot"></span>
-        <span>Runs locally &middot; no data leaves your machine</span>
+        <span>Works with Claude Code, Cursor, Windsurf, Codex</span>
       </p>
 
     </div>
@@ -2989,9 +2983,10 @@ layout: null
     const isMac = /Mac/i.test(navigator.platform || navigator.userAgent) && navigator.maxTouchPoints <= 1;
     if (!isMac) {
       btn.remove();
-      // Leaves the hero without a primary action otherwise.
-      const analyze = document.querySelector('[data-analyze-cta]');
-      if (analyze) analyze.classList.replace('btn-secondary', 'btn-primary');
+      // Leaves the hero without a primary action otherwise. The install command
+      // is the right one to promote here: it is the only path that works off a Mac.
+      const install = document.querySelector('.hero-install');
+      if (install) install.classList.add('is-primary');
       return;
     }
 


### PR DESCRIPTION
Redesigns the landing hero on the Fluid / Ollama model from TRA-607: one focused
download, one copyable command, and nothing else competing with them.

## What was wrong

The hero carried four elements in one row — `Download for macOS`,
`Analyze your AI system`, `View on GitHub`, and a dashed install pill — under a
two-sentence headline, a five-line paragraph, and three bullets that repeated the
metrics strip immediately below. Four things at roughly equal weight is a row,
not a hierarchy.

## What changed

**Type.** H1 is now `Precomputed code intelligence for AI coding agents`;
subtitle is two short sentences ending on the payoff. `clamp(36px, 5.2vw, 60px)`
over `max-width: 900px` is the measured pair that breaks this wording after
"intelligence" and nowhere else — the old `72px/820px` ran it to three lines and
split "AI coding agents" across two of them. The three bullets are gone: the
metrics strip directly under the hero already carries all three numbers, and the
subtitle carries the first one.

**Two actions, not four.** The red DMG pill (`.btn-lg`) and the install command.
Both removed buttons already had a home — the header links to the repo and to
`#install`, which is where `Analyze your AI system` pointed, and both survive at
390px.

**The install line is not a second pill.** It is a technical 8px box on
`--surface` with a `$` prompt, the command, and a `COPY` label behind a hairline.
A pill next to a pill reads as two buttons of equal weight, which is exactly what
the dashed pill did.

**It is a `<button>` now.** As a `<span onclick>` it took no tab stop and no focus
ring, so the only way to copy the command was a mouse. The `$` is `aria-hidden`;
the label is `aria-live="polite"` so `copied` is announced.

**It is visible on a phone.** It was `display: none` under 700px, which left a
phone visitor with a DMG button and no copyable command at all. Below 700px the
row becomes one column and both actions go full width.

**Off macOS still has a primary action.** `detectMac()` removes the DMG button
(TRA-440) and now adds `.is-primary` to the install line, raising its border to
`--text-display`. It used to promote the `Analyze your AI system` button, which no
longer exists — without this change the hero would have had no primary action
anywhere outside a Mac.

**Trust line** is now `Open source (MIT) · Local-first · Works with Claude Code,
Cursor, Windsurf, Codex`.

## Verification

Measured in headless Chrome against a locally rendered copy of the page, at
1440x900 and 390x844, in dark and light:

| Check | Result |
|---|---|
| Contrast, every hero element, both themes | lowest 5.18:1 (`.btn-primary`, white on accent red); `.hero-install .copy` and `.prompt` 6.63 dark / 7.00 light; `.hero-trust` 7.37 / 6.42 |
| Focus ring on the new `<button>` | `rgb(255,255,255)` dark, `rgb(0,0,0)` light — `--text-display`, not Chrome's blue |
| `scrollWidth === innerWidth` at 390px | 390 === 390 |
| `.hero-install` overflow | `scrollWidth === clientWidth` — not a scroll region, needs no `scroll →` label |
| Copy interaction | click flips the label to `copied` |
| Headline line count | 2 at 1440px, 3 at 390px |
| TRA-440 download logic | `[data-dmg]` href, `data-dmg-other`, `detectArch()` arm64 default all unchanged; `tests/docs/download-button.test.ts` green |
| `pnpm run test --run tests/docs/` | 125 passed |

One thing to flag rather than decide alone: **removing the three hero bullets is a
copy change in the SEO agent's zone.** Nothing leaves the page — the metrics strip
under the hero carries the same three claims, and the `<meta name="description">`
is untouched — but it is worth a look.

Rules recorded in `docs/DESIGN-WEB.md` section 8 (numbered last on purpose:
renumbering would break the `§` references in that file and the one in
`docs/index.html`).

Closes TRA-609.
