### PR TITLE
docs: read the PR-benchmark counts from the data file, not by hand

### DIFF
--- a/docs/reduce-claude-code-token-usage.md
+++ b/docs/reduce-claude-code-token-usage.md
@@ -131,7 +131,7 @@ Encoding matters, but not uniformly. Our measurements (`scripts/bench-toon.ts`, 
 
 The rule underneath: compact tabular encodings win when every row has the same scalar columns, and lose the moment a row contains a nested object or an inner array. Full method and the breakeven curve are on the [TOON savings page](/toon-savings.html).
 
-Every number in this section is measured by trace-mcp on trace-mcp. The one measurement taken on code we do not own is the [PR review context benchmark](/pr-context-benchmark.html) — 60 merged pull requests across six open-source repositories — and to see what any of this is worth on your own sessions rather than on ours, [session analytics](/analytics.html) reports the same figures from your local agent logs.
+Every number in this section is measured by trace-mcp on trace-mcp. The one measurement taken on code we do not own is the [PR review context benchmark](/pr-context-benchmark.html) — {{ site.data.pr_context_bench.pr_count }} merged pull requests across {{ site.data.pr_context_bench.repo_count }} open-source repositories — and to see what any of this is worth on your own sessions rather than on ours, [session analytics](/analytics.html) reports the same figures from your local agent logs.
 
 ## 5. Prefer one structural query over many reads
 


### PR DESCRIPTION
Follow-up to #757 (TRA-658).

The cross-link added to `reduce-claude-code-token-usage.md` typed "60 merged pull requests across six open-source repositories" by hand. `pr-context-benchmark.md` already renders both from `docs/_data/pr_context_bench.json`, so the two would drift the next time the benchmark is re-run. Now both pages read the same source.

Markdown text only — no code, no test, no data change.