### PR TITLE
fix(app): a file row shows its location whole or not at all (TRA-504)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -466,10 +466,20 @@ x=38 in every row.
 
 **A file row leads with the filename, not the path.** The name is what identifies
 the row, so it gets `--label` and the front of the line; the *leaf* directory follows
-it in `--label-secondary` and is the only part allowed to shorten. Never the reverse —
-a path-first row spends its width on `src/renderer/tabs/` and then eats the filename's
-extension, which is the one token the reader was looking for (TRA-503). Everything
-above the leaf belongs in the row's tooltip.
+it in `--label-secondary`. Never the reverse — a path-first row spends its width on
+`src/renderer/tabs/` and then eats the filename's extension, which is the one token
+the reader was looking for (TRA-503). Everything above the leaf belongs in the row's
+tooltip.
+
+**Secondary text is shown whole or not at all — it never shortens to a sliver.**
+Giving the location all of the shrink kept the filename intact but ran out at a
+fragment rather than at nothing: `GraphExplorerGPU.t…  t  46` at the 220px default,
+a clipped glyph beside the count at the 180px minimum. A lone letter next to a
+right-aligned number reads as a status badge, not as a place, so it costs width and
+returns nothing (TRA-504). Hide it instead — the row's tooltip still carries the full
+path, and the width goes back to the name, which is what four of twelve rows needed
+to stop truncating. Whether it fits is the one thing CSS cannot ask; measure it
+(`whole-location.ts`) and spend it on a class.
 
 **Anything that lives in the sidebar is a row.** Nav items are rows. Settings is a row.
 The idle update banner is a row. The footer was the last strip running its own
@@ -1479,6 +1489,8 @@ new evidence.
 | Paths truncate at the **head**, keeping the tail | The tail is the part that distinguishes siblings; tail-truncation hid the only useful segment. |
 | Sidebar file paths use a `dir`/`name` flex split, not `direction: rtl` | The rtl hack mangled any path containing `.` or `_` runs (`.idea/workspace.xml` → `idea/workspace.xml.`). |
 | A file row is **name first, location second** — and the location is the leaf directory, not the path (TRA-503) | A 180–320px row fits one of the two. Location-first spent up to 45% of the row on `src/renderer/tabs/` and truncated the filename anyway: `Settings.tsx` rendered as `src/render…Settings.t…`, losing the extension on every row that overflowed. Quick open already listed a file as name-then-directory; the sidebar and Ask now match it. |
+| A row's location is **hidden, not shortened**, once it stops fitting (TRA-504) | Shrink runs out at a fragment, not at nothing: at 220px `tabs` rendered as `t` beside the count, at 180px as a clipped glyph. Measured over twelve rows, dropping it also returned enough width for four filenames to stop truncating. Which rows qualify is measured (`dir.scrollWidth > dir.clientWidth`), because flexbox has no "whole or nothing" — a `7ch` cap makes short names pay and `direction: rtl` is inert under `unicode-bidi: plaintext`. |
+| The measurement is taken with the location **visible** | Measuring a hidden element reports it as fitting, so a row that kept its class would flip state on every pass. |
 | Whitespace separates sidebar groups, not rules | Fewer lines, clearer grouping; matches the platform sidebar. |
 | Rows are windowed past 100 items | A thousand projects costs what a hundred does. |
 | A surface with extra columns collapses them with a **container query**, trailing column first | At the 640px window minimum the app sidebar already takes 220. Ask's chat rail + inspector left the conversation at zero width and painted the inspector over its own toolbar. The rules must be last in the file — a container query adds no specificity. |

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -49,6 +49,7 @@ import { Notebook } from './tabs/Notebook';
 import { ProjectOverview } from './tabs/ProjectOverview';
 import { Settings } from './tabs/Settings';
 import { type Appearance, useTheme } from './theme.js';
+import { useWholeLocation } from './whole-location.js';
 import { Workspace } from './workspace/Workspace';
 
 // The Ask tab is the only thing that pulls react-markdown + remark-gfm in, and
@@ -286,6 +287,9 @@ function ProjectFileExplorer({
   const [selected, setSelected] = useState<string | null>(null);
   const [ctx, setCtx] = useState<{ x: number; y: number; path: string } | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
+  // A row drops its location rather than shrink it to a sliver (TRA-504). The
+  // sidebar is drag-resizable, so this re-measures on every width change too.
+  useWholeLocation(listRef);
   const LIMIT = 30;
 
   // Debounce scope to avoid fetching on every keystroke

--- a/packages/app/src/renderer/__tests__/whole-location.test.ts
+++ b/packages/app/src/renderer/__tests__/whole-location.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+/* TRA-504. `.dir` absorbs all of the row's shrink, so a filename that fills the
+   row leaves it a sliver rather than nothing: `GraphExplorerGPU.t…  t  47` at
+   the 220px default, a clipped glyph fragment at the 180px minimum. The rule is
+   whole or not at all, and the only thing CSS cannot supply is whether it fits.
+
+   jsdom lays nothing out, so the widths are stubbed. `clientWidth` reports 0
+   once the row carries the class, the way `display: none` does — that is what
+   makes the second call in "does not flip" a real check rather than a repeat. */
+
+import { describe, expect, it } from 'vitest';
+import { syncWholeLocation } from '../whole-location';
+
+/** One `.ws-sb-path` row whose location wants `wants` px and is given `given`. */
+function row(host: HTMLElement, name: string, dir: string, wants: number, given: number): void {
+  const path = document.createElement('span');
+  path.className = 'ws-sb-path';
+  path.innerHTML = `<span class="name">${name}</span><span class="dir">${dir}</span>`;
+  const el = path.querySelector('.dir') as HTMLElement;
+  Object.defineProperty(el, 'scrollWidth', { get: () => wants });
+  Object.defineProperty(el, 'clientWidth', {
+    get: () => (path.classList.contains('is-loc-clipped') ? 0 : given),
+  });
+  host.append(path);
+}
+
+function locations(host: HTMLElement): boolean[] {
+  return [...host.querySelectorAll('.ws-sb-path')].map(
+    (p) => !p.classList.contains('is-loc-clipped'),
+  );
+}
+
+describe('syncWholeLocation', () => {
+  it('hides a location that does not fit and keeps one that does', () => {
+    const host = document.createElement('div');
+    row(host, 'Settings.tsx', 'tabs', 28, 28); // fits exactly
+    row(host, 'GraphExplorerGPU.tsx', 'tabs', 28, 6); // one glyph left
+    row(host, 'MemoryExplorer.tsx', 'tabs', 28, 0); // squeezed to nothing
+    syncWholeLocation(host);
+    expect(locations(host)).toEqual([true, false, false]);
+  });
+
+  it('does not flip a hidden location back on, pass after pass', () => {
+    const host = document.createElement('div');
+    row(host, 'GraphExplorerGPU.tsx', 'tabs', 28, 6);
+    syncWholeLocation(host);
+    syncWholeLocation(host);
+    expect(locations(host)).toEqual([false]);
+  });
+
+  it('shows the location again once the row is widened', () => {
+    const host = document.createElement('div');
+    const path = document.createElement('span');
+    path.className = 'ws-sb-path';
+    path.innerHTML = '<span class="name">Settings.tsx</span><span class="dir">tabs</span>';
+    const el = path.querySelector('.dir') as HTMLElement;
+    let given = 6;
+    Object.defineProperty(el, 'scrollWidth', { get: () => 28 });
+    Object.defineProperty(el, 'clientWidth', {
+      get: () => (path.classList.contains('is-loc-clipped') ? 0 : given),
+    });
+    host.append(path);
+
+    syncWholeLocation(host);
+    expect(locations(host)).toEqual([false]);
+    given = 28;
+    syncWholeLocation(host);
+    expect(locations(host)).toEqual([true]);
+  });
+
+  // A file at the project root renders no `.dir` at all (TRA-503).
+  it('leaves a row without a location alone', () => {
+    const host = document.createElement('div');
+    host.innerHTML = '<span class="ws-sb-path"><span class="name">README.md</span></span>';
+    expect(() => syncWholeLocation(host)).not.toThrow();
+    expect(locations(host)).toEqual([true]);
+  });
+});

--- a/packages/app/src/renderer/styles/sidebar.css
+++ b/packages/app/src/renderer/styles/sidebar.css
@@ -275,6 +275,15 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* …down to nothing, literally: a location that cannot render whole is not
+   shown at all. Shrinking one ran out at a sliver instead — `GraphExplorerGPU.t…
+   t  47` at the 220px default, a clipped glyph fragment at the 180px minimum —
+   and a lone letter beside a right-aligned count reads as a status badge, not
+   as a place (TRA-504). The row's tooltip still carries the full path. Which
+   rows qualify is measured in `whole-location.ts`; CSS cannot see it. */
+.ws-sb-path.is-loc-clipped .dir {
+  display: none;
+}
 
 /* Sidebar empty / loading states. */
 .ws-sb-empty {

--- a/packages/app/src/renderer/tabs/AskTab.tsx
+++ b/packages/app/src/renderer/tabs/AskTab.tsx
@@ -24,6 +24,7 @@ import {
   Toolbar,
 } from '../lattice/ui';
 import { parentDir, splitPath } from '../sidebar-prefs.js';
+import { useWholeLocation } from '../whole-location.js';
 
 const BASE = 'http://127.0.0.1:3741';
 
@@ -862,6 +863,10 @@ function ContextInspector({
   onClose: () => void;
 }) {
   const { t } = useTranslation('ask');
+  // Same rule as the sidebar's file list: a path row shows its location whole
+  // or not at all (TRA-504). The inspector narrows with the window.
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  useWholeLocation(bodyRef);
   return (
     <aside className="ask-inspector" aria-label={t('context')}>
       <IslandHeader
@@ -876,7 +881,7 @@ function ContextInspector({
           />
         }
       />
-      <div className="ask-inspector-body">
+      <div className="ask-inspector-body" ref={bodyRef}>
         {!envelope ? (
           <EmptyState
             compact

--- a/packages/app/src/renderer/whole-location.ts
+++ b/packages/app/src/renderer/whole-location.ts
@@ -1,0 +1,55 @@
+/*
+ * A file row shows its location whole, or not at all.
+ *
+ * The row is `<name><location>` on one flex line where the location absorbs
+ * essentially all of the shrink, so the filename survives a 180–320px row
+ * (TRA-503). What that leaves is the case where the filename alone fills the
+ * row: the location does not disappear, it shrinks to a sliver —
+ * `GraphExplorerGPU.t…  t  47` at the 220px default, and a clipped glyph
+ * fragment at the 180px minimum, which reads as a rendering artifact rather
+ * than as text. A lone `t` between a filename and a right-aligned count looks
+ * like a status letter and carries no information either way (TRA-504).
+ *
+ * CSS has no "whole or nothing". A fixed `7ch` cap makes short filenames pay
+ * (`types.ts` → `type…`) and `direction: rtl` head-elision is a no-op under
+ * `unicode-bidi: plaintext` — both were measured and rejected in TRA-503. The
+ * missing piece is one bit CSS cannot derive: whether the location fits. So it
+ * gets measured here and spent on a class.
+ */
+
+import { type RefObject, useLayoutEffect } from 'react';
+
+/**
+ * Mark every `.ws-sb-path` under `host` whose location cannot render whole, and
+ * unmark the rows where it fits again.
+ *
+ * The class comes off before the measurement because the measurement is only
+ * meaningful with the location visible: a hidden element reports itself as
+ * fitting, so a row that kept its class would flip state on every pass.
+ */
+export function syncWholeLocation(host: HTMLElement): void {
+  for (const path of host.querySelectorAll<HTMLElement>('.ws-sb-path')) {
+    const dir = path.querySelector<HTMLElement>('.dir');
+    if (!dir) continue;
+    path.classList.remove('is-loc-clipped');
+    if (dir.scrollWidth > dir.clientWidth) path.classList.add('is-loc-clipped');
+  }
+}
+
+/** Run `syncWholeLocation` over a container of rows whenever they, or its width, change. */
+export function useWholeLocation(ref: RefObject<HTMLElement | null>): void {
+  /* No dependency array on purpose: re-rendering is what changes which rows are
+     in the container, and a ResizeObserver reports size only. Layout, not
+     effect — the class has to be on before the first paint. */
+  useLayoutEffect(() => {
+    const host = ref.current;
+    if (!host) return;
+    const sync = () => syncWholeLocation(host);
+    sync();
+    // jsdom has no ResizeObserver; the tests drive `syncWholeLocation` directly.
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(sync);
+    ro.observe(host);
+    return () => ro.disconnect();
+  });
+}


### PR DESCRIPTION
Closes TRA-504.

TRA-503 made the sidebar file row lead with the filename and gave the leaf directory all of the shrink. That keeps the name intact, but shrink runs out at a fragment rather than at nothing — the location does not disappear, it becomes a sliver.

Measured on the running renderer against the real daemon, sidebar at its 220px default (`scrollWidth`/`clientWidth` of `.dir`, in px):

| Row | Location wants | Gets | Rendered |
|---|---|---|---|
| `GraphExplorerGPU.tsx` | 26 | **4** | `GraphExplorerGPU.t…  t  46` |
| `decision-store.ts` | 49 | 37 | `decision-store.…  me…  63` |
| `topology-db.ts` | 53 | 50 | `topology-db.ts topolo…  47` |
| `trace-mcp-guard.sh` | — | — | `trace-mcp-guard.…  h…  38` |

At the 180px `SIDEBAR_MIN` seven of twelve rows are in that state. A lone `t` between a filename and a right-aligned number reads as a status letter, not as a place.

## What changed

The rule is now: **secondary text is shown whole or not at all.** Flexbox has no "whole or nothing", and the two CSS routes were already measured and rejected in TRA-503 — a `7ch` cap makes short filenames pay (`types.ts` → `type…`), and `direction: rtl` head-elision is inert under `unicode-bidi: plaintext`. The missing piece is one bit CSS cannot derive: whether the location fits.

`whole-location.ts` measures it and spends it on a class (`.ws-sb-path.is-loc-clipped .dir { display: none }`), over both surfaces that render the row — the sidebar file list in `App.tsx` and `PathRow` in `AskTab.tsx`.

Two things worth a reviewer's eye:

- **It measures the location, not the name.** The issue proposed `name.scrollWidth > name.clientWidth`, which is the more obvious signal and the wrong one: at 220px `GraphExplorerGPU.tsx` fits *exactly* (135/135), so a name-clipped test leaves the flagship row untouched while its location still renders as `t`. `dir.scrollWidth > dir.clientWidth` is the literal statement of the rule.
- **The class comes off before the measurement.** A hidden element reports itself as fitting, so a row that kept its class would flip state on every pass. `syncWholeLocation` therefore always measures in the visible state; the third test pins that.

## Result

Hiding the sliver also returns its width to the filename. Over the same twelve rows, **four** names stop truncating at 220px (`decision-store.ts`, `topology-db.ts`, `GraphExplorerGPU.tsx`, `trace-mcp-guard.sh`) and **eight** at 180px. Nothing is lost: the row's `title` already carries the full path.

Verified on the real render, light and dark, at 220 and 180, and through a live drag from 320 → 180 (the locations that stop fitting disappear as the drag passes them; `db`, `n8n`, `tailwind` stay). Ask's context inspector shares the same markup and hook; it mounts clean with no console errors, but its `PathRow` list needs a sent message to populate, so that surface is code-level only this round.

## Checks

`pnpm test` (54 files, 544 tests), `typecheck`, `check:i18n`, `build` — all green locally.
