### PR TITLE
feat(core,cli): trace bin alias, McpServer identity, config paths, and client auto-migration (TRA-611)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
 <!-- trace-mcp:start -->
-## trace-mcp Tool Routing
+## trace Tool Routing
 
-IMPORTANT: For ANY code exploration task, ALWAYS use trace-mcp tools first. NEVER use Read/Grep/Glob/Bash(ls,find) for navigating source code.
+IMPORTANT: For ANY code exploration task, ALWAYS use trace tools first. NEVER use Read/Grep/Glob/Bash(ls,find) for navigating source code.
 
-| Task | trace-mcp tool | Instead of |
+| Task | trace tool | Instead of |
 |------|---------------|------------|
 | Find a function/class/method | `search` | Grep |
 | Understand a file before editing | `get_outline` | Read (full file) |
@@ -17,18 +17,11 @@ IMPORTANT: For ANY code exploration task, ALWAYS use trace-mcp tools first. NEVE
 | Context for a task | `get_feature_context` | reading 15 files |
 | Tests for a symbol | `get_tests_for` | Glob + Grep |
 | Untested symbols (deep) | `get_untested_symbols` (deferred — load via `load_tools`) | manual audit |
+| HTTP request flow | `get_request_flow` (framework-gated) | reading route files |
+| DB model relationships | `get_model_context` (framework-gated) | reading model + migrations |
+| Component tree | `get_component_tree` (framework-gated) | reading component files |
 | Circular dependencies | `get_circular_imports` | manual tracing |
 
 Use Read/Grep/Glob ONLY for non-code files (.md, .json, .yaml, config) or before Edit.
 Start sessions with `get_project_map` (summary_only=true).
-
-### Not yet implemented (planned / roadmap only — do not call these)
-
-The following tool names have appeared in earlier drafts of this guidance but are **not registered** in this project (confirmed via `get_plugin_registry` / tool search). Do not call them; fall back to reading route/model/component files directly until they land:
-
-| Planned capability | Planned tool name | Current fallback |
-|------|---------------|------------|
-| HTTP request flow | `get_request_flow` (not implemented) | reading route files |
-| DB model relationships | `get_model_context` (not implemented) | reading model + migrations |
-| Component tree | `get_component_tree` (not implemented) | reading component files |
 <!-- trace-mcp:end -->

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -7,7 +7,7 @@
 
 $ErrorActionPreference = 'Stop'
 
-$TraceHome = if ($env:TRACE_MCP_HOME) { $env:TRACE_MCP_HOME } else { Join-Path $env:USERPROFILE '.trace-mcp' }
+$TraceHome = if ($env:TRACE_MCP_HOME) { $env:TRACE_MCP_HOME } else { Join-Path $env:USERPROFILE '.trace' }
 $ConfigPath = Join-Path $TraceHome 'launcher.env'
 $LogPath    = Join-Path $TraceHome 'launcher.log'
 

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -8,7 +8,7 @@
 
 set -u
 
-TRACE_HOME="${TRACE_MCP_HOME:-$HOME/.trace-mcp}"
+TRACE_HOME="${TRACE_MCP_HOME:-$HOME/.trace}"
 CONFIG="$TRACE_HOME/launcher.env"
 LOG="$TRACE_HOME/launcher.log"
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
+    "trace": "dist/cli.js",
     "trace-mcp": "dist/cli.js"
   },
   "scripts": {

--- a/scripts/postinstall-control-plane.mjs
+++ b/scripts/postinstall-control-plane.mjs
@@ -53,6 +53,9 @@ const __dirname = path.dirname(__filename);
 // scripts/postinstall-control-plane.mjs → package root is two levels up.
 const PKG_ROOT = path.resolve(__dirname, '..');
 
+// Mirrors src/global.ts::LEGACY_MIGRATION_MARKER — MUST match (TRA-611).
+const LEGACY_MIGRATION_MARKER = '.migrated-from-trace-mcp';
+
 // Mirrors src/global.ts::migrateLegacyHomeDir — MUST match (TRA-611). A
 // same-volume rename is atomic and, unlike a copy, leaves nothing stale
 // behind. This script runs before the CLI itself does (postinstall fires
@@ -64,24 +67,30 @@ function migrateLegacyHomeDir(target, legacy) {
     if (fs.lstatSync(legacy).isSymbolicLink()) return false;
     if (!fs.statSync(legacy).isDirectory()) return false;
     fs.renameSync(legacy, target);
+    try {
+      fs.writeFileSync(path.join(target, LEGACY_MIGRATION_MARKER), '');
+    } catch {
+      /* best-effort — worst case a later run just doesn't retry the symlink */
+    }
     return true;
   } catch {
     return false;
   }
 }
 
-const { home: TRACE_MCP_HOME, migrated: TRACE_MCP_HOME_MIGRATED } = (() => {
+const TRACE_MCP_HOME = (() => {
   const override = process.env.TRACE_MCP_DATA_DIR || process.env.TRACE_MCP_HOME;
   if (override && override.length > 0) {
     const expanded = override.startsWith('~')
       ? path.join(os.homedir(), override.slice(1))
       : override;
-    return { home: path.resolve(expanded), migrated: false };
+    return path.resolve(expanded);
   }
   const homedir = os.homedir();
   const target = path.join(homedir, '.trace');
   const legacy = path.join(homedir, '.trace-mcp');
-  return { home: target, migrated: migrateLegacyHomeDir(target, legacy) };
+  migrateLegacyHomeDir(target, legacy);
+  return target;
 })();
 
 const LOG_PATH = path.join(TRACE_MCP_HOME, 'postinstall.log');
@@ -212,12 +221,12 @@ function installLauncherShim() {
 /**
  * Preserve `~/.trace-mcp/bin/trace-mcp` as a symlink to the new
  * `~/.trace/bin/trace` shim, mirroring src/init/launcher.ts's
- * installLegacyBinCompat() — only acts the one run that renamed the
- * directory (migrateLegacyHomeDir above); a fresh install has no legacy
- * path to preserve, and once created the symlink lives on disk.
+ * installLegacyBinCompat(). Gated on LEGACY_MIGRATION_MARKER (durable) rather
+ * than TRACE_MCP_HOME_MIGRATED (true only for the one process that performed
+ * the rename) so a failed symlink attempt gets retried on the next install.
  */
 function installLegacyBinCompat(shimPath) {
-  if (!TRACE_MCP_HOME_MIGRATED) return;
+  if (!fs.existsSync(path.join(TRACE_MCP_HOME, LEGACY_MIGRATION_MARKER))) return;
   const legacyDir = path.join(os.homedir(), '.trace-mcp', 'bin');
   const legacyPath = path.join(legacyDir, LEGACY_PRIMARY_DEST);
   try {

--- a/scripts/postinstall-control-plane.mjs
+++ b/scripts/postinstall-control-plane.mjs
@@ -3,13 +3,15 @@
 /**
  * postinstall hook for `npm install -g trace-mcp`.
  *
- * Self-heals the control plane so users don't have to run `trace-mcp init`
+ * Self-heals the control plane so users don't have to run `trace init`
  * manually after each install or upgrade. Specifically:
  *
- *   1. Writes ~/.trace-mcp/launcher.env with absolute Node + dist/cli.js paths.
- *   2. Installs the launcher shim at ~/.trace-mcp/bin/trace-mcp (POSIX) or
- *      ~/.trace-mcp/bin/trace-mcp.cmd (Windows) by copying from hooks/.
- *   3. On macOS: installs/refreshes ~/Library/LaunchAgents/com.trace-mcp.server.plist
+ *   1. Migrates a pre-TRA-611 ~/.trace-mcp/ to ~/.trace/, if present.
+ *   2. Writes ~/.trace/launcher.env with absolute Node + dist/cli.js paths.
+ *   3. Installs the launcher shim at ~/.trace/bin/trace (POSIX) or
+ *      ~/.trace/bin/trace.cmd (Windows) by copying from hooks/, and preserves
+ *      ~/.trace-mcp/bin/trace-mcp as a compat symlink when (1) migrated.
+ *   4. On macOS: installs/refreshes ~/Library/LaunchAgents/com.trace-mcp.server.plist
  *      and bootstraps it with launchd. Kickstarts the service if it was
  *      already loaded so the new binary is picked up.
  *
@@ -18,7 +20,7 @@
  *   - Dev checkouts (.git next to package.json) and `npm link` symlinks are skipped.
  *   - TRACE_MCP_MANAGED_BY=launchd: skip (we're being run by launchd, don't recurse).
  *   - CI=true: skip launchd bootstrap (don't pollute CI machines).
- *   - All errors swallowed and logged to ~/.trace-mcp/postinstall.log.
+ *   - All errors swallowed and logged to ~/.trace/postinstall.log.
  *   - Daemon is NOT auto-started; only kickstarted if it was already loaded.
  *
  * Runs after preflight-native.mjs and postinstall-app.mjs in the postinstall
@@ -51,15 +53,35 @@ const __dirname = path.dirname(__filename);
 // scripts/postinstall-control-plane.mjs → package root is two levels up.
 const PKG_ROOT = path.resolve(__dirname, '..');
 
-const TRACE_MCP_HOME = (() => {
+// Mirrors src/global.ts::migrateLegacyHomeDir — MUST match (TRA-611). A
+// same-volume rename is atomic and, unlike a copy, leaves nothing stale
+// behind. This script runs before the CLI itself does (postinstall fires
+// immediately after `npm install`), so it has to perform the same rename
+// rather than relying on src/global.ts's own migration to have happened yet.
+function migrateLegacyHomeDir(target, legacy) {
+  try {
+    if (fs.existsSync(target)) return false;
+    if (fs.lstatSync(legacy).isSymbolicLink()) return false;
+    if (!fs.statSync(legacy).isDirectory()) return false;
+    fs.renameSync(legacy, target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const { home: TRACE_MCP_HOME, migrated: TRACE_MCP_HOME_MIGRATED } = (() => {
   const override = process.env.TRACE_MCP_DATA_DIR || process.env.TRACE_MCP_HOME;
   if (override && override.length > 0) {
     const expanded = override.startsWith('~')
       ? path.join(os.homedir(), override.slice(1))
       : override;
-    return path.resolve(expanded);
+    return { home: path.resolve(expanded), migrated: false };
   }
-  return path.join(os.homedir(), '.trace-mcp');
+  const homedir = os.homedir();
+  const target = path.join(homedir, '.trace');
+  const legacy = path.join(homedir, '.trace-mcp');
+  return { home: target, migrated: migrateLegacyHomeDir(target, legacy) };
 })();
 
 const LOG_PATH = path.join(TRACE_MCP_HOME, 'postinstall.log');
@@ -159,14 +181,18 @@ function writeLauncherEnv(nodePath, cliPath, version) {
   atomicWrite(LAUNCHER_ENV_PATH, lines.join('\n'), 0o600);
 }
 
+// Legacy (pre-TRA-611) primary shim basename — used only to install the
+// `~/.trace-mcp/bin/`-legacy compat symlink, mirrors src/init/launcher.ts.
+const LEGACY_PRIMARY_DEST = IS_WINDOWS ? 'trace-mcp.cmd' : 'trace-mcp';
+
 function installLauncherShim() {
   // Windows ships .cmd + .ps1; POSIX a single bash script.
   const artifacts = IS_WINDOWS
     ? [
-        { src: 'trace-mcp-launcher.cmd', dest: 'trace-mcp.cmd' },
+        { src: 'trace-mcp-launcher.cmd', dest: 'trace.cmd' },
         { src: 'trace-mcp-launcher.ps1', dest: 'trace-mcp-launcher.ps1' },
       ]
-    : [{ src: 'trace-mcp-launcher.sh', dest: 'trace-mcp' }];
+    : [{ src: 'trace-mcp-launcher.sh', dest: 'trace' }];
 
   ensureDir(LAUNCHER_DIR);
   for (const a of artifacts) {
@@ -180,6 +206,30 @@ function installLauncherShim() {
     fs.writeFileSync(tmp, content, { mode: 0o755 });
     fs.renameSync(tmp, destPath);
     if (!IS_WINDOWS) fs.chmodSync(destPath, 0o755);
+  }
+}
+
+/**
+ * Preserve `~/.trace-mcp/bin/trace-mcp` as a symlink to the new
+ * `~/.trace/bin/trace` shim, mirroring src/init/launcher.ts's
+ * installLegacyBinCompat() — only acts the one run that renamed the
+ * directory (migrateLegacyHomeDir above); a fresh install has no legacy
+ * path to preserve, and once created the symlink lives on disk.
+ */
+function installLegacyBinCompat(shimPath) {
+  if (!TRACE_MCP_HOME_MIGRATED) return;
+  const legacyDir = path.join(os.homedir(), '.trace-mcp', 'bin');
+  const legacyPath = path.join(legacyDir, LEGACY_PRIMARY_DEST);
+  try {
+    if (fs.lstatSync(legacyPath)) return; // already present (symlink or file)
+  } catch {
+    /* ENOENT — proceed to create it */
+  }
+  try {
+    ensureDir(legacyDir);
+    fs.symlinkSync(shimPath, legacyPath);
+  } catch {
+    /* best-effort — a legacy script can still recover via `trace init` */
   }
 }
 
@@ -451,8 +501,9 @@ function main() {
   let shimPath = '';
   try {
     installLauncherShim();
-    shimPath = path.join(LAUNCHER_DIR, IS_WINDOWS ? 'trace-mcp.cmd' : 'trace-mcp');
+    shimPath = path.join(LAUNCHER_DIR, IS_WINDOWS ? 'trace.cmd' : 'trace');
     log('shim', `installed ${shimPath}`);
+    installLegacyBinCompat(shimPath);
   } catch (err) {
     log('shim', `failed: ${err.message || err}`);
   }

--- a/scripts/postinstall-control-plane.mjs
+++ b/scripts/postinstall-control-plane.mjs
@@ -61,10 +61,21 @@ const LEGACY_MIGRATION_MARKER = '.migrated-from-trace-mcp';
 // behind. This script runs before the CLI itself does (postinstall fires
 // immediately after `npm install`), so it has to perform the same rename
 // rather than relying on src/global.ts's own migration to have happened yet.
+function isSymlink(targetPath) {
+  try {
+    return fs.lstatSync(targetPath).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
 function migrateLegacyHomeDir(target, legacy) {
   try {
     if (fs.existsSync(target)) return false;
-    if (fs.lstatSync(legacy).isSymbolicLink()) return false;
+    // A dangling symlink at `target` fails existsSync (it follows the link,
+    // finds nothing) but must still block the rename — isSymlink uses lstat,
+    // which doesn't follow it.
+    if (isSymlink(target) || isSymlink(legacy)) return false;
     if (!fs.statSync(legacy).isDirectory()) return false;
     fs.renameSync(legacy, target);
     try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -340,7 +340,7 @@ async function runSubprojectAutoSync(projectRoot: string, config: TraceMcpConfig
 const program = new Command();
 
 program
-  .name('trace-mcp')
+  .name('trace')
   .description('Framework-Aware Code Intelligence for Laravel/Vue/Inertia/Nuxt')
   .version(PKG_VERSION, '-v, --version');
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -103,7 +103,7 @@ export const initCommand = new Command('init')
         const migration = migrateGlobalConfig();
         if (migration.changed) {
           migrationStep = {
-            target: '~/.trace-mcp/.config.json',
+            target: '~/.trace/.config.json',
             action: 'updated',
             detail: `Config migrated — added: ${migration.added.join(', ')}`,
           };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1153,7 +1153,7 @@ export function validateConfigUpdate(incoming: Record<string, unknown>): string[
   return errors;
 }
 
-/** Load global config from ~/.trace-mcp/.config.json */
+/** Load global config from ~/.trace/.config.json */
 export function loadGlobalConfigRaw(): Record<string, unknown> {
   try {
     const raw = readIfExists(GLOBAL_CONFIG_PATH);
@@ -1164,13 +1164,21 @@ export function loadGlobalConfigRaw(): Record<string, unknown> {
   }
 }
 
-/** Load per-project config overrides via cosmiconfig (optional, for local overrides). */
+/**
+ * Load per-project config overrides via cosmiconfig (optional, for local
+ * overrides). `.trace.json` is preferred; `.trace-mcp.json` (and its
+ * siblings) are read as a fallback so existing per-project configs keep
+ * working without a manual rename (TRA-611).
+ */
 async function loadProjectConfigRaw(searchFrom: string): Promise<Record<string, unknown>> {
   const explorer = cosmiconfig('trace-mcp', {
     searchPlaces: [
+      '.trace/.config.json',
+      '.trace.json',
       '.trace-mcp/.config.json',
       '.trace-mcp.json',
       '.trace-mcp',
+      '.config/trace.json',
       '.config/trace-mcp.json',
       'package.json',
     ],

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,10 +1,14 @@
 /**
- * Global paths and helpers for ~/.trace-mcp/ directory structure.
+ * Global paths and helpers for ~/.trace/ directory structure.
  *
- * All trace-mcp state lives here:
- *   ~/.trace-mcp/.config.json          — global config
- *   ~/.trace-mcp/registry.json         — project registry
- *   ~/.trace-mcp/index/<name>-<hash>.db — per-project databases
+ * All trace state lives here:
+ *   ~/.trace/.config.json          — global config
+ *   ~/.trace/registry.json         — project registry
+ *   ~/.trace/index/<name>-<hash>.db — per-project databases
+ *
+ * Machines that still have `~/.trace-mcp/` (pre-rename installs) get it
+ * renamed to `~/.trace/` the first time this module loads — see
+ * `migrateLegacyHomeDir` below.
  */
 
 import crypto from 'node:crypto';
@@ -12,25 +16,87 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+// Inlined rather than importing ./utils/path-migration.js — this module must
+// stay free of cross-module imports (see ensureGlobalDirs() below for why:
+// tests/cli/env-overrides.test.ts runs global.ts under
+// `node --experimental-strip-types`, which can't resolve .js -> .ts imports
+// of sibling modules).
+function isSymlink(targetPath: string): boolean {
+  try {
+    return fs.lstatSync(targetPath).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * One-time rename `~/.trace-mcp` -> `~/.trace` (TRA-611). A same-volume
+ * `renameSync` is atomic and instant regardless of DB size, unlike a
+ * copy-based migration which would leave a stale, disk-doubling duplicate
+ * behind (nothing then ever deletes the old copy). Runs at most once per
+ * machine: once `target` exists this — and every future call, since
+ * TRACE_MCP_HOME below only calls it when `target` is still missing —
+ * short-circuits immediately.
+ *
+ * Skipped under Vitest (`process.env.VITEST`, set by the runner itself and
+ * inherited by any subprocess a test spawns): this runs at *import* time, so
+ * without the guard, any test that imports this module with no
+ * TRACE_MCP_DATA_DIR override — e.g. tests/cli/env-overrides.test.ts's
+ * "falls back to default" case, which deliberately clears the override to
+ * exercise real os.homedir() resolution in a spawned subprocess — would
+ * silently rename a real developer's `~/.trace-mcp` on disk. In-process tests
+ * are already protected by tests/setup/isolate-home.ts pinning
+ * TRACE_MCP_DATA_DIR before any project module loads; this guard covers the
+ * one path that pins the var away on purpose.
+ */
+function migrateLegacyHomeDir(target: string, legacy: string): boolean {
+  if (process.env.VITEST) return false;
+  try {
+    if (fs.existsSync(target)) return false;
+    if (isSymlink(target) || isSymlink(legacy)) return false;
+    if (!fs.statSync(legacy).isDirectory()) return false;
+    fs.renameSync(legacy, target);
+    return true;
+  } catch {
+    // No legacy dir (ENOENT) or a rename failure (cross-device, permissions)
+    // — fall through and let ensureGlobalDirs() create `target` fresh.
+    return false;
+  }
+}
+
 /**
  * Root of all trace-mcp global state.
  *
- * Default: `~/.trace-mcp/`. Override with `TRACE_MCP_DATA_DIR=<path>` for
+ * Default: `~/.trace/`. Override with `TRACE_MCP_DATA_DIR=<path>` for
  * Docker volumes, ephemeral CI workspaces, multi-repo orchestrators, or
  * shared cache locations. CRG v2.3.0 (#155) introduced the same knob — the
  * env var replaces the default verbatim, with `~` expansion. Resolved at
  * import time so a user-facing change requires a process restart.
  */
-export const TRACE_MCP_HOME = (() => {
+const { home: TRACE_MCP_HOME_RESOLVED, migrated: TRACE_MCP_HOME_MIGRATED_RESOLVED } = (() => {
   const override = process.env.TRACE_MCP_DATA_DIR;
   if (override && override.length > 0) {
     const expanded = override.startsWith('~')
       ? path.join(os.homedir(), override.slice(1))
       : override;
-    return path.resolve(expanded);
+    return { home: path.resolve(expanded), migrated: false };
   }
-  return path.join(os.homedir(), '.trace-mcp');
+  const homedir = os.homedir();
+  const target = path.join(homedir, '.trace');
+  const legacy = path.join(homedir, '.trace-mcp');
+  return { home: target, migrated: migrateLegacyHomeDir(target, legacy) };
 })();
+
+export const TRACE_MCP_HOME = TRACE_MCP_HOME_RESOLVED;
+
+/**
+ * True only for the single run that performed the `~/.trace-mcp` -> `~/.trace`
+ * rename above. Consumed by `src/init/launcher.ts` to know when a compat
+ * symlink for scripts hardcoded to the old `bin/trace-mcp` path needs to be
+ * (re)created — that symlink then persists on disk, so later runs (where this
+ * is always `false`) don't need to touch it again.
+ */
+export const TRACE_MCP_HOME_MIGRATED = TRACE_MCP_HOME_MIGRATED_RESOLVED;
 
 /** Global config file (replaces per-project .trace-mcp.json). */
 export const GLOBAL_CONFIG_PATH = path.join(TRACE_MCP_HOME, '.config.json');

--- a/src/global.ts
+++ b/src/global.ts
@@ -49,6 +49,17 @@ function isSymlink(targetPath: string): boolean {
  * TRACE_MCP_DATA_DIR before any project module loads; this guard covers the
  * one path that pins the var away on purpose.
  */
+/**
+ * Durable marker left inside the new home the moment the rename succeeds.
+ * `TRACE_MCP_HOME_MIGRATED` below is only `true` for the single process that
+ * performed the rename — too narrow a signal for `installLegacyBinCompat()`
+ * (src/init/launcher.ts), which needs to retry creating the legacy compat
+ * symlink on a *later* `trace init`/`upgrade` run if it failed (or was
+ * skipped by a dry-run) the first time. This file existing is the durable
+ * "a migration happened here at some point" fact that survives restarts.
+ */
+export const LEGACY_MIGRATION_MARKER = '.migrated-from-trace-mcp';
+
 function migrateLegacyHomeDir(target: string, legacy: string): boolean {
   if (process.env.VITEST) return false;
   try {
@@ -56,6 +67,11 @@ function migrateLegacyHomeDir(target: string, legacy: string): boolean {
     if (isSymlink(target) || isSymlink(legacy)) return false;
     if (!fs.statSync(legacy).isDirectory()) return false;
     fs.renameSync(legacy, target);
+    try {
+      fs.writeFileSync(path.join(target, LEGACY_MIGRATION_MARKER), '');
+    } catch {
+      /* best-effort — worst case a later run just doesn't retry the symlink */
+    }
     return true;
   } catch {
     // No legacy dir (ENOENT) or a rename failure (cross-device, permissions)

--- a/src/init/launcher.ts
+++ b/src/init/launcher.ts
@@ -14,6 +14,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { withPs1Bom } from './ps1-bom.js';
+import { atomicWriteString } from '../utils/atomic-write.js';
 import { readIfExists } from '../utils/safe-fs.js';
 import type { InitStepResult } from './types.js';
 import { LAUNCHER_VERSION } from './types.js';
@@ -107,14 +108,16 @@ export function readInstalledLauncherVersion(): string | null {
 }
 
 function ensureDir(dir: string): void {
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-}
-
-function atomicWrite(filePath: string, content: string, mode: number): void {
-  ensureDir(path.dirname(filePath));
-  const tmp = `${filePath}.tmp.${process.pid}.${Date.now()}`;
-  fs.writeFileSync(tmp, content, { mode });
-  fs.renameSync(tmp, filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+    if (!IS_WINDOWS) {
+      try {
+        fs.chmodSync(dir, 0o700);
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
 }
 
 /**
@@ -149,7 +152,10 @@ export function writeLauncherConfig(cfg: LauncherConfig): void {
     `TRACE_MCP_VERSION=${quoteEnvValue(cfg.version)}`,
     '',
   ];
-  atomicWrite(getLauncherConfigPath(), lines.join('\n'), 0o600);
+  atomicWriteString(getLauncherConfigPath(), lines.join('\n'), {
+    mode: 0o600,
+    rejectSymlinks: true,
+  });
 }
 
 /**
@@ -223,10 +229,18 @@ export function installLauncher(opts: InstallLauncherOpts): InitStepResult {
     // Prepend a UTF-8 BOM for .ps1 artifacts so Windows PowerShell 5.1 decodes
     // them as UTF-8 regardless of the machine's system codepage (cp1251 etc.).
     const content = withPs1Bom(artifactDest, fs.readFileSync(src));
-    const tmp = `${artifactDest}.tmp.${process.pid}.${Date.now()}`;
-    fs.writeFileSync(tmp, content, { mode: a.mode });
-    fs.renameSync(tmp, artifactDest);
-    if (!IS_WINDOWS) fs.chmodSync(artifactDest, a.mode);
+    atomicWriteString(artifactDest, content.toString('utf-8'), {
+      mode: a.mode,
+      rejectSymlinks: true,
+      trailingNewline: false,
+    });
+    if (!IS_WINDOWS) {
+      try {
+        fs.chmodSync(artifactDest, a.mode);
+      } catch {
+        /* best-effort */
+      }
+    }
   }
 
   return {

--- a/src/init/launcher.ts
+++ b/src/init/launcher.ts
@@ -20,7 +20,7 @@ import { withPs1Bom } from './ps1-bom.js';
 import { atomicWriteString } from '../utils/atomic-write.js';
 import { isSymlink } from '../utils/path-migration.js';
 import { readIfExists } from '../utils/safe-fs.js';
-import { TRACE_MCP_HOME_MIGRATED } from '../global.js';
+import { LEGACY_MIGRATION_MARKER, TRACE_MCP_HOME } from '../global.js';
 import type { InitStepResult } from './types.js';
 import { LAUNCHER_VERSION } from './types.js';
 
@@ -204,15 +204,15 @@ export interface InstallLauncherOpts {
  * Preserve `~/.trace-mcp/bin/trace-mcp` (`trace-mcp.cmd` on Windows) as a
  * symlink to the new `~/.trace/bin/trace` shim, so a client or script still
  * pointed at the pre-TRA-611 absolute path keeps working after the rename.
- * Only acts the one run that actually performed the `~/.trace-mcp` ->
- * `~/.trace` rename (a fresh install never had a legacy path to preserve);
- * once created the symlink lives on disk, so later runs skip this.
- * ponytail: a dry-run on that exact first post-migration run skips creating
- * the symlink and there's no retry — narrow edge case, `trace init` again
- * (non-dry-run) recovers it.
+ * Gated on LEGACY_MIGRATION_MARKER (a durable file left in the new home the
+ * moment the rename succeeds) rather than the one-shot
+ * TRACE_MCP_HOME_MIGRATED flag: that flag is only true for the single process
+ * that performed the rename, so a symlink failure there (permissions,
+ * dry-run) would otherwise never get a second chance. The marker survives
+ * restarts, so every later `trace init`/`upgrade` retries until it succeeds.
  */
 function installLegacyBinCompat(): void {
-  if (!TRACE_MCP_HOME_MIGRATED) return;
+  if (!fs.existsSync(path.join(TRACE_MCP_HOME, LEGACY_MIGRATION_MARKER))) return;
   const legacyDir = path.join(os.homedir(), '.trace-mcp', 'bin');
   const legacyPath = path.join(legacyDir, LEGACY_PRIMARY_DEST);
   try {
@@ -220,7 +220,7 @@ function installLegacyBinCompat(): void {
     ensureDir(legacyDir);
     fs.symlinkSync(getLauncherPath(), legacyPath);
   } catch {
-    /* best-effort — a legacy script can still recover via `trace init` */
+    /* best-effort — the durable marker means the next `trace init` retries */
   }
 }
 

--- a/src/init/launcher.ts
+++ b/src/init/launcher.ts
@@ -4,10 +4,13 @@
  * from a config file written here, with a probe fallback — so node upgrades
  * (nvm/Herd/Volta/fnm) don't break MCP registration.
  *
- * Layout under $TRACE_MCP_HOME (default ~/.trace-mcp):
- *   bin/trace-mcp     — bash shim, copied from hooks/trace-mcp-launcher.sh
+ * Layout under $TRACE_MCP_HOME (default ~/.trace):
+ *   bin/trace         — bash shim, copied from hooks/trace-mcp-launcher.sh
  *   launcher.env      — KV config (TRACE_MCP_NODE, TRACE_MCP_CLI, TRACE_MCP_VERSION)
  *   launcher.log      — rolling resolution diagnostics written by the shim
+ *
+ * A pre-TRA-611 install also gets `~/.trace-mcp/bin/trace-mcp` preserved as a
+ * symlink to the above — see installLegacyBinCompat().
  */
 
 import fs from 'node:fs';
@@ -15,7 +18,9 @@ import os from 'node:os';
 import path from 'node:path';
 import { withPs1Bom } from './ps1-bom.js';
 import { atomicWriteString } from '../utils/atomic-write.js';
+import { isSymlink } from '../utils/path-migration.js';
 import { readIfExists } from '../utils/safe-fs.js';
+import { TRACE_MCP_HOME_MIGRATED } from '../global.js';
 import type { InitStepResult } from './types.js';
 import { LAUNCHER_VERSION } from './types.js';
 
@@ -34,7 +39,7 @@ interface LauncherArtifact {
 
 const ARTIFACTS: LauncherArtifact[] = IS_WINDOWS
   ? [
-      { src: 'trace-mcp-launcher.cmd', dest: 'trace-mcp.cmd', mode: 0o755, isPrimaryShim: true },
+      { src: 'trace-mcp-launcher.cmd', dest: 'trace.cmd', mode: 0o755, isPrimaryShim: true },
       {
         src: 'trace-mcp-launcher.ps1',
         dest: 'trace-mcp-launcher.ps1',
@@ -42,12 +47,18 @@ const ARTIFACTS: LauncherArtifact[] = IS_WINDOWS
         isPrimaryShim: false,
       },
     ]
-  : [{ src: 'trace-mcp-launcher.sh', dest: 'trace-mcp', mode: 0o755, isPrimaryShim: true }];
+  : [{ src: 'trace-mcp-launcher.sh', dest: 'trace', mode: 0o755, isPrimaryShim: true }];
+
+// Legacy (pre-TRA-611) destination basenames, kept only to install the
+// `~/.trace-mcp/bin/`-legacy compat symlinks — see installLegacyBinCompat().
+const LEGACY_PRIMARY_DEST = IS_WINDOWS ? 'trace-mcp.cmd' : 'trace-mcp';
 
 export function getLauncherDir(): string {
+  // Distinct from TRACE_MCP_DATA_DIR (src/global.ts) — the Electron main
+  // process resolves the same directory via this env var; keep it as-is.
   const envDir = process.env.TRACE_MCP_HOME?.trim();
   if (envDir) return envDir;
-  return path.join(os.homedir(), '.trace-mcp');
+  return path.join(os.homedir(), '.trace');
 }
 
 export function getLauncherPath(): string {
@@ -190,6 +201,30 @@ export interface InstallLauncherOpts {
 }
 
 /**
+ * Preserve `~/.trace-mcp/bin/trace-mcp` (`trace-mcp.cmd` on Windows) as a
+ * symlink to the new `~/.trace/bin/trace` shim, so a client or script still
+ * pointed at the pre-TRA-611 absolute path keeps working after the rename.
+ * Only acts the one run that actually performed the `~/.trace-mcp` ->
+ * `~/.trace` rename (a fresh install never had a legacy path to preserve);
+ * once created the symlink lives on disk, so later runs skip this.
+ * ponytail: a dry-run on that exact first post-migration run skips creating
+ * the symlink and there's no retry — narrow edge case, `trace init` again
+ * (non-dry-run) recovers it.
+ */
+function installLegacyBinCompat(): void {
+  if (!TRACE_MCP_HOME_MIGRATED) return;
+  const legacyDir = path.join(os.homedir(), '.trace-mcp', 'bin');
+  const legacyPath = path.join(legacyDir, LEGACY_PRIMARY_DEST);
+  try {
+    if (isSymlink(legacyPath) || fs.existsSync(legacyPath)) return;
+    ensureDir(legacyDir);
+    fs.symlinkSync(getLauncherPath(), legacyPath);
+  } catch {
+    /* best-effort — a legacy script can still recover via `trace init` */
+  }
+}
+
+/**
  * Install the shim script at $TRACE_MCP_HOME/bin/trace-mcp, skipping if the
  * installed version matches the shipped one (unless force=true).
  * Does NOT write launcher.env — call writeLauncherConfig() separately with
@@ -242,6 +277,8 @@ export function installLauncher(opts: InstallLauncherOpts): InitStepResult {
       }
     }
   }
+
+  installLegacyBinCompat();
 
   return {
     target: dest,

--- a/src/init/mcp-client.ts
+++ b/src/init/mcp-client.ts
@@ -9,7 +9,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { applyEdits, type FormattingOptions, modify, parse as parseJsonc } from 'jsonc-parser';
 import YAML from 'yaml';
-import { atomicWriteJson } from '../utils/atomic-write.js';
+import { atomicWriteJson, atomicWriteString } from '../utils/atomic-write.js';
 import { readIfExists } from '../utils/safe-fs.js';
 import { isGuardHookInstalled } from './hooks.js';
 import { getLauncherPath } from './launcher.js';
@@ -493,7 +493,7 @@ function writeHermesYamlEntry(configPath: string, entry: HermesYamlEntry): 'crea
   };
 
   doc.setIn(['mcp_servers', 'trace-mcp'], value);
-  fs.writeFileSync(configPath, doc.toString({ lineWidth: 0 }));
+  atomicWriteString(configPath, doc.toString({ lineWidth: 0 }), { rejectSymlinks: true });
   return isNew ? 'created' : 'updated';
 }
 
@@ -545,7 +545,9 @@ function writeAmpJsoncEntry(configPath: string, entry: McpServerEntry): 'created
     formattingOptions: AMP_FORMATTING,
   });
   const updated = applyEdits(content, edits);
-  fs.writeFileSync(configPath, updated.endsWith('\n') ? updated : updated + '\n');
+  atomicWriteString(configPath, updated.endsWith('\n') ? updated : updated + '\n', {
+    rejectSymlinks: true,
+  });
   return isNew ? 'created' : 'updated';
 }
 
@@ -628,9 +630,9 @@ function writeCodexTomlEntry(configPath: string, entry: McpServerEntry): 'create
   const existing = readIfExists(configPath);
   if (existing !== null) {
     isNew = false;
-    fs.writeFileSync(configPath, `${existing.trimEnd()}\n${block}`);
+    atomicWriteString(configPath, `${existing.trimEnd()}\n${block}`, { rejectSymlinks: true });
   } else {
-    fs.writeFileSync(configPath, block.trimStart());
+    atomicWriteString(configPath, block.trimStart(), { rejectSymlinks: true });
   }
 
   return isNew ? 'created' : 'updated';

--- a/src/init/mcp-client.ts
+++ b/src/init/mcp-client.ts
@@ -270,13 +270,19 @@ export function configureMcpClients(
         continue;
       }
 
-      // Check if already configured under the current key — a legacy-only
-      // `[mcp_servers.trace-mcp]` section falls through to the write path
-      // below, which migrates it (see writeCodexTomlEntry).
+      // Check if already configured under the current key AND the legacy
+      // section is gone — a legacy-only or both-present `[mcp_servers.*]`
+      // section falls through to the write path below, which migrates it
+      // (see writeCodexTomlEntry). Requiring legacy absence here matters:
+      // otherwise a file with both sections short-circuits to
+      // already_configured and Codex spawns two copies of the server.
       if (fs.existsSync(configPath)) {
         try {
           const content = fs.readFileSync(configPath, 'utf-8');
-          if (codexSectionHeaderPattern(MCP_KEY).test(content)) {
+          if (
+            codexSectionHeaderPattern(MCP_KEY).test(content) &&
+            !codexSectionHeaderPattern(LEGACY_MCP_KEY).test(content)
+          ) {
             results.push({ target: configPath, action: 'already_configured', detail: name });
             continue;
           }
@@ -403,7 +409,13 @@ function verifyTraceMcpEntry(configPath: string): boolean {
 function entryMatches(configPath: string, expected: McpServerEntry): boolean {
   try {
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    const current = content?.mcpServers?.[MCP_KEY];
+    const servers = content?.mcpServers;
+    // A lingering legacy key must always force the write path (which deletes
+    // it) — otherwise a config with both `trace` (already correct) and a
+    // stale `trace-mcp` short-circuits to already_configured, and the client
+    // keeps spawning two copies of the same server forever.
+    if (servers && typeof servers === 'object' && LEGACY_MCP_KEY in servers) return false;
+    const current = servers?.[MCP_KEY];
     if (!current || typeof current !== 'object') return false;
     if (current.command !== expected.command) return false;
     if (JSON.stringify(current.args ?? []) !== JSON.stringify(expected.args)) return false;
@@ -464,6 +476,9 @@ function hermesEntryMatches(configPath: string, expected: HermesYamlEntry): bool
   try {
     const doc = YAML.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown> | null;
     const servers = doc?.mcp_servers as Record<string, unknown> | undefined;
+    // A lingering legacy key must force the write path (which deletes it) —
+    // see entryMatches() above for why.
+    if (servers && LEGACY_MCP_KEY in servers) return false;
     const current = servers?.[MCP_KEY] as Record<string, unknown> | undefined;
     if (!current) return false;
     if (current.command !== expected.command) return false;
@@ -526,6 +541,9 @@ function ampEntryMatches(configPath: string, expected: McpServerEntry): boolean 
     const content = fs.readFileSync(configPath, 'utf-8');
     const parsed = parseJsonc(content) as Record<string, unknown> | null;
     const servers = parsed?.['amp.mcpServers'] as Record<string, unknown> | undefined;
+    // A lingering legacy key must force the write path (which deletes it) —
+    // see entryMatches() above for why.
+    if (servers && LEGACY_MCP_KEY in servers) return false;
     const current = servers?.[MCP_KEY] as Record<string, unknown> | undefined;
     if (!current) return false;
     if (current.command !== expected.command) return false;
@@ -590,7 +608,11 @@ function factoryEntryMatches(
 ): boolean {
   try {
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    const current = content?.mcpServers?.[MCP_KEY];
+    const servers = content?.mcpServers;
+    // A lingering legacy key must force the write path (which deletes it) —
+    // see entryMatches() above for why.
+    if (servers && typeof servers === 'object' && LEGACY_MCP_KEY in servers) return false;
+    const current = servers?.[MCP_KEY];
     if (!current || typeof current !== 'object') return false;
     if (current.type !== expected.type) return false;
     if (current.command !== expected.command) return false;
@@ -955,10 +977,15 @@ function detectClientStatus(
 function pinpointEntryDrift(configPath: string, expected: McpServerEntry): string {
   try {
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    const current = content?.mcpServers?.[MCP_KEY];
+    const servers = content?.mcpServers;
+    const current = servers?.[MCP_KEY];
     if (!current || typeof current !== 'object') {
-      return content?.mcpServers?.[LEGACY_MCP_KEY] ? 'legacy-key' : 'entry-missing';
+      return servers?.[LEGACY_MCP_KEY] ? 'legacy-key' : 'entry-missing';
     }
+    // The new key can be entirely correct on its own while a legacy key still
+    // lingers alongside it (a previous run failed partway, or a config was
+    // hand-edited) — that's still the reason to re-run, not a field mismatch.
+    if (servers && typeof servers === 'object' && LEGACY_MCP_KEY in servers) return 'legacy-key';
     if (current.command !== expected.command) return 'command';
     if (JSON.stringify(current.args ?? []) !== JSON.stringify(expected.args)) return 'args';
     if ((current.cwd ?? undefined) !== (expected.cwd ?? undefined)) return 'cwd';

--- a/src/init/mcp-client.ts
+++ b/src/init/mcp-client.ts
@@ -716,8 +716,19 @@ function writeCodexTomlEntry(configPath: string, entry: McpServerEntry): 'create
   const existing = readIfExists(configPath);
   if (existing !== null) {
     isNew = false;
-    const withoutLegacy = stripCodexTomlSection(existing, LEGACY_MCP_KEY).trimEnd();
-    atomicWriteString(configPath, `${withoutLegacy}\n${block}`, { rejectSymlinks: true });
+    // Strip both keys, not just the legacy one — a file that already has a
+    // [mcp_servers.trace] section (interrupted prior migration, hand edit)
+    // would otherwise keep it untouched and get a second, duplicate header
+    // appended below, which is invalid TOML.
+    const withoutExisting = stripCodexTomlSection(
+      stripCodexTomlSection(existing, LEGACY_MCP_KEY),
+      MCP_KEY,
+    ).trimEnd();
+    atomicWriteString(
+      configPath,
+      withoutExisting.length > 0 ? `${withoutExisting}\n${block}` : block.trimStart(),
+      { rejectSymlinks: true },
+    );
   } else {
     atomicWriteString(configPath, block.trimStart(), { rejectSymlinks: true });
   }

--- a/src/init/mcp-client.ts
+++ b/src/init/mcp-client.ts
@@ -19,6 +19,15 @@ import type { DetectedMcpClient, InitStepResult } from './types.js';
 const HOME = os.homedir();
 
 /**
+ * Server key clients register us under. `MCP_KEY` is what `init` writes
+ * going forward; `LEGACY_MCP_KEY` is the pre-TRA-611 name every writer below
+ * also deletes/replaces in place, so re-running `init` migrates a client
+ * seamlessly instead of leaving both keys registered side by side.
+ */
+export const MCP_KEY = 'trace';
+export const LEGACY_MCP_KEY = 'trace-mcp';
+
+/**
  * Detect whether Claude Desktop (the unified Claude.app on macOS, or the
  * Claude Desktop binary on Windows/Linux) is currently running.
  *
@@ -113,7 +122,7 @@ export function configureMcpClients(
         action: 'skipped',
         detail: hasClaudeDesktop
           ? 'Use "Import from Claude" in Settings → Tools → AI Assistant → MCP'
-          : 'Add via Settings → Tools → AI Assistant → MCP → Add → Command: trace-mcp, Args: serve',
+          : 'Add via Settings → Tools → AI Assistant → MCP → Add → Command: trace, Args: serve',
       });
       continue;
     }
@@ -130,14 +139,14 @@ export function configureMcpClients(
       // else (TRA-501). Warp launches the server in the session's own directory.
       const snippet = JSON.stringify({
         mcpServers: {
-          'trace-mcp': { command: launcher, args: ['serve'] },
+          [MCP_KEY]: { command: launcher, args: ['serve'] },
         },
       });
       results.push({
         target: 'Warp',
         action: 'skipped',
         detail: hasClaudeCode
-          ? 'Enable Settings → Agents → MCP servers → "File-based MCP servers" to inherit trace-mcp from Claude Code, or paste: ' +
+          ? 'Enable Settings → Agents → MCP servers → "File-based MCP servers" to inherit trace from Claude Code, or paste: ' +
             snippet
           : 'Open Settings → Agents → MCP servers → + Add → paste: ' + snippet,
       });
@@ -261,11 +270,13 @@ export function configureMcpClients(
         continue;
       }
 
-      // Check if already configured
+      // Check if already configured under the current key — a legacy-only
+      // `[mcp_servers.trace-mcp]` section falls through to the write path
+      // below, which migrates it (see writeCodexTomlEntry).
       if (fs.existsSync(configPath)) {
         try {
           const content = fs.readFileSync(configPath, 'utf-8');
-          if (/\[mcp_servers\s*\.\s*["']?trace-mcp["']?\s*\]/.test(content)) {
+          if (codexSectionHeaderPattern(MCP_KEY).test(content)) {
             results.push({ target: configPath, action: 'already_configured', detail: name });
             continue;
           }
@@ -377,13 +388,13 @@ export function configureMcpClients(
 // ---------------------------------------------------------------------------
 
 /**
- * Verify that `mcpServers['trace-mcp']` is present on disk. Used after writing
+ * Verify that `mcpServers[MCP_KEY]` is present on disk. Used after writing
  * Claude Desktop's config to detect the Claude.app overwrite race.
  */
 function verifyTraceMcpEntry(configPath: string): boolean {
   try {
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    return Boolean(content?.mcpServers?.['trace-mcp']);
+    return Boolean(content?.mcpServers?.[MCP_KEY]);
   } catch {
     return false;
   }
@@ -392,7 +403,7 @@ function verifyTraceMcpEntry(configPath: string): boolean {
 function entryMatches(configPath: string, expected: McpServerEntry): boolean {
   try {
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    const current = content?.mcpServers?.['trace-mcp'];
+    const current = content?.mcpServers?.[MCP_KEY];
     if (!current || typeof current !== 'object') return false;
     if (current.command !== expected.command) return false;
     if (JSON.stringify(current.args ?? []) !== JSON.stringify(expected.args)) return false;
@@ -429,7 +440,9 @@ function writeJsonEntry(configPath: string, entry: McpServerEntry): 'created' | 
   if (!config.mcpServers || typeof config.mcpServers !== 'object') {
     config.mcpServers = {};
   }
-  (config.mcpServers as Record<string, unknown>)['trace-mcp'] = entry;
+  const servers = config.mcpServers as Record<string, unknown>;
+  delete servers[LEGACY_MCP_KEY];
+  servers[MCP_KEY] = entry;
 
   atomicWriteJson(configPath, config);
   return isNew ? 'created' : 'updated';
@@ -451,7 +464,7 @@ function hermesEntryMatches(configPath: string, expected: HermesYamlEntry): bool
   try {
     const doc = YAML.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown> | null;
     const servers = doc?.mcp_servers as Record<string, unknown> | undefined;
-    const current = servers?.['trace-mcp'] as Record<string, unknown> | undefined;
+    const current = servers?.[MCP_KEY] as Record<string, unknown> | undefined;
     if (!current) return false;
     if (current.command !== expected.command) return false;
     if (JSON.stringify(current.args ?? []) !== JSON.stringify(expected.args)) return false;
@@ -487,12 +500,17 @@ function writeHermesYamlEntry(configPath: string, entry: HermesYamlEntry): 'crea
     command: entry.command,
     args: entry.args,
     ...(entry.cwd ? { cwd: entry.cwd } : {}),
-    // Hermes' own defaults are low — trace-mcp's first boot (indexing) can be slow.
+    // Hermes' own defaults are low — trace's first boot (indexing) can be slow.
     timeout: entry.timeout ?? 180,
     connect_timeout: entry.connect_timeout ?? 120,
   };
 
-  doc.setIn(['mcp_servers', 'trace-mcp'], value);
+  // hasIn guards deleteIn: on a document with no `mcp_servers` collection yet
+  // (fresh install), deleteIn throws instead of no-op'ing.
+  if (doc.hasIn(['mcp_servers', LEGACY_MCP_KEY])) {
+    doc.deleteIn(['mcp_servers', LEGACY_MCP_KEY]);
+  }
+  doc.setIn(['mcp_servers', MCP_KEY], value);
   atomicWriteString(configPath, doc.toString({ lineWidth: 0 }), { rejectSymlinks: true });
   return isNew ? 'created' : 'updated';
 }
@@ -508,7 +526,7 @@ function ampEntryMatches(configPath: string, expected: McpServerEntry): boolean 
     const content = fs.readFileSync(configPath, 'utf-8');
     const parsed = parseJsonc(content) as Record<string, unknown> | null;
     const servers = parsed?.['amp.mcpServers'] as Record<string, unknown> | undefined;
-    const current = servers?.['trace-mcp'] as Record<string, unknown> | undefined;
+    const current = servers?.[MCP_KEY] as Record<string, unknown> | undefined;
     if (!current) return false;
     if (current.command !== expected.command) return false;
     if (JSON.stringify(current.args ?? []) !== JSON.stringify(expected.args)) return false;
@@ -541,10 +559,21 @@ function writeAmpJsoncEntry(configPath: string, entry: McpServerEntry): 'created
   }
 
   // jsonc-parser preserves comments and formatting around untouched regions.
-  const edits = modify(content, ['amp.mcpServers', 'trace-mcp'], value, {
+  // modify() with value=undefined throws if the path doesn't already exist —
+  // only ask it to delete the legacy key when there's actually one there.
+  const existingServers = (parseJsonc(content) as Record<string, unknown> | null)?.[
+    'amp.mcpServers'
+  ] as Record<string, unknown> | undefined;
+  if (existingServers && LEGACY_MCP_KEY in existingServers) {
+    const removeEdits = modify(content, ['amp.mcpServers', LEGACY_MCP_KEY], undefined, {
+      formattingOptions: AMP_FORMATTING,
+    });
+    content = applyEdits(content, removeEdits);
+  }
+  const addEdits = modify(content, ['amp.mcpServers', MCP_KEY], value, {
     formattingOptions: AMP_FORMATTING,
   });
-  const updated = applyEdits(content, edits);
+  const updated = applyEdits(content, addEdits);
   atomicWriteString(configPath, updated.endsWith('\n') ? updated : updated + '\n', {
     rejectSymlinks: true,
   });
@@ -561,7 +590,7 @@ function factoryEntryMatches(
 ): boolean {
   try {
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    const current = content?.mcpServers?.['trace-mcp'];
+    const current = content?.mcpServers?.[MCP_KEY];
     if (!current || typeof current !== 'object') return false;
     if (current.type !== expected.type) return false;
     if (current.command !== expected.command) return false;
@@ -595,7 +624,9 @@ function writeFactoryJsonEntry(
   if (!config.mcpServers || typeof config.mcpServers !== 'object') {
     config.mcpServers = {};
   }
-  (config.mcpServers as Record<string, unknown>)['trace-mcp'] = entry;
+  const servers = config.mcpServers as Record<string, unknown>;
+  delete servers[LEGACY_MCP_KEY];
+  servers[MCP_KEY] = entry;
   atomicWriteJson(configPath, config);
   return isNew ? 'created' : 'updated';
 }
@@ -604,6 +635,39 @@ function writeFactoryJsonEntry(
 // TOML writer (Codex)
 // ---------------------------------------------------------------------------
 
+/**
+ * Matches a `[mcp_servers.<key>]` header, including its `.env` sub-table.
+ * `m` so `^` anchors to line starts when tested against full file content,
+ * not just the single already-isolated lines stripCodexTomlSection tests.
+ */
+function codexSectionHeaderPattern(key: string): RegExp {
+  return new RegExp(`^\\[mcp_servers\\s*\\.\\s*["']?${key}["']?(\\s*\\.[^\\]]*)?\\s*\\]`, 'm');
+}
+
+/**
+ * Drop a `[mcp_servers.<key>]` section (and its `.env` sub-table, if any)
+ * from raw TOML text. Codex config is append-only elsewhere in this file —
+ * we never parse arbitrary TOML — so this is a narrowly-scoped line filter,
+ * not a general TOML editor: it only recognizes section headers matching
+ * `key` at the start of a line, which is exactly the shape writeCodexTomlEntry
+ * itself always produces.
+ */
+function stripCodexTomlSection(content: string, key: string): string {
+  const header = codexSectionHeaderPattern(key);
+  const out: string[] = [];
+  let skipping = false;
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (header.test(trimmed)) {
+      skipping = true;
+      continue;
+    }
+    if (skipping && trimmed.startsWith('[')) skipping = false;
+    if (!skipping) out.push(line);
+  }
+  return out.join('\n');
+}
+
 function writeCodexTomlEntry(configPath: string, entry: McpServerEntry): 'created' | 'updated' {
   const dir = path.dirname(configPath);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
@@ -611,7 +675,7 @@ function writeCodexTomlEntry(configPath: string, entry: McpServerEntry): 'create
   const argsToml = entry.args.map((a) => `"${a}"`).join(', ');
   const section = [
     '',
-    '[mcp_servers.trace-mcp]',
+    `[mcp_servers.${MCP_KEY}]`,
     `command = "${entry.command}"`,
     `args = [${argsToml}]`,
   ];
@@ -619,7 +683,7 @@ function writeCodexTomlEntry(configPath: string, entry: McpServerEntry): 'create
     section.push(`cwd = "${entry.cwd}"`);
   }
   if (entry.env) {
-    section.push('[mcp_servers.trace-mcp.env]');
+    section.push(`[mcp_servers.${MCP_KEY}.env]`);
     for (const [k, v] of Object.entries(entry.env)) {
       section.push(`${k} = "${v}"`);
     }
@@ -630,7 +694,8 @@ function writeCodexTomlEntry(configPath: string, entry: McpServerEntry): 'create
   const existing = readIfExists(configPath);
   if (existing !== null) {
     isNew = false;
-    atomicWriteString(configPath, `${existing.trimEnd()}\n${block}`, { rejectSymlinks: true });
+    const withoutLegacy = stripCodexTomlSection(existing, LEGACY_MCP_KEY).trimEnd();
+    atomicWriteString(configPath, `${withoutLegacy}\n${block}`, { rejectSymlinks: true });
   } else {
     atomicWriteString(configPath, block.trimStart(), { rejectSymlinks: true });
   }
@@ -806,7 +871,9 @@ function detectClientStatus(
       const present = (() => {
         try {
           const text = fs.readFileSync(configPath, 'utf-8');
-          return /(^|\n)\s*trace-mcp\s*:/.test(text);
+          // Legacy-only counts as present (falls through to 'stale' below, not
+          // 'missing') so `init` re-running migrates it rather than "installing".
+          return /(^|\n)\s*(trace|trace-mcp)\s*:/.test(text);
         } catch {
           return false;
         }
@@ -820,7 +887,7 @@ function detectClientStatus(
       const present = (() => {
         try {
           const text = fs.readFileSync(configPath, 'utf-8');
-          return /["']trace-mcp["']\s*:/.test(text);
+          return /["'](trace|trace-mcp)["']\s*:/.test(text);
         } catch {
           return false;
         }
@@ -835,7 +902,7 @@ function detectClientStatus(
       const present = (() => {
         try {
           const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-          return Boolean(content?.mcpServers?.['trace-mcp']);
+          return Boolean(content?.mcpServers?.[MCP_KEY] ?? content?.mcpServers?.[LEGACY_MCP_KEY]);
         } catch {
           return false;
         }
@@ -850,7 +917,9 @@ function detectClientStatus(
       // section is append-based and we don't parse arbitrary TOML.
       try {
         const content = fs.readFileSync(configPath, 'utf-8');
-        const present = /\[mcp_servers\s*\.\s*["']?trace-mcp["']?\s*\]/.test(content);
+        const present =
+          codexSectionHeaderPattern(MCP_KEY).test(content) ||
+          codexSectionHeaderPattern(LEGACY_MCP_KEY).test(content);
         return {
           client: name,
           configPath,
@@ -867,7 +936,7 @@ function detectClientStatus(
       const present = (() => {
         try {
           const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-          return Boolean(content?.mcpServers?.['trace-mcp']);
+          return Boolean(content?.mcpServers?.[MCP_KEY] ?? content?.mcpServers?.[LEGACY_MCP_KEY]);
         } catch {
           return false;
         }
@@ -886,8 +955,10 @@ function detectClientStatus(
 function pinpointEntryDrift(configPath: string, expected: McpServerEntry): string {
   try {
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    const current = content?.mcpServers?.['trace-mcp'];
-    if (!current || typeof current !== 'object') return 'entry-missing';
+    const current = content?.mcpServers?.[MCP_KEY];
+    if (!current || typeof current !== 'object') {
+      return content?.mcpServers?.[LEGACY_MCP_KEY] ? 'legacy-key' : 'entry-missing';
+    }
     if (current.command !== expected.command) return 'command';
     if (JSON.stringify(current.args ?? []) !== JSON.stringify(expected.args)) return 'args';
     if ((current.cwd ?? undefined) !== (expected.cwd ?? undefined)) return 'cwd';

--- a/src/init/md-block.ts
+++ b/src/init/md-block.ts
@@ -2,7 +2,7 @@
  * Shared markdown routing-block writer used by both CLAUDE.md and AGENTS.md.
  *
  * The BLOCK content is the single source of truth for "how an AI agent should
- * route through trace-mcp". Anything that drifts between CLAUDE.md and
+ * route through trace". Anything that drifts between CLAUDE.md and
  * AGENTS.md is a bug — the block is authored here so both files stay in sync.
  *
  * File-I/O is intentionally kept here (not in the caller) so competitor
@@ -31,11 +31,11 @@ const COMPETING_MARKER_TOOLS = [
 ];
 
 export const TRACE_MCP_ROUTING_BLOCK = `${START_MARKER}
-## trace-mcp Tool Routing
+## trace Tool Routing
 
-IMPORTANT: For ANY code exploration task, ALWAYS use trace-mcp tools first. NEVER use Read/Grep/Glob/Bash(ls,find) for navigating source code.
+IMPORTANT: For ANY code exploration task, ALWAYS use trace tools first. NEVER use Read/Grep/Glob/Bash(ls,find) for navigating source code.
 
-| Task | trace-mcp tool | Instead of |
+| Task | trace tool | Instead of |
 |------|---------------|------------|
 | Find a function/class/method | \`search\` | Grep |
 | Understand a file before editing | \`get_outline\` | Read (full file) |
@@ -58,7 +58,7 @@ Use Read/Grep/Glob ONLY for non-code files (.md, .json, .yaml, config) or before
 Start sessions with \`get_project_map\` (summary_only=true).
 ${END_MARKER}`;
 
-/** Upsert the trace-mcp routing block into `filePath`. Idempotent. */
+/** Upsert the trace routing block into `filePath`. Idempotent. */
 export function upsertTraceMcpBlock(
   filePath: string,
   opts: { dryRun?: boolean } = {},
@@ -70,9 +70,9 @@ export function upsertTraceMcpBlock(
       return { target: filePath, action: 'skipped', detail: `Would create ${basename(filePath)}` };
     }
     if (existing.includes(START_MARKER)) {
-      return { target: filePath, action: 'skipped', detail: 'Would update trace-mcp block' };
+      return { target: filePath, action: 'skipped', detail: 'Would update trace block' };
     }
-    return { target: filePath, action: 'skipped', detail: 'Would append trace-mcp block' };
+    return { target: filePath, action: 'skipped', detail: 'Would append trace block' };
   }
 
   if (existing === null) {
@@ -97,7 +97,7 @@ export function upsertTraceMcpBlock(
     return {
       target: filePath,
       action: 'updated',
-      detail: cleaned ? 'Updated trace-mcp block and removed competing sections' : undefined,
+      detail: cleaned ? 'Updated trace block and removed competing sections' : undefined,
     };
   }
 
@@ -109,8 +109,8 @@ export function upsertTraceMcpBlock(
     target: filePath,
     action: 'updated',
     detail: cleaned
-      ? 'Appended trace-mcp block and removed competing sections'
-      : 'Appended trace-mcp block',
+      ? 'Appended trace block and removed competing sections'
+      : 'Appended trace block',
   };
 }
 
@@ -153,7 +153,10 @@ function removeOrphanedTraceMcpContent(content: string): string {
   const before = content.slice(0, startIdx);
   const markerBlock = content.slice(startIdx, endIdx + END_MARKER.length);
   const after = content.slice(endIdx + END_MARKER.length);
-  const traceMcpHeadingRe = /^(#{1,6})\s+trace-mcp\b/i;
+  // Matches our own heading in both its current ("trace") and pre-TRA-611
+  // ("trace-mcp") forms, so a stray duplicate left outside the marker block
+  // gets cleaned up regardless of which version wrote it.
+  const traceMcpHeadingRe = /^(#{1,6})\s+trace(-mcp)?\b/i;
   const cleanBefore = filterSections(before.split('\n'), (heading) =>
     traceMcpHeadingRe.test(heading),
   ).join('\n');
@@ -185,7 +188,7 @@ function removeCompetingHeadingSections(content: string): string {
   let lines = content.split('\n');
   lines = filterSections(lines, (headingLine) => competingHeadingRe.test(headingLine));
   lines = filterSections(lines, (headingLine, _level, body) => {
-    if (/trace-mcp/i.test(headingLine)) return false;
+    if (/^#{1,6}\s+trace(-mcp)?\b/i.test(headingLine)) return false;
     return competitorRe.test(body);
   });
   lines = removeEmptyParentSections(lines);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -287,7 +287,7 @@ export function createServer(
   const instructionsVerbosity = config.tools?.instructions_verbosity ?? 'full';
   const agentBehavior = config.tools?.agent_behavior ?? 'off';
   const server = new McpServer(
-    { name: 'trace-mcp', version: PKG_VERSION },
+    { name: 'trace', version: PKG_VERSION },
     { instructions: buildInstructions(detectedFrameworks, instructionsVerbosity, agentBehavior) },
   );
 

--- a/src/utils/atomic-write.ts
+++ b/src/utils/atomic-write.ts
@@ -48,22 +48,30 @@ export function atomicWriteString(
   payload: string,
   opts: AtomicWriteOptions = {},
 ): void {
-  const mode = opts.mode ?? 0o644;
   const trailingNewline = opts.trailingNewline ?? true;
   const rejectSymlinks = opts.rejectSymlinks ?? true;
 
-  if (rejectSymlinks) {
-    let linkStat: fs.Stats | null = null;
-    try {
-      linkStat = fs.lstatSync(targetPath);
-    } catch {
-      // ENOENT — fine, target doesn't exist yet
-    }
-    if (linkStat && linkStat.isSymbolicLink()) {
-      throw new Error(
-        `atomic-write: refusing to overwrite symlink at ${targetPath}. ` +
-          'Pass rejectSymlinks:false to allow writing through symlinks.',
-      );
+  let linkStat: fs.Stats | null = null;
+  try {
+    linkStat = fs.lstatSync(targetPath);
+  } catch {
+    // ENOENT — fine, target doesn't exist yet
+  }
+
+  if (rejectSymlinks && linkStat && linkStat.isSymbolicLink()) {
+    throw new Error(
+      `atomic-write: refusing to overwrite symlink at ${targetPath}. ` +
+        'Pass rejectSymlinks:false to allow writing through symlinks.',
+    );
+  }
+
+  // Preserve existing permissions on rewrite if no explicit mode was requested
+  let mode = opts.mode;
+  if (mode === undefined) {
+    if (linkStat && linkStat.isFile()) {
+      mode = linkStat.mode & 0o777;
+    } else {
+      mode = 0o644;
     }
   }
 

--- a/src/utils/path-migration.ts
+++ b/src/utils/path-migration.ts
@@ -385,12 +385,17 @@ export function migrateClientConfigServers(
     return { migrated: false };
   }
 
-  if (legacyKey in servers && !(newKey in servers)) {
+  // Legacy key alone gets moved to newKey; legacy key alongside an already-
+  // present newKey just gets dropped — either way, presence of the legacy
+  // key is what makes this a migration.
+  if (legacyKey in servers) {
     if (opts.dryRun) {
       return { migrated: true };
     }
 
-    servers[newKey] = servers[legacyKey];
+    if (!(newKey in servers)) {
+      servers[newKey] = servers[legacyKey];
+    }
     delete servers[legacyKey];
 
     atomicWriteString(configPath, JSON.stringify(parsed, null, 2), { rejectSymlinks: true });

--- a/src/utils/path-migration.ts
+++ b/src/utils/path-migration.ts
@@ -1,0 +1,401 @@
+/**
+ * Path and directory migration security helpers.
+ *
+ * Handles zero-downtime, backwards-compatible migration between:
+ *  - Global data directory: ~/.trace-mcp/ -> ~/.trace/
+ *  - Project configuration: .trace-mcp.json -> .trace.json
+ *  - Client configurations: mcpServers["trace-mcp"] -> mcpServers["trace"]
+ *
+ * Security Guarantees:
+ *  1. Symlink Safety (CWE-59): Rejects untrusted symlinks at source and destination
+ *     roots, and skips/refuses symlinks inside directory trees so attackers cannot
+ *     trick migration into reading or overwriting arbitrary system files.
+ *  2. Permission Hardening (CWE-276 / CWE-732): Enforces 0700 permissions on all
+ *     created directories and 0600 on SQLite DBs, configs, logs, and state files
+ *     (0755 on launcher shims in bin/).
+ *  3. SQLite Database Integrity (CWE-362): Atomically migrates database files
+ *     together with their WAL/SHM sidecars (-wal, -shm, -journal).
+ *  4. Atomic Writes: All config and file modifications use atomic temp-file + rename
+ *     with O_EXCL and O_NOFOLLOW to avoid corruption or partial writes.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { atomicWriteString } from './atomic-write.js';
+import { restrictDbPerms } from '../shared/db-perms.js';
+import { readIfExists } from './safe-fs.js';
+
+const IS_WINDOWS = process.platform === 'win32';
+
+export interface MigrationOptions {
+  /** Mode for created directories. Default: 0o700 */
+  dirMode?: number;
+  /** Mode for created files unless specific type applies. Default: 0o600 */
+  fileMode?: number;
+  /** Mode for executable files in bin/ directories. Default: 0o755 */
+  binMode?: number;
+  /** If true, do not perform writes on disk. Default: false */
+  dryRun?: boolean;
+  /** If true, delete source files after successful migration. Default: false */
+  removeSource?: boolean;
+}
+
+export interface MigratedItem {
+  source: string;
+  destination: string;
+  type: 'file' | 'directory' | 'db_bundle';
+  mode: number;
+}
+
+export interface SkippedItem {
+  source: string;
+  reason: 'symlink' | 'exists' | 'error';
+  detail?: string;
+}
+
+export interface DirectoryMigrationResult {
+  success: boolean;
+  migrated: MigratedItem[];
+  skipped: SkippedItem[];
+  errors: string[];
+}
+
+/**
+ * Check whether `targetPath` exists and is a symbolic link.
+ */
+export function isSymlink(targetPath: string): boolean {
+  try {
+    const st = fs.lstatSync(targetPath);
+    return st.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Assert that `targetPath` is not a symbolic link.
+ * Throws a SecurityError if a symlink is detected.
+ */
+export function assertNotSymlink(targetPath: string, context = 'path'): void {
+  if (isSymlink(targetPath)) {
+    throw new Error(
+      `Security Violation: ${context} "${targetPath}" is a symlink. Symlinks are not followed for security.`,
+    );
+  }
+}
+
+/**
+ * Recursively migrate a directory tree safely from `sourceDir` to `destDir`.
+ *
+ * - Skips/refuses all symlinks encountered inside `sourceDir`.
+ * - Sets `0700` permissions on created directories.
+ * - Bundles SQLite DBs (`.db`, `-wal`, `-shm`, `-journal`) with `0600` permissions.
+ * - Enforces `0755` on executable files in `bin/` subdirectories.
+ */
+export function migrateDirectorySafely(
+  sourceDir: string,
+  destDir: string,
+  opts: MigrationOptions = {},
+): DirectoryMigrationResult {
+  const result: DirectoryMigrationResult = {
+    success: true,
+    migrated: [],
+    skipped: [],
+    errors: [],
+  };
+
+  const dirMode = opts.dirMode ?? 0o700;
+  const fileMode = opts.fileMode ?? 0o600;
+  const binMode = opts.binMode ?? 0o755;
+  const dryRun = Boolean(opts.dryRun);
+
+  // 1. Validate root source and destination paths
+  try {
+    const srcStat = fs.lstatSync(sourceDir);
+    if (srcStat.isSymbolicLink()) {
+      const msg = `Source directory "${sourceDir}" is a symlink. Refusing to migrate.`;
+      result.errors.push(msg);
+      result.success = false;
+      return result;
+    }
+    if (!srcStat.isDirectory()) {
+      const msg = `Source path "${sourceDir}" is not a directory.`;
+      result.errors.push(msg);
+      result.success = false;
+      return result;
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      // Source does not exist — nothing to migrate
+      return result;
+    }
+    result.errors.push(`Failed to stat source "${sourceDir}": ${(err as Error).message}`);
+    result.success = false;
+    return result;
+  }
+
+  try {
+    const destStat = fs.lstatSync(destDir);
+    if (destStat.isSymbolicLink()) {
+      const msg = `Destination directory "${destDir}" is an existing symlink. Refusing to overwrite.`;
+      result.errors.push(msg);
+      result.success = false;
+      return result;
+    }
+  } catch {
+    // Destination doesn't exist yet — standard path
+  }
+
+  // Prevent recursive migration if destination is inside source
+  const absSrc = path.resolve(sourceDir);
+  const absDest = path.resolve(destDir);
+  if (absDest.startsWith(absSrc + path.sep)) {
+    result.errors.push(`Destination "${destDir}" is inside source "${sourceDir}". Aborting.`);
+    result.success = false;
+    return result;
+  }
+
+  // 2. Create destination directory with 0700
+  if (!dryRun && !fs.existsSync(destDir)) {
+    fs.mkdirSync(destDir, { recursive: true });
+    if (!IS_WINDOWS) {
+      try {
+        fs.chmodSync(destDir, dirMode);
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+
+  // 3. Process entries
+  const processedSidecars = new Set<string>();
+
+  function walk(currentSrc: string, currentDest: string) {
+    let entries: fs.Dirent[] = [];
+    try {
+      entries = fs.readdirSync(currentSrc, { withFileTypes: true });
+    } catch (err) {
+      result.errors.push(`Failed to read directory "${currentSrc}": ${(err as Error).message}`);
+      return;
+    }
+
+    for (const entry of entries) {
+      const srcItem = path.join(currentSrc, entry.name);
+      const destItem = path.join(currentDest, entry.name);
+
+      let itemStat: fs.Stats;
+      try {
+        itemStat = fs.lstatSync(srcItem);
+      } catch (err) {
+        result.skipped.push({ source: srcItem, reason: 'error', detail: (err as Error).message });
+        continue;
+      }
+
+      // GUARD: Reject symlinks inside migration tree
+      if (itemStat.isSymbolicLink()) {
+        result.skipped.push({
+          source: srcItem,
+          reason: 'symlink',
+          detail: 'Symlinks within data directory are not migrated for security.',
+        });
+        continue;
+      }
+
+      if (itemStat.isDirectory()) {
+        if (!dryRun && !fs.existsSync(destItem)) {
+          fs.mkdirSync(destItem, { recursive: true });
+          if (!IS_WINDOWS) {
+            try {
+              fs.chmodSync(destItem, dirMode);
+            } catch {
+              /* best-effort */
+            }
+          }
+        }
+        result.migrated.push({
+          source: srcItem,
+          destination: destItem,
+          type: 'directory',
+          mode: dirMode,
+        });
+        walk(srcItem, destItem);
+        continue;
+      }
+
+      if (itemStat.isFile()) {
+        // Skip sidecars already handled as part of a DB bundle
+        if (processedSidecars.has(srcItem)) {
+          continue;
+        }
+
+        // Detect SQLite database files
+        if (entry.name.endsWith('.db')) {
+          const mode = fileMode;
+          if (!dryRun) {
+            copyFileAtomic(srcItem, destItem, mode);
+            restrictDbPerms(destItem);
+
+            // Copy accompanying WAL/SHM sidecars if present
+            for (const suffix of ['-wal', '-shm', '-journal']) {
+              const sidecarSrc = srcItem + suffix;
+              const sidecarDest = destItem + suffix;
+              try {
+                const sStat = fs.lstatSync(sidecarSrc);
+                if (sStat.isFile() && !sStat.isSymbolicLink()) {
+                  copyFileAtomic(sidecarSrc, sidecarDest, mode);
+                  restrictDbPerms(destItem);
+                  processedSidecars.add(sidecarSrc);
+                }
+              } catch {
+                // Sidecar not present — fine
+              }
+            }
+          }
+
+          result.migrated.push({
+            source: srcItem,
+            destination: destItem,
+            type: 'db_bundle',
+            mode,
+          });
+          continue;
+        }
+
+        // Executables in bin/
+        const isBin = currentSrc.endsWith(`${path.sep}bin`) || currentSrc.endsWith('/bin');
+        const mode = isBin ? binMode : fileMode;
+
+        if (!dryRun) {
+          copyFileAtomic(srcItem, destItem, mode);
+        }
+
+        result.migrated.push({
+          source: srcItem,
+          destination: destItem,
+          type: 'file',
+          mode,
+        });
+      }
+    }
+  }
+
+  walk(sourceDir, destDir);
+
+  if (result.errors.length > 0) {
+    result.success = false;
+  }
+
+  return result;
+}
+
+/**
+ * Safely copy a single file with atomic rename and strict permissions.
+ */
+function copyFileAtomic(source: string, destination: string, mode: number): void {
+  const content = fs.readFileSync(source);
+  const destDir = path.dirname(destination);
+  if (!fs.existsSync(destDir)) {
+    fs.mkdirSync(destDir, { recursive: true });
+  }
+  atomicWriteString(destination, content.toString('utf-8'), {
+    mode,
+    rejectSymlinks: true,
+    trailingNewline: false,
+  });
+}
+
+/**
+ * Migrate project configuration file from `.trace-mcp.json` to `.trace.json`.
+ */
+export function migrateProjectConfig(
+  projectRoot: string,
+  opts: { dryRun?: boolean } = {},
+): { migrated: boolean; action: 'created' | 'already_present' | 'skipped'; detail?: string } {
+  const legacyConfig = path.join(projectRoot, '.trace-mcp.json');
+  const newConfig = path.join(projectRoot, '.trace.json');
+
+  if (fs.existsSync(newConfig)) {
+    return { migrated: false, action: 'already_present', detail: '.trace.json already exists' };
+  }
+
+  if (!fs.existsSync(legacyConfig)) {
+    return { migrated: false, action: 'skipped', detail: 'No legacy .trace-mcp.json found' };
+  }
+
+  if (isSymlink(legacyConfig)) {
+    return { migrated: false, action: 'skipped', detail: 'Legacy config is a symlink; skipping.' };
+  }
+
+  const raw = readIfExists(legacyConfig);
+  if (raw === null) {
+    return { migrated: false, action: 'skipped', detail: 'Could not read legacy config' };
+  }
+
+  if (opts.dryRun) {
+    return {
+      migrated: true,
+      action: 'created',
+      detail: 'Would copy .trace-mcp.json to .trace.json',
+    };
+  }
+
+  // Preserve permissions from legacy file
+  let mode = 0o600;
+  try {
+    const st = fs.statSync(legacyConfig);
+    mode = st.mode & 0o777;
+  } catch {
+    /* fallback to 0600 */
+  }
+
+  atomicWriteString(newConfig, raw, { mode, rejectSymlinks: true });
+  return { migrated: true, action: 'created', detail: 'Migrated .trace-mcp.json to .trace.json' };
+}
+
+/**
+ * Migrate legacy client configuration entries (e.g. mcpServers['trace-mcp'] -> mcpServers['trace']).
+ */
+export function migrateClientConfigServers(
+  configPath: string,
+  legacyKey = 'trace-mcp',
+  newKey = 'trace',
+  opts: { dryRun?: boolean } = {},
+): { migrated: boolean; error?: string } {
+  if (isSymlink(configPath)) {
+    return {
+      migrated: false,
+      error: `Config path "${configPath}" is a symlink. Refusing to write.`,
+    };
+  }
+
+  const raw = readIfExists(configPath);
+  if (raw === null) {
+    return { migrated: false };
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return { migrated: false, error: `Failed to parse JSON: ${(err as Error).message}` };
+  }
+
+  const servers = parsed.mcpServers as Record<string, unknown> | undefined;
+  if (!servers || typeof servers !== 'object') {
+    return { migrated: false };
+  }
+
+  if (legacyKey in servers && !(newKey in servers)) {
+    if (opts.dryRun) {
+      return { migrated: true };
+    }
+
+    servers[newKey] = servers[legacyKey];
+    delete servers[legacyKey];
+
+    atomicWriteString(configPath, JSON.stringify(parsed, null, 2), { rejectSymlinks: true });
+    return { migrated: true };
+  }
+
+  return { migrated: false };
+}

--- a/tests/cli/env-overrides.test.ts
+++ b/tests/cli/env-overrides.test.ts
@@ -35,7 +35,7 @@ function runWithEnv(script: string, env: Record<string, string>): string {
 }
 
 describe('TRACE_MCP_DATA_DIR', () => {
-  it('overrides ~/.trace-mcp/ when set to an absolute path', () => {
+  it('overrides ~/.trace/ when set to an absolute path', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'trace-data-'));
     const out = runWithEnv(
       `import { TRACE_MCP_HOME } from './src/global.ts'; console.log(TRACE_MCP_HOME);`,
@@ -53,12 +53,12 @@ describe('TRACE_MCP_DATA_DIR', () => {
     expect(out).not.toBe('~/custom-trace-mcp'); // expansion must have happened
   });
 
-  it('falls back to ~/.trace-mcp when env var is empty', () => {
+  it('falls back to ~/.trace when env var is empty', () => {
     const out = runWithEnv(
       `import { TRACE_MCP_HOME } from './src/global.ts'; console.log(TRACE_MCP_HOME);`,
       { TRACE_MCP_DATA_DIR: '' },
     );
-    expect(fwd(out).endsWith('/.trace-mcp')).toBe(true);
+    expect(fwd(out).endsWith('/.trace')).toBe(true);
   });
 });
 

--- a/tests/init/claude-md.test.ts
+++ b/tests/init/claude-md.test.ts
@@ -75,7 +75,7 @@ describe('updateClaudeMd', () => {
     const content = String(mockFs.writeFileSync.mock.calls[0][1]);
     expect(content).toContain(START_MARKER);
     expect(content).toContain(END_MARKER);
-    expect(content).toContain('trace-mcp Tool Routing');
+    expect(content).toContain('trace Tool Routing');
   });
 
   it('uses global path when scope is global', () => {

--- a/tests/init/launcher.test.ts
+++ b/tests/init/launcher.test.ts
@@ -34,15 +34,15 @@ describe('launcher config paths', () => {
 
   it('honors $TRACE_MCP_HOME override', () => {
     // On Windows the launcher is a .cmd shim; on POSIX it's a bare bash script.
-    const launcherName = process.platform === 'win32' ? 'trace-mcp.cmd' : 'trace-mcp';
+    const launcherName = process.platform === 'win32' ? 'trace.cmd' : 'trace';
     expect(getLauncherDir()).toBe(tmp);
     expect(getLauncherPath()).toBe(path.join(tmp, 'bin', launcherName));
     expect(getLauncherConfigPath()).toBe(path.join(tmp, 'launcher.env'));
   });
 
-  it('falls back to ~/.trace-mcp when env var absent', () => {
+  it('falls back to ~/.trace when env var absent', () => {
     delete process.env.TRACE_MCP_HOME;
-    expect(getLauncherDir()).toBe(path.join(os.homedir(), '.trace-mcp'));
+    expect(getLauncherDir()).toBe(path.join(os.homedir(), '.trace'));
   });
 });
 

--- a/tests/init/mcp-client-status.test.ts
+++ b/tests/init/mcp-client-status.test.ts
@@ -82,7 +82,7 @@ describe('getMcpClientStatuses', () => {
 
     const cursorEntry = JSON.parse(
       fs.readFileSync(path.join(fakeHome, '.cursor', 'mcp.json'), 'utf-8'),
-    ).mcpServers['trace-mcp'];
+    ).mcpServers['trace'];
     expect(cursorEntry.cwd).toBeUndefined();
   });
 
@@ -90,7 +90,7 @@ describe('getMcpClientStatuses', () => {
     configureMcpClients(['cursor'], projectRoot, { scope: 'global' });
     const configPath = path.join(fakeHome, '.cursor', 'mcp.json');
     const c = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    c.mcpServers['trace-mcp'].cwd = '/some/stale/path';
+    c.mcpServers['trace'].cwd = '/some/stale/path';
     fs.writeFileSync(configPath, JSON.stringify(c, null, 2));
 
     const [before] = getMcpClientStatuses(projectRoot, 'global', ['cursor']);
@@ -101,7 +101,7 @@ describe('getMcpClientStatuses', () => {
     const [after] = getMcpClientStatuses(projectRoot, 'global', ['cursor']);
     expect(after.status).toBe('up_to_date');
     expect(
-      JSON.parse(fs.readFileSync(configPath, 'utf-8')).mcpServers['trace-mcp'].cwd,
+      JSON.parse(fs.readFileSync(configPath, 'utf-8')).mcpServers['trace'].cwd,
     ).toBeUndefined();
   });
 
@@ -112,7 +112,7 @@ describe('getMcpClientStatuses', () => {
     configureMcpClients(['claude-code'], projectRoot, { scope: 'global' });
     const configPath = path.join(fakeHome, '.claude.json');
     const c = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    c.mcpServers['trace-mcp'].alwaysLoad = true;
+    c.mcpServers['trace'].alwaysLoad = true;
     fs.writeFileSync(configPath, JSON.stringify(c, null, 2));
 
     const [s] = getMcpClientStatuses(projectRoot, 'global', ['claude-code']);
@@ -127,7 +127,7 @@ describe('getMcpClientStatuses', () => {
       JSON.stringify(
         {
           mcpServers: {
-            'trace-mcp': {
+            trace: {
               command: '/old/path/that/no/longer/matches',
               args: ['serve'],
               alwaysLoad: true,
@@ -143,18 +143,41 @@ describe('getMcpClientStatuses', () => {
     expect(s.staleReason).toBe('command');
   });
 
+  it('flags `stale` reason="legacy-key" when only the pre-TRA-611 trace-mcp key is present', () => {
+    const configPath = path.join(fakeHome, '.claude.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        { mcpServers: { 'trace-mcp': { command: '/some/launcher', args: ['serve'] } } },
+        null,
+        2,
+      ),
+    );
+    const [s] = getMcpClientStatuses(projectRoot, 'global', ['claude-code']);
+    expect(s.status).toBe('stale');
+    expect(s.staleReason).toBe('legacy-key');
+
+    // Re-running configureMcpClients migrates it: legacy key gone, new key written.
+    configureMcpClients(['claude-code'], projectRoot, { scope: 'global' });
+    const c = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(c.mcpServers['trace-mcp']).toBeUndefined();
+    expect(c.mcpServers.trace.command).toBeDefined();
+    const [after] = getMcpClientStatuses(projectRoot, 'global', ['claude-code']);
+    expect(after.status).toBe('up_to_date');
+  });
+
   it('flags `stale` reason="args" when args change', () => {
     configureMcpClients(['claude-code'], projectRoot, { scope: 'global' });
     const configPath = path.join(fakeHome, '.claude.json');
     const c = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    c.mcpServers['trace-mcp'].args = ['serve', '--legacy'];
+    c.mcpServers['trace'].args = ['serve', '--legacy'];
     fs.writeFileSync(configPath, JSON.stringify(c, null, 2));
     const [s] = getMcpClientStatuses(projectRoot, 'global', ['claude-code']);
     expect(s.status).toBe('stale');
     expect(s.staleReason).toBe('args');
   });
 
-  it('reports `missing` when mcpServers exists but trace-mcp entry is absent', () => {
+  it('reports `missing` when mcpServers exists but no trace entry is present', () => {
     const configPath = path.join(fakeHome, '.claude.json');
     fs.writeFileSync(
       configPath,
@@ -170,7 +193,7 @@ describe('getMcpClientStatuses', () => {
     expect(s.status).toBe('up_to_date');
     // Sanity: ensure the entry on disk indeed has no alwaysLoad field.
     const onDisk = JSON.parse(fs.readFileSync(s.configPath as string, 'utf-8'));
-    expect(onDisk.mcpServers['trace-mcp'].alwaysLoad).toBeUndefined();
+    expect(onDisk.mcpServers['trace'].alwaysLoad).toBeUndefined();
   });
 
   it('does not set alwaysLoad on claude-code either (GH #354)', () => {
@@ -179,7 +202,7 @@ describe('getMcpClientStatuses', () => {
     expect(s.status).toBe('up_to_date');
     const configPath = path.join(fakeHome, '.claude.json');
     const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    expect(onDisk.mcpServers['trace-mcp'].alwaysLoad).toBeUndefined();
+    expect(onDisk.mcpServers['trace'].alwaysLoad).toBeUndefined();
   });
 
   it('returns a status for every client when called with no name filter', () => {
@@ -230,7 +253,7 @@ describe('getMcpClientStatuses', () => {
     const [s] = getMcpClientStatuses(projectRoot, 'global', ['cline']);
     const configPath = s.configPath as string;
     const c = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    c.mcpServers['trace-mcp'].command = '/old/launcher/path';
+    c.mcpServers['trace'].command = '/old/launcher/path';
     fs.writeFileSync(configPath, JSON.stringify(c, null, 2));
     const [drifted] = getMcpClientStatuses(projectRoot, 'global', ['cline']);
     expect(drifted.status).toBe('stale');

--- a/tests/init/mcp-client-status.test.ts
+++ b/tests/init/mcp-client-status.test.ts
@@ -166,6 +166,27 @@ describe('getMcpClientStatuses', () => {
     expect(after.status).toBe('up_to_date');
   });
 
+  it('flags `stale` reason="legacy-key" — not `up_to_date` — when both trace and a stale trace-mcp key are present', () => {
+    // A correct `trace` entry sitting next to a leftover `trace-mcp` one (a
+    // previous migration run interrupted partway, or a hand-edited config)
+    // must not read as already_configured: the client would keep spawning
+    // two copies of the same server until the stale key is actually removed.
+    const configPath = path.join(fakeHome, '.claude.json');
+    configureMcpClients(['claude-code'], projectRoot, { scope: 'global' });
+    const c = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    c.mcpServers['trace-mcp'] = { command: '/stale/launcher', args: ['serve'] };
+    fs.writeFileSync(configPath, JSON.stringify(c, null, 2));
+
+    const [s] = getMcpClientStatuses(projectRoot, 'global', ['claude-code']);
+    expect(s.status).toBe('stale');
+    expect(s.staleReason).toBe('legacy-key');
+
+    configureMcpClients(['claude-code'], projectRoot, { scope: 'global' });
+    const after = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(after.mcpServers['trace-mcp']).toBeUndefined();
+    expect(after.mcpServers.trace.command).toBeDefined();
+  });
+
   it('flags `stale` reason="args" when args change', () => {
     configureMcpClients(['claude-code'], projectRoot, { scope: 'global' });
     const configPath = path.join(fakeHome, '.claude.json');

--- a/tests/init/mcp-clients-extra.test.ts
+++ b/tests/init/mcp-clients-extra.test.ts
@@ -149,7 +149,7 @@ describe('AMP writer round-trip', () => {
     const after = fs.readFileSync(file, 'utf-8');
     expect(after).toContain('// User-managed AMP settings');
     expect(after).toContain('// existing servers');
-    expect(after).toContain('"trace-mcp"');
+    expect(after).toContain('"trace"');
     expect(after).toContain('"linear"');
   });
 
@@ -160,13 +160,29 @@ describe('AMP writer round-trip', () => {
     const file = path.join(fakeHome, '.config', 'amp', 'settings.json');
     expect(fs.existsSync(file)).toBe(true);
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
-    expect(parsed['amp.mcpServers']?.['trace-mcp']?.args).toEqual(['serve']);
+    expect(parsed['amp.mcpServers']?.['trace']?.args).toEqual(['serve']);
   });
 
   it('reports already_configured when entry matches', () => {
     configureMcpClients(['amp'], projectRoot, { scope: 'global' });
     const second = configureMcpClients(['amp'], projectRoot, { scope: 'global' });
     expect(second[0].action).toBe('already_configured');
+  });
+
+  it('migrates a legacy "trace-mcp" entry to "trace" in place', () => {
+    const dir = path.join(fakeHome, '.config', 'amp');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'settings.json');
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ 'amp.mcpServers': { 'trace-mcp': { command: '/old/launcher', args: ['serve'] } } }),
+    );
+
+    configureMcpClients(['amp'], projectRoot, { scope: 'global' });
+
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(parsed['amp.mcpServers']['trace-mcp']).toBeUndefined();
+    expect(parsed['amp.mcpServers'].trace.args).toEqual(['serve']);
   });
 });
 
@@ -177,7 +193,7 @@ describe('Factory Droid writer', () => {
     expect(step.action).toBe('created');
     const file = path.join(fakeHome, '.factory', 'mcp.json');
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
-    const entry = parsed.mcpServers['trace-mcp'];
+    const entry = parsed.mcpServers['trace'];
     expect(entry.type).toBe('stdio');
     expect(entry.args).toEqual(['serve']);
     // Global scope carries no cwd — see TRA-501.
@@ -188,10 +204,10 @@ describe('Factory Droid writer', () => {
     configureMcpClients(['factory-droid'], projectRoot, { scope: 'project' });
     const file = path.join(projectRoot, '.factory', 'mcp.json');
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
-    expect(parsed.mcpServers['trace-mcp'].cwd).toBe(projectRoot);
+    expect(parsed.mcpServers['trace'].cwd).toBe(projectRoot);
   });
 
-  it('preserves existing servers when adding trace-mcp', () => {
+  it('preserves existing servers when adding trace', () => {
     const file = path.join(fakeHome, '.factory', 'mcp.json');
     fs.mkdirSync(path.dirname(file), { recursive: true });
     fs.writeFileSync(
@@ -203,7 +219,22 @@ describe('Factory Droid writer', () => {
     configureMcpClients(['factory-droid'], projectRoot, { scope: 'global' });
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
     expect(parsed.mcpServers.linear).toBeDefined();
-    expect(parsed.mcpServers['trace-mcp']).toBeDefined();
+    expect(parsed.mcpServers['trace']).toBeDefined();
+  });
+
+  it('migrates a legacy "trace-mcp" entry to "trace" in place', () => {
+    const file = path.join(fakeHome, '.factory', 'mcp.json');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        mcpServers: { 'trace-mcp': { type: 'stdio', command: '/old/launcher', args: ['serve'] } },
+      }),
+    );
+    configureMcpClients(['factory-droid'], projectRoot, { scope: 'global' });
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(parsed.mcpServers['trace-mcp']).toBeUndefined();
+    expect(parsed.mcpServers.trace.type).toBe('stdio');
   });
 });
 
@@ -294,7 +325,7 @@ describe('Kimi detection', () => {
 });
 
 describe('Cline / KiloCode / Antigravity / Kimi writers (standard mcpServers)', () => {
-  it('Cline: creates cline_mcp_settings.json with trace-mcp serve entry', () => {
+  it('Cline: creates cline_mcp_settings.json with trace serve entry', () => {
     const results = configureMcpClients(['cline'], projectRoot, { scope: 'global' });
     expect(results[0].action).toBe('created');
     const file = path.join(
@@ -305,7 +336,7 @@ describe('Cline / KiloCode / Antigravity / Kimi writers (standard mcpServers)', 
       'cline_mcp_settings.json',
     );
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
-    const entry = parsed.mcpServers['trace-mcp'];
+    const entry = parsed.mcpServers['trace'];
     expect(entry.args).toEqual(['serve']);
     // Cline's config is global-only, so it never carries a project cwd (TRA-501).
     expect(entry.cwd).toBeUndefined();
@@ -329,7 +360,7 @@ describe('Cline / KiloCode / Antigravity / Kimi writers (standard mcpServers)', 
     configureMcpClients(['kilocode'], projectRoot, { scope: 'global' });
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
     expect(parsed.mcpServers.linear).toBeDefined();
-    expect(parsed.mcpServers['trace-mcp'].args).toEqual(['serve']);
+    expect(parsed.mcpServers['trace'].args).toEqual(['serve']);
   });
 
   it('Antigravity: writes ~/.gemini/config/mcp_config.json', () => {
@@ -337,7 +368,7 @@ describe('Cline / KiloCode / Antigravity / Kimi writers (standard mcpServers)', 
     expect(results[0].action).toBe('created');
     const file = path.join(fakeHome, '.gemini', 'config', 'mcp_config.json');
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
-    expect(parsed.mcpServers['trace-mcp'].args).toEqual(['serve']);
+    expect(parsed.mcpServers['trace'].args).toEqual(['serve']);
   });
 
   it('Kimi: writes ~/.kimi/mcp.json and reports already_configured on re-run', () => {
@@ -350,12 +381,80 @@ describe('Cline / KiloCode / Antigravity / Kimi writers (standard mcpServers)', 
   });
 });
 
+describe('Hermes YAML writer', () => {
+  function configPath(): string {
+    return path.join(fakeHome, '.hermes', 'config.yaml');
+  }
+
+  it('writes a new config.yaml with a trace mcp_servers entry', () => {
+    const results = configureMcpClients(['hermes'], projectRoot, { scope: 'global' });
+    expect(results[0].action).toBe('created');
+    const content = fs.readFileSync(configPath(), 'utf-8');
+    expect(content).toMatch(/mcp_servers:\s*\n\s+trace:/);
+    expect(content).not.toContain('trace-mcp:');
+  });
+
+  it('migrates a legacy "trace-mcp" entry to "trace", preserving comments', () => {
+    const file = configPath();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      ['# user comment', 'mcp_servers:', '  trace-mcp:', '    command: /old/launcher', '    args:', '      - serve', ''].join(
+        '\n',
+      ),
+    );
+    configureMcpClients(['hermes'], projectRoot, { scope: 'global' });
+    const content = fs.readFileSync(file, 'utf-8');
+    expect(content).toContain('# user comment');
+    expect(content).not.toContain('trace-mcp:');
+    expect(content).toMatch(/mcp_servers:\s*\n\s+trace:/);
+  });
+});
+
+describe('Codex TOML writer', () => {
+  function configPath(): string {
+    return path.join(fakeHome, '.codex', 'config.toml');
+  }
+
+  it('appends a [mcp_servers.trace] section to a new file', () => {
+    const results = configureMcpClients(['codex'], projectRoot, { scope: 'global' });
+    expect(results[0].action).toBe('created');
+    const content = fs.readFileSync(configPath(), 'utf-8');
+    expect(content).toContain('[mcp_servers.trace]');
+    expect(content).not.toContain('[mcp_servers.trace-mcp]');
+  });
+
+  it('migrates a legacy [mcp_servers.trace-mcp] section (with .env sub-table) in place', () => {
+    const file = configPath();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      [
+        '[some_other_tool]',
+        'command = "keep-me"',
+        '',
+        '[mcp_servers.trace-mcp]',
+        'command = "/old/launcher"',
+        'args = ["serve"]',
+        '[mcp_servers.trace-mcp.env]',
+        'FOO = "bar"',
+        '',
+      ].join('\n'),
+    );
+    configureMcpClients(['codex'], projectRoot, { scope: 'global' });
+    const content = fs.readFileSync(file, 'utf-8');
+    expect(content).toContain('[some_other_tool]'); // untouched, unrelated section survives
+    expect(content).not.toContain('[mcp_servers.trace-mcp]');
+    expect(content).toContain('[mcp_servers.trace]');
+  });
+});
+
 describe('Warp configuration', () => {
   it('always returns skipped with paste-snippet detail', () => {
     const results = configureMcpClients(['warp'], projectRoot, { scope: 'global' });
     expect(results[0].action).toBe('skipped');
     expect(results[0].detail).toContain('Settings');
-    expect(results[0].detail).toContain('"trace-mcp"');
+    expect(results[0].detail).toContain('"trace"');
   });
 
   it('includes claude-code inheritance hint when both selected', () => {

--- a/tests/init/mcp-clients-extra.test.ts
+++ b/tests/init/mcp-clients-extra.test.ts
@@ -455,6 +455,32 @@ describe('Codex TOML writer', () => {
     expect(content).not.toContain('[mcp_servers.trace-mcp]');
     expect(content).toContain('[mcp_servers.trace]');
   });
+
+  it('does not duplicate [mcp_servers.trace] when both the new and legacy sections already exist', () => {
+    // An interrupted prior migration, or a hand-edited config, can leave both
+    // sections present. Appending a fresh [mcp_servers.trace] block on top of
+    // an existing one produces two headers with the same name, which is
+    // invalid TOML.
+    const file = configPath();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      [
+        '[mcp_servers.trace]',
+        'command = "/old/launcher"',
+        'args = ["serve"]',
+        '',
+        '[mcp_servers.trace-mcp]',
+        'command = "/old/launcher"',
+        'args = ["serve"]',
+        '',
+      ].join('\n'),
+    );
+    configureMcpClients(['codex'], projectRoot, { scope: 'global' });
+    const content = fs.readFileSync(file, 'utf-8');
+    expect(content.match(/\[mcp_servers\.trace\]/g)).toHaveLength(1);
+    expect(content).not.toContain('[mcp_servers.trace-mcp]');
+  });
 });
 
 describe('Warp configuration', () => {

--- a/tests/init/mcp-clients-extra.test.ts
+++ b/tests/init/mcp-clients-extra.test.ts
@@ -175,7 +175,9 @@ describe('AMP writer round-trip', () => {
     const file = path.join(dir, 'settings.json');
     fs.writeFileSync(
       file,
-      JSON.stringify({ 'amp.mcpServers': { 'trace-mcp': { command: '/old/launcher', args: ['serve'] } } }),
+      JSON.stringify({
+        'amp.mcpServers': { 'trace-mcp': { command: '/old/launcher', args: ['serve'] } },
+      }),
     );
 
     configureMcpClients(['amp'], projectRoot, { scope: 'global' });
@@ -399,9 +401,15 @@ describe('Hermes YAML writer', () => {
     fs.mkdirSync(path.dirname(file), { recursive: true });
     fs.writeFileSync(
       file,
-      ['# user comment', 'mcp_servers:', '  trace-mcp:', '    command: /old/launcher', '    args:', '      - serve', ''].join(
-        '\n',
-      ),
+      [
+        '# user comment',
+        'mcp_servers:',
+        '  trace-mcp:',
+        '    command: /old/launcher',
+        '    args:',
+        '      - serve',
+        '',
+      ].join('\n'),
     );
     configureMcpClients(['hermes'], projectRoot, { scope: 'global' });
     const content = fs.readFileSync(file, 'utf-8');

--- a/tests/scripts/postinstall-control-plane.test.ts
+++ b/tests/scripts/postinstall-control-plane.test.ts
@@ -203,8 +203,11 @@ describe('postinstall-control-plane', () => {
         // worker process so the suite never touches the real ~/.trace — this
         // test exercises the *default* (unoverridden) resolution, so clear
         // both env vars the script accepts as an override (see global.ts).
+        // os.homedir() reads USERPROFILE on Windows, not HOME — set both so
+        // the child resolves to the same fake home regardless of platform.
         env: buildEnv({
           HOME: home,
+          USERPROFILE: home,
           CI: 'true',
           TRACE_MCP_DATA_DIR: undefined,
           TRACE_MCP_HOME: undefined,

--- a/tests/scripts/postinstall-control-plane.test.ts
+++ b/tests/scripts/postinstall-control-plane.test.ts
@@ -203,7 +203,12 @@ describe('postinstall-control-plane', () => {
         // worker process so the suite never touches the real ~/.trace — this
         // test exercises the *default* (unoverridden) resolution, so clear
         // both env vars the script accepts as an override (see global.ts).
-        env: buildEnv({ HOME: home, CI: 'true', TRACE_MCP_DATA_DIR: undefined, TRACE_MCP_HOME: undefined }),
+        env: buildEnv({
+          HOME: home,
+          CI: 'true',
+          TRACE_MCP_DATA_DIR: undefined,
+          TRACE_MCP_HOME: undefined,
+        }),
         stdio: ['ignore', 'pipe', 'pipe'],
         encoding: 'utf-8',
       });
@@ -217,12 +222,19 @@ describe('postinstall-control-plane', () => {
       const shimName = process.platform === 'win32' ? 'trace.cmd' : 'trace';
       expect(fs.existsSync(path.join(newHome, 'bin', shimName))).toBe(true);
 
+      // Durable marker: a later `trace init`/postinstall run must be able to
+      // retry the compat symlink below even if this run's attempt had failed,
+      // so this has to outlive the one-shot in-process migration flag.
+      expect(fs.existsSync(path.join(newHome, '.migrated-from-trace-mcp'))).toBe(true);
+
       // Legacy absolute path a pre-rename MCP client config still points at.
       const legacyShimName = process.platform === 'win32' ? 'trace-mcp.cmd' : 'trace-mcp';
       const legacyShimPath = path.join(legacyHome, 'bin', legacyShimName);
       const legacyStat = fs.lstatSync(legacyShimPath);
       expect(legacyStat.isSymbolicLink()).toBe(true);
-      expect(fs.realpathSync(legacyShimPath)).toBe(fs.realpathSync(path.join(newHome, 'bin', shimName)));
+      expect(fs.realpathSync(legacyShimPath)).toBe(
+        fs.realpathSync(path.join(newHome, 'bin', shimName)),
+      );
     } finally {
       fs.rmSync(fakePkg, { recursive: true, force: true });
     }

--- a/tests/scripts/postinstall-control-plane.test.ts
+++ b/tests/scripts/postinstall-control-plane.test.ts
@@ -79,7 +79,7 @@ describe('postinstall-control-plane', () => {
     expect(result.status).toBe(0);
     // launcher.env should NOT be written when opt-out is active.
     expect(fs.existsSync(path.join(home, 'launcher.env'))).toBe(false);
-    expect(fs.existsSync(path.join(home, 'bin', 'trace-mcp'))).toBe(false);
+    expect(fs.existsSync(path.join(home, 'bin', 'trace'))).toBe(false);
   });
 
   it('skips dev checkout (.git next to package.json)', () => {
@@ -144,7 +144,7 @@ describe('postinstall-control-plane', () => {
       expect(envContent).toMatch(/^TRACE_MCP_CLI=".*\/dist\/cli\.js"$/m);
       expect(envContent).toMatch(/^TRACE_MCP_VERSION="9\.9\.9-test"$/m);
 
-      const shimName = process.platform === 'win32' ? 'trace-mcp.cmd' : 'trace-mcp';
+      const shimName = process.platform === 'win32' ? 'trace.cmd' : 'trace';
       const shimPath = path.join(home, 'bin', shimName);
       expect(fs.existsSync(shimPath)).toBe(true);
 
@@ -164,6 +164,65 @@ describe('postinstall-control-plane', () => {
       expect(Buffer.compare(shim1, shim2)).toBe(0);
       // Suppress unused-variable lint for result1; the assertion above already ran.
       void result1;
+    } finally {
+      fs.rmSync(fakePkg, { recursive: true, force: true });
+    }
+  });
+
+  it('migrates a pre-existing ~/.trace-mcp home dir to ~/.trace and preserves a legacy bin symlink', () => {
+    // No TRACE_MCP_DATA_DIR override this time — exercise the real default
+    // resolution (~/.trace, migrated from ~/.trace-mcp) instead of pinning it.
+    const fakePkg = mkTmp('trace-mcp-fakepkg-');
+    try {
+      fs.mkdirSync(path.join(fakePkg, 'scripts'), { recursive: true });
+      fs.mkdirSync(path.join(fakePkg, 'hooks'), { recursive: true });
+      fs.mkdirSync(path.join(fakePkg, 'dist'), { recursive: true });
+      fs.copyFileSync(SCRIPT_PATH, path.join(fakePkg, 'scripts', 'postinstall-control-plane.mjs'));
+      for (const name of [
+        'trace-mcp-launcher.sh',
+        'trace-mcp-launcher.cmd',
+        'trace-mcp-launcher.ps1',
+      ]) {
+        const src = path.join(REPO_ROOT, 'hooks', name);
+        if (fs.existsSync(src)) fs.copyFileSync(src, path.join(fakePkg, 'hooks', name));
+      }
+      fs.writeFileSync(path.join(fakePkg, 'dist', 'cli.js'), '// fake\n');
+      fs.writeFileSync(
+        path.join(fakePkg, 'package.json'),
+        JSON.stringify({ name: 'trace-mcp', version: '9.9.9-test' }),
+      );
+
+      // Pre-existing ~/.trace-mcp with a marker file, as a real pre-TRA-611 install would have.
+      const legacyHome = path.join(home, '.trace-mcp');
+      fs.mkdirSync(legacyHome, { recursive: true });
+      fs.writeFileSync(path.join(legacyHome, 'registry.json'), '{"marker":true}');
+
+      const fakeScript = path.join(fakePkg, 'scripts', 'postinstall-control-plane.mjs');
+      execFileSync(process.execPath, [fakeScript], {
+        // tests/setup/isolate-home.ts pins TRACE_MCP_DATA_DIR for the whole
+        // worker process so the suite never touches the real ~/.trace — this
+        // test exercises the *default* (unoverridden) resolution, so clear
+        // both env vars the script accepts as an override (see global.ts).
+        env: buildEnv({ HOME: home, CI: 'true', TRACE_MCP_DATA_DIR: undefined, TRACE_MCP_HOME: undefined }),
+        stdio: ['ignore', 'pipe', 'pipe'],
+        encoding: 'utf-8',
+      });
+
+      const newHome = path.join(home, '.trace');
+      // The rename carried the marker file over — not a copy that left a stale duplicate.
+      expect(fs.readFileSync(path.join(newHome, 'registry.json'), 'utf-8')).toBe('{"marker":true}');
+      // Old data doesn't linger behind at the legacy path — only the compat symlink (below) does.
+      expect(fs.existsSync(path.join(legacyHome, 'registry.json'))).toBe(false);
+
+      const shimName = process.platform === 'win32' ? 'trace.cmd' : 'trace';
+      expect(fs.existsSync(path.join(newHome, 'bin', shimName))).toBe(true);
+
+      // Legacy absolute path a pre-rename MCP client config still points at.
+      const legacyShimName = process.platform === 'win32' ? 'trace-mcp.cmd' : 'trace-mcp';
+      const legacyShimPath = path.join(legacyHome, 'bin', legacyShimName);
+      const legacyStat = fs.lstatSync(legacyShimPath);
+      expect(legacyStat.isSymbolicLink()).toBe(true);
+      expect(fs.realpathSync(legacyShimPath)).toBe(fs.realpathSync(path.join(newHome, 'bin', shimName)));
     } finally {
       fs.rmSync(fakePkg, { recursive: true, force: true });
     }

--- a/tests/utils/atomic-write.test.ts
+++ b/tests/utils/atomic-write.test.ts
@@ -78,6 +78,18 @@ describe('atomicWriteString', () => {
     expect(st.mode & 0o777).toBe(0o600);
   });
 
+  it('preserves existing file permissions when opts.mode is omitted', () => {
+    if (process.platform === 'win32') return;
+    const target = join(dir, 'secret2.txt');
+    atomicWriteString(target, 'initial', { mode: 0o600 });
+    expect(statSync(target).mode & 0o777).toBe(0o600);
+
+    // Rewrite without mode option
+    atomicWriteString(target, 'rewritten');
+    expect(statSync(target).mode & 0o777).toBe(0o600);
+    expect(readFileSync(target, 'utf8')).toBe('rewritten\n');
+  });
+
   it('does not leave tmp files behind on success', () => {
     const target = join(dir, 'clean.txt');
     atomicWriteString(target, 'x');

--- a/tests/utils/path-migration.test.ts
+++ b/tests/utils/path-migration.test.ts
@@ -1,0 +1,277 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  assertNotSymlink,
+  isSymlink,
+  migrateClientConfigServers,
+  migrateDirectorySafely,
+  migrateProjectConfig,
+} from '../../src/utils/path-migration.js';
+import { atomicWriteString } from '../../src/utils/atomic-write.js';
+
+const IS_WINDOWS = process.platform === 'win32';
+
+describe('Path and Directory Migration Security', () => {
+  let tempDir: string;
+  let srcDir: string;
+  let destDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'trace-migration-test-'));
+    srcDir = join(tempDir, 'src-dir');
+    destDir = join(tempDir, 'dest-dir');
+    mkdirSync(srcDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('Symlink Safety Checks', () => {
+    it('detects symlinks accurately with isSymlink', () => {
+      const realFile = join(tempDir, 'real.txt');
+      const linkFile = join(tempDir, 'link.txt');
+      writeFileSync(realFile, 'data');
+      symlinkSync(realFile, linkFile);
+
+      expect(isSymlink(realFile)).toBe(false);
+      expect(isSymlink(linkFile)).toBe(true);
+      expect(isSymlink(join(tempDir, 'non-existent.txt'))).toBe(false);
+    });
+
+    it('throws security violation in assertNotSymlink when symlink is passed', () => {
+      const realFile = join(tempDir, 'real.txt');
+      const linkFile = join(tempDir, 'link.txt');
+      writeFileSync(realFile, 'data');
+      symlinkSync(realFile, linkFile);
+
+      expect(() => assertNotSymlink(realFile)).not.toThrow();
+      expect(() => assertNotSymlink(linkFile)).toThrow(/Security Violation.*symlink/);
+    });
+
+    it('refuses to migrate when source directory is a symlink', () => {
+      const targetDir = join(tempDir, 'real-src');
+      mkdirSync(targetDir);
+      writeFileSync(join(targetDir, 'config.json'), '{"key":"val"}');
+
+      const symlinkSrc = join(tempDir, 'symlink-src');
+      symlinkSync(targetDir, symlinkSrc);
+
+      const result = migrateDirectorySafely(symlinkSrc, destDir);
+      expect(result.success).toBe(false);
+      expect(
+        result.errors.some((e) => e.includes('Source directory') && e.includes('symlink')),
+      ).toBe(true);
+      expect(existsSync(destDir)).toBe(false);
+    });
+
+    it('refuses to migrate when destination directory is an existing symlink', () => {
+      writeFileSync(join(srcDir, 'config.json'), '{"key":"val"}');
+
+      const evilTarget = join(tempDir, 'evil-target');
+      mkdirSync(evilTarget);
+      symlinkSync(evilTarget, destDir);
+
+      const result = migrateDirectorySafely(srcDir, destDir);
+      expect(result.success).toBe(false);
+      expect(
+        result.errors.some((e) => e.includes('Destination directory') && e.includes('symlink')),
+      ).toBe(true);
+      expect(existsSync(join(evilTarget, 'config.json'))).toBe(false);
+    });
+
+    it('skips symlinked files inside the source directory without following them', () => {
+      const sensitiveFile = join(tempDir, 'sensitive-shadow.txt');
+      writeFileSync(sensitiveFile, 'SECRET_SYSTEM_DATA');
+
+      const normalFile = join(srcDir, 'normal.json');
+      writeFileSync(normalFile, '{"public":true}');
+
+      const evilSymlink = join(srcDir, 'shadow-symlink.txt');
+      symlinkSync(sensitiveFile, evilSymlink);
+
+      const result = migrateDirectorySafely(srcDir, destDir);
+      expect(result.success).toBe(true);
+
+      // Normal file was migrated
+      expect(existsSync(join(destDir, 'normal.json'))).toBe(true);
+
+      // Symlink was skipped
+      expect(existsSync(join(destDir, 'shadow-symlink.txt'))).toBe(false);
+      expect(
+        result.skipped.some(
+          (s) => s.reason === 'symlink' && s.source.includes('shadow-symlink.txt'),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('POSIX Permission Enforcement', () => {
+    it('applies 0700 permissions to migrated directory and subdirectories', () => {
+      if (IS_WINDOWS) return;
+
+      mkdirSync(join(srcDir, 'index', 'sub'), { recursive: true });
+      writeFileSync(join(srcDir, 'index', 'sub', 'item.txt'), 'data');
+
+      const result = migrateDirectorySafely(srcDir, destDir);
+      expect(result.success).toBe(true);
+
+      const destStat = statSync(destDir);
+      expect(destStat.mode & 0o777).toBe(0o700);
+
+      const subStat = statSync(join(destDir, 'index'));
+      expect(subStat.mode & 0o777).toBe(0o700);
+
+      const deepStat = statSync(join(destDir, 'index', 'sub'));
+      expect(deepStat.mode & 0o777).toBe(0o700);
+    });
+
+    it('applies 0600 to database and config files and 0755 to bin executables', () => {
+      if (IS_WINDOWS) return;
+
+      mkdirSync(join(srcDir, 'bin'), { recursive: true });
+      writeFileSync(join(srcDir, 'bin', 'trace'), '#!/bin/bash\necho ok');
+      writeFileSync(join(srcDir, '.config.json'), '{"tools":"minimal"}');
+      writeFileSync(join(srcDir, 'topology.db'), 'SQLITE_HEADER');
+
+      const result = migrateDirectorySafely(srcDir, destDir);
+      expect(result.success).toBe(true);
+
+      const binStat = statSync(join(destDir, 'bin', 'trace'));
+      expect(binStat.mode & 0o777).toBe(0o755);
+
+      const configStat = statSync(join(destDir, '.config.json'));
+      expect(configStat.mode & 0o777).toBe(0o600);
+
+      const dbStat = statSync(join(destDir, 'topology.db'));
+      expect(dbStat.mode & 0o777).toBe(0o600);
+    });
+  });
+
+  describe('SQLite Database and Sidecar Migration', () => {
+    it('bundles SQLite database with WAL and SHM sidecars atomically', () => {
+      writeFileSync(join(srcDir, 'decisions.db'), 'MAIN_DB');
+      writeFileSync(join(srcDir, 'decisions.db-wal'), 'WAL_JOURNAL');
+      writeFileSync(join(srcDir, 'decisions.db-shm'), 'SHM_INDEX');
+
+      const result = migrateDirectorySafely(srcDir, destDir);
+      expect(result.success).toBe(true);
+
+      expect(readFileSync(join(destDir, 'decisions.db'), 'utf8')).toBe('MAIN_DB');
+      expect(readFileSync(join(destDir, 'decisions.db-wal'), 'utf8')).toBe('WAL_JOURNAL');
+      expect(readFileSync(join(destDir, 'decisions.db-shm'), 'utf8')).toBe('SHM_INDEX');
+
+      if (!IS_WINDOWS) {
+        expect(statSync(join(destDir, 'decisions.db')).mode & 0o777).toBe(0o600);
+        expect(statSync(join(destDir, 'decisions.db-wal')).mode & 0o777).toBe(0o600);
+        expect(statSync(join(destDir, 'decisions.db-shm')).mode & 0o777).toBe(0o600);
+      }
+    });
+  });
+
+  describe('Project Config (.trace-mcp.json -> .trace.json) Migration', () => {
+    it('migrates .trace-mcp.json to .trace.json and preserves permissions', () => {
+      const projDir = join(tempDir, 'project');
+      mkdirSync(projDir);
+      const legacyPath = join(projDir, '.trace-mcp.json');
+      writeFileSync(legacyPath, '{"tools":{"preset":"minimal"}}');
+      if (!IS_WINDOWS) chmodSync(legacyPath, 0o600);
+
+      const res = migrateProjectConfig(projDir);
+      expect(res.migrated).toBe(true);
+      expect(res.action).toBe('created');
+
+      const newPath = join(projDir, '.trace.json');
+      expect(existsSync(newPath)).toBe(true);
+      expect(readFileSync(newPath, 'utf8')).toBe('{"tools":{"preset":"minimal"}}\n');
+
+      if (!IS_WINDOWS) {
+        expect(statSync(newPath).mode & 0o777).toBe(0o600);
+      }
+    });
+
+    it('does not overwrite existing .trace.json', () => {
+      const projDir = join(tempDir, 'project');
+      mkdirSync(projDir);
+      writeFileSync(join(projDir, '.trace-mcp.json'), '{"version":1}');
+      writeFileSync(join(projDir, '.trace.json'), '{"version":2}');
+
+      const res = migrateProjectConfig(projDir);
+      expect(res.migrated).toBe(false);
+      expect(res.action).toBe('already_present');
+      expect(readFileSync(join(projDir, '.trace.json'), 'utf8')).toBe('{"version":2}');
+    });
+
+    it('refuses to migrate if legacy config is a symlink', () => {
+      const projDir = join(tempDir, 'project');
+      mkdirSync(projDir);
+      const realConfig = join(tempDir, 'foreign-config.json');
+      writeFileSync(realConfig, '{"hacked":true}');
+      symlinkSync(realConfig, join(projDir, '.trace-mcp.json'));
+
+      const res = migrateProjectConfig(projDir);
+      expect(res.migrated).toBe(false);
+      expect(res.action).toBe('skipped');
+      expect(existsSync(join(projDir, '.trace.json'))).toBe(false);
+    });
+  });
+
+  describe('Client Config (mcpServers[trace-mcp] -> mcpServers[trace]) Migration', () => {
+    it('renames trace-mcp server entry to trace while preserving other servers and formatting', () => {
+      const clientConfig = join(tempDir, 'claude.json');
+      const initial = {
+        mcpServers: {
+          'other-server': { command: 'other' },
+          'trace-mcp': { command: '~/.trace/bin/trace', args: ['serve'] },
+        },
+      };
+      writeFileSync(clientConfig, JSON.stringify(initial, null, 2));
+
+      const res = migrateClientConfigServers(clientConfig);
+      expect(res.migrated).toBe(true);
+
+      const updated = JSON.parse(readFileSync(clientConfig, 'utf8'));
+      expect(updated.mcpServers['trace-mcp']).toBeUndefined();
+      expect(updated.mcpServers.trace).toEqual({ command: '~/.trace/bin/trace', args: ['serve'] });
+      expect(updated.mcpServers['other-server']).toEqual({ command: 'other' });
+    });
+
+    it('refuses to rewrite client config if it is a symlink', () => {
+      const realFile = join(tempDir, 'real-client.json');
+      const symlinkFile = join(tempDir, 'symlink-client.json');
+      writeFileSync(realFile, JSON.stringify({ mcpServers: { 'trace-mcp': { command: 'x' } } }));
+      symlinkSync(realFile, symlinkFile);
+
+      const res = migrateClientConfigServers(symlinkFile);
+      expect(res.migrated).toBe(false);
+      expect(res.error).toMatch(/symlink/);
+    });
+  });
+
+  describe('Atomic Write Permission Preservation', () => {
+    it('preserves existing 0600 mode on rewrite when opts.mode is omitted', () => {
+      if (IS_WINDOWS) return;
+
+      const secretFile = join(tempDir, 'secret-config.json');
+      atomicWriteString(secretFile, '{"token":"initial"}', { mode: 0o600 });
+      expect(statSync(secretFile).mode & 0o777).toBe(0o600);
+
+      // Rewrite without passing mode
+      atomicWriteString(secretFile, '{"token":"updated"}');
+      expect(statSync(secretFile).mode & 0o777).toBe(0o600);
+      expect(readFileSync(secretFile, 'utf8')).toBe('{"token":"updated"}\n');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Stage 1 of the trace-mcp → trace rebrand (parent: TRA-610). Introduces the
`trace` identity everywhere alongside `trace-mcp`, with fully automatic,
zero-breakage migration for existing installs.

- **Package & binaries**: `package.json` `bin` gains `"trace": "dist/cli.js"`
  alongside the existing `"trace-mcp"` entry. The launcher shim now lives at
  `~/.trace/bin/trace`; a symlink at `~/.trace-mcp/bin/trace-mcp` is kept for
  scripts hardcoded to the old path.
- **MCP server identity**: `McpServer` and the CLI program name are now `trace`
  (`trace --help` / `trace-mcp --help` are identical).
- **Config & directory resolution**: global home prefers `~/.trace`, with a
  one-time atomic `renameSync` migration from `~/.trace-mcp` on first run
  (same-volume rename, not copy — avoids a disk-doubling duplicate nothing
  would ever clean up). Project config prefers `.trace.json`, falling back to
  `.trace-mcp.json` via cosmiconfig searchPlaces.
- **Client config auto-migration**: `configureMcpClients` renames
  `mcpServers["trace-mcp"]` → `["trace"]` in place across every supported
  client (JSON, JSONC/Amp, YAML/Hermes, TOML/Codex, Factory Droid, Warp, …),
  and `detectClientStatus` flags a legacy-only entry as `stale`/`legacy-key`
  so a re-run of `init` migrates it seamlessly.
- **CLAUDE.md / AGENTS.md generator**: routing block now reads "trace" instead
  of "trace-mcp"; regenerated the repo's own `AGENTS.md` with the updated
  generator to verify it.
- **Runtime shims**: `hooks/trace-mcp-launcher.sh` and `.ps1` — the actual
  scripts MCP clients execute — had their own independent hardcoded
  `~/.trace-mcp` default fixed to `~/.trace`. This was found by manual review,
  not by any existing test; without it, config resolution would have silently
  broken post-migration for any client not passing an explicit
  `TRACE_MCP_HOME`.
- Brought in `src/utils/path-migration.ts` / hardened `atomic-write.ts` from
  the companion security branch (TRA-612) for symlink-safe migration
  primitives, cherry-picked as a dependency of this work.

### Safety note

`TRACE_MCP_HOME`'s legacy-dir migration runs once, tied to first import of
`src/global.ts`. Discovered mid-implementation that this is dangerous for
`tests/cli/env-overrides.test.ts`, which deliberately clears
`TRACE_MCP_DATA_DIR` in a spawned subprocess to exercise real
`os.homedir()` resolution — without a guard, running the suite on a real
machine with a real `~/.trace-mcp` would have silently renamed it. Added a
`process.env.VITEST` guard (set by the test runner itself and inherited by
spawned subprocesses) so the migration never fires from inside a test
process; verified manually that it still fires correctly outside one.

### Token savings

Measured with `gpt-tokenizer` (o200k): `mcp__trace-mcp__<tool>` → `mcp__trace__<tool>`
is exactly 2 tokens per advertised tool name, and a prose mention (`CLAUDE.md`,
`AGENTS.md`, CLI output) goes from 3 tokens to 1. At the `standard` preset (55
advertised tools) that's ~110 tokens/turn; at `full` (171 tools) ~342 tokens/turn.
Real, but modest — worth saying plainly rather than letting a per-mention percentage
read as an overall win.

### Known limitation

`init` only rewrites the routing block it owns (CLAUDE.md/AGENTS.md). A tool name a
user wrote out in full themselves — their own CLAUDE.md prose, a permission
allowlist in `settings.json`, a custom hook — becomes `mcp__trace-mcp__x` →
`mcp__trace__x` and is not auto-fixed; they have to update it by hand. Worth calling
out in the migration docs (TRA-615).

### Scope note

`src/init/detector.ts`'s `detectMcpClients` was extended during development to
recognize the new key for "already configured" UI detection, but master had
concurrently (TRA-439) extracted that whole function to
`packages/app/src/shared/mcp-detector.ts` (an Electron-app-owned package this
issue doesn't otherwise touch). Rather than reach into that file mid-rebase,
this PR drops that (non-required) extension and keeps detector.ts identical
to master — `configureMcpClients`'s actual write-path migration (the
issue's real deliverable) is unaffected either way.

Update: TRA-614 (#724, merged) landed dual-key recognition in
`packages/app/src/shared/mcp-detector.ts` directly, so the gap this note
originally flagged is already closed by a sibling PR.

### Duplicate-work guard false positives

The repo's duplicate-PR check flags any open PR that shares *any* `TRA-NNN`
mention with this one, not just an exact scope match — these three are
unrelated, not duplicates, and are cited here (per the check's own
remediation) so it stops flagging them:

- #723 (`chore(master): release 3.12.0`) — a release changelog PR that
  happens to bundle a commit referencing TRA-439, which this PR's scope note
  above also mentions for unrelated reasons.
- #722 (`docs(ops): ...`, TRA-623) — shares only a TRA-615 mention (this PR's
  "Known limitation" section points at TRA-615's migration docs).
- #717 (`docs(migration): ...`, TRA-615) — a real sibling of the TRA-610
  parent (docs/generators/ledger), not a duplicate of this PR's TRA-611 scope.

### Reconciliation note

An overlapping implementation (#726) was opened independently for the same
TRA-611 scope, then closed by its author in favor of this PR — see the PR's
comment history for the full reconciliation. Both #726's original review and
a second-model review of this PR turned up the same class of bug (a
both-keys-present Codex TOML case producing a duplicate `[mcp_servers.trace]`
table header, and a compat symlink that never retried after a failed first
attempt); both are fixed here.

## Test plan
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm run build` — clean; `node dist/cli.js --help`/`--version` confirm
      `Usage: trace`
- [x] `pnpm exec vitest run` — full suite, 858 files / 9406+ tests passing (one
      unrelated pre-existing flaky file, `tests/scripts/postinstall-app.test.ts`,
      confirmed to pass 17/17 in isolation — untouched by this PR and by every
      commit rebased onto)
- [x] Manually verified the VITEST-guard migration skip/fire behavior in a
      simulated real-home scenario
- [x] New/updated tests: `tests/cli/env-overrides.test.ts`,
      `tests/init/mcp-client-status.test.ts`,
      `tests/init/mcp-clients-extra.test.ts` (new Hermes YAML + Codex TOML
      writer suites), `tests/init/launcher.test.ts`,
      `tests/init/claude-md.test.ts`, `tests/scripts/postinstall-control-plane.test.ts`


