### PR TITLE
ci(release): gate the Apple signing secrets behind a branch-protected environment (TRA-628)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,6 +225,13 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: macos-latest
+    # The Developer ID certificate lives in this environment, not at repository
+    # level, and the environment only deploys from protected branches (TRA-628).
+    # That is what keeps the signing identity out of reach of a workflow added
+    # on some other branch — `on: push: branches: [master]` above is a property
+    # of this file, and a repository-level secret is readable by any workflow
+    # that names it. Removing this line silently un-gates the certificate.
+    environment: apple-signing
     permissions:
       contents: write
       id-token: write
@@ -266,10 +273,10 @@ jobs:
           npm pkg set version="$ROOT_VERSION"
 
       # Sign + notarize (TRA-436). The certificate never leaves this step's
-      # environment, and this workflow only ever runs on `push: master` or
-      # workflow_dispatch — neither is reachable from a fork — so a fork PR
-      # cannot obtain the signing material. electron-builder reads CSC_* for
-      # the Developer ID identity and APPLE_* for notarytool; it prints neither.
+      # environment; it reaches the job only because the job declares
+      # `environment: apple-signing` above, and only on a protected branch.
+      # electron-builder reads CSC_* for the Developer ID identity and APPLE_*
+      # for notarytool; it prints neither.
       # Do not add `--debug` here: it dumps the resolved env.
       - name: Package with electron-builder
         working-directory: packages/app

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -234,6 +234,32 @@ A missing or invalid attestation means the package was **not** built by the offi
 
 ---
 
+## CI Secret Scoping
+
+A repository-level GitHub Actions secret is readable by **any** workflow in the
+repo that names it, on any branch. The trigger on a given workflow file
+(`on: push: branches: [master]`) protects that file, not the secret. Credentials
+whose loss cannot be undone by rotating a config value therefore live in a
+branch-gated **environment**, so they are simply not injected into a job running
+outside a protected branch:
+
+| Environment | Secrets | Consumer |
+| --- | --- | --- |
+| `apple-signing` | `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` | `release.yml` :: `build-app-mac` |
+| `npm` | npm publish (OIDC), `TRACE_MCP_GA_*` | `release.yml` :: `publish` |
+
+`CSC_LINK` is the Developer ID Application private key: whoever holds it can
+sign and notarize arbitrary software as *Mykola Vysotskyi (UWBRFD57K5)*, and the
+only remedy is revoking the identity — which invalidates every artifact already
+signed with it. That asymmetry is why it gets an environment and, for example,
+`GA4_SA_KEY` (read-only analytics service account, consumed by
+`ga4-snapshot.yml`) deliberately does not: rotating it costs one key swap.
+
+Removing `environment:` from a job that consumes these secrets un-gates them
+silently — the release still succeeds. Treat that line as part of the control.
+
+---
+
 ## Telemetry Credentials — Public by Design
 
 The anonymous active-install ping (`src/telemetry/usage-ping.ts`) uses GA4's
@@ -320,4 +346,5 @@ If you discover a security vulnerability, please report it responsibly:
 | Auto-update Gatekeeper check | `spctl -a -t exec` on staged bundle | No |
 | Auto-update opt-out | Disabled when set | Yes (`TRACE_MCP_NO_AUTO_UPDATE=1`) |
 | npm provenance attestation | Sigstore/OIDC on every release | No |
+| Apple signing secret scope | `apple-signing` environment, protected branches only | No |
 | GA4 telemetry credentials | Public by design, ship in `dist/`, write-only | Yes (`TRACE_MCP_TELEMETRY=off`) |

--- a/tests/ci/release-secret-scoping.test.ts
+++ b/tests/ci/release-secret-scoping.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import YAML from 'yaml';
+
+// The Apple Developer ID certificate is an environment secret, not a
+// repository-level one, so it is only injected into a job that declares
+// `environment: apple-signing` — and that environment only deploys from
+// protected branches (TRA-628, SECURITY.md "CI Secret Scoping").
+//
+// The failure mode this guards is silent: drop the `environment:` line and the
+// release still builds, signs and ships exactly as before, right up until the
+// secrets are re-scoped or someone reads the workflow and concludes the
+// certificate is repo-wide again. Nothing else in the suite notices.
+const APPLE_SECRETS = [
+  'CSC_LINK',
+  'CSC_KEY_PASSWORD',
+  'APPLE_ID',
+  'APPLE_APP_SPECIFIC_PASSWORD',
+  'APPLE_TEAM_ID',
+];
+
+const WORKFLOWS = join(import.meta.dirname, '../../.github/workflows');
+
+function jobsOf(file: string): Record<string, any> {
+  return YAML.parse(readFileSync(join(WORKFLOWS, file), 'utf8')).jobs ?? {};
+}
+
+/** Every `${{ secrets.NAME }}` reference anywhere inside a job definition. */
+function secretsReferencedBy(job: unknown): Set<string> {
+  const found = new Set<string>();
+  for (const m of JSON.stringify(job).matchAll(/secrets\.([A-Z0-9_]+)/g)) found.add(m[1]);
+  return found;
+}
+
+describe('release workflow secret scoping', () => {
+  it('gates every job that touches an Apple signing secret behind the apple-signing environment', () => {
+    const consumers = Object.entries(jobsOf('release.yml')).filter(([, job]) => {
+      const used = secretsReferencedBy(job);
+      return APPLE_SECRETS.some((s) => used.has(s));
+    });
+
+    // If nobody signs any more, this test is guarding nothing — say so loudly
+    // rather than passing vacuously.
+    expect(consumers.map(([name]) => name)).toEqual(['build-app-mac']);
+
+    for (const [name, job] of consumers) {
+      expect(job.environment, `job "${name}" consumes Apple signing secrets`).toBe('apple-signing');
+    }
+  });
+});


### PR DESCRIPTION
Closes TRA-628.

## What changed

`build-app-mac` in `.github/workflows/release.yml` now runs under `environment: apple-signing`. I created that environment on the repo with `deployment_branch_policy.protected_branches: true` and no required reviewers, mirroring the existing `npm` environment:

```
$ gh api repos/nikolai-vysotskyi/trace-mcp/environments --jq '.environments[] | {name, policy: .deployment_branch_policy}'
{"name":"apple-signing","policy":{"custom_branch_policies":false,"protected_branches":true}}
{"name":"npm","policy":{"custom_branch_policies":false,"protected_branches":true}}
```

Plus a `SECURITY.md` section recording which credentials get an environment and why, and a guard test.

## Why

`CSC_LINK` + `CSC_KEY_PASSWORD` is a Developer ID Application private key. A repository-level secret is readable by **any** workflow in the repo that names it, on any branch — the `on: push: branches: [master]` trigger is a property of this file, not of the secret. Losing that key is not a rotation: it revokes the identity and every artifact already signed with it. The npm publish job, the lower-value credential, was already environment-gated; the higher-value one was not.

## This PR alone does not close the hole

Environment secrets override repository secrets of the same name, but repository secrets still reach a job that declares an environment. The gate only takes effect once the five secrets exist **in** `apple-signing` and the repository-level copies are deleted — and secrets are write-only, so only Nikolai can do that half. Ordering, from safest to riskiest, is:

1. this PR merges (no-op while the secrets are still repo-level — the job keeps getting them),
2. the five secrets are added to the `apple-signing` environment,
3. the repository-level copies are deleted.

Steps 2–3 are laid out for him on the issue. Doing 3 before 2 breaks the next release loudly (the `is ad-hoc signed` assertion at `release.yml:359` catches it) rather than shipping an unsigned app.

## Test evidence

`tests/ci/release-secret-scoping.test.ts` parses `release.yml`, finds every job referencing any of the five Apple secrets, and asserts that set is exactly `['build-app-mac']` and that the job declares `environment: apple-signing`. Verified in both directions — with the line, and with it deleted:

```
$ pnpm exec vitest run tests/ci/release-secret-scoping.test.ts
 ✓ tests/ci/release-secret-scoping.test.ts (1 test) 16ms

# same test with `environment: apple-signing` removed from the job:
 × gates every job that touches an Apple signing secret behind the apple-signing environment
AssertionError: job "build-app-mac" consumes Apple signing secrets: expected undefined to be 'apple-signing'
```

The failure it guards is silent — drop the line and the release still builds, signs, notarizes and ships exactly as before, and nothing else in the suite notices. `pnpm run typecheck` and `biome ci` on the new file are clean.

## Not done, on purpose

`GA4_SA_KEY` stays repository-level. Same argument, but it is a read-only analytics service account and rotating it costs one key swap — not worth a second environment plus a second manual re-entry of a JSON blob. Recorded in `SECURITY.md` so the next pass doesn't re-derive it.

Agent: Lead Engineer
