### PR TITLE
test(app): give the AskTab lazy-import test a timeout that fits what it loads (TRA-639)

### DIFF
--- a/packages/app/src/renderer/__tests__/lazy-tabs.test.ts
+++ b/packages/app/src/renderer/__tests__/lazy-tabs.test.ts
@@ -5,8 +5,14 @@ import { describe, expect, it } from 'vitest';
 // string, so renaming or defaulting it type-checks fine and only breaks when a user
 // clicks the tab. This asserts the name the wrapper depends on still exists.
 describe('lazily loaded tabs', () => {
-  it('AskTab is still a named export', async () => {
-    const mod = await import('../tabs/AskTab');
-    expect(typeof mod.AskTab).toBe('function');
-  });
+  // 30s, not the 5s default: this import pulls in the whole markdown/micromark stack —
+  // the suite's single heaviest — and blows the default budget on a loaded machine.
+  it(
+    'AskTab is still a named export',
+    async () => {
+      const mod = await import('../tabs/AskTab');
+      expect(typeof mod.AskTab).toBe('function');
+    },
+    30_000,
+  );
 });


### PR DESCRIPTION
## What

`packages/app/src/renderer/__tests__/lazy-tabs.test.ts` → "AskTab is still a named export" gets an explicit 30 s timeout instead of vitest's 5000 ms default.

## Why

The test body is one line — `await import('../tabs/AskTab')`. That import pulls in the whole markdown/micromark stack, which is the suite's single heaviest import and exactly why TRA-532 (#669) made the tab lazy in the first place.

Measured inside the full `packages/app` suite with `--reporter=json`, on an **idle** machine:

```
lazily loaded tabs AskTab is still a named export | passed | duration 4871.8 ms
```

4871.8 ms against a 5000 ms budget — a 128 ms margin, 2.6%. Any contention on the machine pushes it over, and the suite then fails with `Error: Test timed out in 5000ms` on unmodified `master`, with no assertion failure behind it. That is how it was found: it showed up while verifying #724 and looked like a regression until it reproduced identically on a clean checkout.

CI runners are currently fast enough that it stays green there, so it only ever fails locally — the worst place for it, because the honest answer to "is this mine?" costs a `master` checkout and a full suite re-run on every PR touching `packages/app`. A slower runner turns it into a red PR unrelated to the PR.

## Why scoped, not global

A `testTimeout` bump in `vitest.config.ts` would cover this one but also hide genuinely hung tests elsewhere in the suite. The budget belongs on the test whose cost is unusual.

## Verification

- Baseline on clean `master`: suite green on an idle machine (58 files / 571 tests), AskTab at 4871.8 ms — the margin, not the failure, is what reproduces on demand.
- With the fix: 58 files / 571 tests pass; `pnpm run typecheck` clean.
- Third argument confirmed wired, not decorative — temporarily setting it to `1` produces `Error: Test timed out in 1ms`, so the value is honoured rather than silently ignored.

The assertion itself is untouched: the lazy wrapper in `App.tsx` names the export as a string, so this still fails if `AskTab` is renamed or defaulted.

Refs TRA-639
