### PR TITLE
feat(telemetry): read the ping's `calls` to measure use, not just setup (TRA-673)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -178,27 +178,51 @@ stars, and traffic *views* uniques** — nothing else. Channel-by-channel
 state lives in `ops/user-signal.md`; listing-by-listing state in
 `ops/distribution.md`. GitHub, 2026-09-02: **102 stars, 15 forks.**
 
-### The funnel — four numbers around that denominator (TRA-645)
+### The funnel — five numbers around that denominator (TRA-645, TRA-673)
 
 Active installs is a denominator with nothing on either side of it. Without
 that, every listing rewrite, hero redesign, README restructure and outreach PR
-is graded on taste. Four numbers fix it, one per stage:
+is graded on taste. Five numbers fix it, one per stage:
 
 | Stage | Number | Source | Window |
 | --- | --- | --- | --- |
 | Arrivals | unique visitors to the GitHub repo | `acquisition.views_uniques_14d` | rolling 14 d |
 | Installs | first-ever pings | `installs_28d.new` | 28 d |
 | Activation | % of active installs with ≥1 indexed repository | `activation.activated_pct` | 28 d |
+| Use | % of active installs that called a tool at all | `usage.used_pct` | 28 d |
 | Retention | day ÷ month active installs | `funnel.retention_dau_mau_pct` | 1 d over 28 d |
 
-**Do not refresh these by hand either.** All four are computed by the same
+**Activation and use are two stages, not two readings of one** (TRA-673).
+`repos_indexed` says an install completed *setup*; an install that indexed a
+repo in July and has not called a tool since still counts as activated. The
+ping has carried `calls` — trace-mcp tool calls since the previous ping,
+counted by the MCP server itself and therefore comparable across clients —
+since it was written, and no report read it. `scripts/ga4-snapshot.mjs` now
+does. The published figure is `used_pct`, a per-install boolean, and never a
+call total: the ping's credentials are public, so a summed counter is
+inflatable exactly like `tokens_saved`, while a boolean is bounded above by
+`active_users` and costs one forged install per point.
+
+`usage.by_client_used_pct` is the number with a strategy attached. The
+mechanism that actually routes an agent to our tools — the PreToolUse guard
+hook — is Claude Code only, Cursor and Windsurf get a rules file, and every
+other client gets tool descriptions, which ask rather than route. Session
+mining has providers for two clients. If use holds across clients, the hook is
+a nice-to-have and reach work goes wide; if it collapses without one, our
+addressable market is clients that can enforce routing, and a large share of
+current distribution effort points at installs that will never reach value. We
+ship into MCP directories on a premise of client neutrality and have never
+tested it. **Read the answer beside `by_client_installs`** — the only client
+breakdown we have is 8 claude-code / 2 codex / 1 grok, which concludes nothing.
+
+**Do not refresh these by hand either.** All of them are computed by the same
 daily `ga4-snapshot.yml` run and published under `funnel:` in
 [`adoption-data`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/adoption-data/adoption.yml) —
 that file is where a weekly run reads them, not this page. As of **2026-09-02**:
 178 arrivals (14 d), 24 new installs, retention 51% (35 day / 69 month), and
-activation still blocked — see below.
+activation still blocked — see below. Use is blocked on the same one form.
 
-**Two credentials stand between this and all four numbers**, both verified
+**Two credentials stand between this and all five numbers**, both verified
 against the live property by a `workflow_dispatch` on 2026-09-02
 ([run 33556680379](https://github.com/nikolai-vysotskyi/trace-mcp/actions/runs/33556680379)).
 Neither is a design question; do not re-investigate them, and do not read the
@@ -213,7 +237,14 @@ resulting `null`s as zeros.
    is one form in GA4 Admin → Custom definitions (event scope, parameter name
    `repos_indexed`). Automating it was tried and reverted: the Admin API is not
    enabled on the credential's GCP project (480706841486), so the script could
-   only have logged a failure once a day.
+   only have logged a failure once a day. **The same form now covers four
+   parameters, not one** — `repos_indexed`, `preset` and `tools_advertised`
+   (TRA-643), plus `calls` (TRA-673). All four are event-scoped custom
+   *dimensions*; `calls` is read as a dimension deliberately, because the Data
+   API has no `client_id` and a summed metric can therefore never yield the
+   per-install boolean the use stage is built on. One admin session registers
+   all four, and every day before it is unrecoverable for all four. Do not open
+   a fifth separate ask.
 2. **`GH_TRAFFIC_TOKEN` is unset.** GitHub's traffic endpoints require
    `Administration: read`, a permission `GITHUB_TOKEN` cannot be granted, so the
    workflow gets HTTP 403 and records that in `acquisition.error`. A
@@ -224,17 +255,22 @@ resulting `null`s as zeros.
 
 Three things to keep attached to them. The windows differ, so arrivals →
 installs is a direction and not a conversion rate. The ping's credentials are
-public, so all four are inflatable and are a trend, not an audit. And
-`activated_pct` is taken against its own buckets rather than against
-`active_users.month`, because GA4 deduplicates active users within a dimension
-value and not across them — an install that indexes its first repository
-mid-window is counted on both sides.
+public, so all of them are inflatable and are a trend, not an audit. And both
+`activated_pct` and `used_pct` are taken against their own buckets rather than
+against `active_users.month`, because GA4 deduplicates active users within a
+dimension value and not across them — an install that indexes its first
+repository or makes its first call mid-window is counted on both sides.
 
-Activation is the one to watch. It is the only one of the four that measures
-whether an install ever reached the product's value, and it is the ceiling on
-everything downstream of install: if a meaningful share of installs ping day
-after day with zero indexed repositories, that number outranks every capability
-item below.
+Use is the one to watch — activation was, until it became clear activation only
+measures setup. Every efficiency number we publish assumes the agent calls our
+tools instead of reading files; `used_pct` is the only number that says whether
+it does. It is the ceiling on everything downstream of install, and the gap
+between `activated_pct` and `used_pct` is the population that reached the
+product and stopped.
+
+**The one read-back this is for**, once a snapshot carries it: what share of
+active installs called a tool at all in the window, and whether that share
+differs between hook-capable and hook-less clients. Write the answer here.
 
 Acquisition already has a finding. Over two independent 14-day windows
 (2026-08-30 and 2026-09-02) **not one of the twelve directory listings in
@@ -252,10 +288,11 @@ surface) becomes field-checkable rather than bench-only. The attribution
 hole turned out to be two separate defects, both fixed in the same change —
 see "How to read `by_client`" above.
 
-**What is left is not code.** The two dimensions must be registered in GA4
+**What is left is not code.** The dimensions must be registered in GA4
 (event-scoped, named exactly `preset` and `tools_advertised`) before any
 value reaches `adoption.yml`; GA4 does not backfill, so the series starts at
-registration. Then one read-back after the first snapshot that carries them:
+registration. That registration is now shared with `repos_indexed` and `calls`
+— four parameters, one admin session, one ask. Do not raise it separately. Then one read-back after the first snapshot that carries them:
 what fraction of installs run which preset, and whether the silent
 `full` → `standard` default migration (TRA-538) actually landed. Until that
 read-back exists, "67–86%" stays a bench figure and must be cited as one.

--- a/scripts/ga4-funnel.mjs
+++ b/scripts/ga4-funnel.mjs
@@ -146,8 +146,13 @@ export function usageByClient(rows) {
     const rest = { dimensionValues: row.dimensionValues.slice(1), metricValues: row.metricValues };
     byClient.set(client, [...(byClient.get(client) ?? []), rest]);
   }
-  const used_pct = {};
-  const installs = {};
+  // Null-prototype, because the key is a client name the install chooses for
+  // itself and the ping is unauthenticated: `{}['__proto__'] = x` is a silent
+  // no-op, so a forged `client=__proto__` would delete itself from both maps
+  // with no error and no `unknown` credit — invisible in the one number this
+  // function exists to produce.
+  const used_pct = Object.create(null);
+  const installs = Object.create(null);
   for (const [client, clientRows] of byClient) {
     const u = usage(clientRows);
     used_pct[client] = u.used_pct;

--- a/scripts/ga4-funnel.mjs
+++ b/scripts/ga4-funnel.mjs
@@ -1,17 +1,46 @@
 /**
- * Turning the raw snapshot rows into the four funnel numbers (TRA-645).
+ * Turning the raw snapshot rows into the funnel numbers (TRA-645, TRA-673).
  *
  * Pure functions only, so they are testable without GA4 or GitHub credentials;
  * `ga4-snapshot.mjs` does the fetching and hands the rows here.
  *
  * The funnel exists because every listing rewrite, hero redesign and outreach
  * PR was being graded on taste: we had a denominator (active installs) and
- * nothing on either side of it. Its four stages are
- * arrivals → installs → activation → retention.
+ * nothing on either side of it. Its stages are
+ * arrivals → installs → activation → use → retention.
+ *
+ * Activation and use are deliberately separate: `repos_indexed` says an install
+ * completed *setup*, `calls` says it actually used the tools (TRA-673). The gap
+ * between them is the population that reached the product and stopped.
  */
 
 /** GA4 returns dimension values as strings; an unset one is this literal. */
 const NOT_SET = '(not set)';
+
+/**
+ * Tally `activeUsers` into named buckets by a numeric dimension value.
+ *
+ * `place` maps a non-negative number to a bucket key; anything that is not a
+ * non-negative number — `(not set)`, GA4's `(other)` cardinality overflow, an
+ * empty string — lands in `unknown` rather than in the zero bucket. That
+ * distinction is the whole point: a missing reading is not evidence of a zero.
+ * `Number('')` is 0, so the empty value has to be rejected before the parse.
+ */
+function tally(rows, buckets, place) {
+  let unknown = 0;
+  for (const row of rows ?? []) {
+    const raw = row.dimensionValues?.[0]?.value;
+    const users = Number(row.metricValues?.[0]?.value ?? 0);
+    if (!Number.isFinite(users) || users <= 0) continue;
+    const n = !raw?.trim() || raw === NOT_SET ? Number.NaN : Number(raw);
+    if (!Number.isFinite(n) || n < 0) {
+      unknown += users;
+      continue;
+    }
+    buckets[place(n)] += users;
+  }
+  return { buckets, unknown };
+}
 
 /**
  * Activation from the ping's `repos_indexed` param: an install that reports
@@ -29,26 +58,9 @@ const NOT_SET = '(not set)';
  *   metric `activeUsers`.
  */
 export function activation(rows) {
-  const buckets = { 0: 0, 1: 0, '2-5': 0, '6+': 0 };
-  let unknown = 0;
-  for (const row of rows ?? []) {
-    const raw = row.dimensionValues?.[0]?.value;
-    const users = Number(row.metricValues?.[0]?.value ?? 0);
-    if (!Number.isFinite(users) || users <= 0) continue;
-    // `Number('')` is 0, so an empty value must be rejected before the parse —
-    // otherwise a missing reading is published as an activation failure.
-    const n = !raw?.trim() || raw === NOT_SET ? Number.NaN : Number(raw);
-    if (!Number.isFinite(n) || n < 0) {
-      // A value we cannot place is not evidence either way — kept visible
-      // rather than folded into "0", which would invent an activation failure.
-      unknown += users;
-      continue;
-    }
-    if (n === 0) buckets['0'] += users;
-    else if (n === 1) buckets['1'] += users;
-    else if (n <= 5) buckets['2-5'] += users;
-    else buckets['6+'] += users;
-  }
+  const { buckets, unknown } = tally(rows, { 0: 0, 1: 0, '2-5': 0, '6+': 0 }, (n) =>
+    n === 0 ? '0' : n === 1 ? '1' : n <= 5 ? '2-5' : '6+',
+  );
   const activated = buckets['1'] + buckets['2-5'] + buckets['6+'];
   const placed = buckets['0'] + activated;
   return {
@@ -59,6 +71,89 @@ export function activation(rows) {
     // Null, not 0: no data is a different fact from "nobody activated".
     activated_pct: placed === 0 ? null : Math.round((activated / placed) * 100),
   };
+}
+
+/**
+ * Use, from the ping's `calls` param — trace-mcp tool calls since the previous
+ * ping (`src/telemetry/usage-ping.ts`), counted by the server itself and so
+ * comparable across MCP clients (TRA-673).
+ *
+ * This is the stage `activation` above is not. `repos_indexed` says an install
+ * once registered a project; an install that indexed a repo in July and has not
+ * called a tool since still reads as activated. `calls` says the tools were
+ * actually used in the window.
+ *
+ * The published headline is `used_pct` — the share of installs with *any* call
+ * — not the call total. The ping's GA4 credentials ship in the published bundle
+ * (SECURITY.md "Telemetry Credentials"), so a summed counter is inflatable by
+ * anyone, exactly as `tokens_saved` is; that is what `ga4-savings.mjs` caps.
+ * A per-install boolean is not: inflating it costs one forged install per
+ * point, and it is bounded above by `active_users` no matter how many events
+ * are sent. That is why `calls` is read as a *dimension* here and never summed.
+ *
+ * Same denominator discipline as `activation`: the share is over these rows'
+ * own total, never over `active_users.month`, because `activeUsers` is
+ * deduplicated within a dimension value and not across them — an install that
+ * made its first call mid-window appears in both the `0` row and a non-zero
+ * one.
+ *
+ * ponytail: `calls` is a raw integer, so its cardinality is unbounded and GA4
+ * folds a dimension past 500 daily values into `(other)`, which lands in
+ * `unknown` here. Harmless at ~60 installs and self-announcing if it ever
+ * stops being — a growing `unknown` is the signal. Bucket in the client then.
+ *
+ * @param rows GA4 `runReport` rows, dimension `customEvent:calls`, metric
+ *   `activeUsers`.
+ */
+export function usage(rows) {
+  const { buckets, unknown } = tally(rows, { 0: 0, '1-9': 0, '10-99': 0, '100+': 0 }, (n) =>
+    n === 0 ? '0' : n < 10 ? '1-9' : n < 100 ? '10-99' : '100+',
+  );
+  const used = buckets['1-9'] + buckets['10-99'] + buckets['100+'];
+  const placed = buckets['0'] + used;
+  return {
+    buckets,
+    unknown,
+    used,
+    not_used: buckets['0'],
+    used_pct: share(used, placed),
+  };
+}
+
+/**
+ * `usage`, split by the client the install reports (TRA-673 scope item 2).
+ *
+ * The question this exists for: our strongest routing mechanism — the
+ * PreToolUse guard hook — is Claude Code only, while we ship into MCP
+ * directories on a premise of client neutrality. If `used_pct` holds across
+ * clients the hook is a nice-to-have; if it collapses without one, our
+ * addressable market is "clients that can enforce tool routing" and a lot of
+ * current distribution effort points at installs that will never reach value.
+ *
+ * `installs` is published beside every percentage on purpose: at the client
+ * counts we have (single digits outside Claude Code) a percentage on its own
+ * invites a conclusion the sample cannot carry.
+ *
+ * @param rows GA4 `runReport` rows, dimensions `customEvent:client` then
+ *   `customEvent:calls`, metric `activeUsers`.
+ */
+export function usageByClient(rows) {
+  const byClient = new Map();
+  for (const row of rows ?? []) {
+    const client = row.dimensionValues?.[0]?.value;
+    if (!client) continue;
+    // Re-shape to the single-dimension row `usage` reads, dropping the client.
+    const rest = { dimensionValues: row.dimensionValues.slice(1), metricValues: row.metricValues };
+    byClient.set(client, [...(byClient.get(client) ?? []), rest]);
+  }
+  const used_pct = {};
+  const installs = {};
+  for (const [client, clientRows] of byClient) {
+    const u = usage(clientRows);
+    used_pct[client] = u.used_pct;
+    installs[client] = u.used + u.not_used;
+  }
+  return { used_pct, installs };
 }
 
 /** Percentage, or null when the denominator is missing — never a fake 0. */

--- a/scripts/ga4-snapshot.mjs
+++ b/scripts/ga4-snapshot.mjs
@@ -22,7 +22,7 @@
  */
 import crypto from 'node:crypto';
 import fs from 'node:fs';
-import { activation, share } from './ga4-funnel.mjs';
+import { activation, share, usage, usageByClient } from './ga4-funnel.mjs';
 import { PRICE_MODEL, PRICE_PER_TOKEN, sanitizedTokens, usd } from './ga4-savings.mjs';
 
 const OUT = 'docs/_data/adoption.yml';
@@ -185,6 +185,8 @@ const [
   presets,
   surfaces,
   indexed,
+  called,
+  calledByClient,
   arrivals,
 ] = await Promise.all([
   report(token, propertyId, { dateRanges: range(1), metrics: [{ name: 'activeUsers' }] }),
@@ -248,6 +250,21 @@ const [
     metrics: [{ name: 'activeUsers' }],
     limit: 250,
   }).catch((e) => ({ error: why(e) })),
+  // Use, not setup (TRA-673). Same resolve-with-the-error treatment as
+  // activation, and for a sharper version of the same reason: an empty `usage`
+  // block with no reason reads as "every install uses the tools".
+  report(token, propertyId, {
+    dateRanges: range(28),
+    dimensions: [{ name: 'customEvent:calls' }],
+    metrics: [{ name: 'activeUsers' }],
+    limit: 500,
+  }).catch((e) => ({ error: why(e) })),
+  report(token, propertyId, {
+    dateRanges: range(28),
+    dimensions: [{ name: 'customEvent:client' }, { name: 'customEvent:calls' }],
+    metrics: [{ name: 'activeUsers' }],
+    limit: 1000,
+  }).catch(() => null),
   traffic(process.env.GITHUB_REPOSITORY, process.env.GH_TRAFFIC_TOKEN),
 ]);
 
@@ -269,6 +286,8 @@ const yaml = (obj, indent = 2) =>
     .join('\n') || `${' '.repeat(indent)}{}`;
 
 const act = activation(indexed?.rows);
+const use = usage(called?.rows);
+const useByClient = usageByClient(calledByClient?.rows);
 const newInstalls = installs ? (breakdown(installs).new ?? 0) : 0;
 const yamlNum = (v) => (v === null || v === undefined ? 'null' : v);
 /** An `error:` line when a source failed, nothing when it did not. */
@@ -322,15 +341,23 @@ savings:
 #   arrivals    unique visitors to the GitHub repo, GitHub's rolling 14 days
 #   installs    first-ever pings in 28 days (\`installs_28d.new\`)
 #   activated   % of active installs reporting at least one indexed repository
+#   used        % of active installs that called a tool at all in the window
 #   retention   day / month active installs — how many of the month ran today
+#
+# \`activated\` and \`used\` are two different stages, not two readings of one
+# (TRA-673). \`activated\` is *setup*: it says an install once registered a
+# project, so an install that indexed a repo in July and has not called a tool
+# since still counts. \`used\` is *use*. When they diverge, the gap between them
+# is the population that reached the product and stopped.
 #
 # Mind the windows: arrivals is 14 days and everything else is 28, so
 # arrivals→installs is a direction, not a conversion rate. The unauthenticated-
-# counter caveat above applies to all four.
+# counter caveat above applies to all of them.
 funnel:
   arrivals_uniques_14d: ${yamlNum(arrivals.views_uniques_14d)}
   new_installs_28d: ${newInstalls}
   activated_pct: ${yamlNum(act.activated_pct)}
+  used_pct: ${yamlNum(use.used_pct)}
   retention_dau_mau_pct: ${yamlNum(share(num(d1), num(d28)))}
 
 # Activation, from the ping's \`repos_indexed\` param. An install that reports
@@ -350,6 +377,39 @@ ${errLine(indexed?.error)}  activated: ${act.activated}
   unknown: ${act.unknown}
   by_repos_indexed:
 ${yaml(act.buckets, 4)}
+
+# Use, from the ping's \`calls\` param — trace-mcp tool calls since the previous
+# ping, counted by the MCP server itself and therefore comparable across
+# clients (TRA-673). This is the number every efficiency claim we publish
+# assumes: an agent that reads files instead of calling the tools saves nothing,
+# whatever the benchmark says.
+#
+# \`used_pct\` is the figure to quote, not a call total. The ping's credentials
+# are public, so a summed counter is inflatable exactly like \`tokens_saved\`;
+# a per-install boolean is bounded above by \`active_users\` and costs one forged
+# install per point. Same denominator rule as activation above — the share is
+# over these buckets' own total, never over \`active_users.month\`.
+#
+# \`by_client_used_pct\` is the one that decides distribution strategy. The
+# mechanism that actually routes an agent to our tools — the PreToolUse guard
+# hook — is Claude Code only, and session mining has providers for two clients.
+# If use holds across clients, reach work goes wide; if it collapses without a
+# hook, our addressable market is clients that can enforce routing. Read it
+# beside \`by_client_installs\`: single-digit denominators conclude nothing.
+#
+# Empty until \`calls\` is registered as an event-scoped custom dimension in the
+# property; GA4 does not backfill, so values start at registration.
+usage:
+${errLine(called?.error)}  used: ${use.used}
+  not_used: ${use.not_used}
+  used_pct: ${yamlNum(use.used_pct)}
+  unknown: ${use.unknown}
+  by_calls:
+${yaml(use.buckets, 4)}
+  by_client_used_pct:
+${yaml(useByClient.used_pct, 4)}
+  by_client_installs:
+${yaml(useByClient.installs, 4)}
 
 # Acquisition — where the repo's visitors came from, over GitHub's rolling
 # 14-day window. This is the only acquisition signal available to us: the docs

--- a/scripts/ga4-snapshot.mjs
+++ b/scripts/ga4-snapshot.mjs
@@ -146,7 +146,10 @@ async function traffic(repo, token) {
  * client" got read off a denominator that was never the right one.
  */
 function breakdown(res) {
-  const out = {};
+  // Null-prototype: these keys come from outside (a client name the install
+  // picks for itself, a referrer host), and `{}['__proto__'] = x` is a silent
+  // no-op — that row would vanish from the published breakdown with no trace.
+  const out = Object.create(null);
   for (const row of res?.rows ?? []) {
     const k = row.dimensionValues?.[0]?.value;
     if (k) out[k] = Number(row.metricValues?.[0]?.value ?? 0);
@@ -259,12 +262,21 @@ const [
     metrics: [{ name: 'activeUsers' }],
     limit: 500,
   }).catch((e) => ({ error: why(e) })),
+  // Its own error line rather than a silent `null`: this query can fail on its
+  // own (quota, a malformed second dimension) while the single-dimension one
+  // above succeeds, and empty client maps under a healthy `usage:` block read
+  // as "no client reports use" instead of "this query did not run".
+  //
+  // ponytail: `limit` truncates server-side without saying so — GA4's own
+  // `(other)` folding lands in `unknown`, but a 1000-row cut leaves no trace.
+  // Check `rowCount` if the client × calls combinations ever get near it; at
+  // single-digit clients and ~60 installs they are three orders away.
   report(token, propertyId, {
     dateRanges: range(28),
     dimensions: [{ name: 'customEvent:client' }, { name: 'customEvent:calls' }],
     metrics: [{ name: 'activeUsers' }],
     limit: 1000,
-  }).catch(() => null),
+  }).catch((e) => ({ error: why(e) })),
   traffic(process.env.GITHUB_REPOSITORY, process.env.GH_TRAFFIC_TOKEN),
 ]);
 
@@ -406,7 +418,7 @@ ${errLine(called?.error)}  used: ${use.used}
   unknown: ${use.unknown}
   by_calls:
 ${yaml(use.buckets, 4)}
-  by_client_used_pct:
+${calledByClient?.error ? `  by_client_error: ${JSON.stringify(calledByClient.error)}\n` : ''}  by_client_used_pct:
 ${yaml(useByClient.used_pct, 4)}
   by_client_installs:
 ${yaml(useByClient.installs, 4)}

--- a/tests/scripts/ga4-funnel.test.ts
+++ b/tests/scripts/ga4-funnel.test.ts
@@ -106,6 +106,17 @@ describe('usageByClient', () => {
   it('handles no rows at all', () => {
     expect(usageByClient(undefined)).toEqual({ used_pct: {}, installs: {} });
   });
+
+  it('keeps an install whose client name is a prototype key', () => {
+    // The ping is unauthenticated and the client names itself, so this key is
+    // reachable by anyone. On a plain `{}` the assignment is a silent no-op and
+    // the install disappears from the one number that decides reach strategy.
+    const result = usageByClient([clientRow('__proto__', '5', 7)]);
+
+    expect(result.installs.__proto__).toBe(7);
+    expect(result.used_pct.__proto__).toBe(100);
+    expect({}.hasOwnProperty).toBeTypeOf('function'); // nothing polluted globally
+  });
 });
 
 describe('share', () => {

--- a/tests/scripts/ga4-funnel.test.ts
+++ b/tests/scripts/ga4-funnel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { activation, share } from '../../scripts/ga4-funnel.mjs';
+import { activation, share, usage, usageByClient } from '../../scripts/ga4-funnel.mjs';
 
 /** One GA4 row: a `repos_indexed` value and how many active installs reported it. */
 const row = (value: string, users: number) => ({
@@ -42,6 +42,69 @@ describe('activation', () => {
       activated: 6,
       activated_pct: 100,
     });
+  });
+});
+
+describe('usage', () => {
+  it('splits installs that called a tool from installs that never did', () => {
+    const result = usage([row('0', 12), row('3', 4), row('40', 3), row('900', 1)]);
+
+    expect(result).toMatchObject({
+      not_used: 12,
+      used: 8,
+      used_pct: 40,
+      buckets: { '0': 12, '1-9': 4, '10-99': 3, '100+': 1 },
+      unknown: 0,
+    });
+  });
+
+  it('reports no data as null, not as 0% of installs using the tools', () => {
+    // An unregistered custom dimension returns no rows. Publishing that as
+    // "0% of installs called a tool" would be the most alarming lie in the file.
+    expect(usage([]).used_pct).toBeNull();
+    expect(usage(undefined).used_pct).toBeNull();
+  });
+
+  it('keeps GA4 cardinality overflow and unset values out of both sides', () => {
+    // `(other)` is what GA4 collapses a high-cardinality dimension into, and
+    // `calls` is a raw integer — counting that bucket as zero calls would
+    // manufacture the exact conclusion this measurement exists to test.
+    const result = usage([row('0', 2), row('(other)', 9), row('(not set)', 4), row('', 1)]);
+
+    expect(result.unknown).toBe(14);
+    expect(result.not_used).toBe(2);
+    expect(result.used).toBe(0);
+  });
+
+  it('does not divide by active_users — only by the rows it placed', () => {
+    // 5 installs placed, 3 of them used: 60%, whatever the property's monthly
+    // active count is. Sharing against `active_users` was the TRA-643 bug.
+    expect(usage([row('0', 2), row('7', 3)]).used_pct).toBe(60);
+  });
+});
+
+describe('usageByClient', () => {
+  /** One two-dimension GA4 row: client, `calls` value, active installs. */
+  const clientRow = (client: string, calls: string, users: number) => ({
+    dimensionValues: [{ value: client }, { value: calls }],
+    metricValues: [{ value: String(users) }],
+  });
+
+  it('scores each client against its own installs, not the whole property', () => {
+    const result = usageByClient([
+      clientRow('claude-code', '0', 2),
+      clientRow('claude-code', '25', 6),
+      clientRow('cursor', '0', 3),
+      clientRow('cursor', '4', 1),
+    ]);
+
+    // The hook-capable/hook-less split this measurement exists to answer.
+    expect(result.used_pct).toEqual({ 'claude-code': 75, cursor: 25 });
+    expect(result.installs).toEqual({ 'claude-code': 8, cursor: 4 });
+  });
+
+  it('handles no rows at all', () => {
+    expect(usageByClient(undefined)).toEqual({ used_pct: {}, installs: {} });
   });
 });
 


### PR DESCRIPTION
Closes TRA-673.

## The finding

The daily ping has carried `calls` — trace-mcp tool calls since the previous ping, incremented by `recordCall` in `src/savings.ts` and therefore counted by the MCP server itself rather than by any client — since it was written. It appears zero times in `scripts/ga4-snapshot.mjs`. The funnel's activation stage (TRA-645) reads `repos_indexed`, which says an install once registered a project: an install that indexed a repo in July and has not called a tool since reads as activated.

So the funnel measured **setup**, not **use**, and every efficiency number we publish assumes use.

## What changed

A fifth funnel stage, `usage.used_pct`, plus a per-client split (`usage.by_client_used_pct` beside `by_client_installs`).

**`calls` is read as a custom dimension, not the custom metric the issue proposed.** The Data API has no `client_id` — that only exists in the BigQuery export, as `ga4-savings.mjs` already documents — so a summed metric can never yield a per-install boolean, and the boolean is the statistic scope item 4 asks to headline. A dimension gives it directly, by the same bucketing `activation()` already uses. This does not add an admin step: it changes which form field `calls` goes in, and it stays one session for all four parameters.

Published as a boolean and never as a call total, for the reason in scope item 4: the ping's credentials are public, so a summed counter is inflatable exactly like `tokens_saved` (which is why `ga4-savings.mjs` caps it). A per-install boolean costs one forged install per point and is bounded above by `active_users`.

Same reading discipline as `by_client` (scope item 3): `(not set)` — and GA4's `(other)` cardinality overflow — land in `unknown`, never in the zero bucket, and the share is over the buckets' own total, never over `active_users`.

## Why the client split is the point

The mechanism that actually routes an agent to our tools is not portable. The PreToolUse guard hook that blocks Read/Grep is Claude Code only; Cursor and Windsurf get a rules file; everything else gets tool descriptions, which ask rather than route. Session mining has two providers. We ship into MCP directories on a premise of client neutrality and have never tested it. If use holds across clients, reach work goes wide; if it collapses without a hook, our addressable market is clients that can enforce routing.

## Test evidence

- `tests/scripts/ga4-funnel.test.ts` — 13 passing. New cases cover the split, no-data-as-null (an unregistered dimension must not publish "0% of installs called a tool"), `(other)` / `(not set)` staying out of both sides, the denominator rule, the per-client split, and a client named `__proto__`.
- Full suite: 9556 passed, 10 skipped. `pnpm run build`, `pnpm run typecheck`, `biome ci` clean.
- The emitted `usage:` block was rendered and parsed with the `yaml` package in three shapes — happy path, both queries erroring, and a client name carrying a quote and a newline. That render caught a hand-quoted error line, fixed in the second commit.

## Second-model review

Reviewed by a second model before merge, per workspace rule. It found that `__proto__` as a client name is a silent no-op on a plain object, so a forged ping would delete that install from both client maps with no error and no `unknown` credit — fixed with null-prototype objects in `usageByClient`, and the same one-word fix applied to `breakdown`, which carries the identical attacker-controlled key today. It also flagged the client-split query swallowing its errors, now a visible `by_client_error`.

## Not in this PR

The read-back — what share of active installs called a tool, and whether it differs between hook-capable and hook-less clients. It needs a snapshot that carries the field, which needs the registration below. `docs/ROADMAP.md` states the question and where the answer goes.

## Blocker

`calls` must be registered in GA4 property `551114458` as an event-scoped custom dimension before any value arrives; GA4 does not backfill, so every day before registration is unrecoverable. That is now **four parameters on one admin form** — `repos_indexed`, `preset`, `tools_advertised` (TRA-643/645) and `calls`. Per the workspace rule this is one request, not four; `docs/ROADMAP.md` now says so in both places it comes up.
