### PR TITLE
fix(web): drive the homepage footer from docs_nav, and guard it (TRA-629)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1352,6 +1352,17 @@ layout: null
       transition: color 200ms ease-out;
     }
     .footer-col a:hover { color: var(--text-display); }
+    /* 22 doc links stacked single-file would run 22 rows deep against a
+       4-row Product column. Two grid tracks wide with an auto-fill inner
+       grid, it settles at 3 × 8 — the same `repeat(auto-fill, minmax(...))`
+       rule the doc-page footer uses (DESIGN-WEB.md §2), one cell per link so
+       a wrapped label still reads as one target. */
+    .footer-col-docs { grid-column: span 2; }
+    .footer-doc-links {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+      column-gap: 32px;
+    }
     .footer-bottom {
       display: flex; justify-content: space-between; align-items: center;
       padding-top: 24px;
@@ -2800,23 +2811,26 @@ layout: null
         <a href="#capabilities">Capabilities</a>
         <a href="#install">Install</a>
       </div>
-      <div class="footer-col">
-        <h5>/ Resources</h5>
-        <a href="/tools-reference.html">Tool reference</a>
-        <a href="/configuration.html">Configuration</a>
-        <a href="/architecture.html">Architecture</a>
-        <a href="/supported-frameworks.html">Supported stack</a>
-        <a href="/comparisons.html">Comparisons</a>
-        <a href="/analytics.html">Analytics</a>
-      </div>
-      <div class="footer-col">
-        <h5>/ More docs</h5>
-        <a href="/decision-memory.html">Decision memory</a>
-        <a href="/toon-savings.html">TOON savings</a>
-        <a href="/telemetry.html">Telemetry</a>
-        <a href="/quality-gates.html">Quality gates</a>
-        <a href="/tweakcc.html">tweakcc</a>
-        <a href="/development.html">Development</a>
+      {%- comment -%}
+        Same list as the doc-page footer, from the same data file. The two
+        hand-written columns this replaced named 12 of the 22 pages and never
+        picked up the ones added after them — the whole /vs/ cluster launched
+        with no link from the one page on this site with any external
+        authority. Same failure mode as the accessibility layer in
+        DESIGN-WEB.md §7: the fix landed in _layouts/default.html and this
+        page does not use that layout.
+
+        Which pages are listed, their labels and their order belong to
+        docs_nav.yml and the SEO agent (DESIGN-WEB.md §2); the column split
+        is the only decision made here.
+      {%- endcomment -%}
+      <div class="footer-col footer-col-docs">
+        <h5>/ Docs</h5>
+        <div class="footer-doc-links">
+        {%- for item in site.data.docs_nav -%}
+          <a href="{{ item.url | relative_url }}">{{ item.title }}</a>
+        {%- endfor -%}
+        </div>
       </div>
       <div class="footer-col">
         <h5>/ Source</h5>

--- a/tests/docs/internal-links.test.ts
+++ b/tests/docs/internal-links.test.ts
@@ -159,8 +159,17 @@ describe('docs footer nav covers every indexed page', () => {
     ).toEqual([]);
   });
 
-  it('the layout renders the nav from the data file, not a hardcoded list', () => {
-    const layout = readFileSync(join(DOCS, '_layouts', 'default.html'), 'utf-8');
-    expect(layout).toMatch(/site\.data\.docs_nav/);
-  });
+  /**
+   * Both footers, not just the layout's. This check used to read
+   * `_layouts/default.html` alone, so it could not see that `index.html` —
+   * which has `layout: null` and its own hand-written footer — still listed
+   * 12 of the 22 pages by hand. It had drifted past the whole /vs/ cluster,
+   * unlinked from the one page on the site with any external authority.
+   */
+  it.each([['_layouts/default.html'], ['index.html']])(
+    '%s renders the footer nav from the data file, not a hardcoded list',
+    (page) => {
+      expect(readFileSync(join(DOCS, ...page.split('/')), 'utf-8')).toMatch(/site\.data\.docs_nav/);
+    },
+  );
 });


### PR DESCRIPTION
Closes TRA-629.

## What drifted

`docs/index.html` carried a hand-written `<footer>` naming 12 of the 22 pages in `docs/_data/docs_nav.yml`. The 10 it omitted include the entire five-page `/vs/` cluster plus `tools-index`, `language-matrix`, `pr-context-benchmark` and `daemon-memory` — so the only page on the site with meaningful external authority (525 impressions / 51 clicks in 28 days; every other page is single-digit) linked to none of them.

`_layouts/default.html` has rendered its footer from `site.data.docs_nav` for a while; `index.html` has `layout: null` and never adopted it. This is the same failure mode DESIGN-WEB.md §7 already documents for the accessibility layer and the scroll-region label: a fix lands in the layout and the landing page silently misses it.

The guard test written to catch exactly this (`tests/docs/internal-links.test.ts`) only ever read `_layouts/default.html`, so nothing in CI could see it.

## Change

- `docs/index.html`: the `Resources` + `More docs` columns become one `/ Docs` column driven by `site.data.docs_nav` — all 22 pages, in the nav file's order, with its labels.
- One CSS rule: the column spans two grid tracks with a `repeat(auto-fill, minmax(160px, 1fr))` inner grid, the same one-cell-per-link rule DESIGN-WEB.md §2 sets for the doc-page footer.
- The guard test now runs over both `_layouts/default.html` and `index.html`.

Which pages are listed, their labels and their order remain `docs_nav.yml`'s and the SEO agent's (DESIGN-WEB.md §2). The column split is the only decision made here.

## Test evidence

- `pnpm vitest run tests/docs/` — 126 passed.
- Negative check on the new guard: rewriting `site.data.docs_nav` to `site.data.HARDCODED` in `index.html` fails `index.html renders the footer nav from the data file, not a hardcoded list` and nothing else.
- `pnpm run lint` clean. Full `pnpm run test`: 9384 passed, 1 failure in `tests/ai/onnx.test.ts` from a cold ONNX model download exceeding the 10s timeout — passes on re-run and on `master` with the change stashed, unrelated to this diff.
- Rendered the page's Liquid to static HTML and screenshotted headless at 1440 / 900 / 500px: 3 columns x 8 rows, 2 x 11, and full-width 2 x 11 respectively. No label wraps to an unreadable fragment; `Cut Claude Code token usage` and `PR review context benchmark` take two lines in their own cells, which is what the grid is for.

## What this is not

Search Console reports 10 of 23 pages "unknown to Google", and they are almost exactly these 10 — but every one of them is also 2-4 days old while every indexed page is 2-5 months old. On a site with this little authority a 2-4 day crawl lag is a sufficient explanation by itself, and the sitemap is complete with fresh `lastmod`. So this ships as hygiene — new pages should not launch orphaned, and the guard had a hole — not on a promise of recovered traffic. The SEO autopilot will re-inspect those URLs in ~2 weeks to separate the two.

Agent: Lead Engineer
