### PR TITLE
docs(roadmap): add the evidence item — the one outside measurement is on no entry surface (TRA-616)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -72,8 +72,8 @@ cannot even attribute to a client.
 This is not an argument to slow the engine room down. It is an argument
 that the next several weeks of *strategic* work — the items below, and the
 weekly focus derived from them — should be measured in users reaching first
-value, not in capability shipped. The three "ready to start" items are all
-of that shape.
+value, not in capability shipped. All four "ready to start" items are of
+that shape.
 
 ## Adoption — metric of record
 
@@ -183,9 +183,35 @@ acquisition-channel signal plus one activation number would let the
 distribution, SEO, outreach and web-design autopilots stop arguing from
 aesthetics.
 
+### 4. Put the one measurement made on other people's code where people arrive (TRA-647)
+TRA-534 measured input-token cost across 60 merged bug-fix PRs from six OSS
+repositories: median **13,595 → 1,326 tokens, 90.6% saved**, p90 44,246 →
+3,667, affected call sites readable 20% → 60% with 100% at least located. It
+is pinned (`benchmarks/pr-context/dataset.json`), reproducible
+(`scripts/bench-pr-context.ts`) and rendered from generated data
+(`docs/_data/pr_context_bench.json`), never hand-typed. It is the only
+number this project has that was not produced by the tool measuring itself
+on its own repository.
+
+Measured on `origin/master`, 2026-09-01: `pr-context-benchmark` appears
+**zero times in `docs/index.html` and zero times in `README.md`**. The page
+is reachable from one place, `docs/_data/docs_nav.yml`. Every figure a
+visitor actually sees still comes from our own estimators.
+
+**Why now:** items 1-3 all say the binding gap is reach and first value, and
+this is the cheapest credibility we will ever have — the work is already
+done and published, it just is not on the door. Both doors are being
+rebuilt this week (TRA-607/608/609 on the above-the-fold of the site and the
+README), so it lands inside those rewrites or costs a second redesign later.
+Its honest boundary ships with it: quality on that dataset is *structural*
+coverage, not a model's judgement, and the page already names the 5 PRs of
+60 where the index did not pay off. The quality arm is **TRA-568**, promoted
+out of backlog — a token number without a quality number is an efficiency
+claim, not a value claim, which is exactly the move we criticise peers for.
+
 ## Big bets — design pass before any code
 
-### 4. One door instead of 169 — a router preset (new, TRA-646)
+### 5. One door instead of 169 — a router preset (new, TRA-646)
 Presets took the advertised surface down by hiding tools behind
 `load_tools`. That worked, it broke nothing, and it has an obvious limit:
 even `minimal` still advertises 28 full JSON Schemas, and TRA-186 already
@@ -223,7 +249,7 @@ this is a new mode beside presets or a replacement for `full`. Not a
 contract break if it ships as a preset (`router`), which is the shape to
 design toward.
 
-### 5. Team-shared graph — parked, needs Nikolai's go-ahead (TRA-128)
+### 6. Team-shared graph — parked, needs Nikolai's go-ahead (TRA-128)
 trace-mcp's whole pitch is "reuse instead of recompute", but reuse only
 happens within one developer's laptop, across turns. A team of five on the
 same repo each index it separately and never see each other's decisions —
@@ -243,7 +269,7 @@ no demand-side reason to unpark it either.
   67–86% without a contract break. Do not reopen it for efficiency reasons;
   only merge two tools if they are genuinely the same tool.
 - **Chasing competitor feature/tool-count parity for its own sake** — see
-  `comparisons.md`'s "deliberately NOT chasing" list. Item 4 is the sharper
+  `comparisons.md`'s "deliberately NOT chasing" list. Item 5 is the sharper
   version of why: count was never the metric, in either direction, and the
   two largest peers are competing in the opposite direction anyway.
 - **Rewriting CFG/taint analysis onto a real AST/dataflow engine** — a real


### PR DESCRIPTION
Follow-up to #740. Supersedes #735 (closed).

Two runs of the Product Roadmap autopilot worked in parallel today; #740 landed first and is the better document — measured preset sizes, the ~1% rename token case, the field breakdown from `adoption.yml`. It is kept exactly as written, and my own full rewrite is closed rather than forced over it.

This adds the single item #740 does not cover.

## The finding

TRA-534 measured input-token cost across 60 merged bug-fix PRs from six OSS repositories — median **13,595 → 1,326 tokens (90.6% saved)**, p90 44,246 → 3,667, affected call sites readable 20% → 60% with 100% at least located. Pinned dataset, reproducible script, rendered from generated JSON. It is the only number this project has that was **not** produced by the tool measuring itself on its own repository.

Counting occurrences of `pr-context-benchmark` / `pr_context_bench` on `origin/master` at 2026-09-01: `README.md` — 0, `docs/index.html` — 0. The page is reachable from one place, `docs/_data/docs_nav.yml`. Every figure a visitor to the homepage or README actually sees still comes from our own estimators.

## Why it belongs in this revision

#740's own thesis is that the binding gap is reach and first value, not capability. This is the cheapest credibility available against that gap: the work is already done and published, it is just not on the door — and both doors are being rebuilt this week, so it lands inside those rewrites or costs a second redesign later.

Filed as ready-to-start item 4 (TRA-647), with the honest boundary stated alongside it (structural coverage, not a model's judgement; the page already names the 5 of 60 PRs where the index did not pay off) and the quality arm TRA-568 promoted out of backlog.

## Diff shape

One new `### 4` under "Ready to start"; the two big bets renumber 4/5 → 5/6, with the one internal cross-reference updated to match, and "The three ready-to-start items" → "All four". Nothing else in the file is touched.

## Test evidence

`npx vitest run tests/docs` — 10 files, 126 tests, all passing (includes `internal-links.test.ts`, the suite that reads `ROADMAP.md`).

Markdown-only change, so it takes the documented exception to the second-model review gate.

## On the duplicate-work guard

It matches every `TRA-NNN` string in a body against every open PR's title and body, so a document that *cites* issues collides with the PRs implementing them. Cited here so the check can tell them apart: #741, #723, #717, #736, #722 — none of them touch `docs/ROADMAP.md`, and this PR touches nothing else.


And #752, which implements TRA-647 on `README.md`, `docs/index.html` and `docs/comparisons.md` — it does not touch `docs/ROADMAP.md`, and this PR touches nothing else. That PR is the item landing; this one is the item being written down.
