### PR TITLE
docs: decide the trace rename — command, not project (TRA-644)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,24 +149,34 @@ ping, read them back in `adoption.yml`, and separately find out why `client`
 is unknown 41% of the time — an MCP client that does not identify itself is
 also a client we cannot write install docs for.
 
-### 2. Own the rename cutover end to end, or don't do it (TRA-644)
-The rename to `trace` is being implemented across code, config paths, app
-branding and docs (TRA-610/611/614/615/636/641). What has no owner is the
-**ordering across the surfaces that are not code**: the npm package
-identity, `trace-mcp.com` and every indexed URL on it, ~10 external
-directory listings that carry the old name and stale counts, the official
-MCP registry entry, GitHub topics, and the configs on 61 live installs.
-Each of those is a different autopilot's territory, and a rename is exactly
-the change that fails at the seams between them.
+### 2. Execute the rename in the order the decision fixed (TRA-644 — decided)
+**Decided 2026-09-02: `trace` is the command, `trace-mcp` is the project.**
+Thesis, per-surface table and reopen condition in
+[`ops/rename-to-trace.md`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/ops/rename-to-trace.md).
+The short name takes only what sits on a developer's own disk and is
+migrated by code we control — the CLI binary, the MCP server key, `~/.trace`.
+The npm package, `trace-mcp.com` and its indexed URLs, the `server.json`
+registry identity, the repo name and topics, the ~10 external listings and
+the Electron bundle (TRA-636, cancelled) all keep `trace-mcp`.
 
-**Why now:** the token case is measured at ~1% (TRA-613), so the entire
-justification is positioning — and positioning is precisely what breaks if
-the cutover is partial. Half-renamed, we are a project whose site, registry
-entry, directory listings and package name disagree with its binary, under
-a word (`trace`) generic enough that search will not disambiguate for us,
-on a surface that gets ~20 human views a day. This item is a written
-thesis plus a single sequenced cutover checklist with one owner — not more
-code.
+Two verified facts closed the full-rename option. **`trace` has been taken
+on npm since 2024**, so `npx trace` was never available and the install
+command — the most-copied string we have — could not be renamed under any
+plan; the question was only where the boundary between two names sits. And
+**the whole prize is 0.74–1.23%** (TRA-613), all of it in the server key and
+the CLI verb, none of it in the package name, the domain, the registry entry
+or the bundle. So the boundary goes where the tokens are, which also makes
+this an ordinary two-name split (`ripgrep`/`rg`, `neovim`/`nvim`) rather
+than a partial cutover, and leaves nothing in the program irreversible and
+no door that needs a human.
+
+**What is left is execution, in one order.** TRA-641 first: analytics still
+classify our calls as `tool_server === 'trace-mcp'`, and TRA-614's Migrate
+button is merged but not in v3.11.0 — once the release carrying it ships,
+`get_real_savings` reports zero, silently. Then TRA-611 (#730), then TRA-615
+(#717) rewritten to state the boundary rather than announce a rename. TRA-650
+covers the one real breakage: the tool prefix in allowlists, hook matchers
+and prose that users wrote themselves, which `init` cannot reach.
 
 ### 3. Put a funnel behind the 61, not just a number (TRA-645)
 We now have a denominator, and no funnel. Reach → install → **activation**

--- a/ops/distribution.md
+++ b/ops/distribution.md
@@ -106,6 +106,36 @@ different, less useful product. Developer ID + notarization gives the same
 Gatekeeper outcome with none of that. Don't reopen without a concrete reason
 this changed on Apple's side.
 
+## The `trace` rename does not touch any surface in this table
+
+Decided 2026-09-02 (TRA-644), full reasoning in [`ops/rename-to-trace.md`](rename-to-trace.md):
+**`trace` is the command, `trace-mcp` is the project.** The short name applies
+only to things on a developer's own disk — the CLI binary, the MCP server key
+in their client config, `~/.trace`. Every surface listed above keeps
+`trace-mcp`.
+
+What that means for listings work, so nobody re-opens it:
+
+- **The npm package name is `trace-mcp` permanently.** `trace` on npm is taken
+  (`AndreasMadsen/trace`, "Creates super long stack traces", latest 3.2.0,
+  published 2024-10-23 — verified 2026-09-02). There is no rename to announce.
+- **`server.json` keeps `io.github.nikolai-vysotskyi/trace-mcp`.** It is the
+  identity mcp.so, Smithery and PulseMCP ingest, and it republishes on every
+  release. Renaming it would buy zero tokens and risk the free pickup the whole
+  registry strategy depends on.
+- **No rename submissions to any directory.** The count corrections already in
+  flight stand; nothing else needs to be re-sent.
+- **mcpmarket.com's "Trace" entry is not a defect any more.** It was listed as
+  a mismatch to fix; under this decision it is accurate. Do not spend the $29
+  paid edit or the support email on it.
+- **The repo name, description, topics and `trace-mcp.com` are unchanged.** No
+  redirects, no canonical changes, no re-indexing cost. The site has 5 of 13
+  pages unindexed already (TRA-350) — there is no index coverage to spend.
+
+The measured case for the whole rename was **0.74–1.23%** of the advertised
+tool surface (TRA-613, #720). Anything that would cost this table a listing is
+not worth that, and this row exists so the next run does not re-derive it.
+
 ## Findings that should not be re-derived
 
 **The official registry was the root cause of everything else** (TRA-352,

--- a/ops/rename-to-trace.md
+++ b/ops/rename-to-trace.md
@@ -1,0 +1,129 @@
+# The `trace` rename — decision, boundary, and cutover order
+
+Decided 2026-09-02 (TRA-644). **Go, with a boundary: `trace` is the command,
+`trace-mcp` is the project.** Everything local to a developer's machine takes
+the short name. Nothing addressable from the outside world changes.
+
+Read this before touching any rename issue, and before proposing a rename of
+the package, the domain, the repo, the registry entry or the app bundle —
+those are decided, not open.
+
+## Why not the full rename
+
+**It was never available.** `trace` on npm is taken: `AndreasMadsen/trace`,
+"Creates super long stack traces", latest 3.2.0, last published 2024-10-23
+(verified against `registry.npmjs.org` on 2026-09-02). So `npx trace` can
+never be our install command. The install line is the single most-copied
+string we have — it is in the client config of every user, in every directory
+listing, and on every page of the site. A rename that cannot reach it is not a
+rename; it is a second name. The only real question was where the line between
+the two names sits.
+
+**The token case does not move that line.** TRA-613 (#720) measured a real
+`initialize` + `tools/list` round-trip on four tokenizers: `mcp__trace-mcp__x`
+→ `mcp__trace__x` is 2 tokens per tool on GPT tokenizers, 3 on Claude and
+Gemini — **66 / 120 / 366 tokens** off the `minimal` / `standard` / `full`
+preset, i.e. **0.74–1.23%** of a surface that already costs 8k–45k. This is
+not an efficiency change, and it must not be described as one anywhere.
+
+**So put the line where the tokens are.** Every token in the measurement sits
+in two places: the MCP server key that prefixes every tool name on every turn,
+and the CLI verb in prose. Every cost sits in the other places: the domain and
+its indexed URLs, the registry entry, ~10 directory listings, the GitHub
+identity, the app bundle. Renaming those buys exactly zero tokens.
+
+**The generic-word objection dissolves at that boundary.** Nothing searchable
+becomes "trace". The repo, the domain, `server.json` and every directory entry
+keep `trace-mcp`, so search still disambiguates us the way it does today.
+`trace` appears only where someone has already found us — their shell and
+their client config. mcpmarket.com's existing **"Trace"** listing stops being a
+thing to correct and becomes accurate; no paid edit, no email.
+
+**This is the normal shape, not a compromise.** ripgrep ships `rg`, neovim
+ships `nvim`, the_silver_searcher ships `ag`, kubernetes ships `kubectl`.
+Nobody reads those as half-finished renames. "Half-renamed" is only a failure
+mode when the boundary is unstated — which is what this file fixes.
+
+## What the boundary costs
+
+Two real costs. Both are stated rather than absorbed.
+
+**1. macOS already has a `trace`.** `/usr/bin/trace` is Apple's `trace(1)` —
+"record and modify trace files", a performance-analysis tool (verified on a
+Tahoe machine, 2026-09-02). On the usual developer PATH the npm global prefix
+comes first and ours wins; on a PATH where `/usr/bin` wins, `trace add .` runs
+Apple's tool and prints an error that never mentions us. Handling: both bin
+names stay installed **permanently**, and the migration docs name the
+collision and `trace-mcp` as the unambiguous form. Do not remove the
+`trace-mcp` bin, ever.
+
+**2. The tool prefix moves, and users wrote it down themselves.**
+`mcp__trace-mcp__*` → `mcp__trace__*`. `init` migrates the server entry it
+owns; it cannot migrate what the user typed — permission allowlists, custom
+hooks, their own `CLAUDE.md` prose (#730 says so in its own known-limitations
+section). This is the one place where ~1% of tokens buys a real interruption,
+and it is the only part of this program worth extra engineering. Tracked as
+**TRA-650**; until it lands, the migration docs must tell people to grep their
+own config for `mcp__trace-mcp__`.
+
+## Per-surface disposition
+
+| Surface | Decision | Why |
+|---|---|---|
+| CLI binary | `trace` added, **`trace-mcp` kept forever** | ergonomics; additive and reversible. See the `/usr/bin/trace` collision above |
+| MCP server key in client configs | → `trace`, auto-migrated by `init` | the only place the measured tokens are |
+| Config paths `~/.trace`, `.trace.json` | → new, old read as fallback, one-time atomic rename | local, migrated, reversible per install |
+| User-written tool-name references (allowlists, hooks, prose) | needs its own migration pass | the one real breakage |
+| Analytics `tool_server` classification | must accept `trace`, `trace-mcp`, `trace_mcp` | otherwise the headline savings metric reports zero. See "Ordering" |
+| npm package name | **stays `trace-mcp`. Permanently.** | `trace` taken since 2024. Never announce a package rename |
+| trace-mcp.com, its URLs and titles | **unchanged** — no redirects, no canonical churn, no title rewrites | 5 of 13 pages are already unindexed (TRA-350, blocked) and the `/vs/` cluster is sitemap-only (TRA-626). We have no index coverage to spend |
+| GitHub repo name, topics, description | **unchanged** | the repo name is the registry namespace and every inbound link; 20/20 topic slots are already spent on words people search for |
+| MCP registry `server.json` name | **stays `io.github.nikolai-vysotskyi/trace-mcp`** | it is republished on every release and is what mcp.so, Smithery and PulseMCP ingest. Changing the identity downstream directories key on, to save no tokens, is a pure distribution risk |
+| ~10 external directory listings | **no rename submissions.** Count corrections already in flight stand | nothing to correct — under this decision the listings are right as they are |
+| Electron bundle `productName` / `appId` / `app.name` | **do not rename** — TRA-636 cancelled | moves `userData` (every install loses persisted state), renames the `.app` mid-update, and risks the electron-updater path we only just got working (TRA-437/562/566) — for zero tokens |
+| Docs / README | one migration section, stating the boundary | it is not "we renamed to trace", it is "the project is trace-mcp, the command is `trace`" |
+
+## Ordering
+
+One hard constraint, and the board currently violates it.
+
+1. **TRA-641 first — analytics keys.** `src/analytics/rules.ts:244` and
+   `real-savings.ts:190` classify our own calls as
+   `tool_server === 'trace-mcp' || 'trace_mcp'`. TRA-614's "Migrate to trace"
+   button is merged to master and is **not** in v3.11.0 — so the window is
+   still open. The moment the release carrying it ships, a user clicks
+   Migrate, their sessions log `trace`, and `get_optimization_report` /
+   `get_real_savings` attribute **zero savings** — the product's headline
+   number, silently wrong, with no error. Land the shared-constant fix before
+   the next release.
+2. **Then TRA-611 (#730)** — server identity, config paths, client
+   auto-migration.
+3. **Then TRA-615 (#717)** — docs. Rewrite it to describe the boundary, not a
+   rename.
+4. **TRA-650** — migrate the tool-name references users wrote themselves
+   (allowlists, hook matchers, prose). Not a blocker for #730; the failure
+   mode is an interruption, not data loss.
+5. **Never: TRA-636** — bundle rename. Cancelled.
+
+**Nothing in this program is irreversible.** That is the whole point of the
+boundary: every changed surface is on a user's own disk, dual-named, and
+migrated by code we control.
+
+## No human-only doors
+
+This decision needs no browser login, no purchase, no paid listing edit, no
+domain and no registry re-identification. The batched ask for Nikolai that
+TRA-644 anticipated is **empty** — that is the result, not an omission.
+
+## If someone reopens this
+
+The two facts that close it are checkable in under a minute and should be
+re-checked rather than argued with:
+
+```
+curl -s https://registry.npmjs.org/trace | jq '.name, .["dist-tags"]'   # taken
+man 1 trace                                                            # Apple's
+```
+
+Reopen only if `trace` frees up on npm **and** the token figure moves by an
+order of magnitude. Neither has an obvious path.


### PR DESCRIPTION
Go/no-go for the `trace-mcp` → `trace` rename, taken here rather than by momentum. Docs and ops only, no code.

## Decision

**`trace` is the command, `trace-mcp` is the project.** The short name takes the CLI binary, the MCP server key in client configs and `~/.trace` — everything on a developer's own disk, dual-named and migrated by code we control. The npm package, the domain and its indexed URLs, the `server.json` registry identity, the repo name/topics, the ~10 directory listings and the Electron bundle all keep `trace-mcp`.

## The two facts that close the full-rename option

Both verified 2026-09-02, both re-checkable in under a minute:

1. **`trace` is taken on npm** — `AndreasMadsen/trace`, "Creates super long stack traces", latest 3.2.0, published 2024-10-23. So `npx trace` could never have been our install command. A rename that cannot reach the most-copied string we have is not a rename; it is a second name, and the only real question was where the boundary sits.
2. **The measured prize is 0.74–1.23%** of the advertised tool surface (TRA-613, #720): 66 / 120 / 366 tokens off `minimal` / `standard` / `full`. Every one of those tokens is in the server key and the CLI verb. None is in the package name, the domain, the registry entry or the app bundle — so renaming those buys zero and costs index coverage, listings and a distinguishable name.

Put the boundary exactly where the tokens are. That is also the ordinary shape of a CLI project: ripgrep/`rg`, neovim/`nvim`, kubernetes/`kubectl`.

## Two costs, stated rather than absorbed

- **macOS ships `/usr/bin/trace`** — Apple's `trace(1)`, "record and modify trace files". Our global bin shadows it on the usual dev PATH; where `/usr/bin` wins, `trace add .` runs Apple's tool. Both bin names stay installed permanently and the migration docs name the collision.
- **The tool prefix moves** `mcp__trace-mcp__*` → `mcp__trace__*` in things users wrote themselves — permission allowlists, hooks, their own CLAUDE.md prose. `init` cannot reach those (#730 says so). This is the only part of the program worth extra engineering; filed separately.

## Ordering, and the one constraint the board violates

**TRA-641 (analytics keys) must land before the next release.** `src/analytics/rules.ts:244` and `real-savings.ts:190` classify our own calls as `tool_server === 'trace-mcp' || 'trace_mcp'`. TRA-614's "Migrate to trace" button is merged to master and is **not** in v3.11.0 — so the window is still open. Once the release carrying it ships, a user clicks Migrate, their sessions log `trace`, and `get_optimization_report` / `get_real_savings` report **zero savings** — the headline metric, silently wrong, no error. TRA-641 is in backlog.

Then TRA-611 (#730), then TRA-615 (#717) rewritten to describe the boundary rather than a rename. **TRA-636 (Electron bundle rename) is cancelled** — it moves `userData`, renames the `.app` mid-update and risks the updater path we only just fixed, for zero tokens. Nothing left in the program is irreversible.

## No human-only door

No browser login, no purchase, no paid listing edit, no domain, no registry re-identification. The batched Russian ask TRA-644 anticipated is empty — that is the result, not an omission. mcpmarket.com's existing **"Trace"** listing stops being a defect and becomes accurate.

## Files

- `ops/rename-to-trace.md` — new: thesis, per-surface table, ordering, and the reopen condition.
- `ops/distribution.md` — the ledger now records that no surface in its table changes, per the workspace rule that a listing decision lives in the ledger.
- `docs/ROADMAP.md` — one entry under "Explicitly not doing right now".

Conflict note: #735 (TRA-616) rewrites `docs/ROADMAP.md` wholesale and is still in flight, so this edit was placed in the section both revisions share. Whichever lands second re-adds the bullet.

Closes TRA-644.

Agent: Lead Engineer


## Related open PRs — not duplicates

The duplicate-work guard paired this PR with #740, #736, #723 and #722. None was a duplicate; the guard matches on any shared `TRA-` key and cannot tell a citation from a claim, which is the exact defect #736 (TRA-642) fixes. A decision doc that cites a dozen issues collides with every other doc PR citing any of them.

- **#723** — the release PR names every merged issue in its changelog, so it matches everything. The TRA-642 case verbatim.
- **#722** (TRA-623) — also edits `ops/distribution.md`, in the surfaces table and "next door to try". This PR adds a section immediately before "Findings that should not be re-derived" and touches no row.
- **#740** (TRA-625) — **merged while this PR was in CI**, and its roadmap revision already carries "item 2: own the rename cutover" as a *ready to start* item. Rebased onto it: item 2 is now rewritten in place as the decision plus the execution order, rather than a bullet appended elsewhere. That is the better home for it.
- **#735** (TRA-616) — the other wholesale `docs/ROADMAP.md` rewrite, from a run 5 minutes apart from #740'''s. Those two were duplicates *of each other*, which is the failure mode this guard exists for (#598/#597, #613/#611). #740 won by landing first; #735 is now stale against master and should be closed rather than rebased.

- **#749** (TRA-616) — opened after the note above: the TRA-616 run dropped its wholesale rewrite in favour of a narrow additive item. It appends an evidence item to `docs/ROADMAP.md`; this PR rewrites item 2 of the same file in place. Different sections, no overlap — and the healthy version of what the guard asked for.
