### PR TITLE
fix(app): spawn the CLI through a real executable on Windows (TRA-638)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,16 @@ jobs:
               - 'tests/project-setup/dangerous-root.test.ts'
               - 'tests/topology/**'
               - 'tests/registry.test.ts'
+            # TRA-638: fifth Windows-shaped hole. The app's main process spawns
+            # the CLI, and on Windows the launcher it resolves is a `.cmd` that
+            # execFile cannot launch — three MCP-client IPCs were dead there for
+            # months. The app's own test job is ubuntu-only, so the regression
+            # test lives in tests/app/ and this filter is what puts it on a
+            # Windows runner.
+              - 'packages/app/src/main/daemon-install.ts'
+              - 'packages/app/src/main/daemon-lifecycle.ts'
+              - 'packages/app/src/main/trace-home.ts'
+              - 'tests/app/**'
             core:
               - 'src/**'
               - 'scripts/**'

--- a/packages/app/src/main/daemon-install.ts
+++ b/packages/app/src/main/daemon-install.ts
@@ -23,7 +23,12 @@
  *    install pointing at itself — see `decideTakeover`.
  */
 
-import { execFileSync } from 'node:child_process';
+import {
+  execFile,
+  execFileSync,
+  type ExecFileException,
+  type ExecFileOptions,
+} from 'node:child_process';
 import fs from 'node:fs';
 import http from 'node:http';
 import os from 'node:os';
@@ -217,12 +222,86 @@ export function resolveCliCommand(dir = getLauncherDir()): string {
   return isExecutable(shim) ? shim : SHIM_NAMES[SHIM_NAMES.length - 1];
 }
 
+/** How to spawn the CLI with no shell: `execFile(file, [...prefixArgs, ...argv])`. */
+export interface CliInvocation {
+  file: string;
+  prefixArgs: string[];
+  /** Environment the runner needs, merged over `process.env` by `execCli`. */
+  env?: Record<string, string>;
+}
+
+/**
+ * The shim `resolveCliCommand` returns is a `.cmd` on Windows, and Node cannot
+ * launch a `.bat`/`.cmd` at all without a shell — see
+ * https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows.
+ * Every no-shell `execFile` against it therefore failed, which is why the MCP
+ * clients screen could not read a status, Connect or Update on Windows
+ * (TRA-638). The PATH fallback does not rescue it either: there is no
+ * extensionless `trace-mcp` on Windows.
+ *
+ * `shell: true` is not the fix. The argv these callers pass carries project
+ * paths; it is passed as argv precisely so that spaces and `&` in them are
+ * never interpreted, and turning on a shell would reopen that.
+ *
+ * So run the CLI the way the shim itself runs it: a real executable with
+ * `cli.js` as its first argument. `launcher.env` already records that cli.js,
+ * and our own binary is a Node runtime under `ELECTRON_RUN_AS_NODE` — which is
+ * the whole job of `bin/node-runtime.cmd`. The caller's argv stays argv.
+ */
+export function resolveCliInvocation(
+  opts: { dir?: string; execPath?: string; isWindows?: boolean } = {},
+): CliInvocation {
+  const dir = opts.dir ?? getLauncherDir();
+  const viaShim: CliInvocation = { file: resolveCliCommand(dir), prefixArgs: [] };
+  if (!(opts.isWindows ?? IS_WINDOWS)) return viaShim;
+
+  // Nothing installed to point at: fall through and let the spawn fail with
+  // the same ENOENT it would have anyway, rather than inventing a path.
+  const { cli } = readLauncherEnv(dir);
+  if (!cli || !isFile(cli)) return viaShim;
+
+  return {
+    file: opts.execPath ?? process.execPath,
+    prefixArgs: [cli],
+    env: { ELECTRON_RUN_AS_NODE: '1' },
+  };
+}
+
+/**
+ * `execFile` against the CLI, with the Windows launcher problem solved once.
+ * Callers go through here rather than `resolveCliCommand` so a fourth IPC
+ * cannot quietly reintroduce the spawn that does not work.
+ */
+export function execCli(
+  args: string[],
+  options: Omit<ExecFileOptions, 'encoding'>,
+  callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+): void {
+  const { file, prefixArgs, env } = resolveCliInvocation();
+  execFile(
+    file,
+    [...prefixArgs, ...args],
+    {
+      windowsHide: true,
+      ...options,
+      encoding: 'utf-8',
+      env: { ...process.env, ...options.env, ...env },
+    },
+    callback,
+  );
+}
+
 /**
  * Where the staged server lives inside the packaged app, or null when running
  * from a checkout (`pnpm dev:electron`), where the developer's own npm install
  * owns the control plane and this module must keep its hands off.
  */
-export function bundledServerDir(resourcesPath = process.resourcesPath): string | null {
+export function bundledServerDir(
+  // `process.resourcesPath` is Electron's, and since daemon-lifecycle.ts reaches
+  // this module for `resolveCliInvocation`, the root tsconfig compiles this file
+  // too (src/daemon/__tests__ imports daemon-lifecycle) — with plain Node types.
+  resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath,
+): string | null {
   if (!resourcesPath) return null;
   const dir = path.join(resourcesPath, 'server');
   return isFile(path.join(dir, 'dist', 'cli.js')) ? dir : null;

--- a/packages/app/src/main/daemon-lifecycle.ts
+++ b/packages/app/src/main/daemon-lifecycle.ts
@@ -22,6 +22,7 @@ import { execFileSync, execSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { type CliInvocation, resolveCliInvocation } from './daemon-install';
 import { getLauncherDir, getLauncherShimPath, SHIM_NAMES } from './trace-home';
 
 const isWin = process.platform === 'win32';
@@ -88,9 +89,14 @@ function runDaemonCommand(subcommand: 'start' | 'stop' | 'restart'): {
   ok: boolean;
   error?: string;
 } {
-  let bin: string;
+  // TRA-638: on Windows the shim is a `.cmd`, which execFileSync cannot launch
+  // without a shell — `shell: isWin` below is the only reason this path worked
+  // while the identical MCP-client spawns failed. Prefer the runtime + cli.js
+  // that launcher.env records, so no shell is involved at all.
+  let inv: CliInvocation;
   try {
-    bin = resolveTraceMcpBinary();
+    inv = resolveCliInvocation();
+    if (inv.prefixArgs.length === 0) inv = { file: resolveTraceMcpBinary(), prefixArgs: [] };
   } catch (err) {
     return { ok: false, error: (err as Error).message };
   }
@@ -98,12 +104,13 @@ function runDaemonCommand(subcommand: 'start' | 'stop' | 'restart'): {
   try {
     // execFileSync avoids shell-injection concerns around the resolved path.
     // Windows paths may contain spaces; pass as single arg.
-    execFileSync(bin, ['daemon', subcommand], {
+    execFileSync(inv.file, [...inv.prefixArgs, 'daemon', subcommand], {
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
-      // `shell: true` is required on Windows to resolve .cmd/.bat wrappers
-      // that npm global installs generate.
-      shell: isWin,
+      // Last resort only: a Windows machine with no launcher.env to point at
+      // can still have a `.cmd` on PATH, and this argv is two literals.
+      shell: isWin && inv.prefixArgs.length === 0,
+      env: inv.env ? { ...process.env, ...inv.env } : process.env,
       encoding: 'utf-8',
     });
     return { ok: true };

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -163,7 +163,7 @@ ipcMain.handle('open-in-ide', async (_event, bundlePath: string, filePath: strin
   });
 });
 
-import { type DaemonSetupState, ensureDaemonInstalled, resolveCliCommand } from './daemon-install';
+import { type DaemonSetupState, ensureDaemonInstalled, execCli } from './daemon-install';
 import { isDaemonProcessAlive, restartDaemon } from './daemon-lifecycle';
 import {
   deleteModel as ollamaDelete,
@@ -335,8 +335,7 @@ ipcMain.handle('get-mcp-client-statuses', async (_event, scope: string = 'global
       level?: 'base' | 'standard' | 'max' | null;
     }>;
   }>((resolve) => {
-    execFile(
-      resolveCliCommand(),
+    execCli(
       ['clients', 'status', '--json', '--scope', scope === 'project' ? 'project' : 'global'],
       { timeout: 15_000, maxBuffer: 1024 * 1024 },
       (error, stdout) => {
@@ -385,8 +384,7 @@ ipcMain.handle(
     return new Promise<{ ok: boolean; error?: string }>((resolve) => {
       // Use execFile to avoid shell interpretation: flags like project paths
       // could contain whitespace or special chars and must not be evaluated.
-      execFile(
-        resolveCliCommand(),
+      execCli(
         ['init', ...flags],
         {
           timeout: 30_000,
@@ -414,8 +412,7 @@ ipcMain.handle(
 // the button says it does.
 ipcMain.handle('update-mcp-clients', async (_event, clientNames: string[]) => {
   return new Promise<{ ok: boolean; error?: string }>((resolve) => {
-    execFile(
-      resolveCliCommand(),
+    execCli(
       ['clients', 'update', ...clientNames, '--json'],
       { timeout: 60_000, maxBuffer: 1024 * 1024 },
       (error, stdout, stderr) => {

--- a/tests/app/windows-cli-spawn.test.ts
+++ b/tests/app/windows-cli-spawn.test.ts
@@ -1,0 +1,121 @@
+/**
+ * TRA-638: the desktop app could not spawn its own CLI on Windows.
+ *
+ * The MCP-clients screen ran `execFile(resolveCliCommand(), …)`, and on Windows
+ * `resolveCliCommand` returns `~/.trace-mcp/bin/trace-mcp.cmd` — a file Node
+ * refuses to launch without a shell. Status, Connect and Update all failed, and
+ * looked identical to working buttons while doing so.
+ *
+ * These tests live in the root suite on purpose. The app has its own lockfile
+ * and its own vitest run, and that job (`app-typecheck`) is ubuntu-only, so a
+ * Windows-only defect in `packages/app/src/main` has nowhere in the app's own
+ * suite where it would ever be executed. The root suite is what
+ * `cross-platform-test` runs on windows-latest.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  execCli,
+  resolveCliCommand,
+  resolveCliInvocation,
+} from '../../packages/app/src/main/daemon-install';
+
+/**
+ * A launcher dir shaped like a real install: both shim names present (so the
+ * layout is valid whichever platform reads it) and a launcher.env pointing at a
+ * cli.js that echoes the argv it was handed.
+ */
+function makeLauncherHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tra638-'));
+  const bin = path.join(home, 'bin');
+  fs.mkdirSync(bin, { recursive: true });
+
+  const cli = path.join(home, 'cli.js');
+  fs.writeFileSync(cli, 'console.log(JSON.stringify(process.argv.slice(2)));\n');
+
+  // The POSIX shim, doing what the shipped one does: exec Node on cli.js.
+  fs.writeFileSync(
+    path.join(bin, 'trace'),
+    `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(cli)} "$@"\n`,
+    { mode: 0o755 },
+  );
+  // The Windows shim — present so the resolver has the .cmd it must not pick.
+  fs.writeFileSync(path.join(bin, 'trace.cmd'), '@echo off\r\n', { mode: 0o755 });
+
+  fs.writeFileSync(
+    path.join(home, 'launcher.env'),
+    [`TRACE_CLI="${cli.replaceAll('\\', '/')}"`, 'TRACE_VERSION="3.7.0"', ''].join('\n'),
+  );
+  return home;
+}
+
+describe('resolveCliInvocation', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = makeLauncherHome();
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('never hands execFile a .cmd on Windows', () => {
+    const inv = resolveCliInvocation({ dir: home, isWindows: true, execPath: '/opt/node' });
+
+    expect(inv).toEqual({
+      file: '/opt/node',
+      prefixArgs: [path.join(home, 'cli.js').replaceAll('\\', '/')],
+      env: { ELECTRON_RUN_AS_NODE: '1' },
+    });
+    // What shipped instead, under this exact layout — unlaunchable without a shell.
+    expect(path.extname(resolveCliInvocation({ dir: home, isWindows: true }).file)).not.toBe(
+      '.cmd',
+    );
+  });
+
+  it('stays on the shim off Windows, where it is directly executable', () => {
+    const inv = resolveCliInvocation({ dir: home, isWindows: false });
+    expect(inv).toEqual({ file: resolveCliCommand(home), prefixArgs: [] });
+  });
+
+  it('falls back to the shim when launcher.env names no cli.js', () => {
+    fs.rmSync(path.join(home, 'launcher.env'));
+    const inv = resolveCliInvocation({ dir: home, isWindows: true });
+    expect(inv.prefixArgs).toEqual([]);
+  });
+});
+
+describe('execCli', () => {
+  let home: string;
+  const previous = process.env.TRACE_HOME;
+
+  beforeEach(() => {
+    home = makeLauncherHome();
+    process.env.TRACE_HOME = home;
+  });
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.TRACE_HOME;
+    else process.env.TRACE_HOME = previous;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  /* The status call, spawned for real on whatever OS is running this. On
+     Windows that exercises the runtime + cli.js path; elsewhere, the shim.
+     A shell anywhere in that chain would have eaten the `&`. */
+  it('reaches the CLI with argv intact — spaces and & included', async () => {
+    const argv = await new Promise<string[]>((resolve, reject) => {
+      execCli(
+        ['clients', 'status', '--json', '--scope', 'C:\\Program Files\\a & b'],
+        { timeout: 30_000 },
+        (error, stdout) => (error ? reject(error) : resolve(JSON.parse(stdout))),
+      );
+    });
+
+    expect(argv).toEqual(['clients', 'status', '--json', '--scope', 'C:\\Program Files\\a & b']);
+  });
+});


### PR DESCRIPTION
Fixes TRA-638. Found by Code Reviewer during review of PR #724; the defect predates that PR and was on `master`.

## The bug

`resolveCliCommand()` returns `~/.trace-mcp/bin/trace-mcp.cmd` on Windows, and Node [cannot launch a `.bat`/`.cmd` without a shell](https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows). All three MCP-client IPCs handed it straight to `execFile()`:

- `get-mcp-client-statuses` → the screen silently dropped to presence-only detection and could not tell `up_to_date` from `stale`
- `configure-mcp-client` (Connect) and `update-mcp-clients` (Update) → failed outright

The PATH fallback did not rescue it either — there is no extensionless `trace-mcp` on Windows. Same class as TRA-497: the button looks identical whether it worked or not.

## The fix

`shell: true` is not it. The argv these calls pass carries project paths, and they are argv precisely so no shell interprets their spaces and `&`.

Instead, one invocation descriptor — `resolveCliInvocation() → { file, prefixArgs, env }`:

- **Windows**: a real executable plus the `cli.js` that `launcher.env` already records. Our own binary is a Node runtime under `ELECTRON_RUN_AS_NODE`, which is the whole job of `bin/node-runtime.cmd`.
- **POSIX**: unchanged — the shim, no prefix args.
- **Neither installed**: falls back to the shim so the spawn fails with the same ENOENT it would have anyway, rather than inventing a path.

Callers go through `execCli(args, options, cb)` rather than resolving the command themselves, so a fourth IPC cannot regress by reaching for `resolveCliCommand` directly.

`daemon-lifecycle.ts` used `shell: isWin` for the same reason — that is the only thing that kept the daemon path working while these three failed. It now takes the same invocation and keeps the shell strictly as a last resort, where the argv is two literals.

One incidental change: `bundledServerDir`'s `process.resourcesPath` default is now cast. Reaching `daemon-install.ts` from `daemon-lifecycle.ts` pulls it into the root tsconfig's program (`src/daemon/__tests__/app-restart-policy.test.ts` imports `daemon-lifecycle`), which has plain Node types, not Electron's.

## Test evidence

`tests/app/windows-cli-spawn.test.ts` — 4 tests, and it lives in the root suite on purpose: the app's own vitest job is ubuntu-only, so a Windows-only defect in `packages/app/src/main` had nowhere in that suite where it would ever execute. The root suite is what `cross-platform-test` runs on windows-latest, and the paths filter now routes these files to it (this PR therefore runs the Windows matrix).

Deterministic failure against the pre-fix behaviour, verified on a macOS host by forcing the Windows branch off:

```
- "file": "/opt/node",
- "prefixArgs": ["…/cli.js"],
+ "file": "…/bin/trace",
+ "prefixArgs": [],
 Test Files  1 failed (1)
```

The integration test spawns the real status call — `clients status --json --scope 'C:\Program Files\a & b'` — and asserts the argv round-trips intact; a shell anywhere in the chain would have eaten the `&`.

Local runs, all green:

- root `vitest run --exclude='tests/perf/**'` — 9394 passed, 8 skipped (859 files)
- `packages/app` `pnpm run test` — 571 passed (58 files)
- root `tsc --noEmit`, root `tsup` build
- `packages/app` `tsc --noEmit`, `pnpm run build`, `check:i18n`
- `biome ci .` — 1686 files clean

Not verified on a physical Windows machine — the Windows leg of `cross-platform-test` is the check that does that, and it runs on this PR.

Agent: Lead Engineer
