### PR TITLE
feat(tools): explain empty results with a capped, data-derived note (TRA-680)

### DIFF
--- a/src/tools/register/framework.ts
+++ b/src/tools/register/framework.ts
@@ -23,6 +23,7 @@ import { getTestsFor } from '../framework/tests.js';
 import { CALL_GRAPH_METHODOLOGY } from '../shared/confidence.js';
 import { buildNegativeEvidence } from '../shared/evidence.js';
 import { probeSymbolName } from '../shared/evidence-text-probe.js';
+import { buildEmptyResultNote } from '../shared/empty-note.js';
 import {
   compactUsageRefs,
   DetailLevelSchema,
@@ -303,6 +304,11 @@ export function registerFrameworkTools(server: McpServer, ctx: ServerContext): v
         const anchor = symbol_id ?? fqn ?? file_path;
         const sym = symbol_id ? store.getSymbolBySymbolId(symbol_id) : undefined;
         const probe = probeSymbolName(store, projectRoot, anchor);
+        const note = buildEmptyResultNote(
+          store,
+          projectRoot,
+          result.value.target.file ?? file_path,
+        );
         const enriched = {
           ...result.value,
           evidence: buildNegativeEvidence({
@@ -314,6 +320,7 @@ export function registerFrameworkTools(server: McpServer, ctx: ServerContext): v
             symbolKind: sym?.kind,
             textOccurrences: probe.occurrences,
           }),
+          ...(note ? { empty_result_note: note } : {}),
         };
         return { content: [{ type: 'text', text: jh('find_usages', enriched) }] };
       }
@@ -373,6 +380,7 @@ export function registerFrameworkTools(server: McpServer, ctx: ServerContext): v
         const stats = store.getStats();
         const sym = store.getSymbolBySymbolId(root.symbol_id);
         const probe = probeSymbolName(store, projectRoot, root.symbol_id);
+        const note = buildEmptyResultNote(store, projectRoot, root.file);
         const enriched = {
           ...result.value,
           _methodology: CALL_GRAPH_METHODOLOGY,
@@ -385,6 +393,7 @@ export function registerFrameworkTools(server: McpServer, ctx: ServerContext): v
             symbolKind: sym?.kind,
             textOccurrences: probe.occurrences,
           }),
+          ...(note ? { empty_result_note: note } : {}),
         };
         return { content: [{ type: 'text', text: jh('get_call_graph', enriched) }] };
       }

--- a/src/tools/register/navigation/lookup-tools.ts
+++ b/src/tools/register/navigation/lookup-tools.ts
@@ -16,6 +16,7 @@ import { getFileOutline, getSymbol } from '../../navigation/navigation.js';
 import { getRelatedSymbols } from '../../navigation/related.js';
 import { fallbackOutline } from '../../navigation/zero-index.js';
 import { CHANGE_IMPACT_METHODOLOGY } from '../../shared/confidence.js';
+import { buildEmptyResultNote } from '../../shared/empty-note.js';
 import { compactOutlineSymbols, DetailLevelSchema, isMinimal } from '../../_common/detail-level.js';
 import { OutputFormatSchema, encodeResponse } from '../../_common/output-format.js';
 
@@ -325,6 +326,10 @@ export function registerLookupTools(server: McpServer, ctx: ServerContext): void
       const payload: Record<string, unknown> = includeMethodology
         ? { ...result.value, _methodology: CHANGE_IMPACT_METHODOLOGY }
         : { ...result.value };
+      if (result.value.totalAffected === 0) {
+        const note = buildEmptyResultNote(store, projectRoot, result.value.target.path);
+        if (note) payload.empty_result_note = note;
+      }
       // Enrich with linked decisions (code-aware memory)
       if (decisionStore) {
         const linkedDecisions = decisionsForImpact(

--- a/src/tools/shared/empty-note.ts
+++ b/src/tools/shared/empty-note.ts
@@ -1,0 +1,140 @@
+/**
+ * Capped, data-derived caveat for zero-result responses (TRA-680).
+ *
+ * `total: 0` is ambiguous: it can mean "this symbol genuinely has no callers", or
+ * "the index cannot see them here". An agent that reads the first meaning either
+ * states a wrong conclusion or falls back to reading the repo by hand — the
+ * multi-thousand-token behaviour this product exists to prevent.
+ *
+ * The note is derived from what the index actually stored, never from a
+ * hand-written table of "languages we know are weak": that would rot every time
+ * a resolver improves and would silently lie about languages we have since fixed.
+ * Concretely it reads the `resolution_tier` distribution of the call edges the
+ * index holds for the target's language, plus the file's freshness.
+ *
+ * Only usage / caller / impact queries call this — a caveat about call
+ * resolution on a file outline or a symbol lookup would be pure noise.
+ */
+
+import type { Store } from '../../db/store.js';
+import { computeFileFreshness } from '../../scoring/freshness.js';
+
+/**
+ * Hard cap on the emitted note. This is a token saving only while it stays much
+ * smaller than the fallback it prevents; an advisory that grows is a regression.
+ */
+export const EMPTY_RESULT_NOTE_MAX_LEN = 140;
+
+/** Tiers where the edge endpoint was actually resolved, not guessed by name. */
+const RESOLVED_TIERS = ['scip_resolved', 'lsp_resolved', 'ast_resolved'];
+
+/** Edge kinds whose presence depends on call resolution. */
+const CALL_EDGE_TYPES = ['calls', 'references'];
+
+/** Below this resolved share the index cannot back a confident zero. */
+const LOW_RESOLUTION_SHARE = 0.5;
+
+/** Fewer call edges than this and the share is noise, not a measurement. */
+const MIN_SAMPLE = 20;
+
+export interface CallEdgeResolution {
+  total: number;
+  resolved: number;
+  /** resolved / total, or 0 when the language has no call edges at all. */
+  share: number;
+}
+
+/**
+ * Resolved-edge share of the call edges this index holds for `language`.
+ *
+ * A call edge is attributed to the language of the file its SOURCE lives in —
+ * that is the file whose parse produced the edge, so it is the resolver whose
+ * quality the share measures. Sources are symbols for `calls`/`references`, but
+ * file nodes appear too, so both node types are mapped back to a file.
+ *
+ * ponytail: full scan of the call edges, run only on the empty-result path.
+ * Add a per-language aggregate table if empty results ever become hot.
+ */
+export function callEdgeResolution(store: Store, language: string): CallEdgeResolution {
+  const row = store.db
+    .prepare(
+      `SELECT COUNT(*) AS total,
+              COALESCE(SUM(CASE WHEN e.resolution_tier IN (${RESOLVED_TIERS.map(() => '?').join(',')})
+                                THEN 1 ELSE 0 END), 0) AS resolved
+         FROM edges e
+         JOIN edge_types et ON et.id = e.edge_type_id
+         JOIN nodes n ON n.id = e.source_node_id
+         LEFT JOIN symbols s ON n.node_type = 'symbol' AND s.id = n.ref_id
+         JOIN files f ON f.id = CASE n.node_type
+                                  WHEN 'symbol' THEN s.file_id
+                                  WHEN 'file' THEN n.ref_id
+                                END
+        WHERE et.name IN (${CALL_EDGE_TYPES.map(() => '?').join(',')})
+          AND f.language = ?`,
+    )
+    .get(...RESOLVED_TIERS, ...CALL_EDGE_TYPES, language) as
+    | { total: number; resolved: number }
+    | undefined;
+
+  const total = row?.total ?? 0;
+  const resolved = row?.resolved ?? 0;
+  return { total, resolved, share: total === 0 ? 0 : resolved / total };
+}
+
+/** Truncate to the budget rather than letting a long path blow it. */
+function cap(text: string): string {
+  return text.length <= EMPTY_RESULT_NOTE_MAX_LEN
+    ? text
+    : `${text.slice(0, EMPTY_RESULT_NOTE_MAX_LEN - 1)}…`;
+}
+
+/**
+ * Build the note for a zero-result usage/caller/impact response, or `undefined`
+ * when the index has no reason to be unsure. `filePath` is the indexed path of
+ * the queried target.
+ *
+ * Checks, first hit wins — one note, never a list:
+ *   1. the index is behind the working tree for that file;
+ *   2. the target's language has no call edges in this index at all;
+ *   3. too few call edges to measure;
+ *   4. a low resolved share for that language.
+ */
+export function buildEmptyResultNote(
+  store: Store,
+  projectRoot: string,
+  filePath: string | undefined,
+): string | undefined {
+  if (!filePath) return undefined;
+  const file = store.getFile(filePath);
+  // Not indexed at all — the zero says nothing about the code.
+  if (!file)
+    return cap(`${filePath} is not in the index; this zero reflects coverage, not the code.`);
+
+  if (computeFileFreshness(projectRoot, file) !== 'fresh') {
+    return cap(
+      `Index is behind ${file.path} on disk — reindex before reading this zero as "no callers".`,
+    );
+  }
+
+  const language = file.language;
+  if (!language) return undefined;
+
+  const { total, share } = callEdgeResolution(store, language);
+  if (total === 0) {
+    return cap(
+      `No ${language} call edges in this index at all — this zero reflects coverage, not the code.`,
+    );
+  }
+  if (total < MIN_SAMPLE) {
+    return cap(
+      `Only ${total} ${language} call edges indexed — too few to read this zero as proof of no callers.`,
+    );
+  }
+  if (share < LOW_RESOLUTION_SHARE) {
+    const pct = Math.round(share * 100);
+    return cap(
+      `Only ${pct}% of ${language} call edges here resolve — this zero may be a resolver gap, not absence.`,
+    );
+  }
+  return undefined;
+}

--- a/tests/tools/empty-result-note.test.ts
+++ b/tests/tools/empty-result-note.test.ts
@@ -1,0 +1,160 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Store } from '../../src/db/store.js';
+import { findReferences } from '../../src/tools/framework/references.js';
+import {
+  buildEmptyResultNote,
+  callEdgeResolution,
+  EMPTY_RESULT_NOTE_MAX_LEN,
+} from '../../src/tools/shared/empty-note.js';
+import { createTestStore, createTmpDir } from '../test-utils.js';
+
+/**
+ * Add a file that really exists on disk (so freshness resolves to 'fresh')
+ * plus a symbol in it, and return the graph node id of the symbol.
+ */
+function addSymbol(
+  store: Store,
+  root: string,
+  relPath: string,
+  language: string,
+  name: string,
+): number {
+  const abs = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  if (!fs.existsSync(abs)) fs.writeFileSync(abs, `// ${name}\n`);
+  const existing = store.getFile(relPath);
+  const fileId =
+    existing?.id ??
+    store.insertFile(relPath, language, null, null, null, Math.floor(fs.statSync(abs).mtimeMs));
+  const symbolDbId = store.insertSymbol(fileId, {
+    symbolId: `${relPath}::${name}#function`,
+    name,
+    kind: 'function' as never,
+    byteStart: 0,
+    byteEnd: 10,
+    lineStart: 1,
+    lineEnd: 2,
+  });
+  return store.getNodeId('symbol', symbolDbId)!;
+}
+
+/** Wire `count` call edges into the store, `resolvedCount` of them at a resolved tier. */
+function addCallEdges(
+  store: Store,
+  root: string,
+  language: string,
+  ext: string,
+  count: number,
+  resolvedCount: number,
+): void {
+  const sink = addSymbol(store, root, `src/sink${ext}`, language, 'sink');
+  for (let i = 0; i < count; i++) {
+    const src = addSymbol(store, root, `src/caller${i}${ext}`, language, `caller${i}`);
+    store.insertEdge(
+      src,
+      sink,
+      'calls',
+      true,
+      undefined,
+      false,
+      i < resolvedCount ? 'ast_resolved' : 'text_matched',
+    );
+  }
+}
+
+describe('empty-result note', () => {
+  let store: Store;
+  let root: string;
+
+  beforeEach(() => {
+    store = createTestStore();
+    store.ensureEdgeType('calls', 'code', 'Function calls');
+    store.ensureEdgeType('references', 'code', 'Symbol references');
+    root = createTmpDir('trace-mcp-empty-note-');
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('emits no caveat for a language whose call edges resolve well', () => {
+    addCallEdges(store, root, 'typescript', '.ts', 40, 40);
+    const target = 'src/lonely.ts';
+    addSymbol(store, root, target, 'typescript', 'lonely');
+
+    expect(buildEmptyResultNote(store, root, target)).toBeUndefined();
+  });
+
+  it('emits a caveat for a language whose call edges mostly do not resolve', () => {
+    addCallEdges(store, root, 'ruby', '.rb', 40, 4);
+    const target = 'src/lonely.rb';
+    addSymbol(store, root, target, 'ruby', 'lonely');
+
+    const note = buildEmptyResultNote(store, root, target);
+    expect(note).toBeDefined();
+    // Derived from the stored tiers, not from a hand-written list of languages.
+    expect(note).toContain('10%');
+    expect(note).toContain('ruby');
+  });
+
+  it('is scoped per language — a weak neighbour does not taint a strong one', () => {
+    addCallEdges(store, root, 'ruby', '.rb', 40, 0);
+    addCallEdges(store, root, 'typescript', '.ts', 40, 40);
+    addSymbol(store, root, 'src/lonely.ts', 'typescript', 'lonely');
+    addSymbol(store, root, 'src/lonely.rb', 'ruby', 'lonely');
+
+    expect(buildEmptyResultNote(store, root, 'src/lonely.ts')).toBeUndefined();
+    expect(buildEmptyResultNote(store, root, 'src/lonely.rb')).toBeDefined();
+  });
+
+  it('flags a language with no call edges indexed at all', () => {
+    addCallEdges(store, root, 'typescript', '.ts', 40, 40);
+    addSymbol(store, root, 'src/lonely.go', 'go', 'Lonely');
+
+    expect(buildEmptyResultNote(store, root, 'src/lonely.go')).toContain('No go call edges');
+  });
+
+  it('flags a target that was never indexed', () => {
+    expect(buildEmptyResultNote(store, root, 'src/ghost.ts')).toContain('not in the index');
+  });
+
+  it('flags an index that is behind the working tree', () => {
+    addCallEdges(store, root, 'typescript', '.ts', 40, 40);
+    const target = 'src/edited.ts';
+    addSymbol(store, root, target, 'typescript', 'edited');
+    const abs = path.join(root, target);
+    const future = Date.now() + 60_000;
+    fs.utimesSync(abs, future / 1000, future / 1000);
+
+    expect(buildEmptyResultNote(store, root, target)).toContain('Index is behind');
+  });
+
+  it('never exceeds the note budget, even for a long path', () => {
+    const longPath = `src/${'nested/'.repeat(40)}deep.rb`;
+    addCallEdges(store, root, 'ruby', '.rb', 40, 0);
+    addSymbol(store, root, longPath, 'ruby', 'deep');
+
+    const note = buildEmptyResultNote(store, root, longPath)!;
+    expect(note.length).toBeLessThanOrEqual(EMPTY_RESULT_NOTE_MAX_LEN);
+  });
+
+  it('leaves non-empty responses byte-identical', () => {
+    addCallEdges(store, root, 'ruby', '.rb', 40, 0);
+    const before = JSON.stringify(
+      findReferences(store, { symbolId: 'src/sink.rb::sink#function' })._unsafeUnwrap(),
+    );
+
+    const result = findReferences(store, { symbolId: 'src/sink.rb::sink#function' });
+    const value = result._unsafeUnwrap();
+    expect(value.total).toBeGreaterThan(0);
+    expect(JSON.stringify(value)).toBe(before);
+    expect(Object.keys(value)).not.toContain('empty_result_note');
+  });
+
+  it('reports the resolved share it derived the note from', () => {
+    addCallEdges(store, root, 'ruby', '.rb', 10, 3);
+    expect(callEdgeResolution(store, 'ruby')).toEqual({ total: 10, resolved: 3, share: 0.3 });
+  });
+});


### PR DESCRIPTION
Closes TRA-680.

## Problem

`total: 0` on a navigation or impact query is ambiguous. It can mean "this code genuinely has no callers", or "the index cannot see them here". An agent that reads the first meaning either states a wrong conclusion confidently, or gives up on the index and reads the repository by hand — the multi-thousand-token behaviour this product exists to prevent.

## Change

New `src/tools/shared/empty-note.ts`. On empty results only, `find_usages`, `get_call_graph` and `get_change_impact` attach one `empty_result_note` string, capped at 140 characters. First hit wins, never a list:

1. the target is not in the index at all;
2. the index is behind the working tree for that file (reuses the existing `computeFileFreshness`);
3. the target's language has no call edges in this index at all;
4. fewer than 20 call edges for that language — too few to measure;
5. resolved share below 50% for that language.

The share comes from the stored `resolution_tier` column (`callEdgeResolution`), aggregated over `calls`/`references` edges attributed to the language of the file their source lives in — the file whose parse produced the edge. Deliberately not a hardcoded list of known-weak languages: that has to be pruned by hand every time a resolver improves and will silently lie about languages we have since fixed.

Scoped to call-resolution queries only. File outlines and symbol lookups are untouched — a call-resolution caveat there is noise.

The aggregate is a full scan of call edges, run only on the empty-result path; marked with a `ponytail:` comment naming the upgrade path (per-language aggregate table) if empty results ever become hot.

## Test evidence

`tests/tools/empty-result-note.test.ts`, 9 tests:

- high-coverage language produces **no** caveat; low-coverage language does, with the percentage derived from the stored tiers;
- per-language scoping: a weak language next door does not taint a strong one;
- language with zero call edges, target never indexed, index behind the working tree;
- the 140-char budget holds for a pathologically long path;
- non-empty responses are byte-identical and carry no `empty_result_note`.

Full suite: 9598 passed, 10 skipped. `pnpm run typecheck` and `pnpm run build` clean.

## Contract

Additive and empty-path-only: every response that carries results is byte-identical to today. No schema or tool-signature change.

Agent: Lead Engineer
