### PR TITLE
docs(roadmap): record the State Engine positioning question (TRA-616)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -273,6 +273,31 @@ that item 3 sharpens the trigger condition: with 61 installs across 11
 countries and no evidence of a single multi-seat user, there is currently
 no demand-side reason to unpark it either.
 
+### 7. Decide what the State Engine makes us — waiting on its own numbers (TRA-649)
+`trace_state_*` — init, patch, get, checkpoint, rollback over a SQLite task
+store with RFC 7396 merge patches, plus a `trace://state/{task_id}`
+resource — is a second product pillar, and it arrived through an
+implementation epic rather than a positioning decision. It is not code
+intelligence: it is a bet that re-establishing *what the task is* costs an
+agent as much as re-establishing what the code is. That is the same
+recomputation argument this product was built on, one level up, and it may
+well be right. But nothing states it as a position — not the homepage, not
+`README.md`, not `comparisons.md`, and not this file until now.
+
+**Status: waiting on phase 4, not parked.** Three questions, in order.
+(a) Does the A/B show state cutting tokens *and* holding task success? Two
+numbers, not one — token reduction with flat or worse Pass@1 is a
+compression result, not a pillar, and that is worth knowing before the
+number becomes a headline. (b) Is there one sentence a user repeats that
+covers both halves? If it needs an "also", the surface is two products in
+one binary — a legitimate answer, but then the second one needs its own
+door rather than five more tools inside a 169-tool list. (c) If it is one
+product, the public surfaces are all describing half of it.
+
+**Why it is here and not in "ready to start":** the answer to (a) is being
+measured right now, and guessing at it would produce exactly the kind of
+claim item 4 exists to stop us making.
+
 ## Explicitly not doing right now
 
 - **Tool consolidation as a token play.** Superseded by presets, which got


### PR DESCRIPTION
Second and last follow-up to #740 from this roadmap run. #749 added the evidence item; this adds the one remaining gap.

## What is missing

`ROADMAP.md` names the linear context engine once, in the list of capability that landed fast. What it does not record is that `trace_state_*` — init, patch, get, checkpoint, rollback over a SQLite task store, plus a `trace://state/{task_id}` resource — is a **second product pillar with no positioning decision behind it**. It is not code intelligence. It is a bet that re-establishing *what the task is* costs an agent as much as re-establishing what the code is — plausibly right, and the same recomputation argument this product was built on, one level up.

Nothing states it as a position: not the homepage, not `README.md`, not `comparisons.md`, and not the roadmap.

## Where it goes

Item 7, in the big-bets section, explicitly **waiting on its own phase-4 A/B rather than ready to start**. Three questions in order: does the measurement show state cutting tokens *and* holding task success (two numbers, not one — token reduction with flat Pass@1 is a compression result, not a pillar); is there one sentence a user repeats that covers both halves; and if it is one product, which public surfaces are describing half of it.

The reason it is not "ready to start" is the point of #749's item: the answer to the first question is being measured right now, and guessing at it would be exactly the kind of claim we criticise peers for. Owner is TRA-649.

## Diff shape

One block appended after the existing big bets, so nothing renumbers and no existing line changes. `docs/ROADMAP.md` only.

## Test evidence

`npx vitest run tests/docs` — 10 files, 127 tests, all passing.

Markdown-only change, so it takes the documented exception to the second-model review gate.

## On the duplicate-work guard

It matches every issue key in a body against every open PR, so a roadmap document collides with the PRs implementing what it points at. Cited so the check can tell them apart — none of these touch `docs/ROADMAP.md`, and this PR touches nothing else: #752, #741, #723, #717, #722, #715.
