### PR TITLE
docs(contributing): record why master's protection is not strict

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,17 @@ GitHub account re-creates the same unresolvable check.
 
 trace-mcp currently has a single maintainer with commit access. `master` is protected by required status checks (CodeQL, Semgrep, `impact-report`) — these run on every PR and must pass before merge. There is no required-approving-review count: with one collaborator, a "1 approval" rule can never be satisfied by anyone but the PR author, so it was dropped rather than kept as a check that always reads "satisfied" without anyone having looked. If a second maintainer joins, review requirements will be reinstated.
 
+Branch protection deliberately does **not** require a branch to be up to date with `master`
+before merging (`strict: false`, set 2026-09-01). The four required checks — CodeQL,
+`Semgrep scan`, `impact-report`, `scope-guard` — all read the pull request's own diff, so
+re-running them against a base that moved five minutes ago adds no signal. Work lands here
+from several agents in parallel and `master` moves faster than those checks take to finish,
+so requiring an up-to-date branch turned every merge into a race that most attempts lost:
+update the branch, wait ~4 minutes for the scans, find the branch behind again. Correctness
+against a moving base is what `test` and `build` are for — they run on every PR and again on
+`master` after merge. Don't switch strict mode back on to fix a bad merge; set up GitHub's
+merge queue instead, which handles the same problem without the busy-wait.
+
 ## How to Contribute
 
 1. Fork the repository


### PR DESCRIPTION
## Summary

Records, in the file contributors and agents actually read, why `master`'s branch protection has `strict: false` — so the next run doesn't "fix" it by switching require-up-to-date back on.

## Why

The four required contexts — CodeQL, `Semgrep scan`, `impact-report`, `scope-guard` — all read the pull request's own diff. Re-running them against a base that moved five minutes ago adds no signal, but `strict: true` made it mandatory.

With several agents landing work in parallel, `master` moves every ~4–10 minutes while those scans take ~4 minutes. Measured this evening: master took commits at 20:08, 20:13, 20:20, 20:24, 20:31 and 20:41. A merge attempt is update-branch → wait for scans → merge, and by the time the scans finished the branch was behind again. #729 sat green and approved through three full cycles of that before the setting was changed; it merged on the first try afterwards.

`strict` was turned off on the `master` protection rule at 2026-09-01 20:47 UTC. The required checks themselves are unchanged — nothing was removed from the gate.

Correctness against a moving base is what `test` and `build` cover; they run on every PR and again on `master` after merge. If the raciness ever needs a stronger answer than this, the answer is GitHub's merge queue, not strict mode — noted in the text so it isn't re-derived from scratch.

## Test evidence

Documentation only — one paragraph added to `CONTRIBUTING.md`, no code paths touched.

Agent: Lead Engineer
