### PR TITLE
feat(cli,init): register as `trace`, with auto-migration from `trace-mcp` (TRA-611)

### DIFF
--- a/.claude-plugin/.mcp.json
+++ b/.claude-plugin/.mcp.json
@@ -1,5 +1,5 @@
 {
-  "trace-mcp": {
+  "trace": {
     "command": "trace-mcp"
   }
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "commands": [],
   "mcpServers": {
-    "trace-mcp": {
+    "trace": {
       "command": "trace-mcp"
     }
   },

--- a/.codex-plugin/.mcp.json
+++ b/.codex-plugin/.mcp.json
@@ -1,5 +1,5 @@
 {
-  "trace-mcp": {
+  "trace": {
     "command": "trace-mcp"
   }
 }

--- a/hooks/trace-mcp-guard.sh
+++ b/hooks/trace-mcp-guard.sh
@@ -461,10 +461,11 @@ if (( HEARTBEAT_DEAD == 0 )) && [[ -f "$STATUS_FILE" ]] && [[ -f "$PROJECT_ROOT/
   STATUS_TRANSPORT=$(jq -r '.transport // empty' "$STATUS_FILE" 2>/dev/null || echo "")
   # trace-mcp entries with a "type"/"url" key are HTTP; entries with a
   # "command" key (no type/url) are stdio. Skip silently on missing/malformed
-  # config or an entry not named trace-mcp/trace-mcp-http rather than guess.
+  # config or an entry not named trace/trace-mcp (or their -http variants)
+  # rather than guess.
   EXPECTED_TRANSPORT=$(jq -r '
     (.mcpServers // {}) as $s
-    | ($s["trace-mcp"] // $s["trace-mcp-http"] // empty) as $e
+    | ($s["trace"] // $s["trace-http"] // $s["trace-mcp"] // $s["trace-mcp-http"] // empty) as $e
     | if ($e | length) == 0 then empty
       elif ($e.type == "http") or ($e.url != null) then "http"
       elif ($e.command != null) then "stdio"

--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.3.0 (Windows)
+REM trace-mcp-launcher v0.4.0 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.3.0 (Windows)
+# trace-mcp-launcher v0.4.0 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.
@@ -7,7 +7,21 @@
 
 $ErrorActionPreference = 'Stop'
 
-$TraceHome = if ($env:TRACE_MCP_HOME) { $env:TRACE_MCP_HOME } else { Join-Path $env:USERPROFILE '.trace-mcp' }
+# Home resolution, in the same precedence order as src/global.ts. The
+# script-relative fallback is the one that always holds: this file is installed
+# under <home>/bin/, so its own location names the home even when the default
+# moved (~/.trace-mcp -> ~/.trace, TRA-610) and no env var is set.
+$TraceHome =
+    if     ($env:TRACE_HOME)          { $env:TRACE_HOME }
+    elseif ($env:TRACE_MCP_HOME)      { $env:TRACE_MCP_HOME }
+    elseif ($env:TRACE_DATA_DIR)      { $env:TRACE_DATA_DIR }
+    elseif ($env:TRACE_MCP_DATA_DIR)  { $env:TRACE_MCP_DATA_DIR }
+    else {
+        $selfHome = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+        if     ($selfHome -and (Test-Path (Join-Path $selfHome 'launcher.env'))) { $selfHome }
+        elseif (Test-Path (Join-Path $env:USERPROFILE '.trace'))                 { Join-Path $env:USERPROFILE '.trace' }
+        else                                                                     { Join-Path $env:USERPROFILE '.trace-mcp' }
+    }
 $ConfigPath = Join-Path $TraceHome 'launcher.env'
 $LogPath    = Join-Path $TraceHome 'launcher.log'
 

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.3.0
+# trace-mcp-launcher v0.4.0
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a minimal
 # probe fallback for when the config is stale (e.g. Node was reinstalled).
@@ -8,7 +8,29 @@
 
 set -u
 
-TRACE_HOME="${TRACE_MCP_HOME:-$HOME/.trace-mcp}"
+# Home resolution, in the same precedence order as src/global.ts. The
+# script-relative fallback is the one that always holds: this file is
+# installed at <home>/bin/trace-mcp, so its own location names the home even
+# when the default moved (~/.trace-mcp → ~/.trace, TRA-610) and no env var is
+# set. The literal defaults below only matter if the shim is run from a copy.
+if [ -n "${TRACE_HOME:-}" ]; then
+  :
+elif [ -n "${TRACE_MCP_HOME:-}" ]; then
+  TRACE_HOME="$TRACE_MCP_HOME"
+elif [ -n "${TRACE_DATA_DIR:-}" ]; then
+  TRACE_HOME="$TRACE_DATA_DIR"
+elif [ -n "${TRACE_MCP_DATA_DIR:-}" ]; then
+  TRACE_HOME="$TRACE_MCP_DATA_DIR"
+else
+  _self_dir=$(cd "$(dirname "$0")/.." 2>/dev/null && pwd)
+  if [ -n "$_self_dir" ] && [ -r "$_self_dir/launcher.env" ]; then
+    TRACE_HOME="$_self_dir"
+  elif [ -d "$HOME/.trace" ]; then
+    TRACE_HOME="$HOME/.trace"
+  else
+    TRACE_HOME="$HOME/.trace-mcp"
+  fi
+fi
 CONFIG="$TRACE_HOME/launcher.env"
 LOG="$TRACE_HOME/launcher.log"
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
+    "trace": "dist/cli.js",
     "trace-mcp": "dist/cli.js"
   },
   "scripts": {

--- a/scripts/postinstall-control-plane.mjs
+++ b/scripts/postinstall-control-plane.mjs
@@ -52,14 +52,23 @@ const __dirname = path.dirname(__filename);
 const PKG_ROOT = path.resolve(__dirname, '..');
 
 const TRACE_MCP_HOME = (() => {
-  const override = process.env.TRACE_MCP_DATA_DIR || process.env.TRACE_MCP_HOME;
+  const override =
+    process.env.TRACE_HOME ||
+    process.env.TRACE_MCP_HOME ||
+    process.env.TRACE_DATA_DIR ||
+    process.env.TRACE_MCP_DATA_DIR;
   if (override && override.length > 0) {
     const expanded = override.startsWith('~')
       ? path.join(os.homedir(), override.slice(1))
       : override;
     return path.resolve(expanded);
   }
-  return path.join(os.homedir(), '.trace-mcp');
+  // Post-TRA-610 root, falling back to the pre-rename one when postinstall runs
+  // before src/global.ts has had a chance to move it (npm runs us first).
+  const home = path.join(os.homedir(), '.trace');
+  const legacy = path.join(os.homedir(), '.trace-mcp');
+  if (!fs.existsSync(home) && fs.existsSync(legacy)) return legacy;
+  return home;
 })();
 
 const LOG_PATH = path.join(TRACE_MCP_HOME, 'postinstall.log');

--- a/src/analytics/analytics-store.ts
+++ b/src/analytics/analytics-store.ts
@@ -30,6 +30,15 @@ function buildInputSnippet(tc: ToolCallEvent): string | null {
   return null;
 }
 
+/**
+ * Every `tool_server` value that means "this call went through us".
+ *
+ * `trace` is the current MCP server name (TRA-610); `trace-mcp` is what
+ * pre-rename sessions logged, and `trace_mcp` is the underscore spelling some
+ * clients normalise server keys to. Historical rows keep counting.
+ */
+export const TRACE_TOOL_SERVERS: ReadonlySet<string> = new Set(['trace', 'trace-mcp', 'trace_mcp']);
+
 export interface ToolCallRow {
   tool_name: string;
   tool_server: string;

--- a/src/analytics/real-savings.ts
+++ b/src/analytics/real-savings.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Store } from '../db/store.js';
-import type { ToolCallRow } from './analytics-store.js';
+import { TRACE_TOOL_SERVERS, type ToolCallRow } from './analytics-store.js';
 
 interface FileAlternative {
   file: string;
@@ -187,7 +187,7 @@ export function analyzeRealSavings(
     const s = sessionMap.get(tc.session_id) ?? { hasTrace: false, tokens: 0, toolCalls: 0 };
     s.tokens += tc.output_tokens_estimate;
     s.toolCalls++;
-    if (tc.tool_server === 'trace-mcp' || tc.tool_server === 'trace_mcp') {
+    if (TRACE_TOOL_SERVERS.has(tc.tool_server)) {
       s.hasTrace = true;
     }
     sessionMap.set(tc.session_id, s);

--- a/src/analytics/rules.ts
+++ b/src/analytics/rules.ts
@@ -3,7 +3,7 @@
  * and recommends trace-mcp alternatives.
  */
 
-import type { ToolCallRow } from './analytics-store.js';
+import { TRACE_TOOL_SERVERS, type ToolCallRow } from './analytics-store.js';
 
 interface OptimizationHit {
   rule: string;
@@ -241,7 +241,7 @@ const unusedTraceTools: Rule = {
         entry = { hasTrace: false, navTokens: 0, hasNav: false };
         sessions.set(c.session_id, entry);
       }
-      if (c.tool_server === 'trace-mcp' || c.tool_server === 'trace_mcp') {
+      if (TRACE_TOOL_SERVERS.has(c.tool_server)) {
         entry.hasTrace = true;
       }
       const sn = c.tool_short_name;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -340,7 +340,7 @@ async function runSubprojectAutoSync(projectRoot: string, config: TraceMcpConfig
 const program = new Command();
 
 program
-  .name('trace-mcp')
+  .name('trace')
   .description('Framework-Aware Code Intelligence for Laravel/Vue/Inertia/Nuxt')
   .version(PKG_VERSION, '-v, --version');
 
@@ -355,7 +355,7 @@ program
     const projectRoot = process.cwd();
 
     // Auto-update: check if a newer trace-mcp version is available and install it.
-    // Controlled by ~/.trace-mcp/.config.json: { "auto_update": true, "auto_update_check_interval_hours": 24 }
+    // Controlled by ~/.trace/.config.json: { "auto_update": true, "auto_update_check_interval_hours": 24 }
     const globalRaw = loadGlobalConfigRaw();
     if (globalRaw.auto_update !== false) {
       const intervalHours =
@@ -436,7 +436,7 @@ program
     if (autoSpawnDaemon) {
       logger.info(
         'Daemon auto-spawn is enabled. To run pure stdio: `trace-mcp daemon stop`, ' +
-          'or set TRACE_MCP_NO_DAEMON=1 / auto_spawn_daemon=false in ~/.trace-mcp/.config.json.',
+          'or set TRACE_MCP_NO_DAEMON=1 / auto_spawn_daemon=false in ~/.trace/.config.json.',
       );
     } else {
       logger.info('Daemon auto-spawn is disabled — running local-only (stdio).');

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -154,7 +154,7 @@ daemonCommand
         console.log('  Auto-spawn: enabled (a stdio session will start it on demand).');
         console.log(
           '  Disable with `trace-mcp daemon stop`, or set TRACE_MCP_NO_DAEMON=1 / ' +
-            'auto_spawn_daemon=false in ~/.trace-mcp/.config.json for a single session.',
+            'auto_spawn_daemon=false in ~/.trace/.config.json for a single session.',
         );
       }
       process.exit(1);

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -103,7 +103,7 @@ export const initCommand = new Command('init')
         const migration = migrateGlobalConfig();
         if (migration.changed) {
           migrationStep = {
-            target: '~/.trace-mcp/.config.json',
+            target: '~/.trace/.config.json',
             action: 'updated',
             detail: `Config migrated — added: ${migration.added.join(', ')}`,
           };

--- a/src/cli/preflight.ts
+++ b/src/cli/preflight.ts
@@ -2,7 +2,7 @@
  * First-run preflight checks (#124).
  *
  * Catches the environment problems that otherwise surface mid-`init` as a raw
- * stack trace — wrong Node version, an unwritable `~/.trace-mcp/`, or no MCP
+ * stack trace — wrong Node version, an unwritable `~/.trace/`, or no MCP
  * client config to write into — and turns each into a short, actionable
  * message. Pure and individually testable: every check takes its input as an
  * argument so the suite never depends on the real machine.
@@ -53,7 +53,7 @@ export function checkNodeVersion(version: string = process.versions.node): Prefl
   return { name: 'node-version', severity: 'ok', message: `Node ${version}` };
 }
 
-/** Verify `~/.trace-mcp/` can be created and written to. */
+/** Verify `~/.trace/` can be created and written to. */
 export function checkHomeWritable(home: string = TRACE_MCP_HOME): PreflightCheck {
   try {
     fs.mkdirSync(home, { recursive: true });
@@ -68,7 +68,7 @@ export function checkHomeWritable(home: string = TRACE_MCP_HOME): PreflightCheck
       severity: 'error',
       message: `Cannot write to ${home}${code ? ` (${code})` : ''}.`,
       hint:
-        'Fix permissions on the directory (e.g. `chmod u+rwx ~/.trace-mcp`) or set ' +
+        'Fix permissions on the directory (e.g. `chmod u+rwx ~/.trace`) or set ' +
         'TRACE_MCP_DATA_DIR to a writable location, then re-run `trace-mcp init`.',
     };
   }

--- a/src/cli/prune.ts
+++ b/src/cli/prune.ts
@@ -538,7 +538,7 @@ export function scanOrPruneDecisions(apply = false): DecisionsPruneSummary {
 
 export const pruneCommand = new Command('prune')
   .description(
-    'Audit ~/.trace-mcp/index for orphan/expired DBs (dry-run by default; use --apply to delete)',
+    'Audit ~/.trace/index for orphan/expired DBs (dry-run by default; use --apply to delete)',
   )
   .option('--apply', 'Actually delete orphan + expired session DBs')
   .option('--aggressive', 'Also delete stray small (<5 files) DBs older than 30 days')

--- a/src/config.ts
+++ b/src/config.ts
@@ -324,7 +324,7 @@ const TelemetryObservabilitySchema = z
 
 const TelemetryConfigSchema = z
   .object({
-    /** When true, persist tool-call latency to ~/.trace-mcp/telemetry.db. Off by default to avoid
+    /** When true, persist tool-call latency to ~/.trace/telemetry.db. Off by default to avoid
      *  unsolicited disk writes — analyze_perf works without the sink (in-memory ring). */
     enabled: z.boolean().default(false),
     /** Maximum rows to retain. Older rows are pruned when exceeded. 0 disables pruning. */
@@ -480,7 +480,7 @@ const TopologyConfigSchema = z
  *   otherwise                      → dropped         (current behaviour)
  *
  * Tunable via `decisions.review_threshold` / `decisions.reject_threshold`
- * in `~/.trace-mcp/.config.json` or `.trace-mcp.json` per project.
+ * in `~/.trace/.config.json` or `.trace.json` per project.
  * Defaults match `DEFAULT_REVIEW_THRESHOLD` / `DEFAULT_REJECT_THRESHOLD`
  * in `src/memory/conversation-miner.ts` (kept in sync).
  */
@@ -676,7 +676,7 @@ const MemoryConfigSchema = z
         dir: z
           .string()
           .optional()
-          .describe('Override audit log directory. Default ~/.trace-mcp/decisions/.'),
+          .describe('Override audit log directory. Default ~/.trace/decisions/.'),
         retentionDays: z
           .number()
           .int()
@@ -953,7 +953,7 @@ export const TraceMcpConfigSchema = z.object({
   logging: z
     .object({
       file: z.boolean().default(false),
-      path: z.string().default('~/.trace-mcp/run.log'),
+      path: z.string().default('~/.trace/run.log'),
       level: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).default('info'),
       max_size_mb: z.number().positive().max(500).default(10),
     })
@@ -1153,7 +1153,7 @@ export function validateConfigUpdate(incoming: Record<string, unknown>): string[
   return errors;
 }
 
-/** Load global config from ~/.trace-mcp/.config.json */
+/** Load global config from ~/.trace/.config.json */
 export function loadGlobalConfigRaw(): Record<string, unknown> {
   try {
     const raw = readIfExists(GLOBAL_CONFIG_PATH);
@@ -1166,8 +1166,13 @@ export function loadGlobalConfigRaw(): Record<string, unknown> {
 
 /** Load per-project config overrides via cosmiconfig (optional, for local overrides). */
 async function loadProjectConfigRaw(searchFrom: string): Promise<Record<string, unknown>> {
+  // `.trace*` first, `.trace-mcp*` after: a project that still carries the
+  // pre-rename file keeps working, and one that has both prefers the new name.
   const explorer = cosmiconfig('trace-mcp', {
     searchPlaces: [
+      '.trace/.config.json',
+      '.trace.json',
+      '.config/trace.json',
       '.trace-mcp/.config.json',
       '.trace-mcp.json',
       '.trace-mcp',
@@ -1217,7 +1222,7 @@ export async function loadConfig(searchFrom?: string): Promise<TraceMcpResult<Tr
     // Remove 'projects' key from global raw — it's not part of TraceMcpConfig
     const { projects: _projects, ...globalDefaults } = globalRaw;
 
-    // Load local cosmiconfig overrides (if any .trace-mcp.json exists in project)
+    // Load local cosmiconfig overrides (if any .trace.json exists in project)
     const localRaw = searchFrom ? await loadProjectConfigRaw(searchFrom) : {};
 
     // Merge: global defaults → per-project section from global config → local overrides

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,10 +1,13 @@
 /**
- * Global paths and helpers for ~/.trace-mcp/ directory structure.
+ * Global paths and helpers for the ~/.trace/ directory structure.
  *
- * All trace-mcp state lives here:
- *   ~/.trace-mcp/.config.json          — global config
- *   ~/.trace-mcp/registry.json         — project registry
- *   ~/.trace-mcp/index/<name>-<hash>.db — per-project databases
+ * All trace state lives here:
+ *   ~/.trace/.config.json          — global config
+ *   ~/.trace/registry.json         — project registry
+ *   ~/.trace/index/<name>-<hash>.db — per-project databases
+ *
+ * Installs from before the `trace-mcp` → `trace` rename keep their data in
+ * `~/.trace-mcp/`; `migrateLegacyHome()` below moves it across on first import.
  */
 
 import crypto from 'node:crypto';
@@ -12,31 +15,106 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+const defaultHome = (): string => path.join(os.homedir(), '.trace');
+const legacyHome = (): string => path.join(os.homedir(), '.trace-mcp');
+
 /**
- * Root of all trace-mcp global state.
+ * One-time move of `~/.trace-mcp/` → `~/.trace/`, leaving a symlink behind at
+ * the old location. The symlink is what keeps existing installs working: MCP
+ * client configs written by an older `init` hold an absolute path to the
+ * launcher shim under `~/.trace-mcp/bin/`, and older daemons/desktop-app
+ * builds still read the old root directly.
  *
- * Default: `~/.trace-mcp/`. Override with `TRACE_MCP_DATA_DIR=<path>` for
- * Docker volumes, ephemeral CI workspaces, multi-repo orchestrators, or
- * shared cache locations. CRG v2.3.0 (#155) introduced the same knob — the
- * env var replaces the default verbatim, with `~` expansion. Resolved at
- * import time so a user-facing change requires a process restart.
+ * Runs at import time, before any path constant below is consumed — deferring
+ * it to `ensureGlobalDirs()` would let a reader that never calls it (registry
+ * lookups, `daemon status`) see an empty new home while the data sits in the
+ * old one.
+ *
+ * Deliberately does nothing when both roots already exist as real directories:
+ * merging two live state dirs is a data-loss risk, and that only happens if
+ * old and new versions were run side by side.
  */
-export const TRACE_MCP_HOME = (() => {
-  const override = process.env.TRACE_MCP_DATA_DIR;
+function migrateLegacyHome(): void {
+  const target = defaultHome();
+  const legacy = legacyHome();
+  try {
+    if (fs.existsSync(target)) {
+      // Already moved. Retry the compatibility link if an earlier run created
+      // the directory but failed to link it back — the move is one-shot, so
+      // without this retry every pre-rename client config pointing at
+      // ~/.trace-mcp/bin/ would stay broken forever.
+      linkLegacyHome(target, legacy);
+      return;
+    }
+    // lstat, not stat: an existing symlink means a previous run already moved it.
+    if (!fs.lstatSync(legacy).isDirectory()) return;
+    fs.renameSync(legacy, target);
+    linkLegacyHome(target, legacy);
+  } catch {
+    // Legacy home absent, or an unreadable/unwritable HOME. Nothing to migrate.
+  }
+}
+
+/** Point `legacy` at `target` when nothing occupies it yet. Best-effort. */
+function linkLegacyHome(target: string, legacy: string): void {
+  try {
+    fs.lstatSync(legacy);
+    return; // already a link, or a real dir we must not clobber
+  } catch {
+    // Nothing at the legacy path — fall through and create the link.
+  }
+  try {
+    fs.symlinkSync(target, legacy, process.platform === 'win32' ? 'junction' : 'dir');
+  } catch {
+    // Windows without developer mode / restricted FS — the move still stands.
+  }
+}
+
+/**
+ * Root of all trace global state.
+ *
+ * Default: `~/.trace/`. Override for Docker volumes, ephemeral CI workspaces,
+ * multi-repo orchestrators, or shared cache locations with, in precedence
+ * order, `TRACE_HOME` / `TRACE_MCP_HOME` / `TRACE_DATA_DIR` /
+ * `TRACE_MCP_DATA_DIR` — one root under four names: `*_HOME` is what the
+ * launcher shim has always read, `*_DATA_DIR` what the index side read, and
+ * each has a pre-rename `TRACE_MCP_*` spelling. CRG v2.3.0 (#155) introduced
+ * the same knob — the env var replaces the default verbatim, with `~` expansion.
+ * Resolved at import time so a user-facing change requires a process restart.
+ */
+export const TRACE_HOME = resolveTraceHome();
+
+/**
+ * The same resolution as {@link TRACE_HOME}, re-read on every call.
+ *
+ * Everything that can take the frozen constant should — this exists for the
+ * launcher, which is also reachable from a process that sets the env var after
+ * `global.ts` was already imported.
+ */
+export function resolveTraceHome(): string {
+  const override =
+    process.env.TRACE_HOME ||
+    process.env.TRACE_MCP_HOME ||
+    process.env.TRACE_DATA_DIR ||
+    process.env.TRACE_MCP_DATA_DIR;
   if (override && override.length > 0) {
     const expanded = override.startsWith('~')
       ? path.join(os.homedir(), override.slice(1))
       : override;
     return path.resolve(expanded);
   }
-  return path.join(os.homedir(), '.trace-mcp');
-})();
+  migrateLegacyHome();
+  return defaultHome();
+}
 
-/** Global config file (replaces per-project .trace-mcp.json). */
-export const GLOBAL_CONFIG_PATH = path.join(TRACE_MCP_HOME, '.config.json');
+/** Pre-rename name for {@link TRACE_HOME}. Kept so importers don't all churn. */
+export const TRACE_MCP_HOME = TRACE_HOME;
+
+/** Global config file (replaces per-project .trace.json / .trace-mcp.json). */
+export const GLOBAL_CONFIG_PATH = path.join(TRACE_HOME, '.config.json');
 
 /** Directory for per-project SQLite databases. */
-export const INDEX_DIR = path.join(TRACE_MCP_HOME, 'index');
+export const INDEX_DIR = path.join(TRACE_HOME, 'index');
 
 /**
  * Index DBs for one-shot agent-run checkouts (TRA-396). Kept in their own
@@ -50,31 +128,31 @@ export const INDEX_DIR = path.join(TRACE_MCP_HOME, 'index');
 export const EPHEMERAL_INDEX_DIR = path.join(INDEX_DIR, 'ephemeral');
 
 /** Global project registry. */
-export const REGISTRY_PATH = path.join(TRACE_MCP_HOME, 'registry.json');
+export const REGISTRY_PATH = path.join(TRACE_HOME, 'registry.json');
 
 /** Topology database (cross-service graph). */
-export const TOPOLOGY_DB_PATH = path.join(TRACE_MCP_HOME, 'topology.db');
+export const TOPOLOGY_DB_PATH = path.join(TRACE_HOME, 'topology.db');
 
 /** Decision memory database (cross-session knowledge graph). */
-export const DECISIONS_DB_PATH = path.join(TRACE_MCP_HOME, 'decisions.db');
+export const DECISIONS_DB_PATH = path.join(TRACE_HOME, 'decisions.db');
 
 /** Per-project + per-operation PID lock files (see src/utils/pid-lock.ts). */
-export const LOCKS_DIR = path.join(TRACE_MCP_HOME, 'locks');
+export const LOCKS_DIR = path.join(TRACE_HOME, 'locks');
 
 /** Default port the daemon listens on. */
 export const DEFAULT_DAEMON_PORT = 3741;
 
 /** Daemon log file path. */
-export const DAEMON_LOG_PATH = path.join(TRACE_MCP_HOME, 'daemon.log');
+export const DAEMON_LOG_PATH = path.join(TRACE_HOME, 'daemon.log');
 
 /**
  * Opt-out sentinel for the background daemon (#202). When this file exists,
  * `ensureDaemon`/`tryAutoSpawnDaemon` treat the daemon as explicitly disabled:
  * they do NOT (re)install the launchd plist or spawn a detached process. Written
- * by `trace-mcp daemon stop`, cleared by `trace-mcp daemon start`/`restart`.
+ * by `trace daemon stop`, cleared by `trace daemon start`/`restart`.
  * Lets a user who prefers pure stdio remove the daemon and have it stay gone.
  */
-export const DAEMON_DISABLED_PATH = path.join(TRACE_MCP_HOME, 'daemon.disabled');
+export const DAEMON_DISABLED_PATH = path.join(TRACE_HOME, 'daemon.disabled');
 
 /** launchd plist path for auto-start on macOS. */
 export const LAUNCHD_PLIST_PATH = path.join(
@@ -242,7 +320,7 @@ export const DEFAULT_CONFIG_JSONC = `{
   // ── Logging ───────────────────────────────────────────────────────
   "logging": {
     "file": false,                                 // enable file logging
-    "path": "~/.trace-mcp/run.log",                // log file location
+    "path": "~/.trace/run.log",                    // log file location
     "level": "info",                               // "trace" | "debug" | "info" | "warn" | "error" | "fatal"
     "max_size_mb": 10                              // rotate when log exceeds this size
   },
@@ -267,7 +345,7 @@ export const DEFAULT_CONFIG_JSONC = `{
 }
 `;
 
-/** Ensure ~/.trace-mcp/ and ~/.trace-mcp/index/ exist. */
+/** Ensure ~/.trace/ and ~/.trace/index/ exist. */
 export function ensureGlobalDirs(): void {
   fs.mkdirSync(EPHEMERAL_INDEX_DIR, { recursive: true }); // also creates INDEX_DIR
 
@@ -279,7 +357,7 @@ export function ensureGlobalDirs(): void {
   // global.ts under `node --experimental-strip-types` and can't resolve
   // `.js → .ts` imports of sibling modules.
   if (process.platform !== 'win32') {
-    for (const dir of [TRACE_MCP_HOME, INDEX_DIR, EPHEMERAL_INDEX_DIR]) {
+    for (const dir of [TRACE_HOME, INDEX_DIR, EPHEMERAL_INDEX_DIR]) {
       try {
         fs.chmodSync(dir, 0o700);
       } catch {
@@ -320,7 +398,7 @@ export function projectName(absolutePath: string): string {
 /** Path to the live session snapshot file (read by PreCompact hook). */
 export function getSnapshotPath(projectRoot: string): string {
   const absRoot = path.resolve(projectRoot);
-  return path.join(TRACE_MCP_HOME, 'sessions', `${projectHash(absRoot)}-snapshot.json`);
+  return path.join(TRACE_HOME, 'sessions', `${projectHash(absRoot)}-snapshot.json`);
 }
 
 /**

--- a/src/init/launcher.ts
+++ b/src/init/launcher.ts
@@ -4,15 +4,16 @@
  * from a config file written here, with a probe fallback — so node upgrades
  * (nvm/Herd/Volta/fnm) don't break MCP registration.
  *
- * Layout under $TRACE_MCP_HOME (default ~/.trace-mcp):
+ * Layout under $TRACE_HOME (default ~/.trace):
  *   bin/trace-mcp     — bash shim, copied from hooks/trace-mcp-launcher.sh
+ *                       (name kept: MCP client configs hold its absolute path)
  *   launcher.env      — KV config (TRACE_MCP_NODE, TRACE_MCP_CLI, TRACE_MCP_VERSION)
  *   launcher.log      — rolling resolution diagnostics written by the shim
  */
 
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
+import { resolveTraceHome } from '../global.js';
 import { withPs1Bom } from './ps1-bom.js';
 import { readIfExists } from '../utils/safe-fs.js';
 import type { InitStepResult } from './types.js';
@@ -20,13 +21,13 @@ import { LAUNCHER_VERSION } from './types.js';
 
 const IS_WINDOWS = process.platform === 'win32';
 
-// Artifacts shipped from hooks/ and installed under $TRACE_MCP_HOME/bin/.
+// Artifacts shipped from hooks/ and installed under $TRACE_HOME/bin/.
 // On Unix a single shim file carries the resolution logic; on Windows a
 // .cmd shim is what MCP clients spawn, but the actual logic lives in a
 // sibling .ps1 so we can parse JSON/config without bat-script pain.
 interface LauncherArtifact {
   src: string; // basename inside hooks/
-  dest: string; // basename inside $TRACE_MCP_HOME/bin/
+  dest: string; // basename inside $TRACE_HOME/bin/
   mode: number;
   isPrimaryShim: boolean; // the file MCP clients invoke
 }
@@ -44,9 +45,11 @@ const ARTIFACTS: LauncherArtifact[] = IS_WINDOWS
   : [{ src: 'trace-mcp-launcher.sh', dest: 'trace-mcp', mode: 0o755, isPrimaryShim: true }];
 
 export function getLauncherDir(): string {
-  const envDir = process.env.TRACE_MCP_HOME?.trim();
-  if (envDir) return envDir;
-  return path.join(os.homedir(), '.trace-mcp');
+  // Shared with the index/registry/daemon roots: resolveTraceHome() already
+  // folds in TRACE_HOME/TRACE_MCP_HOME/TRACE_DATA_DIR and the one-time
+  // ~/.trace-mcp → ~/.trace move. Re-deriving it here is how the shim used to
+  // end up in a different root than everything else under the same env.
+  return resolveTraceHome();
 }
 
 export function getLauncherPath(): string {
@@ -184,7 +187,7 @@ export interface InstallLauncherOpts {
 }
 
 /**
- * Install the shim script at $TRACE_MCP_HOME/bin/trace-mcp, skipping if the
+ * Install the shim script at $TRACE_HOME/bin/trace-mcp, skipping if the
  * installed version matches the shipped one (unless force=true).
  * Does NOT write launcher.env — call writeLauncherConfig() separately with
  * the current process's node + cli paths.

--- a/src/init/mcp-client.ts
+++ b/src/init/mcp-client.ts
@@ -19,6 +19,91 @@ import type { DetectedMcpClient, InitStepResult } from './types.js';
 const HOME = os.homedir();
 
 /**
+ * Key trace registers itself under in every MCP client config.
+ *
+ * Clients prefix each tool name with it (`mcp__trace__search`), so the key is
+ * re-sent to the model on every prompt turn, once per advertised tool — which
+ * is why it is as short as it is (TRA-610).
+ */
+export const MCP_SERVER_KEY = 'trace';
+
+/** Pre-TRA-610 key. Still read for detection; removed whenever we write. */
+export const LEGACY_MCP_SERVER_KEY = 'trace-mcp';
+
+/** An entry as it comes off disk — every field optional until compared. */
+type OnDiskEntry = Partial<McpServerEntry & { type: string }> & Record<string, unknown>;
+
+/** Read our entry from a parsed `mcpServers`-shaped map, new key winning. */
+function pickServerEntry<T>(servers: Record<string, T> | undefined | null): T | undefined {
+  if (!servers) return undefined;
+  return servers[MCP_SERVER_KEY] ?? servers[LEGACY_MCP_SERVER_KEY];
+}
+
+/** Parse a JSON client config and hand back its `mcpServers` map, if any. */
+function readMcpServers(configPath: string): Record<string, unknown> | undefined {
+  try {
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    return content?.mcpServers as Record<string, unknown> | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * True when the pre-rename key is on disk at all.
+ *
+ * Deliberately not "only the legacy key": a config carrying BOTH keys is the
+ * worst state, not a benign one — the client spawns two copies of the server —
+ * so it has to read as needing a rewrite, never as `already_configured`.
+ */
+function hasLegacyKey(servers: Record<string, unknown> | undefined | null): boolean {
+  return Boolean(servers) && servers?.[LEGACY_MCP_SERVER_KEY] !== undefined;
+}
+
+/** A `[mcp_servers.trace-mcp]` / `[mcp_servers.trace-mcp.env]` table header line. */
+const LEGACY_CODEX_HEADER_RE = /^\s*\[mcp_servers\s*\.\s*["']?trace-mcp["']?(\.[^\]]*)?\]\s*$/;
+
+/** Either spelling of our own table, current or pre-rename. */
+const OUR_CODEX_HEADER_RE = /^\s*\[mcp_servers\s*\.\s*["']?trace(-mcp)?["']?(\.[^\]]*)?\]\s*$/;
+
+/** Any TOML table header line — where a preceding table's body ends. */
+const ANY_TOML_HEADER_RE = /^\s*\[/;
+
+/**
+ * Drop every table of ours from a Codex `config.toml` — both the pre-rename
+ * `trace-mcp` spelling and the current `trace` one.
+ *
+ * Scans by line rather than by regex over the whole file: a table's body ends
+ * at the next *header line*, and `[` also opens an array, so a pattern that
+ * consumed up to the next `[` anywhere turned `args = ["serve"]` into an
+ * orphan `["serve"]` table and left the file invalid TOML.
+ *
+ * Removing the current spelling too is what makes the append-based writer
+ * idempotent: without it, rewriting a config that already has
+ * `[mcp_servers.trace]` stacks a second copy of the same table.
+ *
+ * Known ceiling: a multi-line basic string whose continuation line starts with
+ * `[` would end the body early. Real MCP entries are command/args/cwd/env, so
+ * this stays a line scan rather than pulling in a TOML parser.
+ */
+function stripOwnCodexTables(content: string): string {
+  const out: string[] = [];
+  let inOwnTable = false;
+  for (const line of content.split('\n')) {
+    if (OUR_CODEX_HEADER_RE.test(line)) {
+      inOwnTable = true;
+      continue;
+    }
+    if (inOwnTable) {
+      if (!ANY_TOML_HEADER_RE.test(line)) continue;
+      inOwnTable = false;
+    }
+    out.push(line);
+  }
+  return out.join('\n');
+}
+
+/**
  * Detect whether Claude Desktop (the unified Claude.app on macOS, or the
  * Claude Desktop binary on Windows/Linux) is currently running.
  *
@@ -130,7 +215,7 @@ export function configureMcpClients(
       // else (TRA-501). Warp launches the server in the session's own directory.
       const snippet = JSON.stringify({
         mcpServers: {
-          'trace-mcp': { command: launcher, args: ['serve'] },
+          [MCP_SERVER_KEY]: { command: launcher, args: ['serve'] },
         },
       });
       results.push({
@@ -265,7 +350,10 @@ export function configureMcpClients(
       if (fs.existsSync(configPath)) {
         try {
           const content = fs.readFileSync(configPath, 'utf-8');
-          if (/\[mcp_servers\s*\.\s*["']?trace-mcp["']?\s*\]/.test(content)) {
+          const hasLegacyTable = content
+            .split('\n')
+            .some((line) => LEGACY_CODEX_HEADER_RE.test(line));
+          if (!hasLegacyTable && /\[mcp_servers\s*\.\s*["']?trace["']?\s*\]/.test(content)) {
             results.push({ target: configPath, action: 'already_configured', detail: name });
             continue;
           }
@@ -377,13 +465,13 @@ export function configureMcpClients(
 // ---------------------------------------------------------------------------
 
 /**
- * Verify that `mcpServers['trace-mcp']` is present on disk. Used after writing
+ * Verify that `mcpServers['trace']` is present on disk. Used after writing
  * Claude Desktop's config to detect the Claude.app overwrite race.
  */
 function verifyTraceMcpEntry(configPath: string): boolean {
   try {
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    return Boolean(content?.mcpServers?.['trace-mcp']);
+    return Boolean(content?.mcpServers?.[MCP_SERVER_KEY]);
   } catch {
     return false;
   }
@@ -392,7 +480,8 @@ function verifyTraceMcpEntry(configPath: string): boolean {
 function entryMatches(configPath: string, expected: McpServerEntry): boolean {
   try {
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    const current = content?.mcpServers?.['trace-mcp'];
+    if (hasLegacyKey(content?.mcpServers)) return false;
+    const current = pickServerEntry(content?.mcpServers) as OnDiskEntry | undefined;
     if (!current || typeof current !== 'object') return false;
     if (current.command !== expected.command) return false;
     if (JSON.stringify(current.args ?? []) !== JSON.stringify(expected.args)) return false;
@@ -429,7 +518,9 @@ function writeJsonEntry(configPath: string, entry: McpServerEntry): 'created' | 
   if (!config.mcpServers || typeof config.mcpServers !== 'object') {
     config.mcpServers = {};
   }
-  (config.mcpServers as Record<string, unknown>)['trace-mcp'] = entry;
+  const servers = config.mcpServers as Record<string, unknown>;
+  servers[MCP_SERVER_KEY] = entry;
+  delete servers[LEGACY_MCP_SERVER_KEY];
 
   atomicWriteJson(configPath, config);
   return isNew ? 'created' : 'updated';
@@ -446,12 +537,13 @@ interface HermesYamlEntry extends McpServerEntry {
 
 /** Parse existing config.yaml (if any) and check whether our entry already
  *  matches. Uses a real YAML parse so comments and neighbouring keys are not
- *  mistaken for the trace-mcp block. */
+ *  mistaken for our own block. */
 function hermesEntryMatches(configPath: string, expected: HermesYamlEntry): boolean {
   try {
     const doc = YAML.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown> | null;
     const servers = doc?.mcp_servers as Record<string, unknown> | undefined;
-    const current = servers?.['trace-mcp'] as Record<string, unknown> | undefined;
+    if (hasLegacyKey(servers)) return false;
+    const current = pickServerEntry(servers) as Record<string, unknown> | undefined;
     if (!current) return false;
     if (current.command !== expected.command) return false;
     if (JSON.stringify(current.args ?? []) !== JSON.stringify(expected.args)) return false;
@@ -462,7 +554,7 @@ function hermesEntryMatches(configPath: string, expected: HermesYamlEntry): bool
   }
 }
 
-/** Update or append the `mcp_servers.trace-mcp` block in `~/.hermes/config.yaml`.
+/** Update or append the `mcp_servers.trace` block in `~/.hermes/config.yaml`.
  *  Preserves existing keys/comments by parsing → mutating via the Document API →
  *  serializing back, which keeps the surrounding document shape intact. */
 function writeHermesYamlEntry(configPath: string, entry: HermesYamlEntry): 'created' | 'updated' {
@@ -492,7 +584,8 @@ function writeHermesYamlEntry(configPath: string, entry: HermesYamlEntry): 'crea
     connect_timeout: entry.connect_timeout ?? 120,
   };
 
-  doc.setIn(['mcp_servers', 'trace-mcp'], value);
+  doc.setIn(['mcp_servers', MCP_SERVER_KEY], value);
+  doc.deleteIn(['mcp_servers', LEGACY_MCP_SERVER_KEY]);
   fs.writeFileSync(configPath, doc.toString({ lineWidth: 0 }));
   return isNew ? 'created' : 'updated';
 }
@@ -508,7 +601,8 @@ function ampEntryMatches(configPath: string, expected: McpServerEntry): boolean 
     const content = fs.readFileSync(configPath, 'utf-8');
     const parsed = parseJsonc(content) as Record<string, unknown> | null;
     const servers = parsed?.['amp.mcpServers'] as Record<string, unknown> | undefined;
-    const current = servers?.['trace-mcp'] as Record<string, unknown> | undefined;
+    if (hasLegacyKey(servers)) return false;
+    const current = pickServerEntry(servers) as Record<string, unknown> | undefined;
     if (!current) return false;
     if (current.command !== expected.command) return false;
     if (JSON.stringify(current.args ?? []) !== JSON.stringify(expected.args)) return false;
@@ -541,10 +635,18 @@ function writeAmpJsoncEntry(configPath: string, entry: McpServerEntry): 'created
   }
 
   // jsonc-parser preserves comments and formatting around untouched regions.
-  const edits = modify(content, ['amp.mcpServers', 'trace-mcp'], value, {
+  const edits = modify(content, ['amp.mcpServers', MCP_SERVER_KEY], value, {
     formattingOptions: AMP_FORMATTING,
   });
-  const updated = applyEdits(content, edits);
+  let updated = applyEdits(content, edits);
+  // `undefined` is jsonc-parser's remove: drops the pre-rename entry so the
+  // client doesn't end up spawning two copies of the same server.
+  updated = applyEdits(
+    updated,
+    modify(updated, ['amp.mcpServers', LEGACY_MCP_SERVER_KEY], undefined, {
+      formattingOptions: AMP_FORMATTING,
+    }),
+  );
   fs.writeFileSync(configPath, updated.endsWith('\n') ? updated : updated + '\n');
   return isNew ? 'created' : 'updated';
 }
@@ -559,7 +661,8 @@ function factoryEntryMatches(
 ): boolean {
   try {
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    const current = content?.mcpServers?.['trace-mcp'];
+    if (hasLegacyKey(content?.mcpServers)) return false;
+    const current = pickServerEntry(content?.mcpServers) as OnDiskEntry | undefined;
     if (!current || typeof current !== 'object') return false;
     if (current.type !== expected.type) return false;
     if (current.command !== expected.command) return false;
@@ -593,7 +696,9 @@ function writeFactoryJsonEntry(
   if (!config.mcpServers || typeof config.mcpServers !== 'object') {
     config.mcpServers = {};
   }
-  (config.mcpServers as Record<string, unknown>)['trace-mcp'] = entry;
+  const factoryServers = config.mcpServers as Record<string, unknown>;
+  factoryServers[MCP_SERVER_KEY] = entry;
+  delete factoryServers[LEGACY_MCP_SERVER_KEY];
   atomicWriteJson(configPath, config);
   return isNew ? 'created' : 'updated';
 }
@@ -609,7 +714,7 @@ function writeCodexTomlEntry(configPath: string, entry: McpServerEntry): 'create
   const argsToml = entry.args.map((a) => `"${a}"`).join(', ');
   const section = [
     '',
-    '[mcp_servers.trace-mcp]',
+    `[mcp_servers.${MCP_SERVER_KEY}]`,
     `command = "${entry.command}"`,
     `args = [${argsToml}]`,
   ];
@@ -617,7 +722,7 @@ function writeCodexTomlEntry(configPath: string, entry: McpServerEntry): 'create
     section.push(`cwd = "${entry.cwd}"`);
   }
   if (entry.env) {
-    section.push('[mcp_servers.trace-mcp.env]');
+    section.push(`[mcp_servers.${MCP_SERVER_KEY}.env]`);
     for (const [k, v] of Object.entries(entry.env)) {
       section.push(`${k} = "${v}"`);
     }
@@ -628,7 +733,10 @@ function writeCodexTomlEntry(configPath: string, entry: McpServerEntry): 'create
   const existing = readIfExists(configPath);
   if (existing !== null) {
     isNew = false;
-    fs.writeFileSync(configPath, `${existing.trimEnd()}\n${block}`);
+    // Drop our existing tables first — appending without this leaves the
+    // client with two registrations of the same server.
+    const stripped = stripOwnCodexTables(existing);
+    fs.writeFileSync(configPath, `${stripped.trimEnd()}\n${block}`);
   } else {
     fs.writeFileSync(configPath, block.trimStart());
   }
@@ -656,7 +764,8 @@ function writeCodexTomlEntry(configPath: string, entry: McpServerEntry): 'create
  * - `missing`      — config file or trace-mcp entry not present.
  * - `up_to_date`   — entry on disk equals what we'd write now.
  * - `stale`        — entry exists but a field we manage drifts (command path,
- *                    args, cwd, env, alwaysLoad). UI should show "Update".
+ *                    args, cwd, env, alwaysLoad), or it is still filed under
+ *                    the pre-rename `trace-mcp` key. UI should show "Update".
  * - `unmanageable` — client doesn't expose a writable file (Warp,
  *                    JetBrains AI Assistant — IDE/cloud-managed config).
  * - `unknown`      — config exists but format is too lax to compare safely
@@ -801,44 +910,45 @@ function detectClientStatus(
   switch (name) {
     case 'hermes': {
       const hermesEntry = expected as HermesYamlEntry;
-      const present = (() => {
-        try {
-          const text = fs.readFileSync(configPath, 'utf-8');
-          return /(^|\n)\s*trace-mcp\s*:/.test(text);
-        } catch {
-          return false;
-        }
-      })();
+      const text = readIfExists(configPath) ?? '';
+      const present = /(^|\n)\s*trace(-mcp)?\s*:/.test(text);
       if (!present) return { client: name, configPath, status: 'missing' };
+      if (/(^|\n)\s*trace-mcp\s*:/.test(text) || !/(^|\n)\s*trace\s*:/.test(text)) {
+        return { client: name, configPath, status: 'stale', staleReason: 'server-key' };
+      }
       return hermesEntryMatches(configPath, hermesEntry)
         ? { client: name, configPath, status: 'up_to_date' }
         : { client: name, configPath, status: 'stale', staleReason: 'fields' };
     }
     case 'amp': {
-      const present = (() => {
+      const ampServers = (() => {
         try {
-          const text = fs.readFileSync(configPath, 'utf-8');
-          return /["']trace-mcp["']\s*:/.test(text);
+          const parsed = parseJsonc(fs.readFileSync(configPath, 'utf-8')) as Record<
+            string,
+            unknown
+          > | null;
+          return parsed?.['amp.mcpServers'] as Record<string, unknown> | undefined;
         } catch {
-          return false;
+          return undefined;
         }
       })();
-      if (!present) return { client: name, configPath, status: 'missing' };
+      if (!pickServerEntry(ampServers)) return { client: name, configPath, status: 'missing' };
+      if (hasLegacyKey(ampServers)) {
+        return { client: name, configPath, status: 'stale', staleReason: 'server-key' };
+      }
       return ampEntryMatches(configPath, expected as McpServerEntry)
         ? { client: name, configPath, status: 'up_to_date' }
         : { client: name, configPath, status: 'stale', staleReason: 'fields' };
     }
     case 'factory-droid': {
       const factoryEntry = expected as McpServerEntry & { type: 'stdio' };
-      const present = (() => {
-        try {
-          const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-          return Boolean(content?.mcpServers?.['trace-mcp']);
-        } catch {
-          return false;
-        }
-      })();
-      if (!present) return { client: name, configPath, status: 'missing' };
+      const factoryServers = readMcpServers(configPath);
+      if (!pickServerEntry(factoryServers)) {
+        return { client: name, configPath, status: 'missing' };
+      }
+      if (hasLegacyKey(factoryServers)) {
+        return { client: name, configPath, status: 'stale', staleReason: 'server-key' };
+      }
       return factoryEntryMatches(configPath, factoryEntry)
         ? { client: name, configPath, status: 'up_to_date' }
         : { client: name, configPath, status: 'stale', staleReason: 'fields' };
@@ -848,12 +958,12 @@ function detectClientStatus(
       // section is append-based and we don't parse arbitrary TOML.
       try {
         const content = fs.readFileSync(configPath, 'utf-8');
-        const present = /\[mcp_servers\s*\.\s*["']?trace-mcp["']?\s*\]/.test(content);
-        return {
-          client: name,
-          configPath,
-          status: present ? 'unknown' : 'missing',
-        };
+        const legacy = content.split('\n').some((line) => LEGACY_CODEX_HEADER_RE.test(line));
+        if (legacy) return { client: name, configPath, status: 'stale', staleReason: 'server-key' };
+        const current = /\[mcp_servers\s*\.\s*["']?trace["']?\s*\]/.test(content);
+        return current
+          ? { client: name, configPath, status: 'unknown' }
+          : { client: name, configPath, status: 'missing' };
       } catch {
         return { client: name, configPath, status: 'missing' };
       }
@@ -862,15 +972,11 @@ function detectClientStatus(
       // claude-code, claw-code, claude-desktop, cursor, windsurf, continue, junie,
       // cline, kilocode, antigravity, kimi all use the standard mcpServers JSON
       // shape compared by entryMatches().
-      const present = (() => {
-        try {
-          const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-          return Boolean(content?.mcpServers?.['trace-mcp']);
-        } catch {
-          return false;
-        }
-      })();
-      if (!present) return { client: name, configPath, status: 'missing' };
+      const servers = readMcpServers(configPath);
+      if (!pickServerEntry(servers)) return { client: name, configPath, status: 'missing' };
+      if (hasLegacyKey(servers)) {
+        return { client: name, configPath, status: 'stale', staleReason: 'server-key' };
+      }
       if (entryMatches(configPath, expected as McpServerEntry)) {
         return { client: name, configPath, status: 'up_to_date' };
       }
@@ -884,7 +990,8 @@ function detectClientStatus(
 function pinpointEntryDrift(configPath: string, expected: McpServerEntry): string {
   try {
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    const current = content?.mcpServers?.['trace-mcp'];
+    if (hasLegacyKey(content?.mcpServers)) return 'server-key';
+    const current = pickServerEntry(content?.mcpServers) as OnDiskEntry | undefined;
     if (!current || typeof current !== 'object') return 'entry-missing';
     if (current.command !== expected.command) return 'command';
     if (JSON.stringify(current.args ?? []) !== JSON.stringify(expected.args)) return 'args';

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -96,4 +96,4 @@ export const SESSION_START_HOOK_VERSION = '0.2.0';
 export const USER_PROMPT_SUBMIT_HOOK_VERSION = '0.2.0';
 export const STOP_HOOK_VERSION = '0.2.0';
 export const SESSION_END_HOOK_VERSION = '0.2.0';
-export const LAUNCHER_VERSION = '0.3.0';
+export const LAUNCHER_VERSION = '0.4.0';

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -287,7 +287,7 @@ export function createServer(
   const instructionsVerbosity = config.tools?.instructions_verbosity ?? 'full';
   const agentBehavior = config.tools?.agent_behavior ?? 'off';
   const server = new McpServer(
-    { name: 'trace-mcp', version: PKG_VERSION },
+    { name: 'trace', version: PKG_VERSION },
     { instructions: buildInstructions(detectedFrameworks, instructionsVerbosity, agentBehavior) },
   );
 

--- a/tests/cli/env-overrides.test.ts
+++ b/tests/cli/env-overrides.test.ts
@@ -8,7 +8,7 @@
  * launching trace-mcp must see /foo, full stop.
  */
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, sep } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -53,12 +53,73 @@ describe('TRACE_MCP_DATA_DIR', () => {
     expect(out).not.toBe('~/custom-trace-mcp'); // expansion must have happened
   });
 
-  it('falls back to ~/.trace-mcp when env var is empty', () => {
+  it('falls back to ~/.trace when env var is empty', () => {
+    // Fake HOME: with no override the fallback also runs the one-time
+    // ~/.trace-mcp → ~/.trace move, which must never touch the real home.
+    const fakeHome = mkdtempSync(join(tmpdir(), 'trace-fake-home-'));
     const out = runWithEnv(
       `import { TRACE_MCP_HOME } from './src/global.ts'; console.log(TRACE_MCP_HOME);`,
-      { TRACE_MCP_DATA_DIR: '' },
+      { TRACE_MCP_DATA_DIR: '', HOME: fakeHome, USERPROFILE: fakeHome },
     );
-    expect(fwd(out).endsWith('/.trace-mcp')).toBe(true);
+    expect(fwd(out).endsWith('/.trace')).toBe(true);
+  });
+
+  it('repairs the compatibility symlink a previous run failed to create (TRA-610)', () => {
+    // Simulates the "renamed, then symlinkSync threw" case: the new home
+    // exists, the legacy path does not. The move is one-shot, so without a
+    // retry every pre-rename client config pointing at ~/.trace-mcp/bin/ would
+    // stay broken forever.
+    const fakeHome = mkdtempSync(join(tmpdir(), 'trace-fake-home-'));
+    mkdirSync(join(fakeHome, '.trace'), { recursive: true });
+    writeFileSync(join(fakeHome, '.trace', 'registry.json'), '{"projects":[]}');
+
+    const out = runWithEnv(
+      `import { TRACE_MCP_HOME } from './src/global.ts'; console.log(TRACE_MCP_HOME);`,
+      { TRACE_MCP_DATA_DIR: '', HOME: fakeHome, USERPROFILE: fakeHome },
+    );
+
+    expect(out).toBe(join(fakeHome, '.trace'));
+    expect(readFileSync(join(fakeHome, '.trace-mcp', 'registry.json'), 'utf-8')).toContain(
+      'projects',
+    );
+  });
+
+  it('leaves a real ~/.trace-mcp directory alone when ~/.trace already exists', () => {
+    // Old and new versions run side by side. Merging two live state dirs is a
+    // data-loss risk, so neither side may be touched.
+    const fakeHome = mkdtempSync(join(tmpdir(), 'trace-fake-home-'));
+    mkdirSync(join(fakeHome, '.trace'), { recursive: true });
+    mkdirSync(join(fakeHome, '.trace-mcp'), { recursive: true });
+    writeFileSync(join(fakeHome, '.trace', 'registry.json'), '{"projects":["new"]}');
+    writeFileSync(join(fakeHome, '.trace-mcp', 'registry.json'), '{"projects":["old"]}');
+
+    runWithEnv(`import { TRACE_MCP_HOME } from './src/global.ts'; console.log(TRACE_MCP_HOME);`, {
+      TRACE_MCP_DATA_DIR: '',
+      HOME: fakeHome,
+      USERPROFILE: fakeHome,
+    });
+
+    expect(readFileSync(join(fakeHome, '.trace', 'registry.json'), 'utf-8')).toContain('new');
+    expect(readFileSync(join(fakeHome, '.trace-mcp', 'registry.json'), 'utf-8')).toContain('old');
+  });
+
+  it('moves a pre-rename ~/.trace-mcp to ~/.trace and symlinks it back (TRA-610)', () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), 'trace-fake-home-'));
+    const legacy = join(fakeHome, '.trace-mcp');
+    mkdirSync(legacy, { recursive: true });
+    writeFileSync(join(legacy, 'registry.json'), '{"projects":[]}');
+
+    const out = runWithEnv(
+      `import { TRACE_MCP_HOME } from './src/global.ts'; console.log(TRACE_MCP_HOME);`,
+      { TRACE_MCP_DATA_DIR: '', HOME: fakeHome, USERPROFILE: fakeHome },
+    );
+
+    expect(out).toBe(join(fakeHome, '.trace'));
+    // Data moved…
+    expect(readFileSync(join(fakeHome, '.trace', 'registry.json'), 'utf-8')).toContain('projects');
+    // …and the old path still resolves, so launcher paths baked into existing
+    // MCP client configs keep working.
+    expect(readFileSync(join(legacy, 'registry.json'), 'utf-8')).toContain('projects');
   });
 });
 

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -154,3 +154,69 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
     expect(stderr).toMatch(/node binary not found|trace-mcp package not found/);
   });
 });
+
+// TRA-610: the shim's own home resolution. It is installed at <home>/bin/, so
+// these run the copy from its installed location rather than from hooks/ —
+// resolving from `hooks/` would land two levels above the repo.
+describe.skipIf(process.platform === 'win32')('launcher shim home resolution (TRA-610)', () => {
+  function installShim(home: string, dirName: string): string {
+    const bin = path.join(home, dirName, 'bin');
+    fs.mkdirSync(bin, { recursive: true });
+    const dest = path.join(bin, 'trace-mcp');
+    fs.copyFileSync(LAUNCHER_SRC, dest);
+    fs.chmodSync(dest, 0o755);
+    return dest;
+  }
+
+  function runInstalled(shim: string, env: Record<string, string>): RunResult {
+    const result = spawnSync(shim, ['serve'], {
+      env: { ...env, PATH: '/usr/bin:/bin' },
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+    return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+  }
+
+  it('finds launcher.env under ~/.trace on a clean install, with no env vars set', () => {
+    const { home, node, cli } = setupFakeHome();
+    fs.rmSync(path.join(home, '.trace-mcp'), { recursive: true, force: true });
+    const shim = installShim(home, '.trace');
+    writeConfig(path.join(home, '.trace'), node, cli);
+
+    const { status, stdout } = runInstalled(shim, { HOME: home });
+
+    // Before the fix the shim looked under $HOME/.trace-mcp, missed the
+    // config, and fell through to probing with no node on PATH → exit 127.
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+  });
+
+  it('still reads a pre-migration ~/.trace-mcp install', () => {
+    const { home, traceHome, node, cli } = setupFakeHome();
+    const shim = installShim(home, '.trace-mcp');
+    writeConfig(traceHome, node, cli);
+
+    const { status, stdout } = runInstalled(shim, { HOME: home });
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+  });
+
+  it.each(['TRACE_HOME', 'TRACE_MCP_HOME', 'TRACE_DATA_DIR', 'TRACE_MCP_DATA_DIR'])(
+    '%s overrides the default home',
+    (envName) => {
+      const { home, node, cli } = setupFakeHome();
+      const shim = installShim(home, '.trace');
+      // Config lives only in the override root, so a shim that ignored the
+      // variable would find nothing and exit 127.
+      const alt = path.join(home, 'alt-home');
+      fs.mkdirSync(alt, { recursive: true });
+      writeConfig(alt, node, cli);
+
+      const { status, stdout } = runInstalled(shim, { HOME: home, [envName]: alt });
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+    },
+  );
+});

--- a/tests/init/launcher.test.ts
+++ b/tests/init/launcher.test.ts
@@ -40,9 +40,23 @@ describe('launcher config paths', () => {
     expect(getLauncherConfigPath()).toBe(path.join(tmp, 'launcher.env'));
   });
 
-  it('falls back to ~/.trace-mcp when env var absent', () => {
-    delete process.env.TRACE_MCP_HOME;
-    expect(getLauncherDir()).toBe(path.join(os.homedir(), '.trace-mcp'));
+  it('falls back to ~/.trace when no override is set (TRA-610)', () => {
+    // Every spelling has to go, not just TRACE_MCP_HOME — the vitest setup
+    // file sets TRACE_MCP_DATA_DIR for the whole run, and a fake HOME keeps
+    // the ~/.trace-mcp → ~/.trace move off the developer's real home.
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-fake-home-'));
+    const saved = { ...process.env };
+    try {
+      for (const k of ['TRACE_HOME', 'TRACE_MCP_HOME', 'TRACE_DATA_DIR', 'TRACE_MCP_DATA_DIR']) {
+        delete process.env[k];
+      }
+      process.env.HOME = fakeHome;
+      process.env.USERPROFILE = fakeHome;
+      expect(getLauncherDir()).toBe(path.join(os.homedir(), '.trace'));
+    } finally {
+      process.env = saved;
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/init/mcp-client-status.test.ts
+++ b/tests/init/mcp-client-status.test.ts
@@ -82,7 +82,7 @@ describe('getMcpClientStatuses', () => {
 
     const cursorEntry = JSON.parse(
       fs.readFileSync(path.join(fakeHome, '.cursor', 'mcp.json'), 'utf-8'),
-    ).mcpServers['trace-mcp'];
+    ).mcpServers['trace'];
     expect(cursorEntry.cwd).toBeUndefined();
   });
 
@@ -90,7 +90,7 @@ describe('getMcpClientStatuses', () => {
     configureMcpClients(['cursor'], projectRoot, { scope: 'global' });
     const configPath = path.join(fakeHome, '.cursor', 'mcp.json');
     const c = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    c.mcpServers['trace-mcp'].cwd = '/some/stale/path';
+    c.mcpServers['trace'].cwd = '/some/stale/path';
     fs.writeFileSync(configPath, JSON.stringify(c, null, 2));
 
     const [before] = getMcpClientStatuses(projectRoot, 'global', ['cursor']);
@@ -101,7 +101,7 @@ describe('getMcpClientStatuses', () => {
     const [after] = getMcpClientStatuses(projectRoot, 'global', ['cursor']);
     expect(after.status).toBe('up_to_date');
     expect(
-      JSON.parse(fs.readFileSync(configPath, 'utf-8')).mcpServers['trace-mcp'].cwd,
+      JSON.parse(fs.readFileSync(configPath, 'utf-8')).mcpServers['trace'].cwd,
     ).toBeUndefined();
   });
 
@@ -112,7 +112,7 @@ describe('getMcpClientStatuses', () => {
     configureMcpClients(['claude-code'], projectRoot, { scope: 'global' });
     const configPath = path.join(fakeHome, '.claude.json');
     const c = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    c.mcpServers['trace-mcp'].alwaysLoad = true;
+    c.mcpServers['trace'].alwaysLoad = true;
     fs.writeFileSync(configPath, JSON.stringify(c, null, 2));
 
     const [s] = getMcpClientStatuses(projectRoot, 'global', ['claude-code']);
@@ -127,7 +127,7 @@ describe('getMcpClientStatuses', () => {
       JSON.stringify(
         {
           mcpServers: {
-            'trace-mcp': {
+            trace: {
               command: '/old/path/that/no/longer/matches',
               args: ['serve'],
               alwaysLoad: true,
@@ -147,7 +147,7 @@ describe('getMcpClientStatuses', () => {
     configureMcpClients(['claude-code'], projectRoot, { scope: 'global' });
     const configPath = path.join(fakeHome, '.claude.json');
     const c = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    c.mcpServers['trace-mcp'].args = ['serve', '--legacy'];
+    c.mcpServers['trace'].args = ['serve', '--legacy'];
     fs.writeFileSync(configPath, JSON.stringify(c, null, 2));
     const [s] = getMcpClientStatuses(projectRoot, 'global', ['claude-code']);
     expect(s.status).toBe('stale');
@@ -170,7 +170,7 @@ describe('getMcpClientStatuses', () => {
     expect(s.status).toBe('up_to_date');
     // Sanity: ensure the entry on disk indeed has no alwaysLoad field.
     const onDisk = JSON.parse(fs.readFileSync(s.configPath as string, 'utf-8'));
-    expect(onDisk.mcpServers['trace-mcp'].alwaysLoad).toBeUndefined();
+    expect(onDisk.mcpServers['trace'].alwaysLoad).toBeUndefined();
   });
 
   it('does not set alwaysLoad on claude-code either (GH #354)', () => {
@@ -179,7 +179,7 @@ describe('getMcpClientStatuses', () => {
     expect(s.status).toBe('up_to_date');
     const configPath = path.join(fakeHome, '.claude.json');
     const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    expect(onDisk.mcpServers['trace-mcp'].alwaysLoad).toBeUndefined();
+    expect(onDisk.mcpServers['trace'].alwaysLoad).toBeUndefined();
   });
 
   it('returns a status for every client when called with no name filter', () => {
@@ -230,7 +230,7 @@ describe('getMcpClientStatuses', () => {
     const [s] = getMcpClientStatuses(projectRoot, 'global', ['cline']);
     const configPath = s.configPath as string;
     const c = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    c.mcpServers['trace-mcp'].command = '/old/launcher/path';
+    c.mcpServers['trace'].command = '/old/launcher/path';
     fs.writeFileSync(configPath, JSON.stringify(c, null, 2));
     const [drifted] = getMcpClientStatuses(projectRoot, 'global', ['cline']);
     expect(drifted.status).toBe('stale');
@@ -240,10 +240,19 @@ describe('getMcpClientStatuses', () => {
   it('reports codex as `unknown` (presence-only) when section exists', () => {
     const configPath = path.join(fakeHome, '.codex', 'config.toml');
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
-    fs.writeFileSync(configPath, '[mcp_servers.trace-mcp]\ncommand = "x"\nargs = ["serve"]\n');
+    fs.writeFileSync(configPath, '[mcp_servers.trace]\ncommand = "x"\nargs = ["serve"]\n');
     const [s] = getMcpClientStatuses(projectRoot, 'global', ['codex']);
     expect(s.status).toBe('unknown');
     expect(s.configPath).toBe(configPath);
+  });
+
+  it('reports codex `stale` when only the pre-rename section is present (TRA-610)', () => {
+    const configPath = path.join(fakeHome, '.codex', 'config.toml');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, '[mcp_servers.trace-mcp]\ncommand = "x"\nargs = ["serve"]\n');
+    const [s] = getMcpClientStatuses(projectRoot, 'global', ['codex']);
+    expect(s.status).toBe('stale');
+    expect(s.staleReason).toBe('server-key');
   });
 });
 

--- a/tests/init/mcp-clients-extra.test.ts
+++ b/tests/init/mcp-clients-extra.test.ts
@@ -11,6 +11,7 @@ let projectRoot: string;
 
 let detectMcpClients: typeof import('../../src/init/detector.js').detectMcpClients;
 let configureMcpClients: typeof import('../../src/init/mcp-client.js').configureMcpClients;
+let getMcpClientStatuses: typeof import('../../src/init/mcp-client.js').getMcpClientStatuses;
 
 beforeEach(async () => {
   sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-clients-'));
@@ -35,7 +36,7 @@ beforeEach(async () => {
   // Force re-evaluation of module-level `const HOME = os.homedir()` against the spy.
   vi.resetModules();
   ({ detectMcpClients } = await import('../../src/init/detector.js'));
-  ({ configureMcpClients } = await import('../../src/init/mcp-client.js'));
+  ({ configureMcpClients, getMcpClientStatuses } = await import('../../src/init/mcp-client.js'));
 });
 
 afterEach(() => {
@@ -149,7 +150,7 @@ describe('AMP writer round-trip', () => {
     const after = fs.readFileSync(file, 'utf-8');
     expect(after).toContain('// User-managed AMP settings');
     expect(after).toContain('// existing servers');
-    expect(after).toContain('"trace-mcp"');
+    expect(after).toContain('"trace"');
     expect(after).toContain('"linear"');
   });
 
@@ -160,7 +161,7 @@ describe('AMP writer round-trip', () => {
     const file = path.join(fakeHome, '.config', 'amp', 'settings.json');
     expect(fs.existsSync(file)).toBe(true);
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
-    expect(parsed['amp.mcpServers']?.['trace-mcp']?.args).toEqual(['serve']);
+    expect(parsed['amp.mcpServers']?.['trace']?.args).toEqual(['serve']);
   });
 
   it('reports already_configured when entry matches', () => {
@@ -177,7 +178,7 @@ describe('Factory Droid writer', () => {
     expect(step.action).toBe('created');
     const file = path.join(fakeHome, '.factory', 'mcp.json');
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
-    const entry = parsed.mcpServers['trace-mcp'];
+    const entry = parsed.mcpServers['trace'];
     expect(entry.type).toBe('stdio');
     expect(entry.args).toEqual(['serve']);
     // Global scope carries no cwd — see TRA-501.
@@ -188,7 +189,7 @@ describe('Factory Droid writer', () => {
     configureMcpClients(['factory-droid'], projectRoot, { scope: 'project' });
     const file = path.join(projectRoot, '.factory', 'mcp.json');
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
-    expect(parsed.mcpServers['trace-mcp'].cwd).toBe(projectRoot);
+    expect(parsed.mcpServers['trace'].cwd).toBe(projectRoot);
   });
 
   it('preserves existing servers when adding trace-mcp', () => {
@@ -203,7 +204,7 @@ describe('Factory Droid writer', () => {
     configureMcpClients(['factory-droid'], projectRoot, { scope: 'global' });
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
     expect(parsed.mcpServers.linear).toBeDefined();
-    expect(parsed.mcpServers['trace-mcp']).toBeDefined();
+    expect(parsed.mcpServers['trace']).toBeDefined();
   });
 });
 
@@ -305,7 +306,7 @@ describe('Cline / KiloCode / Antigravity / Kimi writers (standard mcpServers)', 
       'cline_mcp_settings.json',
     );
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
-    const entry = parsed.mcpServers['trace-mcp'];
+    const entry = parsed.mcpServers['trace'];
     expect(entry.args).toEqual(['serve']);
     // Cline's config is global-only, so it never carries a project cwd (TRA-501).
     expect(entry.cwd).toBeUndefined();
@@ -329,7 +330,7 @@ describe('Cline / KiloCode / Antigravity / Kimi writers (standard mcpServers)', 
     configureMcpClients(['kilocode'], projectRoot, { scope: 'global' });
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
     expect(parsed.mcpServers.linear).toBeDefined();
-    expect(parsed.mcpServers['trace-mcp'].args).toEqual(['serve']);
+    expect(parsed.mcpServers['trace'].args).toEqual(['serve']);
   });
 
   it('Antigravity: writes ~/.gemini/config/mcp_config.json', () => {
@@ -337,7 +338,7 @@ describe('Cline / KiloCode / Antigravity / Kimi writers (standard mcpServers)', 
     expect(results[0].action).toBe('created');
     const file = path.join(fakeHome, '.gemini', 'config', 'mcp_config.json');
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
-    expect(parsed.mcpServers['trace-mcp'].args).toEqual(['serve']);
+    expect(parsed.mcpServers['trace'].args).toEqual(['serve']);
   });
 
   it('Kimi: writes ~/.kimi/mcp.json and reports already_configured on re-run', () => {
@@ -355,12 +356,225 @@ describe('Warp configuration', () => {
     const results = configureMcpClients(['warp'], projectRoot, { scope: 'global' });
     expect(results[0].action).toBe('skipped');
     expect(results[0].detail).toContain('Settings');
-    expect(results[0].detail).toContain('"trace-mcp"');
+    expect(results[0].detail).toContain('"trace"');
   });
 
   it('includes claude-code inheritance hint when both selected', () => {
     const results = configureMcpClients(['warp', 'claude-code'], projectRoot, { scope: 'global' });
     const warp = results.find((r) => r.target === 'Warp');
     expect(warp?.detail).toContain('File-based MCP servers');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TRA-610: `trace-mcp` → `trace`. A config that still carries the old key must
+// come out with exactly one entry, under the new key — leaving both behind
+// would make the client spawn two copies of the same server, which is the
+// opposite of the token saving the rename is for.
+// ---------------------------------------------------------------------------
+
+describe('legacy server-key migration (TRA-610)', () => {
+  it('JSON: replaces the pre-rename mcpServers key, keeping other servers', () => {
+    const file = path.join(fakeHome, '.gemini', 'config', 'mcp_config.json');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        mcpServers: {
+          linear: { command: 'linear-mcp' },
+          'trace-mcp': { command: '/old/launcher', args: ['serve'] },
+        },
+      }),
+    );
+
+    configureMcpClients(['antigravity'], projectRoot, { scope: 'global' });
+
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(parsed.mcpServers['trace-mcp']).toBeUndefined();
+    expect(parsed.mcpServers.trace.args).toEqual(['serve']);
+    expect(parsed.mcpServers.linear).toBeDefined();
+  });
+
+  it('Factory Droid JSON: replaces the pre-rename key', () => {
+    const file = path.join(fakeHome, '.factory', 'mcp.json');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        mcpServers: { 'trace-mcp': { type: 'stdio', command: '/old', args: ['serve'] } },
+      }),
+    );
+
+    configureMcpClients(['factory-droid'], projectRoot, { scope: 'global' });
+
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(parsed.mcpServers['trace-mcp']).toBeUndefined();
+    expect(parsed.mcpServers.trace.type).toBe('stdio');
+  });
+
+  it('AMP JSONC: replaces the pre-rename key and keeps comments', () => {
+    const file = path.join(fakeHome, '.config', 'amp', 'settings.jsonc');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      [
+        '// User-managed AMP settings',
+        '{',
+        '  "amp.mcpServers": {',
+        '    "trace-mcp": { "command": "/old", "args": ["serve"] }',
+        '  }',
+        '}',
+        '',
+      ].join('\n'),
+    );
+
+    configureMcpClients(['amp'], projectRoot, { scope: 'global' });
+
+    const after = fs.readFileSync(file, 'utf-8');
+    expect(after).toContain('// User-managed AMP settings');
+    expect(after).not.toContain('"trace-mcp"');
+    expect(after).toContain('"trace"');
+  });
+
+  it('Hermes YAML: replaces the pre-rename key', () => {
+    const file = path.join(fakeHome, '.hermes', 'config.yaml');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      'mcp_servers:\n  trace-mcp:\n    command: /old\n    args:\n      - serve\n',
+    );
+
+    configureMcpClients(['hermes'], projectRoot, { scope: 'global' });
+
+    const after = fs.readFileSync(file, 'utf-8');
+    expect(after).not.toMatch(/^\s+trace-mcp:/m);
+    expect(after).toMatch(/^\s+trace:/m);
+  });
+
+  it('Codex TOML: drops the pre-rename table instead of appending a second one', () => {
+    const file = path.join(fakeHome, '.codex', 'config.toml');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      [
+        'model = "gpt-5"',
+        '',
+        '[mcp_servers.trace-mcp]',
+        'command = "/old"',
+        'args = ["serve"]',
+        '',
+        '[mcp_servers.linear]',
+        'command = "linear-mcp"',
+        '',
+      ].join('\n'),
+    );
+
+    configureMcpClients(['codex'], projectRoot, { scope: 'global' });
+
+    const after = fs.readFileSync(file, 'utf-8');
+    expect(after).not.toContain('[mcp_servers.trace-mcp]');
+    expect(after).toContain('[mcp_servers.trace]');
+    expect(after).toContain('[mcp_servers.linear]');
+    expect(after).toContain('model = "gpt-5"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Review findings on the TRA-610 migration. Each of these shipped green once
+// because the original tests asserted on substrings rather than on the parsed
+// result, so they assert on structure here.
+// ---------------------------------------------------------------------------
+
+describe('legacy server-key migration — review regressions (TRA-610)', () => {
+  it('Codex TOML: leaves the rest of the file valid, `args` array intact', () => {
+    const file = path.join(fakeHome, '.codex', 'config.toml');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      [
+        'model = "gpt-5"',
+        '',
+        '[mcp_servers.trace-mcp]',
+        'command = "/old"',
+        'args = ["serve"]',
+        '',
+        '[mcp_servers.trace-mcp.env]',
+        'FOO = "1"',
+        '',
+        '[mcp_servers.linear]',
+        'command = "linear-mcp"',
+        'args = ["run", "--flag"]',
+        '',
+      ].join('\n'),
+    );
+
+    configureMcpClients(['codex'], projectRoot, { scope: 'global' });
+
+    const after = fs.readFileSync(file, 'utf-8');
+    // The bug turned `args = ["serve"]` into an orphan `["serve"]` table header.
+    for (const line of after.split('\n')) {
+      if (/^\s*\[/.test(line)) {
+        expect(line).toMatch(/^\s*\[[A-Za-z_][\w.\-"']*\]\s*$/);
+      }
+    }
+    expect(after).not.toContain('[mcp_servers.trace-mcp]');
+    expect(after).not.toContain('[mcp_servers.trace-mcp.env]');
+    expect(after).toContain('[mcp_servers.trace]');
+    expect(after).toContain('model = "gpt-5"');
+    expect(after).toContain('[mcp_servers.linear]');
+    expect(after).toContain('args = ["run", "--flag"]');
+  });
+
+  it('Codex TOML: a legacy table is rewritten even when a `trace` table exists', () => {
+    const file = path.join(fakeHome, '.codex', 'config.toml');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      '[mcp_servers.trace]\ncommand = "/new"\n\n[mcp_servers.trace-mcp]\ncommand = "/old"\n',
+    );
+
+    configureMcpClients(['codex'], projectRoot, { scope: 'global' });
+
+    const after = fs.readFileSync(file, 'utf-8');
+    expect(after).not.toContain('[mcp_servers.trace-mcp]');
+    expect(after.match(/\[mcp_servers\.trace\]/g)).toHaveLength(1);
+  });
+
+  it('JSON: a config holding BOTH keys is rewritten, not reported already_configured', () => {
+    const file = path.join(projectRoot, '.cursor', 'mcp.json');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    // Seed a `trace` entry that matches exactly what we would write, so only
+    // the surviving legacy key can force the rewrite.
+    configureMcpClients(['cursor'], projectRoot, { scope: 'project' });
+    const seeded = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    seeded.mcpServers['trace-mcp'] = { command: '/old', args: ['serve'] };
+    seeded.mcpServers.linear = { command: 'linear-mcp' };
+    fs.writeFileSync(file, JSON.stringify(seeded, null, 2));
+
+    const [status] = getMcpClientStatuses(projectRoot, 'project', ['cursor']);
+    expect(status.status).toBe('stale');
+    expect(status.staleReason).toBe('server-key');
+
+    const results = configureMcpClients(['cursor'], projectRoot, { scope: 'project' });
+    expect(results[0].action).not.toBe('already_configured');
+
+    const after = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(after.mcpServers['trace-mcp']).toBeUndefined();
+    expect(after.mcpServers.trace).toBeDefined();
+    expect(after.mcpServers.linear).toBeDefined();
+  });
+
+  it('Hermes YAML: both keys present is reported stale, and the old one is dropped', () => {
+    const file = path.join(fakeHome, '.hermes', 'config.yaml');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    configureMcpClients(['hermes'], projectRoot, { scope: 'global' });
+    fs.appendFileSync(file, '  trace-mcp:\n    command: /old\n');
+
+    const [status] = getMcpClientStatuses(projectRoot, 'global', ['hermes']);
+    expect(status.status).toBe('stale');
+    expect(status.staleReason).toBe('server-key');
+
+    configureMcpClients(['hermes'], projectRoot, { scope: 'global' });
+    expect(fs.readFileSync(file, 'utf-8')).not.toMatch(/^\s+trace-mcp:/m);
   });
 });

--- a/tests/plugin/manifest-sync.test.ts
+++ b/tests/plugin/manifest-sync.test.ts
@@ -27,7 +27,7 @@ describe('Claude Code plugin manifests', () => {
   it('plugin.json mcpServers points at the bin name from package.json', () => {
     const bin = pkg.bin as Record<string, string>;
     const servers = plugin.mcpServers as Record<string, { command: string }>;
-    const command = servers['trace-mcp']?.command;
+    const command = servers['trace']?.command;
     expect(command).toBeDefined();
     // command must be one of the declared bin names so npm install -g exposes it on PATH
     expect(Object.keys(bin)).toContain(command);
@@ -165,7 +165,7 @@ describe('Codex CLI plugin manifests', () => {
     expect(plugin.mcpServers).toBe('./.mcp.json');
     const bin = pkg.bin as Record<string, string>;
     const mcpConfig = readJson('.codex-plugin', '.mcp.json') as Record<string, { command: string }>;
-    const command = mcpConfig['trace-mcp']?.command;
+    const command = mcpConfig['trace']?.command;
     expect(command).toBeDefined();
     expect(Object.keys(bin)).toContain(command);
   });

--- a/tests/setup/isolate-home.ts
+++ b/tests/setup/isolate-home.ts
@@ -33,9 +33,9 @@ import { join } from 'node:path';
 
 if (!process.env.TRACE_MCP_DATA_DIR) {
   // Preserve a pointer to the real home before we redirect it. When the override
-  // is unset the real home is the package default (~/.trace-mcp).
+  // is unset the real home is the package default (~/.trace).
   if (!process.env.TRACE_MCP_REAL_DATA_DIR) {
-    process.env.TRACE_MCP_REAL_DATA_DIR = join(homedir(), '.trace-mcp');
+    process.env.TRACE_MCP_REAL_DATA_DIR = join(homedir(), '.trace');
   }
 
   const isolated = mkdtempSync(join(tmpdir(), 'trace-mcp-test-home-'));


### PR DESCRIPTION
Closes TRA-611. Part of TRA-610.

Sibling PRs on the same rename, no file overlap with this one: #717 (TRA-615, docs + CLAUDE.md/IDE-rules generators + distribution ledger), #724 (TRA-614, desktop app), #720 (TRA-613, tokenizer benchmark). The first revision of this PR reached into all three; it was rebuilt on current `master` carrying only TRA-611's files.

## Why

MCP clients prefix every tool name with the server key, so the key is re-sent to the model on **every prompt turn, once per advertised tool**. Measured with the repo's pinned `gpt-tokenizer` (o200k), `mcp__trace-mcp__<tool>` → `mcp__trace__<tool>` is exactly **2 tokens per tool name**:

| Preset | Advertised tools | Saved per turn |
|--------|-----------------:|---------------:|
| `standard` (default) | 55 | ~110 tokens |
| `full` | 171 | ~342 tokens |

A prose mention goes from 3 tokens to 1. This is a real but modest per-turn win, not a step change — the reason to do it now is that a rename only gets more expensive with every install. #720 has the full multi-tokenizer measurement.

## What changed

**Identity** — `package.json` ships both `trace` and `trace-mcp` bins (npm package name unchanged); `program.name()` and MCP `serverInfo.name` become `trace`.

**Client config migration** — `init` / `clients update` write `mcpServers.trace` and *delete* the pre-rename key across JSON, AMP JSONC, Factory JSON, Hermes YAML and Codex TOML. A config holding the legacy key never reads as `already_configured`, even with a matching `trace` entry beside it — both present is the worst state, not a benign one. `clients status` reports it `stale` / `staleReason: "server-key"`, which is the signal #724's Migrate button keys off.

**State directory** — `~/.trace-mcp/` moves to `~/.trace/` on first import of `global.ts`, leaving a symlink at the old path. The symlink is load-bearing: client configs hold an absolute path to the launcher shim under `~/.trace-mcp/bin/`, and an older daemon or app build reads the old root directly. If the link cannot be created, a later run retries it; the move itself is one-shot. Both roots existing as real directories is left alone — merging live state is a data-loss risk.

Migration runs at import rather than from `ensureGlobalDirs()`: a reader that never calls it (registry lookups, `daemon status`) would otherwise see an empty new home while the data sat in the old one.

**One home resolver, four env names** — `TRACE_HOME` > `TRACE_MCP_HOME` > `TRACE_DATA_DIR` > `TRACE_MCP_DATA_DIR`, now shared by `getLauncherDir()` *and the shim scripts themselves*. Launcher version 0.3.0 → 0.4.0 so `init` reinstalls them.

**Config lookup** — `.trace.json` / `.trace/.config.json` / `.config/trace.json` first, falling back to the `.trace-mcp*` spellings.

**Followers** — guard hook `.mcp.json` lookup, analytics `tool_server` classification (`TRACE_TOOL_SERVERS` keeps historical `trace-mcp` / `trace_mcp` rows counting), plugin manifests.

## Review round 1 — four confirmed bugs, fixed

Thanks to Code Reviewer; all four were real and three of them would have shipped green, because the original tests asserted on substrings rather than on the parsed result. Each fix has a regression test that asserts on structure.

1. **Codex TOML corruption (HIGH).** The removal regex ended a table at the next `[` *anywhere*, so `args = ["serve"]` turned into an orphan `["serve"]` table and left the file invalid TOML. Replaced with a line-aware scanner bounded by table-header lines. It now also strips our *current* table, which makes the append-based writer idempotent — otherwise bypassing the fast path stacked a second `[mcp_servers.trace]`.
2. **Both-keys config treated as configured (MEDIUM).** Every matcher let the new key win and returned before the writer could delete the old one. All five matchers now refuse to match while the legacy key survives.
3. **Launcher shims did not follow the new home (HIGH).** `hooks/trace-mcp-launcher.sh` / `.ps1` read only `TRACE_MCP_HOME`, defaulting to `~/.trace-mcp`. On a clean install they would have missed the `launcher.env` written beside them and fallen through to probing — exit 127 where probing does not reach. They now resolve from their own installed location first, which is correct by construction, then the four env names, then the two defaults.
4. **Failed symlink never retried (MEDIUM).** The rename is one-shot, so a swallowed `symlinkSync` failure left every pre-rename client config broken forever. A later run now repairs the link.

Finding 5 (desktop Codex detection) lands in #724, which owns that file.

## Deliberately not renamed

The npm package name and `server.json`'s registry identifier (external listings — `ops/distribution.md` rule); the `bin/trace-mcp` shim filename (client configs hold its absolute path, and the name costs nothing); the project-local `.trace-mcp/index.db` config default (changing it orphans existing indexes for no token benefit).

## Known breakage we cannot auto-fix

Anywhere a user wrote a tool name out in full — their own `CLAUDE.md`, a permission allowlist, a custom hook — `mcp__trace-mcp__x` becomes `mcp__trace__x`. The routing block `init` manages is updated for them (#717); text they wrote is not. Also: the daemon proxies MCP, so `serverInfo` reflects the *daemon's* version until it restarts after upgrade.

## Test evidence

New tests: legacy-key migration per format with the Codex case asserting every remaining table header parses; both-keys-present for JSON, Hermes and Codex; shim home resolution on a clean install, on a pre-migration install, and once per env name; symlink repair and the both-roots-exist no-op, driven as subprocesses against a fake `HOME`.

**9404 tests pass**, `tsc --noEmit` clean, `biome ci` clean, `pnpm run build` clean.

End to end against a throwaway `HOME` (populated `~/.trace-mcp`, `.claude.json` on the old key, `config.toml` with a legacy table beside an unrelated server):

```
--- clients status BEFORE ---
  claude-code stale server-key
  codex       stale server-key
--- home migration ---
  ~/.trace is dir:       True
  ~/.trace-mcp is link:  True
  registry via old path: {"projects":[]}
--- clients update ---
  .claude.json keys:       ['linear', 'trace']
  legacy key gone:         True
  codex legacy table gone: True
  codex `trace` tables:    1
  codex linear args kept:  True
  codex orphan tables:     none
--- clients status AFTER ---
  claude-code up_to_date
  codex       unknown        (TOML is presence-only by design)
--- serve-http initialize ---
  {"name": "trace", "version": "3.11.0"}
```

Agent: Lead Engineer
