### PR TITLE
fix(update): align Windows NSIS naming, fail-closed channel manifest audit, per-bundle running detection (TRA-592)

### DIFF
--- a/packages/app/electron-builder.yml
+++ b/packages/app/electron-builder.yml
@@ -108,6 +108,7 @@ win:
       arch:
         - x64
 nsis:
+  artifactName: ${productName}.Setup.${version}.${ext}
   oneClick: true
   perMachine: false
   allowToChangeInstallationDirectory: false

--- a/scripts/postinstall-app.mjs
+++ b/scripts/postinstall-app.mjs
@@ -241,23 +241,53 @@ for (const dir of new Set(
 if (INSTALLED_APPS.length === 0) process.exit(0);
 
 /**
- * Returns true if the installed trace-mcp.app is currently running.
+ * Returns true if the specific installed trace-mcp.app is currently running.
  *
- * `TRACE_MCP_APP_RUNNING=1` is not a hint but a fact: the Electron app sets it
- * on the npm install it spawns itself, so on that path being alive is known
- * rather than inferred. pgrep stays for `npm i -g trace-mcp` typed in a
- * terminal, where nobody can tell us. It false-negatived once — while the app
- * was the very process driving the install — and this script then renamed a
- * live bundle aside and moved a new one into its place (TRA-431).
+ * `TRACE_MCP_APP_RUNNING=1` is set by the app on the install it spawns itself.
+ * On that path, the running bundle is identified via runningBundlePath().
+ * For terminal installs (`npm i -g trace-mcp`), pgrep finds all active PIDs and
+ * ps resolves their executable path to check if this specific bundle is active.
+ *
+ * Scoped per bundle: when two installed copies exist (e.g. ~/Applications and
+ * /Applications), a running instance of one must not block the other non-running
+ * legacy bundle from being swapped in place.
  */
-function appIsRunning() {
-  if (process.env.TRACE_MCP_APP_RUNNING === '1') return true;
+function isAppPathRunning(appPath) {
+  if (process.env.TRACE_MCP_APP_RUNNING === '1') {
+    const running = runningBundlePath({ pgrepBin: PGREP_BIN, psBin: PS_BIN });
+    if (running) return path.resolve(running) === path.resolve(appPath);
+    return true;
+  }
   try {
-    // pgrep -f matches the full command line; the main binary path is unique enough.
-    const out = execFileSync(PGREP_BIN, ['-f', `${APP_NAME}/Contents/MacOS/`], {
+    const pids = execFileSync(PGREP_BIN, ['-f', `${APP_NAME}/Contents/MacOS/`], {
       stdio: ['ignore', 'pipe', 'ignore'],
-    });
-    return out.toString().trim().length > 0;
+      encoding: 'utf-8',
+      timeout: 5_000,
+    })
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => /^\d+$/.test(line));
+
+    if (pids.length === 0) return false;
+
+    const targetPrefix = path.resolve(appPath) + path.sep;
+    let anyCommResolved = false;
+    for (const pid of pids) {
+      try {
+        const comm = execFileSync(PS_BIN, ['-p', pid, '-o', 'comm='], {
+          stdio: ['ignore', 'pipe', 'ignore'],
+          encoding: 'utf-8',
+          timeout: 5_000,
+        }).trim();
+        if (comm) {
+          anyCommResolved = true;
+          if (comm.startsWith(targetPrefix)) return true;
+        }
+      } catch {}
+    }
+    // If ps answered for any pid and none matched this appPath, it is not running.
+    // If ps failed on all pids (e.g. test stub with only pgrep), fall back to safe true.
+    return !anyCommResolved;
   } catch {
     return false; // pgrep exits 1 when no match
   }
@@ -545,7 +575,7 @@ async function main() {
           // bundle takes seconds, and a user who launches the app during that
           // window would otherwise have the next bundle swapped against a
           // stale "not running" answer — the TRA-431 failure, once per copy.
-          appRunning: appIsRunning(),
+          appRunning: isAppPathRunning(appPath),
           tmpDir,
         });
       } catch {

--- a/scripts/verify-release-assets.mjs
+++ b/scripts/verify-release-assets.mjs
@@ -49,11 +49,40 @@ export function expectedAssets(version) {
 }
 
 /**
+ * Verifies that every file target referenced in a channel manifest (latest.yml or
+ * latest-mac.yml) exists in the release assets and has non-zero size.
+ *
+ * @param {string} manifestName
+ * @param {string} manifestContent
+ * @param {Map<string, number>} bySize
+ * @returns {string[]}
+ */
+export function auditChannelManifest(manifestName, manifestContent, bySize) {
+  const problems = [];
+  const matches = manifestContent.matchAll(/(?:url|path):\s*([^\s#\r\n]+)/g);
+  for (const match of matches) {
+    const filename = match[1].trim();
+    if (filename.startsWith('http://') || filename.startsWith('https://')) continue;
+    if (!bySize.has(filename)) {
+      problems.push(
+        `${manifestName} references '${filename}', but it is missing from release assets`,
+      );
+    } else if ((bySize.get(filename) ?? 0) <= 0) {
+      problems.push(
+        `${manifestName} references '${filename}', but the release asset is empty (0 bytes)`,
+      );
+    }
+  }
+  return problems;
+}
+
+/**
  * @param {string} version
  * @param {Array<{name: string, size?: number}>} assets  `gh release view --json assets`
+ * @param {Record<string, string>} [manifestContents] Optional map of channel filename -> raw yaml content
  * @returns {string[]} human-readable problems; empty means the release is complete
  */
-export function auditReleaseAssets(version, assets) {
+export function auditReleaseAssets(version, assets, manifestContents = {}) {
   const bySize = new Map(assets.map((a) => [a.name, a.size ?? 0]));
   const problems = [];
   for (const name of expectedAssets(version)) {
@@ -68,6 +97,13 @@ export function auditReleaseAssets(version, assets) {
       problems.push(`empty or truncated: ${name} (${bySize.get(name)} bytes)`);
     }
   }
+
+  for (const [manifestName, content] of Object.entries(manifestContents)) {
+    if (content) {
+      problems.push(...auditChannelManifest(manifestName, content, bySize));
+    }
+  }
+
   return problems;
 }
 
@@ -82,7 +118,21 @@ async function main() {
   for await (const chunk of process.stdin) raw += chunk;
   const assets = JSON.parse(raw);
 
-  const problems = auditReleaseAssets(version, assets);
+  const manifestContents = {};
+  for (const manifestName of ['latest.yml', 'latest-mac.yml']) {
+    const asset = Array.isArray(assets) ? assets.find((a) => a.name === manifestName) : null;
+    const url = asset?.browser_download_url || asset?.url;
+    if (url) {
+      try {
+        const res = await fetch(url, { headers: { 'User-Agent': 'trace-mcp' } });
+        if (res.ok) {
+          manifestContents[manifestName] = await res.text();
+        }
+      } catch {}
+    }
+  }
+
+  const problems = auditReleaseAssets(version, assets, manifestContents);
   if (problems.length > 0) {
     console.error(`Release ${version} is incomplete — updates would silently no-op:`);
     for (const p of problems) console.error(`  ${p}`);

--- a/scripts/verify-release-assets.mjs
+++ b/scripts/verify-release-assets.mjs
@@ -59,10 +59,32 @@ export function expectedAssets(version) {
  */
 export function auditChannelManifest(manifestName, manifestContent, bySize) {
   const problems = [];
-  const matches = manifestContent.matchAll(/(?:url|path):\s*([^\s#\r\n]+)/g);
-  for (const match of matches) {
-    const filename = match[1].trim();
-    if (filename.startsWith('http://') || filename.startsWith('https://')) continue;
+  if (!manifestContent || manifestContent.trim().length === 0) {
+    return [`${manifestName} is empty or unreadable`];
+  }
+
+  const matches = Array.from(manifestContent.matchAll(/(?:url|path):\s*([^\s#\r\n]+)/g));
+  const filenames = matches
+    .map((m) => m[1].trim())
+    .filter((f) => !f.startsWith('http://') && !f.startsWith('https://'));
+
+  if (filenames.length === 0) {
+    return [`${manifestName} contains no valid file targets (url or path)`];
+  }
+
+  if (manifestName === 'latest.yml') {
+    const hasInstaller = filenames.some((f) => f.endsWith('.exe') || f.endsWith('.zip'));
+    if (!hasInstaller) {
+      problems.push(`${manifestName} contains no Windows installer (.exe/.zip) target`);
+    }
+  } else if (manifestName === 'latest-mac.yml') {
+    const hasZip = filenames.some((f) => f.endsWith('.zip'));
+    if (!hasZip) {
+      problems.push(`${manifestName} contains no macOS zip target`);
+    }
+  }
+
+  for (const filename of filenames) {
     if (!bySize.has(filename)) {
       problems.push(
         `${manifestName} references '${filename}', but it is missing from release assets`,
@@ -99,7 +121,7 @@ export function auditReleaseAssets(version, assets, manifestContents = {}) {
   }
 
   for (const [manifestName, content] of Object.entries(manifestContents)) {
-    if (content) {
+    if (content !== undefined) {
       problems.push(...auditChannelManifest(manifestName, content, bySize));
     }
   }
@@ -119,20 +141,33 @@ async function main() {
   const assets = JSON.parse(raw);
 
   const manifestContents = {};
+  const fetchErrors = [];
+
   for (const manifestName of ['latest.yml', 'latest-mac.yml']) {
     const asset = Array.isArray(assets) ? assets.find((a) => a.name === manifestName) : null;
-    const url = asset?.browser_download_url || asset?.url;
-    if (url) {
-      try {
-        const res = await fetch(url, { headers: { 'User-Agent': 'trace-mcp' } });
-        if (res.ok) {
-          manifestContents[manifestName] = await res.text();
-        }
-      } catch {}
+    if (!asset) continue; // Will be reported as missing by auditReleaseAssets
+    const url = asset.browser_download_url || asset.url;
+    if (!url) {
+      fetchErrors.push(`cannot download ${manifestName}: no download URL in asset record`);
+      continue;
+    }
+    try {
+      const res = await fetch(url, { headers: { 'User-Agent': 'trace-mcp' } });
+      if (!res.ok) {
+        fetchErrors.push(
+          `failed to download ${manifestName} (${url}): HTTP ${res.status} ${res.statusText}`,
+        );
+      } else {
+        manifestContents[manifestName] = await res.text();
+      }
+    } catch (err) {
+      fetchErrors.push(
+        `failed to download ${manifestName} (${url}): ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 
-  const problems = auditReleaseAssets(version, assets, manifestContents);
+  const problems = [...fetchErrors, ...auditReleaseAssets(version, assets, manifestContents)];
   if (problems.length > 0) {
     console.error(`Release ${version} is incomplete — updates would silently no-op:`);
     for (const p of problems) console.error(`  ${p}`);

--- a/scripts/verify-release-assets.mjs
+++ b/scripts/verify-release-assets.mjs
@@ -64,7 +64,29 @@ export function auditChannelManifest(manifestName, manifestContent, bySize, vers
     return [`${manifestName} is empty or unreadable`];
   }
 
-  const matches = Array.from(manifestContent.matchAll(/(?:url|path):\s*([^\s#\r\n]+)/g));
+  const stripped = manifestContent
+    .split('\n')
+    .map((line) => {
+      const commentIdx = line.indexOf('#');
+      return commentIdx >= 0 ? line.slice(0, commentIdx) : line;
+    })
+    .join('\n');
+
+  if (version) {
+    const versionMatch = stripped.match(/^\s*version:\s*['"]?([^\s'"]+)['"]?/m);
+    const manifestVersion = versionMatch ? versionMatch[1] : null;
+    if (!manifestVersion) {
+      problems.push(`${manifestName} is missing a top-level 'version' field`);
+    } else if (manifestVersion !== version) {
+      problems.push(
+        `${manifestName} version '${manifestVersion}' does not match release version '${version}'`,
+      );
+    }
+  }
+
+  const matches = Array.from(
+    stripped.matchAll(/^\s*(?:-\s*)?(?:url|path):\s*['"]?([^\s'"]+)['"]?/gm),
+  );
   const filenames = matches
     .map((m) => m[1].trim())
     .filter((f) => !f.startsWith('http://') && !f.startsWith('https://'));

--- a/scripts/verify-release-assets.mjs
+++ b/scripts/verify-release-assets.mjs
@@ -55,9 +55,10 @@ export function expectedAssets(version) {
  * @param {string} manifestName
  * @param {string} manifestContent
  * @param {Map<string, number>} bySize
+ * @param {string} [version]
  * @returns {string[]}
  */
-export function auditChannelManifest(manifestName, manifestContent, bySize) {
+export function auditChannelManifest(manifestName, manifestContent, bySize, version) {
   const problems = [];
   if (!manifestContent || manifestContent.trim().length === 0) {
     return [`${manifestName} is empty or unreadable`];
@@ -72,15 +73,39 @@ export function auditChannelManifest(manifestName, manifestContent, bySize) {
     return [`${manifestName} contains no valid file targets (url or path)`];
   }
 
-  if (manifestName === 'latest.yml') {
-    const hasInstaller = filenames.some((f) => f.endsWith('.exe') || f.endsWith('.zip'));
-    if (!hasInstaller) {
-      problems.push(`${manifestName} contains no Windows installer (.exe/.zip) target`);
+  if (version) {
+    if (manifestName === 'latest.yml') {
+      const expectedExe = `trace-mcp.Setup.${version}.exe`;
+      if (!filenames.includes(expectedExe)) {
+        problems.push(
+          `${manifestName} does not reference the expected Windows installer '${expectedExe}'`,
+        );
+      }
+    } else if (manifestName === 'latest-mac.yml') {
+      const expectedIntel = `trace-mcp-${version}-mac.zip`;
+      const expectedArm = `trace-mcp-${version}-arm64-mac.zip`;
+      if (!filenames.includes(expectedIntel)) {
+        problems.push(
+          `${manifestName} does not reference the expected Intel macOS update '${expectedIntel}'`,
+        );
+      }
+      if (!filenames.includes(expectedArm)) {
+        problems.push(
+          `${manifestName} does not reference the expected Apple Silicon macOS update '${expectedArm}'`,
+        );
+      }
     }
-  } else if (manifestName === 'latest-mac.yml') {
-    const hasZip = filenames.some((f) => f.endsWith('.zip'));
-    if (!hasZip) {
-      problems.push(`${manifestName} contains no macOS zip target`);
+  } else {
+    if (manifestName === 'latest.yml') {
+      const hasExe = filenames.some((f) => f.endsWith('.exe'));
+      if (!hasExe) {
+        problems.push(`${manifestName} contains no Windows installer (.exe) target`);
+      }
+    } else if (manifestName === 'latest-mac.yml') {
+      const hasZip = filenames.some((f) => f.endsWith('-mac.zip'));
+      if (!hasZip) {
+        problems.push(`${manifestName} contains no macOS update (-mac.zip) target`);
+      }
     }
   }
 
@@ -122,7 +147,7 @@ export function auditReleaseAssets(version, assets, manifestContents = {}) {
 
   for (const [manifestName, content] of Object.entries(manifestContents)) {
     if (content !== undefined) {
-      problems.push(...auditChannelManifest(manifestName, content, bySize));
+      problems.push(...auditChannelManifest(manifestName, content, bySize, version));
     }
   }
 

--- a/scripts/verify-upgrade-path.mjs
+++ b/scripts/verify-upgrade-path.mjs
@@ -46,11 +46,29 @@ const zipSuffix = arch === 'arm64' ? '-arm64-mac.zip' : '-mac.zip';
 const repoRoot = path.resolve(new URL('..', import.meta.url).pathname);
 const expected = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf-8')).version;
 
-const gh = (...a) => execFileSync('gh', a, { encoding: 'utf-8', maxBuffer: 32 << 20 });
+const gh = (...a) => {
+  try {
+    return execFileSync('gh', a, { encoding: 'utf-8', maxBuffer: 32 << 20 });
+  } catch (err) {
+    return null;
+  }
+};
 
-const from =
-  argOf('--from') ??
-  gh(
+async function resolveFromRelease() {
+  const fromArg = argOf('--from');
+  if (fromArg) return fromArg;
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO}/releases?per_page=10`, {
+      headers: { 'User-Agent': 'trace-mcp' },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (Array.isArray(data) && data.length > 0) {
+        return data[data.length - 1].tag_name;
+      }
+    }
+  } catch {}
+  const ghOut = gh(
     'release',
     'list',
     '--repo',
@@ -61,81 +79,129 @@ const from =
     'tagName',
     '--jq',
     '.[-1].tagName',
-  ).trim();
-
-console.log(`upgrade path: ${from} (${arch}) -> ${expected}`);
-
-// `/private/tmp`, not `/tmp`: locate-app.mjs rejects install paths under a
-// `workdir`/`build`/... segment as local builds, and the applier's own
-// is-this-the-entrypoint check compares argv[1] against a realpath'd
-// import.meta.url. A symlinked or implausible sandbox makes this script pass
-// while testing nothing.
-const sandbox = fs.mkdtempSync(path.join('/private/tmp', 'trace-mcp-upgrade-'));
-const apps = path.join(sandbox, 'Applications');
-const home = path.join(sandbox, 'home');
-fs.mkdirSync(apps);
-fs.mkdirSync(path.join(home, '.trace-mcp'), { recursive: true });
-
-// ponytail: a stub that reports "nothing running" rather than a fake process
-// tree. pgrep answers for the whole machine, so without this the developer's own
-// running copy becomes the update target — the postinstall would report success
-// having swapped a bundle this script never created.
-const pgrepStub = path.join(sandbox, 'pgrep-none');
-fs.writeFileSync(pgrepStub, '#!/bin/sh\nexit 1\n');
-fs.chmodSync(pgrepStub, 0o755);
-
-let failure = null;
-try {
-  gh('release', 'download', from, '--repo', REPO, '--pattern', `*${zipSuffix}`, '--dir', sandbox);
-  const zip = fs.readdirSync(sandbox).find((n) => n.endsWith(zipSuffix));
-  if (!zip) throw new Error(`${from} publishes no ${zipSuffix} asset`);
-  execFileSync('/usr/bin/ditto', ['-x', '-k', path.join(sandbox, zip), apps]);
-
-  const appPath = path.join(apps, 'trace-mcp.app');
-  const versionOf = (p) =>
-    execFileSync(
-      '/usr/libexec/PlistBuddy',
-      ['-c', 'Print :CFBundleShortVersionString', path.join(p, 'Contents', 'Info.plist')],
-      { encoding: 'utf-8' },
-    ).trim();
-
-  const before = versionOf(appPath);
-  if (before === expected) throw new Error(`${from} is already ${expected} — nothing to verify`);
-  console.log(`  installed ${before}`);
-
-  fs.writeFileSync(
-    path.join(home, '.trace-mcp', 'app-location.json'),
-    JSON.stringify({ appPath, bundleId: BUNDLE_ID, version: before, writtenAt: Date.now() }),
   );
+  if (ghOut) return ghOut.trim();
+  throw new Error('Could not resolve past releases via GitHub API or gh CLI');
+}
 
-  execFileSync('node', [path.join(repoRoot, 'scripts', 'postinstall-app.mjs')], {
-    stdio: 'inherit',
-    env: {
-      ...process.env,
-      HOME: home,
-      TRACE_MCP_APP_DIRS: apps,
-      TRACE_MCP_PGREP_BIN: pgrepStub,
-    },
-  });
-
-  const after = versionOf(appPath);
-  if (after !== expected) {
-    throw new Error(`bundle is ${after}, expected ${expected} — the update did not land`);
+async function downloadReleaseZip(tag, suffix, destDir) {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO}/releases/tags/${tag}`, {
+      headers: { 'User-Agent': 'trace-mcp' },
+    });
+    if (res.ok) {
+      const release = await res.json();
+      const asset = release.assets?.find((a) => a.name.endsWith(suffix));
+      if (!asset) throw new Error(`${tag} publishes no ${suffix} asset`);
+      const dl = await fetch(asset.browser_download_url, {
+        headers: { 'User-Agent': 'trace-mcp' },
+      });
+      if (!dl.ok) throw new Error(`HTTP ${dl.status} downloading ${asset.name}`);
+      const buffer = await dl.arrayBuffer();
+      const zipFile = path.join(destDir, asset.name);
+      fs.writeFileSync(zipFile, Buffer.from(buffer));
+      return;
+    }
+  } catch (err) {
+    if (err.message?.includes('publishes no')) throw err;
   }
-  console.log(`  bundle is now ${after}`);
-
-  // An unsigned or broken bundle launches to a Gatekeeper refusal, which is the
-  // same dead end as not updating at all.
-  execFileSync('/usr/sbin/spctl', ['-a', '-t', 'exec', appPath], { stdio: 'pipe' });
-  console.log('  gatekeeper: accepted');
-} catch (err) {
-  failure = err;
-} finally {
-  fs.rmSync(sandbox, { recursive: true, force: true });
+  const ghRes = gh(
+    'release',
+    'download',
+    tag,
+    '--repo',
+    REPO,
+    '--pattern',
+    `*${suffix}`,
+    '--dir',
+    destDir,
+  );
+  if (ghRes === null) {
+    throw new Error(`Failed to download ${tag} asset matching *${suffix}`);
+  }
 }
 
-if (failure) {
-  console.error(`FAIL ${from} -> ${expected}: ${failure.message}`);
+async function run() {
+  const from = await resolveFromRelease();
+  console.log(`upgrade path: ${from} (${arch}) -> ${expected}`);
+
+  // `/private/tmp`, not `/tmp`: locate-app.mjs rejects install paths under a
+  // `workdir`/`build`/... segment as local builds, and the applier's own
+  // is-this-the-entrypoint check compares argv[1] against a realpath'd
+  // import.meta.url. A symlinked or implausible sandbox makes this script pass
+  // while testing nothing.
+  const sandbox = fs.mkdtempSync(path.join('/private/tmp', 'trace-mcp-upgrade-'));
+  const apps = path.join(sandbox, 'Applications');
+  const home = path.join(sandbox, 'home');
+  fs.mkdirSync(apps);
+  fs.mkdirSync(path.join(home, '.trace-mcp'), { recursive: true });
+
+  // ponytail: a stub that reports "nothing running" rather than a fake process
+  // tree. pgrep answers for the whole machine, so without this the developer's own
+  // running copy becomes the update target — the postinstall would report success
+  // having swapped a bundle this script never created.
+  const pgrepStub = path.join(sandbox, 'pgrep-none');
+  fs.writeFileSync(pgrepStub, '#!/bin/sh\nexit 1\n');
+  fs.chmodSync(pgrepStub, 0o755);
+
+  let failure = null;
+  try {
+    await downloadReleaseZip(from, zipSuffix, sandbox);
+    const zip = fs.readdirSync(sandbox).find((n) => n.endsWith(zipSuffix));
+    if (!zip) throw new Error(`${from} publishes no ${zipSuffix} asset`);
+    execFileSync('/usr/bin/ditto', ['-x', '-k', path.join(sandbox, zip), apps]);
+
+    const appPath = path.join(apps, 'trace-mcp.app');
+    const versionOf = (p) =>
+      execFileSync(
+        '/usr/libexec/PlistBuddy',
+        ['-c', 'Print :CFBundleShortVersionString', path.join(p, 'Contents', 'Info.plist')],
+        { encoding: 'utf-8' },
+      ).trim();
+
+    const before = versionOf(appPath);
+    if (before === expected) throw new Error(`${from} is already ${expected} — nothing to verify`);
+    console.log(`  installed ${before}`);
+
+    fs.writeFileSync(
+      path.join(home, '.trace-mcp', 'app-location.json'),
+      JSON.stringify({ appPath, bundleId: BUNDLE_ID, version: before, writtenAt: Date.now() }),
+    );
+
+    execFileSync('node', [path.join(repoRoot, 'scripts', 'postinstall-app.mjs')], {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        HOME: home,
+        TRACE_MCP_APP_DIRS: apps,
+        TRACE_MCP_PGREP_BIN: pgrepStub,
+      },
+    });
+
+    const after = versionOf(appPath);
+    if (after !== expected) {
+      throw new Error(`bundle is ${after}, expected ${expected} — the update did not land`);
+    }
+    console.log(`  bundle is now ${after}`);
+
+    // An unsigned or broken bundle launches to a Gatekeeper refusal, which is the
+    // same dead end as not updating at all.
+    execFileSync('/usr/sbin/spctl', ['-a', '-t', 'exec', appPath], { stdio: 'pipe' });
+    console.log('  gatekeeper: accepted');
+  } catch (err) {
+    failure = err;
+  } finally {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+
+  if (failure) {
+    console.error(`FAIL ${from} -> ${expected}: ${failure.message}`);
+    process.exit(1);
+  }
+  console.log(`PASS ${from} -> ${expected}`);
+}
+
+run().catch((err) => {
+  console.error(`FAIL: ${err.message}`);
   process.exit(1);
-}
-console.log(`PASS ${from} -> ${expected}`);
+});

--- a/tests/scripts/postinstall-app.test.ts
+++ b/tests/scripts/postinstall-app.test.ts
@@ -394,17 +394,13 @@ describe.skipIf(process.platform !== 'darwin')('postinstall-app.mjs bundle swap'
     expect(fs.readFileSync(path.join(systemDir, '.trace-mcp-pending-version'), 'utf-8')).toBe(
       '3.5.2',
     );
-    // The other copy is an install too, so it is re-staged rather than left
-    // holding the corrupt leftover: same version, and a zip that verifies.
-    expect(fs.readFileSync(path.join(fx.installDir, '.trace-mcp-pending-version'), 'utf-8')).toBe(
-      '3.5.2',
-    );
-    expect(fs.readFileSync(path.join(fx.installDir, '.trace-mcp-pending.zip')).toString()).not.toBe(
-      'orphan',
-    );
-    expect(
-      fs.readFileSync(path.join(fx.installDir, '.trace-mcp-pending.sha256'), 'utf-8'),
-    ).not.toBe('f'.repeat(64));
+    // The other copy is not running, so it is updated directly in place
+    // rather than left holding corrupt leftover staging: bundle moved to 3.5.2,
+    // and the old orphan staging files are cleaned up.
+    expect(readBundleVersion(fx.appPath)).toBe('3.5.2');
+    expect(fs.existsSync(path.join(fx.installDir, '.trace-mcp-pending.zip'))).toBe(false);
+    expect(fs.existsSync(path.join(fx.installDir, '.trace-mcp-pending.sha256'))).toBe(false);
+    expect(fs.existsSync(path.join(fx.installDir, '.trace-mcp-pending-version'))).toBe(false);
   });
 
   /* Found on the founder's machine: `/Applications/trace-mcp.app` sat on 3.3.0

--- a/tests/scripts/verify-release-assets.test.ts
+++ b/tests/scripts/verify-release-assets.test.ts
@@ -5,8 +5,19 @@ import { describe, expect, it } from 'vitest';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MODULE_PATH = path.join(__dirname, '..', '..', 'scripts', 'verify-release-assets.mjs');
 
-const { auditReleaseAssets, expectedAssets } = (await import(MODULE_PATH)) as {
-  auditReleaseAssets: (version: string, assets: { name: string; size?: number }[]) => string[];
+const { auditReleaseAssets, auditChannelManifest, expectedAssets } = (await import(
+  MODULE_PATH
+)) as {
+  auditReleaseAssets: (
+    version: string,
+    assets: { name: string; size?: number }[],
+    manifestContents?: Record<string, string>,
+  ) => string[];
+  auditChannelManifest: (
+    manifestName: string,
+    manifestContent: string,
+    bySize: Map<string, number>,
+  ) => string[];
   expectedAssets: (version: string) => string[];
 };
 
@@ -99,5 +110,32 @@ describe('verify-release-assets', () => {
   // the tag through unstripped would report every asset as missing.
   it('reports everything missing when handed a tag instead of a version', () => {
     expect(auditReleaseAssets('v3.1.1', completeRelease('3.1.1'))).toHaveLength(12);
+  });
+
+  it('verifies that latest.yml referenced installer matches release assets', () => {
+    const validYml = `
+version: 3.1.1
+files:
+  - url: trace-mcp.Setup.3.1.1.exe
+    sha512: abc123
+path: trace-mcp.Setup.3.1.1.exe
+`;
+    expect(
+      auditReleaseAssets('3.1.1', completeRelease('3.1.1'), { 'latest.yml': validYml }),
+    ).toEqual([]);
+
+    const mismatchedYml = `
+version: 3.1.1
+files:
+  - url: trace-mcp-Setup-3.1.1.exe
+    sha512: abc123
+path: trace-mcp-Setup-3.1.1.exe
+`;
+    expect(
+      auditReleaseAssets('3.1.1', completeRelease('3.1.1'), { 'latest.yml': mismatchedYml }),
+    ).toEqual([
+      "latest.yml references 'trace-mcp-Setup-3.1.1.exe', but it is missing from release assets",
+      "latest.yml references 'trace-mcp-Setup-3.1.1.exe', but it is missing from release assets",
+    ]);
   });
 });

--- a/tests/scripts/verify-release-assets.test.ts
+++ b/tests/scripts/verify-release-assets.test.ts
@@ -138,4 +138,26 @@ path: trace-mcp-Setup-3.1.1.exe
       "latest.yml references 'trace-mcp-Setup-3.1.1.exe', but it is missing from release assets",
     ]);
   });
+
+  it('rejects empty, unreadable, or targetless channel manifests', () => {
+    expect(auditReleaseAssets('3.1.1', completeRelease('3.1.1'), { 'latest.yml': '' })).toEqual([
+      'latest.yml is empty or unreadable',
+    ]);
+
+    expect(
+      auditReleaseAssets('3.1.1', completeRelease('3.1.1'), { 'latest.yml': 'foo: bar\nbaz: 123' }),
+    ).toEqual(['latest.yml contains no valid file targets (url or path)']);
+
+    expect(
+      auditReleaseAssets('3.1.1', completeRelease('3.1.1'), {
+        'latest.yml': 'path: trace-mcp-3.1.1-arm64.dmg',
+      }),
+    ).toEqual(['latest.yml contains no Windows installer (.exe/.zip) target']);
+
+    expect(
+      auditReleaseAssets('3.1.1', completeRelease('3.1.1'), {
+        'latest-mac.yml': 'path: trace-mcp-3.1.1-arm64.dmg',
+      }),
+    ).toEqual(['latest-mac.yml contains no macOS zip target']);
+  });
 });

--- a/tests/scripts/verify-release-assets.test.ts
+++ b/tests/scripts/verify-release-assets.test.ts
@@ -134,6 +134,7 @@ path: trace-mcp-Setup-3.1.1.exe
     expect(
       auditReleaseAssets('3.1.1', completeRelease('3.1.1'), { 'latest.yml': mismatchedYml }),
     ).toEqual([
+      "latest.yml does not reference the expected Windows installer 'trace-mcp.Setup.3.1.1.exe'",
       "latest.yml references 'trace-mcp-Setup-3.1.1.exe', but it is missing from release assets",
       "latest.yml references 'trace-mcp-Setup-3.1.1.exe', but it is missing from release assets",
     ]);
@@ -152,12 +153,48 @@ path: trace-mcp-Setup-3.1.1.exe
       auditReleaseAssets('3.1.1', completeRelease('3.1.1'), {
         'latest.yml': 'path: trace-mcp-3.1.1-arm64.dmg',
       }),
-    ).toEqual(['latest.yml contains no Windows installer (.exe/.zip) target']);
+    ).toEqual([
+      "latest.yml does not reference the expected Windows installer 'trace-mcp.Setup.3.1.1.exe'",
+    ]);
 
     expect(
       auditReleaseAssets('3.1.1', completeRelease('3.1.1'), {
-        'latest-mac.yml': 'path: trace-mcp-3.1.1-arm64.dmg',
+        'latest.yml': 'path: trace-mcp-3.1.1-win.zip',
       }),
-    ).toEqual(['latest-mac.yml contains no macOS zip target']);
+    ).toEqual([
+      "latest.yml does not reference the expected Windows installer 'trace-mcp.Setup.3.1.1.exe'",
+    ]);
+
+    expect(
+      auditReleaseAssets('3.1.1', completeRelease('3.1.1'), {
+        'latest-mac.yml': 'path: trace-mcp-3.1.1-win.zip',
+      }),
+    ).toEqual([
+      "latest-mac.yml does not reference the expected Intel macOS update 'trace-mcp-3.1.1-mac.zip'",
+      "latest-mac.yml does not reference the expected Apple Silicon macOS update 'trace-mcp-3.1.1-arm64-mac.zip'",
+    ]);
+
+    expect(
+      auditReleaseAssets('3.1.1', completeRelease('3.1.1'), {
+        'latest-mac.yml': 'path: trace-mcp-3.1.1-mac.zip',
+      }),
+    ).toEqual([
+      "latest-mac.yml does not reference the expected Apple Silicon macOS update 'trace-mcp-3.1.1-arm64-mac.zip'",
+    ]);
+  });
+
+  it('accepts valid latest-mac.yml referencing both macOS architectures', () => {
+    const validMacYml = `
+version: 3.1.1
+files:
+  - url: trace-mcp-3.1.1-mac.zip
+    sha512: abc123
+  - url: trace-mcp-3.1.1-arm64-mac.zip
+    sha512: def456
+path: trace-mcp-3.1.1-mac.zip
+`;
+    expect(
+      auditReleaseAssets('3.1.1', completeRelease('3.1.1'), { 'latest-mac.yml': validMacYml }),
+    ).toEqual([]);
   });
 });

--- a/tests/scripts/verify-release-assets.test.ts
+++ b/tests/scripts/verify-release-assets.test.ts
@@ -151,7 +151,7 @@ path: trace-mcp-Setup-3.1.1.exe
 
     expect(
       auditReleaseAssets('3.1.1', completeRelease('3.1.1'), {
-        'latest.yml': 'path: trace-mcp-3.1.1-arm64.dmg',
+        'latest.yml': 'version: 3.1.1\npath: trace-mcp-3.1.1-arm64.dmg',
       }),
     ).toEqual([
       "latest.yml does not reference the expected Windows installer 'trace-mcp.Setup.3.1.1.exe'",
@@ -159,7 +159,7 @@ path: trace-mcp-Setup-3.1.1.exe
 
     expect(
       auditReleaseAssets('3.1.1', completeRelease('3.1.1'), {
-        'latest.yml': 'path: trace-mcp-3.1.1-win.zip',
+        'latest.yml': 'version: 3.1.1\npath: trace-mcp-3.1.1-win.zip',
       }),
     ).toEqual([
       "latest.yml does not reference the expected Windows installer 'trace-mcp.Setup.3.1.1.exe'",
@@ -167,7 +167,7 @@ path: trace-mcp-Setup-3.1.1.exe
 
     expect(
       auditReleaseAssets('3.1.1', completeRelease('3.1.1'), {
-        'latest-mac.yml': 'path: trace-mcp-3.1.1-win.zip',
+        'latest-mac.yml': 'version: 3.1.1\npath: trace-mcp-3.1.1-win.zip',
       }),
     ).toEqual([
       "latest-mac.yml does not reference the expected Intel macOS update 'trace-mcp-3.1.1-mac.zip'",
@@ -176,11 +176,45 @@ path: trace-mcp-Setup-3.1.1.exe
 
     expect(
       auditReleaseAssets('3.1.1', completeRelease('3.1.1'), {
-        'latest-mac.yml': 'path: trace-mcp-3.1.1-mac.zip',
+        'latest-mac.yml': 'version: 3.1.1\npath: trace-mcp-3.1.1-mac.zip',
       }),
     ).toEqual([
       "latest-mac.yml does not reference the expected Apple Silicon macOS update 'trace-mcp-3.1.1-arm64-mac.zip'",
     ]);
+  });
+
+  it('rejects targets appearing only in comments', () => {
+    const commentedYml = `
+version: 3.1.1
+# path: trace-mcp.Setup.3.1.1.exe
+# url: trace-mcp.Setup.3.1.1.exe
+`;
+    expect(
+      auditReleaseAssets('3.1.1', completeRelease('3.1.1'), { 'latest.yml': commentedYml }),
+    ).toEqual(['latest.yml contains no valid file targets (url or path)']);
+  });
+
+  it('rejects manifests with mismatched or missing top-level version', () => {
+    const staleVersionYml = `
+version: 0.0.1
+files:
+  - url: trace-mcp.Setup.3.1.1.exe
+    sha512: abc123
+path: trace-mcp.Setup.3.1.1.exe
+`;
+    expect(
+      auditReleaseAssets('3.1.1', completeRelease('3.1.1'), { 'latest.yml': staleVersionYml }),
+    ).toEqual(["latest.yml version '0.0.1' does not match release version '3.1.1'"]);
+
+    const missingVersionYml = `
+files:
+  - url: trace-mcp.Setup.3.1.1.exe
+    sha512: abc123
+path: trace-mcp.Setup.3.1.1.exe
+`;
+    expect(
+      auditReleaseAssets('3.1.1', completeRelease('3.1.1'), { 'latest.yml': missingVersionYml }),
+    ).toEqual(["latest.yml is missing a top-level 'version' field"]);
   });
 
   it('accepts valid latest-mac.yml referencing both macOS architectures', () => {


### PR DESCRIPTION
## Summary

Update Health & Upgrade Path audit (TRA-592) found and fixed a silent update-delivery failure chain:

- **Windows `latest.yml` 404**: electron-builder's default NSIS artifact name (`trace-mcp-Setup-<version>.exe`) didn't match the published asset name electron-updater expected, so Windows update checks 404'd. Fixed with an explicit `artifactName` in `packages/app/electron-builder.yml`.
- **Fail-closed channel manifest audit**: `scripts/verify-release-assets.mjs` now downloads and parses `latest.yml`/`latest-mac.yml` on every release gate, and rejects the release unless the manifest is reachable, its top-level `version` matches, and it references the exact expected installer/zip targets (both mac architectures, the exact Windows NSIS filename) — closing off manifests that "look present" but point at nothing usable.
- **Per-bundle running detection**: `postinstall-app.mjs` previously treated *any* running `trace-mcp` process as blocking *every* installed bundle, so a second/legacy `.app` copy could get silently skipped instead of updated in place. It now checks whether the specific bundle being updated is the one running, and reclaims orphaned `.trace-mcp-pending*` staging directories left beside non-running bundles.
- `scripts/verify-upgrade-path.mjs` gained a direct GitHub REST/`fetch` fallback so upgrade-path verification doesn't depend on an authenticated local `gh`.

## Verification

- `node scripts/verify-upgrade-path.mjs` (v3.3.0 → current) and `--from v1.50.0` (major-version leap) — both PASS, including Gatekeeper (`spctl`) validation.
- `pnpm vitest run tests/scripts/verify-release-assets.test.ts tests/scripts/postinstall-app.test.ts tests/scripts/locate-app.test.ts` — 51/51 passed.
- Full core suite: 857 files / 9407 tests passed (1 unrelated pre-existing timing-flaky perf test, confirmed passing in isolation).
- App package suite: 58 files / 572 tests passed.
- `pnpm run typecheck` and `pnpm run biome:ci` — clean.
- Reviewed and approved by Code Reviewer across 4 review rounds (fail-open→fail-closed manifest handling, exact target enforcement, anchored YAML parsing + version check).
- Rebased onto current `master` after review to avoid a stale-base squash merge; re-ran the full verification suite post-rebase.

Agent: Implementation Engineer
