### PR TITLE
docs(roadmap): revise for v3.11.0 — presets supersede tool consolidation, adoption is live (TRA-625)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,41 +8,72 @@ noindex: true
 # Product Roadmap
 
 Strategic view of trace-mcp, revisited roughly weekly by the Product Roadmap
-& Vision autopilot, which also turns 2-4 of the items below into that week's
+& Vision autopilot, which also turns the items below into that week's
 operational focus (see the "This Week's Focus" section of the trace-mcp
 Operations project). This file tracks *why* something should move the
 product forward — not day-to-day bugs, tool tweaks, or indexing hygiene
 (those live as regular issues, tracked by other autopilots). An item is
 removed here once it ships, is superseded, or turns out not to matter.
 
-## Where the product stands
+## Where the product stands (revised 2026-09-02)
 
-Both items that were "ready to start" two revisions ago shipped:
-**CI-native PR intelligence** (TRA-127) and the **multi-project tool
-surface** (TRA-93/TRA-143). The item that replaced them last revision has
-now also shipped: **TRA-186's tool-schema-tax cut** landed in two releases
-(v1.48.3 PR #377, v1.48.4 PR #380) — tool description text 73,947→~64k
-chars, per-parameter description text 32,281→30,245 chars, both now
-regression-guarded by `tool-schema-budget.test.ts`. That's a real but modest
-cut (~6% off the ~203k-char/~50.7k-token baseline Nikolai measured), because
-the investigation surfaced the actual shape of the cost: of the ~94k
-inputSchema chars, only ~30-32k is prose (`.describe()` text) we control —
-the remaining ~60k+ is structural JSON Schema (`type`, `required`, `enum`,
-`minimum`/`maximum`) generated from legitimate parameter counts, which
-**cannot shrink without removing parameters or consolidating tools** —
-both are breaking MCP tool-contract changes, not prose edits. See item 1
-below for the resulting next step.
+The previous revision of this file described a v1.48.x product with an
+unsolved tool-schema tax and no adoption number. Both of those are now out
+of date, and the second one changes what this roadmap should be about.
 
-Per `docs/comparisons.md`'s own honest self-assessment, six of seven
-competitive gaps from the last deep pass are shipped and adversarially
-re-validated. The two remaining technical gaps (a peer-reviewed bug-risk
-metric; CFG/taint staying line-based/lexical instead of full AST/dataflow)
-are known architectural ceilings, not low-hanging fruit — leave them
-tracked in `comparisons.md`, not here.
+**The schema-tax thread is closed, and not the way this file predicted.**
+The last revision's only "ready to start" item was *scope tool-consolidation
+candidates into per-tool migration issues* — merge `pin_file`/`pin_symbol`,
+`search`/`search_with_mode`, the three edit-safety tools, and accept a
+breaking MCP tool-contract change in exchange for a smaller advertised
+surface. That item is **removed as superseded**: role-based presets
+(TRA-601/602/603, shipped) got the same win with **no contract break at
+all**. A preset is a *deferral*, not a restriction — every tool stays
+registered and `load_tools` pulls any of it back mid-session — so the
+advertised surface shrinks while capability stays whole. Measured on this
+repo: `minimal` 28 tools (now the default), `standard` 60, and six role
+presets between 26 and 42, for a **67% cut on the widest role preset
+(`dev`) and 86% on the narrowest (`design`)** against `full`. Ceilings are
+regression-guarded in `preset-surface-budget.test.ts`; documented sizes are
+checked against the real filter by `preset-claims.test.ts`. Nothing about
+tool consolidation is worth a contract break now.
 
-The other standing question is unchanged: **who trace-mcp serves and how
-far the current single-developer, single-repo model can stretch before it
-needs to change shape.**
+**The rename to `trace` is the largest thing in flight, and its measured
+efficiency case is ~1%.** TRA-613 (PR #720) benchmarked the actual rename
+against a real `initialize` + `tools/list` round-trip on four tokenizers:
+2 tokens per tool on GPT tokenizers, 3 on Claude/Gemini — 66 / 120 / 366
+tokens off `minimal` / `standard` / `full`, i.e. **0.74–1.23%** of what
+that surface already costs. That is a fine result and a bad justification.
+If the rename ships, it ships as a **positioning** decision, and it has to
+be judged and sequenced as one — see item 2 below.
+
+**Everything else is capability that landed fast.** Twelve releases in
+seven days (v3.2.0 → v3.11.0, 345 commits), a signed and notarized macOS
+DMG with electron-updater, an app that installs and repairs its own daemon,
+first-run setup, topology/decision-store pruning, Rust import resolution,
+and the SKILL.state linear context engine landing behind PR #715. The
+engine room is not the problem.
+
+## The one thing this roadmap is now about
+
+For the first time we can read the adoption metric of record, and it says
+**61 monthly active installs**.
+
+Set that beside the production rate — 27 autopilots, 12 releases and 345
+commits in the last seven days — and the ratio is the strategy. We are
+shipping roughly fifty commits a day for sixty-one users. Every gap this
+file has tracked for months has been a *capability* gap, and we have closed
+them at a rate almost nothing else closes them at. The gap that is actually
+binding is on the other side: **reach, and first value.** 102 GitHub stars
+after five months, ~20 human page views a day on the site, Reddit as our
+single largest referrer and unreadable to us, and 41% of installs that we
+cannot even attribute to a client.
+
+This is not an argument to slow the engine room down. It is an argument
+that the next several weeks of *strategic* work — the items below, and the
+weekly focus derived from them — should be measured in users reaching first
+value, not in capability shipped. The three "ready to start" items are all
+of that shape.
 
 ## Adoption — metric of record
 
@@ -53,8 +84,7 @@ day, opt-out via `TRACE_MCP_TELEMETRY=off`). Read it in the GA4 property
 holds unrelated properties; do not write to those).
 
 **Do not refresh this by hand.** `.github/workflows/ga4-snapshot.yml` pulls the
-numbers daily via the GA4 Data API — active users by day/week/month, and the
-breakdown by version, country and MCP client — and publishes them to the
+numbers daily via the GA4 Data API and publishes them to the
 [`adoption-data`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/adoption-data/adoption.yml)
 branch, plus each run's job summary. That branch is the durable record: GA4
 keeps event data for 14 months at most, so anything older survives only there.
@@ -68,88 +98,146 @@ anyone**. Active installs is the best adoption signal we have, not an
 auditable one; read it as a trend, and treat a sudden step change as
 suspect until corroborated.
 
-**npm weekly downloads are not an adoption metric** and should not be cited
-as one. Measured 2026-08-28 (TRA-273): 9,013 downloads over 92 days, but
-every daily peak is a publish day — 226 on 08-10 (v1.47.0), 344 on 08-17
-(v1.47.1), 1,322 on 08-27 (nine releases). Strip publish days and the
-baseline is flat at 20–45/day for the whole quarter. The graph measures our
-release cadence and registry mirrors, not users. If it must appear in a
-report, annotate the publish days.
-
-Re-confirmed 2026-08-29 (TRA-413) with a stronger tell than publish-day
-peaks: `https://api.npmjs.org/versions/trace-mcp/last-week` shows all 104
-published versions clustered at a near-uniform 136–198 weekly downloads
-while the median version is 2, and day-old releases hit parity with
-month-old ones instantly. That is a mirror sweeping the version history,
-not users — nobody installs `1.48.0`, `1.48.1` and `1.48.2` in equal
-measure. Decision: the npm-downloads badge is removed from the homepage
-trust strip and no download figure is cited on any public surface. Adoption
-metric of record is GitHub stars + traffic uniques. Re-check the per-version
-flatness quarterly, not per run.
-
-The same caveat now covers **git clones** (measured 2026-08-30, TRA-540):
-16,006 clones / 928 uniques in 14 days, ramping 166 → 8,736 per day across
-08-24…08-29 while human page views stayed flat at ~20/day. Unique *cloners*
-inflated along with the raw count (62 → 300), so clone uniques are no safer
-than clone totals. Whatever swept the npm version history swept git too. The
-metric of record is therefore GitHub stars plus traffic **views** uniques only
-— clones are excluded from it. Channel-by-channel state now lives in
-`ops/user-signal.md`.
-
-GitHub stars, same date: 101 total (April 58, May 23, June 8, July 5,
-August 6), 14 forks — a launch burst that decayed ~10× and stayed flat.
-
-| Date | Active installs | Notes |
+| Date | Active installs (day / week / month) | Notes |
 | --- | --- | --- |
-| 2026-08-28 | _pending GA4 read access_ | Ping verified end to end: published `trace-mcp@2.0.0` carries baked credentials, payload validates against the Measurement Protocol debug endpoint. |
+| 2026-08-28 | _pending GA4 read access_ | Ping verified end to end against the Measurement Protocol debug endpoint. |
+| 2026-09-01 | **54 / 61 / 61** | First real read. 310 events in 28 days; 15 new installs, 8 returning, 5 upgrades, 31 unattributed. 11 countries. Clients: 25 unknown, 8 claude-code, 2 codex, 1 grok. Versions seen: 3.8.0 (17), 3.10.0 (13), 3.7.0 (2), 3.6.0 (1), 3.5.2 (1). |
+
+Two things that number is already telling us, both actionable and both
+picked up as items below:
+
+- **We cannot attribute 41% of installs to a client** (25 of 61 report
+  `unknown`), and the ping carries no field for the active tool preset at
+  all. So the flagship efficiency claim — 67–86% — is bench-verified and
+  **not field-verified**. Item 1.
+- **Version spread is wider than a 12-release week should produce.** More
+  installs are seen on 3.8.0 than on 3.10.0, and 3.9.0 does not appear at
+  all — which is consistent with TRA-566 (v3.9.0 shipped with no Windows
+  assets and no `latest.yml`, so Windows updates were silently dead), but
+  is not yet proven to be that. Worth attributing before assuming it is
+  benign.
+
+**npm weekly downloads are not an adoption metric** and should not be cited
+as one. Settled twice (TRA-273, TRA-413): all published versions cluster at
+a near-uniform weekly count while the median version has ~2 real installs,
+and day-old releases hit parity with month-old ones instantly. That is a
+mirror sweeping the version history. **Git clones are out too** (TRA-540):
+16,006 clones / 928 uniques in 14 days while human page views stayed flat
+at ~20/day, with unique *cloners* inflating alongside the raw count.
+
+The public-facing metric of record is therefore **active installs, GitHub
+stars, and traffic *views* uniques** — nothing else. Channel-by-channel
+state lives in `ops/user-signal.md`; listing-by-listing state in
+`ops/distribution.md`. GitHub, 2026-09-02: **102 stars, 15 forks.**
 
 ## Ready to start
 
-### 1. Scope tool-consolidation candidates into per-tool migration issues (follow-up to TRA-186)
-TRA-186's own investigation named the candidate list (pin_file/pin_symbol,
-discover_claude_sessions/discover_hermes_sessions, search/search_with_mode,
-the three "is it safe to edit" tools, and others surfaced during the trim)
-and explicitly recommended **not** folding consolidation into that issue,
-since each merge is a breaking MCP tool-contract change and needs its own
-migration note (which callers break, what the replacement call looks like).
-This item is: pull that list into scoped issues, one (or a small related
-group) per issue, each with a concrete before/after tool signature and a
-migration note — a design/scoping pass, not a code-first pass.
+### 1. Field-verify the preset savings, and close the attribution hole in the ping (TRA-643)
+The ping (`src/telemetry/usage-ping.ts`) sends `version`, `platform`,
+`node_major`, `tokens_saved`, `calls`, `client`, `install_type`,
+`previous_version`, device, `model` and `repos_indexed` — and **nothing
+about the tool surface the session actually advertised.** So the number the
+whole product now leads with (67–86% off the tool surface) is measured on
+this repo's bench and unmeasured in the field, and 25 of 61 installs do not
+even say which client they run.
 
-**Why now:** it's the only remaining lever that moves the ~50k baseline
-materially (prose trimming is now regression-tested and tapped out at ~6%).
-It's also the more consequential kind of change — every merge is a contract
-break for anyone with the old tool name pinned — so it deserves the
-scoping rigor TRA-186 asked for, not a batch rewrite done casually.
+**Why now:** presets are the single biggest efficiency change we have ever
+shipped, they became the default silently (TRA-538 rewrote pre-v3.3
+`"preset": "full"` configs on upgrade), and we have no way to see whether
+that landed. Add the active preset and the advertised tool count to the
+ping, read them back in `adoption.yml`, and separately find out why `client`
+is unknown 41% of the time — an MCP client that does not identify itself is
+also a client we cannot write install docs for.
 
-## Big bet — needs a design pass before any code
+### 2. Own the rename cutover end to end, or don't do it (TRA-644)
+The rename to `trace` is being implemented across code, config paths, app
+branding and docs (TRA-610/611/614/615/636/641). What has no owner is the
+**ordering across the surfaces that are not code**: the npm package
+identity, `trace-mcp.com` and every indexed URL on it, ~10 external
+directory listings that carry the old name and stale counts, the official
+MCP registry entry, GitHub topics, and the configs on 61 live installs.
+Each of those is a different autopilot's territory, and a rename is exactly
+the change that fails at the seams between them.
 
-### 2. Team-shared graph — parked, needs Nikolai's go-ahead (TRA-128)
-trace-mcp's whole pitch is "reuse instead of recompute" — but today reuse
-only happens *within one developer's laptop, across turns*. A team of five
-engineers on the same repo each index it separately, each mine their own
-decisions separately, and never see each other's "why was this built this
-way" answers. That's the same recomputation leak the product exists to
-close, just at the team level instead of the turn level.
+**Why now:** the token case is measured at ~1% (TRA-613), so the entire
+justification is positioning — and positioning is precisely what breaks if
+the cutover is partial. Half-renamed, we are a project whose site, registry
+entry, directory listings and package name disagree with its binary, under
+a word (`trace`) generic enough that search will not disambiguate for us,
+on a surface that gets ~20 human views a day. This item is a written
+thesis plus a single sequenced cutover checklist with one owner — not more
+code.
 
-The design pass (TRA-128) is done: a lightweight shared-graph mode — a
-daemon reachable by a team instead of localhost-only, with a shared decision
-store — would turn trace-mcp from a personal productivity tool into a team
-artifact, and is the kind of capability that could eventually justify a
-hosted/paid tier. But the design's own recommended smallest slice is a
-network-reachable server component, which falls squarely in the one
-category this project's rules reserve for Nikolai's explicit call (no
-hosted backend / paid infra on an autopilot's own authority). **Status:
-correctly parked, not stalled** — the design stays valid and ready to
-resume the moment there's an explicit go-ahead or an actual team asking for
-it (the issue's own trigger condition). Nothing to do here until then.
+### 3. Put a funnel behind the 61, not just a number (TRA-645)
+We now have a denominator, and no funnel. Reach → install → **activation**
+→ retention is mostly derivable from what we already collect: `repos_indexed`
+tells us whether an install ever indexed anything, `install_type` separates
+new from returning, `by_version` shows whether they stay current. Nothing
+tells us where they came from — GitHub referrers say Reddit, which we
+cannot read (`ops/user-signal.md`), and the directory ledger tracks presence
+but never arrival.
+
+**Why now:** with 61 installs, a 10-install swing is a 16% move and every
+listing, page and README rewrite is currently graded on taste. One
+acquisition-channel signal plus one activation number would let the
+distribution, SEO, outreach and web-design autopilots stop arguing from
+aesthetics.
+
+## Big bets — design pass before any code
+
+### 4. One door instead of 169 — a router preset (new, TRA-646)
+Presets took the advertised surface down by hiding tools behind
+`load_tools`. That worked, it broke nothing, and it has an obvious limit:
+even `minimal` still advertises 28 full JSON Schemas, and TRA-186 already
+established that ~60k of the schema cost is *structural* — `type`,
+`required`, `enum`, bounds generated from legitimate parameter counts —
+which no prose edit touches.
+
+The structural version of the same idea is to stop being a 169-tool server
+at all: advertise a **router plus a catalog** — `plan_turn` already exists
+as an opening-move router, `load_tools` already exists as the pull
+mechanism — and let everything else be summoned by name rather than
+declared up front. The advertised surface would become roughly constant
+instead of scaling with the tool count, which also decouples our tool
+growth from our context cost permanently, and inverts the one axis every
+peer competes on (more tools = better) into one we can defend with numbers.
+
+**Unknowns that a design pass has to answer before any code:** whether a
+model reliably reaches for a tool it cannot see (this is the whole bet, and
+it is an empirical question we can A/B today with `load_tools` as it
+stands); the extra round-trip cost of summon-then-call versus the saved
+schema cost; what happens to clients that cache `tools/list`; and whether
+this is a new mode beside presets or a replacement for `full`. Not a
+contract break if it ships as a preset (`router`), which is the shape to
+design toward.
+
+### 5. Team-shared graph — parked, needs Nikolai's go-ahead (TRA-128)
+trace-mcp's whole pitch is "reuse instead of recompute", but reuse only
+happens within one developer's laptop, across turns. A team of five on the
+same repo each index it separately and never see each other's decisions —
+the same recomputation leak the product exists to close, at team scale.
+
+The design pass (TRA-128) is done and stays valid. Its own smallest slice
+is a network-reachable server component, which falls in the one category
+reserved for Nikolai's explicit call (no hosted backend / paid infra on an
+autopilot's authority). **Status: correctly parked, not stalled.** Note
+that item 3 sharpens the trigger condition: with 61 installs across 11
+countries and no evidence of a single multi-seat user, there is currently
+no demand-side reason to unpark it either.
 
 ## Explicitly not doing right now
 
-- Chasing competitor feature/tool-count parity for its own sake — see
-  `comparisons.md`'s "deliberately NOT chasing" list. Still holds, and item
-  1 above is the sharper version of why: count alone was never the right
-  metric to chase, in either direction.
-- Rewriting CFG/taint analysis onto a real AST/dataflow engine — real gap,
-  correctly filed as a known ceiling, not a roadmap item until something
-  forces the issue (e.g. a security-critical false negative in the wild).
+- **Tool consolidation as a token play.** Superseded by presets, which got
+  67–86% without a contract break. Do not reopen it for efficiency reasons;
+  only merge two tools if they are genuinely the same tool.
+- **Chasing competitor feature/tool-count parity for its own sake** — see
+  `comparisons.md`'s "deliberately NOT chasing" list. Item 4 is the sharper
+  version of why: count was never the metric, in either direction.
+- **Rewriting CFG/taint analysis onto a real AST/dataflow engine** — a real
+  gap, correctly filed in `comparisons.md` as a known ceiling, not a
+  roadmap item until something forces it (e.g. a security-critical false
+  negative in the wild).
+- **Adding language #82 or framework #88 as a headline.** 81/87 is already
+  past the point where the count persuades anyone; per-language *edge
+  resolution depth* (the `resolution_tier` we already store) is the claim
+  worth making, and it is the coverage autopilot's focus this week.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -202,6 +202,18 @@ instead of scaling with the tool count, which also decouples our tool
 growth from our context cost permanently, and inverts the one axis every
 peer competes on (more tools = better) into one we can defend with numbers.
 
+**This is not speculative — the market leader already ships it.**
+`comparisons.md`'s own August 2026 source read found that codegraph (68.7K
+stars) implements eight MCP tools and **advertises exactly one of them** by
+default: `DEFAULT_MCP_TOOLS` is the single-element set `{explore}`, with
+the rest re-enablable through an allowlist env var. Their whole advertised
+surface costs roughly **1.9K tokens**. Their stated reason, in a source
+comment, is not token cost at all — it is that *presence itself steers
+mis-picks*. codebase-memory-mcp (41.2K stars) makes a weaker version of the
+same call with tool profiles. So the open question is not whether anyone
+would ship this; it is whether it survives at 169 tools instead of 8, which
+is exactly what a design pass is for.
+
 **Unknowns that a design pass has to answer before any code:** whether a
 model reliably reaches for a tool it cannot see (this is the whole bet, and
 it is an empirical question we can A/B today with `load_tools` as it
@@ -232,7 +244,8 @@ no demand-side reason to unpark it either.
   only merge two tools if they are genuinely the same tool.
 - **Chasing competitor feature/tool-count parity for its own sake** — see
   `comparisons.md`'s "deliberately NOT chasing" list. Item 4 is the sharper
-  version of why: count was never the metric, in either direction.
+  version of why: count was never the metric, in either direction, and the
+  two largest peers are competing in the opposite direction anyway.
 - **Rewriting CFG/taint analysis onto a real AST/dataflow engine** — a real
   gap, correctly filed in `comparisons.md` as a known ceiling, not a
   roadmap item until something forces it (e.g. a security-critical false


### PR DESCRIPTION
Weekly Product Roadmap & Vision revision of `docs/ROADMAP.md`. Documentation only — no code, no schema, no CI change.

**What changed and why**

The file described a v1.48.x product. Three things in it were stale:

1. Its only "ready to start" item proposed **breaking tool consolidation** to cut the schema tax. Superseded — role presets (TRA-601/602/603) got 67–86% off the advertised surface with no MCP contract break. Removed rather than carried forward.
2. The adoption table read `pending GA4 read access`. The `adoption-data` branch now returns **54 / 61 / 61** active installs; first real row added, with the two gaps it exposes (41% of installs report `client: unknown`; the ping has no preset field, so 67–86% is bench-verified only).
3. Nothing in it mentioned the rename to `trace`, the largest thing in flight. TRA-613 measured its token benefit at **0.74–1.23%**, so it is recorded as a positioning decision that needs sequencing, not an efficiency one.

**New items filed from this revision:** TRA-643 (field-verify presets + client attribution), TRA-644 (rename cutover ownership), TRA-645 (adoption funnel), TRA-646 (big-bet design pass: a router preset that decouples context cost from tool count).

Markdown-only, so exempt from the second-model review gate per the workspace rule.