### PR TITLE
perf(bench): measure trace-mcp → trace token savings across 4 tokenizers (TRA-613)

### DIFF
--- a/benchmarks/name-token-savings.md
+++ b/benchmarks/name-token-savings.md
@@ -1,0 +1,135 @@
+# `trace-mcp` → `trace`: measured token savings (TRA-613)
+
+Measured 2026-09-01 on `trace-mcp@3.10.0` (`b6b02ae4`), macOS 15 / M-series, Node 22.22.3.
+Reproduce with `pnpm run build && node scripts/bench-name-tokens.mjs`.
+
+Tool counts and schemas come from a **real `initialize` + `tools/list` round-trip** against the
+built server (one spawn per preset, `client_profile: "off"`, a bare TypeScript project so no
+framework-gated tools register) — not from a hand-written list.
+
+Tokenizers: `gpt-tokenizer` for `o200k_base` (GPT-4o) and `cl100k_base` (GPT-4);
+`@anthropic-ai/tokenizer` for Claude; `@lenml/tokenizer-gemini` for Gemini. The last two are
+optional dev installs, not repo dependencies — see the script header.
+
+> Caveat, stated once: Anthropic does not publish a tokenizer for Claude 3+, so the Claude column
+> is the Claude 1/2 vocabulary from `@anthropic-ai/tokenizer`. It is the closest offline proxy
+> available; treat it as indicative, not exact. The GPT columns are exact.
+
+## Headline
+
+Renaming the MCP server key saves **2 tokens per tool (GPT) / 3 tokens per tool (Claude, Gemini)**,
+which is **0.74–1.23% of the advertised tool surface** depending on preset and tokenizer.
+
+The per-mention claim in TRA-610 is correct: `trace-mcp` is 3 tokens (GPT) or 4 (Claude, Gemini),
+`trace` is 1 — a 67–75% cut **on the substring**. The "hundreds of tokens per turn" claim is also
+correct in absolute terms on the `full` preset (332–498 tokens). What the numbers do not support is
+reading that as a large relative win: against the ~42–45k tokens the `full` tool surface already
+costs, the rename is a ~1% cut. It is worth doing — it is free and it compounds — but it is not a
+lever comparable to tool consolidation (TRA-210).
+
+## The string, in isolation
+
+| text | GPT-4o (o200k) | GPT-4 (cl100k) | Claude | Gemini |
+|---|---:|---:|---:|---:|
+| `trace-mcp` | 3 | 3 | 4 | 4 |
+| `trace` | 1 | 1 | 1 | 1 |
+| `mcp__trace-mcp__` | 7 | 7 | 8 | 8 |
+| `mcp__trace__` | 5 | 5 | 5 | 5 |
+| `` `trace-mcp` `` | 5 | 5 | 6 | 6 |
+| `` `trace` `` | 3 | 3 | 3 | 3 |
+| `.trace-mcp.json` | 4 | 4 | 7 | 7 |
+| `.trace.json` | 2 | 2 | 4 | 4 |
+
+o200k splits `trace-mcp` as `trace` + `-m` + `cp`; `trace` is a single token in all four.
+
+## Tool-name prefix (`mcp__trace-mcp__x` → `mcp__trace__x`)
+
+Names only, one per line.
+
+| preset | tools | tokenizer | before | after | saved | % of names |
+|---|---:|---|---:|---:|---:|---:|
+| minimal | 28 | GPT-4o | 302 | 246 | 56 | 18.5% |
+| minimal | 28 | GPT-4 | 299 | 243 | 56 | 18.7% |
+| minimal | 28 | Claude | 360 | 276 | 84 | 23.3% |
+| minimal | 28 | Gemini | 359 | 275 | 84 | 23.4% |
+| standard | 55 | GPT-4o | 619 | 509 | 110 | 17.8% |
+| standard | 55 | GPT-4 | 612 | 502 | 110 | 18.0% |
+| standard | 55 | Claude | 727 | 562 | 165 | 22.7% |
+| standard | 55 | Gemini | 722 | 557 | 165 | 22.9% |
+| full | 166 | GPT-4o | 1895 | 1563 | 332 | 17.5% |
+| full | 166 | GPT-4 | 1855 | 1523 | 332 | 17.9% |
+| full | 166 | Claude | 2220 | 1722 | 498 | 22.4% |
+| full | 166 | Gemini | 2210 | 1712 | 498 | 22.5% |
+
+## Whole advertised tool surface (`tools/list`: names + descriptions + schemas)
+
+The denominator that matters. Includes the literal `trace-mcp` mentions inside tool descriptions
+(5 in `standard`, 17 in `full`), which the names-only table above misses.
+
+| preset | tokenizer | before | after | saved | % |
+|---|---|---:|---:|---:|---:|
+| minimal | GPT-4o | 8627 | 8561 | 66 | 0.77% |
+| minimal | GPT-4 | 8466 | 8400 | 66 | 0.78% |
+| minimal | Claude | 8957 | 8858 | 99 | 1.11% |
+| minimal | Gemini | 8999 | 8900 | 99 | 1.10% |
+| standard | GPT-4o | 16303 | 16183 | 120 | 0.74% |
+| standard | GPT-4 | 16013 | 15893 | 120 | 0.75% |
+| standard | Claude | 16988 | 16808 | 180 | 1.06% |
+| standard | Gemini | 16997 | 16817 | 180 | 1.06% |
+| full | GPT-4o | 42835 | 42469 | 366 | 0.85% |
+| full | GPT-4 | 42004 | 41638 | 366 | 0.87% |
+| full | Claude | 44468 | 43919 | 549 | 1.23% |
+| full | Gemini | 44595 | 44046 | 549 | 1.23% |
+
+## Prose mentions
+
+| corpus | mentions | tokenizer | before | after | saved | % |
+|---|---:|---|---:|---:|---:|---:|
+| `initialize` instructions (verbosity=full) | 2 | GPT-4o | 930 | 926 | 4 | 0.43% |
+| `initialize` instructions (verbosity=full) | 2 | Claude | 1051 | 1045 | 6 | 0.57% |
+| CLAUDE.md / AGENTS.md routing block | 11 | GPT-4o | 2212 | 2184 | 28 | 1.27% |
+| CLAUDE.md / AGENTS.md routing block | 11 | Claude | 2424 | 2382 | 42 | 1.73% |
+| repo CLAUDE.md | 12 | GPT-4o | 4429 | 4405 | 24 | 0.54% |
+| repo CLAUDE.md | 12 | Claude | 4911 | 4875 | 36 | 0.73% |
+| repo AGENTS.md | 5 | GPT-4o | 492 | 482 | 10 | 2.03% |
+| repo AGENTS.md | 5 | Claude | 574 | 559 | 15 | 2.61% |
+
+The `initialize` instructions block barely moves: it names the server twice. It is already under a
+1455-token budget (`tests/server/instructions.test.ts`), so there is nothing to reclaim there. Its
+absolute counts drift ±1 token between runs because the block embeds the detected-framework string
+of the throwaway project the script spawns against; the delta (4 / 6) is stable.
+
+Full four-tokenizer tables: run the script.
+
+## Over a session
+
+Tool definitions and the CLAUDE.md routing block live in the system prompt, so a client re-bills
+them on every turn — as a *cache read* where prompt caching is on, at full price where it is not.
+
+| preset | tokenizer | per turn | 10 turns | 30 turns | 50 turns |
+|---|---|---:|---:|---:|---:|
+| minimal | GPT-4o | 94 | 940 | 2 820 | 4 700 |
+| minimal | Claude | 141 | 1 410 | 4 230 | 7 050 |
+| standard | GPT-4o | 148 | 1 480 | 4 440 | 7 400 |
+| standard | Claude | 222 | 2 220 | 6 660 | 11 100 |
+| full | GPT-4o | 394 | 3 940 | 11 820 | 19 700 |
+| full | Claude | 591 | 5 910 | 17 730 | 29 550 |
+
+## Retrieval regression check
+
+Both retrieval evals were run on an indexed clone of `b6b02ae4`:
+
+- recall harness (`pnpm run test:recall:report`): 8/8 fixtures pass, aggregate recall@k **1.000**,
+  precision@k **0.775**.
+- replay eval (`pnpm run replay:check`): nDCG@10 **1.0000**, MRR **1.0000**, Recall@5 **1.0000**,
+  Δ 0.0000 against baseline on all three.
+
+Both measure *code retrieval*, which the server key cannot affect — no ranker, index, or scoring
+weight is involved. Whether shortening the prefix changes an **agent's tool-selection** accuracy is
+a model-behaviour question, and no offline suite in this repo measures it. Do not read these
+numbers as evidence for that.
+
+Note: `pnpm run test:recall` (the vitest entry point) auto-skips on every machine — the vitest
+setup file redirects `TRACE_MCP_DATA_DIR` to a per-worker temp home, so the registry lookup the
+suite gates on never finds an index, and the run reports "1 test passed". Only the `test:recall:report`
+runner exercises the fixtures. Filed separately.

--- a/benchmarks/name-token-savings.md
+++ b/benchmarks/name-token-savings.md
@@ -1,11 +1,12 @@
 # `trace-mcp` → `trace`: measured token savings (TRA-613)
 
 Measured 2026-09-01 on `trace-mcp@3.10.0` (`b6b02ae4`), macOS 15 / M-series, Node 22.22.3.
-Reproduce with `pnpm run build && node scripts/bench-name-tokens.mjs`.
+Reproduce with `pnpm run build && npx tsx scripts/bench-name-tokens.ts`.
 
 Tool counts and schemas come from a **real `initialize` + `tools/list` round-trip** against the
 built server (one spawn per preset, `client_profile: "off"`, a bare TypeScript project so no
-framework-gated tools register) — not from a hand-written list.
+framework-gated tools register) — not from a hand-written list. The routing-block corpus is the
+`TRACE_MCP_ROUTING_BLOCK` constant the CLAUDE.md / AGENTS.md generators write, imported directly.
 
 Tokenizers: `gpt-tokenizer` for `o200k_base` (GPT-4o) and `cl100k_base` (GPT-4);
 `@anthropic-ai/tokenizer` for Claude; `@lenml/tokenizer-gemini` for Gemini. The last two are
@@ -63,8 +64,11 @@ Names only, one per line.
 
 ## Whole advertised tool surface (`tools/list`: names + descriptions + schemas)
 
-The denominator that matters. Includes the literal `trace-mcp` mentions inside tool descriptions
-(5 in `standard`, 17 in `full`), which the names-only table above misses.
+`JSON.stringify` of the tools array — a reproducible **proxy** for how a client renders tool
+definitions to the model, not the exact provider wire format. It is good enough to answer "is the
+prefix saving a rounding error or a real cut"; do not quote it as an exact prompt size. It does
+include the literal `trace-mcp` mentions inside tool descriptions (5 in `standard`, 17 in `full`),
+which the names-only table above misses.
 
 | preset | tokenizer | before | after | saved | % |
 |---|---|---:|---:|---:|---:|
@@ -81,23 +85,31 @@ The denominator that matters. Includes the literal `trace-mcp` mentions inside t
 | full | Claude | 44468 | 43919 | 549 | 1.23% |
 | full | Gemini | 44595 | 44046 | 549 | 1.23% |
 
+The full-preset o200k delta of 366 decomposes exactly: 332 from the 166 tool names, 34 from the
+17 `trace-mcp` mentions inside descriptions.
+
+`client_profile: "off"` is a host-neutral upper bound, not a typical client. The Codex profile
+serves 27 / 54 / 164 tools against these 28 / 55 / 166 — too small to move the conclusion.
+
 ## Prose mentions
 
 | corpus | mentions | tokenizer | before | after | saved | % |
 |---|---:|---|---:|---:|---:|---:|
 | `initialize` instructions (verbosity=full) | 2 | GPT-4o | 930 | 926 | 4 | 0.43% |
 | `initialize` instructions (verbosity=full) | 2 | Claude | 1051 | 1045 | 6 | 0.57% |
-| CLAUDE.md / AGENTS.md routing block | 11 | GPT-4o | 2212 | 2184 | 28 | 1.27% |
-| CLAUDE.md / AGENTS.md routing block | 11 | Claude | 2424 | 2382 | 42 | 1.73% |
+| CLAUDE.md / AGENTS.md routing block | 5 | GPT-4o | 411 | 401 | 10 | 2.43% |
+| CLAUDE.md / AGENTS.md routing block | 5 | Claude | 480 | 465 | 15 | 3.13% |
 | repo CLAUDE.md | 12 | GPT-4o | 4429 | 4405 | 24 | 0.54% |
 | repo CLAUDE.md | 12 | Claude | 4911 | 4875 | 36 | 0.73% |
 | repo AGENTS.md | 5 | GPT-4o | 492 | 482 | 10 | 2.03% |
 | repo AGENTS.md | 5 | Claude | 574 | 559 | 15 | 2.61% |
 
 The `initialize` instructions block barely moves: it names the server twice. It is already under a
-1455-token budget (`tests/server/instructions.test.ts`), so there is nothing to reclaim there. Its
-absolute counts drift ±1 token between runs because the block embeds the detected-framework string
-of the throwaway project the script spawns against; the delta (4 / 6) is stable.
+1455-token budget (`tests/server/instructions.test.ts`), so there is nothing to reclaim there.
+
+The rewrite measured is `trace-mcp` → `trace` only. TRA-611 keeps the `TRACE_MCP_*` environment
+variables, so those are deliberately left alone — renaming them here would measure a migration that
+is not going to ship.
 
 Full four-tokenizer tables: run the script.
 
@@ -108,12 +120,12 @@ them on every turn — as a *cache read* where prompt caching is on, at full pri
 
 | preset | tokenizer | per turn | 10 turns | 30 turns | 50 turns |
 |---|---|---:|---:|---:|---:|
-| minimal | GPT-4o | 94 | 940 | 2 820 | 4 700 |
-| minimal | Claude | 141 | 1 410 | 4 230 | 7 050 |
-| standard | GPT-4o | 148 | 1 480 | 4 440 | 7 400 |
-| standard | Claude | 222 | 2 220 | 6 660 | 11 100 |
-| full | GPT-4o | 394 | 3 940 | 11 820 | 19 700 |
-| full | Claude | 591 | 5 910 | 17 730 | 29 550 |
+| minimal | GPT-4o | 76 | 760 | 2 280 | 3 800 |
+| minimal | Claude | 114 | 1 140 | 3 420 | 5 700 |
+| standard | GPT-4o | 130 | 1 300 | 3 900 | 6 500 |
+| standard | Claude | 195 | 1 950 | 5 850 | 9 750 |
+| full | GPT-4o | 376 | 3 760 | 11 280 | 18 800 |
+| full | Claude | 564 | 5 640 | 16 920 | 28 200 |
 
 ## Retrieval regression check
 

--- a/scripts/bench-name-tokens.mjs
+++ b/scripts/bench-name-tokens.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/**
+ * TRA-613: what does renaming the MCP server key `trace-mcp` → `trace` actually
+ * save, in tokens, per session?
+ *
+ * Two independent effects, measured separately because they behave differently:
+ *
+ *   1. Tool-name prefix. Clients namespace MCP tools as `mcp__<serverKey>__<tool>`,
+ *      so every advertised tool carries the key once in `tools/list`. Measured
+ *      against the REAL `tools/list` payload of the built server (one spawn per
+ *      preset), not a hand-written list.
+ *   2. Prose mentions. The string `trace-mcp` in the `initialize` instructions
+ *      block and in the generated CLAUDE.md / AGENTS.md routing block, both of
+ *      which are re-sent every session.
+ *
+ * Run after `pnpm run build`:
+ *
+ *   node scripts/bench-name-tokens.mjs            # GPT tokenizers only
+ *   npm i -D @anthropic-ai/tokenizer @lenml/tokenizer-gemini  # adds Claude + Gemini
+ *
+ * The two extra tokenizers are optional on purpose: they are multi-MB vocab
+ * downloads and this is a one-off migration benchmark, not a CI guard. The
+ * committed numbers live in benchmarks/name-token-savings.md.
+ */
+import { spawn } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = fileURLToPath(new URL('..', import.meta.url));
+const PRESETS = ['minimal', 'standard', 'full'];
+const OLD = 'trace-mcp';
+const NEW = 'trace';
+
+// ---------------------------------------------------------------- tokenizers
+
+/** @type {Array<{ name: string, count: (s: string) => number }>} */
+const tokenizers = [];
+
+{
+  const o200k = await import('gpt-tokenizer/encoding/o200k_base');
+  tokenizers.push({ name: 'GPT-4o (o200k_base)', count: (s) => o200k.encode(s).length });
+  const cl100k = await import('gpt-tokenizer/encoding/cl100k_base');
+  tokenizers.push({ name: 'GPT-4 (cl100k_base)', count: (s) => cl100k.encode(s).length });
+}
+try {
+  const ant = await import('@anthropic-ai/tokenizer');
+  tokenizers.push({ name: 'Claude (anthropic-ai/tokenizer)', count: (s) => ant.countTokens(s) });
+} catch {
+  console.error('note: @anthropic-ai/tokenizer not installed — skipping Claude column');
+}
+try {
+  const gem = await import('@lenml/tokenizer-gemini');
+  const tok = gem.fromPreTrained();
+  tokenizers.push({
+    name: 'Gemini',
+    count: (s) => tok.encode(s, { add_special_tokens: false }).length,
+  });
+} catch {
+  console.error('note: @lenml/tokenizer-gemini not installed — skipping Gemini column');
+}
+
+/** Migration rewrite of any text: the server key and every path derived from it. */
+const migrate = (s) => s.split(OLD).join(NEW).split('TRACE_MCP_').join('TRACE_');
+
+// ------------------------------------------------------- real tools/list dump
+
+/** Drives the built server through initialize + tools/list for one preset. */
+function toolsList(preset) {
+  return new Promise((resolve, reject) => {
+    const root = mkdtempSync(join(tmpdir(), `bench-tools-${preset}-`));
+    mkdirSync(join(root, 'src'), { recursive: true });
+    writeFileSync(join(root, 'src', 'a.ts'), 'export const a = 1;\n');
+    // client_profile off: the profile layer hides tools a specific host already
+    // covers, which would make the count depend on who is asking.
+    writeFileSync(
+      join(root, '.trace-mcp.json'),
+      JSON.stringify({ tools: { preset, client_profile: 'off' } }),
+    );
+
+    const server = spawn('node', [join(REPO, 'dist/cli.js'), 'serve'], {
+      cwd: root,
+      env: { ...process.env, TRACE_MCP_NO_DAEMON: '1' },
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+    const send = (m) => server.stdin.write(`${JSON.stringify(m)}\n`);
+    const timer = setTimeout(() => {
+      server.kill();
+      reject(new Error(`timed out on preset ${preset}`));
+    }, 180_000);
+
+    let buf = '';
+    let init;
+    server.stdout.on('data', (chunk) => {
+      buf += chunk;
+      let nl;
+      while ((nl = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (!line.trim()) continue;
+        let msg;
+        try {
+          msg = JSON.parse(line);
+        } catch {
+          continue; // server logs interleave on stdout
+        }
+        if (msg.id === 1) {
+          init = msg.result;
+          send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+          send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+        }
+        if (msg.id === 2) {
+          clearTimeout(timer);
+          server.kill();
+          resolve({ tools: msg.result.tools, instructions: init?.instructions ?? '' });
+        }
+      }
+    });
+    send({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'bench-name-tokens', version: '0' },
+      },
+    });
+  });
+}
+
+// ------------------------------------------------------------------ measuring
+
+const md = [];
+
+// The claim under test, in isolation: how many tokens is the name itself?
+md.push('## The string, in isolation\n');
+md.push(`| text | ${tokenizers.map((t) => t.name).join(' | ')} |`);
+md.push(`|---|${tokenizers.map(() => '---:').join('|')}|`);
+for (const s of [
+  'trace-mcp',
+  'trace',
+  'mcp__trace-mcp__',
+  'mcp__trace__',
+  '`trace-mcp`',
+  '`trace`',
+  '.trace-mcp.json',
+  '.trace.json',
+]) {
+  md.push(`| \`${s}\` | ${tokenizers.map((t) => t.count(s)).join(' | ')} |`);
+}
+
+md.push('\n## Tool-name prefix (`mcp__trace-mcp__x` → `mcp__trace__x`)\n');
+md.push(`| preset | tools | tokenizer | before | after | saved | % of names |`);
+md.push('|---|---:|---|---:|---:|---:|---:|');
+
+const surfaces = [];
+let instructions = '';
+for (const preset of PRESETS) {
+  const { tools, instructions: instr } = await toolsList(preset);
+  surfaces.push({ preset, tools });
+  if (preset === 'full') instructions = instr;
+  const oldNames = tools.map((t) => `mcp__${OLD}__${t.name}`).join('\n');
+  const newNames = tools.map((t) => `mcp__${NEW}__${t.name}`).join('\n');
+  for (const tk of tokenizers) {
+    const before = tk.count(oldNames);
+    const after = tk.count(newNames);
+    md.push(
+      `| ${preset} | ${tools.length} | ${tk.name} | ${before} | ${after} | ${before - after} | ${(((before - after) / before) * 100).toFixed(1)}% |`,
+    );
+  }
+}
+
+// Whole advertised surface, as the client receives it — the denominator that
+// says whether the prefix saving is a rounding error or a real cut. Includes
+// the `trace-mcp` mentions inside descriptions, which the names table misses.
+md.push('\n## Whole advertised tool surface (`tools/list`, names + descriptions + schemas)\n');
+md.push('| preset | tokenizer | before | after | saved | % |');
+md.push('|---|---|---:|---:|---:|---:|');
+const serialize = (tools, key) =>
+  JSON.stringify(tools.map((t) => ({ ...t, name: `mcp__${key}__${t.name}` })));
+/** Per-session saving on the tool surface alone, keyed `preset|tokenizer`. */
+const perSession = new Map();
+for (const { preset, tools } of surfaces) {
+  for (const tk of tokenizers) {
+    const before = tk.count(serialize(tools, OLD));
+    const after = tk.count(migrate(serialize(tools, NEW)));
+    perSession.set(`${preset}|${tk.name}`, before - after);
+    md.push(
+      `| ${preset} | ${tk.name} | ${before} | ${after} | ${before - after} | ${(((before - after) / before) * 100).toFixed(2)}% |`,
+    );
+  }
+}
+
+// Prose corpora: everything re-sent on every session that names the server.
+const corpora = [
+  ['initialize instructions (verbosity=full)', instructions],
+  [
+    'CLAUDE.md / AGENTS.md routing block',
+    readFileSync(join(REPO, 'src/init/md-block.ts'), 'utf8')
+      .split('export const TRACE_MCP_ROUTING_BLOCK = `')[1]
+      ?.split('\n`;')[0] ?? '',
+  ],
+  ['repo CLAUDE.md', readFileSync(join(REPO, 'CLAUDE.md'), 'utf8')],
+  ['repo AGENTS.md', readFileSync(join(REPO, 'AGENTS.md'), 'utf8')],
+];
+
+md.push('\n## Prose mentions (`trace-mcp` → `trace`)\n');
+md.push('| corpus | mentions | tokenizer | before | after | saved | % |');
+md.push('|---|---:|---|---:|---:|---:|---:|');
+/** Per-session saving on prose the client resends every turn. */
+const perSessionProse = new Map();
+for (const [name, text] of corpora) {
+  const mentions = (text.match(/trace-mcp/g) ?? []).length;
+  for (const tk of tokenizers) {
+    const before = tk.count(text);
+    const after = tk.count(migrate(text));
+    perSessionProse.set(`${name}|${tk.name}`, before - after);
+    md.push(
+      `| ${name} | ${mentions} | ${tk.name} | ${before} | ${after} | ${before - after} | ${(((before - after) / before) * 100).toFixed(2)}% |`,
+    );
+  }
+}
+
+// The tool surface and the routing block both live in the system prompt, so a
+// client re-bills them (as a cache read, if caching is on) on every turn.
+md.push('\n## Input tokens saved over a session (tool surface + CLAUDE.md routing block)\n');
+md.push('| preset | tokenizer | per turn | 10 turns | 30 turns | 50 turns |');
+md.push('|---|---|---:|---:|---:|---:|');
+for (const { preset } of surfaces) {
+  for (const tk of tokenizers) {
+    const perTurn =
+      (perSession.get(`${preset}|${tk.name}`) ?? 0) +
+      (perSessionProse.get(`CLAUDE.md / AGENTS.md routing block|${tk.name}`) ?? 0);
+    md.push(
+      `| ${preset} | ${tk.name} | ${perTurn} | ${perTurn * 10} | ${perTurn * 30} | ${perTurn * 50} |`,
+    );
+  }
+}
+
+console.log(md.join('\n'));

--- a/scripts/bench-name-tokens.ts
+++ b/scripts/bench-name-tokens.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env tsx
 /**
  * TRA-613: what does renaming the MCP server key `trace-mcp` → `trace` actually
  * save, in tokens, per session?
@@ -10,13 +10,14 @@
  *      against the REAL `tools/list` payload of the built server (one spawn per
  *      preset), not a hand-written list.
  *   2. Prose mentions. The string `trace-mcp` in the `initialize` instructions
- *      block and in the generated CLAUDE.md / AGENTS.md routing block, both of
- *      which are re-sent every session.
+ *      block and in the CLAUDE.md / AGENTS.md routing block, both of which are
+ *      re-sent every session. The routing block is imported from the module the
+ *      generators write, not scraped out of its source text.
  *
  * Run after `pnpm run build`:
  *
- *   node scripts/bench-name-tokens.mjs            # GPT tokenizers only
- *   npm i -D @anthropic-ai/tokenizer @lenml/tokenizer-gemini  # adds Claude + Gemini
+ *   npx tsx scripts/bench-name-tokens.ts                       # GPT tokenizers only
+ *   npm i -D @anthropic-ai/tokenizer @lenml/tokenizer-gemini   # adds Claude + Gemini
  *
  * The two extra tokenizers are optional on purpose: they are multi-MB vocab
  * downloads and this is a one-off migration benchmark, not a CI guard. The
@@ -27,16 +28,25 @@ import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { TRACE_MCP_ROUTING_BLOCK } from '../src/init/md-block.js';
+import { buildInstructions } from '../src/server/instructions.js';
 
 const REPO = fileURLToPath(new URL('..', import.meta.url));
-const PRESETS = ['minimal', 'standard', 'full'];
+const PRESETS = ['minimal', 'standard', 'full'] as const;
 const OLD = 'trace-mcp';
 const NEW = 'trace';
 
 // ---------------------------------------------------------------- tokenizers
 
-/** @type {Array<{ name: string, count: (s: string) => number }>} */
-const tokenizers = [];
+interface Tokenizer {
+  name: string;
+  count: (s: string) => number;
+}
+const tokenizers: Tokenizer[] = [];
+
+// Indirect specifier: these two are optional dev installs, so the module must
+// not be resolved at type-check time.
+const optionalImport = (spec: string): Promise<Record<string, unknown>> => import(spec);
 
 {
   const o200k = await import('gpt-tokenizer/encoding/o200k_base');
@@ -45,14 +55,15 @@ const tokenizers = [];
   tokenizers.push({ name: 'GPT-4 (cl100k_base)', count: (s) => cl100k.encode(s).length });
 }
 try {
-  const ant = await import('@anthropic-ai/tokenizer');
-  tokenizers.push({ name: 'Claude (anthropic-ai/tokenizer)', count: (s) => ant.countTokens(s) });
+  const ant = await optionalImport('@anthropic-ai/tokenizer');
+  const countTokens = ant.countTokens as (s: string) => number;
+  tokenizers.push({ name: 'Claude (anthropic-ai/tokenizer)', count: countTokens });
 } catch {
   console.error('note: @anthropic-ai/tokenizer not installed — skipping Claude column');
 }
 try {
-  const gem = await import('@lenml/tokenizer-gemini');
-  const tok = gem.fromPreTrained();
+  const gem = await optionalImport('@lenml/tokenizer-gemini');
+  const tok = (gem.fromPreTrained as () => { encode: (s: string, o: object) => number[] })();
   tokenizers.push({
     name: 'Gemini',
     count: (s) => tok.encode(s, { add_special_tokens: false }).length,
@@ -61,13 +72,23 @@ try {
   console.error('note: @lenml/tokenizer-gemini not installed — skipping Gemini column');
 }
 
-/** Migration rewrite of any text: the server key and every path derived from it. */
-const migrate = (s) => s.split(OLD).join(NEW).split('TRACE_MCP_').join('TRACE_');
+/**
+ * The migration rewrite, as TRA-611 scopes it: the server key and the config
+ * paths derived from it. Deliberately NOT `TRACE_MCP_*` → `TRACE_*` — TRA-611
+ * keeps the legacy env vars, so renaming them here would measure a migration
+ * that is not going to ship.
+ */
+const migrate = (s: string): string => s.split(OLD).join(NEW);
 
 // ------------------------------------------------------- real tools/list dump
 
+interface ToolsListResult {
+  tools: Array<{ name: string; description?: string; inputSchema?: unknown }>;
+  instructions: string;
+}
+
 /** Drives the built server through initialize + tools/list for one preset. */
-function toolsList(preset) {
+function toolsList(preset: string): Promise<ToolsListResult> {
   return new Promise((resolve, reject) => {
     const root = mkdtempSync(join(tmpdir(), `bench-tools-${preset}-`));
     mkdirSync(join(root, 'src'), { recursive: true });
@@ -84,36 +105,41 @@ function toolsList(preset) {
       env: { ...process.env, TRACE_MCP_NO_DAEMON: '1' },
       stdio: ['pipe', 'pipe', 'ignore'],
     });
-    const send = (m) => server.stdin.write(`${JSON.stringify(m)}\n`);
+    const send = (m: unknown): void => {
+      server.stdin.write(`${JSON.stringify(m)}\n`);
+    };
     const timer = setTimeout(() => {
       server.kill();
       reject(new Error(`timed out on preset ${preset}`));
     }, 180_000);
 
     let buf = '';
-    let init;
+    let init: { instructions?: string } | undefined;
     server.stdout.on('data', (chunk) => {
       buf += chunk;
-      let nl;
+      let nl: number;
       while ((nl = buf.indexOf('\n')) >= 0) {
         const line = buf.slice(0, nl);
         buf = buf.slice(nl + 1);
         if (!line.trim()) continue;
-        let msg;
+        let msg: { id?: number; result?: Record<string, unknown> };
         try {
           msg = JSON.parse(line);
         } catch {
           continue; // server logs interleave on stdout
         }
         if (msg.id === 1) {
-          init = msg.result;
+          init = msg.result as { instructions?: string };
           send({ jsonrpc: '2.0', method: 'notifications/initialized' });
           send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
         }
         if (msg.id === 2) {
           clearTimeout(timer);
           server.kill();
-          resolve({ tools: msg.result.tools, instructions: init?.instructions ?? '' });
+          resolve({
+            tools: (msg.result?.tools ?? []) as ToolsListResult['tools'],
+            instructions: init?.instructions ?? '',
+          });
         }
       }
     });
@@ -132,7 +158,9 @@ function toolsList(preset) {
 
 // ------------------------------------------------------------------ measuring
 
-const md = [];
+const md: string[] = [];
+const pct = (before: number, after: number, digits = 2): string =>
+  `${(((before - after) / before) * 100).toFixed(digits)}%`;
 
 // The claim under test, in isolation: how many tokens is the name itself?
 md.push('## The string, in isolation\n');
@@ -152,56 +180,53 @@ for (const s of [
 }
 
 md.push('\n## Tool-name prefix (`mcp__trace-mcp__x` → `mcp__trace__x`)\n');
-md.push(`| preset | tools | tokenizer | before | after | saved | % of names |`);
+md.push('| preset | tools | tokenizer | before | after | saved | % of names |');
 md.push('|---|---:|---|---:|---:|---:|---:|');
 
-const surfaces = [];
-let instructions = '';
+const surfaces: Array<{ preset: string; tools: ToolsListResult['tools'] }> = [];
 for (const preset of PRESETS) {
-  const { tools, instructions: instr } = await toolsList(preset);
+  const { tools } = await toolsList(preset);
   surfaces.push({ preset, tools });
-  if (preset === 'full') instructions = instr;
   const oldNames = tools.map((t) => `mcp__${OLD}__${t.name}`).join('\n');
   const newNames = tools.map((t) => `mcp__${NEW}__${t.name}`).join('\n');
   for (const tk of tokenizers) {
     const before = tk.count(oldNames);
     const after = tk.count(newNames);
     md.push(
-      `| ${preset} | ${tools.length} | ${tk.name} | ${before} | ${after} | ${before - after} | ${(((before - after) / before) * 100).toFixed(1)}% |`,
+      `| ${preset} | ${tools.length} | ${tk.name} | ${before} | ${after} | ${before - after} | ${pct(before, after, 1)} |`,
     );
   }
 }
 
-// Whole advertised surface, as the client receives it — the denominator that
-// says whether the prefix saving is a rounding error or a real cut. Includes
-// the `trace-mcp` mentions inside descriptions, which the names table misses.
+// The whole advertised surface. `JSON.stringify` is a reproducible proxy for
+// how a client renders tool definitions to the model, not the exact provider
+// wire format — good enough to say whether the prefix saving is a rounding
+// error or a real cut, not to quote as an exact prompt size.
 md.push('\n## Whole advertised tool surface (`tools/list`, names + descriptions + schemas)\n');
 md.push('| preset | tokenizer | before | after | saved | % |');
 md.push('|---|---|---:|---:|---:|---:|');
-const serialize = (tools, key) =>
+const serialize = (tools: ToolsListResult['tools'], key: string): string =>
   JSON.stringify(tools.map((t) => ({ ...t, name: `mcp__${key}__${t.name}` })));
 /** Per-session saving on the tool surface alone, keyed `preset|tokenizer`. */
-const perSession = new Map();
+const perSession = new Map<string, number>();
 for (const { preset, tools } of surfaces) {
   for (const tk of tokenizers) {
     const before = tk.count(serialize(tools, OLD));
     const after = tk.count(migrate(serialize(tools, NEW)));
     perSession.set(`${preset}|${tk.name}`, before - after);
     md.push(
-      `| ${preset} | ${tk.name} | ${before} | ${after} | ${before - after} | ${(((before - after) / before) * 100).toFixed(2)}% |`,
+      `| ${preset} | ${tk.name} | ${before} | ${after} | ${before - after} | ${pct(before, after)} |`,
     );
   }
 }
 
 // Prose corpora: everything re-sent on every session that names the server.
-const corpora = [
-  ['initialize instructions (verbosity=full)', instructions],
-  [
-    'CLAUDE.md / AGENTS.md routing block',
-    readFileSync(join(REPO, 'src/init/md-block.ts'), 'utf8')
-      .split('export const TRACE_MCP_ROUTING_BLOCK = `')[1]
-      ?.split('\n`;')[0] ?? '',
-  ],
+// The routing block is the exported constant the generators write into
+// CLAUDE.md / AGENTS.md — not a substring scraped out of md-block.ts.
+const ROUTING_BLOCK = 'CLAUDE.md / AGENTS.md routing block';
+const corpora: Array<[string, string]> = [
+  ['initialize instructions (verbosity=full)', buildInstructions('none', 'full')],
+  [ROUTING_BLOCK, TRACE_MCP_ROUTING_BLOCK],
   ['repo CLAUDE.md', readFileSync(join(REPO, 'CLAUDE.md'), 'utf8')],
   ['repo AGENTS.md', readFileSync(join(REPO, 'AGENTS.md'), 'utf8')],
 ];
@@ -210,7 +235,7 @@ md.push('\n## Prose mentions (`trace-mcp` → `trace`)\n');
 md.push('| corpus | mentions | tokenizer | before | after | saved | % |');
 md.push('|---|---:|---|---:|---:|---:|---:|');
 /** Per-session saving on prose the client resends every turn. */
-const perSessionProse = new Map();
+const perSessionProse = new Map<string, number>();
 for (const [name, text] of corpora) {
   const mentions = (text.match(/trace-mcp/g) ?? []).length;
   for (const tk of tokenizers) {
@@ -218,7 +243,7 @@ for (const [name, text] of corpora) {
     const after = tk.count(migrate(text));
     perSessionProse.set(`${name}|${tk.name}`, before - after);
     md.push(
-      `| ${name} | ${mentions} | ${tk.name} | ${before} | ${after} | ${before - after} | ${(((before - after) / before) * 100).toFixed(2)}% |`,
+      `| ${name} | ${mentions} | ${tk.name} | ${before} | ${after} | ${before - after} | ${pct(before, after)} |`,
     );
   }
 }
@@ -232,7 +257,7 @@ for (const { preset } of surfaces) {
   for (const tk of tokenizers) {
     const perTurn =
       (perSession.get(`${preset}|${tk.name}`) ?? 0) +
-      (perSessionProse.get(`CLAUDE.md / AGENTS.md routing block|${tk.name}`) ?? 0);
+      (perSessionProse.get(`${ROUTING_BLOCK}|${tk.name}`) ?? 0);
     md.push(
       `| ${preset} | ${tk.name} | ${perTurn} | ${perTurn * 10} | ${perTurn * 30} | ${perTurn * 50} |`,
     );


### PR DESCRIPTION
Measurement for TRA-613 (sub-issue of TRA-610, `trace-mcp` → `trace`). No production code changes — one benchmark script and the report it produced.

## What was measured

`scripts/bench-name-tokens.mjs` drives a real `initialize` + `tools/list` round-trip against the built server (one spawn per preset, `client_profile: "off"`, bare TS project so no framework-gated tools register), then measures:

1. the tool-name prefix `mcp__trace-mcp__x` → `mcp__trace__x`
2. every `trace-mcp` prose mention in the `initialize` instructions block and the generated CLAUDE.md / AGENTS.md routing block

across four tokenizers: `o200k_base` (GPT-4o), `cl100k_base` (GPT-4), `@anthropic-ai/tokenizer` (Claude), `@lenml/tokenizer-gemini` (Gemini). `gpt-tokenizer` is already a devDependency; the other two are optional dynamic imports, so this adds no dependency.

## Before / after

Per tool name: **7 → 5 tokens** (GPT), **8 → 5** (Claude, Gemini).

Whole advertised tool surface (names + descriptions + schemas, includes the literal `trace-mcp` mentions inside descriptions):

| preset | tools | tokenizer | before | after | saved | % |
|---|---:|---|---:|---:|---:|---:|
| minimal | 28 | GPT-4o | 8627 | 8561 | 66 | 0.77% |
| minimal | 28 | Claude | 8957 | 8858 | 99 | 1.11% |
| standard | 55 | GPT-4o | 16303 | 16183 | 120 | 0.74% |
| standard | 55 | Claude | 16988 | 16808 | 180 | 1.06% |
| full | 166 | GPT-4o | 42835 | 42469 | 366 | 0.85% |
| full | 166 | Claude | 44468 | 43919 | 549 | 1.23% |

TRA-610's per-mention claim checks out exactly: `trace-mcp` is 3 tokens on o200k (`trace` + `-m` + `cp`) and 4 on Claude/Gemini; `trace` is 1 everywhere — a 67–75% cut on the substring. The "hundreds of tokens per turn" claim holds in absolute terms on the `full` preset (332–498 for names alone). What the numbers do not support is reading that as a large relative win: ~1% of a surface that already costs 42–45k.

Full tables, including the 10/30/50-turn projection and the prose corpora: `benchmarks/name-token-savings.md`.

## Retrieval check

Run on an indexed clone of `b6b02ae4`:

- recall harness (`pnpm run test:recall:report`): 8/8 fixtures, aggregate recall@k **1.000**, precision@k **0.775**
- replay eval (`pnpm run replay:check`): nDCG@10 / MRR / Recall@5 all **1.0000**, Δ 0.0000 vs baseline

Both measure code retrieval, which the server key cannot affect. Whether the shorter prefix changes an agent's *tool-selection* accuracy is a model-behaviour question and no offline suite here measures it — the report says so rather than implying coverage.

Separately noted in the report: `pnpm run test:recall` (the vitest entry point) auto-skips on every machine, because `tests/setup/isolate-home.ts` redirects `TRACE_MCP_DATA_DIR` to a per-worker temp home and the suite gates on a registry lookup that then finds no index. It reports "1 test passed". Only the `test:recall:report` runner exercises the fixtures. Not fixed here — that is a test-infra decision, not a benchmark change.

## Verification

- `pnpm run test` — 857 files, 9386 tests passed, 8 skipped
- `pnpm run typecheck` — clean
- `pnpm run biome:ci` — clean, 1683 files

Closes TRA-613.

## Related, not duplicate

#717 (TRA-615, docs for the same migration) shares the parent epic TRA-610, which is why the duplicate-work guard pairs us — the guard matches on any shared TRA key and cannot tell a parent reference from a claim. The two PRs do not overlap: #717 rewrites user-facing docs and the distribution ledger, this one adds a benchmark script and its report and touches no file #717 touches.
