### PR TITLE
fix(app): the guard card says "not running" once, and says what to do about it (TRA-490)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -635,6 +635,20 @@ does not blink a banner with it, while recovery publishes immediately. Escalatin
 makes a working app look broken. Keep apart only what the user would act on differently —
 "busy" and "not running" are two states because one is a wait and the other is a button.
 
+**A badge states the condition; the line under it states the cause and the next
+step.** A red `Not running` badge with `trace-mcp server not running` printed 190px
+below it is one fact twice, and the second copy is where the advice should have been
+(TRA-490). If the second line cannot say something the badge does not — why this
+happened, or what the reader does about it — it does not get written at all.
+
+**A cause crosses the IPC boundary as a code, never as a sentence.** The main process
+knows *that* the heartbeat is stale; only the renderer knows the language the app is in
+and how much room the line has. `guard-control.ts` used to hand over
+`Heartbeat stale (412s)`, which the renderer printed verbatim in all ten locales and in
+seconds nobody counts. Main returns `'heartbeat_stale'` plus the number; the renderer
+owns the wording and the time formatting. This applies to every status a surface reads
+over IPC or HTTP, not to the guard alone.
+
 **A surface whose every section reads one source states its failure once, at
 surface level.** Five sections that each fetch from the daemon do not produce five
 pieces of information when the daemon is down — they produce one, said five times.

--- a/packages/app/src/main/guard-control.ts
+++ b/packages/app/src/main/guard-control.ts
@@ -26,6 +26,13 @@ export const MIN_TRACE_MCP_VERSION = '1.32.7';
 
 export type GuardMode = 'strict' | 'coach' | 'off';
 
+/** Why health is not "ok" — a cause the renderer can turn into a next step.
+    A free-form English sentence used to travel here instead, which a localized
+    app printed verbatim next to a badge that already said the same word
+    (TRA-490). "down" has more than one cause and they need different advice:
+    a server that stopped is not a server that was never started. */
+export type GuardReason = 'heartbeat_stale' | 'channel_quiet' | 'never_started';
+
 export interface GuardStatus {
   /** "ok" | "stalled" | "down" | "unknown" — derived from status JSON. */
   health: 'ok' | 'stalled' | 'down' | 'unknown';
@@ -43,8 +50,10 @@ export interface GuardStatus {
   quietSeconds?: number;
   /** Manual bypass active until (epoch seconds). 0 = no bypass. */
   bypassUntil?: number;
-  /** Free-form reason, useful when health != "ok". */
-  reason?: string;
+  /** Why health != "ok". The renderer owns the wording. */
+  reason?: GuardReason;
+  /** Age in seconds behind `reason`, when it has one. */
+  reasonSeconds?: number;
   /** Epoch seconds when guard was first initialized for this project. */
   initializedAt?: number;
   /** Epoch seconds when coach mode auto-promotes to strict (only set in coach). */
@@ -201,11 +210,13 @@ export function getGuardStatus(projectRoot: string): GuardStatus {
       : Number.POSITIVE_INFINITY;
 
     let health: GuardStatus['health'] = 'ok';
-    let reason: string | undefined;
+    let reason: GuardReason | undefined;
+    let reasonSeconds: number | undefined;
 
     if (heartbeatAge > HEARTBEAT_STALE_SEC) {
       health = 'down';
-      reason = `Heartbeat stale (${heartbeatAge}s)`;
+      reason = 'heartbeat_stale';
+      reasonSeconds = Number.isFinite(heartbeatAge) ? heartbeatAge : undefined;
     } else if (
       typeof parsed.tool_calls_total === 'number' &&
       parsed.tool_calls_total > 0 &&
@@ -216,7 +227,8 @@ export function getGuardStatus(projectRoot: string): GuardStatus {
       );
       if (quiet > STALL_THRESHOLD_SEC) {
         health = 'stalled';
-        reason = `MCP channel quiet for ${quiet}s`;
+        reason = 'channel_quiet';
+        reasonSeconds = quiet;
       }
     }
 
@@ -234,6 +246,7 @@ export function getGuardStatus(projectRoot: string): GuardStatus {
       quietSeconds,
       bypassUntil,
       reason,
+      reasonSeconds,
       initializedAt,
       coachExpiresAt,
       autoPromoted: autoPromoted || undefined,
@@ -252,7 +265,6 @@ export function getGuardStatus(projectRoot: string): GuardStatus {
           health: 'ok',
           mode,
           bypassUntil,
-          reason: 'Legacy heartbeat only — server pre-v0.8',
           initializedAt,
           coachExpiresAt,
           autoPromoted: autoPromoted || undefined,
@@ -262,7 +274,8 @@ export function getGuardStatus(projectRoot: string): GuardStatus {
         health: 'down',
         mode,
         bypassUntil,
-        reason: `Legacy heartbeat stale (${age}s)`,
+        reason: 'heartbeat_stale',
+        reasonSeconds: age,
         initializedAt,
         coachExpiresAt,
         autoPromoted: autoPromoted || undefined,
@@ -276,7 +289,7 @@ export function getGuardStatus(projectRoot: string): GuardStatus {
     health: 'down',
     mode,
     bypassUntil,
-    reason: 'trace-mcp server not running',
+    reason: 'never_started',
     initializedAt,
     coachExpiresAt,
     autoPromoted: autoPromoted || undefined,

--- a/packages/app/src/main/preload.ts
+++ b/packages/app/src/main/preload.ts
@@ -181,7 +181,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       toolCallsFailed?: number;
       quietSeconds?: number;
       bypassUntil?: number;
-      reason?: string;
+      reason?: 'heartbeat_stale' | 'channel_quiet' | 'never_started';
+      reasonSeconds?: number;
       initializedAt?: number;
       coachExpiresAt?: number;
       autoPromoted?: boolean;

--- a/packages/app/src/renderer/components/GuardSection.tsx
+++ b/packages/app/src/renderer/components/GuardSection.tsx
@@ -24,7 +24,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { t } from '../i18n';
-import { formatDate } from '../i18n/format';
+import { formatDate, relativeTime } from '../i18n/format';
 import {
   Badge,
   Button,
@@ -39,12 +39,14 @@ import {
 
 type GuardMode = 'strict' | 'coach' | 'off';
 type GuardHealth = 'ok' | 'stalled' | 'down' | 'unknown';
+type GuardReason = 'heartbeat_stale' | 'channel_quiet' | 'never_started';
 
 interface GuardState {
   health: GuardHealth;
   mode: GuardMode;
   bypassUntil?: number;
-  reason?: string;
+  reason?: GuardReason;
+  reasonSeconds?: number;
   coachExpiresAt?: number;
   autoPromoted?: boolean;
 }
@@ -68,6 +70,23 @@ const MODE_OPTIONS: ReadonlyArray<{ value: GuardMode; label: string; title: stri
 
 const POLL_MS = 15_000;
 const BYPASS_MINUTES = 10;
+
+/** The one line under the card: why enforcement is not running, and the one
+    thing that changes it. It never restates the badge — "Not running" is the
+    condition, this is the cause and the next step (TRA-490). Cases with no
+    honest advice render nothing rather than a sentence that ends nowhere. */
+export function reasonLine(state: GuardState, now: number): string | null {
+  if (!state.reason) return null;
+  if (state.reason === 'never_started') return t('guard:reason.neverStarted');
+  const ago =
+    state.reasonSeconds === undefined
+      ? null
+      : relativeTime(now - state.reasonSeconds * 1000, now);
+  if (!ago) return null;
+  return state.reason === 'heartbeat_stale'
+    ? t('guard:reason.heartbeatStale', { ago })
+    : t('guard:reason.channelQuiet', { ago });
+}
 
 /** "in 9 minutes" / "in 6 days". Future-tense sibling of `relativeTime`, which
     is past-only by design — hence its own counted keys rather than a call into
@@ -238,9 +257,9 @@ export function GuardSection({ root }: { root: string }) {
           </>
         ) : null}
       </Card>
-      {state?.reason && state.health !== 'ok' ? (
+      {state && state.health !== 'ok' && reasonLine(state, now) ? (
         <p className="text-[11px] leading-[13px] px-1" style={{ color: 'var(--label-secondary)' }}>
-          {state.reason}
+          {reasonLine(state, now)}
         </p>
       ) : null}
     </Section>

--- a/packages/app/src/renderer/components/__tests__/GuardSection.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/GuardSection.test.tsx
@@ -90,7 +90,7 @@ it('dates a stopped server instead of printing a raw second count', async () => 
   stubGuard({ health: 'down', mode: 'strict', reason: 'heartbeat_stale', reasonSeconds: 412 });
   render(<GuardSection root={ROOT} />);
 
-  expect(await screen.findByText(/trace-mcp last checked in 6 minutes ago/)).toBeTruthy();
+  expect(await screen.findByText(/trace-mcp last reported 6 minutes ago/)).toBeTruthy();
 });
 
 it('says nothing under the card when the cause carries no advice', async () => {

--- a/packages/app/src/renderer/components/__tests__/GuardSection.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/GuardSection.test.tsx
@@ -9,7 +9,8 @@ interface StatusShape {
   health: 'ok' | 'stalled' | 'down' | 'unknown';
   mode: 'strict' | 'coach' | 'off';
   bypassUntil?: number;
-  reason?: string;
+  reason?: 'heartbeat_stale' | 'channel_quiet' | 'never_started';
+  reasonSeconds?: number;
   coachExpiresAt?: number;
   autoPromoted?: boolean;
 }
@@ -50,7 +51,7 @@ it('initializes the project before reading its status', async () => {
 });
 
 it('still reports status when initialization throws', async () => {
-  const guard = stubGuard({ health: 'down', mode: 'strict', reason: 'server not running' });
+  const guard = stubGuard({ health: 'down', mode: 'strict', reason: 'never_started' });
   guard.initialize.mockRejectedValueOnce(new Error('read-only volume'));
   render(<GuardSection root={ROOT} />);
 
@@ -73,11 +74,31 @@ it.each([
   expect(container.querySelector('.lx-badge')).toBeTruthy();
 });
 
-it('shows the failure reason as reading text, not only as a tone', async () => {
-  stubGuard({ health: 'down', mode: 'strict', reason: 'Heartbeat stale (412s)' });
+/* The badge names the condition; the line names the cause and the next step.
+   Restating "not running" under a red badge that already says it is what
+   TRA-490 filed, so the assertion is on the advice, not on any sentence. */
+it('follows the badge with the cause and the one thing to do next', async () => {
+  stubGuard({ health: 'down', mode: 'strict', reason: 'never_started' });
   render(<GuardSection root={ROOT} />);
 
-  expect(await screen.findByText('Heartbeat stale (412s)')).toBeTruthy();
+  const line = await screen.findByText(/hasn't started trace-mcp in this project yet/);
+  expect(line.textContent).toContain('Restart it');
+  expect(screen.getAllByText(/Not running/)).toHaveLength(1);
+});
+
+it('dates a stopped server instead of printing a raw second count', async () => {
+  stubGuard({ health: 'down', mode: 'strict', reason: 'heartbeat_stale', reasonSeconds: 412 });
+  render(<GuardSection root={ROOT} />);
+
+  expect(await screen.findByText(/trace-mcp last checked in 6 minutes ago/)).toBeTruthy();
+});
+
+it('says nothing under the card when the cause carries no advice', async () => {
+  stubGuard({ health: 'down', mode: 'strict' });
+  const { container } = render(<GuardSection root={ROOT} />);
+
+  await screen.findByText('Not running');
+  expect(container.querySelectorAll('p')).toHaveLength(0);
 });
 
 /* ── Mode ─────────────────────────────────────────────────────────────────── */

--- a/packages/app/src/renderer/electron.d.ts
+++ b/packages/app/src/renderer/electron.d.ts
@@ -108,7 +108,8 @@ declare global {
           toolCallsFailed?: number;
           quietSeconds?: number;
           bypassUntil?: number;
-          reason?: string;
+          reason?: 'heartbeat_stale' | 'channel_quiet' | 'never_started';
+          reasonSeconds?: number;
           initializedAt?: number;
           coachExpiresAt?: number;
           autoPromoted?: boolean;

--- a/packages/app/src/shared/i18n/catalog/de/guard.ts
+++ b/packages/app/src/shared/i18n/catalog/de/guard.ts
@@ -41,6 +41,10 @@ export const guard = {
   'health.down': 'Läuft nicht',
   'health.unknown': 'Unbekannt',
 
+  'reason.neverStarted': 'Dein Coding-Assistent hat trace-mcp in diesem Projekt noch nie gestartet. Starte ihn neu, damit der Guard greift.',
+  'reason.heartbeatStale': 'Letztes Lebenszeichen von trace-mcp: {{ago}}. Starte deinen Coding-Assistenten neu, um die Durchsetzung fortzusetzen.',
+  'reason.channelQuiet': 'Der Guard ist installiert und wartet — der letzte Tool-Aufruf war {{ago}}.',
+
   'mode.aria': 'Guard-Modus',
   'mode.strict': 'Strikt',
   'mode.strictHelp': 'Read, Grep und Glob blockieren, wenn ein trace-mcp-Tool die Frage beantwortet',

--- a/packages/app/src/shared/i18n/catalog/en/guard.ts
+++ b/packages/app/src/shared/i18n/catalog/en/guard.ts
@@ -52,7 +52,7 @@ export const guard = {
   'health.unknown': 'Unknown',
 
   'reason.neverStarted': "Your coding assistant hasn't started trace-mcp in this project yet. Restart it to pick up the guard.",
-  'reason.heartbeatStale': 'trace-mcp last checked in {{ago}}. Restart your coding assistant to resume enforcement.',
+  'reason.heartbeatStale': 'trace-mcp last reported {{ago}}. Restart your coding assistant to resume enforcement.',
   'reason.channelQuiet': 'The guard is installed and waiting — the last tool call was {{ago}}.',
 
   'mode.aria': 'Guard mode',

--- a/packages/app/src/shared/i18n/catalog/en/guard.ts
+++ b/packages/app/src/shared/i18n/catalog/en/guard.ts
@@ -51,6 +51,10 @@ export const guard = {
   'health.down': 'Not running',
   'health.unknown': 'Unknown',
 
+  'reason.neverStarted': "Your coding assistant hasn't started trace-mcp in this project yet. Restart it to pick up the guard.",
+  'reason.heartbeatStale': 'trace-mcp last checked in {{ago}}. Restart your coding assistant to resume enforcement.',
+  'reason.channelQuiet': 'The guard is installed and waiting — the last tool call was {{ago}}.',
+
   'mode.aria': 'Guard mode',
   'mode.strict': 'Strict',
   'mode.strictHelp': 'Block Read, Grep and Glob when a trace-mcp tool answers the question',

--- a/packages/app/src/shared/i18n/catalog/es/guard.ts
+++ b/packages/app/src/shared/i18n/catalog/es/guard.ts
@@ -39,6 +39,10 @@ export const guard = {
   'health.down': 'No está en marcha',
   'health.unknown': 'Desconocido',
 
+  'reason.neverStarted': 'Tu asistente de código aún no ha iniciado trace-mcp en este proyecto. Reinícialo para que tome el guard.',
+  'reason.heartbeatStale': 'trace-mcp respondió por última vez {{ago}}. Reinicia tu asistente de código para reanudar la aplicación.',
+  'reason.channelQuiet': 'El guard está instalado y a la espera: la última llamada a una herramienta fue {{ago}}.',
+
   'mode.aria': 'Modo del guard',
   'mode.strict': 'Estricto',
   'mode.strictHelp': 'Bloquear Read, Grep y Glob cuando una herramienta de trace-mcp responde a la pregunta',

--- a/packages/app/src/shared/i18n/catalog/fr/guard.ts
+++ b/packages/app/src/shared/i18n/catalog/fr/guard.ts
@@ -41,6 +41,10 @@ export const guard = {
   'health.down': 'Arrêté',
   'health.unknown': 'Inconnu',
 
+  'reason.neverStarted': "Votre assistant de code n'a pas encore lancé trace-mcp dans ce projet. Redémarrez-le pour activer le guard.",
+  'reason.heartbeatStale': "Dernier signe de vie de trace-mcp : {{ago}}. Redémarrez votre assistant de code pour reprendre l'application des règles.",
+  'reason.channelQuiet': 'Le guard est installé et en attente — le dernier appel d’outil date de {{ago}}.',
+
   'mode.aria': 'Mode du guard',
   'mode.strict': 'Strict',
   'mode.strictHelp':

--- a/packages/app/src/shared/i18n/catalog/hi/guard.ts
+++ b/packages/app/src/shared/i18n/catalog/hi/guard.ts
@@ -39,6 +39,10 @@ export const guard = {
   'health.down': 'नहीं चल रहा',
   'health.unknown': 'अज्ञात',
 
+  'reason.neverStarted': 'आपके कोडिंग असिस्टेंट ने इस प्रोजेक्ट में अभी तक trace-mcp शुरू नहीं किया है। गार्ड चालू करने के लिए उसे फिर से शुरू करें।',
+  'reason.heartbeatStale': 'trace-mcp ने आखिरी बार {{ago}} जवाब दिया था। लागू करना फिर से शुरू करने के लिए अपना कोडिंग असिस्टेंट रीस्टार्ट करें।',
+  'reason.channelQuiet': 'गार्ड इंस्टॉल है और इंतज़ार कर रहा है — आखिरी टूल कॉल {{ago}} थी।',
+
   'mode.aria': 'Guard मोड',
   'mode.strict': 'Strict',
   'mode.strictHelp': 'जब कोई trace-mcp टूल जवाब दे सके, तब Read, Grep और Glob रोकें',

--- a/packages/app/src/shared/i18n/catalog/ja/guard.ts
+++ b/packages/app/src/shared/i18n/catalog/ja/guard.ts
@@ -39,6 +39,10 @@ export const guard = {
   'health.down': '停止中',
   'health.unknown': '不明',
 
+  'reason.neverStarted': 'このプロジェクトではコーディングアシスタントがまだ trace-mcp を起動していません。再起動するとガードが有効になります。',
+  'reason.heartbeatStale': 'trace-mcp の最後の応答は{{ago}}です。コーディングアシスタントを再起動すると強制が再開します。',
+  'reason.channelQuiet': 'ガードはインストール済みで待機中です。最後のツール呼び出しは{{ago}}でした。',
+
   'mode.aria': 'ガードのモード',
   'mode.strict': 'ストリクト',
   'mode.strictHelp': 'trace-mcp のツールで答えられる場合、Read、Grep、Glob をブロックします',

--- a/packages/app/src/shared/i18n/catalog/ko/guard.ts
+++ b/packages/app/src/shared/i18n/catalog/ko/guard.ts
@@ -39,6 +39,10 @@ export const guard = {
   'health.down': '실행 중 아님',
   'health.unknown': '알 수 없음',
 
+  'reason.neverStarted': '이 프로젝트에서 코딩 어시스턴트가 아직 trace-mcp를 시작하지 않았습니다. 어시스턴트를 다시 시작하면 가드가 적용됩니다.',
+  'reason.heartbeatStale': 'trace-mcp의 마지막 응답은 {{ago}}입니다. 코딩 어시스턴트를 다시 시작하면 적용이 재개됩니다.',
+  'reason.channelQuiet': '가드는 설치되어 대기 중입니다. 마지막 도구 호출은 {{ago}}였습니다.',
+
   'mode.aria': '가드 모드',
   'mode.strict': '엄격',
   'mode.strictHelp': 'trace-mcp 툴로 답할 수 있으면 Read, Grep, Glob을 차단',

--- a/packages/app/src/shared/i18n/catalog/pt-BR/guard.ts
+++ b/packages/app/src/shared/i18n/catalog/pt-BR/guard.ts
@@ -41,6 +41,10 @@ export const guard = {
   'health.down': 'Parado',
   'health.unknown': 'Desconhecido',
 
+  'reason.neverStarted': 'Seu assistente de código ainda não iniciou o trace-mcp neste projeto. Reinicie-o para carregar o guard.',
+  'reason.heartbeatStale': 'O trace-mcp respondeu pela última vez {{ago}}. Reinicie seu assistente de código para retomar a aplicação.',
+  'reason.channelQuiet': 'O guard está instalado e aguardando — a última chamada de ferramenta foi {{ago}}.',
+
   'mode.aria': 'Modo do guard',
   'mode.strict': 'Estrito',
   'mode.strictHelp': 'Bloquear Read, Grep e Glob quando uma ferramenta do trace-mcp resolve',

--- a/packages/app/src/shared/i18n/catalog/ru/guard.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/guard.ts
@@ -44,6 +44,10 @@ export const guard = {
   'health.down': 'Не запущен',
   'health.unknown': 'Неизвестно',
 
+  'reason.neverStarted': 'Ассистент ещё ни разу не запускал trace-mcp в этом проекте. Перезапустите его, чтобы страж заработал.',
+  'reason.heartbeatStale': 'Последний отклик trace-mcp — {{ago}}. Перезапустите ассистента, чтобы вернуть ограничения.',
+  'reason.channelQuiet': 'Страж установлен и ждёт — последний вызов инструмента был {{ago}}.',
+
   'mode.aria': 'Режим стража',
   'mode.strict': 'Строгий',
   'mode.strictHelp': 'Блокировать Read, Grep и Glob, когда на вопрос отвечает инструмент trace-mcp',

--- a/packages/app/src/shared/i18n/catalog/zh/guard.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/guard.ts
@@ -39,6 +39,10 @@ export const guard = {
   'health.down': '未运行',
   'health.unknown': '未知',
 
+  'reason.neverStarted': '此项目中的编程助手还没有启动过 trace-mcp。重启助手即可让守卫生效。',
+  'reason.heartbeatStale': 'trace-mcp 最后一次响应是{{ago}}。重启编程助手即可恢复拦截。',
+  'reason.channelQuiet': '守卫已安装并在等待——最后一次工具调用是{{ago}}。',
+
   'mode.aria': 'guard 模式',
   'mode.strict': '严格',
   'mode.strictHelp': '当 trace-mcp 工具能回答同一个问题时，拦截 Read、Grep 和 Glob',


### PR DESCRIPTION
Closes TRA-490.

## Before

The Guard card with the guard down stated one condition twice and offered no way out:

- the Status row: a red `⚠ Not running` badge;
- the line under the card: `trace-mcp server not running` — `state.reason`, a free-form English string built in `guard-control.ts` and printed verbatim by the renderer in all ten locales.

Same fact, 190px apart, one of them in a colour that says "act on this". The card's only controls (Mode, Pause for 10 minutes) shape *how* enforcement behaves, and neither can matter while nothing is enforcing.

This lands on people who just followed the app's own onboarding: the guard sheet ends with "restart Claude Code so it picks up the new hook configuration", and until that restart the heartbeat sentinel is absent — so the card they are dropped onto shows a red failure badge with no next step.

## After

`getGuardStatus` returns a reason **code** (`heartbeat_stale` / `channel_quiet` / `never_started`) plus its age in seconds. `down` had more than one cause and they need different advice — a server that stopped is not a server that was never started, and the old code flattened both into one badge and one sentence.

The renderer turns the code into one localized line that names the cause and the one thing that changes it:

- `never_started` — "Your coding assistant hasn't started trace-mcp in this project yet. Restart it to pick up the guard."
- `heartbeat_stale` — "trace-mcp last checked in 6 minutes ago. Restart your coding assistant to resume enforcement." (time via `relativeTime`, not a raw second count)
- `channel_quiet` — "The guard is installed and waiting — the last tool call was 12 minutes ago."

No advice we can honestly give → no line at all, rather than a sentence that ends nowhere. Ten locales updated. The card geometry is unchanged: same 32px rows, same 11px/13 `--label-secondary` footnote (4.64:1 light / 5.37:1 dark).

## Rules into DESIGN.md

Two, both in "One condition gets one sentence":

- a badge states the condition, the line under it states the cause and the next step — if the second line cannot say something the badge does not, it is not written;
- a cause crosses the IPC boundary as a code, never as a sentence: main knows *that* the heartbeat is stale, only the renderer knows the language and the room it has.

## Verification

Electron window over CDP, offscreen (never on screen — TRA-403), Project Overview with a real project and no MCP server started for it. Light, dark, and Increase Contrast + Reduce Transparency all render the new line legibly. `packages/app`: 58 files / 575 tests pass, `tsc --noEmit` clean, `check:i18n` clean.
