### PR TITLE
fix(web): stack the hero's two mono caps rows on a phone (TRA-607)

### DIFF
--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -463,17 +463,24 @@ of mono caps always fails:
 
 - `.hero-trust` wraps mid-list and a `.dot` separator ends the line. Measured
   on the last box of each line, not judged by eye: a dot was the rightmost box
-  at 660, 600, 520, 430, 390, 360 and 320px — every width below the existing
-  700px breakpoint, and none above it. This is §9's "no label breaks into
-  fragments" rule one section up the page. Below 700px it is a column, the
-  dots are `display: none`, and `.ok`'s emphasis is dropped: stacked, one
-  highlighted item of three reads as a heading over the other two rather than
-  as the strongest peer.
+  at 660, 600, 520, 430, 390, 360 and 320px, and at none of 700, 760, 820,
+  900, 1024 or 1440px. Those are the tested widths — the sweep samples them,
+  it does not walk every integer — so read it as "every tested width below the
+  breakpoint". This is §9's "no label breaks into fragments" rule one section
+  up the page. At 700px and below it is a column, the dots are
+  `display: none`, and `.ok`'s emphasis is dropped: stacked, one highlighted
+  item of three reads as a heading over the other two rather than as the
+  strongest peer.
 - `.hero-meta` is `label / divider / label`, and `flex-wrap` is not set, so it
   never breaks between its children — instead both labels wrap *inside*
   themselves into two cramped columns with a divider that has no width left to
   draw. It stops fitting on one line at 520px (17px → 33px) and takes three
-  lines at 320px. Below 700px it is a column and the divider is hidden.
+  lines at 320px. At 700px and below it is a column and the divider is hidden.
+
+`@media (max-width: 700px)` includes 700px itself, so the stacked form starts
+*at* 700px while the defect it fixes starts just below — the rule is applied
+one tested step wider than the failure. Inline behaviour is what you get above
+700px, not at it.
 
 Both are bound to the hero's existing 700px breakpoint rather than to the
 520px where `.hero-meta` actually breaks. That is deliberate — one breakpoint

--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -456,6 +456,32 @@ back in the browser, wait out the 200ms `border-color` transition — a
 "AI coding agents" across two of them. Change the wording, re-measure the line
 count at 1440px and at 390px.
 
+**The hero's two mono caps rows stack below 700px, and neither is a wrapped
+flex row on a phone** (TRA-607). `.hero-meta` and `.hero-trust` are single
+rows at desktop widths and both fail small, in the two ways a `flex-wrap` row
+of mono caps always fails:
+
+- `.hero-trust` wraps mid-list and a `.dot` separator ends the line. Measured
+  on the last box of each line, not judged by eye: a dot was the rightmost box
+  at 660, 600, 520, 430, 390, 360 and 320px — every width below the existing
+  700px breakpoint, and none above it. This is §9's "no label breaks into
+  fragments" rule one section up the page. Below 700px it is a column, the
+  dots are `display: none`, and `.ok`'s emphasis is dropped: stacked, one
+  highlighted item of three reads as a heading over the other two rather than
+  as the strongest peer.
+- `.hero-meta` is `label / divider / label`, and `flex-wrap` is not set, so it
+  never breaks between its children — instead both labels wrap *inside*
+  themselves into two cramped columns with a divider that has no width left to
+  draw. It stops fitting on one line at 520px (17px → 33px) and takes three
+  lines at 320px. Below 700px it is a column and the divider is hidden.
+
+Both are bound to the hero's existing 700px breakpoint rather than to the
+520px where `.hero-meta` actually breaks. That is deliberate — one breakpoint
+for the hero beats a second one 180px away — and it costs 17px of height
+between 520px and 700px. The stack costs `.hero-trust` 20px at 390px (58 →
+78), all of it below the two actions, so the CTA moves 6px and nothing above
+the fold is lost.
+
 ---
 
 ## 9. The landing footer

--- a/docs/index.html
+++ b/docs/index.html
@@ -638,10 +638,10 @@ layout: null
       .hero-install { font-size: 12px; min-height: 52px; padding: 0 14px; gap: 10px; }
       .hero-alt-arch { font-size: 11px; margin-top: 12px; }
       /* One item per line, no dots. As a wrapped row a separator ends a line at
-         every width from 660px down — measured, not assumed: the last box on the
-         first line is a `.dot` at 660, 600, 520, 430, 390, 360 and 320. Stacking
-         costs nothing, because the row already spent two lines there (41px at
-         430px, 58px at 390px) to say the same three things. */
+         every tested width from 660px down — measured, not assumed: the last box
+         on the first line is a `.dot` at 660, 600, 520, 430, 390, 360 and 320.
+         Stacking removes that at a cost of 20px at 390px (58px → 78px), all of
+         it below the two actions. */
       .hero-trust {
         font-size: 11px;
         margin-top: 14px;

--- a/docs/index.html
+++ b/docs/index.html
@@ -637,7 +637,35 @@ layout: null
       .hero-cta .btn { padding: 14px 22px; font-size: 11px; justify-content: center; }
       .hero-install { font-size: 12px; min-height: 52px; padding: 0 14px; gap: 10px; }
       .hero-alt-arch { font-size: 11px; margin-top: 12px; }
-      .hero-trust { font-size: 11px; gap: 8px; margin-top: 14px; }
+      /* One item per line, no dots. As a wrapped row a separator ends a line at
+         every width from 660px down — measured, not assumed: the last box on the
+         first line is a `.dot` at 660, 600, 520, 430, 390, 360 and 320. Stacking
+         costs nothing, because the row already spent two lines there (41px at
+         430px, 58px at 390px) to say the same three things. */
+      .hero-trust {
+        font-size: 11px;
+        margin-top: 14px;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 6px;
+      }
+      .hero-trust .dot { display: none; }
+      /* Stacked, the row's one emphasised item stops reading as the strongest of
+         three peers and starts reading as a heading over the two below it — a
+         hierarchy that is not there. Inline (≥700px) the emphasis still works,
+         so it is dropped here only. */
+      .hero-trust .ok { color: inherit; font-weight: inherit; }
+      /* Both labels on their own line rather than two columns fighting over 390px.
+         The row stops fitting at 520px (17px → 33px) and takes three lines at
+         320px; the divider has no width left to draw by then, so it goes. This
+         reuses the hero's 700px breakpoint instead of adding a second one 180px
+         away — the cost is 17px of height between 520px and 700px. */
+      .hero-meta {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 6px;
+      }
+      .hero-meta .divider { display: none; }
     }
 
     /* ── Metrics strip (proof row under hero) ── */

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://trace-mcp.com/</loc>
-    <lastmod>2026-09-01</lastmod>
+    <lastmod>2026-09-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
Closes the website half of TRA-607 (the hero's own two-action layout landed in TRA-609 / #718; the numbers and copy are TRA-647 / #752 and are untouched here).

## What was wrong

The hero's two mono caps rows — `.hero-meta` above the headline and `.hero-trust` below the two actions — are `display: flex` rows tuned for desktop, and both fail below 700px. Both are above the fold on every phone.

**`.hero-trust` ends a line on a separator.** Measured on the rightmost box of each line rather than judged by eye: a `.dot` was the last box on the first line at **660, 600, 520, 430, 390, 360 and 320px** — every width below the hero's existing 700px breakpoint, and none above it. On a 390px phone the first line read `OPEN SOURCE (MIT) · LOCAL-FIRST ·` with the separator dangling. This is the same defect class as §9's "no footer nav label breaks into fragments", one section up the page.

**`.hero-meta` never breaks between its children.** `flex-wrap` is not set, so instead of wrapping label / divider / label onto separate lines, both labels wrap *inside* themselves into two cramped columns with a divider that has no width left to draw. The row stops fitting on one line at **520px** (17px → 33px) and takes three lines at 320px.

## What changed

Below 700px both rows become columns; the dots and the divider are hidden. `.hero-trust .ok`'s emphasis is dropped in the stacked variant — one highlighted item of three reads as a heading over the other two once they are stacked, which is a hierarchy that is not there. Inline at ≥700px the emphasis still works and is kept.

Both rules are bound to the hero's existing 700px breakpoint rather than to the 520px where `.hero-meta` actually breaks. Deliberate: one breakpoint for the hero beats a second one 180px away. It costs 17px of height between 520px and 700px, and that trade is written down in §8.

## Verification

| | before | after |
|---|---|---|
| dangling separator, 320–660px | 1 at every width | 0 at every width |
| `.hero-meta` at 390px | 33px, two colliding columns | 39px, two clean lines |
| `.hero-trust` at 390px | 58px, wrapped + dangling dot | 78px, three lines |
| `.hero-cta` top at 390px | 370px | 376px |

- **Desktop unchanged**: `.hero-meta` 17px, `.hero-trust` 18px, zero dangling separators at 1440px both before and after.
- The §5 contrast sweep on `/` — **0 failures**, 436 elements, both themes.
- `document.documentElement.scrollWidth === window.innerWidth` at all of 1440, 1024, 900, 820, 760, 700, 660, 600, 520, 430, 390, 360, 320px.
- Screenshotted at 390px and 1440px in **both themes**, headless and isolated (Nikolai's screen never touched).
- `pnpm vitest run tests/docs/` — 138 passed.

The `.hero-cta` moves 6px down on a phone; the other 20px lands below it, so nothing above the fold is lost.

## Not in this PR

`docs/index.html` also carries a first-screen problem this diff deliberately does not touch, because it is content and it belongs to the SEO agent and to #752: **"MIT" appears three times in the first two screens** (`.hero-meta` "MIT LICENSE", `.hero-trust` "OPEN SOURCE (MIT)", and the trust strip's MIT badge 80px below), and `.hero-trust`'s client list duplicates the trust strip's client row. Measured separately: on a 390px phone the visitor passes **four consecutive bands of claims over 606px** — hero-trust, three metric tiles, three trust badges, six client chips — before the first thing the product actually does (`.app-banner`, at 1221px, 1.4 screens down). Against the Ollama reference in the issue that is the remaining gap, and it is a content-architecture call, not a CSS one.

Agent: Web Design Agent
