### PR TITLE
fix(analytics,hooks,plugins): recognize trace as a trace-mcp server key (TRA-641)

### DIFF
--- a/.claude-plugin/.mcp.json
+++ b/.claude-plugin/.mcp.json
@@ -1,5 +1,5 @@
 {
-  "trace-mcp": {
+  "trace": {
     "command": "trace-mcp"
   }
 }

--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -17,7 +17,7 @@ npm install -g trace-mcp
 trace-mcp init       # writes ~/.trace-mcp/launcher.env
 ```
 
-The plugin's `mcpServers.trace-mcp.command` points at the `trace-mcp` binary, so Claude Code will spawn it directly. No extra wiring needed.
+The plugin's `mcpServers.trace.command` points at the `trace-mcp` binary, so Claude Code will spawn it directly. No extra wiring needed.
 
 ## Install
 

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "commands": [],
   "mcpServers": {
-    "trace-mcp": {
+    "trace": {
       "command": "trace-mcp"
     }
   },

--- a/.codex-plugin/.mcp.json
+++ b/.codex-plugin/.mcp.json
@@ -1,5 +1,5 @@
 {
-  "trace-mcp": {
+  "trace": {
     "command": "trace-mcp"
   }
 }

--- a/hooks/trace-mcp-guard.sh
+++ b/hooks/trace-mcp-guard.sh
@@ -461,10 +461,13 @@ if (( HEARTBEAT_DEAD == 0 )) && [[ -f "$STATUS_FILE" ]] && [[ -f "$PROJECT_ROOT/
   STATUS_TRANSPORT=$(jq -r '.transport // empty' "$STATUS_FILE" 2>/dev/null || echo "")
   # trace-mcp entries with a "type"/"url" key are HTTP; entries with a
   # "command" key (no type/url) are stdio. Skip silently on missing/malformed
-  # config or an entry not named trace-mcp/trace-mcp-http rather than guess.
+  # config or an entry not named trace/trace-http/trace-mcp/trace-mcp-http
+  # rather than guess. "trace"/"trace-http" are the post-rename keys
+  # (TRA-611/614 "Migrate to trace"); the "trace-mcp"/"trace-mcp-http" keys
+  # are checked too for pre-migration configs. See TRA-641.
   EXPECTED_TRANSPORT=$(jq -r '
     (.mcpServers // {}) as $s
-    | ($s["trace-mcp"] // $s["trace-mcp-http"] // empty) as $e
+    | ($s["trace"] // $s["trace-http"] // $s["trace-mcp"] // $s["trace-mcp-http"] // empty) as $e
     | if ($e | length) == 0 then empty
       elif ($e.type == "http") or ($e.url != null) then "http"
       elif ($e.command != null) then "stdio"

--- a/src/analytics/analytics-store.ts
+++ b/src/analytics/analytics-store.ts
@@ -30,6 +30,23 @@ function buildInputSnippet(tc: ToolCallEvent): string | null {
   return null;
 }
 
+/**
+ * All known `tool_server` spellings that identify a call as trace-mcp's own
+ * MCP tool, keyed from `mcp__<server>__<tool>` (see parseToolName in
+ * log-parser.ts). `trace` is the current key after the trace-mcp -> trace
+ * rename (TRA-611); `trace-mcp` / `trace_mcp` are the pre-rename legacy
+ * keys. Historical session logs recorded before the rename -- and clients
+ * that haven't migrated yet -- still carry the legacy spellings, so all
+ * three must keep resolving to "ours" for analytics (get_optimization_report,
+ * get_real_savings) to stay correct across the migration. See TRA-641.
+ */
+export const TRACE_TOOL_SERVERS: ReadonlySet<string> = new Set(['trace', 'trace-mcp', 'trace_mcp']);
+
+/** True when `server` (a ToolCallRow.tool_server value) identifies a trace-mcp tool call. */
+export function isTraceToolServer(server: string): boolean {
+  return TRACE_TOOL_SERVERS.has(server);
+}
+
 export interface ToolCallRow {
   tool_name: string;
   tool_server: string;

--- a/src/analytics/real-savings.ts
+++ b/src/analytics/real-savings.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Store } from '../db/store.js';
-import type { ToolCallRow } from './analytics-store.js';
+import { isTraceToolServer, type ToolCallRow } from './analytics-store.js';
 
 interface FileAlternative {
   file: string;
@@ -187,7 +187,7 @@ export function analyzeRealSavings(
     const s = sessionMap.get(tc.session_id) ?? { hasTrace: false, tokens: 0, toolCalls: 0 };
     s.tokens += tc.output_tokens_estimate;
     s.toolCalls++;
-    if (tc.tool_server === 'trace-mcp' || tc.tool_server === 'trace_mcp') {
+    if (isTraceToolServer(tc.tool_server)) {
       s.hasTrace = true;
     }
     sessionMap.set(tc.session_id, s);

--- a/src/analytics/rules.ts
+++ b/src/analytics/rules.ts
@@ -3,7 +3,7 @@
  * and recommends trace-mcp alternatives.
  */
 
-import type { ToolCallRow } from './analytics-store.js';
+import { isTraceToolServer, type ToolCallRow } from './analytics-store.js';
 
 interface OptimizationHit {
   rule: string;
@@ -241,7 +241,7 @@ const unusedTraceTools: Rule = {
         entry = { hasTrace: false, navTokens: 0, hasNav: false };
         sessions.set(c.session_id, entry);
       }
-      if (c.tool_server === 'trace-mcp' || c.tool_server === 'trace_mcp') {
+      if (isTraceToolServer(c.tool_server)) {
         entry.hasTrace = true;
       }
       const sn = c.tool_short_name;

--- a/tests/analytics/analytics-store.test.ts
+++ b/tests/analytics/analytics-store.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { AnalyticsStore } from '../../src/analytics/analytics-store.js';
+import { AnalyticsStore, isTraceToolServer } from '../../src/analytics/analytics-store.js';
 import type { ParsedSession } from '../../src/analytics/log-parser.js';
 import { createTmpDir, removeTmpDir } from '../test-utils.js';
 
@@ -236,5 +236,25 @@ describe('AnalyticsStore', () => {
     expect(searchCall).toBeDefined();
     expect(searchCall!.input_snippet).toContain('authenticate user');
     expect(searchCall!.input_snippet).toContain('"semantic":"on"');
+  });
+});
+
+// TRA-641: the trace-mcp -> trace rename (TRA-611/614) means a migrated
+// client logs tool_server: "trace" instead of "trace-mcp"/"trace_mcp".
+// isTraceToolServer is the single shared predicate every analytics call
+// site (rules.ts, real-savings.ts) must use so historical rows and
+// post-migration rows both keep counting as "our own" tool calls.
+describe('isTraceToolServer', () => {
+  it('recognizes all known trace-mcp server key spellings', () => {
+    expect(isTraceToolServer('trace')).toBe(true);
+    expect(isTraceToolServer('trace-mcp')).toBe(true);
+    expect(isTraceToolServer('trace_mcp')).toBe(true);
+  });
+
+  it('does not match unrelated or merely-similar server keys', () => {
+    expect(isTraceToolServer('builtin')).toBe(false);
+    expect(isTraceToolServer('phpstorm')).toBe(false);
+    expect(isTraceToolServer('trace-mcp-http')).toBe(false);
+    expect(isTraceToolServer('')).toBe(false);
   });
 });

--- a/tests/analytics/rules.test.ts
+++ b/tests/analytics/rules.test.ts
@@ -186,6 +186,47 @@ describe('rules / analyzeOptimizations', () => {
     });
   });
 
+  // TRA-641: unused-trace-tools decides "did this session use trace-mcp?"
+  // by matching tool_server. After the trace-mcp -> trace rename (TRA-611/
+  // 614), a migrated client logs tool_server: "trace" instead of
+  // "trace-mcp"/"trace_mcp" -- this must still count as trace-mcp usage, or
+  // every migrated session's nav calls (Read/Grep/Glob) get wrongly flagged
+  // as "trace-mcp tools available but never called".
+  describe('unused-trace-tools rule', () => {
+    const traceServerSpellings = ['trace', 'trace-mcp', 'trace_mcp'] as const;
+
+    for (const server of traceServerSpellings) {
+      it(`recognizes tool_server="${server}" as trace-mcp usage -- nav calls are not flagged`, () => {
+        const calls: ToolCallRow[] = [
+          makeToolCall({
+            tool_name: `mcp__${server}__search`,
+            tool_server: server,
+            tool_short_name: 'search',
+            target_file: null,
+          }),
+          makeToolCall({ tool_name: 'Read', tool_short_name: 'Read', tool_server: 'builtin' }),
+          makeToolCall({ tool_name: 'Read', tool_short_name: 'Read', tool_server: 'builtin' }),
+        ];
+
+        const report = analyzeOptimizations(calls, 'all');
+        const hit = report.optimizations.find((o) => o.rule === 'unused-trace-tools');
+        expect(hit).toBeUndefined();
+      });
+    }
+
+    it('flags a session that only uses nav tools with no recognized trace-mcp call', () => {
+      const calls: ToolCallRow[] = [
+        makeToolCall({ tool_name: 'Read', tool_short_name: 'Read', tool_server: 'builtin' }),
+        makeToolCall({ tool_name: 'Read', tool_short_name: 'Read', tool_server: 'builtin' }),
+        makeToolCall({ tool_name: 'Grep', tool_short_name: 'Grep', tool_server: 'builtin' }),
+      ];
+
+      const report = analyzeOptimizations(calls, 'all');
+      const hit = report.optimizations.find((o) => o.rule === 'unused-trace-tools');
+      expect(hit).toBeDefined();
+    });
+  });
+
   describe('semantic-degraded-no-provider rule', () => {
     it('detects search calls whose semantic request silently fell back to lexical', () => {
       const calls: ToolCallRow[] = [

--- a/tests/hooks/guard.test.ts
+++ b/tests/hooks/guard.test.ts
@@ -131,14 +131,17 @@ function writeStatus(
   return file;
 }
 
-/** Write a project-level .mcp.json declaring trace-mcp's configured transport. */
-function writeMcpJson(cwd: string, kind: 'stdio' | 'http'): string {
+/** Write a project-level .mcp.json declaring trace-mcp's configured transport.
+ * `key` defaults to the legacy "trace-mcp" server key; pass "trace" to
+ * simulate a config produced by the post-rename "Migrate to trace" flow
+ * (TRA-611/614) -- see TRA-641. */
+function writeMcpJson(cwd: string, kind: 'stdio' | 'http', key = 'trace-mcp'): string {
   const file = path.join(cwd, '.mcp.json');
   const entry =
     kind === 'stdio'
       ? { command: 'trace-mcp', args: ['serve'] }
       : { type: 'http', url: 'http://127.0.0.1:3741/mcp' };
-  fs.writeFileSync(file, JSON.stringify({ mcpServers: { 'trace-mcp': entry } }));
+  fs.writeFileSync(file, JSON.stringify({ mcpServers: { [key]: entry } }));
   return file;
 }
 
@@ -516,6 +519,39 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-guard.sh v0.7', () => {
     });
     writeMcpJson(projectDir, 'stdio');
     const file = path.join(projectDir, 'match.ts');
+    fs.writeFileSync(file, 'export {};');
+    expect(runGuard('Read', { file_path: file }, sessionId, projectDir).allowed).toBe(false);
+  });
+
+  // TRA-641: after the "Migrate to trace" one-click flow (TRA-614), a
+  // user's .mcp.json keys the server as "trace" instead of "trace-mcp".
+  // The transport-mismatch lookup must recognize the new key too, or the
+  // check silently stops firing for every migrated user.
+  it('transport mismatch: detects it under the post-migration "trace" key too', () => {
+    writeStatus(projectDir, {
+      tool_calls_total: 5,
+      last_successful_tool_call_at: new Date().toISOString(),
+      mcp_sessions_active: 1,
+      transport: 'http',
+    });
+    writeMcpJson(projectDir, 'stdio', 'trace');
+    const file = path.join(projectDir, 'mismatch-trace.ts');
+    fs.writeFileSync(file, 'export {};');
+    const decision = runGuard('Read', { file_path: file }, sessionId, projectDir);
+    expect(decision.allowed).toBe(true);
+    expect(decision.context ?? '').toContain("'http'");
+    expect(decision.context ?? '').toContain("'stdio'");
+  });
+
+  it('transport match: "trace" key with matching transport still enforces strict', () => {
+    writeStatus(projectDir, {
+      tool_calls_total: 5,
+      last_successful_tool_call_at: new Date().toISOString(),
+      mcp_sessions_active: 1,
+      transport: 'stdio',
+    });
+    writeMcpJson(projectDir, 'stdio', 'trace');
+    const file = path.join(projectDir, 'match-trace.ts');
     fs.writeFileSync(file, 'export {};');
     expect(runGuard('Read', { file_path: file }, sessionId, projectDir).allowed).toBe(false);
   });

--- a/tests/plugin/manifest-sync.test.ts
+++ b/tests/plugin/manifest-sync.test.ts
@@ -27,7 +27,11 @@ describe('Claude Code plugin manifests', () => {
   it('plugin.json mcpServers points at the bin name from package.json', () => {
     const bin = pkg.bin as Record<string, string>;
     const servers = plugin.mcpServers as Record<string, { command: string }>;
-    const command = servers['trace-mcp']?.command;
+    // TRA-641: the server key is "trace" (post-rename, TRA-611/614) even
+    // though the command it invokes is still "trace-mcp" -- a user on an
+    // older global install has no `trace` bin yet.
+    expect(Object.keys(servers)).toEqual(['trace']);
+    const command = servers['trace']?.command;
     expect(command).toBeDefined();
     // command must be one of the declared bin names so npm install -g exposes it on PATH
     expect(Object.keys(bin)).toContain(command);
@@ -165,7 +169,10 @@ describe('Codex CLI plugin manifests', () => {
     expect(plugin.mcpServers).toBe('./.mcp.json');
     const bin = pkg.bin as Record<string, string>;
     const mcpConfig = readJson('.codex-plugin', '.mcp.json') as Record<string, { command: string }>;
-    const command = mcpConfig['trace-mcp']?.command;
+    // TRA-641: same key change as the Claude Code plugin -- "trace" key,
+    // "trace-mcp" command (see the analogous assertion above).
+    expect(Object.keys(mcpConfig)).toEqual(['trace']);
+    const command = mcpConfig['trace']?.command;
     expect(command).toBeDefined();
     expect(Object.keys(bin)).toContain(command);
   });

--- a/tests/tools/behavioural/get-real-savings.behavioural.test.ts
+++ b/tests/tools/behavioural/get-real-savings.behavioural.test.ts
@@ -157,4 +157,62 @@ describe('get_real_savings — analyzeRealSavings() behavioural contract', () =>
     expect(report.sessionsAnalyzed).toBe(2);
     expect(report.fileReadsAnalyzed).toBe(3);
   });
+
+  // TRA-641: abComparison's "with trace-mcp" bucket is decided by matching
+  // tool_server. After the trace-mcp -> trace rename (TRA-611/614), a
+  // migrated client logs tool_server: "trace" instead of
+  // "trace-mcp"/"trace_mcp" -- sessions using the new key must still land in
+  // "withTrace", or get_real_savings' headline A/B numbers silently go to
+  // zero the moment a user migrates.
+  describe('abComparison hasTrace detection across tool_server spellings', () => {
+    function traceCall(sessionId: string, server: string): ToolCallRow {
+      return {
+        tool_name: `mcp__${server}__search`,
+        tool_server: server,
+        tool_short_name: 'search',
+        output_size_chars: 500,
+        output_tokens_estimate: 150,
+        target_file: null,
+        is_error: 0,
+        session_id: sessionId,
+        input_snippet: null,
+      };
+    }
+
+    function nonTraceCall(sessionId: string): ToolCallRow {
+      return {
+        tool_name: 'Read',
+        tool_server: 'builtin',
+        tool_short_name: 'Read',
+        output_size_chars: 500,
+        output_tokens_estimate: 150,
+        target_file: null,
+        is_error: 0,
+        session_id: sessionId,
+        input_snippet: null,
+      };
+    }
+
+    it('counts "trace", "trace-mcp", and "trace_mcp" sessions all as "with trace-mcp"', () => {
+      const store = createTestStore();
+      const calls: ToolCallRow[] = [
+        // Two sessions on the post-migration "trace" key.
+        traceCall('with-trace-1', 'trace'),
+        traceCall('with-trace-2', 'trace'),
+        // One session each on the pre-migration legacy keys.
+        traceCall('with-legacy-hyphen', 'trace-mcp'),
+        traceCall('with-legacy-underscore', 'trace_mcp'),
+        // Two sessions with no trace-mcp usage at all.
+        nonTraceCall('without-1'),
+        nonTraceCall('without-2'),
+      ];
+
+      const report = analyzeRealSavings(store, calls, 'all');
+      expect(report.abComparison).toBeDefined();
+      // Without the fix, "trace" sessions fall through to "without" and
+      // these counts come out as 2 / 4 instead of 4 / 2.
+      expect(report.abComparison?.sessionsWithTraceMcp.count).toBe(4);
+      expect(report.abComparison?.sessionsWithoutTraceMcp.count).toBe(2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The `trace-mcp` -> `trace` rename (core/CLI/client migration #730, benchmark #720, desktop app #724, docs #717 — all part of the same epic) means a migrated client logs its tool calls under `tool_server: "trace"` instead of `"trace-mcp"`/`"trace_mcp"`. Three places compared `tool_server` (or an equivalent manifest key) against the old spellings only. This PR adds one shared predicate and points every call site at it, so historical rows and post-migration rows both keep counting.

- **`src/analytics/rules.ts` (`unused-trace-tools` rule) and `src/analytics/real-savings.ts` (A/B `hasTrace` comparison)** — most important: without this, `get_optimization_report` / `get_real_savings` silently attribute zero trace-mcp usage the instant a user migrates. No error, nothing in the logs — just a wrong headline number.
- **`hooks/trace-mcp-guard.sh`** — the stdio/http transport-mismatch check (GH #297) looked up `.mcp.json` under `"trace-mcp"`/`"trace-mcp-http"` only; a migrated project's `.mcp.json` (keyed `"trace"`) would silently skip the check instead of catching a real mismatch.
- **`.claude-plugin/.mcp.json`, `.claude-plugin/plugin.json`, `.codex-plugin/.mcp.json`** — the `mcpServers` key changes from `"trace-mcp"` to `"trace"` (the `command` stays `"trace-mcp"`, since a user on an older global install has no `trace` bin yet). Otherwise a plugin-marketplace install lands on `mcp__trace-mcp__*` while an `init` install on the same machine lands on `mcp__trace__*`.

New shared constant/helper in `src/analytics/analytics-store.ts`:

```ts
export const TRACE_TOOL_SERVERS: ReadonlySet<string> = new Set(['trace', 'trace-mcp', 'trace_mcp']);
export function isTraceToolServer(server: string): boolean {
  return TRACE_TOOL_SERVERS.has(server);
}
```

`rules.ts` and `real-savings.ts` now call `isTraceToolServer(...)` instead of hardcoding their own OR-chains.

This is release-critical per the issue: the desktop app's "Migrate to trace" button (#724) is already merged to master and ships in the release after v3.11.0 — this needs to land before that release, not after.

## Duplicate-work guard false positive

Follow-up to #717: this issue's own description names #717 (docs/generators) as one of the four rename PRs that left this gap, alongside #730/#720/#724 (all already merged). Not a duplicate of #717's own docs scope — no file overlap.

Also related but not a duplicate: #756 (`fix(init): migrate legacy mcp__trace-mcp__ tool prefix in settings.json`) is a sibling rename-cleanup PR landing concurrently, touching `settings.json`/`init`/`updater` — no file overlap with this PR's analytics/hooks/plugin-manifest scope.

## Test plan

- [x] New tests covering all three `tool_server` spellings (`trace`, `trace-mcp`, `trace_mcp`) resolving correctly:
  - `isTraceToolServer` unit tests (`tests/analytics/analytics-store.test.ts`)
  - `unused-trace-tools` rule recognizes all three spellings as trace-mcp usage (`tests/analytics/rules.test.ts`)
  - `get_real_savings` A/B comparison buckets all three spellings into `sessionsWithTraceMcp` (`tests/tools/behavioural/get-real-savings.behavioural.test.ts`)
  - guard hook transport-mismatch detection under the new `"trace"` `.mcp.json` key (`tests/hooks/guard.test.ts`)
  - plugin manifest tests updated for the `"trace"` mcpServers key (`tests/plugin/manifest-sync.test.ts`)
- [x] Full suite: `pnpm run test` — 859 test files passed, 9465 tests passed, 0 failed (in a clean isolated clone of this branch)
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run biome:ci` — clean, no fixes needed
- [x] `pnpm run build` — clean

Agent: Implementation Engineer
