### PR TITLE
fix(release): sign, notarize and staple the macOS DMG container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,13 +281,72 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm exec electron-builder --mac --arm64 --x64 --publish never
 
+      # electron-builder notarizes the .app in `afterSign` and only then
+      # assembles the DMG around it, so the container a human actually downloads
+      # carried no signature and no ticket of its own through 3.10.0 — Gatekeeper
+      # had nothing to assess when it mounted the image (TRA-627). Sign, notarize
+      # and staple the DMG itself, in that order, before checksums and the
+      # provenance attestation are computed over it.
+      #
+      # `dmg.sign: true` in electron-builder.yml is deliberately not used: it
+      # runs `codesign --sign` with no `--timestamp`, and notarization rejects a
+      # signature without a secure timestamp. Signing here also keeps the whole
+      # container step in one place.
+      - name: Sign, notarize and staple the DMGs
+        working-directory: packages/app
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          # electron-builder signs out of a temp keychain it deletes on exit, so
+          # the certificate has to be imported once more here. Keychain and the
+          # decoded .p12 both live in RUNNER_TEMP, which the runner discards, and
+          # the .p12 is deleted as soon as it is imported.
+          KEYCHAIN="$RUNNER_TEMP/dmg-signing.keychain-db"
+          P12="$RUNNER_TEMP/dmg-signing.p12"
+          KEYCHAIN_PASSWORD=$(uuidgen)
+          printenv CSC_LINK | base64 --decode > "$P12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings "$KEYCHAIN"  # no auto-lock mid-notarization
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$P12" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign
+          rm -f "$P12"
+          # Without this, codesign blocks on an "allow access" prompt that no one
+          # can answer on a runner.
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+
+          # By hash, not by name: the certificate's common name is not one of the
+          # secrets, and a near-miss name would silently pick the wrong identity.
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" | awk '/Developer ID Application/ { print $2; exit }')
+          if [ -z "$IDENTITY" ]; then
+            echo "::error::no Developer ID Application identity in the imported certificate"
+            exit 1
+          fi
+
+          for DMG in release/*.dmg; do
+            codesign --sign "$IDENTITY" --timestamp --keychain "$KEYCHAIN" "$DMG"
+            xcrun notarytool submit "$DMG" \
+              --apple-id "$APPLE_ID" \
+              --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID" \
+              --wait
+            xcrun stapler staple "$DMG"
+          done
+
+          security delete-keychain "$KEYCHAIN"
+
       # electron-builder reports a skipped signature as a warning and exits 0,
       # so a missing or expired certificate would publish an ad-hoc build that
       # Gatekeeper rejects — the exact TRA-436 symptom — with a green release.
       # Assert the real properties instead: a Developer ID team identifier, and
-      # a stapled notarization ticket. `spctl` is checked on the unzipped app
-      # rather than the DMG because the ticket is stapled to the .app.
-      - name: Assert the app is signed and notarized
+      # a stapled notarization ticket. Both the .app and the DMG around it are
+      # checked: 3.10.0 shipped a correct app inside a container with neither
+      # (TRA-627), and only an assertion on the container itself notices that.
+      - name: Assert the app and the DMG are signed and notarized
         working-directory: packages/app
         run: |
           # Both arches, each asserted: one leg silently ad-hoc signed would
@@ -303,6 +362,21 @@ jobs:
             codesign --verify --deep --strict --verbose=2 "$APP"
             xcrun stapler validate "$APP"
             spctl -a -vvv -t install "$APP"
+          done
+
+          # The container, assessed the way DiskImageMounter assesses it —
+          # `-t open`, primary signature, which is what 3.10.0's DMG failed.
+          DMGS=$(find release -maxdepth 1 -name '*.dmg')
+          if [ -z "$DMGS" ]; then echo "::error::no DMG produced"; exit 1; fi
+          echo "$DMGS" | while read -r DMG; do
+            # Diagnostics first: on a failure below, this is the line that says why.
+            codesign -dv --verbose=4 "$DMG" 2>&1 || true
+            if ! codesign --verify --strict "$DMG" 2> /dev/null; then
+              echo "::error::$DMG carries no valid signature — the DMG signing step did not sign this image"
+              exit 1
+            fi
+            xcrun stapler validate "$DMG"
+            spctl -a -vvv -t open --context context:primary-signature "$DMG"
           done
 
       # electron-updater reads `latest-mac.yml` and nothing else. A build that

--- a/ops/distribution.md
+++ b/ops/distribution.md
@@ -60,6 +60,17 @@ Nikolai's machine. The macOS release now ships a **DMG per architecture** for
 humans plus the zip the staged-zip updater consumes, both built from a
 Developer ID Application-signed, notarized, stapled `.app`.
 
+**The DMG container is signed and notarized too, from the first release after
+2026-09-01** (TRA-627). Through 3.10.0 only the `.app` inside carried a ticket:
+`codesign -dvvv` on the published `trace-mcp-3.10.0-arm64.dmg` said "code object
+is not signed at all" and `spctl -a -t open` rejected it for "no usable
+signature", because electron-builder notarizes in `afterSign` and assembles the
+image afterwards. Signing, notarizing and stapling the image is now an explicit
+release step, and the release fails if either the app or the container comes out
+without a ticket. Do **not** replace that step with `dmg.sign: true` in
+`electron-builder.yml`: dmg-builder signs without `--timestamp`, and Apple
+refuses to notarize a signature that has no secure timestamp.
+
 Where it lives: `mac:` block in `packages/app/electron-builder.yml`,
 entitlements in `packages/app/build/entitlements.mac*.plist` (one comment per
 key saying why it is there — keep it that way, an unjustified entitlement list

--- a/packages/app/electron-builder.yml
+++ b/packages/app/electron-builder.yml
@@ -84,6 +84,19 @@ mac:
 # suffix on Intel, which would make the two legs indistinguishable by name.
 dmg:
   artifactName: ${productName}-${version}-${arch}.dmg
+  # No `sign: true` here on purpose. dmg-builder signs the image with a bare
+  # `codesign --sign`, without `--timestamp`, and notarization rejects a
+  # signature that carries no secure timestamp — so the container would end up
+  # signed but un-notarizable. `.github/workflows/release.yml` signs, notarizes
+  # and staples the DMG itself after electron-builder finishes (TRA-627).
+  #
+  # Which is also why the DMG must stay out of `latest-mac.yml`: that feed is
+  # written during packaging, and stapling afterwards changes the file, so the
+  # recorded sha512 and size would be wrong the moment they were published.
+  # Nothing reads them — electron-updater takes macOS updates from the zip and
+  # the download button on the landing page resolves the DMG through the GitHub
+  # releases API — so the entries were noise even while they were accurate.
+  writeUpdateInfo: false
 
 win:
   icon: build/icon.ico


### PR DESCRIPTION
Closes TRA-627.

## The state this fixes

Verified on the published `v3.10.0` asset, not on build output:

```
$ codesign -dvvv trace-mcp-3.10.0-arm64.dmg
trace-mcp-3.10.0-arm64.dmg: code object is not signed at all

$ xcrun stapler validate trace-mcp-3.10.0-arm64.dmg
does not have a ticket stapled to it.

$ spctl -a -vvv -t open --context context:primary-signature trace-mcp-3.10.0-arm64.dmg
rejected  (source=no usable signature)
```

The `.app` inside the same image assesses as `Notarized Developer ID`. electron-builder
notarizes in `afterSign` and assembles the DMG afterwards, so the container a human
actually downloads carries nothing Gatekeeper can assess when it mounts. The existing
signing gate never noticed because it globs `release/mac*/*.app` — the unpacked bundle.

## What changed

**`.github/workflows/release.yml`**

- New step between packaging and checksums: import the Developer ID cert into a keychain
  of its own, `codesign --timestamp` each DMG, `notarytool submit --wait`, `stapler staple`.
  Placed before `generate-shasums.mjs` and the SLSA attestation so both cover the final file.
  The keychain is needed because electron-builder deletes the temp keychain it signed from
  when the CLI exits; it lives in `RUNNER_TEMP` and is deleted at the end of the step, and
  the decoded `.p12` is removed the moment it is imported.
- The assertion step now covers the container too: `codesign --verify --strict`,
  `stapler validate`, and `spctl -a -t open --context context:primary-signature` — the exact
  check 3.10.0's DMG failed. Without this the next config drift reproduces this state behind
  a green release.

**`packages/app/electron-builder.yml`**

- `dmg.sign: true` is deliberately *not* used, and there is a comment saying why: dmg-builder
  runs `codesign --sign` with no `--timestamp`, and notarization refuses a signature that
  carries no secure timestamp, so the container would come out signed but un-notarizable.
- `dmg.writeUpdateInfo: false`. `latest-mac.yml` currently lists both DMGs with a `sha512`
  and `size`, and that feed is written during packaging — stapling afterwards would publish
  two digests that no longer match the files. Nothing reads them: `MacUpdater` picks the zip,
  and the landing page's download button resolves the DMG through the GitHub releases API.

**`ops/distribution.md`** — the ledger entry, per the rule in CLAUDE.md.

## Test evidence

The certificate is a repo secret, so the signing half can only be proven by a real release.
What was verified locally:

- Both `run:` blocks parse as YAML and pass `bash -n`; step order is packaging → sign/notarize →
  assert → checksums → attestation → upload.
- The new assertion block, extracted from the workflow and run for real against an unsigned
  `hdiutil`-built DMG, exits 1 with
  `::error::release/fake-1.0.0-arm64.dmg carries no valid signature` — i.e. it fails on exactly
  the state 3.10.0 shipped. With no DMG present it exits 1 with `::error::no DMG produced`.
  `xcrun stapler validate` on a non-notarized image exits 65, so the second gate holds too.
- The keychain sequence (create / unlock / import / `set-key-partition-list`) was run against a
  throwaway self-signed `.p12`: the cert imports and the `find-identity | awk` extraction returns
  the right hash field. `codesign` itself cannot be exercised with a fixture cert — it needs a
  trusted Developer ID identity — so that line is proven only by CI. The local run never touched
  the machine's keychain search list.
- `dmg.writeUpdateInfo` confirmed to be a real key in app-builder-lib 26.15.7's schema
  (`DmgOptions` is `additionalProperties: false`, so an invented key would fail the build).
- `pnpm exec vitest run tests/scripts/verify-release-assets.test.ts tests/docs/download-button.test.ts`
  — 13 passed.

Not verified: the GUI double-click path on a browser-downloaded DMG. That needs a real download
on a machine I should not be popping dialogs on, and `hdiutil` does not consult Gatekeeper, so
mounting a quarantined copy would prove nothing either way.

Agent: Lead Engineer
