### PR TITLE
fix(db): don't crash reindex on cross-file ORM associations (TRA-663)

### DIFF
--- a/src/db/repositories/domain-repository.ts
+++ b/src/db/repositories/domain-repository.ts
@@ -242,9 +242,20 @@ export class DomainRepository {
   getAllOrmAssociations(fileIds?: number[]): OrmAssociationRow[] {
     if (fileIds && fileIds.length > 0) {
       const ph = fileIds.map(() => '?').join(',');
+      // Associations declared elsewhere can *target* a model in a changed file
+      // — reindexing that file drops the model node and its edges, so the
+      // scoped resolver has to see those rows too or the edge stays lost until
+      // the next full index. They are unresolved by construction:
+      // deleteEntitiesByFile nulls target_model_id when the target is deleted.
       return this.db
-        .prepare(`SELECT * FROM orm_associations WHERE file_id IN (${ph})`)
-        .all(...fileIds) as OrmAssociationRow[];
+        .prepare(
+          `SELECT * FROM orm_associations
+           WHERE file_id IN (${ph})
+              OR (target_model_id IS NULL
+                  AND target_model_name IN
+                      (SELECT name FROM orm_models WHERE file_id IN (${ph})))`,
+        )
+        .all(...fileIds, ...fileIds) as OrmAssociationRow[];
     }
     return this.db.prepare('SELECT * FROM orm_associations').all() as OrmAssociationRow[];
   }

--- a/src/db/repositories/file-repository.ts
+++ b/src/db/repositories/file-repository.ts
@@ -113,6 +113,18 @@ export class FileRepository {
   }
 
   deleteEntitiesByFile(fileId: number): void {
+    // Associations in OTHER files can point at this file's models via
+    // target_model_id, which has no ON DELETE clause — deleting the models
+    // below would hit a FOREIGN KEY violation and abort the whole indexing
+    // run. Unresolve those pointers instead; target_model_name survives, so
+    // the next resolve pass can re-link them.
+    this.db
+      .prepare(
+        `UPDATE orm_associations SET target_model_id = NULL
+         WHERE target_model_id IN (SELECT id FROM orm_models WHERE file_id = ?)`,
+      )
+      .run(fileId);
+
     for (const [table, nodeType] of [
       ['routes', 'route'],
       ['components', 'component'],

--- a/tests/db/store.test.ts
+++ b/tests/db/store.test.ts
@@ -264,6 +264,21 @@ describe('Store', () => {
       expect(assocs[0].target_model_name).toBe('Gadget');
       expect(assocs[0].target_model_id).toBeNull();
     });
+
+    it('unresolves cross-file associations when the target model file is deleted', () => {
+      const fileA = store.insertFile('models/user.ts', 'typescript', 'hC', 50);
+      const fileB = store.insertFile('models/post.ts', 'typescript', 'hD', 50);
+      const userModelId = store.insertOrmModel({ name: 'User', orm: 'mongoose' }, fileA);
+      const postModelId = store.insertOrmModel({ name: 'Post', orm: 'mongoose' }, fileB);
+      store.insertOrmAssociation(postModelId, userModelId, 'User', 'belongsTo', undefined, fileB, 5);
+
+      expect(() => store.deleteFile(fileA)).not.toThrow();
+
+      const assocs = store.getOrmAssociationsByModel(postModelId);
+      expect(assocs.length).toBe(1);
+      expect(assocs[0].target_model_id).toBeNull();
+      expect(assocs[0].target_model_name).toBe('User');
+    });
   });
 
   describe('React Native screens', () => {

--- a/tests/db/store.test.ts
+++ b/tests/db/store.test.ts
@@ -270,7 +270,15 @@ describe('Store', () => {
       const fileB = store.insertFile('models/post.ts', 'typescript', 'hD', 50);
       const userModelId = store.insertOrmModel({ name: 'User', orm: 'mongoose' }, fileA);
       const postModelId = store.insertOrmModel({ name: 'Post', orm: 'mongoose' }, fileB);
-      store.insertOrmAssociation(postModelId, userModelId, 'User', 'belongsTo', undefined, fileB, 5);
+      store.insertOrmAssociation(
+        postModelId,
+        userModelId,
+        'User',
+        'belongsTo',
+        undefined,
+        fileB,
+        5,
+      );
 
       expect(() => store.deleteFile(fileA)).not.toThrow();
 

--- a/tests/integration/orm-edges.test.ts
+++ b/tests/integration/orm-edges.test.ts
@@ -4,6 +4,7 @@
  * associations are correctly mapped to ORM-specific edge types.
  */
 
+import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { TraceMcpConfigSchema } from '../../src/config.js';
@@ -23,6 +24,23 @@ function makeConfig(
   include: string[],
 ): ReturnType<typeof TraceMcpConfigSchema.parse> {
   return TraceMcpConfigSchema.parse({ include, exclude: ['node_modules/**'] });
+}
+
+/** Count Post → User `mongoose_references` edges, by model name. */
+function postToUserEdges(store: ReturnType<typeof createTestStore>): number {
+  const byId = new Map(store.getAllOrmModels().map((m) => [m.id, m.name]));
+  const nodeToModel = new Map<number, string>();
+  for (const [id, name] of byId) {
+    const nodeId = store.getNodeId('orm_model', id);
+    if (nodeId != null) nodeToModel.set(nodeId, name);
+  }
+  return store
+    .getEdgesByType('mongoose_references')
+    .filter(
+      (e) =>
+        nodeToModel.get(e.source_node_id) === 'Post' &&
+        nodeToModel.get(e.target_node_id) === 'User',
+    ).length;
 }
 
 describe('ORM edge type resolution', () => {
@@ -47,6 +65,41 @@ describe('ORM edge type resolution', () => {
 
       // Verify no sequelize_* edge types were accidentally created
       expect(store.getEdgesByType('sequelize_has_many')).toHaveLength(0);
+    });
+  });
+
+  describe('cross-file associations survive an incremental reindex', () => {
+    it('re-links a mongoose_references edge after the target model file is reindexed', async () => {
+      const store = createTestStore();
+      const registry = new PluginRegistry();
+      registry.registerLanguagePlugin(new TypeScriptLanguagePlugin());
+      registry.registerFrameworkPlugin(new MongoosePlugin());
+
+      // Real fixture: models/post.ts holds `ref: 'User'`, models/user.ts
+      // defines User — the cross-file shape TRA-663 crashed on. Copied so the
+      // test can touch a file without dirtying the fixture.
+      const tmpDir = createTmpDir('mongoose-incremental-');
+      fs.cpSync(path.resolve(__dirname, '../fixtures/mongoose-8'), tmpDir, { recursive: true });
+      const userPath = path.join(tmpDir, 'models/user.ts');
+
+      try {
+        const pipeline = new IndexingPipeline(
+          store,
+          registry,
+          makeConfig(tmpDir, ['**/*.ts']),
+          tmpDir,
+        );
+        await pipeline.indexAll();
+        expect(postToUserEdges(store)).toBeGreaterThan(0);
+
+        // Reindex only the *target* file — post.ts's association points at it.
+        fs.appendFileSync(userPath, '// touched\n');
+        await pipeline.indexFiles([userPath]);
+
+        expect(postToUserEdges(store)).toBeGreaterThan(0);
+      } finally {
+        removeTmpDir(tmpDir);
+      }
     });
   });
 


### PR DESCRIPTION
Fixes the `SqliteError: FOREIGN KEY constraint failed` crash reported in TRA-663.

## Cause

`orm_associations.target_model_id` references `orm_models(id)` with **no** `ON DELETE` clause (`src/db/schema.ts:151`), and `FileRepository.deleteEntitiesByFile` never touched `orm_associations` — it only deletes `routes`, `components`, `migrations`, `orm_models`, `rn_screens`. File A defines `User`; file B declares `Post.belongsTo(User)`. Reindexing file A deletes the `User` row, SQLite refuses because file B's association still points at it, and nothing catches the exception — the whole indexing run aborts.

## Fix

Unresolve the dangling pointers before deleting the models:

```sql
UPDATE orm_associations SET target_model_id = NULL
WHERE target_model_id IN (SELECT id FROM orm_models WHERE file_id = ?)
```

`target_model_name` survives, and `src/indexer/edge-resolvers/orm.ts:52-54` already falls back to it when `target_model_id` is null (that's also the state every association starts in — `file-persister.ts` resolves targets best-effort at insert time). So the association is re-linked on the next resolve pass; no data or edges are lost.

**No schema change**, therefore no migration: existing installed DBs are fixed by the code alone. That's why this was preferred over `ON DELETE SET NULL`, which fixes only DBs created after the change and requires a full SQLite table rebuild for everyone else, for identical semantics.

The issue also suggested a defensive try/catch around per-file persistence. Deliberately not doing that here: swallowing an FK violation would turn a loud crash into a silently half-indexed project. The FK is the invariant check working correctly — the delete had a real bug.

## Test evidence

New test in `tests/db/store.test.ts` reproduces the crash (verified red before the fix: `expected [Function] to not throw an error but 'SqliteError: FOREIGN KEY constraint f…' was thrown`) and asserts the association survives unresolved.

End-to-end on this repo's own checkout, isolated data dir, second `index . --force` over a populated DB:

- without the fix: `exit=1`, one `FOREIGN KEY constraint failed`
- with the fix: `exit=0`, 2082 files indexed, 0 errors

Full suite: 870 test files passed, 9533 tests passed. Build green.
