### PR TITLE
fix(ci): exempt the release PR from the duplicate-work guard (TRA-642)

### DIFF
--- a/scripts/check-duplicate-pr.mjs
+++ b/scripts/check-duplicate-pr.mjs
@@ -21,12 +21,24 @@ export function issueKeys(text) {
 }
 
 /**
+ * A release-please PR restates every issue in the changelog it assembles, so it
+ * collides with every open PR by construction — and the work it names is already
+ * merged, which is the opposite of duplicated. Excluded on both sides.
+ *
+ * @param {{title?: string}} pr
+ */
+export function isReleasePr(pr) {
+  return /^chore\(.*\): release \d/.test(pr.title ?? '');
+}
+
+/**
  * Open PRs that claim the same TRA issue as `pr` and that `pr` does not cite.
  *
  * @param {{number: number, title: string, body?: string}} pr
  * @param {Array<{number: number, title: string, body?: string}>} openPrs
  */
 export function findDuplicatePrs(pr, openPrs) {
+  if (isReleasePr(pr)) return [];
   const keys = issueKeys(`${pr.title}\n${pr.body ?? ''}`);
   if (keys.length === 0) return [];
   const cited = new Set(
@@ -36,6 +48,7 @@ export function findDuplicatePrs(pr, openPrs) {
     (other) =>
       other.number !== pr.number &&
       !cited.has(other.number) &&
+      !isReleasePr(other) &&
       issueKeys(`${other.title}\n${other.body ?? ''}`).some((k) => keys.includes(k)),
   );
 }

--- a/tests/ci/duplicate-pr.test.ts
+++ b/tests/ci/duplicate-pr.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 // @ts-expect-error — plain .mjs script, no type declarations
-import { findDuplicatePrs, formatReport, issueKeys } from '../../scripts/check-duplicate-pr.mjs';
+import {
+  findDuplicatePrs,
+  formatReport,
+  isReleasePr,
+  issueKeys,
+} from '../../scripts/check-duplicate-pr.mjs';
 
 // Fixtures are the real PRs from the TRA-476 incident, trimmed to the fields
 // the check reads. Two of these pairs are duplicates that cost a full
@@ -36,6 +41,22 @@ const PR_612 = {
   body: 'Follow-up to #608.',
 };
 
+// #723, the release-please PR that the guard failed on 2026-09-01: its body is
+// the changelog, so it names every issue merged since the last release.
+const PR_723 = {
+  number: 723,
+  title: 'chore(master): release 3.12.0',
+  body: '## 3.12.0\n\n### Features\n\n* first-run setup flow (TRA-439)\n* price the default tool surface (TRA-448)\n* dead-daemon pane (TRA-469)',
+};
+
+describe('isReleasePr', () => {
+  it('recognises the release-please title and nothing else', () => {
+    expect(isReleasePr(PR_723)).toBe(true);
+    expect(isReleasePr({ title: 'chore(deps): bump vitest' })).toBe(false);
+    expect(isReleasePr(PR_597)).toBe(false);
+  });
+});
+
 describe('issueKeys', () => {
   it('collects distinct keys case-insensitively', () => {
     expect(issueKeys('Closes TRA-448, supersedes tra-448 and TRA-455')).toEqual([
@@ -69,6 +90,14 @@ describe('findDuplicatePrs', () => {
 
   it('ignores itself and unrelated issues', () => {
     expect(findDuplicatePrs(PR_597, [PR_597, PR_611])).toEqual([]);
+  });
+
+  it('never flags the release PR, whose changelog names every merged issue', () => {
+    expect(findDuplicatePrs(PR_723, [PR_597, PR_611])).toEqual([]);
+  });
+
+  it('never flags a PR against the release PR either', () => {
+    expect(findDuplicatePrs(PR_597, [PR_723])).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## What broke

`chore(master): release 3.12.0` (#723) fails the **Duplicate PR Check**:

```
This PR claims the same TRA issue as an open PR:
- #730 — feat(core,cli): trace bin alias, McpServer identity, config paths… (TRA-611)
- #717 — docs(migration): update docs, generators, and distribution ledger… (TRA-615)
```

release-please builds its body from the changelog, so the release PR names every TRA issue merged since the last release. `findDuplicatePrs` reads those as claims. But changelog entries are *merged* work — the opposite of a duplicate — and the collision is structural: any open PR that shares an issue key with anything already released trips it. The release train sits red until someone overrides the check.

## The change

One predicate, applied on both sides:

- the release PR is never flagged, and
- no PR is ever flagged *against* the release PR (the symmetric false positive, which is how #730 would have tripped once its own guard ran).

Detection is the release-please title (`chore(<scope>): release <version>`), not the branch name — the script already fetches `title`, so no extra API field.

## Test evidence

`tests/ci/duplicate-pr.test.ts` gains a #723 fixture (real title, changelog body naming TRA-439/448/469) and three cases. Verified non-vacuous — reverted the script and re-ran:

```
× recognises the release-please title and nothing else
× never flags the release PR, whose changelog names every merged issue
× never flags a PR against the release PR either
 Tests  3 failed | 8 passed (11)
```

With the fix: `Tests 11 passed (11)`. Biome clean on both files.

## Not fixed here

#722 vs #717 both claim TRA-615 and both are real PRs — that flag is correct and still needs reconciling by hand.

The guard runs on `pull_request: [opened, reopened, edited]` and checks out the script from `base.sha`, so #723 clears once this lands on master and release-please next edits the PR.

Agent: Lead Engineer

Closes TRA-642.