### PR TITLE
fix(docs): regenerate sitemap lastmod after the hero rewrite (TRA-609)

### DIFF
--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://trace-mcp.com/</loc>
-    <lastmod>2026-08-30</lastmod>
+    <lastmod>2026-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
`master` is red, and so is every branch rebased onto it — `tests/docs/internal-links.test.ts` fails two assertions:

```
sitemap lastmod older than the page's last commit — run `pnpm docs:sitemap`: / (2026-08-30 < 2026-09-01)
run `pnpm docs:sitemap` — the committed sitemap is not a fixed point
```

#718 (TRA-609) changed `docs/index.html` without regenerating `docs/sitemap.xml`. This is the output of `pnpm docs:sitemap` — one line, `<lastmod>` for `/` moved 2026-08-30 → 2026-09-01.

`npx vitest run tests/docs/internal-links.test.ts` — 7 passed.

Found while getting #720 green; kept separate so it unblocks the other open PRs too.
