### PR TITLE
fix(server): unknown tool preset falls back to the default surface, not the full one (TRA-648)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -495,6 +495,12 @@ What escalation cannot do is widen `tools.exclude`. Exclusion stays a hard
 restriction; `load_tools` reports those names under `blocked` and leaves them
 off. If you want a tool gone, exclude it — don't rely on the preset.
 
+A preset name that doesn't resolve — a typo, or a preset added in a version
+newer than the one installed — falls back to `minimal` and logs a warning naming
+the available presets. Before v3.12 it fell back to `full`, which turned a typo
+in a flag set to save tokens into a 36.3k-token surface instead of a 7.8k one.
+Failing toward the cheap surface costs at most one `load_tools` round-trip.
+
 Measured `tools/list` cost of each preset on this repo (serialized chars, then
 o200k tokens, 2026-09-01): `design` 21.9k / 5.0k, `perf` 32.3k / 7.5k, `minimal`
 34.0k / 7.8k, `review` 37.3k / 8.6k, `security` 41.5k / 9.6k, `architecture`

--- a/src/server/__tests__/tool-filter.test.ts
+++ b/src/server/__tests__/tool-filter.test.ts
@@ -1,0 +1,86 @@
+/**
+ * What a session gets when its preset name does not resolve (TRA-648).
+ *
+ * The fallback used to be `all`, so a typo in `TRACE_MCP_PRESET` — or a preset
+ * that only exists in a version newer than the one installed, which is every
+ * agent configured for the TRA-603 role presets before 3.12.0 publishes — was
+ * served the whole 151-tool surface. Measured on this repo 2026-09-01: `design`
+ * is 5,042 o200k tokens of `tools/list`, `full` is 36,277. That is a 7.2x
+ * increase in the exact direction opposite to what the flag was set for, with
+ * nothing anywhere saying so.
+ *
+ * These pin the direction of the failure, not the sizes — sizes are guarded by
+ * src/tools/register/__tests__/preset-surface-budget.test.ts.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import type { TraceMcpConfig } from '../../config.js';
+import { TOOL_PRESETS } from '../../tools/project/presets.js';
+import {
+  createToolFilter,
+  DEFAULT_PRESET,
+  resolveSessionPreset,
+  UNGATED_META_TOOLS,
+} from '../tool-filter.js';
+
+/** In `minimal`, absent from it, and gated (so it proves the filter is not `all`). */
+const OUTSIDE_DEFAULT = 'taint_analysis';
+
+afterEach(() => {
+  delete process.env.TRACE_MCP_PRESET;
+});
+
+describe('unknown preset names fail toward the cheap surface (TRA-648)', () => {
+  it('backs the default with a real preset', () => {
+    expect(Object.keys(TOOL_PRESETS)).toContain(DEFAULT_PRESET);
+    expect(TOOL_PRESETS[DEFAULT_PRESET]).not.toBe('all');
+    expect(TOOL_PRESETS[DEFAULT_PRESET]).not.toContain(OUTSIDE_DEFAULT);
+  });
+
+  it('serves the default surface, not the full one, for an unresolvable config preset', () => {
+    const allowed = createToolFilter({ tools: { preset: 'desgin' } } as TraceMcpConfig);
+    expect(allowed('search')).toBe(true);
+    expect(
+      allowed(OUTSIDE_DEFAULT),
+      `An unknown preset served "${OUTSIDE_DEFAULT}" — it fell back to the full surface, ` +
+        'which is 7.2x the tools/list payload the session asked for.',
+    ).toBe(false);
+    // Whatever it falls back to must still carry its own escape hatch.
+    expect(allowed('load_tools')).toBe(true);
+  });
+
+  it('does the same for an unresolvable TRACE_MCP_PRESET', () => {
+    process.env.TRACE_MCP_PRESET = 'perfomance';
+    const allowed = createToolFilter({} as TraceMcpConfig);
+    expect(allowed('search')).toBe(true);
+    expect(allowed(OUTSIDE_DEFAULT)).toBe(false);
+  });
+
+  it('reports the preset actually in force, plus the name that did not resolve', () => {
+    const unknown = resolveSessionPreset({ tools: { preset: 'desgin' } } as TraceMcpConfig);
+    expect(unknown.name).toBe(DEFAULT_PRESET);
+    expect(unknown.unknownName).toBe('desgin');
+    expect(unknown.tools).not.toBe('all');
+  });
+
+  it('leaves resolvable names alone', () => {
+    for (const name of Object.keys(TOOL_PRESETS)) {
+      const resolved = resolveSessionPreset({ tools: { preset: name } } as TraceMcpConfig);
+      expect(resolved.name).toBe(name);
+      expect(resolved.unknownName).toBeUndefined();
+    }
+    expect(resolveSessionPreset({ tools: { preset: 'full' } } as TraceMcpConfig).tools).toBe('all');
+  });
+
+  it('still lets tools.include reach past the fallback', () => {
+    // The escalation path an unknown name leaves the user is not just load_tools.
+    const allowed = createToolFilter({
+      tools: { preset: 'desgin', include: [OUTSIDE_DEFAULT] },
+    } as TraceMcpConfig);
+    expect(allowed(OUTSIDE_DEFAULT)).toBe(true);
+  });
+
+  it('keeps the meta tools ungated whichever way the fallback goes', () => {
+    const allowed = createToolFilter({ tools: { preset: 'desgin' } } as TraceMcpConfig);
+    for (const name of UNGATED_META_TOOLS) expect(allowed(name), name).toBe(true);
+  });
+});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -40,7 +40,6 @@ import { HermesSessionProvider } from '../session/providers/hermes.js';
 import { getSessionProviderRegistry } from '../session/providers/registry.js';
 import { flushSessionSummary } from '../session/resume.js';
 import { SessionTracker } from '../session/tracker.js';
-import { resolvePreset } from '../tools/project/presets.js';
 import { registerAdvancedTools } from '../tools/register/advanced.js';
 import { registerAnalysisTools } from '../tools/register/analysis.js';
 import { registerCoreTools } from '../tools/register/core.js';
@@ -61,7 +60,7 @@ import { createExploredTracker } from './explored-tracker.js';
 import { startHeartbeat } from './heartbeat.js';
 import { buildInstructions } from './instructions.js';
 import { installRetiredToolHints } from './retired-tools.js';
-import { resolvePresetName } from './tool-filter.js';
+import { resolveSessionPreset } from './tool-filter.js';
 import { installToolGate } from './tool-gate.js';
 import type { MetaContext, ProjectRelay, ServerContext, ToolHandlerMap } from './types.js';
 
@@ -526,9 +525,9 @@ export function createServer(
   // Install tool gate (preset filtering, description overrides, savings/journal wrapping)
   // Single source of truth for the default, shared with the daemon proxy's
   // per-session filter — the two used to spell it out separately.
-  const presetName = resolvePresetName(config);
-  const presetResult = resolvePreset(presetName);
-  const activePreset = presetResult ?? 'all';
+  // Unknown names fall back to the default surface and warn (TRA-648) — never
+  // to `full`, which silently made the cheap-by-request session the expensive one.
+  const { name: presetName, tools: activePreset } = resolveSessionPreset(config);
 
   // Status sentinel — guard hook uses this to detect a live, healthy trace-mcp.
   // Records tool-call counters + last successful call timestamp so the v0.8+

--- a/src/server/tool-filter.ts
+++ b/src/server/tool-filter.ts
@@ -13,7 +13,8 @@
  * default path) saw the full surface regardless of its preset.
  */
 import type { TraceMcpConfig } from '../config.js';
-import { resolvePreset } from '../tools/project/presets.js';
+import { logger } from '../logger.js';
+import { listPresets, resolvePreset } from '../tools/project/presets.js';
 
 /**
  * Tools registered through `_originalTool` in src/tools/register/session.ts —
@@ -49,12 +50,52 @@ export const UNGATED_META_TOOLS: ReadonlySet<string> = new Set([
  * session before it asks its first question.
  */
 export function resolvePresetName(config: TraceMcpConfig): string {
-  return process.env.TRACE_MCP_PRESET ?? config.tools?.preset ?? 'minimal';
+  return process.env.TRACE_MCP_PRESET ?? config.tools?.preset ?? DEFAULT_PRESET;
 }
 
-/** Resolved preset set; unknown names fall back to the full surface. */
+/** The shipped default, and the surface an unresolvable preset name falls back to. */
+export const DEFAULT_PRESET = 'minimal';
+
+/** Unknown names already warned about, so the warning is once per process, not once per filter. */
+const warnedUnknownPresets = new Set<string>();
+
+/**
+ * Resolve the session's preset, failing toward the *cheap* surface (TRA-648).
+ *
+ * This used to fall back to `all` when the name didn't resolve, which turned a
+ * typo in `TRACE_MCP_PRESET` — or a preset that only exists in a newer version
+ * than the one installed — into a silent 7.2x cost increase (`design` is 21
+ * tools / 5,042 tokens; `full` is 151 / 36,277), landing on exactly the session
+ * that asked to be cheap. Since TRA-402 gave presets `load_tools`, guessing
+ * small costs one escalation round-trip and guessing large costs ~31k tokens
+ * per session, so the cheap surface is the right way to fail. The name is
+ * reported too, because callers log it and `get_preset_info` reports it — a
+ * session must not claim to be running a preset it isn't.
+ */
+export function resolveSessionPreset(config: TraceMcpConfig): {
+  name: string;
+  tools: Set<string> | 'all';
+  unknownName?: string;
+} {
+  const requested = resolvePresetName(config);
+  const resolved = resolvePreset(requested);
+  if (resolved) return { name: requested, tools: resolved };
+
+  if (!warnedUnknownPresets.has(requested)) {
+    warnedUnknownPresets.add(requested);
+    logger.warn(
+      { preset: requested, fallback: DEFAULT_PRESET, available: listPresets().map((p) => p.name) },
+      `Unknown tool preset "${requested}" — using "${DEFAULT_PRESET}" instead. ` +
+        'Anything outside it is one `load_tools` call away.',
+    );
+  }
+  // Non-null: DEFAULT_PRESET is a key of TOOL_PRESETS, pinned by tool-filter.test.ts.
+  return { name: DEFAULT_PRESET, tools: resolvePreset(DEFAULT_PRESET)!, unknownName: requested };
+}
+
+/** Resolved preset set; unknown names fall back to the default surface. */
 export function resolveActivePreset(config: TraceMcpConfig): Set<string> | 'all' {
-  return resolvePreset(resolvePresetName(config)) ?? 'all';
+  return resolveSessionPreset(config).tools;
 }
 
 /**


### PR DESCRIPTION
Closes TRA-648.

## The bug

`resolveActivePreset` resolved an unrecognised preset name to the **full** tool surface:

```ts
return resolvePreset(resolvePresetName(config)) ?? 'all';
```

So a typo in `TRACE_MCP_PRESET`, or a preset name that only exists in a version newer than the one installed, did not warn and did not fall back to the default — it served everything. This is live right now: TRA-603 added `dev`/`security`/`design`/`perf` in #732, but they are in no published version yet (npm `latest` is 3.11.0), and TRA-604 is rolling `TRACE_MCP_PRESET=<role>` out to the workspace agents. Every one of those sessions gets the full surface instead of its role preset, with nothing anywhere saying so.

## Before / after

Reconstructed `tools/list` payload (same method as `preset-surface-budget.test.ts` — `name` + `description` + JSON-Schema `inputSchema`), tokens via `gpt-tokenizer` o200k, on this repo at `2d8e3057`:

| unknown preset name resolves to | tools | chars | tokens |
|---|---|---|---|
| **before** — `full` | 151 | 157,695 | **36,277** |
| **after** — `minimal` | 28 | 34,041 | **7,806** |
| _(what `design` would have cost)_ | 21 | 21,911 | 5,042 |

**−28,471 tokens (−78.5%) per session** on a mistyped or not-yet-shipped preset name — paid before the session asks its first question.

Measured on Nikolai's machine (darwin 25.5.0, node 22), single reconstruction per preset — the payload is deterministic, so n=1 is the sample size.

## The change

- `resolveSessionPreset(config)` is the single resolver: returns `{ name, tools, unknownName? }`. An unresolvable name falls back to `DEFAULT_PRESET` (`minimal`) and logs **once per process**, naming the unresolved preset and listing the available ones:
  ```
  WARN  preset="desgin" fallback="minimal" available=["minimal","standard","full","review","dev","security","design","perf","architecture"]
        Unknown tool preset "desgin" — using "minimal" instead. Anything outside it is one `load_tools` call away.
  ```
- It reports the preset **actually in force**, so the startup log and `get_preset_info` can no longer claim a preset the session isn't running.
- `server.ts` had its own copy of the resolve-and-default logic; it now calls the same function. Net −2 lines there.
- Both entry points are covered: the local server path (`tool-gate.ts`) and the daemon proxy path (`daemon/router/session.ts` → `createToolFilter`), which is why the warning lives in the resolver rather than in `server.ts`.

Option 1 from the issue, not option 2 (keep `full`, warn loudly): `load_tools` already removed the "a preset is permanent" problem the `?? 'all'` fallback was written against, so guessing small costs one escalation round-trip and guessing large costs 28.5k tokens.

## Guard

New `src/server/__tests__/tool-filter.test.ts` (7 tests) — the file the `tool-filter.ts` docblock has been claiming exists. It pins the *direction* of the failure, not the sizes (those stay in `preset-surface-budget.test.ts`): an unknown name via config and via env serves the default surface, `taint_analysis` stays gated, `load_tools` and the ungated meta tools stay reachable, `tools.include` still reaches past the fallback, every resolvable name is untouched, and `DEFAULT_PRESET` is a real non-`all` preset key.

## Token cost / MCP contract

Strictly reduces token cost; no tool contract change. The only behaviour change visible to a caller is that a preset name the server does not recognise now yields the default surface plus `load_tools` instead of everything — the escalation path makes nothing unreachable either way.

## Verification

- `pnpm run test` — 9450 passed, 8 skipped, 862 files
- `pnpm run typecheck` — clean
- `npx biome ci` on the changed files — clean
- `pnpm run build` — clean

Docs: `docs/configuration.md` now states the fallback and why it changed.

Agent: Performance Agent
