### PR TITLE
fix(init): migrate legacy mcp__trace-mcp__ tool prefix in settings.json (TRA-650)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: "trace-mcp Configuration Reference — all config options (works with none)"
 description: "Every trace-mcp config option in .trace-mcp.json — indexing, quality gates, LSP enrichment, TOON output, telemetry. Configuration is optional; trace-mcp works out of the box for standard projects."
-updated: 2026-09-01
+updated: 2026-09-02
 ---
 
 # Configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -719,6 +719,29 @@ No existing tool's schema changes because of this — `call_project_tool` dispat
 
 For all other clients only the Base tier applies — there is no equivalent of Claude Code hooks or tweakcc in those tools.
 
+### Renaming `trace-mcp` → `trace`: what `init` can and can't reach
+
+MCP clients advertise every tool prefixed with the server key, so the rename
+also renames the tool prefix a client-side config may reference in full:
+`mcp__trace-mcp__search` becomes `mcp__trace__search`. `trace init` (and the
+post-update migration that runs automatically when the daemon starts after
+an upgrade) rewrites this everywhere it owns the file:
+
+- The `mcpServers` entry itself, in every supported client above.
+- Claude Code / Claw Code **permission allowlist entries**
+  (`permissions.allow` / `permissions.deny`) and **hook `matcher` strings**,
+  in both the global `settings.json` and the project-scoped
+  `settings.local.json`.
+
+**What stays manual.** Anything you wrote yourself outside those specific
+fields is not touched — most commonly, tool names spelled out in your own
+prose inside `CLAUDE.md` / `AGENTS.md` (`init` only rewrites the routing
+block it generated, not arbitrary text you added), or a permission/hook
+config in a file trace-mcp doesn't manage the shape of. If a tool call stops
+matching a hook, or an allowlisted tool starts re-prompting for approval
+after upgrading, grep your own config for `mcp__trace-mcp__` and replace it
+with `mcp__trace__`.
+
 ### Multica workspace agents
 
 Multica agents don't run `trace-mcp init` — each agent's MCP wiring is set directly with `multica agent update --mcp-config-file <json>` (or `agent create --mcp-config-file` on first setup), scoped to that one agent. Every agent inherits a runtime-provided `trace-mcp` entry that runs the unconfigured default preset (`minimal`); to give a role its own preset, override the `trace-mcp` entry by name — the agent's own `mcp_config` always wins that collision:

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -62,7 +62,7 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/configuration.html</loc>
-    <lastmod>2026-09-01</lastmod>
+    <lastmod>2026-09-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -18,6 +18,7 @@ import {
   installWorktreeHook,
   installLifecycleHooks,
   cleanupLegacyHooks,
+  migrateLegacyToolPrefix,
 } from '../init/hooks.js';
 import { setupLauncher } from '../init/launcher.js';
 import { configureMcpClients } from '../init/mcp-client.js';
@@ -679,6 +680,13 @@ function executeSteps(
       steps.push(...installHermesHooks({ dryRun: opts.dryRun, autoAllowlist: true }));
     }
   }
+
+  // 3b. Legacy tool-name prefix in permission allowlists + hook matchers
+  // (mcp__trace-mcp__* -> mcp__trace__*). Independent of `opts.installHooks`:
+  // a permission allowlist entry can exist (from a user manually approving a
+  // tool call) whether or not our own hooks are installed this run, so this
+  // must not be nested inside the `if (opts.installHooks)` block above.
+  steps.push(...migrateLegacyToolPrefix({ dryRun: opts.dryRun }));
 
   // 4. CLAUDE.md (global)
   if (opts.claudeMdScope === 'global') {

--- a/src/init/hooks.ts
+++ b/src/init/hooks.ts
@@ -7,11 +7,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { atomicWriteJson } from '../utils/atomic-write.js';
-import {
-  LEGACY_TOOL_NAME_PREFIX,
-  NEW_TOOL_NAME_PREFIX,
-  migrateToolNamePrefixInFile,
-} from '../utils/path-migration.js';
+import { buildToolPrefixMigrationStep } from '../utils/path-migration.js';
 import { readIfExists } from '../utils/safe-fs.js';
 import { withPs1Bom } from './ps1-bom.js';
 import type { InitStepResult } from './types.js';
@@ -669,39 +665,24 @@ export function cleanupLegacyHooks(opts: { global?: boolean; dryRun?: boolean })
  * Scans the same two files per client that `installHook` already writes to
  * — the global `settings.json` and the project-scoped `settings.local.json`
  * — so coverage here can never drift from what trace-mcp itself already
- * manages in those files. Surgical string rewrite only (see
- * `migrateToolNamePrefixInFile`): everything else in the file, including
- * content trace-mcp does not own, comes back byte-for-byte unchanged.
+ * manages in those files. Deliberately does NOT gate on `clientExists()`
+ * (unlike `cleanupLegacyHooks`/`installHook`): that only checks the GLOBAL
+ * config dir, so gating both scopes on it wrongly skipped an existing
+ * project-scoped `settings.local.json` on a machine with no `~/.claude` at
+ * all (TRA-650 review). `buildToolPrefixMigrationStep` already treats a
+ * missing file as a no-op, so scanning unconditionally is both correct and
+ * cheap. Surgical string rewrite only (see `migrateToolNamePrefixInFile`):
+ * everything else in the file, including content trace-mcp does not own,
+ * comes back byte-for-byte unchanged.
  */
 export function migrateLegacyToolPrefix(opts: { dryRun?: boolean } = {}): InitStepResult[] {
   const results: InitStepResult[] = [];
 
   for (const client of CLIENTS) {
-    if (!clientExists(client)) continue;
-
     for (const global of [true, false]) {
       const sPath = settingsPath(client, global);
-      const res = migrateToolNamePrefixInFile(
-        sPath,
-        LEGACY_TOOL_NAME_PREFIX,
-        NEW_TOOL_NAME_PREFIX,
-        { dryRun: opts.dryRun },
-      );
-
-      if (res.error) {
-        results.push({ target: sPath, action: 'skipped', detail: res.error });
-        continue;
-      }
-      if (!res.migrated) continue;
-
-      const plural = res.occurrences === 1 ? '' : 's';
-      results.push({
-        target: sPath,
-        action: 'updated',
-        detail: opts.dryRun
-          ? `Would rewrite ${res.occurrences} legacy tool-prefix reference${plural} (mcp__trace-mcp__ → mcp__trace__)`
-          : `Rewrote ${res.occurrences} legacy tool-prefix reference${plural} (mcp__trace-mcp__ → mcp__trace__)`,
-      });
+      const step = buildToolPrefixMigrationStep(sPath, { dryRun: opts.dryRun });
+      if (step) results.push(step);
     }
   }
 

--- a/src/init/hooks.ts
+++ b/src/init/hooks.ts
@@ -7,6 +7,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { atomicWriteJson } from '../utils/atomic-write.js';
+import {
+  LEGACY_TOOL_NAME_PREFIX,
+  NEW_TOOL_NAME_PREFIX,
+  migrateToolNamePrefixInFile,
+} from '../utils/path-migration.js';
 import { readIfExists } from '../utils/safe-fs.js';
 import { withPs1Bom } from './ps1-bom.js';
 import type { InitStepResult } from './types.js';
@@ -639,6 +644,63 @@ export function cleanupLegacyHooks(opts: { global?: boolean; dryRun?: boolean })
         target: sPath,
         action: 'updated',
         detail: `Removed legacy hooks: ${[...removedNames].join(', ')}`,
+      });
+    }
+  }
+
+  return results;
+}
+
+// --- Legacy tool-name prefix migration (TRA-650) -------------------------
+
+/**
+ * Rewrite the legacy `mcp__trace-mcp__` MCP tool-name prefix to `mcp__trace__`
+ * wherever a Claude-family settings file has it — permission allowlist
+ * entries (`permissions.allow` / `permissions.deny`) and hook `matcher`
+ * strings a user wrote themselves, naming one of our tools in full.
+ *
+ * `configureMcpClients` (TRA-611) only migrates the `mcpServers` entry; it
+ * never touches settings.json — a different file entirely for Claude Code,
+ * whose permission/hook config lives separately from its MCP server list.
+ * Without this, every allowlisted trace tool re-prompts for approval after
+ * the rename, and any hook matcher keyed on our old tool names silently
+ * stops firing.
+ *
+ * Scans the same two files per client that `installHook` already writes to
+ * — the global `settings.json` and the project-scoped `settings.local.json`
+ * — so coverage here can never drift from what trace-mcp itself already
+ * manages in those files. Surgical string rewrite only (see
+ * `migrateToolNamePrefixInFile`): everything else in the file, including
+ * content trace-mcp does not own, comes back byte-for-byte unchanged.
+ */
+export function migrateLegacyToolPrefix(opts: { dryRun?: boolean } = {}): InitStepResult[] {
+  const results: InitStepResult[] = [];
+
+  for (const client of CLIENTS) {
+    if (!clientExists(client)) continue;
+
+    for (const global of [true, false]) {
+      const sPath = settingsPath(client, global);
+      const res = migrateToolNamePrefixInFile(
+        sPath,
+        LEGACY_TOOL_NAME_PREFIX,
+        NEW_TOOL_NAME_PREFIX,
+        { dryRun: opts.dryRun },
+      );
+
+      if (res.error) {
+        results.push({ target: sPath, action: 'skipped', detail: res.error });
+        continue;
+      }
+      if (!res.migrated) continue;
+
+      const plural = res.occurrences === 1 ? '' : 's';
+      results.push({
+        target: sPath,
+        action: 'updated',
+        detail: opts.dryRun
+          ? `Would rewrite ${res.occurrences} legacy tool-prefix reference${plural} (mcp__trace-mcp__ → mcp__trace__)`
+          : `Rewrote ${res.occurrences} legacy tool-prefix reference${plural} (mcp__trace-mcp__ → mcp__trace__)`,
       });
     }
   }

--- a/src/init/mcp-client.ts
+++ b/src/init/mcp-client.ts
@@ -10,6 +10,7 @@ import path from 'node:path';
 import { applyEdits, type FormattingOptions, modify, parse as parseJsonc } from 'jsonc-parser';
 import YAML from 'yaml';
 import { atomicWriteJson, atomicWriteString } from '../utils/atomic-write.js';
+import { buildToolPrefixMigrationStep } from '../utils/path-migration.js';
 import { readIfExists } from '../utils/safe-fs.js';
 import { isGuardHookInstalled } from './hooks.js';
 import { getLauncherPath } from './launcher.js';
@@ -384,6 +385,35 @@ export function configureMcpClients(
         detail: `Error: ${(err as Error).message}`,
       });
     }
+  }
+
+  // TRA-650: the mcpServers entry above and a Claude-family client's
+  // settings.json (permission allowlist entries, hook `matcher` strings) are
+  // two different files that go stale on the exact same rename — rewriting
+  // the tool-name prefix here keeps them in sync as part of this function's
+  // own consistency boundary. This is deliberately in `configureMcpClients`
+  // itself, not only in `trace init`'s `migrateLegacyToolPrefix` step: the
+  // desktop app's "Migrate" button calls `trace clients update`, which calls
+  // this function directly and nothing else (see clients.ts's own comment on
+  // why it can't route through `init`) — without this, clicking Migrate left
+  // an allowlisted tool re-prompting and a hook matcher silently dead
+  // immediately after the click (review finding on this PR).
+  for (const name of clientNames) {
+    const configDir = CLAUDE_FAMILY_CONFIG_DIR[name];
+    if (!configDir) continue;
+
+    // claude-desktop shares '.claude' with claude-code here but, like its
+    // mcpServers entry above (see ALWAYS_GLOBAL_CLIENTS on buildExpectedEntry),
+    // its settings.json is never project-scoped — a project-scoped run must
+    // not go pinning a `<project>/.claude/settings.local.json` write for it.
+    const effectiveScope: McpScope = ALWAYS_GLOBAL_CLIENTS.has(name) ? 'global' : opts.scope;
+    const settingsFile =
+      effectiveScope === 'global'
+        ? path.join(HOME, configDir, 'settings.json')
+        : path.resolve(projectRoot, configDir, 'settings.local.json');
+
+    const step = buildToolPrefixMigrationStep(settingsFile, { dryRun: opts.dryRun });
+    if (step) results.push(step);
   }
 
   return results;
@@ -790,9 +820,12 @@ export interface McpClientStatus {
 
 /**
  * Where each Claude-family client keeps the settings.json that hooks are wired
- * into. Other clients don't run hooks, so they have no level.
+ * into. Other clients don't run hooks, so they have no level. Also the file
+ * `configureMcpClients` migrates the legacy tool-name prefix in (TRA-650) —
+ * exported so `clients update` targets exactly the same set without a second,
+ * possibly-drifting list.
  */
-const CLAUDE_FAMILY_CONFIG_DIR: Partial<Record<DetectedMcpClient['name'], string>> = {
+export const CLAUDE_FAMILY_CONFIG_DIR: Partial<Record<DetectedMcpClient['name'], string>> = {
   'claude-code': '.claude',
   'claude-desktop': '.claude',
   'claw-code': '.claw',

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -537,7 +537,13 @@ export async function runPostUpdateMigrations(): Promise<void> {
   const [
     { migrateGlobalConfig },
     { detectGuardHook },
-    { installGuardHook, installReindexHook, installPrecompactHook, installWorktreeHook },
+    {
+      installGuardHook,
+      installReindexHook,
+      installPrecompactHook,
+      installWorktreeHook,
+      migrateLegacyToolPrefix,
+    },
     { updateClaudeMd },
     { listProjects, markAllProjectsPendingReindex },
   ] = await Promise.all([
@@ -575,6 +581,24 @@ export async function runPostUpdateMigrations(): Promise<void> {
     logger.info('Post-update: CLAUDE.md updated');
   } catch (err) {
     logger.warn({ error: err }, 'Post-update: CLAUDE.md update failed (non-fatal)');
+  }
+
+  // 3b. Migrate the legacy `mcp__trace-mcp__` tool-name prefix in Claude-
+  // family permission allowlists and hook matchers (TRA-650). Deliberately
+  // unconditional (unlike the hook re-install above, which is gated on
+  // `hasGuardHook`): a permission allowlist entry can exist from a user
+  // manually approving a tool call, with no guard hook installed at all —
+  // gating this on `hasGuardHook` would silently miss that case.
+  try {
+    const migrated = migrateLegacyToolPrefix();
+    if (migrated.length > 0) {
+      logger.info(
+        { files: migrated.map((m) => m.target) },
+        `Post-update: rewrote legacy tool-name prefix in ${migrated.length} file(s)`,
+      );
+    }
+  } catch (err) {
+    logger.warn({ error: err }, 'Post-update: tool-prefix migration failed (non-fatal)');
   }
 
   // 4. Mark every project as needing a reindex at the new version. The

--- a/src/utils/path-migration.ts
+++ b/src/utils/path-migration.ts
@@ -404,3 +404,83 @@ export function migrateClientConfigServers(
 
   return { migrated: false };
 }
+
+/**
+ * Default legacy/new MCP tool-name prefix pair for the trace-mcp -> trace
+ * rebrand (TRA-650). MCP clients advertise every tool as
+ * `mcp__<server-key>__<tool>`, so renaming the server key also renames the
+ * prefix a user may have written out in full themselves — in a permission
+ * allowlist entry, a hook matcher, or elsewhere.
+ */
+export const LEGACY_TOOL_NAME_PREFIX = 'mcp__trace-mcp__';
+export const NEW_TOOL_NAME_PREFIX = 'mcp__trace__';
+
+export interface ToolNamePrefixMigrationResult {
+  /** Whether the file was (or, under dryRun, would be) rewritten. */
+  migrated: boolean;
+  /** Number of legacy-prefix occurrences found. */
+  occurrences: number;
+  error?: string;
+}
+
+/**
+ * Rewrite every occurrence of a legacy MCP tool-name prefix
+ * (`mcp__trace-mcp__` by default) to the new one (`mcp__trace__`) inside an
+ * arbitrary text file — a permission allowlist entry (`permissions.allow` /
+ * `permissions.deny`), a hook `matcher` string, or any other place a user
+ * wrote one of our tool names out in full.
+ *
+ * `migrateClientConfigServers` above (and `configureMcpClients`) already
+ * migrate the `mcpServers` entry itself; this covers everything else that
+ * rename silently breaks (TRA-650) — files whose overall shape trace-mcp
+ * does not own, so a JSON.parse + JSON.stringify round-trip is the wrong
+ * tool here: it would reformat/reorder content that belongs to the user
+ * (and some of these files, like Claude Code's settings.json, may carry
+ * keys or formatting no schema in this codebase knows about). A literal
+ * substring replace changes only the exact bytes of the legacy prefix and
+ * returns everything else byte-for-byte, including whether the file ends
+ * with a trailing newline.
+ */
+export function migrateToolNamePrefixInFile(
+  filePath: string,
+  legacyPrefix: string = LEGACY_TOOL_NAME_PREFIX,
+  newPrefix: string = NEW_TOOL_NAME_PREFIX,
+  opts: { dryRun?: boolean } = {},
+): ToolNamePrefixMigrationResult {
+  if (isSymlink(filePath)) {
+    return {
+      migrated: false,
+      occurrences: 0,
+      error: `Refusing to write through symlink at "${filePath}".`,
+    };
+  }
+
+  const raw = readIfExists(filePath);
+  if (raw === null) return { migrated: false, occurrences: 0 };
+
+  const parts = raw.split(legacyPrefix);
+  const occurrences = parts.length - 1;
+  if (occurrences === 0) return { migrated: false, occurrences: 0 };
+
+  if (opts.dryRun) return { migrated: true, occurrences };
+
+  // Preserve the file's existing permissions — this is a rewrite, not a
+  // fresh write, and the file may carry secrets-adjacent tool-approval state.
+  let mode = 0o600;
+  try {
+    mode = fs.statSync(filePath).mode & 0o777;
+  } catch {
+    /* fall back to 0600 */
+  }
+
+  atomicWriteString(filePath, parts.join(newPrefix), {
+    mode,
+    rejectSymlinks: true,
+    // Never let atomic-write's own newline normalization add or remove a
+    // trailing newline — the substring replace above already preserves
+    // whatever the original file ended with, byte for byte.
+    trailingNewline: false,
+  });
+
+  return { migrated: true, occurrences };
+}

--- a/src/utils/path-migration.ts
+++ b/src/utils/path-migration.ts
@@ -24,6 +24,7 @@ import path from 'node:path';
 import { atomicWriteString } from './atomic-write.js';
 import { restrictDbPerms } from '../shared/db-perms.js';
 import { readIfExists } from './safe-fs.js';
+import type { InitStepResult } from '../init/types.js';
 
 const IS_WINDOWS = process.platform === 'win32';
 
@@ -483,4 +484,38 @@ export function migrateToolNamePrefixInFile(
   });
 
   return { migrated: true, occurrences };
+}
+
+/**
+ * Run {@link migrateToolNamePrefixInFile} against `filePath` and translate
+ * the result into the `InitStepResult` shape shared by `init`/`upgrade`/
+ * `clients update` reporting, so every caller renders it the same way.
+ * Returns `null` when there is nothing to report — the file doesn't exist,
+ * or it already carries the new prefix only — so callers can push straight
+ * into a results array without a second `migrated` check.
+ */
+export function buildToolPrefixMigrationStep(
+  filePath: string,
+  opts: { dryRun?: boolean } = {},
+): InitStepResult | null {
+  const res = migrateToolNamePrefixInFile(
+    filePath,
+    LEGACY_TOOL_NAME_PREFIX,
+    NEW_TOOL_NAME_PREFIX,
+    opts,
+  );
+
+  if (res.error) {
+    return { target: filePath, action: 'skipped', detail: res.error };
+  }
+  if (!res.migrated) return null;
+
+  const plural = res.occurrences === 1 ? '' : 's';
+  return {
+    target: filePath,
+    action: 'updated',
+    detail: opts.dryRun
+      ? `Would rewrite ${res.occurrences} legacy tool-prefix reference${plural} (mcp__trace-mcp__ → mcp__trace__)`
+      : `Rewrote ${res.occurrences} legacy tool-prefix reference${plural} (mcp__trace-mcp__ → mcp__trace__)`,
+  };
 }

--- a/tests/init/mcp-client-status.test.ts
+++ b/tests/init/mcp-client-status.test.ts
@@ -397,3 +397,50 @@ describe('configureMcpClients ↔ getMcpClientStatuses round-trip', () => {
     }
   });
 });
+
+// TRA-650: `trace clients update` (the desktop app's "Migrate" button) calls
+// configureMcpClients() directly and nothing else — it never routes through
+// `trace init`'s migrateLegacyToolPrefix step. So the mcpServers rename and
+// the settings.json tool-prefix rewrite must both happen inside
+// configureMcpClients() itself, or clicking Migrate leaves an allowlisted
+// tool re-prompting and a hook matcher silently dead.
+describe('configureMcpClients migrates the settings.json tool-name prefix too', () => {
+  it('rewrites a legacy permission allowlist entry and hook matcher alongside the mcpServers rename', () => {
+    const settingsPath = path.join(fakeHome, '.claude', 'settings.json');
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        permissions: { allow: ['mcp__trace-mcp__search', 'Bash(git log)'] },
+        hooks: {
+          PreToolUse: [{ matcher: 'mcp__trace-mcp__search', hooks: [{ type: 'command' }] }],
+        },
+      }),
+    );
+
+    const results = configureMcpClients(['claude-code'], projectRoot, { scope: 'global' });
+
+    const updated = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    expect(updated.permissions.allow).toEqual(['mcp__trace__search', 'Bash(git log)']);
+    expect(updated.hooks.PreToolUse[0].matcher).toBe('mcp__trace__search');
+    expect(results.some((r) => r.target === settingsPath && r.action === 'updated')).toBe(true);
+  });
+
+  it('resolves the settings.json path against ~/.claude for claude-desktop even under --scope project', () => {
+    // claude-desktop is ALWAYS_GLOBAL — its mcpServers entry and settings.json
+    // both stay under HOME regardless of the requested scope. A regression
+    // here would instead create/write <projectRoot>/.claude/settings.local.json.
+    const globalSettingsPath = path.join(fakeHome, '.claude', 'settings.json');
+    fs.mkdirSync(path.dirname(globalSettingsPath), { recursive: true });
+    fs.writeFileSync(
+      globalSettingsPath,
+      JSON.stringify({ permissions: { allow: ['mcp__trace-mcp__search'] } }),
+    );
+
+    configureMcpClients(['claude-desktop'], projectRoot, { scope: 'project' });
+
+    const updated = JSON.parse(fs.readFileSync(globalSettingsPath, 'utf8'));
+    expect(updated.permissions.allow).toEqual(['mcp__trace__search']);
+    expect(fs.existsSync(path.join(projectRoot, '.claude', 'settings.local.json'))).toBe(false);
+  });
+});

--- a/tests/init/tool-prefix-migration.test.ts
+++ b/tests/init/tool-prefix-migration.test.ts
@@ -93,8 +93,6 @@ describe('migrateLegacyToolPrefix', () => {
   });
 
   it('rewrites the project-scoped settings.local.json for the current working directory', () => {
-    // .claude must exist under HOME for clientExists() to consider the
-    // client "installed" at all — matches the gate installHook() itself uses.
     mkdirSync(join(tempHome, '.claude'), { recursive: true });
     const projectClaudeDir = join(tempProject, '.claude');
     mkdirSync(projectClaudeDir, { recursive: true });
@@ -108,9 +106,34 @@ describe('migrateLegacyToolPrefix', () => {
   });
 
   it('is a no-op when no Claude-family client is installed on this machine', () => {
-    // Neither ~/.claude nor ~/.claw exists — clientExists() gates both out.
+    // Neither ~/.claude nor ~/.claw exists, and there's no project-scoped
+    // settings.local.json either — nothing to migrate.
     const results = migrateLegacyToolPrefix();
     expect(results).toEqual([]);
+  });
+
+  it('rewrites project-scoped settings.local.json even when the global client directory does not exist', () => {
+    // Regression (TRA-650 review): migrateLegacyToolPrefix used to gate both
+    // the global AND project-scoped candidate files on clientExists(), which
+    // only checks ~/.claude — so `trace init --skip-hooks --scope project` on
+    // a checkout with local settings but no global Claude Code install
+    // silently skipped the rewrite. Deliberately no ~/.claude here.
+    const projectClaudeDir = join(tempProject, '.claude');
+    mkdirSync(projectClaudeDir, { recursive: true });
+    const localSettingsPath = join(projectClaudeDir, 'settings.local.json');
+    writeFileSync(localSettingsPath, '{"permissions":{"allow":["mcp__trace-mcp__search"]}}');
+
+    const results = migrateLegacyToolPrefix();
+
+    const updated = JSON.parse(readFileSync(localSettingsPath, 'utf8'));
+    expect(updated.permissions.allow).toEqual(['mcp__trace__search']);
+    // process.cwd() can resolve through a symlink differently than the
+    // pre-chdir tempProject string (e.g. macOS /var vs /private/var), so
+    // compare the step by basename rather than an exact path match. Normalize
+    // separators too — path.join on win32 emits backslashes.
+    expect(
+      results.some((r) => r.target.replace(/\\/g, '/').endsWith('.claude/settings.local.json')),
+    ).toBe(true);
   });
 
   it('does not touch a settings file with no legacy references', () => {

--- a/tests/init/tool-prefix-migration.test.ts
+++ b/tests/init/tool-prefix-migration.test.ts
@@ -1,0 +1,180 @@
+/**
+ * `migrateLegacyToolPrefix` (TRA-650) — end-to-end over real files.
+ *
+ * Unlike hooks.test.ts, this does NOT mock `node:fs`: the whole point is to
+ * prove the on-disk rewrite is correct byte-for-byte, which is easiest to
+ * trust against a real filesystem rather than a mocked call-log. Only
+ * `node:os`'s `homedir()` is mocked (before the dynamic import, since
+ * `hooks.ts` reads it once at module load) so the test writes under a
+ * disposable temp directory instead of the real `~/.claude`.
+ */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let tempHome: string;
+let tempProject: string;
+let originalCwd: string;
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os');
+  const homedir = () => process.env.TRACE_TEST_HOME as string;
+  return {
+    ...actual,
+    homedir,
+    default: { ...(actual as unknown as { default: Record<string, unknown> }).default, homedir },
+  };
+});
+
+let migrateLegacyToolPrefix: typeof import('../../src/init/hooks.js').migrateLegacyToolPrefix;
+
+beforeEach(async () => {
+  vi.resetModules();
+  tempHome = mkdtempSync(join(tmpdir(), 'trace-tool-prefix-home-'));
+  tempProject = mkdtempSync(join(tmpdir(), 'trace-tool-prefix-project-'));
+  process.env.TRACE_TEST_HOME = tempHome;
+  originalCwd = process.cwd();
+  process.chdir(tempProject);
+
+  const mod = await import('../../src/init/hooks.js');
+  migrateLegacyToolPrefix = mod.migrateLegacyToolPrefix;
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(tempHome, { recursive: true, force: true });
+  rmSync(tempProject, { recursive: true, force: true });
+  delete process.env.TRACE_TEST_HOME;
+  vi.restoreAllMocks();
+});
+
+describe('migrateLegacyToolPrefix', () => {
+  it('rewrites a global permission allowlist entry and a hook matcher, both naming legacy tools', () => {
+    const claudeDir = join(tempHome, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    const settingsPath = join(claudeDir, 'settings.json');
+    const original = JSON.stringify(
+      {
+        permissions: {
+          allow: ['mcp__trace-mcp__search', 'mcp__trace-mcp__get_symbol', 'Bash(git log)'],
+          deny: ['mcp__trace-mcp__remove_dead_code'],
+        },
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'mcp__trace-mcp__search',
+              hooks: [{ type: 'command', command: '/opt/my-org/audit-hook.sh' }],
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    );
+    writeFileSync(settingsPath, original);
+
+    const results = migrateLegacyToolPrefix();
+
+    const updated = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(updated.permissions.allow).toEqual([
+      'mcp__trace__search',
+      'mcp__trace__get_symbol',
+      'Bash(git log)',
+    ]);
+    expect(updated.permissions.deny).toEqual(['mcp__trace__remove_dead_code']);
+    expect(updated.hooks.PreToolUse[0].matcher).toBe('mcp__trace__search');
+    // The user's own hook command is untouched.
+    expect(updated.hooks.PreToolUse[0].hooks[0].command).toBe('/opt/my-org/audit-hook.sh');
+
+    const step = results.find((r) => r.target === settingsPath);
+    expect(step?.action).toBe('updated');
+    expect(step?.detail).toContain('4');
+  });
+
+  it('rewrites the project-scoped settings.local.json for the current working directory', () => {
+    // .claude must exist under HOME for clientExists() to consider the
+    // client "installed" at all — matches the gate installHook() itself uses.
+    mkdirSync(join(tempHome, '.claude'), { recursive: true });
+    const projectClaudeDir = join(tempProject, '.claude');
+    mkdirSync(projectClaudeDir, { recursive: true });
+    const localSettingsPath = join(projectClaudeDir, 'settings.local.json');
+    writeFileSync(localSettingsPath, '{"permissions":{"allow":["mcp__trace-mcp__search"]}}');
+
+    migrateLegacyToolPrefix();
+
+    const updated = JSON.parse(readFileSync(localSettingsPath, 'utf8'));
+    expect(updated.permissions.allow).toEqual(['mcp__trace__search']);
+  });
+
+  it('is a no-op when no Claude-family client is installed on this machine', () => {
+    // Neither ~/.claude nor ~/.claw exists — clientExists() gates both out.
+    const results = migrateLegacyToolPrefix();
+    expect(results).toEqual([]);
+  });
+
+  it('does not touch a settings file with no legacy references', () => {
+    const claudeDir = join(tempHome, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    const settingsPath = join(claudeDir, 'settings.json');
+    const original = '{"permissions":{"allow":["mcp__trace__search","Bash(ls)"]}}';
+    writeFileSync(settingsPath, original);
+
+    const results = migrateLegacyToolPrefix();
+
+    expect(readFileSync(settingsPath, 'utf8')).toBe(original);
+    expect(results.find((r) => r.target === settingsPath)).toBeUndefined();
+  });
+
+  it('dry run reports the change without writing', () => {
+    const claudeDir = join(tempHome, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    const settingsPath = join(claudeDir, 'settings.json');
+    const original = '{"permissions":{"allow":["mcp__trace-mcp__search"]}}';
+    writeFileSync(settingsPath, original);
+
+    const results = migrateLegacyToolPrefix({ dryRun: true });
+
+    expect(readFileSync(settingsPath, 'utf8')).toBe(original);
+    const step = results.find((r) => r.target === settingsPath);
+    expect(step?.detail).toMatch(/would rewrite/i);
+  });
+
+  it('reports a skipped step with an error for a settings.json that is a symlink, and leaves the real target untouched', () => {
+    const claudeDir = join(tempHome, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    const realFile = join(tempHome, 'real-settings.json');
+    writeFileSync(realFile, '{"permissions":{"allow":["mcp__trace-mcp__search"]}}');
+    symlinkSync(realFile, join(claudeDir, 'settings.json'));
+
+    const results = migrateLegacyToolPrefix();
+
+    const step = results.find((r) => r.target === join(claudeDir, 'settings.json'));
+    expect(step?.action).toBe('skipped');
+    expect(step?.detail).toMatch(/symlink/i);
+    expect(readFileSync(realFile, 'utf8')).toContain('mcp__trace-mcp__search');
+  });
+
+  it('covers both .claude and .claw when both are installed', () => {
+    mkdirSync(join(tempHome, '.claude'), { recursive: true });
+    mkdirSync(join(tempHome, '.claw'), { recursive: true });
+    writeFileSync(
+      join(tempHome, '.claude', 'settings.json'),
+      '{"permissions":{"allow":["mcp__trace-mcp__search"]}}',
+    );
+    writeFileSync(
+      join(tempHome, '.claw', 'settings.json'),
+      '{"permissions":{"allow":["mcp__trace-mcp__get_symbol"]}}',
+    );
+
+    migrateLegacyToolPrefix();
+
+    expect(
+      JSON.parse(readFileSync(join(tempHome, '.claude', 'settings.json'), 'utf8')).permissions
+        .allow,
+    ).toEqual(['mcp__trace__search']);
+    expect(
+      JSON.parse(readFileSync(join(tempHome, '.claw', 'settings.json'), 'utf8')).permissions.allow,
+    ).toEqual(['mcp__trace__get_symbol']);
+  });
+});

--- a/tests/updater.test.ts
+++ b/tests/updater.test.ts
@@ -44,6 +44,7 @@ vi.mock('../src/init/hooks.js', () => ({
   installReindexHook: vi.fn(() => ({ target: 'reindex', action: 'updated' })),
   installPrecompactHook: vi.fn(() => ({ target: 'precompact', action: 'updated' })),
   installWorktreeHook: vi.fn(() => [{ target: 'worktree', action: 'updated' }]),
+  migrateLegacyToolPrefix: vi.fn(() => []),
 }));
 vi.mock('../src/init/claude-md.js', () => ({
   updateClaudeMd: vi.fn(() => ({ target: 'claude-md', action: 'updated' })),
@@ -162,6 +163,10 @@ describe('runPostUpdateMigrations', () => {
     const { updateClaudeMd } = await import('../src/init/claude-md.js');
     expect(updateClaudeMd).toHaveBeenCalled();
 
+    // Should have migrated the legacy tool-name prefix (TRA-650)
+    const { migrateLegacyToolPrefix } = await import('../src/init/hooks.js');
+    expect(migrateLegacyToolPrefix).toHaveBeenCalled();
+
     // Should stamp new version in cache
     const written = getWrittenCache();
     expect(written).not.toBeNull();
@@ -180,12 +185,17 @@ describe('runPostUpdateMigrations', () => {
 
     await runPostUpdateMigrations();
 
-    const { installGuardHook } = await import('../src/init/hooks.js');
+    const { installGuardHook, migrateLegacyToolPrefix } = await import('../src/init/hooks.js');
     expect(installGuardHook).not.toHaveBeenCalled();
 
     // But CLAUDE.md should still be updated
     const { updateClaudeMd } = await import('../src/init/claude-md.js');
     expect(updateClaudeMd).toHaveBeenCalled();
+
+    // The tool-prefix migration is NOT gated on the guard hook being
+    // installed (TRA-650) — a permission allowlist entry can exist from a
+    // user manually approving a tool call, with no guard hook at all.
+    expect(migrateLegacyToolPrefix).toHaveBeenCalled();
   });
 
   it('continues on hook install failure', async () => {
@@ -194,6 +204,24 @@ describe('runPostUpdateMigrations', () => {
     const hooks = await import('../src/init/hooks.js');
     vi.mocked(hooks.installGuardHook).mockImplementation(() => {
       throw new Error('hook fail');
+    });
+
+    // Should not throw
+    await runPostUpdateMigrations();
+
+    // Should still update CLAUDE.md and stamp version
+    const { updateClaudeMd } = await import('../src/init/claude-md.js');
+    expect(updateClaudeMd).toHaveBeenCalled();
+    const written = getWrittenCache();
+    expect(written!.installedVersion).toBe('2.0.0');
+  });
+
+  it('continues on tool-prefix migration failure', async () => {
+    setupCache({ lastChecked: Date.now(), latestVersion: '2.0.0', installedVersion: '1.9.0' });
+
+    const hooks = await import('../src/init/hooks.js');
+    vi.mocked(hooks.migrateLegacyToolPrefix).mockImplementation(() => {
+      throw new Error('tool-prefix migration fail');
     });
 
     // Should not throw

--- a/tests/utils/path-migration.test.ts
+++ b/tests/utils/path-migration.test.ts
@@ -18,6 +18,7 @@ import {
   migrateClientConfigServers,
   migrateDirectorySafely,
   migrateProjectConfig,
+  migrateToolNamePrefixInFile,
 } from '../../src/utils/path-migration.js';
 import { atomicWriteString } from '../../src/utils/atomic-write.js';
 
@@ -257,6 +258,124 @@ describe('Path and Directory Migration Security', () => {
       const res = migrateClientConfigServers(symlinkFile);
       expect(res.migrated).toBe(false);
       expect(res.error).toMatch(/symlink/);
+    });
+  });
+
+  describe('Tool Name Prefix (mcp__trace-mcp__* -> mcp__trace__*) Migration', () => {
+    it('rewrites a permission allowlist entry naming the legacy tool prefix', () => {
+      const settingsPath = join(tempDir, 'settings.json');
+      const original =
+        '{\n  "permissions": {\n    "allow": [\n      "mcp__trace-mcp__search",\n      "Bash(git status)"\n    ]\n  }\n}\n';
+      writeFileSync(settingsPath, original);
+
+      const res = migrateToolNamePrefixInFile(settingsPath);
+      expect(res.migrated).toBe(true);
+      expect(res.occurrences).toBe(1);
+
+      const updated = readFileSync(settingsPath, 'utf8');
+      expect(updated).toBe(original.replace('mcp__trace-mcp__search', 'mcp__trace__search'));
+      const parsed = JSON.parse(updated);
+      expect(parsed.permissions.allow).toEqual(['mcp__trace__search', 'Bash(git status)']);
+    });
+
+    it('rewrites every occurrence in a hook matcher string and counts them', () => {
+      const settingsPath = join(tempDir, 'settings.json');
+      const original = JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'mcp__trace-mcp__search|mcp__trace-mcp__get_symbol',
+              hooks: [{ type: 'command', command: '/bin/my-custom-hook.sh' }],
+            },
+          ],
+        },
+      });
+      writeFileSync(settingsPath, original);
+
+      const res = migrateToolNamePrefixInFile(settingsPath);
+      expect(res.migrated).toBe(true);
+      expect(res.occurrences).toBe(2);
+
+      const parsed = JSON.parse(readFileSync(settingsPath, 'utf8'));
+      expect(parsed.hooks.PreToolUse[0].matcher).toBe('mcp__trace__search|mcp__trace__get_symbol');
+      // Untouched sibling content survives verbatim.
+      expect(parsed.hooks.PreToolUse[0].hooks[0].command).toBe('/bin/my-custom-hook.sh');
+    });
+
+    it('preserves unrelated content and formatting byte-for-byte, including no trailing newline', () => {
+      const settingsPath = join(tempDir, 'settings.json');
+      // Irregular indentation and no trailing newline — content trace-mcp does
+      // not own the shape of, so a JSON.parse + stringify round-trip would
+      // silently reformat it. Must come back identical apart from the prefix.
+      const original =
+        '{"weird":   "spacing",\n"permissions":{"allow":["mcp__trace-mcp__search"]},\n"nested":{"deep":{"value":42}}}';
+      writeFileSync(settingsPath, original);
+
+      const res = migrateToolNamePrefixInFile(settingsPath);
+      expect(res.migrated).toBe(true);
+
+      const updated = readFileSync(settingsPath, 'utf8');
+      expect(updated).toBe(original.replace('mcp__trace-mcp__search', 'mcp__trace__search'));
+      expect(updated.endsWith('\n')).toBe(false);
+    });
+
+    it('is a no-op and does not write when the legacy prefix is absent', () => {
+      const settingsPath = join(tempDir, 'settings.json');
+      const original = '{"permissions":{"allow":["mcp__trace__search"]}}';
+      writeFileSync(settingsPath, original);
+      const before = statSync(settingsPath).mtimeMs;
+
+      const res = migrateToolNamePrefixInFile(settingsPath);
+      expect(res.migrated).toBe(false);
+      expect(res.occurrences).toBe(0);
+      expect(readFileSync(settingsPath, 'utf8')).toBe(original);
+      expect(statSync(settingsPath).mtimeMs).toBe(before);
+    });
+
+    it('returns migrated:false without error for a file that does not exist', () => {
+      const res = migrateToolNamePrefixInFile(join(tempDir, 'nope.json'));
+      expect(res.migrated).toBe(false);
+      expect(res.occurrences).toBe(0);
+      expect(res.error).toBeUndefined();
+    });
+
+    it('dry-run reports the migration without writing', () => {
+      const settingsPath = join(tempDir, 'settings.json');
+      const original = '{"permissions":{"allow":["mcp__trace-mcp__search"]}}';
+      writeFileSync(settingsPath, original);
+
+      const res = migrateToolNamePrefixInFile(settingsPath, undefined, undefined, {
+        dryRun: true,
+      });
+      expect(res.migrated).toBe(true);
+      expect(res.occurrences).toBe(1);
+      expect(readFileSync(settingsPath, 'utf8')).toBe(original);
+    });
+
+    it('refuses to write through a symlink', () => {
+      const realFile = join(tempDir, 'real-settings.json');
+      const symlinkFile = join(tempDir, 'settings.json');
+      writeFileSync(
+        realFile,
+        JSON.stringify({ permissions: { allow: ['mcp__trace-mcp__search'] } }),
+      );
+      symlinkSync(realFile, symlinkFile);
+
+      const res = migrateToolNamePrefixInFile(symlinkFile);
+      expect(res.migrated).toBe(false);
+      expect(res.error).toMatch(/symlink/);
+      // The real file behind the symlink was never touched either.
+      expect(readFileSync(realFile, 'utf8')).toContain('mcp__trace-mcp__search');
+    });
+
+    it('preserves the file mode on rewrite', () => {
+      if (IS_WINDOWS) return;
+      const settingsPath = join(tempDir, 'settings.json');
+      writeFileSync(settingsPath, '{"permissions":{"allow":["mcp__trace-mcp__search"]}}');
+      chmodSync(settingsPath, 0o644);
+
+      migrateToolNamePrefixInFile(settingsPath);
+      expect(statSync(settingsPath).mode & 0o777).toBe(0o644);
     });
   });
 


### PR DESCRIPTION
## Summary

`configureMcpClients` (TRA-611, #730) renames `mcpServers["trace-mcp"]` -> `["trace"]` in every supported client config. It never touches a *different* file: Claude Code / Claw Code `settings.json`, where a user's own permission allowlist (`permissions.allow`/`deny`) and hook `matcher` strings name our tools out in full as `mcp__trace-mcp__<tool>`. After the rename those tools advertise as `mcp__trace__<tool>`, so:

- an allowlisted tool silently re-prompts for approval on every call, and
- a hook matcher keyed on the old prefix stops firing — no error, it just never matches again.

This closes that gap.

## What changed

- `src/utils/path-migration.ts` — `migrateToolNamePrefixInFile()`: a surgical substring rewrite (`mcp__trace-mcp__` -> `mcp__trace__`) over an arbitrary text file, reusing `atomic-write.ts`'s symlink-safe write. Deliberately **not** a JSON parse/reserialize — `settings.json` is a file we don't own the shape of, so this returns everything else byte-for-byte, including whether the file ends with a trailing newline.
- `src/init/hooks.ts` — `migrateLegacyToolPrefix()`: runs that rewrite over the same two files per Claude-family client that `installHook()` already writes to (global `settings.json` + project-scoped `settings.local.json`), for both `.claude` and `.claw`.
- `src/cli/init.ts` — wires it into `trace init`, unconditional on `--skip-hooks` (a permission allowlist entry can exist without our own hooks being installed at all). Results flow through the existing `InitStepResult` reporting, so a migrated file shows up in `init`'s normal Updated output.
- `src/updater.ts` — also runs on every post-update migration (daemon/CLI startup after a version bump), unconditional on `hasGuardHook`, so users who never manually re-run `init` are still reached before the "Migrate to trace" release (TRA-614) ships at scale.
- `docs/configuration.md` — new "Renaming `trace-mcp` -> `trace`: what `init` can and can't reach" section documenting what's auto-migrated vs. what stays manual (arbitrary `CLAUDE.md`/`AGENTS.md` prose naming tools in full), with the explicit "grep your own config for `mcp__trace-mcp__`" instruction (TRA-615).

## Client coverage checked

Went through all 17 supported clients rather than assuming. Only Claude Code / Claw Code / Claude Desktop (sharing `settings.json` per `CLAUDE_FAMILY_CONFIG_DIR` in `mcp-client.ts`) use the `mcp__<server>__<tool>` naming convention outside their `mcpServers` entry — that's specific to Claude Code's permission/hook schema. The other 14 (Cursor, Windsurf, Continue, Junie, Codex, Hermes, AMP, Warp, Factory Droid, Cline, Kilo Code, Antigravity, Kimi, JetBrains AI) have no equivalent out-of-band tool-name reference.

## Known follow-up, not addressed here

The desktop app's per-client "Migrate" button (TRA-614) shells out to `trace clients update`, which by its own documented design (see the comment at its `ipcMain.handle('update-mcp-clients', ...)`) only rewrites the `mcpServers` entry — "writes the entry and nothing else". It does not run this migration. Whether that button's contract should widen to cover `settings.json` too is a product/scope decision for whoever owns that surface — flagging it rather than deciding it here.

## Duplicate-work guard false positive

The repo's duplicate-PR check flags any open PR that shares *any* `TRA-NNN` mention with this one, not just an exact scope match. This PR's prose above cites TRA-641 and TRA-615 for unrelated reasons — neither is a duplicate of this PR's TRA-650 scope:

- #755 (`fix(analytics,hooks,plugins): recognize trace as a trace-mcp server key`, TRA-641) — a sibling rename-cleanup PR landing concurrently; this PR's "Client coverage checked" section only cites it as related-but-different prior art, touches none of the same files.
- #717 (`docs(migration): ...`, TRA-615) — this PR's docs change points at TRA-615's migration-docs guidance; not a duplicate of that PR's own (still-open) docs scope.

## Test plan

- [x] New tests: `tests/utils/path-migration.test.ts` (9 new cases covering rewrite correctness, byte-for-byte preservation, no-op, dry-run, symlink refusal, mode preservation), `tests/init/tool-prefix-migration.test.ts` (7 end-to-end cases against real files: global + project-scope settings, both `.claude`/`.claw`, dry-run, symlink, no-installed-client no-op), `tests/updater.test.ts` (+2 cases: called unconditionally on version bump, non-fatal on failure).
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm run build` — clean
- [x] `pnpm run biome:ci` — clean
- [x] `pnpm test` — full suite: 862/864 files, 9483/9491 tests passed (2 skipped files / 8 skipped tests, pre-existing and unrelated)

Agent: Implementation Engineer
