### PR TITLE
fix(scripts): resolve the CLI state dir instead of hardcoding ~/.trace-mcp (TRA-667)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -265,7 +265,7 @@ zip and replaced the `.app` itself, staging the zip beside the bundle when the
 app was running so a helper could swap it on exit. It failed fourteen
 consecutive times without a single success (TRA-431) and is gone — along with
 `scripts/apply-pending-update.mjs`, the pending marker files, and
-`~/.trace-mcp/app-update-state.json`.
+`~/.trace/app-update-state.json`.
 
 Builds up to and including 3.8.0 are ad-hoc signed and cannot self-update, so
 `scripts/postinstall-app.mjs` still swaps **those** bundles — and only those. It
@@ -284,8 +284,17 @@ under `release/mac-arm64/` is a real, correctly signed-looking bundle, so plist
 validation alone accepts it; `isPlausibleInstallPath` (duplicated in
 `scripts/locate-app.mjs` and `packages/app/src/main/install-path.ts`, kept honest
 by `install-path.test.ts`) is what rejects build trees and checkouts. Recording
-one in `~/.trace-mcp/app-location.json` froze a user's install for three major
+one in `~/.trace/app-location.json` froze a user's install for three major
 versions.
+
+`app-location.json` and `app-update-state.json` both live in the CLI state
+directory, which `src/global.ts` renamed from `~/.trace-mcp` to `~/.trace` in
+TRA-611 — by *renaming* the old directory on first import, so on a migrated
+machine the old path is gone. The plain-Node scripts cannot import that module (it is TypeScript, and importing it
+would perform the rename as a side effect), so they resolve the directory
+through `scripts/trace-home.mjs`, which mirrors the app's
+`packages/app/src/main/trace-home.ts::getLauncherDir`: prefer `~/.trace` only
+when it is actually on disk, otherwise stay on `~/.trace-mcp`.
 
 ---
 

--- a/packages/app/scripts/perf-measure.mjs
+++ b/packages/app/scripts/perf-measure.mjs
@@ -22,6 +22,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { traceHomeDir } from '../../../scripts/trace-home.mjs';
+
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PORT = 9333;
 
@@ -387,7 +389,7 @@ function cliPath() {
 
 function ensureFixture(pin) {
   const repoRoot = path.resolve(appDir, '..', '..');
-  const dir = path.join(os.homedir(), '.trace-mcp', 'perf-fixture', pin.commit.slice(0, 12));
+  const dir = path.join(traceHomeDir(), 'perf-fixture', pin.commit.slice(0, 12));
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(path.dirname(dir), { recursive: true });
     execFileSync('git', ['worktree', 'add', '--detach', dir, pin.commit], {

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import fs from 'fs';
 import { t } from './i18n';
 import { registerAppMenu } from './menu';
+import { getLauncherDir } from './trace-home';
 import { ACCESSORY_APP, createTray, restoreAppearance, showMenuWindow } from './tray';
 import { updateChannelFor } from './update-channel';
 import { detectMcpClients } from '../shared/mcp-detector';
@@ -981,17 +982,24 @@ function parseNpmRenamePaths(stderr: string): { src?: string; dest?: string } {
   return { src, dest };
 }
 
-// Update flow uses ~/.trace-mcp/update.log for full audit trail — every
+// Update flow uses <CLI state dir>/update.log for full audit trail — every
 // `apply-update` attempt records command, exit code, full stdout/stderr. The
 // renderer only sees a short summary, so the log is the place to look when a
 // user reports "Update failed".
-const UPDATE_LOG = path.join(os.homedir(), '.trace-mcp', 'update.log');
+//
+// Resolved per call, not once at import: the CLI can rename ~/.trace-mcp to
+// ~/.trace (TRA-611) while this app is running, and a cached path would keep
+// recreating the directory the rename just removed.
+function updateLogPath(): string {
+  return path.join(getLauncherDir(), 'update.log');
+}
 
 function appendUpdateLog(entry: Record<string, unknown>): void {
   try {
-    fs.mkdirSync(path.dirname(UPDATE_LOG), { recursive: true });
+    const target = updateLogPath();
+    fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.appendFileSync(
-      UPDATE_LOG,
+      target,
       JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n',
     );
   } catch {
@@ -1059,7 +1067,7 @@ ipcMain.handle('apply-update', async () => {
       // rather than parking the user in a state they cannot leave (TRA-431).
       downloadPercent = undefined;
       appendUpdateLog({ event: 'apply-update:failed', summary });
-      return { ok: false, error: `${summary}\n\nFull log: ${UPDATE_LOG}` };
+      return { ok: false, error: `${summary}\n\nFull log: ${updateLogPath()}` };
     }
   }
 
@@ -1070,7 +1078,7 @@ ipcMain.handle('apply-update', async () => {
   if (!npmBin) {
     const msg = `Could not locate \`npm\`. Looked in: SHELL profile, /opt/homebrew, /usr/local, nvm, Herd. Install Node/npm or add it to your login shell PATH.`;
     appendUpdateLog({ event: 'apply-update:no-npm' });
-    return { ok: false, error: `${msg}\n\nFull log: ${UPDATE_LOG}` };
+    return { ok: false, error: `${msg}\n\nFull log: ${updateLogPath()}` };
   }
   // Execute the resolved npm binary directly with execFile (no shell) so we
   // don't depend on PATH and avoid command-line injection if npmBin contains
@@ -1164,7 +1172,7 @@ ipcMain.handle('apply-update', async () => {
     appendUpdateLog({ event: 'apply-update:fail', summary });
     return {
       ok: false,
-      error: `${summary}\n\nFull log: ${UPDATE_LOG}`,
+      error: `${summary}\n\nFull log: ${updateLogPath()}`,
     };
   }
   const installedVersion = readInstalledVersion(npmRoots);

--- a/scripts/bench-toon.ts
+++ b/scripts/bench-toon.ts
@@ -35,6 +35,7 @@ import { encode as tokenEncode } from 'gpt-tokenizer';
 import { decode as toonDecode } from '@toon-format/toon';
 import { z } from 'zod';
 
+import { INDEX_DIR } from '../src/global.js';
 import { initializeDatabase } from '../src/db/schema.js';
 import { Store } from '../src/db/store.js';
 import { DecisionStore } from '../src/memory/decision-store.js';
@@ -347,7 +348,7 @@ function renderTable(rows: Row[]): string {
 // ── Live index access ──────────────────────────────────────────────────────
 
 function findSelfIndexDb(): string | null {
-  const indexDir = path.join(os.homedir(), '.trace-mcp', 'index');
+  const indexDir = INDEX_DIR;
   if (!fs.existsSync(indexDir)) return null;
   // The trace-mcp self index is named trace-mcp-<hash>.db (no -session suffix).
   // Pick the biggest non-session file as a tiebreaker if multiple exist.

--- a/scripts/locate-app.mjs
+++ b/scripts/locate-app.mjs
@@ -16,7 +16,8 @@
  *
  * Resolution chain (highest-confidence first):
  *
- *   1. **Marker file** `~/.trace-mcp/app-location.json`, written by Electron
+ *   1. **Marker file** `~/.trace/app-location.json` (`~/.trace-mcp` on a
+ *      machine the CLI has not renamed yet), written by Electron
  *      main on every startup from `process.execPath`. This is exact: the path
  *      came from the running bundle itself, not from a guess about install
  *      conventions. The marker is the steady-state mechanism after the first
@@ -46,6 +47,8 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+
+import { traceHomeDir } from './trace-home.mjs';
 
 export const APP_NAME = 'trace-mcp.app';
 export const BUNDLE_ID = 'com.trace-mcp.app';
@@ -160,7 +163,7 @@ export function locateInstalledApp(options = {}) {
   const mdfindBin = options.mdfindBin ?? '/usr/bin/mdfind';
   const plistBuddyBin = options.plistBuddyBin ?? '/usr/libexec/PlistBuddy';
   const fallbackDirs = options.fallbackDirs ?? [path.join(home, 'Applications'), '/Applications'];
-  const markerPath = path.join(home, '.trace-mcp', LOCATION_MARKER_FILENAME);
+  const markerPath = path.join(traceHomeDir(options.homeDir), LOCATION_MARKER_FILENAME);
 
   const fromMarker = resolveFromMarker(markerPath, bundleId, plistBuddyBin);
   if (fromMarker) return { appPath: fromMarker, source: 'marker' };
@@ -315,7 +318,9 @@ export function recoverInterruptedSwap(options = {}) {
   // locateInstalledApp() here, because after an interrupted swap the path it
   // names no longer validates. Read the raw path instead.
   const dirs = new Set(fallbackDirs);
-  const markerAppPath = readMarkerAppPath(path.join(home, '.trace-mcp', LOCATION_MARKER_FILENAME));
+  const markerAppPath = readMarkerAppPath(
+    path.join(traceHomeDir(options.homeDir), LOCATION_MARKER_FILENAME),
+  );
   if (markerAppPath) dirs.add(path.dirname(markerAppPath));
 
   const backupPattern = new RegExp(`^${escapeRegExp(appName)}\\.bak-\\d+$`);
@@ -376,8 +381,7 @@ export function writeAppLocationMarker(appPath, meta = {}) {
   // Never record a build output as the install location — see TRA-357.
   if (!isPlausibleInstallPath(appPath)) return;
   try {
-    const home = meta.homeDir ?? os.homedir();
-    const markerDir = path.join(home, '.trace-mcp');
+    const markerDir = traceHomeDir(meta.homeDir);
     fs.mkdirSync(markerDir, { recursive: true });
     const payload = {
       appPath,

--- a/scripts/postinstall-app.mjs
+++ b/scripts/postinstall-app.mjs
@@ -52,6 +52,7 @@ import {
   recoverInterruptedSwap,
   runningBundlePath,
 } from './locate-app.mjs';
+import { traceHomeDir } from './trace-home.mjs';
 
 // Every installed bundle on this machine, the primary target first. Empty
 // means no install was found — the script then exits 0 like the old hardcoded
@@ -92,7 +93,7 @@ if (process.env.TRACE_MCP_NO_AUTO_UPDATE === '1') process.exit(0);
  *
  * macOS: `launchctl stop` triggers SIGTERM; the plist's KeepAlive=true auto
  *   respawns the service using the now-updated binary path.
- * Linux/Windows: kill the PID recorded in ~/.trace-mcp/daemon.pid. The next
+ * Linux/Windows: kill the PID recorded in the CLI state dir's daemon.pid. The next
  *   stdio session or Electron tray poll will ensureDaemon() back up.
  * Manually-spawned dev daemons (no pidfile, no launchd) are not touched —
  *   the developer will restart them as needed.
@@ -103,7 +104,7 @@ function stopRunningDaemon() {
       execFileSync(LAUNCHCTL_BIN, ['stop', 'com.trace-mcp.server'], { stdio: 'ignore' });
       return;
     }
-    const pidFile = path.join(os.homedir(), '.trace-mcp', 'daemon.pid');
+    const pidFile = path.join(traceHomeDir(), 'daemon.pid');
     if (!fs.existsSync(pidFile)) return;
     const pid = parseInt(fs.readFileSync(pidFile, 'utf-8').trim(), 10);
     if (!Number.isInteger(pid) || pid <= 0) return;
@@ -129,7 +130,7 @@ stopRunningDaemon();
 // that goes looking for state. Deleted here because this hook is the one piece
 // of code every upgrading install runs.
 try {
-  fs.unlinkSync(path.join(os.homedir(), '.trace-mcp', 'app-update-state.json'));
+  fs.unlinkSync(path.join(traceHomeDir(), 'app-update-state.json'));
 } catch {
   /* absent on a clean machine — the normal case */
 }

--- a/scripts/trace-home.mjs
+++ b/scripts/trace-home.mjs
@@ -1,0 +1,38 @@
+/**
+ * Where the CLI keeps its runtime state, for the plain-Node scripts.
+ *
+ * TRA-611 renamed `~/.trace-mcp` → `~/.trace`, and `src/global.ts` performs the
+ * rename on first import. These scripts cannot import that module — it is
+ * TypeScript, and importing it would trigger the rename as a side effect — so
+ * they carry the same two-line fallback the Electron main process has in
+ * `packages/app/src/main/trace-home.ts::getLauncherDir`.
+ *
+ * Same rule as there: **prefer the new name only when it is actually on disk.**
+ * Guessing `.trace` on a machine whose CLI still writes `.trace-mcp` costs a
+ * split brain (a marker or pidfile nothing else reads); waiting for the
+ * directory to exist costs nothing, because the CLI creates it before anything
+ * needs to be found in it.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * `TRACE_HOME` / `TRACE_MCP_HOME` are honoured only when the caller did not pin
+ * a home directory: an explicit `homeDir` is a test seam or a sandbox root, and
+ * an env var leaking in from the developer's shell would send the lookup back
+ * out to the real machine.
+ *
+ * @param {string} [homeDir] Override `os.homedir()` (tests, sandboxes).
+ * @returns {string} Absolute path to the CLI state directory.
+ */
+export function traceHomeDir(homeDir) {
+  if (homeDir === undefined) {
+    const envDir = process.env.TRACE_HOME?.trim() || process.env.TRACE_MCP_HOME?.trim();
+    if (envDir) return envDir;
+    homeDir = os.homedir();
+  }
+  const current = path.join(homeDir, '.trace');
+  return fs.existsSync(current) ? current : path.join(homeDir, '.trace-mcp');
+}

--- a/scripts/verify-upgrade-path.mjs
+++ b/scripts/verify-upgrade-path.mjs
@@ -27,6 +27,8 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { traceHomeDir } from './trace-home.mjs';
+
 const REPO = 'nikolai-vysotskyi/trace-mcp';
 const BUNDLE_ID = 'com.trace-mcp.app';
 
@@ -134,7 +136,9 @@ async function run() {
   const apps = path.join(sandbox, 'Applications');
   const home = path.join(sandbox, 'home');
   fs.mkdirSync(apps);
-  fs.mkdirSync(path.join(home, '.trace-mcp'), { recursive: true });
+  // The post-rename layout (TRA-611) is what a current machine has, so that is
+  // what the postinstall run below has to be exercised against.
+  fs.mkdirSync(path.join(home, '.trace'), { recursive: true });
 
   // ponytail: a stub that reports "nothing running" rather than a fake process
   // tree. pgrep answers for the whole machine, so without this the developer's own
@@ -164,7 +168,7 @@ async function run() {
     console.log(`  installed ${before}`);
 
     fs.writeFileSync(
-      path.join(home, '.trace-mcp', 'app-location.json'),
+      path.join(traceHomeDir(home), 'app-location.json'),
       JSON.stringify({ appPath, bundleId: BUNDLE_ID, version: before, writtenAt: Date.now() }),
     );
 

--- a/tests/scripts/locate-app.test.ts
+++ b/tests/scripts/locate-app.test.ts
@@ -148,6 +148,33 @@ describe.skipIf(process.platform === 'win32')('locateInstalledApp', () => {
     expect(result?.appPath).toBe(markerTarget);
   });
 
+  /* TRA-667: `src/global.ts` renames ~/.trace-mcp to ~/.trace on first import, so
+     after the migration the old directory is gone. A resolver hardcoded to it
+     reads nothing and silently degrades to an mdfind/fallback guess. */
+  it('reads the marker from ~/.trace once the CLI has migrated', () => {
+    const markerTarget = createFakeBundle(path.join(home, 'marker-dest'));
+    fs.mkdirSync(path.join(home, '.trace'), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, '.trace', 'app-location.json'),
+      JSON.stringify({
+        appPath: markerTarget,
+        bundleId: BUNDLE_ID,
+        version: '1.2.3',
+        writtenAt: Date.now(),
+      }),
+    );
+
+    const { result } = runLocate({
+      homeDir: home,
+      fallbackDirs: [],
+      mdfindBin: createMdfindStub(home, ['/nowhere/should-not-be-used.app']),
+      platform: 'darwin',
+    });
+
+    expect(result?.source).toBe('marker');
+    expect(result?.appPath).toBe(markerTarget);
+  });
+
   it('rejects a marker whose bundle no longer exists, falls through to mdfind', () => {
     // Marker points at a path that was deleted between launches.
     fs.mkdirSync(path.join(home, '.trace-mcp'), { recursive: true });
@@ -314,6 +341,16 @@ describe.skipIf(process.platform === 'win32')('locateInstalledApp', () => {
     runWriteMarker(home, builtBundle, '1.51.1');
 
     expect(fs.existsSync(path.join(home, '.trace-mcp', 'app-location.json'))).toBe(false);
+  });
+
+  it('writeAppLocationMarker writes into ~/.trace once the CLI has migrated', () => {
+    fs.mkdirSync(path.join(home, '.trace'), { recursive: true });
+    const target = createFakeBundle(path.join(home, 'bundle-here'));
+
+    runWriteMarker(home, target, '1.51.1');
+
+    expect(fs.existsSync(path.join(home, '.trace', 'app-location.json'))).toBe(true);
+    expect(fs.existsSync(path.join(home, '.trace-mcp'))).toBe(false);
   });
 
   it('writeAppLocationMarker round-trips through the marker reader', () => {

--- a/tests/scripts/trace-home.test.ts
+++ b/tests/scripts/trace-home.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The scripts' copy of the `~/.trace-mcp` → `~/.trace` fallback (TRA-667).
+ *
+ * The case that costs something is "the CLI already migrated": `src/global.ts`
+ * *renames* the old directory away on first import, so a script still building
+ * paths from `~/.trace-mcp` afterwards points at a directory that no longer
+ * exists — the postinstall then never stops the running daemon, and the app
+ * location marker is silently missed.
+ *
+ * The mirror of this for the Electron main process lives in
+ * `packages/app/src/main/__tests__/trace-home.test.ts`.
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { traceHomeDir } from '../../scripts/trace-home.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const MODULE_PATH = path.join(REPO_ROOT, 'scripts', 'trace-home.mjs');
+
+let home: string;
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'scripts-trace-home-'));
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+/** Resolve in a child process, so `os.homedir()` and env are really the ones we set. */
+function resolveWithEnv(env: Record<string, string>): string {
+  const harness = path.join(home, 'harness.mjs');
+  fs.writeFileSync(
+    harness,
+    `import { traceHomeDir } from ${JSON.stringify(MODULE_PATH)};\n` +
+      `process.stdout.write(traceHomeDir());\n`,
+  );
+  return execFileSync(process.execPath, [harness], {
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: home, USERPROFILE: home, ...env },
+  });
+}
+
+describe('traceHomeDir', () => {
+  it('follows the CLI to ~/.trace once the rename has happened', () => {
+    fs.mkdirSync(path.join(home, '.trace'));
+    expect(traceHomeDir(home)).toBe(path.join(home, '.trace'));
+  });
+
+  it('stays on ~/.trace-mcp while the CLI has not renamed yet', () => {
+    fs.mkdirSync(path.join(home, '.trace-mcp'));
+    expect(traceHomeDir(home)).toBe(path.join(home, '.trace-mcp'));
+  });
+
+  it('prefers ~/.trace when both are on disk mid-migration', () => {
+    fs.mkdirSync(path.join(home, '.trace'));
+    fs.mkdirSync(path.join(home, '.trace-mcp'));
+    expect(traceHomeDir(home)).toBe(path.join(home, '.trace'));
+  });
+
+  it('defaults to ~/.trace-mcp when neither directory exists', () => {
+    expect(traceHomeDir(home)).toBe(path.join(home, '.trace-mcp'));
+  });
+
+  /* An explicit home is a sandbox root; a TRACE_HOME in the developer's shell
+     must not redirect a lookup that was deliberately pinned. */
+  it('ignores TRACE_HOME when the caller pinned a home directory', () => {
+    process.env.TRACE_HOME = '/somewhere/else';
+    try {
+      expect(traceHomeDir(home)).toBe(path.join(home, '.trace-mcp'));
+    } finally {
+      delete process.env.TRACE_HOME;
+    }
+  });
+
+  it.each(['TRACE_HOME', 'TRACE_MCP_HOME'])('honours %s when no home is pinned', (key) => {
+    fs.mkdirSync(path.join(home, '.trace'));
+    expect(resolveWithEnv({ [key]: '/somewhere/else' })).toBe('/somewhere/else');
+  });
+
+  it('resolves from os.homedir() when nothing is pinned', () => {
+    fs.mkdirSync(path.join(home, '.trace'));
+    expect(resolveWithEnv({ TRACE_HOME: '', TRACE_MCP_HOME: '' })).toBe(path.join(home, '.trace'));
+  });
+});


### PR DESCRIPTION
## What

`src/global.ts` renamed the CLI state directory `~/.trace-mcp` → `~/.trace` in TRA-611, and it does so by **renaming** the old directory on first import. Everything outside `src/` that still built paths from the old name therefore points at a directory that no longer exists on a migrated machine.

Concrete consequences:

- `scripts/postinstall-app.mjs` — `daemon.pid` was never found on Linux/Windows, so the running daemon was not stopped before the bundle was replaced and kept the old one open. Also left `app-update-state.json` behind.
- `scripts/locate-app.mjs` — the `app-location.json` marker (read *and* written) was missed, so the app-location resolution silently fell through to an mdfind/`~/Applications` guess.
- `packages/app/src/main/index.ts` — `update.log`.
- `scripts/verify-upgrade-path.mjs`, `packages/app/scripts/perf-measure.mjs`, `scripts/bench-toon.ts` — same class, dev/verification tooling.

## How

New `scripts/trace-home.mjs` exports `traceHomeDir(homeDir?)` — the plain-Node mirror of the Electron main process's `packages/app/src/main/trace-home.ts::getLauncherDir`. The scripts cannot import `src/global.ts`: it is TypeScript, and importing it would perform the rename as a side effect.

Same rule as the app's copy: **prefer `~/.trace` only when it is actually on disk**, otherwise stay on `~/.trace-mcp`. Guessing the new name on a machine whose CLI still writes the old one costs a split brain; waiting for the directory to exist costs nothing.

One deliberate difference from the app's version: `TRACE_HOME` / `TRACE_MCP_HOME` are honoured only when the caller did not pass an explicit `homeDir`. An explicit home is a test seam or a sandbox root, and an env var leaking in from the developer's shell would send a deliberately pinned lookup back out to the real machine.

`index.ts` now resolves the log path per call rather than once at import, so a rename happening while the app is running does not keep recreating the directory the rename just removed.

`bench-toon.ts` uses `INDEX_DIR` from `src/global.ts` directly — that script already imports the module transitively, so there is no new side effect.

Out of scope (checked, deliberately untouched): `packages/app/src/main/guard-control.ts`, `scripts/bench-pr-context.ts` and `scripts/capture-screenshots.mjs` use a **project-local** `.trace-mcp` directory, not the home state dir. `scripts/postinstall-control-plane.mjs` already carries its own inlined copy of the migration.

## Tests

- New `tests/scripts/trace-home.test.ts` (8 tests): migrated, not-yet-migrated, both-present, neither-present, plus env handling resolved in a child process.
- `tests/scripts/locate-app.test.ts`: two new cases — the marker is *read* from `~/.trace` after migration, and *written* there (and not into a recreated `~/.trace-mcp`).

`pnpm test` — 9554 passed / 8 skipped, 874 files. `packages/app` vitest — 578 passed. Build, `tsc --noEmit`, and `biome ci` clean.

`docs/development.md` documented these markers under `~/.trace-mcp` and was correct until this change; it is updated here.

Follow-up to #766 — TRA-667 was found while auditing the docs for TRA-666, and `docs/development.md` documented these markers under `~/.trace-mcp` correctly until this change landed.

Closes TRA-667.

Agent: Lead Engineer

