### PR TITLE
docs: refresh the roadmap for the v3.x product (TRA-616)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,41 +8,54 @@ noindex: true
 # Product Roadmap
 
 Strategic view of trace-mcp, revisited roughly weekly by the Product Roadmap
-& Vision autopilot, which also turns 2-4 of the items below into that week's
-operational focus (see the "This Week's Focus" section of the trace-mcp
-Operations project). This file tracks *why* something should move the
-product forward — not day-to-day bugs, tool tweaks, or indexing hygiene
-(those live as regular issues, tracked by other autopilots). An item is
-removed here once it ships, is superseded, or turns out not to matter.
+& Vision autopilot, which also writes that week's operational focus — one
+substantive item per topical autopilot — into the "This Week's Focus" section
+of the trace-mcp Operations project description. This file tracks *why*
+something should move the product forward — not day-to-day bugs, tool tweaks,
+or indexing hygiene (those live as regular issues, tracked by other
+autopilots). An item is removed here once it ships, is superseded, or turns
+out not to matter.
 
 ## Where the product stands
 
-Both items that were "ready to start" two revisions ago shipped:
-**CI-native PR intelligence** (TRA-127) and the **multi-project tool
-surface** (TRA-93/TRA-143). The item that replaced them last revision has
-now also shipped: **TRA-186's tool-schema-tax cut** landed in two releases
-(v1.48.3 PR #377, v1.48.4 PR #380) — tool description text 73,947→~64k
-chars, per-parameter description text 32,281→30,245 chars, both now
-regression-guarded by `tool-schema-budget.test.ts`. That's a real but modest
-cut (~6% off the ~203k-char/~50.7k-token baseline Nikolai measured), because
-the investigation surfaced the actual shape of the cost: of the ~94k
-inputSchema chars, only ~30-32k is prose (`.describe()` text) we control —
-the remaining ~60k+ is structural JSON Schema (`type`, `required`, `enum`,
-`minimum`/`maximum`) generated from legitimate parameter counts, which
-**cannot shrink without removing parameters or consolidating tools** —
-both are breaking MCP tool-contract changes, not prose edits. See item 1
-below for the resulting next step.
+**Shipping is not the constraint.** In the seven days to 2026-09-01 the
+repository took 358 commits and published 31 releases, going from v1.48.4 to
+v3.11.0. In the same window the adoption metric of record moved from ~0 to 61
+monthly active installs, and GitHub stars sat at 102 — the same flat line
+they have held since the April launch burst decayed. Every item below is
+written against that asymmetry: the product gains capability far faster than
+it gains users, so a capability item now has to answer "who finds out" before
+it earns a slot.
 
-Per `docs/comparisons.md`'s own honest self-assessment, six of seven
-competitive gaps from the last deep pass are shipped and adversarially
-re-validated. The two remaining technical gaps (a peer-reviewed bug-risk
-metric; CFG/taint staying line-based/lexical instead of full AST/dataflow)
-are known architectural ceilings, not low-hanging fruit — leave them
-tracked in `comparisons.md`, not here.
+The last revision's "ready to start" item — scoping tool consolidation into
+per-tool migration issues — is **closed, and by a better answer than the one
+it proposed.** TRA-193 did the scoping (TRA-210 was cancelled as its
+duplicate), and the conclusion was that consolidation is not the right lever:
+v3.3 shipped **tool presets** instead (`tools.preset`, default `standard`,
+progressive disclosure via `load_tools`), which cuts what a session pays for
+schemas without breaking a single tool name. Schema cost is now a solved,
+regression-guarded problem. What has never been measured is the other half —
+what our tools *return* per call, turn after turn.
 
-The other standing question is unchanged: **who trace-mcp serves and how
-far the current single-developer, single-repo model can stretch before it
-needs to change shape.**
+Two things changed the product's shape this week, and both need a decision,
+not just a follow-up ticket:
+
+- **We can finally prove the core claim on somebody else's code.** TRA-534
+  measured input-token cost over 60 merged bug-fix PRs from six OSS repos
+  (`docs/pr-context-benchmark.md`, generated into
+  `docs/_data/pr_context_bench.json`): median **13,595 → 1,326 tokens, 90.6%
+  saved**, p90 44,246 → 3,667, and affected call sites readable rising 20% →
+  60% with 100% at least located. Until this, every reduction figure we
+  published came from our own estimators. See item 1 and item 2.
+- **The State Engine makes trace two things.** TRA-596 (phases 1-3 shipped,
+  phase 4 open) added `trace_state_*`, a SQLite task-state store with RFC
+  7396 merge patches and a `trace://state/{task_id}` resource — agent working
+  state, not code structure. That is a second product pillar arriving without
+  a positioning decision behind it. See item 3.
+
+The standing question is unchanged and now sharper: **who trace-mcp serves,
+and how far the single-developer, single-repo model stretches before it needs
+to change shape.**
 
 ## Adoption — metric of record
 
@@ -61,12 +74,20 @@ keeps event data for 14 months at most, so anything older survives only there.
 It is deliberately not on `master`: a PR opened by `GITHUB_TOKEN` never
 triggers CI, so it could never satisfy the required checks.
 
+| Date | Active installs | Notes |
+| --- | --- | --- |
+| 2026-09-01 | **61 monthly, 61 weekly, 54 daily** (310 events/28d) | First read with real data. Day ≈ week ≈ month means the install base is small and nearly all of it pings every day — an active core, not a decaying tail. |
+| 2026-08-28 | _pending GA4 read access_ | Ping verified end to end: published `trace-mcp@2.0.0` carries baked credentials, payload validates against the Measurement Protocol debug endpoint. |
+
 Caveat when citing it: the ping's credentials ship in plaintext inside the
 published npm package (public by design — see SECURITY.md "Telemetry
 Credentials"), so the events are **unauthenticated and can be inflated by
 anyone**. Active installs is the best adoption signal we have, not an
 auditable one; read it as a trend, and treat a sudden step change as
-suspect until corroborated.
+suspect until corroborated. The same branch carries a cumulative
+`tokens_saved` counter with a sanitized and a raw figure side by side — quote
+the sanitized one, and read a widening gap between them as someone flooding
+the endpoint.
 
 **npm weekly downloads are not an adoption metric** and should not be cited
 as one. Measured 2026-08-28 (TRA-273): 9,013 downloads over 92 days, but
@@ -83,73 +104,104 @@ while the median version is 2, and day-old releases hit parity with
 month-old ones instantly. That is a mirror sweeping the version history,
 not users — nobody installs `1.48.0`, `1.48.1` and `1.48.2` in equal
 measure. Decision: the npm-downloads badge is removed from the homepage
-trust strip and no download figure is cited on any public surface. Adoption
-metric of record is GitHub stars + traffic uniques. Re-check the per-version
-flatness quarterly, not per run.
+trust strip and no download figure is cited on any public surface.
 
-The same caveat now covers **git clones** (measured 2026-08-30, TRA-540):
+The same caveat covers **git clones** (measured 2026-08-30, TRA-540):
 16,006 clones / 928 uniques in 14 days, ramping 166 → 8,736 per day across
 08-24…08-29 while human page views stayed flat at ~20/day. Unique *cloners*
 inflated along with the raw count (62 → 300), so clone uniques are no safer
 than clone totals. Whatever swept the npm version history swept git too. The
-metric of record is therefore GitHub stars plus traffic **views** uniques only
-— clones are excluded from it. Channel-by-channel state now lives in
+supporting metrics are therefore GitHub stars plus traffic **views** uniques
+only — clones are excluded. Channel-by-channel state lives in
 `ops/user-signal.md`.
 
-GitHub stars, same date: 101 total (April 58, May 23, June 8, July 5,
-August 6), 14 forks — a launch burst that decayed ~10× and stayed flat.
-
-| Date | Active installs | Notes |
-| --- | --- | --- |
-| 2026-08-28 | _pending GA4 read access_ | Ping verified end to end: published `trace-mcp@2.0.0` carries baked credentials, payload validates against the Measurement Protocol debug endpoint. |
+GitHub, 2026-09-01: **102 stars, 15 forks** — 100 on 08-28, 102 on 08-30, so
+the star line is flat to within noise while releases ship daily. Traffic
+(measured 08-30): 568 views / 175 uniques per 14 days, ~13–23 uniques/day,
+top referrer reddit.com.
 
 ## Ready to start
 
-### 1. Scope tool-consolidation candidates into per-tool migration issues (follow-up to TRA-186)
-TRA-186's own investigation named the candidate list (pin_file/pin_symbol,
-discover_claude_sessions/discover_hermes_sessions, search/search_with_mode,
-the three "is it safe to edit" tools, and others surfaced during the trim)
-and explicitly recommended **not** folding consolidation into that issue,
-since each merge is a breaking MCP tool-contract change and needs its own
-migration note (which callers break, what the replacement call looks like).
-This item is: pull that list into scoped issues, one (or a small related
-group) per issue, each with a concrete before/after tool signature and a
-migration note — a design/scoping pass, not a code-first pass.
+### 1. Put the measured number where people arrive
+`docs/pr-context-benchmark.md` is the only original, reproducible evidence
+the project has ever produced, and it is reachable from exactly one place:
+`docs/_data/docs_nav.yml`. It is named **zero times** in `docs/index.html`
+and zero times in `README.md`. Both of those are being rewritten right now
+(TRA-607, TRA-608, TRA-609) — which makes this the week the number either
+lands above the fold or misses the rewrite entirely.
 
-**Why now:** it's the only remaining lever that moves the ~50k baseline
-materially (prose trimming is now regression-tested and tapped out at ~6%).
-It's also the more consequential kind of change — every merge is a contract
-break for anyone with the old tool name pinned — so it deserves the
-scoping rigor TRA-186 asked for, not a batch rewrite done casually.
+**Why it matters:** the site's whole pitch currently rests on figures our own
+estimators produced about our own repository. "90.6% median saving across 60
+merged pull requests in six open-source repositories, reproducible with a
+script in the repo" is a categorically different claim, and it is the one
+argument a skeptical reader cannot wave off. **Why now:** the hero rewrites
+are in flight, and retrofitting evidence into a finished hero is a second
+redesign.
+
+### 2. Second arm of the benchmark: does the cheaper context review as well?
+TRA-568 sits in backlog. Item 1's number invites one obvious rebuttal — *you
+saved 90% of the tokens by showing the model 90% less code* — and the current
+benchmark answers it only structurally (affected call sites readable 20% →
+60%, all located). The missing arm is quality: run an LLM reviewer over the
+same 60 PRs on both context arms and compare the findings against what the
+merged PR actually fixed.
+
+**Why it matters:** a token number without a quality number is an efficiency
+claim, not a value claim, and every competitor's inflated "95% reduction" is
+exactly that. Publishing both — including a result where we lose — is the
+credibility position no peer on `docs/comparisons.md` currently occupies.
+Promote it out of backlog.
+
+### 3. Decide what the State Engine makes us
+`trace_state_*` (TRA-596) stores agent task state: init, patch, get,
+checkpoint, rollback, plus a `trace://state/{task_id}` resource. That is not
+code intelligence. It is a bet that the expensive thing in an agent session
+is re-establishing *what the task is*, alongside re-establishing what the
+code is — a real and defensible position, but a different product from
+"precomputed code graph", and it arrived through an implementation epic
+rather than a positioning decision.
+
+**Scope:** a short design pass, not code. (a) Does phase 4's A/B (TRA-600)
+show state cutting tokens *and* holding task success, or only the first?
+(b) Do the two pillars share one sentence a user can repeat, or is the tool
+surface now two products in one binary? (c) If the answer is one product,
+`docs/comparisons.md` and the homepage need the second pillar in them —
+today neither mentions it. **Why now:** phases 1-3 are already in
+`waiting_for_release`; the positioning question gets harder to answer the
+more surface ships around it.
 
 ## Big bet — needs a design pass before any code
 
-### 2. Team-shared graph — parked, needs Nikolai's go-ahead (TRA-128)
+### 4. Team-shared graph — parked, needs Nikolai's go-ahead (TRA-128)
 trace-mcp's whole pitch is "reuse instead of recompute" — but today reuse
 only happens *within one developer's laptop, across turns*. A team of five
 engineers on the same repo each index it separately, each mine their own
 decisions separately, and never see each other's "why was this built this
 way" answers. That's the same recomputation leak the product exists to
-close, just at the team level instead of the turn level.
+close, one level up.
 
-The design pass (TRA-128) is done: a lightweight shared-graph mode — a
-daemon reachable by a team instead of localhost-only, with a shared decision
-store — would turn trace-mcp from a personal productivity tool into a team
-artifact, and is the kind of capability that could eventually justify a
-hosted/paid tier. But the design's own recommended smallest slice is a
-network-reachable server component, which falls squarely in the one
-category this project's rules reserve for Nikolai's explicit call (no
-hosted backend / paid infra on an autopilot's own authority). **Status:
-correctly parked, not stalled** — the design stays valid and ready to
-resume the moment there's an explicit go-ahead or an actual team asking for
-it (the issue's own trigger condition). Nothing to do here until then.
+The design pass (TRA-128) is done. Two things have strengthened it since:
+the decision store now prunes stale roots (TRA-595), and the State Engine
+(item 3) adds a *second* per-developer store with the same team-level leak —
+task state is at least as re-derivable across a team as code structure is.
+But the design's smallest viable slice is still a network-reachable server
+component, which is the one category this project's rules reserve for
+Nikolai's explicit call (no hosted backend or paid infra on an autopilot's
+own authority). **Status: correctly parked, not stalled.** Nothing to do here
+until there is a go-ahead or an actual team asking for it.
 
 ## Explicitly not doing right now
 
-- Chasing competitor feature/tool-count parity for its own sake — see
-  `comparisons.md`'s "deliberately NOT chasing" list. Still holds, and item
-  1 above is the sharper version of why: count alone was never the right
-  metric to chase, in either direction.
-- Rewriting CFG/taint analysis onto a real AST/dataflow engine — real gap,
-  correctly filed as a known ceiling, not a roadmap item until something
-  forces the issue (e.g. a security-critical false negative in the wild).
+- **Consolidating tools to shrink the schema surface.** Settled: TRA-193
+  scoped it, presets (v3.3) achieved the goal without breaking a tool name,
+  and `tool-schema-budget.test.ts` guards the result. Reopen only if preset
+  sizes start drifting past their budgets.
+- **Chasing competitor feature/tool-count parity for its own sake** — see
+  `comparisons.md`'s "deliberately NOT chasing" list. Item 1 is the sharper
+  version of why: count was never the metric, evidence is.
+- **Rewriting CFG/taint analysis onto a real AST/dataflow engine** — real
+  gap, correctly filed as a known ceiling, not a roadmap item until
+  something forces it (e.g. a security-critical false negative in the wild).
+- **Solving Reddit's anti-bot gates** to read our largest referrer — settled
+  in `ops/user-signal.md`. It needs a human with a logged-in browser, and
+  working around those gates is not something we do.


### PR DESCRIPTION
The roadmap still described a v1.48 product. Its one "ready to start" item was scoping tool consolidation — work that TRA-193 completed and then answered a different way (presets shipped in v3.3, TRA-210 cancelled as a duplicate), so the item had been dead for days.

## What changed

**Where the product stands** — rewritten around the asymmetry the numbers actually show: 358 commits and 31 releases in the seven days to 2026-09-01 (v1.48.4 → v3.11.0) against 61 monthly active installs and a star count flat at 102 since April. Capability is outrunning reach, so a capability item now has to answer "who finds out".

**Three new ready-to-start items**, replacing the dead one:

1. *Put the measured number where people arrive.* `docs/pr-context-benchmark.md` (90.6% median saving over 60 merged PRs in six OSS repos) is reachable only from `docs_nav.yml` — it is named zero times in `docs/index.html` and zero times in `README.md`, both of which are being rewritten right now (TRA-607/608/609).
2. *Second arm of the benchmark* — promote TRA-568 out of backlog. A token number without a quality number is an efficiency claim, not a value claim.
3. *Decide what the State Engine makes us* — TRA-596 added agent task state as a second product pillar through an implementation epic, with no positioning decision behind it. Design pass, not code.

**Adoption** — first reading with real data (61 monthly / 61 weekly / 54 daily, GA4 2026-09-01); day ≈ week ≈ month, so the base is small and almost entirely active. Existing caveats on npm downloads, clones and telemetry inflation kept verbatim.

**Explicitly not doing** — the consolidation question is folded in here as settled, plus the Reddit anti-bot dead end from `ops/user-signal.md`.

## Test evidence

`npx vitest run tests/docs` — 10 files, 125 tests, all passing (includes `internal-links.test.ts`, which is the suite that reads `ROADMAP.md`).

Markdown-only change, so it takes the documented exception to the second-model review gate.

## Not a duplicate of #715

The duplicate-work guard flagged this PR because the body names `TRA-596` — but only as roadmap context. This PR is TRA-616 (a roadmap document revision); the implementation of TRA-596 is #715, and the two share no file. Same for the other issue keys quoted here (TRA-568, TRA-607/608/609): they are cited as items the roadmap points at, not claimed by this PR.
