### PR TITLE
fix(tests): use file:// URLs for the trace-home subprocess harness

### DIFF
--- a/tests/scripts/trace-home.test.ts
+++ b/tests/scripts/trace-home.test.ts
@@ -15,13 +15,16 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { traceHomeDir } from '../../scripts/trace-home.mjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
-const MODULE_PATH = path.join(REPO_ROOT, 'scripts', 'trace-home.mjs');
+// A bare Windows path (`C:\...`) is not a valid ESM specifier — it doesn't
+// start with `/`, so Node treats it as a bare package name instead of an
+// absolute path and resolution fails. `file://` URLs work on every platform.
+const MODULE_SPECIFIER = pathToFileURL(path.join(REPO_ROOT, 'scripts', 'trace-home.mjs')).href;
 
 let home: string;
 
@@ -38,7 +41,7 @@ function resolveWithEnv(env: Record<string, string>): string {
   const harness = path.join(home, 'harness.mjs');
   fs.writeFileSync(
     harness,
-    `import { traceHomeDir } from ${JSON.stringify(MODULE_PATH)};\n` +
+    `import { traceHomeDir } from ${JSON.stringify(MODULE_SPECIFIER)};\n` +
       `process.stdout.write(traceHomeDir());\n`,
   );
   return execFileSync(process.execPath, [harness], {


### PR DESCRIPTION
## Summary

- Windows CI (`cross-platform-test (windows-latest)`) was failing 3 tests in `tests/scripts/trace-home.test.ts`, blocking the v3.12.0 release PR (#723).
- Root cause: `resolveWithEnv` spawns a child process that dynamically `import`s `scripts/trace-home.mjs` by embedding a raw filesystem path as the specifier. On Windows that path looks like `C:\...`, which doesn't start with `/` — Node's ESM resolver treats it as a bare package name instead of an absolute path, so resolution fails and the harness process errors out.
- `traceHomeDir` itself is unaffected; the other 5 tests in the file call it in-process and pass on all platforms. Confirmed the same pattern is used in `tests/scripts/locate-app.test.ts` / `locate-app-recovery.test.ts`, but those suites are already `describe.skipIf(process.platform === 'win32')`'d (they cover macOS `.app` bundle discovery), so they never hit it.
- Fix: build the import specifier with `pathToFileURL(...).href` instead of the raw path — works identically on POSIX and Windows.

## Test plan
- [x] `pnpm run test -- --run tests/scripts/trace-home.test.ts` — 8/8 pass locally (macOS)
- [x] `pnpm run test` (full suite) — 9550 passed / 10 skipped
- [x] `pnpm run build` — succeeds
- [x] `pnpm run lint` (tsc --noEmit) — clean
- [ ] CI `cross-platform-test` on windows-latest — pending, this is the change under test