### PR TITLE
fix(web): raise --text-disabled and dark --accent to clear 4.5:1 (TRA-539)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ packages/app/server-payload/
 # Recall harness reports — regenerated on every run
 tests/recall-harness/report.json
 tests/recall-harness/report.md
+
+# Jekyll build output (contrast sweep serves it when present)
+docs/_site/

--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -26,34 +26,58 @@ no shadows.
 Two surfaces implement these: `docs/index.html` (landing, inline `<style>`) and
 `docs/assets/css/docs.css` (every documentation page). The values must match.
 
-| Token | Dark | Light |
-|---|---|---|
-| `--black` (page) | `#000000` | `#F5F5F5` |
-| `--surface` | `#111111` | `#FFFFFF` |
-| `--surface-raised` | `#1A1A1A` | `#F0F0F0` |
-| `--border` | `#222222` | `#E8E8E8` |
-| `--border-visible` | `#333333` | `#CCCCCC` |
-| `--text-disabled` | `#666666` | `#6D6D6D` |
-| `--text-secondary` | `#999999` | `#595959` |
-| `--text-primary` | `#E8E8E8` | `#1A1A1A` |
-| `--text-display` | `#FFFFFF` | `#000000` |
-| `--accent` | `#D71921` | `#B3151C` |
+Surfaces — a text token has to clear its ratio against **every** one of these
+it is painted on, because all three are in use on the same page:
 
-**Compute a light-mode ratio against the surface the text actually sits on.**
-Light mode has three of them — the page is `#F5F5F5`, a card or table or code
-block is `#FFFFFF`, and a raised cell is `#F0F0F0`. `#FFFFFF` is the most
-forgiving of the three and the one a colour picker defaults to, so a value
-checked only against white lands ~0.4 short on the page it ships on. That is
-how `--text-disabled` shipped at `#767676`: recorded here as "4.54:1", which
-is its ratio on `#FFFFFF` — on the `#F5F5F5` page it is 4.166:1, and every
-`scroll →` and `SEE ALSO` label on all 17 doc pages sat under AA for months
-while this file said they passed. `#6D6D6D` clears 4.5:1 on all three
-(4.75 / 5.17 / 4.54). Quote the worst of the three, not the best.
+| | Page | Surface | Raised |
+|---|---|---|---|
+| Dark | `--black` `#000000` | `--surface` `#111111` | `--surface-raised` `#1A1A1A` |
+| Light | `--black` `#F5F5F5` | `--surface` `#FFFFFF` | `--surface-raised` `#F0F0F0` |
 
-One light value still diverges on purpose: `--accent` is `#B3151C` on doc
-pages and `#D71921` on the landing. Both pass at body size (6.3:1 and 4.76:1
-on `#F5F5F5`); the docs run the darker one because a doc page is a wall of
-inline links, the landing runs the brand red because it is the brand.
+Borders: `--border` `#222222` / `#E8E8E8`, `--border-visible` `#333333` /
+`#CCCCCC`. Not text — no ratio applies.
+
+Text and accent tokens, with the ratio against each of the three surfaces of
+their own theme, worst first. **The worst number is the one that governs.**
+
+| Token | Dark | page / surface / raised | Light | page / surface / raised |
+|---|---|---|---|---|
+| `--text-disabled` | `#848484` | **4.65** / 5.05 / 5.61 | `#6D6D6D` | **4.54** / 4.75 / 5.17 |
+| `--text-secondary` | `#999999` | **6.11** / 6.63 / 7.37 | `#595959` | **6.15** / 6.42 / 7.00 |
+| `--text-primary` | `#E8E8E8` | **14.20** / 15.41 / 17.14 | `#1A1A1A` | **15.27** / 15.96 / 17.40 |
+| `--text-display` | `#FFFFFF` | **17.40** / 18.88 / 21.00 | `#000000` | **18.43** / 19.26 / 21.00 |
+| `--accent` | `#E54047` | 4.27 / **4.64** / 5.16 | `#B3151C` | **6.06** / 6.33 / 6.91 |
+| `--accent-solid` | `#D71921` | fill only — white text on it is 5.18 | `#D71921` | same |
+
+`--accent` in dark is the one token that does **not** clear 4.5:1 everywhere:
+`#E54047` on `--surface-raised` is 4.27. Red text is therefore not allowed on
+`--surface-raised` in dark. It is not currently used there anywhere; the
+contrast sweep below is what keeps it that way. Raising the red further to
+clear `#1A1A1A` too would push it to roughly `#EA5057`, which reads pink
+rather than red, and red being *this* red is not negotiable.
+
+`--accent-solid` `#D71921` is the brand red as a **fill** — the landing's
+primary button, where the ratio that matters is white text on the red, not the
+red on a page. `--accent` (link/glyph red) is lighter in dark and darker in
+light because a foreground has to fight the background; a fill does not.
+Never use `--accent-solid` as a text colour, and never use `--accent` as a
+fill under white text (`#E54047` behind white is 4.07 and fails).
+
+**Compute a ratio against the surface the text actually sits on, in both
+themes.** `#FFFFFF` in light and `#000000` in dark are the most forgiving
+backgrounds of their theme and the ones a colour picker defaults to, so a
+value checked only against them lands short on the surfaces it ships on. That
+error has now shipped twice:
+
+- `--text-disabled` light shipped at `#767676`, recorded here as "4.54:1" —
+  its ratio on `#FFFFFF`. On the `#F5F5F5` page it is 4.17, and every
+  `scroll →` and `SEE ALSO` label on all 17 doc pages sat under AA for months
+  while this file said they passed.
+- `--text-disabled` dark shipped at `#666666` with **no ratio recorded at
+  all**: 3.66 on `#000000`, 3.29 on `#111111`. That is the `✗` capability
+  mark — 161 of them on `comparisons.html` alone — plus every `[OK]` bracket,
+  `SCROLL →`, `LICENSE`, and the terminal's comment lines. The "no" answer in
+  our own comparison table was the least readable text on the site.
 
 Dark mode is the default. Light is opt-in and equally first-class — never
 ship a change checked in one mode only.
@@ -225,7 +249,12 @@ WebP conversion.
 - Toast popups — use inline `[SAVED]` / `[ERROR: …]`.
 - Filled or multi-colour icons, emoji as UI — including `✅` / `❌` / `⚠️`
   as capability marks in a table.
-- A second accent colour. Red is the only one.
+- A second accent colour. Red is the only one. `--accent` and `--accent-solid`
+  are two lightnesses of the same red for two jobs (§1), not two accents.
+- `--accent` as a fill under white text, or `--accent-solid` as a text colour.
+- Red text on `--surface-raised` in dark — 4.27:1, the one gap in §1.
+- A colour value recorded with a ratio against a background it is not painted
+  on. Quote the worst of the three surfaces, in both themes.
 - `border-radius` over 16px on a card.
 - Spring or bounce easing. Only `cubic-bezier(0.25, 0.1, 0.25, 1)`.
 - Parallax or scroll-jacking.
@@ -248,12 +277,30 @@ appearance without a screenshot or a measurement is not a finding.
 - [ ] Exactly one image of a light/dark pair has computed `display: block` —
       read it off the element, in each theme.
 - [ ] Theme choice survives landing → doc page navigation.
-- [ ] Body text ≥ 4.5:1, large text ≥ 3:1, in both — measured by walking the
-      rendered page and reading each element's own computed `color` against
-      its nearest opaque ancestor background, not by checking the token table
-      against one assumed surface. The token table has been wrong twice; the
-      DOM has not. Sweep the landing separately from a doc page: it carries
-      its own copy of the tokens (§7) and has drifted from this table before.
+- [ ] Contrast sweep is green. Not a claim — a command:
+
+      ```
+      node scripts/contrast-sweep.mjs
+      ```
+
+      It serves `docs/` locally, renders the landing and every doc page in
+      headless Chrome in both themes, and for every element carrying its own
+      text reads the computed `color` against its nearest opaque ancestor
+      background — the real painted background, not an assumed surface.
+      Body text needs 4.5:1, large text (≥24px, or ≥18.66px bold) 3:1.
+      `aria-hidden="true"` subtrees are skipped as decoration. Exit code is
+      non-zero on any failure; pass paths (`node scripts/contrast-sweep.mjs /
+      /comparisons.html`) to sweep a subset.
+
+      This bullet used to say "measure it, don't check the token table" and
+      the table was still wrong in both themes at the time. Eyeballing a grey
+      is exactly what failed here, twice — so the check is a command that
+      fails, not a sentence that asks you to be careful. The landing is swept
+      alongside the doc pages because it carries its own copy of the tokens
+      (§7) and has drifted from this table before.
+- [ ] A new `aria-hidden` on anything the sweep now skips is deliberate
+      decoration, not a way to silence a failure. Only two exist: the YC badge
+      mark and the landing's 400px ghost `94%`.
 
 **Widths**
 - [ ] Desktop (1440px) and narrow (≤500px) both screenshotted.

--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -25,6 +25,8 @@ no shadows.
 
 Two surfaces implement these: `docs/index.html` (landing, inline `<style>`) and
 `docs/assets/css/docs.css` (every documentation page). The values must match.
+A token that exists in only one of them is a component token and must say so
+here — otherwise it reads as drift. There is exactly one: `--accent-solid`.
 
 Surfaces — a text token has to clear its ratio against **every** one of these
 it is painted on, because all three are in use on the same page:
@@ -38,16 +40,21 @@ Borders: `--border` `#222222` / `#E8E8E8`, `--border-visible` `#333333` /
 `#CCCCCC`. Not text — no ratio applies.
 
 Text and accent tokens, with the ratio against each of the three surfaces of
-their own theme, worst first. **The worst number is the one that governs.**
+their own theme, **in the column order of the surface table above — page,
+surface, raised.** The governing number is bold.
 
 | Token | Dark | page / surface / raised | Light | page / surface / raised |
 |---|---|---|---|---|
-| `--text-disabled` | `#848484` | **4.65** / 5.05 / 5.61 | `#6D6D6D` | **4.54** / 4.75 / 5.17 |
-| `--text-secondary` | `#999999` | **6.11** / 6.63 / 7.37 | `#595959` | **6.15** / 6.42 / 7.00 |
-| `--text-primary` | `#E8E8E8` | **14.20** / 15.41 / 17.14 | `#1A1A1A` | **15.27** / 15.96 / 17.40 |
-| `--text-display` | `#FFFFFF` | **17.40** / 18.88 / 21.00 | `#000000` | **18.43** / 19.26 / 21.00 |
-| `--accent` | `#E54047` | 4.27 / **4.64** / 5.16 | `#B3151C` | **6.06** / 6.33 / 6.91 |
-| `--accent-solid` | `#D71921` | fill only — white text on it is 5.18 | `#D71921` | same |
+| `--text-disabled` | `#848484` | 5.61 / 5.05 / **4.65** | `#6D6D6D` | 4.75 / 5.17 / **4.54** |
+| `--text-secondary` | `#999999` | 7.37 / 6.63 / **6.11** | `#595959` | 6.42 / 7.00 / **6.15** |
+| `--text-primary` | `#E8E8E8` | 17.14 / 15.41 / **14.20** | `#1A1A1A` | 15.96 / 17.40 / **15.27** |
+| `--text-display` | `#FFFFFF` | 21.00 / 18.88 / **17.40** | `#000000` | 19.26 / 21.00 / **18.43** |
+| `--accent` | `#E54047` | 5.16 / 4.64 / **4.27** | `#B3151C` | 6.33 / 6.91 / **6.06** |
+
+**`--surface-raised` is always the worst of the three,** in both themes — it is
+the lightest surface in dark and the darkest in light, so it is the one every
+foreground has the least room against. Never quote a token's ratio from `page`
+because it is the biggest number.
 
 `--accent` in dark is the one token that does **not** clear 4.5:1 everywhere:
 `#E54047` on `--surface-raised` is 4.27. Red text is therefore not allowed on
@@ -56,12 +63,18 @@ contrast sweep below is what keeps it that way. Raising the red further to
 clear `#1A1A1A` too would push it to roughly `#EA5057`, which reads pink
 rather than red, and red being *this* red is not negotiable.
 
-`--accent-solid` `#D71921` is the brand red as a **fill** — the landing's
-primary button, where the ratio that matters is white text on the red, not the
-red on a page. `--accent` (link/glyph red) is lighter in dark and darker in
-light because a foreground has to fight the background; a fill does not.
-Never use `--accent-solid` as a text colour, and never use `--accent` as a
-fill under white text (`#E54047` behind white is 4.07 and fails).
+**`--accent-solid` `#D71921` is not in the table above and is not a shared
+token.** It is the brand red as a **fill** — the landing's primary button —
+so it is never a foreground and has no ratio against a surface. The only
+ratio it has is white text on it: **5.18**. It lives in `docs/index.html`
+alone and is deliberately absent from `docs/assets/css/docs.css`, which has
+no filled-red component; adding it there would be a dead token. If a doc page
+ever grows one, define it there in the same PR.
+
+`--accent` (link/glyph red) is lighter in dark and darker in light because a
+foreground has to fight its background; a fill does not. Never use
+`--accent-solid` as a text colour, and never use `--accent` as a fill under
+white text — `#E54047` behind white is 4.07 and fails.
 
 **Compute a ratio against the surface the text actually sits on, in both
 themes.** `#FFFFFF` in light and `#000000` in dark are the most forgiving
@@ -283,14 +296,23 @@ appearance without a screenshot or a measurement is not a finding.
       node scripts/contrast-sweep.mjs
       ```
 
-      It serves `docs/` locally, renders the landing and every doc page in
-      headless Chrome in both themes, and for every element carrying its own
-      text reads the computed `color` against its nearest opaque ancestor
-      background — the real painted background, not an assumed surface.
-      Body text needs 4.5:1, large text (≥24px, or ≥18.66px bold) 3:1.
-      `aria-hidden="true"` subtrees are skipped as decoration. Exit code is
-      non-zero on any failure; pass paths (`node scripts/contrast-sweep.mjs /
-      /comparisons.html`) to sweep a subset.
+      It serves `docs/` locally, renders the landing and every doc page —
+      recursively, so `docs/vs/*` is included — in headless Chrome in both
+      themes, and for every element carrying its own text reads the computed
+      `color` against its nearest opaque ancestor background, the real
+      painted background rather than an assumed surface. Body text needs
+      4.5:1, large text (≥24px, or ≥18.66px bold) 3:1, with no tolerance:
+      4.49 fails. `aria-hidden="true"` subtrees are skipped as decoration.
+      Exit code is non-zero on any failure; pass paths
+      (`node scripts/contrast-sweep.mjs / /comparisons.html`) for a subset.
+
+      **Know what it does not cover.** Without a Jekyll build it re-renders
+      Markdown with its own small converter, so a construct that converter
+      does not implement paints no element and any selector styling that
+      construct goes untested. It is a regression gate on the token ladder,
+      not proof of full coverage. For the real published DOM, build the site
+      first — the sweep serves `docs/_site` verbatim when it exists. Run it
+      that way before changing anything structural, not just a token.
 
       This bullet used to say "measure it, don't check the token table" and
       the table was still wrong in both themes at the time. Eyeballing a grey

--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -65,12 +65,12 @@
   --surface-raised: #1a1a1a;
   --border: #222222;
   --border-visible: #333333;
-  --text-disabled: #666666;
+  --text-disabled: #848484; /* 5.63:1 on #000000, 5.07:1 on #111111, 4.66:1 on #1A1A1A — #666666 was 3.29:1 */
   --text-secondary: #999999;
   --text-primary: #e8e8e8;
   --text-display: #ffffff;
-  --accent: #d71921;
-  --accent-subtle: rgba(215, 25, 33, 0.15);
+  --accent: #e54047; /* 5.16:1 on #000000, 4.64:1 on #111111 — #D71921 was 4.05:1 */
+  --accent-subtle: rgba(229, 64, 71, 0.15);
 
   --nav-bg: rgba(0, 0, 0, 0.85);
   --dot-color: var(--border);
@@ -92,8 +92,8 @@
   --text-secondary: #595959;
   --text-primary: #1a1a1a;
   --text-display: #000000;
-  --accent: #b3151c; /* 6.3:1 on #F5F5F5, 6.9:1 on #FFFFFF — the landing keeps #D71921 */
-  --accent-subtle: rgba(215, 25, 33, 0.12);
+  --accent: #b3151c; /* 6.33:1 on #F5F5F5, 6.91:1 on #FFFFFF */
+  --accent-subtle: rgba(179, 21, 28, 0.12);
 
   --nav-bg: rgba(245, 245, 245, 0.85);
   --dot-color: var(--border-visible);

--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -65,11 +65,11 @@
   --surface-raised: #1a1a1a;
   --border: #222222;
   --border-visible: #333333;
-  --text-disabled: #848484; /* 5.63:1 on #000000, 5.07:1 on #111111, 4.66:1 on #1A1A1A — #666666 was 3.29:1 */
+  --text-disabled: #848484; /* 5.61 page / 5.05 surface / 4.65 raised (governs) — #666666 was 3.29 on surface */
   --text-secondary: #999999;
   --text-primary: #e8e8e8;
   --text-display: #ffffff;
-  --accent: #e54047; /* 5.16:1 on #000000, 4.64:1 on #111111 — #D71921 was 4.05:1 */
+  --accent: #e54047; /* 5.16 page / 4.64 surface / 4.27 raised — no red text on raised, see DESIGN-WEB.md #1 */
   --accent-subtle: rgba(229, 64, 71, 0.15);
 
   --nav-bg: rgba(0, 0, 0, 0.85);
@@ -88,11 +88,11 @@
   --surface-raised: #f0f0f0;
   --border: #e8e8e8;
   --border-visible: #cccccc;
-  --text-disabled: #6d6d6d; /* 4.75:1 on #F5F5F5, 4.54:1 on #F0F0F0 — #767676 was 4.17:1 */
+  --text-disabled: #6d6d6d; /* 4.75 page / 5.17 surface / 4.54 raised (governs) — #767676 was 4.17 on page */
   --text-secondary: #595959;
   --text-primary: #1a1a1a;
   --text-display: #000000;
-  --accent: #b3151c; /* 6.33:1 on #F5F5F5, 6.91:1 on #FFFFFF */
+  --accent: #b3151c; /* 6.33 page / 6.91 surface / 6.06 raised (governs) */
   --accent-subtle: rgba(179, 21, 28, 0.12);
 
   --nav-bg: rgba(245, 245, 245, 0.85);

--- a/docs/index.html
+++ b/docs/index.html
@@ -270,13 +270,13 @@ layout: null
       --surface-raised: #1A1A1A;
       --border: #222222;
       --border-visible: #333333;
-      --text-disabled: #848484; /* 5.63:1 on #000000, 5.07:1 on #111111, 4.66:1 on #1A1A1A — #666666 was 3.29:1 */
+      --text-disabled: #848484; /* 5.61 page / 5.05 surface / 4.65 raised (governs) — #666666 was 3.29 on surface */
       --text-secondary: #999999;
       --text-primary: #E8E8E8;
       --text-display: #FFFFFF;
-      --accent: #E54047; /* 5.16:1 on #000000, 4.64:1 on #111111 — #D71921 was 4.05:1 */
+      --accent: #E54047; /* 5.16 page / 4.64 surface / 4.27 raised — no red text on raised, see DESIGN-WEB.md #1 */
       --accent-subtle: rgba(229, 64, 71, 0.15);
-      --accent-solid: #D71921; /* fill under white text: 5.38:1 with #FFFFFF */
+      --accent-solid: #D71921; /* landing-only fill under white text: 5.18:1 with #FFFFFF */
       --success: #4A9E5C;
       --warning: #D4A843;
 
@@ -296,13 +296,13 @@ layout: null
       --surface-raised: #F0F0F0;
       --border: #E8E8E8;
       --border-visible: #CCCCCC;
-      --text-disabled: #6D6D6D; /* 4.75:1 on #F5F5F5, 4.54:1 on #F0F0F0 — #999999 was 2.6:1 */
+      --text-disabled: #6D6D6D; /* 4.75 page / 5.17 surface / 4.54 raised (governs) — #999999 was 2.61 on page */
       --text-secondary: #595959;
       --text-primary: #1A1A1A;
       --text-display: #000000;
-      --accent: #B3151C; /* 6.33:1 on #F5F5F5, 6.91:1 on #FFFFFF */
+      --accent: #B3151C; /* 6.33 page / 6.91 surface / 6.06 raised (governs) */
       --accent-subtle: rgba(179, 21, 28, 0.12);
-      --accent-solid: #D71921; /* fill under white text: 5.38:1 with #FFFFFF */
+      --accent-solid: #D71921; /* landing-only fill under white text: 5.18:1 with #FFFFFF */
       --success: #2E7D3E;
       --warning: #A8822E;
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -270,12 +270,13 @@ layout: null
       --surface-raised: #1A1A1A;
       --border: #222222;
       --border-visible: #333333;
-      --text-disabled: #666666;
+      --text-disabled: #848484; /* 5.63:1 on #000000, 5.07:1 on #111111, 4.66:1 on #1A1A1A — #666666 was 3.29:1 */
       --text-secondary: #999999;
       --text-primary: #E8E8E8;
       --text-display: #FFFFFF;
-      --accent: #D71921;
-      --accent-subtle: rgba(215, 25, 33, 0.15);
+      --accent: #E54047; /* 5.16:1 on #000000, 4.64:1 on #111111 — #D71921 was 4.05:1 */
+      --accent-subtle: rgba(229, 64, 71, 0.15);
+      --accent-solid: #D71921; /* fill under white text: 5.38:1 with #FFFFFF */
       --success: #4A9E5C;
       --warning: #D4A843;
 
@@ -299,8 +300,9 @@ layout: null
       --text-secondary: #595959;
       --text-primary: #1A1A1A;
       --text-display: #000000;
-      --accent: #D71921;
-      --accent-subtle: rgba(215, 25, 33, 0.12);
+      --accent: #B3151C; /* 6.33:1 on #F5F5F5, 6.91:1 on #FFFFFF */
+      --accent-subtle: rgba(179, 21, 28, 0.12);
+      --accent-solid: #D71921; /* fill under white text: 5.38:1 with #FFFFFF */
       --success: #2E7D3E;
       --warning: #A8822E;
 
@@ -490,7 +492,7 @@ layout: null
       white-space: nowrap;
     }
     .btn-primary {
-      background: var(--accent);
+      background: var(--accent-solid);
       color: #FFFFFF;
       box-shadow: 0 0 0 0 rgba(215, 25, 33, 0.4);
       transition: background-color 200ms cubic-bezier(0.25, 0.1, 0.25, 1),
@@ -1538,7 +1540,7 @@ layout: null
       width: 8px; height: 8px;
       background: var(--accent);
       border-radius: 50%;
-      box-shadow: 0 0 12px rgba(215, 25, 33, 0.45);
+      box-shadow: 0 0 12px color-mix(in srgb, var(--accent) 45%, transparent);
       flex-shrink: 0;
     }
     .pain-text {

--- a/scripts/contrast-sweep.mjs
+++ b/scripts/contrast-sweep.mjs
@@ -323,7 +323,10 @@ const EVAL_SCRIPT = String.raw`
         bgHex: '#' + bg.map(x => Math.round(x).toString(16).padStart(2, '0')).join(''),
         ratio: Math.round(ratio * 100) / 100,
         required,
-        pass: ratio >= required - 0.05
+        // No epsilon: the ratio is computed at full precision, so 4.45 is a real
+        // AA failure, not a rounding artefact. A tolerance here would hide the
+        // near-misses this sweep exists to catch.
+        pass: ratio >= required
       });
     }
     return results;

--- a/scripts/contrast-sweep.mjs
+++ b/scripts/contrast-sweep.mjs
@@ -1,3 +1,16 @@
+// Contrast sweep for trace-mcp.com — see docs/DESIGN-WEB.md §5.
+//
+// Renders every page in headless Chrome in both themes and checks each element
+// carrying its own text against its real painted background.
+//
+// Two source modes. If a Jekyll build exists at docs/_site, it is served as-is
+// and the DOM under test is exactly what Pages publishes — run `jekyll build`
+// first and you get the real thing. Without one, doc pages are re-rendered here
+// by a small Markdown converter that covers what the site's own pages use.
+// That fallback approximates the DOM: a construct it does not implement paints
+// no element, so a selector styling that construct goes untested. It is a
+// regression gate for the token ladder, not a proof of full coverage. Extend
+// the converter when a page starts using something new.
 import { spawn } from 'node:child_process';
 import http from 'node:http';
 import fs from 'node:fs';
@@ -9,6 +22,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, '..');
 const DOCS_DIR = path.join(REPO_ROOT, 'docs');
+const SITE_DIR = path.join(DOCS_DIR, '_site');
+const USE_BUILT_SITE = fs.existsSync(SITE_DIR) && fs.statSync(SITE_DIR).isDirectory();
 
 // Helper to calculate relative luminance & contrast ratio
 function sRGBtoLin(c) {
@@ -140,6 +155,8 @@ function renderMarkdownToHtml(mdContent) {
       out.push(`<h4>${formatInline(line.slice(5))}</h4>`);
     } else if (line.startsWith('---')) {
       out.push('<hr>');
+    } else if (line.startsWith('> ') || line.trim() === '>') {
+      out.push(`<blockquote><p>${formatInline(line.replace(/^>\s?/, ''))}</p></blockquote>`);
     } else if (line.startsWith('- ')) {
       out.push(`<ul><li>${formatInline(line.slice(2))}</li></ul>`);
     } else if (/^\d+\.\s/.test(line)) {
@@ -336,11 +353,44 @@ const EVAL_SCRIPT = String.raw`
 })()
 `;
 
-/** Serves docs/ the way Pages does: .md rendered through the layout, everything else verbatim. */
+function mimeFor(filePath) {
+  return (
+    {
+      '.html': 'text/html; charset=utf-8',
+      '.css': 'text/css',
+      '.js': 'text/javascript',
+      '.woff2': 'font/woff2',
+      '.png': 'image/png',
+      '.webp': 'image/webp',
+      '.svg': 'image/svg+xml',
+      '.ico': 'image/x-icon',
+      '.json': 'application/json',
+    }[path.extname(filePath)] || 'application/octet-stream'
+  );
+}
+
+/**
+ * Serves the site. With a Jekyll build at docs/_site, serves that verbatim —
+ * the real published DOM. Otherwise re-renders .md through the layout locally.
+ */
 export function createDocsServer() {
+  const root = USE_BUILT_SITE ? SITE_DIR : DOCS_DIR;
   return http.createServer((req, res) => {
     let reqPath = req.url.split('?')[0];
     if (reqPath === '/') reqPath = '/index.html';
+
+    if (USE_BUILT_SITE) {
+      let p = path.join(root, reqPath);
+      if (fs.existsSync(p) && fs.statSync(p).isDirectory()) p = path.join(p, 'index.html');
+      if (!fs.existsSync(p) || !fs.statSync(p).isFile()) {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': mimeFor(p) });
+      res.end(fs.readFileSync(p));
+      return;
+    }
 
     // Check if markdown page requested
     const directPath = path.join(DOCS_DIR, reqPath);
@@ -369,17 +419,7 @@ export function createDocsServer() {
         res.end(str);
         return;
       }
-      const ext = path.extname(directPath);
-      const mime =
-        {
-          '.css': 'text/css',
-          '.js': 'text/javascript',
-          '.woff2': 'font/woff2',
-          '.png': 'image/png',
-          '.webp': 'image/webp',
-          '.svg': 'image/svg+xml',
-        }[ext] || 'application/octet-stream';
-      res.writeHead(200, { 'Content-Type': mime });
+      res.writeHead(200, { 'Content-Type': mimeFor(directPath) });
       res.end(data);
       return;
     }
@@ -526,20 +566,26 @@ export async function runContrastSweep(pageUrls) {
   }
 }
 
+/** Every published doc page, recursively. Jekyll's own `_`-prefixed dirs are not pages. */
+function discoverDocPages(dir = DOCS_DIR, prefix = '') {
+  const out = [];
+  for (const entry of fs
+    .readdirSync(dir, { withFileTypes: true })
+    .sort((a, b) => a.name.localeCompare(b.name))) {
+    if (entry.name.startsWith('_') || entry.name.startsWith('.')) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...discoverDocPages(full, `${prefix}/${entry.name}`));
+    else if (entry.name.endsWith('.md'))
+      out.push(`${prefix}/${entry.name.replace(/\.md$/, '.html')}`);
+  }
+  return out;
+}
+
 if (process.argv[1] === __filename) {
   const pages = process.argv.slice(2);
-  // Default: the landing plus every doc page, so a new page cannot ship unswept.
-  const targetPages =
-    pages.length > 0
-      ? pages
-      : [
-          '/',
-          ...fs
-            .readdirSync(DOCS_DIR)
-            .filter((f) => f.endsWith('.md'))
-            .sort()
-            .map((f) => '/' + f.replace(/\.md$/, '.html')),
-        ];
+  // Default: the landing plus every doc page, recursively — docs/vs/*.md are
+  // published pages too and were missed by a flat scan.
+  const targetPages = pages.length > 0 ? pages : ['/', ...discoverDocPages()];
   runContrastSweep(targetPages)
     .then((report) => {
       console.log('\n=== Contrast Sweep Report ===\n');

--- a/scripts/contrast-sweep.mjs
+++ b/scripts/contrast-sweep.mjs
@@ -17,24 +17,22 @@ function sRGBtoLin(c) {
 }
 
 function parseRgb(colorStr) {
-  const match = colorStr.match(/rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)/);
+  const match = colorStr.match(
+    /rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)/,
+  );
   if (!match) return [0, 0, 0, 1];
   return [
     parseFloat(match[1]),
     parseFloat(match[2]),
     parseFloat(match[3]),
-    match[4] !== undefined ? parseFloat(match[4]) : 1
+    match[4] !== undefined ? parseFloat(match[4]) : 1,
   ];
 }
 
 function blend(fg, bg) {
   const [fr, fgCol, fb, fa] = fg;
   const [br, bgCol, bb] = bg;
-  return [
-    fr * fa + br * (1 - fa),
-    fgCol * fa + bgCol * (1 - fa),
-    fb * fa + bb * (1 - fa)
-  ];
+  return [fr * fa + br * (1 - fa), fgCol * fa + bgCol * (1 - fa), fb * fa + bb * (1 - fa)];
 }
 
 function luminance(rgb) {
@@ -117,8 +115,12 @@ function renderMarkdownToHtml(mdContent) {
     }
 
     if (line.trim().startsWith('|') && line.trim().endsWith('|')) {
-      const cells = line.trim().slice(1, -1).split('|').map(c => c.trim());
-      if (cells.every(c => /^:?-+:?$/.test(c))) {
+      const cells = line
+        .trim()
+        .slice(1, -1)
+        .split('|')
+        .map((c) => c.trim());
+      if (cells.every((c) => /^:?-+:?$/.test(c))) {
         continue;
       }
       inTable = true;
@@ -143,7 +145,12 @@ function renderMarkdownToHtml(mdContent) {
     } else if (/^\d+\.\s/.test(line)) {
       out.push(`<ol><li>${formatInline(line.replace(/^\d+\.\s+/, ''))}</li></ol>`);
     } else if (line.trim().length > 0) {
-      if (line.trim().startsWith('<script') || line.trim().startsWith('</script>') || line.trim().startsWith('{') || line.trim().startsWith('}')) {
+      if (
+        line.trim().startsWith('<script') ||
+        line.trim().startsWith('</script>') ||
+        line.trim().startsWith('{') ||
+        line.trim().startsWith('}')
+      ) {
         out.push(line);
       } else {
         out.push(`<p>${formatInline(line)}</p>`);
@@ -163,8 +170,8 @@ function buildDocHtml(mdFilePath) {
   let navItems = [];
   try {
     const navYaml = fs.readFileSync(path.join(DOCS_DIR, '_data/docs_nav.yml'), 'utf8');
-    const titles = [...navYaml.matchAll(/title:\s*([^\n]+)/g)].map(m => m[1].trim());
-    const urls = [...navYaml.matchAll(/url:\s*([^\n]+)/g)].map(m => m[1].trim());
+    const titles = [...navYaml.matchAll(/title:\s*([^\n]+)/g)].map((m) => m[1].trim());
+    const urls = [...navYaml.matchAll(/url:\s*([^\n]+)/g)].map((m) => m[1].trim());
     navItems = titles.map((t, i) => ({ title: t, url: urls[i] || '#' }));
   } catch (e) {}
 
@@ -175,13 +182,25 @@ function buildDocHtml(mdFilePath) {
 
   let html = layout
     .replace('{{ content }}', renderedContent)
-    .replace(/\{\{\s*'\/fonts\/[^']+'\s*\|\s*relative_url\s*\}\}/g, '/fonts/space-grotesk-variable-latin.woff2')
-    .replace(/\{\{\s*'\/assets\/css\/docs\.css'\s*\|\s*relative_url\s*\}\}/g, '/assets/css/docs.css')
+    .replace(
+      /\{\{\s*'\/fonts\/[^']+'\s*\|\s*relative_url\s*\}\}/g,
+      '/fonts/space-grotesk-variable-latin.woff2',
+    )
+    .replace(
+      /\{\{\s*'\/assets\/css\/docs\.css'\s*\|\s*relative_url\s*\}\}/g,
+      '/assets/css/docs.css',
+    )
     .replace(/\{\{\s*'\/'\s*\|\s*relative_url\s*\}\}/g, '/')
     .replace(/\{%\s*seo\s*%\}/g, '<title>Docs</title>')
     .replace(/\{%-?\s*if page\.noindex\s*-?%\}[\s\S]*?\{%-?\s*endif\s*-?%\}/g, '')
-    .replace(/\{%-?\s*if page\.updated\s*-?%\}[\s\S]*?\{%-?\s*endif\s*-?%\}/g, '<p class="page-updated">Last updated: August 30, 2026</p>')
-    .replace(/\{%-?\s*for item in site\.data\.docs_nav\s*-?%\}[\s\S]*?\{%-?\s*endfor\s*-?%\}/g, navHtml)
+    .replace(
+      /\{%-?\s*if page\.updated\s*-?%\}[\s\S]*?\{%-?\s*endif\s*-?%\}/g,
+      '<p class="page-updated">Last updated: August 30, 2026</p>',
+    )
+    .replace(
+      /\{%-?\s*for item in site\.data\.docs_nav\s*-?%\}[\s\S]*?\{%-?\s*endfor\s*-?%\}/g,
+      navHtml,
+    )
     .replace(/\{%-?[\s\S]*?-?%\}/g, '');
 
   return html;
@@ -319,10 +338,12 @@ export function createDocsServer() {
   return http.createServer((req, res) => {
     let reqPath = req.url.split('?')[0];
     if (reqPath === '/') reqPath = '/index.html';
-    
+
     // Check if markdown page requested
     const directPath = path.join(DOCS_DIR, reqPath);
-    const mdPath = reqPath.endsWith('.html') ? path.join(DOCS_DIR, reqPath.replace(/\.html$/, '.md')) : null;
+    const mdPath = reqPath.endsWith('.html')
+      ? path.join(DOCS_DIR, reqPath.replace(/\.html$/, '.md'))
+      : null;
 
     if (mdPath && fs.existsSync(mdPath) && fs.statSync(mdPath).isFile()) {
       const html = buildDocHtml(mdPath);
@@ -346,14 +367,15 @@ export function createDocsServer() {
         return;
       }
       const ext = path.extname(directPath);
-      const mime = {
-        '.css': 'text/css',
-        '.js': 'text/javascript',
-        '.woff2': 'font/woff2',
-        '.png': 'image/png',
-        '.webp': 'image/webp',
-        '.svg': 'image/svg+xml'
-      }[ext] || 'application/octet-stream';
+      const mime =
+        {
+          '.css': 'text/css',
+          '.js': 'text/javascript',
+          '.woff2': 'font/woff2',
+          '.png': 'image/png',
+          '.webp': 'image/webp',
+          '.svg': 'image/svg+xml',
+        }[ext] || 'application/octet-stream';
       res.writeHead(200, { 'Content-Type': mime });
       res.end(data);
       return;
@@ -366,7 +388,7 @@ export function createDocsServer() {
 
 export async function runContrastSweep(pageUrls) {
   const server = createDocsServer();
-  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
   const serverPort = server.address().port;
 
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chrome-sweep-'));
@@ -378,7 +400,7 @@ export async function runContrastSweep(pageUrls) {
     `--user-data-dir=${tmpDir}`,
     '--disable-gpu',
     '--no-first-run',
-    'about:blank'
+    'about:blank',
   ]);
 
   try {
@@ -386,14 +408,16 @@ export async function runContrastSweep(pageUrls) {
     for (let i = 0; i < 100; i++) {
       try {
         const listData = await new Promise((resolve, reject) => {
-          http.get(`http://127.0.0.1:${chromePort}/json/list`, res => {
-            let buf = '';
-            res.on('data', d => buf += d);
-            res.on('end', () => resolve(buf));
-          }).on('error', reject);
+          http
+            .get(`http://127.0.0.1:${chromePort}/json/list`, (res) => {
+              let buf = '';
+              res.on('data', (d) => (buf += d));
+              res.on('end', () => resolve(buf));
+            })
+            .on('error', reject);
         });
         // Chrome also exposes browser_ui targets (omnibox popup) — only a real page can navigate.
-        const page = JSON.parse(listData).find(t => t.type === 'page' && t.webSocketDebuggerUrl);
+        const page = JSON.parse(listData).find((t) => t.type === 'page' && t.webSocketDebuggerUrl);
         if (page) {
           pageWsUrl = page.webSocketDebuggerUrl;
           break;
@@ -401,7 +425,7 @@ export async function runContrastSweep(pageUrls) {
       } catch (e) {
         // Chrome not listening yet.
       }
-      await new Promise(r => setTimeout(r, 200));
+      await new Promise((r) => setTimeout(r, 200));
     }
 
     if (!pageWsUrl) throw new Error('Could not connect to Chrome CDP page target');
@@ -413,18 +437,19 @@ export async function runContrastSweep(pageUrls) {
     });
 
     let msgId = 1;
-    const send = (method, params = {}) => new Promise((resolve) => {
-      const id = msgId++;
-      const handler = (e) => {
-        const res = JSON.parse(e.data);
-        if (res.id === id) {
-          ws.removeEventListener('message', handler);
-          resolve(res.result);
-        }
-      };
-      ws.addEventListener('message', handler);
-      ws.send(JSON.stringify({ id, method, params }));
-    });
+    const send = (method, params = {}) =>
+      new Promise((resolve) => {
+        const id = msgId++;
+        const handler = (e) => {
+          const res = JSON.parse(e.data);
+          if (res.id === id) {
+            ws.removeEventListener('message', handler);
+            resolve(res.result);
+          }
+        };
+        ws.addEventListener('message', handler);
+        ws.send(JSON.stringify({ id, method, params }));
+      });
 
     await send('Page.enable');
     await send('Runtime.enable');
@@ -432,7 +457,7 @@ export async function runContrastSweep(pageUrls) {
       width: 1440,
       height: 900,
       deviceScaleFactor: 1,
-      mobile: false
+      mobile: false,
     });
 
     const report = [];
@@ -440,7 +465,7 @@ export async function runContrastSweep(pageUrls) {
     for (const urlPath of pageUrls) {
       const fullUrl = `http://127.0.0.1:${serverPort}${urlPath.startsWith('/') ? urlPath : '/' + urlPath}`;
       await send('Page.navigate', { url: fullUrl });
-      await new Promise(r => setTimeout(r, 1000));
+      await new Promise((r) => setTimeout(r, 1000));
 
       for (const theme of ['dark', 'light']) {
         await send('Runtime.evaluate', {
@@ -456,39 +481,43 @@ export async function runContrastSweep(pageUrls) {
               document.documentElement.setAttribute('data-theme', '${theme}');
               if (window.__sweepMeasure) window.__sweepMeasure();
             })()
-          `
+          `,
         });
-        await new Promise(r => setTimeout(r, 400));
+        await new Promise((r) => setTimeout(r, 400));
 
         const evalRes = await send('Runtime.evaluate', {
           expression: EVAL_SCRIPT,
-          returnByValue: true
+          returnByValue: true,
         });
         if (evalRes?.exceptionDetails) {
           throw new Error(`${urlPath} (${theme}): ${evalRes.exceptionDetails.text}`);
         }
 
         const elements = evalRes?.result?.value || [];
-        const failures = elements.filter(e => !e.pass);
+        const failures = elements.filter((e) => !e.pass);
         report.push({
           page: urlPath,
           theme,
           total: elements.length,
-          failures
+          failures,
         });
       }
     }
 
     ws.close();
     chrome.kill('SIGTERM');
-    await new Promise(r => chrome.on('close', r));
-    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (e) {}
+    await new Promise((r) => chrome.on('close', r));
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch (e) {}
     server.close();
     return report;
   } catch (err) {
     chrome.kill('SIGTERM');
-    await new Promise(r => chrome.on('close', r));
-    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (e) {}
+    await new Promise((r) => chrome.on('close', r));
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch (e) {}
     server.close();
     throw err;
   }
@@ -497,37 +526,47 @@ export async function runContrastSweep(pageUrls) {
 if (process.argv[1] === __filename) {
   const pages = process.argv.slice(2);
   // Default: the landing plus every doc page, so a new page cannot ship unswept.
-  const targetPages = pages.length > 0 ? pages : [
-    '/',
-    ...fs.readdirSync(DOCS_DIR)
-      .filter(f => f.endsWith('.md'))
-      .sort()
-      .map(f => '/' + f.replace(/\.md$/, '.html'))
-  ];
-  runContrastSweep(targetPages).then(report => {
-    console.log('\n=== Contrast Sweep Report ===\n');
-    let totalFailures = 0;
-    for (const r of report) {
-      console.log(`Page: ${r.page} | Theme: ${r.theme} | Checked: ${r.total} elements | Failures: ${r.failures.length}`);
-      if (r.failures.length > 0) {
-        totalFailures += r.failures.length;
-        const worst = [...r.failures].sort((a, b) => a.ratio - b.ratio)[0];
-        console.log(`  Worst ratio: ${worst.ratio}:1 (required: ${worst.required}:1) on "${worst.text}" (fg: ${worst.fgHex}, bg: ${worst.bgHex})`);
-        console.log(`  Failing elements summary:`);
-        const byHex = {};
-        for (const f of r.failures) {
-          const key = `${f.fgHex} on ${f.bgHex} (${f.selector})`;
-          byHex[key] = (byHex[key] || 0) + 1;
-        }
-        for (const [k, count] of Object.entries(byHex)) {
-          console.log(`    - ${count}x: ${k}`);
+  const targetPages =
+    pages.length > 0
+      ? pages
+      : [
+          '/',
+          ...fs
+            .readdirSync(DOCS_DIR)
+            .filter((f) => f.endsWith('.md'))
+            .sort()
+            .map((f) => '/' + f.replace(/\.md$/, '.html')),
+        ];
+  runContrastSweep(targetPages)
+    .then((report) => {
+      console.log('\n=== Contrast Sweep Report ===\n');
+      let totalFailures = 0;
+      for (const r of report) {
+        console.log(
+          `Page: ${r.page} | Theme: ${r.theme} | Checked: ${r.total} elements | Failures: ${r.failures.length}`,
+        );
+        if (r.failures.length > 0) {
+          totalFailures += r.failures.length;
+          const worst = [...r.failures].sort((a, b) => a.ratio - b.ratio)[0];
+          console.log(
+            `  Worst ratio: ${worst.ratio}:1 (required: ${worst.required}:1) on "${worst.text}" (fg: ${worst.fgHex}, bg: ${worst.bgHex})`,
+          );
+          console.log(`  Failing elements summary:`);
+          const byHex = {};
+          for (const f of r.failures) {
+            const key = `${f.fgHex} on ${f.bgHex} (${f.selector})`;
+            byHex[key] = (byHex[key] || 0) + 1;
+          }
+          for (const [k, count] of Object.entries(byHex)) {
+            console.log(`    - ${count}x: ${k}`);
+          }
         }
       }
-    }
-    console.log(`\nTotal failing elements: ${totalFailures}`);
-    if (totalFailures > 0) process.exitCode = 1;
-  }).catch(e => {
-    console.error('Sweep error:', e);
-    process.exit(1);
-  });
+      console.log(`\nTotal failing elements: ${totalFailures}`);
+      if (totalFailures > 0) process.exitCode = 1;
+    })
+    .catch((e) => {
+      console.error('Sweep error:', e);
+      process.exit(1);
+    });
 }

--- a/scripts/contrast-sweep.mjs
+++ b/scripts/contrast-sweep.mjs
@@ -1,0 +1,533 @@
+import { spawn } from 'node:child_process';
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..');
+const DOCS_DIR = path.join(REPO_ROOT, 'docs');
+
+// Helper to calculate relative luminance & contrast ratio
+function sRGBtoLin(c) {
+  const s = c / 255;
+  return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+
+function parseRgb(colorStr) {
+  const match = colorStr.match(/rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)/);
+  if (!match) return [0, 0, 0, 1];
+  return [
+    parseFloat(match[1]),
+    parseFloat(match[2]),
+    parseFloat(match[3]),
+    match[4] !== undefined ? parseFloat(match[4]) : 1
+  ];
+}
+
+function blend(fg, bg) {
+  const [fr, fgCol, fb, fa] = fg;
+  const [br, bgCol, bb] = bg;
+  return [
+    fr * fa + br * (1 - fa),
+    fgCol * fa + bgCol * (1 - fa),
+    fb * fa + bb * (1 - fa)
+  ];
+}
+
+function luminance(rgb) {
+  return 0.2126 * sRGBtoLin(rgb[0]) + 0.7152 * sRGBtoLin(rgb[1]) + 0.0722 * sRGBtoLin(rgb[2]);
+}
+
+function contrast(rgb1, rgb2) {
+  const l1 = luminance(rgb1);
+  const l2 = luminance(rgb2);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+// Basic markdown to HTML renderer for doc pages
+function renderMarkdownToHtml(mdContent) {
+  let md = mdContent.replace(/^---[\s\S]*?---\s*/, '');
+  md = md.replace(/\{\{\s*site\.data\.counts\.languages\s*\}\}/g, '81');
+  md = md.replace(/\{\{\s*site\.data\.counts\.frameworks\s*\}\}/g, '87');
+  md = md.replace(/\{\{\s*site\.data\.counts\.tools\s*\}\}/g, '171');
+
+  const lines = md.split('\n');
+  const out = [];
+  let inCode = false;
+  let inTable = false;
+  let tableRows = [];
+
+  function flushTable() {
+    if (!inTable || tableRows.length === 0) return;
+    let html = '<div class="table-scroll" role="group" aria-label="Table"><table>\n<thead>\n<tr>';
+    const headerCells = tableRows[0];
+    for (const cell of headerCells) {
+      html += `<th scope="col">${formatInline(cell)}</th>`;
+    }
+    html += '</tr>\n</thead>\n<tbody>\n';
+    for (let i = 1; i < tableRows.length; i++) {
+      html += '<tr>';
+      for (let j = 0; j < tableRows[i].length; j++) {
+        const cell = tableRows[i][j];
+        if (j === 0) html += `<th scope="row">${formatInline(cell)}</th>`;
+        else html += `<td>${formatInline(cell)}</td>`;
+      }
+      html += '</tr>\n';
+    }
+    html += '</tbody>\n</table></div>\n';
+    out.push(html);
+    tableRows = [];
+    inTable = false;
+  }
+
+  function formatInline(str) {
+    let s = str.trim();
+    s = s.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+    s = s.replace(/_([^_]+)_/g, '<em>$1</em>');
+    s = s.replace(/`([^`]+)`/g, '<code>$1</code>');
+    s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+    s = s.replace(/✓/g, '<span class="mark mark-yes" role="img" aria-label="Yes">✓</span>');
+    s = s.replace(/✗/g, '<span class="mark mark-no" role="img" aria-label="No">✗</span>');
+    return s;
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (line.startsWith('```')) {
+      if (inTable) flushTable();
+      if (!inCode) {
+        inCode = true;
+        out.push('<pre role="group" aria-label="Code sample"><code>');
+      } else {
+        inCode = false;
+        out.push('</code></pre>');
+      }
+      continue;
+    }
+
+    if (inCode) {
+      out.push(line.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') + '\n');
+      continue;
+    }
+
+    if (line.trim().startsWith('|') && line.trim().endsWith('|')) {
+      const cells = line.trim().slice(1, -1).split('|').map(c => c.trim());
+      if (cells.every(c => /^:?-+:?$/.test(c))) {
+        continue;
+      }
+      inTable = true;
+      tableRows.push(cells);
+      continue;
+    } else if (inTable) {
+      flushTable();
+    }
+
+    if (line.startsWith('# ')) {
+      out.push(`<h1>${formatInline(line.slice(2))}</h1>`);
+    } else if (line.startsWith('## ')) {
+      out.push(`<h2>${formatInline(line.slice(3))}</h2>`);
+    } else if (line.startsWith('### ')) {
+      out.push(`<h3>${formatInline(line.slice(4))}</h3>`);
+    } else if (line.startsWith('#### ')) {
+      out.push(`<h4>${formatInline(line.slice(5))}</h4>`);
+    } else if (line.startsWith('---')) {
+      out.push('<hr>');
+    } else if (line.startsWith('- ')) {
+      out.push(`<ul><li>${formatInline(line.slice(2))}</li></ul>`);
+    } else if (/^\d+\.\s/.test(line)) {
+      out.push(`<ol><li>${formatInline(line.replace(/^\d+\.\s+/, ''))}</li></ol>`);
+    } else if (line.trim().length > 0) {
+      if (line.trim().startsWith('<script') || line.trim().startsWith('</script>') || line.trim().startsWith('{') || line.trim().startsWith('}')) {
+        out.push(line);
+      } else {
+        out.push(`<p>${formatInline(line)}</p>`);
+      }
+    }
+  }
+  if (inTable) flushTable();
+
+  return out.join('\n');
+}
+
+function buildDocHtml(mdFilePath) {
+  const mdContent = fs.readFileSync(mdFilePath, 'utf8');
+  const renderedContent = renderMarkdownToHtml(mdContent);
+  const layout = fs.readFileSync(path.join(DOCS_DIR, '_layouts/default.html'), 'utf8');
+
+  let navItems = [];
+  try {
+    const navYaml = fs.readFileSync(path.join(DOCS_DIR, '_data/docs_nav.yml'), 'utf8');
+    const titles = [...navYaml.matchAll(/title:\s*([^\n]+)/g)].map(m => m[1].trim());
+    const urls = [...navYaml.matchAll(/url:\s*([^\n]+)/g)].map(m => m[1].trim());
+    navItems = titles.map((t, i) => ({ title: t, url: urls[i] || '#' }));
+  } catch (e) {}
+
+  let navHtml = '';
+  for (const item of navItems) {
+    navHtml += `<a href="${item.url}">${item.title}</a>\n`;
+  }
+
+  let html = layout
+    .replace('{{ content }}', renderedContent)
+    .replace(/\{\{\s*'\/fonts\/[^']+'\s*\|\s*relative_url\s*\}\}/g, '/fonts/space-grotesk-variable-latin.woff2')
+    .replace(/\{\{\s*'\/assets\/css\/docs\.css'\s*\|\s*relative_url\s*\}\}/g, '/assets/css/docs.css')
+    .replace(/\{\{\s*'\/'\s*\|\s*relative_url\s*\}\}/g, '/')
+    .replace(/\{%\s*seo\s*%\}/g, '<title>Docs</title>')
+    .replace(/\{%-?\s*if page\.noindex\s*-?%\}[\s\S]*?\{%-?\s*endif\s*-?%\}/g, '')
+    .replace(/\{%-?\s*if page\.updated\s*-?%\}[\s\S]*?\{%-?\s*endif\s*-?%\}/g, '<p class="page-updated">Last updated: August 30, 2026</p>')
+    .replace(/\{%-?\s*for item in site\.data\.docs_nav\s*-?%\}[\s\S]*?\{%-?\s*endfor\s*-?%\}/g, navHtml)
+    .replace(/\{%-?[\s\S]*?-?%\}/g, '');
+
+  return html;
+}
+
+// In-browser evaluation script
+const EVAL_SCRIPT = String.raw`
+(() => {
+  try {
+    function parseRgb(str) {
+      const m = str.match(/rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)/);
+      if (!m) return [0, 0, 0, 1];
+      return [
+        parseFloat(m[1]),
+        parseFloat(m[2]),
+        parseFloat(m[3]),
+        m[4] !== undefined ? parseFloat(m[4]) : 1
+      ];
+    }
+
+    function blend(fg, bg) {
+      const [fr, fgCol, fb, fa] = fg;
+      const [br, bgCol, bb] = bg;
+      return [
+        fr * fa + br * (1 - fa),
+        fgCol * fa + bgCol * (1 - fa),
+        fb * fa + bb * (1 - fa)
+      ];
+    }
+
+    function sRGBtoLin(c) {
+      const s = c / 255;
+      return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+    }
+
+    function luminance(rgb) {
+      return 0.2126 * sRGBtoLin(rgb[0]) + 0.7152 * sRGBtoLin(rgb[1]) + 0.0722 * sRGBtoLin(rgb[2]);
+    }
+
+    function contrast(rgb1, rgb2) {
+      const l1 = luminance(rgb1);
+      const l2 = luminance(rgb2);
+      const lighter = Math.max(l1, l2);
+      const darker = Math.min(l1, l2);
+      return (lighter + 0.05) / (darker + 0.05);
+    }
+
+    function getEffectiveBg(el) {
+      let current = el;
+      let bgStack = [];
+      while (current && current !== document) {
+        const style = window.getComputedStyle(current);
+        const bg = parseRgb(style.backgroundColor);
+        if (bg[3] > 0) {
+          bgStack.unshift(bg);
+          if (bg[3] >= 0.99) break;
+        }
+        current = current.parentElement;
+      }
+      const theme = document.documentElement.getAttribute('data-theme') || 'dark';
+      let composite = theme === 'light' ? [245, 245, 245] : [0, 0, 0];
+      for (const bg of bgStack) {
+        composite = blend(bg, composite);
+      }
+      return composite;
+    }
+
+    function isAriaHidden(el) {
+      let cur = el;
+      while (cur && cur !== document) {
+        if (cur.getAttribute && cur.getAttribute('aria-hidden') === 'true') return true;
+        cur = cur.parentElement;
+      }
+      return false;
+    }
+
+    const results = [];
+    const allElements = Array.from(document.querySelectorAll('*'));
+    for (const el of allElements) {
+      if (isAriaHidden(el)) continue;
+      if (el.tagName === 'SCRIPT' || el.tagName === 'STYLE' || el.tagName === 'NOSCRIPT' || el.tagName === 'SVG' || el.tagName === 'HEAD' || el.tagName === 'HTML') continue;
+
+      let hasDirectText = false;
+      for (const child of el.childNodes) {
+        if (child.nodeType === 3 && child.textContent.trim().length > 0) {
+          hasDirectText = true;
+          break;
+        }
+      }
+      if (!hasDirectText) continue;
+
+      const style = window.getComputedStyle(el);
+      if (style.display === 'none' || style.visibility === 'hidden' || parseFloat(style.opacity) === 0) continue;
+
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) continue;
+
+      const fg = parseRgb(style.color);
+      const bg = getEffectiveBg(el);
+      const effectiveFg = fg[3] < 1 ? blend(fg, bg) : [fg[0], fg[1], fg[2]];
+
+      const ratio = contrast(effectiveFg, bg);
+      const fontSize = parseFloat(style.fontSize);
+      const fontWeight = parseInt(style.fontWeight, 10) || 400;
+      const isLarge = fontSize >= 24 || (fontSize >= 18.66 && fontWeight >= 700);
+      const required = isLarge ? 3.0 : 4.5;
+
+      const text = el.textContent.replace(/\s+/g, ' ').trim().slice(0, 50);
+      const selector = el.className ? el.tagName.toLowerCase() + '.' + String(el.className).trim().split(/\s+/).join('.') : el.tagName.toLowerCase();
+
+      results.push({
+        selector,
+        text,
+        fontSize,
+        fontWeight,
+        isLarge,
+        fgRgb: effectiveFg.map(x => Math.round(x)),
+        bgRgb: bg.map(x => Math.round(x)),
+        fgHex: '#' + effectiveFg.map(x => Math.round(x).toString(16).padStart(2, '0')).join(''),
+        bgHex: '#' + bg.map(x => Math.round(x).toString(16).padStart(2, '0')).join(''),
+        ratio: Math.round(ratio * 100) / 100,
+        required,
+        pass: ratio >= required - 0.05
+      });
+    }
+    return results;
+  } catch (err) {
+    return [{ error: err.message, stack: err.stack }];
+  }
+})()
+`;
+
+/** Serves docs/ the way Pages does: .md rendered through the layout, everything else verbatim. */
+export function createDocsServer() {
+  return http.createServer((req, res) => {
+    let reqPath = req.url.split('?')[0];
+    if (reqPath === '/') reqPath = '/index.html';
+    
+    // Check if markdown page requested
+    const directPath = path.join(DOCS_DIR, reqPath);
+    const mdPath = reqPath.endsWith('.html') ? path.join(DOCS_DIR, reqPath.replace(/\.html$/, '.md')) : null;
+
+    if (mdPath && fs.existsSync(mdPath) && fs.statSync(mdPath).isFile()) {
+      const html = buildDocHtml(mdPath);
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(html);
+      return;
+    }
+
+    if (fs.existsSync(directPath) && fs.statSync(directPath).isFile()) {
+      let data = fs.readFileSync(directPath);
+      if (directPath.endsWith('.html')) {
+        let str = data.toString('utf8');
+        if (str.startsWith('---')) {
+          str = str.replace(/^---[\s\S]*?---\s*/, '');
+          str = str.replace(/\{\{\s*site\.data\.counts\.languages\s*\}\}/g, '81');
+          str = str.replace(/\{\{\s*site\.data\.counts\.frameworks\s*\}\}/g, '87');
+          str = str.replace(/\{\{\s*site\.data\.counts\.tools\s*\}\}/g, '171');
+        }
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(str);
+        return;
+      }
+      const ext = path.extname(directPath);
+      const mime = {
+        '.css': 'text/css',
+        '.js': 'text/javascript',
+        '.woff2': 'font/woff2',
+        '.png': 'image/png',
+        '.webp': 'image/webp',
+        '.svg': 'image/svg+xml'
+      }[ext] || 'application/octet-stream';
+      res.writeHead(200, { 'Content-Type': mime });
+      res.end(data);
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('Not found');
+  });
+}
+
+export async function runContrastSweep(pageUrls) {
+  const server = createDocsServer();
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const serverPort = server.address().port;
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chrome-sweep-'));
+  const chromePort = 9300 + Math.floor(Math.random() * 400);
+  const chrome = spawn('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome', [
+    '--headless',
+    `--remote-debugging-port=${chromePort}`,
+    '--remote-allow-origins=*',
+    `--user-data-dir=${tmpDir}`,
+    '--disable-gpu',
+    '--no-first-run',
+    'about:blank'
+  ]);
+
+  try {
+    let pageWsUrl = null;
+    for (let i = 0; i < 100; i++) {
+      try {
+        const listData = await new Promise((resolve, reject) => {
+          http.get(`http://127.0.0.1:${chromePort}/json/list`, res => {
+            let buf = '';
+            res.on('data', d => buf += d);
+            res.on('end', () => resolve(buf));
+          }).on('error', reject);
+        });
+        // Chrome also exposes browser_ui targets (omnibox popup) — only a real page can navigate.
+        const page = JSON.parse(listData).find(t => t.type === 'page' && t.webSocketDebuggerUrl);
+        if (page) {
+          pageWsUrl = page.webSocketDebuggerUrl;
+          break;
+        }
+      } catch (e) {
+        // Chrome not listening yet.
+      }
+      await new Promise(r => setTimeout(r, 200));
+    }
+
+    if (!pageWsUrl) throw new Error('Could not connect to Chrome CDP page target');
+
+    const ws = new WebSocket(pageWsUrl);
+    await new Promise((resolve, reject) => {
+      ws.onopen = resolve;
+      ws.onerror = reject;
+    });
+
+    let msgId = 1;
+    const send = (method, params = {}) => new Promise((resolve) => {
+      const id = msgId++;
+      const handler = (e) => {
+        const res = JSON.parse(e.data);
+        if (res.id === id) {
+          ws.removeEventListener('message', handler);
+          resolve(res.result);
+        }
+      };
+      ws.addEventListener('message', handler);
+      ws.send(JSON.stringify({ id, method, params }));
+    });
+
+    await send('Page.enable');
+    await send('Runtime.enable');
+    await send('Emulation.setDeviceMetricsOverride', {
+      width: 1440,
+      height: 900,
+      deviceScaleFactor: 1,
+      mobile: false
+    });
+
+    const report = [];
+
+    for (const urlPath of pageUrls) {
+      const fullUrl = `http://127.0.0.1:${serverPort}${urlPath.startsWith('/') ? urlPath : '/' + urlPath}`;
+      await send('Page.navigate', { url: fullUrl });
+      await new Promise(r => setTimeout(r, 1000));
+
+      for (const theme of ['dark', 'light']) {
+        await send('Runtime.evaluate', {
+          expression: `
+            (() => {
+              let s = document.getElementById('__sweep_style');
+              if (!s) {
+                s = document.createElement('style');
+                s.id = '__sweep_style';
+                s.textContent = '* { transition: none !important; animation: none !important; }';
+                document.head.appendChild(s);
+              }
+              document.documentElement.setAttribute('data-theme', '${theme}');
+              if (window.__sweepMeasure) window.__sweepMeasure();
+            })()
+          `
+        });
+        await new Promise(r => setTimeout(r, 400));
+
+        const evalRes = await send('Runtime.evaluate', {
+          expression: EVAL_SCRIPT,
+          returnByValue: true
+        });
+        if (evalRes?.exceptionDetails) {
+          throw new Error(`${urlPath} (${theme}): ${evalRes.exceptionDetails.text}`);
+        }
+
+        const elements = evalRes?.result?.value || [];
+        const failures = elements.filter(e => !e.pass);
+        report.push({
+          page: urlPath,
+          theme,
+          total: elements.length,
+          failures
+        });
+      }
+    }
+
+    ws.close();
+    chrome.kill('SIGTERM');
+    await new Promise(r => chrome.on('close', r));
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (e) {}
+    server.close();
+    return report;
+  } catch (err) {
+    chrome.kill('SIGTERM');
+    await new Promise(r => chrome.on('close', r));
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (e) {}
+    server.close();
+    throw err;
+  }
+}
+
+if (process.argv[1] === __filename) {
+  const pages = process.argv.slice(2);
+  // Default: the landing plus every doc page, so a new page cannot ship unswept.
+  const targetPages = pages.length > 0 ? pages : [
+    '/',
+    ...fs.readdirSync(DOCS_DIR)
+      .filter(f => f.endsWith('.md'))
+      .sort()
+      .map(f => '/' + f.replace(/\.md$/, '.html'))
+  ];
+  runContrastSweep(targetPages).then(report => {
+    console.log('\n=== Contrast Sweep Report ===\n');
+    let totalFailures = 0;
+    for (const r of report) {
+      console.log(`Page: ${r.page} | Theme: ${r.theme} | Checked: ${r.total} elements | Failures: ${r.failures.length}`);
+      if (r.failures.length > 0) {
+        totalFailures += r.failures.length;
+        const worst = [...r.failures].sort((a, b) => a.ratio - b.ratio)[0];
+        console.log(`  Worst ratio: ${worst.ratio}:1 (required: ${worst.required}:1) on "${worst.text}" (fg: ${worst.fgHex}, bg: ${worst.bgHex})`);
+        console.log(`  Failing elements summary:`);
+        const byHex = {};
+        for (const f of r.failures) {
+          const key = `${f.fgHex} on ${f.bgHex} (${f.selector})`;
+          byHex[key] = (byHex[key] || 0) + 1;
+        }
+        for (const [k, count] of Object.entries(byHex)) {
+          console.log(`    - ${count}x: ${k}`);
+        }
+      }
+    }
+    console.log(`\nTotal failing elements: ${totalFailures}`);
+    if (totalFailures > 0) process.exitCode = 1;
+  }).catch(e => {
+    console.error('Sweep error:', e);
+    process.exit(1);
+  });
+}

--- a/scripts/contrast-sweep.mjs
+++ b/scripts/contrast-sweep.mjs
@@ -507,6 +507,11 @@ export async function runContrastSweep(pageUrls) {
 
     for (const urlPath of pageUrls) {
       const fullUrl = `http://127.0.0.1:${serverPort}${urlPath.startsWith('/') ? urlPath : '/' + urlPath}`;
+      // A missing page must fail the run, not get audited as if it were the page:
+      // an error body is a handful of default-coloured words that can pass or fail
+      // on its own and tells you nothing about the page you meant to check.
+      const probe = await fetch(fullUrl);
+      if (!probe.ok) throw new Error(`${urlPath} returned HTTP ${probe.status} — not swept`);
       await send('Page.navigate', { url: fullUrl });
       await new Promise((r) => setTimeout(r, 1000));
 
@@ -566,26 +571,42 @@ export async function runContrastSweep(pageUrls) {
   }
 }
 
-/** Every published doc page, recursively. Jekyll's own `_`-prefixed dirs are not pages. */
-function discoverDocPages(dir = DOCS_DIR, prefix = '') {
+/**
+ * Every page to sweep, recursively. Jekyll's own `_`-prefixed dirs are not pages.
+ *
+ * With a build, walk the generated tree: a source path cannot be mapped to a URL
+ * by hand because front matter can set `permalink` (docs/perf/README.md publishes
+ * as /perf/), and guessing produces a 404 the sweep would then audit as if it
+ * were the page. Without a build, walk the sources — that mapping is the same one
+ * createDocsServer uses to render them, so it is correct by construction.
+ */
+function discoverPages() {
+  if (USE_BUILT_SITE) return walk(SITE_DIR, '', '.html').sort();
+  return ['/', ...walk(DOCS_DIR, '', '.md').sort()];
+}
+
+function walk(dir, prefix, ext) {
   const out = [];
-  for (const entry of fs
-    .readdirSync(dir, { withFileTypes: true })
-    .sort((a, b) => a.name.localeCompare(b.name))) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     if (entry.name.startsWith('_') || entry.name.startsWith('.')) continue;
     const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...discoverDocPages(full, `${prefix}/${entry.name}`));
-    else if (entry.name.endsWith('.md'))
-      out.push(`${prefix}/${entry.name.replace(/\.md$/, '.html')}`);
+    if (entry.isDirectory()) {
+      out.push(...walk(full, `${prefix}/${entry.name}`, ext));
+    } else if (entry.name.endsWith(ext)) {
+      // A built index.html *is* its directory's URL; anything else keeps its name.
+      out.push(
+        entry.name === 'index.html'
+          ? `${prefix}/`
+          : `${prefix}/${entry.name.replace(/\.md$/, '.html')}`,
+      );
+    }
   }
   return out;
 }
 
 if (process.argv[1] === __filename) {
   const pages = process.argv.slice(2);
-  // Default: the landing plus every doc page, recursively — docs/vs/*.md are
-  // published pages too and were missed by a flat scan.
-  const targetPages = pages.length > 0 ? pages : ['/', ...discoverDocPages()];
+  const targetPages = pages.length > 0 ? pages : discoverPages();
   runContrastSweep(targetPages)
     .then((report) => {
       console.log('\n=== Contrast Sweep Report ===\n');
@@ -611,7 +632,11 @@ if (process.argv[1] === __filename) {
           }
         }
       }
-      console.log(`\nTotal failing elements: ${totalFailures}`);
+      // Report the count rather than leaving anyone to quote one from memory.
+      console.log(
+        `\nSwept ${targetPages.length} pages x 2 themes from ${USE_BUILT_SITE ? 'the Jekyll build in docs/_site' : 'Markdown sources (fallback renderer — see the header comment)'}.`,
+      );
+      console.log(`Total failing elements: ${totalFailures}`);
       if (totalFailures > 0) process.exitCode = 1;
     })
     .catch((e) => {


### PR DESCRIPTION
Closes TRA-539.

## The failure

`--text-disabled` failed the 4.5:1 body-text ratio on **every page in dark
mode**. `#666666` is 3.66:1 on `#000000` and 3.29:1 on `--surface` `#111111`.

The failing text is not incidental — it is the **`✗` capability mark** (161 per
page on `comparisons.html`), every `[OK]`/`[READY]` bracket, `SCROLL →`,
`LICENSE`, `GITHUB STARS`, the version string, and the terminal's comment
lines. The `✗` is our own TRA-447 fix: we replaced `❌` with `✗ at
--text-disabled` and shipped a "no" a reader with low vision cannot reliably
see.

Dark `--accent` `#D71921` is 4.05:1 on `#000000` — a second, smaller failure,
on body-size link text across doc pages.

Light mode already passed: the light ladder was restacked in an earlier PR
(`#767676` → `#6D6D6D`, `--text-secondary` → `#595959`).

## Measured, not asserted

Headless Chrome, landing + all 18 doc pages, both themes, each element's
computed `color` against its own nearest opaque ancestor background,
`aria-hidden` decoration excluded:

| | failing elements |
|---|---|
| before | **362** (dark; light already 0) |
| after | **0** |

## Changes

| token | before | after | worst ratio after |
|---|---|---|---|
| dark `--text-disabled` | `#666666` | `#848484` | 4.65 on `#1A1A1A` |
| dark `--accent` | `#D71921` | `#E54047` | 4.64 on `#111111` |
| landing light `--accent` | `#D71921` | `#B3151C` | 6.06 on `#F0F0F0` |
| `--accent-solid` (new) | — | `#D71921` | 5.18 (white text on it) |

`--accent-solid` exists because the landing's primary button is a **fill** with
white text: `#E54047` behind white is 4.07 and would have failed. Red stays the
single accent — `--accent` and `--accent-solid` are two lightnesses of the same
red for two jobs, not two accents.

The landing light `--accent` change also closes the last token divergence
between `docs/index.html` and `docs/assets/css/docs.css`, which §1 has always
said must not exist.

Dark `--accent` is the one token that does not clear 4.5:1 everywhere: 4.27 on
`--surface-raised`. It is not used there, and §1 + §4 now say it must not be.
Pushing the red further to clear `#1A1A1A` lands near `#EA5057`, which reads
pink.

## Standard

- §1 replaced. Every text token now carries its ratio against **all three
  surfaces of its theme**, worst first. The old table recorded light
  `--text-disabled` as "4.54:1" — its ratio on `#FFFFFF`, a background doc
  prose never sits on — and gave the dark column no ratio at all. That is why
  nobody caught this.
- §5's contrast bullet used to ask reviewers to measure carefully. It is now a
  command that exits non-zero: `node scripts/contrast-sweep.mjs`. Eyeballing a
  grey is exactly what failed here, twice.
- §4 gains four entries covering the fill/text split and the raised-surface gap.

## New script

`scripts/contrast-sweep.mjs` serves `docs/` the way Pages does (Markdown through
the layout), renders every page in headless Chrome in both themes, and walks the
DOM. Defaults to the landing plus every `docs/*.md`, so a new page cannot ship
unswept. Pass paths to narrow it.

## Review

Screenshotted at 1440px and 390px in both themes: landing hero, the problem
section (light `--accent` dots and `/` glyph), and the `comparisons.html`
capability table. The `✗` is legible in both themes and still visibly quieter
than `✓` at `--text-display` — the opacity hierarchy the marks depend on holds.

Agent: Web Design Agent
