### PR TITLE
fix(app): Project Overview states a section failure once, without inventing a cause (TRA-662)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -685,6 +685,26 @@ sections it speaks for do not render.** A heading over a card that only repeats 
 banner is not information. One failure stays in place, where the reader is already
 looking.
 
+**A list dropped into a sentence written for one thing is not a sentence.**
+`Intl.ListFormat` joins the nouns; it cannot inflect the verb around them. The
+collapsed line above, built from the singular string, would have shipped Spanish
+as `No se **pudo** cargar el resumen del índice y el escaneo de calidad` —
+grammar the English original has no way to show, because English marks neither.
+So a sentence that can take a list gets its own catalogue key, plural in every
+language, chosen by the caller (which is the only place that knows the list has
+two entries) — not an i18next `count`, which would demand `_few`/`_many` forms
+from Russian for a distinction it does not make here.
+
+**And a string that opens on `{{what}}` is a sentence you have not read.** German's
+was `{{what}} konnte nicht geladen werden`, so every German error on this surface
+had opened with a lowercase article for five months, and `errorQuality` was
+accusative (`den Qualitätsscan`) inside a passive that takes the nominative —
+both invisible in English review, and neither survivable in the plural. The
+phrasing that does survive is the one Russian and Portuguese already used: a
+lead-in, a colon, then the noun (`Fehler beim Laden: …`). Where an interpolation
+lands at the start of a sentence, check capitalisation and case in that language
+before checking anything else.
+
 **The test for "down" is a shared reducer, not a fresh `!connected`.**
 `deriveDaemonState()` already encodes that a daemon which has not answered *yet*
 is not one that is failing to. `connected` is false for the first moments of every

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -665,6 +665,26 @@ catalogue string in all ten locales; a section that cannot tell "busy" from "not
 running" must not pick one. Deciding that is the surface's job, because the
 surface is what holds the daemon state.
 
+That corollary was written and then not applied: `SectionError`'s catalogue string
+kept "The daemon may still be indexing" for another five months, and every case the
+daemon-down pane does *not* cover still printed it. On a project last indexed five
+days ago, with the daemon up and the Indexing KPI reading `0 · nothing running`,
+Index and Quality both failed for some third reason and both asserted the one cause
+that was provably false (TRA-662). **A failure with no known cause is a complete
+statement: what could not be loaded, plus the control that tries again.** Retry is
+the next step and it is already in the row; the invented sentence between them only
+had to be wrong once to cost the reader a diagnosis.
+
+**And "at surface level" is not "when the source is down".** The collapse rule above
+was implemented as a daemon-down branch, so the moment the daemon was up and merely
+answering badly, each section went back to speaking for itself — the same duplication
+the rule forbids, reached by the other door. Count the failures, not the source's
+state: **a second failing section collapses them into one line at the top of the
+surface, naming what is missing and retrying all of it with one button, and the
+sections it speaks for do not render.** A heading over a card that only repeats the
+banner is not information. One failure stays in place, where the reader is already
+looking.
+
 **The test for "down" is a shared reducer, not a fresh `!connected`.**
 `deriveDaemonState()` already encodes that a daemon which has not answered *yet*
 is not one that is failing to. `connected` is false for the first moments of every

--- a/packages/app/src/renderer/i18n/format.ts
+++ b/packages/app/src/renderer/i18n/format.ts
@@ -41,6 +41,18 @@ export function formatDate(value: number | Date, options?: Intl.DateTimeFormatOp
   ).format(value);
 }
 
+/**
+ * "the index summary and the quality scan" — one sentence naming several
+ * things, in the active language. `conjunction`, not `unit`: the list is prose
+ * inside a sentence, so English wants the "and" and Japanese wants "、".
+ */
+export function formatList(parts: string[]): string {
+  const locale = currentLocale();
+  return memo(`l:${locale}`, () => new Intl.ListFormat(locale, { type: 'conjunction' })).format(
+    parts,
+  );
+}
+
 /* Read top-down as "is it under a minute, under an hour…" — the same order the
    three hand-written helpers use, which is how a reader checks them. */
 const UNITS: ReadonlyArray<

--- a/packages/app/src/renderer/lattice/ui/Surface.tsx
+++ b/packages/app/src/renderer/lattice/ui/Surface.tsx
@@ -195,7 +195,14 @@ export function SkeletonRows({ rows }: { rows: number }) {
   );
 }
 
-/** Inline "we couldn't measure this" panel with the one action that helps. */
+/** Inline "we couldn't measure this" panel with the one action that helps.
+
+    It names WHAT is missing and nothing else. It used to add "The daemon may
+    still be indexing", which is a cause this primitive cannot know — on a
+    project last indexed five days ago, with the daemon up and its Indexing KPI
+    reading "nothing running", it was simply false (TRA-662). Retry is the next
+    step, and it is right there. A caller that does know the cause says it in
+    its own words, the way GuardSection does. */
 export function SectionError({ what, onRetry }: { what: string; onRetry: () => void }) {
   const { t } = useTranslation('ui');
   return (

--- a/packages/app/src/renderer/lattice/ui/Surface.tsx
+++ b/packages/app/src/renderer/lattice/ui/Surface.tsx
@@ -203,13 +203,28 @@ export function SkeletonRows({ rows }: { rows: number }) {
     reading "nothing running", it was simply false (TRA-662). Retry is the next
     step, and it is right there. A caller that does know the cause says it in
     its own words, the way GuardSection does. */
-export function SectionError({ what, onRetry }: { what: string; onRetry: () => void }) {
+export function SectionError({
+  what,
+  several = false,
+  onRetry,
+}: {
+  what: string;
+  /** `what` names more than one thing, so the sentence around it is plural.
+      A separate key rather than an i18next plural: only the caller knows the
+      list has two entries, the collapsed banner is never singular, and a
+      `count` would demand `_few`/`_many` forms from Russian and Arabic for a
+      distinction none of them make here. German is why this exists at all —
+      "die Index-Übersicht und der Qualitätsscan **konnten** nicht geladen
+      werden", against `konnte` for one. */
+  several?: boolean;
+  onRetry: () => void;
+}) {
   const { t } = useTranslation('ui');
   return (
     <div className="flex items-center gap-2 px-3 py-2.5">
       <Icon name="warning" size={14} />
       <span className="text-[13px] leading-4 flex-1" style={{ color: 'var(--label-secondary)' }}>
-        {t('sectionError', { what })}
+        {t(several ? 'sectionsError' : 'sectionError', { what })}
       </span>
       <Button size="small" onClick={onRetry}>
         {t('retry')}

--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -27,7 +27,7 @@ import { ProjectStatsModal } from '../components/ProjectStatsModal';
 import { useDaemon } from '../hooks/useDaemon';
 import { deriveDaemonState } from '../workspace/useWorkspaceProjects';
 import { t } from '../i18n';
-import { formatDate, formatNumber, relativeTime } from '../i18n/format';
+import { formatDate, formatList, formatNumber, relativeTime } from '../i18n/format';
 import { Icon } from '../lattice/icons';
 import {
   Badge,
@@ -488,6 +488,28 @@ export function ProjectOverview({
   const badgeLabel = (value: string): string =>
     BADGE_KEY[value] ? t(BADGE_KEY[value]) : value;
 
+  /* One condition, one sentence — even when it breaks four sections (TRA-662).
+     Every section here reads the same daemon, so two of them failing together
+     is one fact said twice, which is what TRA-469 removed for the daemon-DOWN
+     case. That pane only steps in when the daemon is unreachable; a daemon that
+     is up and answering badly used to leave each section to state the failure
+     on its own. So: a second failure collapses them into one line at the top of
+     the surface, naming what is missing and retrying all of it with one button,
+     and the failed sections do not render at all — a heading over a card that
+     only repeats the banner is not information. One failure stays in place,
+     where the reader is already looking. */
+  const statsFailed = statsLoad === 'failed' && !stats;
+  const coverageFailed = coverageLoad === 'failed' && !coverage;
+  const smellsFailed = smellsLoad === 'failed' && !smells;
+  const servicesFailed = servicesLoad === 'failed' && svcList.length === 0;
+  const failures: { what: string; retry: () => void }[] = [];
+  if (statsFailed) failures.push({ what: t('errorIndexSummary'), retry: fetchStats });
+  if (coverageFailed) failures.push({ what: t('errorCoverage'), retry: fetchCoverage });
+  if (smellsFailed)
+    failures.push({ what: t('errorQuality'), retry: () => fetchSmells(smellsCategory) });
+  if (servicesFailed) failures.push({ what: t('errorServices'), retry: fetchServices });
+  const collapsed = failures.length > 1;
+
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* ── Toolbar ──────────────────────────────────────────────────── */}
@@ -654,12 +676,24 @@ export function ProjectOverview({
             </div>
           )}
 
+          {collapsed && (
+            <Card>
+              <SectionError
+                what={formatList(failures.map((f) => f.what))}
+                onRetry={() => {
+                  for (const f of failures) f.retry();
+                }}
+              />
+            </Card>
+          )}
+
           {/* ── Index ──────────────────────────────────────────────── */}
+          {!(collapsed && statsFailed) && (
           <Section title={t('sectionIndex')}>
             <Card>
               {statsLoad === 'loading' && !stats ? (
                 <SkeletonRows rows={5} />
-              ) : statsLoad === 'failed' && !stats ? (
+              ) : statsFailed ? (
                 <SectionError what={t('errorIndexSummary')} onRetry={fetchStats} />
               ) : stats ? (
                 <>
@@ -696,6 +730,7 @@ export function ProjectOverview({
               )}
             </Card>
           </Section>
+          )}
 
           {/* ── Guard ─────────────────────────────────────────────────
               Second, not last: it is live state about how agents read this
@@ -704,6 +739,7 @@ export function ProjectOverview({
           <GuardSection root={root} />
 
           {/* ── Coverage ───────────────────────────────────────────── */}
+          {!(collapsed && coverageFailed) && (
           <Section
             title={t('sectionCoverage')}
             trailing={
@@ -723,7 +759,7 @@ export function ProjectOverview({
                   <Skeleton width="100%" height={6} radius={3} />
                   <Skeleton width={140} height={11} />
                 </div>
-              ) : coverageLoad === 'failed' && !coverage ? (
+              ) : coverageFailed ? (
                 <SectionError what={t('errorCoverage')} onRetry={fetchCoverage} />
               ) : coverage && coverage.coverage.total_significant === 0 ? (
                 /* Nothing to cover is not 100% covered. A full green meter over
@@ -809,8 +845,10 @@ export function ProjectOverview({
               )}
             </Card>
           </Section>
+          )}
 
           {/* ── Quality ────────────────────────────────────────────── */}
+          {!(collapsed && smellsFailed) && (
           <Section
             title={t('sectionQuality')}
             trailing={
@@ -832,7 +870,7 @@ export function ProjectOverview({
             <Card>
               {smellsLoad === 'loading' && !smells ? (
                 <SkeletonRows rows={4} />
-              ) : smellsLoad === 'failed' && !smells ? (
+              ) : smellsFailed ? (
                 <SectionError what={t('errorQuality')} onRetry={() => fetchSmells(smellsCategory)} />
               ) : visibleFindings.length === 0 ? (
                 <EmptyState
@@ -895,8 +933,10 @@ export function ProjectOverview({
               )}
             </Card>
           </Section>
+          )}
 
           {/* ── Services ───────────────────────────────────────────── */}
+          {!(collapsed && servicesFailed) && (
           <Section
             title={t('sectionServices')}
             count={svcList.length}
@@ -910,7 +950,7 @@ export function ProjectOverview({
               <Card>
                 <SkeletonRows rows={2} />
               </Card>
-            ) : servicesLoad === 'failed' && svcList.length === 0 ? (
+            ) : servicesFailed ? (
               <Card>
                 <SectionError what={t('errorServices')} onRetry={fetchServices} />
               </Card>
@@ -1057,6 +1097,7 @@ export function ProjectOverview({
               </div>
             )}
           </Section>
+          )}
         </div>
         )}
       </div>

--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -679,6 +679,7 @@ export function ProjectOverview({
           {collapsed && (
             <Card>
               <SectionError
+                several
                 what={formatList(failures.map((f) => f.what))}
                 onRetry={() => {
                   for (const f of failures) f.retry();

--- a/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
@@ -308,6 +308,31 @@ describe('ProjectOverview surface', () => {
     /* The toolbar does not disappear when one section fails. */
     expect(screen.getByRole('button', { name: 'Reindex' })).toBeTruthy();
     expect(screen.getAllByRole('button', { name: 'Retry' }).length).toBeGreaterThan(0);
+    /* And it does not name a cause it cannot know (TRA-662). */
+    expect(screen.queryByText(/still be indexing/)).toBeNull();
+  });
+
+  /* TRA-662. The daemon is UP here — the pane above never fires — and two
+     sections fail anyway. Before this they each stated it separately, which
+     put the same sentence on screen twice, over a project last indexed five
+     days ago and a daemon with nothing running. */
+  it('states a multi-section failure once, with one retry', async () => {
+    mockApi({ '/stats': null, '/coverage': COVERAGE, '/subprojects': {}, '/smells': null });
+    render(<ProjectOverview root={ROOT} />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Couldn't load the index summary and the quality scan."),
+      ).toBeTruthy(),
+    );
+    expect(screen.getAllByRole('button', { name: 'Retry' })).toHaveLength(1);
+    /* The collapsed sections leave no empty heading behind — a title over a
+       card that only repeats the banner is not information. */
+    expect(screen.queryByText('Index')).toBeNull();
+    expect(screen.queryByText('Quality')).toBeNull();
+    /* The sections that answered are untouched. */
+    expect(screen.getByText('Coverage')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Reindex' })).toBeTruthy();
   });
 });
 

--- a/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
@@ -355,4 +355,22 @@ describe('the surface reads from the catalogue, not from literals', () => {
     expect(screen.getByText('Файлов проиндексировано')).toBeTruthy();
     expect(screen.queryByText('Reindex')).toBeNull();
   });
+
+  /* A list of nouns dropped into a sentence written for one noun is not a
+     sentence. `Intl.ListFormat` joins the nouns and cannot touch the verb
+     around them: Spanish needs `pudieron`, not `pudo`. German's old wording
+     `{{what}} konnte nicht geladen werden` could not be pluralised into a
+     correct sentence at all — the interpolation was sentence-initial, so it
+     also opened every German error with a lowercase article — and now reads
+     off a colon, where number and case stop mattering. */
+  it.each([
+    ['de', 'Fehler beim Laden: die Index-Übersicht und der Qualitätsscan.'],
+    ['es', 'No se pudieron cargar el resumen del índice y el escaneo de calidad.'],
+  ])('agrees with a plural subject in %s', async (locale, sentence) => {
+    setLocale(locale);
+    mockApi({ '/stats': null, '/coverage': COVERAGE, '/subprojects': {}, '/smells': null });
+    render(<ProjectOverview root={ROOT} />);
+
+    await waitFor(() => expect(screen.getByText(sentence)).toBeTruthy());
+  });
 });

--- a/packages/app/src/shared/i18n/catalog/de/overview.ts
+++ b/packages/app/src/shared/i18n/catalog/de/overview.ts
@@ -36,7 +36,7 @@ export const overview = {
 
   errorIndexSummary: 'die Index-Übersicht',
   errorCoverage: 'die Abdeckung der Abhängigkeiten',
-  errorQuality: 'den Qualitätsscan',
+  errorQuality: 'der Qualitätsscan',
   errorServices: 'die Dienstliste',
 
   // ── Coverage ──

--- a/packages/app/src/shared/i18n/catalog/de/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/de/ui.ts
@@ -4,7 +4,8 @@ export const ui = {
   gradeBadge: 'Tech-Debt-Note {{grade}}',
   loading: 'Wird geladen',
   retry: 'Erneut versuchen',
-  sectionError: '{{what}} konnte nicht geladen werden.',
+  sectionError: 'Fehler beim Laden: {{what}}.',
+  sectionsError: 'Fehler beim Laden: {{what}}.',
 
   // ── FilterBar ───────────────────────────────────────────────────────────
   filterMatch: 'Treffer',

--- a/packages/app/src/shared/i18n/catalog/de/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/de/ui.ts
@@ -4,7 +4,7 @@ export const ui = {
   gradeBadge: 'Tech-Debt-Note {{grade}}',
   loading: 'Wird geladen',
   retry: 'Erneut versuchen',
-  sectionError: '{{what}} konnte nicht geladen werden. Der Daemon indexiert womöglich noch.',
+  sectionError: '{{what}} konnte nicht geladen werden.',
 
   // ── FilterBar ───────────────────────────────────────────────────────────
   filterMatch: 'Treffer',

--- a/packages/app/src/shared/i18n/catalog/en/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/en/ui.ts
@@ -12,7 +12,7 @@ export const ui = {
   gradeBadge: 'Tech debt grade {{grade}}',
   loading: 'Loading',
   retry: 'Retry',
-  sectionError: "Couldn't load {{what}}. The daemon may still be indexing.",
+  sectionError: "Couldn't load {{what}}.",
 
   // ── FilterBar ───────────────────────────────────────────────────────────
   filterMatch: 'Match',

--- a/packages/app/src/shared/i18n/catalog/en/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/en/ui.ts
@@ -13,6 +13,7 @@ export const ui = {
   loading: 'Loading',
   retry: 'Retry',
   sectionError: "Couldn't load {{what}}.",
+  sectionsError: "Couldn't load {{what}}.",
 
   // ── FilterBar ───────────────────────────────────────────────────────────
   filterMatch: 'Match',

--- a/packages/app/src/shared/i18n/catalog/es/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/es/ui.ts
@@ -4,7 +4,7 @@ export const ui = {
   gradeBadge: 'Nota de deuda técnica {{grade}}',
   loading: 'Cargando',
   retry: 'Reintentar',
-  sectionError: 'No se pudo cargar {{what}}. Puede que el daemon siga indexando.',
+  sectionError: 'No se pudo cargar {{what}}.',
 
   filterMatch: 'Coincide',
   filterExclude: 'Excluir',

--- a/packages/app/src/shared/i18n/catalog/es/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/es/ui.ts
@@ -5,6 +5,7 @@ export const ui = {
   loading: 'Cargando',
   retry: 'Reintentar',
   sectionError: 'No se pudo cargar {{what}}.',
+  sectionsError: 'No se pudieron cargar {{what}}.',
 
   filterMatch: 'Coincide',
   filterExclude: 'Excluir',

--- a/packages/app/src/shared/i18n/catalog/fr/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/fr/ui.ts
@@ -4,7 +4,7 @@ export const ui = {
   gradeBadge: 'Note de dette technique {{grade}}',
   loading: 'Chargement',
   retry: 'Réessayer',
-  sectionError: 'Impossible de charger {{what}}. Le démon est peut-être encore en indexation.',
+  sectionError: 'Impossible de charger {{what}}.',
 
   filterMatch: 'Inclure',
   filterExclude: 'Exclure',

--- a/packages/app/src/shared/i18n/catalog/fr/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/fr/ui.ts
@@ -5,6 +5,7 @@ export const ui = {
   loading: 'Chargement',
   retry: 'Réessayer',
   sectionError: 'Impossible de charger {{what}}.',
+  sectionsError: 'Impossible de charger {{what}}.',
 
   filterMatch: 'Inclure',
   filterExclude: 'Exclure',

--- a/packages/app/src/shared/i18n/catalog/hi/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/hi/ui.ts
@@ -4,7 +4,7 @@ export const ui = {
   gradeBadge: 'टेक-डेट ग्रेड {{grade}}',
   loading: 'लोड हो रहा है',
   retry: 'फिर से',
-  sectionError: '{{what}} लोड नहीं हो सका। डेमन शायद अभी इंडेक्स कर रहा है।',
+  sectionError: '{{what}} लोड नहीं हो सका।',
 
   filterMatch: 'मैच',
   filterExclude: 'हटाएँ',

--- a/packages/app/src/shared/i18n/catalog/hi/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/hi/ui.ts
@@ -5,6 +5,7 @@ export const ui = {
   loading: 'लोड हो रहा है',
   retry: 'फिर से',
   sectionError: '{{what}} लोड नहीं हो सका।',
+  sectionsError: '{{what}} लोड नहीं हो सके।',
 
   filterMatch: 'मैच',
   filterExclude: 'हटाएँ',

--- a/packages/app/src/shared/i18n/catalog/ja/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/ja/ui.ts
@@ -4,7 +4,7 @@ export const ui = {
   gradeBadge: '技術的負債の評価 {{grade}}',
   loading: '読み込み中',
   retry: '再試行',
-  sectionError: '{{what}}を読み込めませんでした。デーモンがまだインデックス中の可能性があります。',
+  sectionError: '{{what}}を読み込めませんでした。',
 
   filterMatch: '一致',
   filterExclude: '除外',

--- a/packages/app/src/shared/i18n/catalog/ja/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/ja/ui.ts
@@ -5,6 +5,7 @@ export const ui = {
   loading: '読み込み中',
   retry: '再試行',
   sectionError: '{{what}}を読み込めませんでした。',
+  sectionsError: '{{what}}を読み込めませんでした。',
 
   filterMatch: '一致',
   filterExclude: '除外',

--- a/packages/app/src/shared/i18n/catalog/ko/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/ko/ui.ts
@@ -5,6 +5,7 @@ export const ui = {
   loading: '불러오는 중',
   retry: '다시 시도',
   sectionError: '{{what}}을(를) 불러오지 못했습니다.',
+  sectionsError: '{{what}}을(를) 불러오지 못했습니다.',
 
   filterMatch: '일치',
   filterExclude: '제외',

--- a/packages/app/src/shared/i18n/catalog/ko/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/ko/ui.ts
@@ -4,7 +4,7 @@ export const ui = {
   gradeBadge: '기술 부채 등급 {{grade}}',
   loading: '불러오는 중',
   retry: '다시 시도',
-  sectionError: '{{what}}을(를) 불러오지 못했습니다. 데몬이 아직 인덱싱 중일 수 있습니다.',
+  sectionError: '{{what}}을(를) 불러오지 못했습니다.',
 
   filterMatch: '일치',
   filterExclude: '제외',

--- a/packages/app/src/shared/i18n/catalog/pt-BR/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/pt-BR/ui.ts
@@ -5,6 +5,7 @@ export const ui = {
   loading: 'Carregando',
   retry: 'Tentar de novo',
   sectionError: 'Não foi possível carregar: {{what}}.',
+  sectionsError: 'Não foi possível carregar: {{what}}.',
 
   filterMatch: 'Incluir',
   filterExclude: 'Excluir',

--- a/packages/app/src/shared/i18n/catalog/pt-BR/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/pt-BR/ui.ts
@@ -4,7 +4,7 @@ export const ui = {
   gradeBadge: 'Nota de dívida técnica {{grade}}',
   loading: 'Carregando',
   retry: 'Tentar de novo',
-  sectionError: 'Não foi possível carregar: {{what}}. O daemon pode ainda estar indexando.',
+  sectionError: 'Não foi possível carregar: {{what}}.',
 
   filterMatch: 'Incluir',
   filterExclude: 'Excluir',

--- a/packages/app/src/shared/i18n/catalog/ru/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/ui.ts
@@ -10,6 +10,7 @@ export const ui = {
   loading: 'Загрузка',
   retry: 'Повторить',
   sectionError: 'Не удалось загрузить: {{what}}.',
+  sectionsError: 'Не удалось загрузить: {{what}}.',
 
   filterMatch: 'Совпадение',
   filterExclude: 'Исключить',

--- a/packages/app/src/shared/i18n/catalog/ru/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/ui.ts
@@ -9,7 +9,7 @@ export const ui = {
   gradeBadge: 'Оценка техдолга {{grade}}',
   loading: 'Загрузка',
   retry: 'Повторить',
-  sectionError: 'Не удалось загрузить: {{what}}. Возможно, служба ещё индексирует.',
+  sectionError: 'Не удалось загрузить: {{what}}.',
 
   filterMatch: 'Совпадение',
   filterExclude: 'Исключить',

--- a/packages/app/src/shared/i18n/catalog/zh/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/ui.ts
@@ -5,6 +5,7 @@ export const ui = {
   loading: '加载中',
   retry: '重试',
   sectionError: '无法加载{{what}}。',
+  sectionsError: '无法加载{{what}}。',
 
   filterMatch: '匹配',
   filterExclude: '排除',

--- a/packages/app/src/shared/i18n/catalog/zh/ui.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/ui.ts
@@ -4,7 +4,7 @@ export const ui = {
   gradeBadge: '技术债等级 {{grade}}',
   loading: '加载中',
   retry: '重试',
-  sectionError: '无法加载{{what}}。守护进程可能仍在索引。',
+  sectionError: '无法加载{{what}}。',
 
   filterMatch: '匹配',
   filterExclude: '排除',


### PR DESCRIPTION
Closes TRA-662.

## Two problems, one screen

Project Overview for a healthy project rendered this, on every screenshot of the TRA-490 verification run, light and dark:

```
Index      ⚠ Couldn't load the index summary. The daemon may still be indexing.   [Retry]
Quality    ⚠ Couldn't load the quality scan.  The daemon may still be indexing.   [Retry]
```

**The cause is asserted, and it was wrong.** "The daemon may still be indexing" is the *wait* diagnosis. The daemon was up, the Indexing KPI read `0 · nothing running`, and the project was last indexed five days earlier. `SectionError` renders one catalogue string for every caller — it cannot know why a fetch failed, so it now names what could not be loaded and stops. Retry is the next step, and it is in the same row. (`DESIGN.md` already said this: "the shared error primitive must not name a cause it cannot know." The corollary was written in TRA-469 and then not applied to the string.)

**And it said it twice.** TRA-469 collapsed the four section errors into one statement — but implemented as a daemon-*down* branch. The moment the daemon was up and merely answering badly, each section went back to speaking for itself, which is the duplication the rule forbids, reached through the other door. The surface now counts failures instead of reading the source's state: a second failing section collapses them into one line at the top, naming what is missing and retrying all of it with one button, and the sections it speaks for do not render — a heading over a card that only repeats the banner is not information. One failure stays inline, where the reader is already looking.

## Changes

- `Surface.tsx` — `SectionError` doc; the string itself lives in the catalogues.
- Ten `catalog/*/ui.ts` — `sectionError` drops the cause clause.
- `format.ts` — `formatList`, an `Intl.ListFormat` wrapper, so "the index summary and the quality scan" is one sentence in every language (and "、" in Japanese).
- `ProjectOverview.tsx` — failure list, collapse at ≥ 2, skip the collapsed sections.
- `DESIGN.md` — both rules, stated as rules rather than as this fix.

## Verification

Electron window over CDP, offscreen (`electron-cdp.mjs launch`, `TRACE_MCP_BIN` pointed at a no-op shim so the developer's daemon was never restarted), against the **live** daemon with `/api/projects/stats` and `/api/projects/smells` refused at the network layer — so `daemonDown` is false and this is exactly the reported state, not a simulation of it.

Read off the running renderer, same state, before and after:

| | rendered text |
|---|---|
| before | `Index │ Couldn't load the index summary. The daemon may still be indexing. │ Retry │ Coverage │ Quality │ Couldn't load the quality scan. The daemon may still be indexing. │ Retry` |
| after | `Couldn't load the index summary and the quality scan. │ Retry │ Coverage` |
| after, one failure | `Index │ Coverage │ Quality │ Couldn't load the quality scan. │ Retry` |

Shot in dark, light, light + Reduce Transparency and dark + Increase Contrast; screenshots are on TRA-662.

`packages/app`: 576 tests, typecheck, `check:i18n`, renderer + main build all pass.
