### PR TITLE
docs(configuration): warn that --preset needs a release that has it (TRA-664)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -748,6 +748,8 @@ Multica agents don't run `trace-mcp init` — each agent's MCP wiring is set dir
 multica agent update <agent-id> --mcp-config-file ./trace-mcp-dev.json
 ```
 
+> **Check that the agent's installed `trace-mcp` supports `--preset` before rolling this out.** The flag shipped after 3.11.0; an older binary exits immediately with `unknown option '--preset'`, and because a dead MCP server is silent, the agent simply runs with **zero** trace-mcp tools instead of a smaller set. Verify with `trace-mcp --help | grep -- --preset` on the machine the agent runs on. Same trap applies to a `command` pointing at a build inside a per-task working directory — those get cleaned up.
+
 The role → preset matrix used in the trace-mcp workspace itself (adjust to your own roles):
 
 | Agent role | Preset | Why |


### PR DESCRIPTION
## What

One paragraph in `docs/configuration.md` (Multica workspace agents section): before wiring an agent to `--preset`, check the installed `trace-mcp` actually supports the flag.

## Why — measured, not theoretical

`--preset` landed on master after v3.11.0 and is not in any published release. The npm-installed `trace-mcp` 3.11.0 answers:

```
$ trace-mcp --preset perf
error: unknown option '--preset'
```

The process exits, the MCP client sees a dead server, and there is no user-visible error — the agent just runs with **zero** trace-mcp tools. "90% fewer schema tokens" and "100% fewer" look identical from the outside.

This actually happened in the trace-mcp Multica workspace (TRA-604 rollout at `2026-09-01T20:39:39Z`). Counted over agent session logs, split on that timestamp:

| Group | Sessions | With trace-mcp tools | trace-mcp tool calls |
|---|---|---|---|
| 5 preset-configured agents — before | 11 | 10 | 124 |
| 5 preset-configured agents — after | 10 | **0** | **0** |
| Unconfigured agents (control) — before | 30 | 29 | 132 |
| Unconfigured agents (control) — after | 14 | 13 | 25 |

Both code reviewers were among the five, so the mandatory review gate ran without code intelligence for ~11 hours. The agent configs have been reverted (agent-level `mcp_config` cleared, workspace default restored); they get `--preset` back once a release containing it ships.

The note also covers the other shape of the same failure: a `command` pointing into a per-task working directory, which gets cleaned up.

Docs-only.
