### PR TITLE
docs(config): document Multica workspace agent MCP preset wiring (TRA-604)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -719,6 +719,34 @@ No existing tool's schema changes because of this — `call_project_tool` dispat
 
 For all other clients only the Base tier applies — there is no equivalent of Claude Code hooks or tweakcc in those tools.
 
+### Multica workspace agents
+
+Multica agents don't run `trace-mcp init` — each agent's MCP wiring is set directly with `multica agent update --mcp-config-file <json>` (or `agent create --mcp-config-file` on first setup), scoped to that one agent. Every agent inherits a runtime-provided `trace-mcp` entry that runs the unconfigured default preset (`minimal`); to give a role its own preset, override the `trace-mcp` entry by name — the agent's own `mcp_config` always wins that collision:
+
+```json
+{
+  "mcpServers": {
+    "trace-mcp": { "command": "trace-mcp", "args": ["--preset", "dev"] }
+  }
+}
+```
+
+```bash
+multica agent update <agent-id> --mcp-config-file ./trace-mcp-dev.json
+```
+
+The role → preset matrix used in the trace-mcp workspace itself (adjust to your own roles):
+
+| Agent role | Preset | Why |
+|---|---|---|
+| Independent code review | `review` | rename-safety, quality gates, risk/impact assessment — no refactor or design tools |
+| Security audit | `security` | `scan_security`, `taint_analysis`, SBOM, config audit — no refactor/design tools |
+| Design/UX review | `design` | component tree, screens, navigation, state — no security/perf tools |
+| Implementation & bugfixing | `dev` | refactor + codemod tools (`apply_rename`, `extract_function`, `change_signature`) |
+| Performance analysis | `perf` | `analyze_perf`, complexity/coupling trends, risk hotspots |
+
+`multica agent update --mcp-config*` **replaces** the agent's entire `mcp_config` — it does not merge. If the agent already has other private MCP servers configured, read them back first (only a workspace owner/admin can; `mcp_config` reads redacted for agent actors) and include them in the new payload, or the update will silently remove them.
+
 ---
 
 ## stdio vs HTTP — choosing your setup


### PR DESCRIPTION
## Summary
- Document how Multica workspace agents get a role-tailored trace-mcp tool preset: an `agent update --mcp-config-file` override of the `trace-mcp` server entry (same name wins the collision), not `trace-mcp init`.
- Record the role → preset matrix actually deployed to this workspace's agents (Code Reviewer/Reviewer B → `review`, Security Agent → `security`, Design/UX Agent → `design`, Implementation Engineer → `dev`, Performance Agent → `perf`).
- Flag the replace-not-merge gotcha: `mcp_config` update replaces the whole object, and agent actors can never read it back to check what's there first.

Part of TRA-604 (Multica Workspace Agent MCP Configuration & End-to-End Validation).

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm biome:ci` — clean, 1685 files
- [x] `pnpm test` — 858 files / 9403 tests passed, 0 failures
- [x] Docs-only change, no code touched