### PR TITLE
test(app): SetupWizard 'allows choosing another folder' no longer races the guess (TRA-640)

### DIFF
--- a/packages/app/src/renderer/components/__tests__/SetupWizard.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/SetupWizard.test.tsx
@@ -211,7 +211,10 @@ it('allows choosing another folder with selectFolder', async () => {
   render(<SetupWizard onClose={() => {}} initialStep="project" />);
 
   await screen.findByText('Index your first project');
-  const changeButton = screen.getByRole('button', { name: 'Change folder…' });
+  // The project step's title renders synchronously; guessFirstProject() still
+  // needs a tick to resolve and swap the "no folder" card for the guessed one
+  // (TRA-640) — findByRole waits for that instead of racing it.
+  const changeButton = await screen.findByRole('button', { name: 'Change folder…' });
   fireEvent.click(changeButton);
 
   await screen.findByText('custom-repo');


### PR DESCRIPTION
Closes TRA-640.

`tests/.../SetupWizard.test.tsx > allows choosing another folder with selectFolder` flaked on the merge gate: the project step's title (`t('guard:wizard.project.title')`) renders synchronously the moment `step === 'project'`, but `guessedProject` starts `null` until `guessFirstProject()`'s promise resolves and swaps the empty-state card ("Choose folder…" button) for the guessed-project card ("Change folder…" button).

The test did `await screen.findByText('Index your first project')` (which only waits for the title) then immediately `screen.getByRole('button', { name: 'Change folder…' })` synchronously — a straight race against the guess resolving, exactly as diagnosed in TRA-640.

## Fix

`getByRole` → `findByRole` for the "Change folder…" button, so the test waits for the guessed-project card instead of assuming it's already there.

## Test evidence

- `SetupWizard.test.tsx` alone × 8 runs: 12/12 passed every time (previously would occasionally hit the empty-state card first).
- `pnpm -C packages/app exec vitest run` (full app suite, the exact contention conditions TRA-640 reproduced under): 575 passed.
- `pnpm exec vitest run` (full root suite): 868 files, 9530 passed, 10 skipped, 0 failed.
- `pnpm run lint`, `pnpm run build`, `pnpm run biome:ci`, `pnpm -C packages/app exec tsc --noEmit`: all clean.

Agent: Implementation Engineer