### PR TITLE
perf(app): reconcile both TRA-617 passes, measure the app offscreen, price the idle Graph tab

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -14,18 +14,33 @@ noindex: true
 Machine-readable history lives in [`baseline.json`](./baseline.json) — append one `runs[]`
 entry per measurement pass, never rewrite an old one. This file is the human summary.
 
-## Current numbers (3.6.0, `39026ebd` — the AskTab split, macOS 26.5 / arm64, median of 3)
+## Current numbers (3.10.0, `b6b02ae4`, darwin 25.5.0 / arm64, median of 3)
 
 | Metric | Value | Ceiling | Status |
 |---|---|---|---|
-| `renderer_fcp_ms` | 216 | — | ok — **the startup metric of record** |
-| `cold_start_ms` | 801 | 3000 | ok, but load-sensitive (see below) |
-| `window_interactive_ms` | 506 | — | load-sensitive, do not trend it |
-| `heap_idle_mb` (5 min idle) | 9.5 | — | ok |
+| `renderer_fcp_ms` | 136 | — | ok — **the startup metric of record** |
+| `cold_start_ms` | 629 | 3000 | ok, but load-sensitive (see below) |
+| `window_interactive_ms` | 362 | — | load-sensitive, do not trend it |
+| `heap_idle_mb` (5 min idle) | 10.7 | — | ok |
 | `main_cpu_idle_pct` | 0 | 2 | ok |
-| `renderer_eager_kb` | 2102 | — | **the size metric of record** (see below) |
-| `renderer_bundle_kb` | 2272 | — | +34% vs 1700 — regression, addressed this run |
+| `ui_p95_ms` | 668 | — | **first real value** — was null in the four runs before |
+| `heap_after_workload_mb` | 11.6 | — | first real value |
+| `heap_growth_mb_per_hour` | +1.39 | 50 | ok — no leak over 572 cycles |
+| `tree_rss_idle_mb` (app + daemon) | 955 | — | first real value |
+| `tree_rss_peak_mb` (app + daemon) | 1691 | — | first real value |
+| `tree_cpu_peak_pct` (combined, sums cores) | 156 | — | first real value |
+| `rss_after_index_settle_mb` (daemon only) | 383 | 500 | ok settled — **but 727 MB while serving, see below** |
+| `renderer_eager_kb` | 2100 | — | **the size metric of record**, flat vs 2102 |
+| `renderer_bundle_kb` | 2270 | — | flat vs 2272 |
 | `artifact_mb` | not re-packed | ×1.5 growth | last measured 4.85 / 268.1 at `6ebbbd56` |
+
+**Open finding — the daemon costs ~700 MB to serve one small project.** With a fresh data
+dir, a private port and exactly one registered project (this repo at the pinned fixture
+commit, 1817 files / 9698 symbols), `serve-http` sat at 727 MB RSS idle and peaked at
+1014 MB, dropping to 383 MB only after the app disconnected and ten minutes passed. That
+reproduces, under control, the 884 MB the 2026-08-30 run saw on an ambient daemon and did
+not file because that daemon's history was unknown. It is not history: one small project
+really does cost that much resident while it is being served.
 
 ### Which size number to trend
 
@@ -49,27 +64,69 @@ ceiling only.
 When a run has to happen on a loaded machine, an interleaved A/B — alternating one sample
 of each build, several rounds — cancels the drift that a back-to-back A-then-B run does not.
 
-`ui_p95_ms`, `heap_after_workload_mb` and `heap_growth_mb_per_hour` are still unfilled in
-`baseline.json`. The harness that produces them landed with TRA-258 and has been run
-end to end, but a publishable pass needs a daemon on 127.0.0.1:3741 that speaks this
-checkout's API — the renderer's `BASE` is hardcoded, so the workload cannot be pointed
-anywhere else. On a machine where another trace-mcp version owns that port, the fixture
-never gets served and the run aborts with `the daemon on 3741 never served <fixture>`.
-Take the first clean pass on a machine with no competing daemon.
+### The workload no longer needs port 3741 (TRA-617)
+
+For four consecutive runs `ui_p95_ms`, `heap_after_workload_mb` and
+`heap_growth_mb_per_hour` were recorded as `null` with the same reason: a foreign daemon
+owned 127.0.0.1:3741 for the whole run. The renderer's `BASE` is hardcoded to that port in
+six files, so the harness used to wait up to four minutes for the port to come free and
+then measure against whatever daemon held it — on a machine that runs a dozen agent
+checkouts and a 20-project registry, that port is never free, and "wait for an
+uncontended host" is a precondition that never arrives.
+
+The harness now does what `tabs-scale.mjs` already did: it runs **its own daemon on a
+private port (37412) against a throwaway `TRACE_MCP_DATA_DIR`**, and rewrites every
+renderer request to `:3741` onto it over CDP (`Fetch.requestPaused` →
+`Fetch.continueRequest` with a swapped port). Only daemon requests are intercepted;
+assets and the `file://` document are untouched. The app's own watchdog still polls the
+real 3741, so `TRACE_MCP_BIN` points at a no-op shim to stop it starting anything.
+
+The consequence for reading the numbers: the daemon under test serves **one** project, the
+pinned fixture, and nothing else. That is the point — it isolates the app from the
+machine's registry — but it means `tree_rss_*` here are not comparable to the 2026-08-28
+daemon-memory entry, which measured a daemon holding 40 to 110 real projects.
+
+**The same trap, one layer up: the CDP port.** The harness used to hardcode
+`--remote-debugging-port=9333` and attach to the first page target it found there. A Chrome
+started by `chrome-devtools-mcp` with the same debugging port already owned it, so the run
+attached to a *Chrome tab*, drove that, and reported `cold_start_ms: 23` and
+`window_interactive_ms: 16327` without complaining once. Each launch now takes a free port
+from 9333–9353 and then checks that the process listening on it is inside its own child's
+process tree, failing the run outright if it is not. A perf harness that silently measures
+the wrong process is worse than one that does not run.
 
 ## How to take a measurement
 
 ```bash
 pnpm run build                          # repo root — the workload indexes the fixture with this CLI
+pnpm -C packages/app install            # packages/app is a separate package, not a pnpm workspace
 pnpm -C packages/app run build          # required — the harness measures the prod bundle
 pnpm -C packages/app run pack           # optional — needed for artifact_mb
 PERF_COMMIT=$(git rev-parse --short HEAD) \
   pnpm -C packages/app run perf -- --samples 3 --idle-seconds 300 \
-                                     --workload --workload-minutes 30 --opens 20
+                                     --workload --workload-minutes 30 --opens 10
 ```
 
-Drop `--workload` for a startup-only pass (~6 min). With it the run takes ~40 min and
-adds `ui_p95_ms`, `heap_after_workload_mb` and `heap_growth_mb_per_hour`.
+Drop `--workload` for a startup-only pass (~6 min). With it the run takes ~55 min
+(30 min of cycles plus a 10-minute daemon settle, `--settle-minutes`) and adds
+`ui_p95_ms`, `heap_after_workload_mb`, `heap_growth_mb_per_hour` and the process-tree
+set below.
+
+### The process-tree metrics
+
+Sampled every 5 s for the whole workload, across both trees under test — the Electron app
+(main + renderer + GPU/network helpers) and the daemon (`serve-http` plus its index worker
+processes; worker *threads* are counted inside their host process's RSS by `ps`).
+
+| Metric | What it is |
+|---|---|
+| `tree_rss_idle_mb` | app + daemon RSS with the fixture indexed and served and nothing driven — a 60 s hold taken before the first project open |
+| `tree_rss_peak_mb` | highest app + daemon RSS seen at any point in the run |
+| `tree_cpu_peak_pct` | highest combined `%cpu` (sums over cores, so >100 is normal) |
+| `rss_after_index_settle_mb` | daemon RSS after the app is gone and it has sat idle for `--settle-minutes`, still holding the fixture's index |
+
+`workload.tree_series` keeps every fifth sample, so the shape over the run survives in
+`baseline.json` without carrying 500 rows.
 
 The harness ([`packages/app/scripts/perf-measure.mjs`](../../packages/app/scripts/perf-measure.mjs))
 launches the built app against a throwaway `--user-data-dir`, drives it over CDP, and
@@ -117,6 +174,21 @@ How each number is derived:
   the first paint. Switching to the Graph tab paints an empty canvas within a few
   milliseconds and then does the real work; first-paint timing reports single-digit
   milliseconds for every action and would never catch a regression.
+- **Mutations inside `.cosmos-gpu-label` do not count** (pin `revision` 2, TRA-617). The
+  GPU graph repaints its HTML label overlay every animation frame — measured at ~730
+  mutations/second, unbroken, with no input at all — so the whole-document observer never
+  saw 120 ms of quiet and every Graph-tab action ran to the cap. The first run to reach
+  this code reported `ui_p95_ms` as exactly 5000 with a search median of 4987: the
+  harness's ceiling, not the app. Scoping the observer past a permanent animation is not
+  a leniency — an animation that never stops cannot signal that anything finished.
+  The limit this leaves: WebGL drawing is invisible to a `MutationObserver` either way, so
+  `switch_view` into Graph times the surrounding DOM, not the graph's own render. "The
+  graph has actually loaded" is enforced separately, by the `matchCount() > 0` gate before
+  the cycle loop starts.
+- The **search median reads near zero and that is not a bug**: the graph typeahead filters
+  nodes the renderer already holds, so the list updates within a few milliseconds of the
+  keystroke. `ui_p95_ms` takes the worst per-action p95 precisely so a cheap action cannot
+  hide an expensive one.
 - **`heap_after_workload_mb`** — the post-GC heap after the first complete cycle.
 - **`heap_growth_mb_per_hour`** — least-squares slope of the post-GC heap series over the
   whole run. Over 50 is an issue on its own, whatever the delta to the previous run.
@@ -131,6 +203,20 @@ Compare against the median of the last 5 runs: >+10% is a warning to note, >+25%
 (or two consecutive warnings) is a regression worth an issue.
 
 ## Changes worth remembering
+
+**2026-09-01 — the three workload metrics were never blocked on a quiet machine.**
+Four entries in a row recorded `ui_p95_ms` / `heap_after_workload_mb` /
+`heap_growth_mb_per_hour` as null, each blaming a foreign daemon on 3741 and each deferring
+to a future uncontended host. That host does not exist on this machine and the wait was the
+wrong fix: the harness needed to stop asking for a port it does not own. Giving it a private
+daemon port plus a CDP request rewrite filled all three, and the process-tree set with them,
+on a machine at load average 21.9 with the ambient 22-project daemon still holding 3741
+throughout. Two harness defects fell out of finally running it end to end: `ui_p95_ms` read
+exactly 5000 (the settle cap — see the `.cosmos-gpu-label` note above), and a hardcoded CDP
+port let the harness attach to somebody else's Chrome and report a 23 ms cold start. Both
+had been latent since TRA-258. The lesson is not about ports: a metric that has never once
+produced a value is not a measurement, it is a plan, and it should be treated as untested
+code until it prints a number.
 
 **2026-08-30 — the Ask tab was carrying the markdown stack into startup.**
 `renderer_bundle_kb` had gone 1461 → 1700 → 2272 KB, with the entry chunk alone at

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -14,24 +14,76 @@ noindex: true
 Machine-readable history lives in [`baseline.json`](./baseline.json) — append one `runs[]`
 entry per measurement pass, never rewrite an old one. This file is the human summary.
 
-## Current numbers (3.6.0, `39026ebd` — the AskTab split, macOS 26.5 / arm64, median of 3)
+## Current numbers (3.11.0, `e56f4573`, macOS 26.5 / arm64, median of 3)
 
-The `artifact_mb` rows are newer than the rest of the table: 3.11.0, `64b14a12`, a
-single artifact-only pack on the same machine. Sizes are deterministic, so they do not
-need a median.
+First pass in which the fixed workload ran end to end, so the three workload metrics are
+filled for the first time (TRA-617). `artifact_mb` is still the 3.11.0 artifact-only pack
+from `64b14a12` — this run changed no dependency, so those sizes did not move.
 
 | Metric | Value | Ceiling | Status |
 |---|---|---|---|
-| `renderer_fcp_ms` | 216 | — | ok — **the startup metric of record** |
-| `cold_start_ms` | 801 | 3000 | ok, but load-sensitive (see below) |
-| `window_interactive_ms` | 506 | — | load-sensitive, do not trend it |
+| `renderer_first_content_ms` | 133 | — | ok — **the startup metric of record** (new series) |
+| `renderer_fcp_ms` | null | — | structurally unavailable offscreen — see below |
+| `cold_start_ms` | 483 | 3000 | ok, load-sensitive |
+| `window_interactive_ms` | 169 | — | load-sensitive, do not trend it |
+| `ui_p95_ms` | 529 | — | **first real value** — search p95 529, open p95 278, switch p95 177 |
 | `heap_idle_mb` (5 min idle) | 9.5 | — | ok |
+| `heap_after_workload_mb` | 7.89 | — | first value |
+| `heap_growth_mb_per_hour` | 1.37 | 50 | ok — 30 min, 667 cycles, no leak |
+| `renderer_cpu_idle_pct.overview` | 0.2 | — | ok |
+| `renderer_cpu_idle_pct.graph` | **27.7** | — | **the Graph tab never idles** — see below |
 | `main_cpu_idle_pct` | 0 | 2 | ok |
-| `renderer_eager_kb` | 2102 | — | **the size metric of record** (see below) |
-| `renderer_bundle_kb` | 2272 | — | +34% vs 1700 — regression, addressed this run |
-| `artifact_mb.mac_app_unpacked` | 346.2 | ×1.5 growth | re-anchored 2026-09-02, was 478.2 |
-| `artifact_mb.mac_server_payload` | 77 | **100 MB, absolute** | ok — see below |
-| `artifact_mb.mac_asar` | 6 | ×1.5 growth | ok |
+| `renderer_eager_kb` | 2131 | — | **the size metric of record** |
+| `renderer_bundle_kb` | 2301 | — | +1.3% vs 2272 — noise |
+| `artifact_mb.mac_app_unpacked` | 346.2 | x1.5 growth | 3.11.0 pack, unchanged |
+| `artifact_mb.mac_server_payload` | 77 | **100 MB, absolute** | ok |
+| `artifact_mb.mac_asar` | 6 | x1.5 growth | ok |
+
+### The run never shows a window
+
+Every pass launches the app with `TRACE_MCP_AGENT_RUN=1`, which leaves the window
+unmapped (`HIDDEN_WINDOWS` in `src/main/tray.ts`). A 50-minute pass runs on the machine
+somebody is using and must not steal their screen or their Space.
+
+The cost is that `first-contentful-paint` does not exist: Chromium only emits a paint
+entry for a frame the compositor presented, and an unmapped window presents none. So
+`renderer_fcp_ms` is null on every agent run. The replacement is
+**`renderer_first_content_ms`** — a `performance.mark('app-first-content')` the renderer
+sets itself the moment React commits the first content under `#root`
+(`src/renderer/main.tsx`). Same clock, same absence of CDP round-trip, one step earlier
+in the pipeline. **It starts a new series: 133 ms here is not comparable to run 4's
+216 ms of `renderer_fcp_ms`.**
+
+### `ui_p95_ms` was unmeasurable, not just unmeasured
+
+The settle detector calls an action done when the DOM has been quiet for 120 ms. The
+graph's `.cosmos-gpu-label` layer rewrites `transform` and `textContent` on every
+animation frame, indefinitely, so the DOM was never quiet and every action ran into the
+5 s cap. Measured on this machine, same commit, 110 searches: median **4981 ms** with the
+layer counted, **0 ms** without it, 15 cap hits versus none. The number the old detector
+would have published was a measure of the graph animation.
+
+That layer is now excluded (`LIVE` in `perf-measure.mjs`). `workload.churn` in the JSON
+records what was still mutating whenever an action does hit the cap — empty is the healthy
+answer, and anything in it names the element instead of leaving the next run to guess.
+`workload.search_ms_buckets` separates "everything is slow" from "one action in twenty
+stalls"; they want opposite fixes.
+
+### The Graph tab burns 27.7% of a core with nobody touching it
+
+`renderer_cpu_idle_pct` (new this run) is renderer CPU over a 60 s window with no input,
+per view, taken from `cputime` deltas rather than `ps -o %cpu`, which is a decaying
+lifetime average and cannot answer "busy right now". Overview reads 0.2% of a core;
+Graph reads 27.7% (27.0% on an independent 5-minute run the same day). The label layer
+above is the visible half of it: the simulation is continuously re-heated, so the tab
+keeps rendering forever whether or not anything moved. Tracked as its own issue.
+
+### A workload that fails late still reports
+
+A cycle that throws now ends the loop and publishes the samples already taken, marked
+with `workload.aborted`. The attempt before this one lost 19 minutes and 188 cycles to a
+single CDP timeout at minute 19 — which is how three runs in a row ended with these
+fields still null. Below 10 cycles the run still fails: the growth fit would be noise.
 
 ### Which artifact number to trend
 
@@ -57,21 +109,19 @@ render. **Trend `renderer_eager_kb`**; keep `renderer_bundle_kb` as the total-we
 `cold_start_ms` and `window_interactive_ms` are wall-clock across the harness's 20 ms
 poll loop and its CDP round-trips. On a busy machine that inflates them by hundreds of
 milliseconds while the app itself is unchanged — the 2026-08-29 run measured 349 → 1005 ms
-on a machine at load average 11–22 and none of it was the product. `renderer_fcp_ms` is
+on a machine at load average 11–22 and none of it was the product. `renderer_first_content_ms` is
 read off the renderer's own clock after the fact and carries none of that, so **compare
-`renderer_fcp_ms` across runs**; treat the other two as a sanity check against the 3 s
-ceiling only.
+`renderer_first_content_ms` across runs**; treat the other two as a sanity check against
+the 3 s ceiling only. `renderer_fcp_ms` is kept in the JSON but is null on any run that
+does not show a window, which is every agent run.
 
 When a run has to happen on a loaded machine, an interleaved A/B — alternating one sample
 of each build, several rounds — cancels the drift that a back-to-back A-then-B run does not.
 
-`ui_p95_ms`, `heap_after_workload_mb` and `heap_growth_mb_per_hour` are still unfilled in
-`baseline.json`. The harness that produces them landed with TRA-258 and has been run
-end to end, but a publishable pass needs a daemon on 127.0.0.1:3741 that speaks this
-checkout's API — the renderer's `BASE` is hardcoded, so the workload cannot be pointed
-anywhere else. On a machine where another trace-mcp version owns that port, the fixture
-never gets served and the run aborts with `the daemon on 3741 never served <fixture>`.
-Take the first clean pass on a machine with no competing daemon.
+`ui_p95_ms`, `heap_after_workload_mb` and `heap_growth_mb_per_hour` were unfilled until
+2026-09-02, when the workload first completed. It does not need an exclusive daemon: when
+another trace-mcp already holds 3741 the harness registers the fixture with it and hands
+it back at the end, and when nothing holds the port it starts its own and kills it after.
 
 ## How to take a measurement
 

--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -42,7 +42,7 @@
           "main_cpu_idle_pct": 0
         }
       ],
-      "notes": "Installation run \u2014 first entry in the series, no regression comparison possible. Harness: packages/app/scripts/perf-measure.mjs (CDP against a production build, throwaway --user-data-dir per sample). Startup, idle heap and idle CPU are all far inside the absolute ceilings (349 ms vs 3000, 0% vs 2%). Artifact fix landed in this same run: app.asar 21.8 MB -> 1.6 MB and the .app 286 MB -> 265 MB by excluding node_modules from the electron-builder file set (the main process imports only Node builtins + electron; Vite already bundles every renderer dep) and dropping the unused `menubar` dependency. Startup timings are unaffected by that change \u2014 the dev launch path never touches the asar; the 439 ms measured earlier in the same session vs 349 ms here is machine warm-up, not a code delta. Measured negative result: stubbing out the 702 KB cosmos.gl chunk (eagerly loaded via a static import in the entry chunk) moved cold start only 439 -> 417 ms (~5%), so lazy-loading the graph view is not worth the refactor at this size. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour not measured this run \u2014 they need a fixed indexed project fixture, which the next run should add."
+      "notes": "Installation run — first entry in the series, no regression comparison possible. Harness: packages/app/scripts/perf-measure.mjs (CDP against a production build, throwaway --user-data-dir per sample). Startup, idle heap and idle CPU are all far inside the absolute ceilings (349 ms vs 3000, 0% vs 2%). Artifact fix landed in this same run: app.asar 21.8 MB -> 1.6 MB and the .app 286 MB -> 265 MB by excluding node_modules from the electron-builder file set (the main process imports only Node builtins + electron; Vite already bundles every renderer dep) and dropping the unused `menubar` dependency. Startup timings are unaffected by that change — the dev launch path never touches the asar; the 439 ms measured earlier in the same session vs 349 ms here is machine warm-up, not a code delta. Measured negative result: stubbing out the 702 KB cosmos.gl chunk (eagerly loaded via a static import in the entry chunk) moved cold start only 439 -> 417 ms (~5%), so lazy-loading the graph view is not worth the refactor at this size. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour not measured this run — they need a fixed indexed project fixture, which the next run should add."
     },
     {
       "date": "2026-08-28T17:15:00Z",
@@ -71,7 +71,7 @@
           "app_network_utility": 19
         }
       },
-      "notes": "Daemon memory, not the Electron app (GPU out of scope). Source of the 3.34 GB `node` process in the Activity Monitor screenshot: `serve-http`. Identified from the daemon's own vitals heartbeat in ~/.trace-mcp/daemon.log \u2014 peak sample was rss 3619 MB / heap_used 2758 MB at uptime 66 s with projects_loaded=107, against a 166 MB idle baseline with 0 projects. Cause is startup fan-out, not a leak: loadAllRegistered() eagerly added all 110 registered projects. Controlled measurement in an isolated TRACE_MCP_DATA_DIR with 40 *empty* two-file projects: 212 MB (n=1) -> 381 MB (n=10) -> 1198 MB (n=40), i.e. ~9 MB of LIVE JS heap per loaded project (423 MB heapUsed after a forced CDP GC) before the project holds any code. Not a leak \u2014 after the idle-unload sweep dropped all 40 projects a forced GC returned heapUsed to 62 MB and RSS to 198 MB; the flat `heap_used_mb` seen in vitals on an idle daemon is stale-since-last-GC reporting, and macOS holds RSS pages well past the heap shrinking, so both Activity Monitor and vitals rss overstate. Fix: `daemon_eager_load_projects` (default 8) caps startup loading to the most recently indexed projects; the rest lazily load on first MCP connect via the existing idle-unload reload path. Same 40-project fixture after the fix: peak 378 MB (-67%), settled 253 MB, and a deferred project still serves (initialize -> 200, project reaches ready). Single real repo (this one, ~900 files) on the fixed daemon: peak 442 MB, 312 MB after a 10-minute settle. Harness: scale-probe.mjs / lazy-check.mjs / mem-probe.mjs from the TRA-278 workdir (not committed \u2014 they drive a real daemon against throwaway data dirs)."
+      "notes": "Daemon memory, not the Electron app (GPU out of scope). Source of the 3.34 GB `node` process in the Activity Monitor screenshot: `serve-http`. Identified from the daemon's own vitals heartbeat in ~/.trace-mcp/daemon.log — peak sample was rss 3619 MB / heap_used 2758 MB at uptime 66 s with projects_loaded=107, against a 166 MB idle baseline with 0 projects. Cause is startup fan-out, not a leak: loadAllRegistered() eagerly added all 110 registered projects. Controlled measurement in an isolated TRACE_MCP_DATA_DIR with 40 *empty* two-file projects: 212 MB (n=1) -> 381 MB (n=10) -> 1198 MB (n=40), i.e. ~9 MB of LIVE JS heap per loaded project (423 MB heapUsed after a forced CDP GC) before the project holds any code. Not a leak — after the idle-unload sweep dropped all 40 projects a forced GC returned heapUsed to 62 MB and RSS to 198 MB; the flat `heap_used_mb` seen in vitals on an idle daemon is stale-since-last-GC reporting, and macOS holds RSS pages well past the heap shrinking, so both Activity Monitor and vitals rss overstate. Fix: `daemon_eager_load_projects` (default 8) caps startup loading to the most recently indexed projects; the rest lazily load on first MCP connect via the existing idle-unload reload path. Same 40-project fixture after the fix: peak 378 MB (-67%), settled 253 MB, and a deferred project still serves (initialize -> 200, project reaches ready). Single real repo (this one, ~900 files) on the fixed daemon: peak 442 MB, 312 MB after a 10-minute settle. Harness: scale-probe.mjs / lazy-check.mjs / mem-probe.mjs from the TRA-278 workdir (not committed — they drive a real daemon against throwaway data dirs)."
     },
     {
       "date": "2026-08-29T13:35:00Z",
@@ -99,7 +99,7 @@
           "win": null
         }
       },
-      "notes": "MACHINE WAS LOADED \u2014 load average 11-22 throughout (a dozen sibling agent checkouts running their own Electron builds). cold_start_ms and window_interactive_ms are NOT comparable to run 1's 349/121: both are wall-clock across this harness's 20 ms poll loop and CDP round-trips, which a loaded machine inflates by hundreds of ms. Do not read the 349 -> 1005 as a regression. This run adds renderer_fcp_ms, read off the renderer's own clock after the fact and so free of harness latency; use it as the startup metric of record from now on. Interleaved A/B on this same loaded machine, 7 rounds, one sample each, alternating builds: 9459d4ce (run 1's commit) median FCP 288 ms, 9cdccf9b (pre-i18n) 300 ms, 6ebbbd56 (HEAD) 284 ms. Renderer boot is flat-to-slightly-better across the whole range \u2014 the macOS 26 redesign and the i18n runtime cost nothing measurable at startup. The same interleave on window_interactive_ms said 176 -> 507 ms (+188%), which was entirely the harness; that is what motivated the new metric. renderer_bundle_kb 1461 -> 1700 (+16%, warning zone, no issue): i18next+react-i18next runtime +48 KB (e0ec6cc2), the en/ru catalogues +65 KB (TRA-384/385/386), rest CSS/app. REGRESSION FOUND AND FIXED THIS RUN: mac_asar 1.6 -> 5.8 MB (3.6x, past the 1.5x ceiling). TRA-257's blanket !node_modules/** had to be replaced by an explicit node_modules/** include so the main process keeps electron-updater; that re-admitted every production dependency, and the i18n PR made react-i18next (1.0 MB) plus its @babel/runtime tree (1.1 MB) production dependencies even though Vite already bundles them into dist/renderer. Moving react-i18next to devDependencies: 5.8 -> 4.85 MB. The remaining 4.85 is genuine main-process runtime (electron-updater + js-yaml + i18next, which the app menu/tray need). Guarded by packages/app/src/main/__tests__/packaged-deps.test.ts. Process-tree RSS (tree_rss_*) deliberately not taken: a dozen unrelated agent Electron trees were resident, so any ps-based tree number would have been noise. Take those on a quiet machine; run 2's daemon numbers still stand."
+      "notes": "MACHINE WAS LOADED — load average 11-22 throughout (a dozen sibling agent checkouts running their own Electron builds). cold_start_ms and window_interactive_ms are NOT comparable to run 1's 349/121: both are wall-clock across this harness's 20 ms poll loop and CDP round-trips, which a loaded machine inflates by hundreds of ms. Do not read the 349 -> 1005 as a regression. This run adds renderer_fcp_ms, read off the renderer's own clock after the fact and so free of harness latency; use it as the startup metric of record from now on. Interleaved A/B on this same loaded machine, 7 rounds, one sample each, alternating builds: 9459d4ce (run 1's commit) median FCP 288 ms, 9cdccf9b (pre-i18n) 300 ms, 6ebbbd56 (HEAD) 284 ms. Renderer boot is flat-to-slightly-better across the whole range — the macOS 26 redesign and the i18n runtime cost nothing measurable at startup. The same interleave on window_interactive_ms said 176 -> 507 ms (+188%), which was entirely the harness; that is what motivated the new metric. renderer_bundle_kb 1461 -> 1700 (+16%, warning zone, no issue): i18next+react-i18next runtime +48 KB (e0ec6cc2), the en/ru catalogues +65 KB (TRA-384/385/386), rest CSS/app. REGRESSION FOUND AND FIXED THIS RUN: mac_asar 1.6 -> 5.8 MB (3.6x, past the 1.5x ceiling). TRA-257's blanket !node_modules/** had to be replaced by an explicit node_modules/** include so the main process keeps electron-updater; that re-admitted every production dependency, and the i18n PR made react-i18next (1.0 MB) plus its @babel/runtime tree (1.1 MB) production dependencies even though Vite already bundles them into dist/renderer. Moving react-i18next to devDependencies: 5.8 -> 4.85 MB. The remaining 4.85 is genuine main-process runtime (electron-updater + js-yaml + i18next, which the app menu/tray need). Guarded by packages/app/src/main/__tests__/packaged-deps.test.ts. Process-tree RSS (tree_rss_*) deliberately not taken: a dozen unrelated agent Electron trees were resident, so any ps-based tree number would have been noise. Take those on a quiet machine; run 2's daemon numbers still stand."
     },
     {
       "date": "2026-08-30T13:21:30.832Z",
@@ -152,7 +152,959 @@
           "main_cpu_idle_pct": 0
         }
       ],
-      "notes": "Measured with this run's own AskTab code split applied, so it is recorded against the split commit (39026ebd), not its pre-split parent ccc3b45b \u2014 re-measuring at ccc3b45b gives ~2270 KB eager and would read as a regression. renderer_bundle_kb 1700 -> 2272 (+34%) is a real regression against run 3 and is what this run went after: the entry chunk alone had grown 740 -> 1316 KB since 3.2.0. react-markdown + remark-gfm (the Ask tab's only dependency, ~24% of the entry chunk's source) were eagerly bundled; putting AskTab behind React.lazy moved 168 KB out of the startup path (entry 1316 -> 1148 KB). renderer_bundle_kb is unchanged by that fix by construction \u2014 it sums every file on disk \u2014 so this run adds renderer_eager_kb (entry + everything index.html preloads): 2270 -> 2102 KB. Trend renderer_eager_kb from here; renderer_bundle_kb stays as the total-weight check. renderer_fcp_ms 216 vs run 3's 220 and vs 168 measured on the same machine an hour earlier pre-fix: the split does not move FCP, it only removes bytes \u2014 same shape as the 2026-08-28 cosmos.gl negative result. Machine load 6-22 throughout (a dozen sibling agent checkouts), so cold_start_ms/window_interactive_ms are sanity checks against the 3 s ceiling only. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour still null: a foreign daemon held 3741 for this whole run. Process-tree snapshot (uncontrolled, ambient machine, do not trend): the installed app idles at 315 MB across 3 processes, fine; a `serve-http` daemon serving only /tmp/tmcpchk/demo held 884 MB RSS, past the 500 MB idle ceiling. Not filed as an issue because that daemon's history is unknown on a machine running a dozen agents - next run should reproduce it in a controlled scenario before filing."
+      "notes": "Measured with this run's own AskTab code split applied, so it is recorded against the split commit (39026ebd), not its pre-split parent ccc3b45b — re-measuring at ccc3b45b gives ~2270 KB eager and would read as a regression. renderer_bundle_kb 1700 -> 2272 (+34%) is a real regression against run 3 and is what this run went after: the entry chunk alone had grown 740 -> 1316 KB since 3.2.0. react-markdown + remark-gfm (the Ask tab's only dependency, ~24% of the entry chunk's source) were eagerly bundled; putting AskTab behind React.lazy moved 168 KB out of the startup path (entry 1316 -> 1148 KB). renderer_bundle_kb is unchanged by that fix by construction — it sums every file on disk — so this run adds renderer_eager_kb (entry + everything index.html preloads): 2270 -> 2102 KB. Trend renderer_eager_kb from here; renderer_bundle_kb stays as the total-weight check. renderer_fcp_ms 216 vs run 3's 220 and vs 168 measured on the same machine an hour earlier pre-fix: the split does not move FCP, it only removes bytes — same shape as the 2026-08-28 cosmos.gl negative result. Machine load 6-22 throughout (a dozen sibling agent checkouts), so cold_start_ms/window_interactive_ms are sanity checks against the 3 s ceiling only. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour still null: a foreign daemon held 3741 for this whole run. Process-tree snapshot (uncontrolled, ambient machine, do not trend): the installed app idles at 315 MB across 3 processes, fine; a `serve-http` daemon serving only /tmp/tmcpchk/demo held 884 MB RSS, past the 500 MB idle ceiling. Not filed as an issue because that daemon's history is unknown on a machine running a dozen agents - next run should reproduce it in a controlled scenario before filing."
+    },
+    {
+      "date": "2026-09-01T20:40:17.691Z",
+      "app_version": "3.10.0",
+      "commit": "b6b02ae4",
+      "env": {
+        "os": "darwin 25.5.0",
+        "arch": "arm64",
+        "node": "22.22.3"
+      },
+      "samples": 3,
+      "metrics": {
+        "cold_start_ms": 629,
+        "window_interactive_ms": 362,
+        "renderer_fcp_ms": 136,
+        "ui_p95_ms": 668,
+        "heap_idle_mb": 10.7,
+        "heap_after_workload_mb": 11.62,
+        "heap_growth_mb_per_hour": 1.39,
+        "tree_rss_peak_mb": 1691,
+        "tree_rss_idle_mb": 955,
+        "tree_cpu_peak_pct": 155.7,
+        "rss_after_index_settle_mb": 383,
+        "main_cpu_idle_pct": 0,
+        "renderer_bundle_kb": 2270,
+        "renderer_eager_kb": 2100,
+        "artifact_mb": {
+          "mac_app_unpacked": null,
+          "mac_asar": null
+        }
+      },
+      "raw_samples": [
+        {
+          "cold_start_ms": 629,
+          "window_interactive_ms": 362,
+          "renderer_fcp_ms": 132
+        },
+        {
+          "cold_start_ms": 604,
+          "window_interactive_ms": 338,
+          "renderer_fcp_ms": 140
+        },
+        {
+          "cold_start_ms": 637,
+          "window_interactive_ms": 363,
+          "renderer_fcp_ms": 136,
+          "heap_idle_mb": 10.7,
+          "main_cpu_idle_pct": 0
+        }
+      ],
+      "workload": {
+        "fixture": {
+          "commit": "fc47c10f44eb539cbb01b0bb2e4ff633c59b7151",
+          "revision": 2,
+          "files": 1817,
+          "symbols": 9698
+        },
+        "minutes": 30,
+        "index_s": 7,
+        "settle_minutes": 10,
+        "cycles": 572,
+        "cycle_errors": 0,
+        "open_warmup_ms": 74,
+        "open_retries": 0,
+        "open_project_ms": [
+          45,
+          45,
+          62,
+          46,
+          47,
+          45,
+          46,
+          45,
+          43,
+          46,
+          44
+        ],
+        "actions": {
+          "open_project": {
+            "n": 11,
+            "median_ms": 45,
+            "p95_ms": 62
+          },
+          "search": {
+            "n": 5720,
+            "median_ms": 0,
+            "p95_ms": 668
+          },
+          "switch_view": {
+            "n": 1717,
+            "median_ms": 10,
+            "p95_ms": 175
+          }
+        },
+        "heap_series": [
+          {
+            "t_min": 0.05,
+            "heap_mb": 11.62
+          },
+          {
+            "t_min": 0.61,
+            "heap_mb": 11.63
+          },
+          {
+            "t_min": 1.17,
+            "heap_mb": 11.67
+          },
+          {
+            "t_min": 1.77,
+            "heap_mb": 10.61
+          },
+          {
+            "t_min": 2.39,
+            "heap_mb": 9.3
+          },
+          {
+            "t_min": 3,
+            "heap_mb": 9.31
+          },
+          {
+            "t_min": 3.6,
+            "heap_mb": 9.35
+          },
+          {
+            "t_min": 4.17,
+            "heap_mb": 9.38
+          },
+          {
+            "t_min": 4.73,
+            "heap_mb": 9.54
+          },
+          {
+            "t_min": 5.31,
+            "heap_mb": 9.42
+          },
+          {
+            "t_min": 5.9,
+            "heap_mb": 9.4
+          },
+          {
+            "t_min": 6.52,
+            "heap_mb": 9.41
+          },
+          {
+            "t_min": 7.14,
+            "heap_mb": 9.42
+          },
+          {
+            "t_min": 7.77,
+            "heap_mb": 9.43
+          },
+          {
+            "t_min": 8.35,
+            "heap_mb": 9.58
+          },
+          {
+            "t_min": 8.92,
+            "heap_mb": 9.46
+          },
+          {
+            "t_min": 9.47,
+            "heap_mb": 9.59
+          },
+          {
+            "t_min": 10.1,
+            "heap_mb": 12.13
+          },
+          {
+            "t_min": 10.7,
+            "heap_mb": 9.67
+          },
+          {
+            "t_min": 11.31,
+            "heap_mb": 9.7
+          },
+          {
+            "t_min": 11.92,
+            "heap_mb": 9.7
+          },
+          {
+            "t_min": 12.38,
+            "heap_mb": 9.74
+          },
+          {
+            "t_min": 12.71,
+            "heap_mb": 9.74
+          },
+          {
+            "t_min": 13.02,
+            "heap_mb": 9.77
+          },
+          {
+            "t_min": 13.34,
+            "heap_mb": 9.77
+          },
+          {
+            "t_min": 13.77,
+            "heap_mb": 9.86
+          },
+          {
+            "t_min": 14.22,
+            "heap_mb": 9.77
+          },
+          {
+            "t_min": 14.61,
+            "heap_mb": 9.77
+          },
+          {
+            "t_min": 14.97,
+            "heap_mb": 9.75
+          },
+          {
+            "t_min": 15.52,
+            "heap_mb": 9.75
+          },
+          {
+            "t_min": 16.16,
+            "heap_mb": 11.09
+          },
+          {
+            "t_min": 16.77,
+            "heap_mb": 11.09
+          },
+          {
+            "t_min": 17.39,
+            "heap_mb": 9.77
+          },
+          {
+            "t_min": 17.94,
+            "heap_mb": 12.24
+          },
+          {
+            "t_min": 18.52,
+            "heap_mb": 9.79
+          },
+          {
+            "t_min": 19.1,
+            "heap_mb": 9.81
+          },
+          {
+            "t_min": 19.59,
+            "heap_mb": 9.78
+          },
+          {
+            "t_min": 20.18,
+            "heap_mb": 9.77
+          },
+          {
+            "t_min": 20.7,
+            "heap_mb": 9.8
+          },
+          {
+            "t_min": 21.19,
+            "heap_mb": 12.32
+          },
+          {
+            "t_min": 21.79,
+            "heap_mb": 9.9
+          },
+          {
+            "t_min": 22.37,
+            "heap_mb": 9.78
+          },
+          {
+            "t_min": 22.84,
+            "heap_mb": 9.9
+          },
+          {
+            "t_min": 23.33,
+            "heap_mb": 9.83
+          },
+          {
+            "t_min": 23.67,
+            "heap_mb": 9.83
+          },
+          {
+            "t_min": 24.06,
+            "heap_mb": 9.82
+          },
+          {
+            "t_min": 24.41,
+            "heap_mb": 9.81
+          },
+          {
+            "t_min": 24.77,
+            "heap_mb": 9.81
+          },
+          {
+            "t_min": 25.2,
+            "heap_mb": 9.81
+          },
+          {
+            "t_min": 25.8,
+            "heap_mb": 9.81
+          },
+          {
+            "t_min": 26.4,
+            "heap_mb": 9.81
+          },
+          {
+            "t_min": 27,
+            "heap_mb": 9.82
+          },
+          {
+            "t_min": 27.54,
+            "heap_mb": 9.85
+          },
+          {
+            "t_min": 27.93,
+            "heap_mb": 9.85
+          },
+          {
+            "t_min": 28.25,
+            "heap_mb": 12.32
+          },
+          {
+            "t_min": 28.81,
+            "heap_mb": 9.82
+          },
+          {
+            "t_min": 29.41,
+            "heap_mb": 9.83
+          },
+          {
+            "t_min": 29.99,
+            "heap_mb": 9.87
+          },
+          {
+            "t_min": 30.01,
+            "heap_mb": 9.87
+          }
+        ],
+        "tree_series": [
+          {
+            "t": 1788292743314,
+            "app_rss_mb": 509,
+            "app_cpu_pct": 0.1,
+            "app_procs": 4,
+            "daemon_rss_mb": 727,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1236,
+            "cpu_pct": 0.1
+          },
+          {
+            "t": 1788292788325,
+            "app_rss_mb": 511,
+            "app_cpu_pct": 0,
+            "app_procs": 4,
+            "daemon_rss_mb": 444,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 955,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788292833335,
+            "app_rss_mb": 621,
+            "app_cpu_pct": 60.8,
+            "app_procs": 4,
+            "daemon_rss_mb": 808,
+            "daemon_cpu_pct": 44.7,
+            "daemon_procs": 1,
+            "rss_mb": 1429,
+            "cpu_pct": 105.5
+          },
+          {
+            "t": 1788292878355,
+            "app_rss_mb": 627,
+            "app_cpu_pct": 65.9,
+            "app_procs": 4,
+            "daemon_rss_mb": 915,
+            "daemon_cpu_pct": 0.2,
+            "daemon_procs": 1,
+            "rss_mb": 1542,
+            "cpu_pct": 66.1
+          },
+          {
+            "t": 1788292923364,
+            "app_rss_mb": 626,
+            "app_cpu_pct": 60.5,
+            "app_procs": 4,
+            "daemon_rss_mb": 932,
+            "daemon_cpu_pct": 17.2,
+            "daemon_procs": 1,
+            "rss_mb": 1558,
+            "cpu_pct": 77.7
+          },
+          {
+            "t": 1788292968369,
+            "app_rss_mb": 632,
+            "app_cpu_pct": 59.8,
+            "app_procs": 4,
+            "daemon_rss_mb": 932,
+            "daemon_cpu_pct": 3.3,
+            "daemon_procs": 1,
+            "rss_mb": 1564,
+            "cpu_pct": 63.1
+          },
+          {
+            "t": 1788293013392,
+            "app_rss_mb": 639,
+            "app_cpu_pct": 73,
+            "app_procs": 4,
+            "daemon_rss_mb": 934,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1573,
+            "cpu_pct": 73
+          },
+          {
+            "t": 1788293058440,
+            "app_rss_mb": 640,
+            "app_cpu_pct": 101.1,
+            "app_procs": 4,
+            "daemon_rss_mb": 937,
+            "daemon_cpu_pct": 0.1,
+            "daemon_procs": 1,
+            "rss_mb": 1577,
+            "cpu_pct": 101.2
+          },
+          {
+            "t": 1788293103417,
+            "app_rss_mb": 643,
+            "app_cpu_pct": 71.1,
+            "app_procs": 4,
+            "daemon_rss_mb": 965,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1608,
+            "cpu_pct": 71.1
+          },
+          {
+            "t": 1788293148444,
+            "app_rss_mb": 643,
+            "app_cpu_pct": 60.4,
+            "app_procs": 4,
+            "daemon_rss_mb": 949,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1592,
+            "cpu_pct": 60.4
+          },
+          {
+            "t": 1788293193431,
+            "app_rss_mb": 643,
+            "app_cpu_pct": 29.4,
+            "app_procs": 4,
+            "daemon_rss_mb": 970,
+            "daemon_cpu_pct": 22.3,
+            "daemon_procs": 1,
+            "rss_mb": 1613,
+            "cpu_pct": 51.7
+          },
+          {
+            "t": 1788293238451,
+            "app_rss_mb": 642,
+            "app_cpu_pct": 35.9,
+            "app_procs": 4,
+            "daemon_rss_mb": 969,
+            "daemon_cpu_pct": 58.2,
+            "daemon_procs": 1,
+            "rss_mb": 1611,
+            "cpu_pct": 94.1
+          },
+          {
+            "t": 1788293283455,
+            "app_rss_mb": 650,
+            "app_cpu_pct": 61.1,
+            "app_procs": 4,
+            "daemon_rss_mb": 979,
+            "daemon_cpu_pct": 0.2,
+            "daemon_procs": 1,
+            "rss_mb": 1628,
+            "cpu_pct": 61.3
+          },
+          {
+            "t": 1788293328464,
+            "app_rss_mb": 650,
+            "app_cpu_pct": 63.6,
+            "app_procs": 4,
+            "daemon_rss_mb": 993,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1644,
+            "cpu_pct": 63.6
+          },
+          {
+            "t": 1788293373556,
+            "app_rss_mb": 651,
+            "app_cpu_pct": 102.2,
+            "app_procs": 4,
+            "daemon_rss_mb": 986,
+            "daemon_cpu_pct": 1,
+            "daemon_procs": 1,
+            "rss_mb": 1637,
+            "cpu_pct": 103.2
+          },
+          {
+            "t": 1788293418498,
+            "app_rss_mb": 654,
+            "app_cpu_pct": 73.5,
+            "app_procs": 4,
+            "daemon_rss_mb": 979,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1633,
+            "cpu_pct": 73.5
+          },
+          {
+            "t": 1788293463509,
+            "app_rss_mb": 654,
+            "app_cpu_pct": 62.3,
+            "app_procs": 4,
+            "daemon_rss_mb": 969,
+            "daemon_cpu_pct": 7.3,
+            "daemon_procs": 1,
+            "rss_mb": 1623,
+            "cpu_pct": 69.6
+          },
+          {
+            "t": 1788293508532,
+            "app_rss_mb": 657,
+            "app_cpu_pct": 65.2,
+            "app_procs": 4,
+            "daemon_rss_mb": 971,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1628,
+            "cpu_pct": 65.2
+          },
+          {
+            "t": 1788293553638,
+            "app_rss_mb": 640,
+            "app_cpu_pct": 28.4,
+            "app_procs": 4,
+            "daemon_rss_mb": 1001,
+            "daemon_cpu_pct": 35.5,
+            "daemon_procs": 1,
+            "rss_mb": 1640,
+            "cpu_pct": 63.9
+          },
+          {
+            "t": 1788293598632,
+            "app_rss_mb": 646,
+            "app_cpu_pct": 27.9,
+            "app_procs": 4,
+            "daemon_rss_mb": 984,
+            "daemon_cpu_pct": 19.8,
+            "daemon_procs": 1,
+            "rss_mb": 1630,
+            "cpu_pct": 47.7
+          },
+          {
+            "t": 1788293643633,
+            "app_rss_mb": 657,
+            "app_cpu_pct": 99.9,
+            "app_procs": 4,
+            "daemon_rss_mb": 975,
+            "daemon_cpu_pct": 10.4,
+            "daemon_procs": 1,
+            "rss_mb": 1632,
+            "cpu_pct": 110.3
+          },
+          {
+            "t": 1788293688751,
+            "app_rss_mb": 645,
+            "app_cpu_pct": 45.5,
+            "app_procs": 4,
+            "daemon_rss_mb": 989,
+            "daemon_cpu_pct": 26.4,
+            "daemon_procs": 1,
+            "rss_mb": 1635,
+            "cpu_pct": 71.9
+          },
+          {
+            "t": 1788293733657,
+            "app_rss_mb": 661,
+            "app_cpu_pct": 66.1,
+            "app_procs": 4,
+            "daemon_rss_mb": 988,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1649,
+            "cpu_pct": 66.1
+          },
+          {
+            "t": 1788293778653,
+            "app_rss_mb": 661,
+            "app_cpu_pct": 49.3,
+            "app_procs": 4,
+            "daemon_rss_mb": 970,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1631,
+            "cpu_pct": 49.3
+          },
+          {
+            "t": 1788293823676,
+            "app_rss_mb": 665,
+            "app_cpu_pct": 37.9,
+            "app_procs": 4,
+            "daemon_rss_mb": 972,
+            "daemon_cpu_pct": 25.2,
+            "daemon_procs": 1,
+            "rss_mb": 1636,
+            "cpu_pct": 63.1
+          },
+          {
+            "t": 1788293868685,
+            "app_rss_mb": 666,
+            "app_cpu_pct": 58.8,
+            "app_procs": 4,
+            "daemon_rss_mb": 980,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1646,
+            "cpu_pct": 58.8
+          },
+          {
+            "t": 1788293913704,
+            "app_rss_mb": 667,
+            "app_cpu_pct": 63.7,
+            "app_procs": 4,
+            "daemon_rss_mb": 978,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1645,
+            "cpu_pct": 63.7
+          },
+          {
+            "t": 1788293958755,
+            "app_rss_mb": 663,
+            "app_cpu_pct": 93.4,
+            "app_procs": 4,
+            "daemon_rss_mb": 1000,
+            "daemon_cpu_pct": 10.7,
+            "daemon_procs": 1,
+            "rss_mb": 1663,
+            "cpu_pct": 104.1
+          },
+          {
+            "t": 1788294003746,
+            "app_rss_mb": 670,
+            "app_cpu_pct": 83.2,
+            "app_procs": 4,
+            "daemon_rss_mb": 976,
+            "daemon_cpu_pct": 15.2,
+            "daemon_procs": 1,
+            "rss_mb": 1646,
+            "cpu_pct": 98.4
+          },
+          {
+            "t": 1788294048841,
+            "app_rss_mb": 648,
+            "app_cpu_pct": 48.9,
+            "app_procs": 4,
+            "daemon_rss_mb": 977,
+            "daemon_cpu_pct": 28.9,
+            "daemon_procs": 1,
+            "rss_mb": 1625,
+            "cpu_pct": 77.8
+          },
+          {
+            "t": 1788294093793,
+            "app_rss_mb": 668,
+            "app_cpu_pct": 85.8,
+            "app_procs": 4,
+            "daemon_rss_mb": 997,
+            "daemon_cpu_pct": 1,
+            "daemon_procs": 1,
+            "rss_mb": 1665,
+            "cpu_pct": 86.8
+          },
+          {
+            "t": 1788294138824,
+            "app_rss_mb": 668,
+            "app_cpu_pct": 92,
+            "app_procs": 4,
+            "daemon_rss_mb": 999,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1667,
+            "cpu_pct": 92
+          },
+          {
+            "t": 1788294183953,
+            "app_rss_mb": 660,
+            "app_cpu_pct": 29.6,
+            "app_procs": 4,
+            "daemon_rss_mb": 982,
+            "daemon_cpu_pct": 28.9,
+            "daemon_procs": 1,
+            "rss_mb": 1641,
+            "cpu_pct": 58.5
+          },
+          {
+            "t": 1788294228848,
+            "app_rss_mb": 670,
+            "app_cpu_pct": 92.3,
+            "app_procs": 4,
+            "daemon_rss_mb": 988,
+            "daemon_cpu_pct": 0.6,
+            "daemon_procs": 1,
+            "rss_mb": 1658,
+            "cpu_pct": 92.9
+          },
+          {
+            "t": 1788294273878,
+            "app_rss_mb": 665,
+            "app_cpu_pct": 73.8,
+            "app_procs": 4,
+            "daemon_rss_mb": 992,
+            "daemon_cpu_pct": 29.6,
+            "daemon_procs": 1,
+            "rss_mb": 1657,
+            "cpu_pct": 103.4
+          },
+          {
+            "t": 1788294318879,
+            "app_rss_mb": 668,
+            "app_cpu_pct": 108.3,
+            "app_procs": 4,
+            "daemon_rss_mb": 974,
+            "daemon_cpu_pct": 39,
+            "daemon_procs": 1,
+            "rss_mb": 1641,
+            "cpu_pct": 147.3
+          },
+          {
+            "t": 1788294363877,
+            "app_rss_mb": 674,
+            "app_cpu_pct": 88,
+            "app_procs": 4,
+            "daemon_rss_mb": 994,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1668,
+            "cpu_pct": 88
+          },
+          {
+            "t": 1788294408880,
+            "app_rss_mb": 673,
+            "app_cpu_pct": 81.9,
+            "app_procs": 4,
+            "daemon_rss_mb": 992,
+            "daemon_cpu_pct": 8.3,
+            "daemon_procs": 1,
+            "rss_mb": 1664,
+            "cpu_pct": 90.2
+          },
+          {
+            "t": 1788294453983,
+            "app_rss_mb": 673,
+            "app_cpu_pct": 100.4,
+            "app_procs": 4,
+            "daemon_rss_mb": 1006,
+            "daemon_cpu_pct": 0.1,
+            "daemon_procs": 1,
+            "rss_mb": 1679,
+            "cpu_pct": 100.5
+          },
+          {
+            "t": 1788294498963,
+            "app_rss_mb": 654,
+            "app_cpu_pct": 36.7,
+            "app_procs": 4,
+            "daemon_rss_mb": 1014,
+            "daemon_cpu_pct": 29.2,
+            "daemon_procs": 1,
+            "rss_mb": 1668,
+            "cpu_pct": 65.9
+          },
+          {
+            "t": 1788294543892,
+            "app_rss_mb": 676,
+            "app_cpu_pct": 77.6,
+            "app_procs": 4,
+            "daemon_rss_mb": 998,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1674,
+            "cpu_pct": 77.6
+          },
+          {
+            "t": 1788294588907,
+            "app_rss_mb": 674,
+            "app_cpu_pct": 58.3,
+            "app_procs": 4,
+            "daemon_rss_mb": 991,
+            "daemon_cpu_pct": 43.6,
+            "daemon_procs": 1,
+            "rss_mb": 1666,
+            "cpu_pct": 101.9
+          },
+          {
+            "t": 1788294634007,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 1018,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1018,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788294679964,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 500,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 500,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788294725490,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 500,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 500,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788294771183,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 500,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 500,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788294816812,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 500,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 500,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788294862410,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 454,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 454,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788294907780,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 383,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 383,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788294953468,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 383,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 383,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788294999135,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 383,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 383,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788295045128,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 383,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 383,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788295090787,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 383,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 383,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788295136419,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 383,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 383,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788295181958,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 383,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 383,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788295212283,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 383,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 383,
+            "cpu_pct": 0
+          }
+        ]
+      },
+      "notes": "First run to fill ui_p95_ms, heap_after_workload_mb, heap_growth_mb_per_hour and the process-tree set — they had been null in four consecutive entries (TRA-617). The stated blocker each time was \"a foreign daemon held 3741 for the whole run\", and the plan was to wait for an uncontended host. That host does not exist here: this machine permanently runs a dozen sibling agent checkouts, and the ambient daemon held 3741 with 22 registered projects and one mid-index throughout this run too. The blocker was never contention, it was port ownership. The harness now runs its own daemon on 37412 against a throwaway TRACE_MCP_DATA_DIR and rewrites the renderer's hardcoded 127.0.0.1:3741 onto it over CDP (Fetch.requestPaused -> continueRequest with a swapped port) — the technique scripts/tabs-scale.mjs already used. HARNESS DEFECT FOUND AND FIXED, and it invalidates nothing earlier only because nothing earlier ever produced these numbers: ui_p95_ms first came out as exactly 5000 with a search median of 4987, which is the harness's own 5 s settle cap, not the app. Cause, measured: the GPU graph repaints its .cosmos-gpu-label overlay every animation frame — 3810-5863 mutations per 8 s window with no input at all, ~730/s — so the whole-document MutationObserver never saw the 120 ms of quiet that ends an action, and every Graph-tab action ran to the cap. Mutations inside that layer no longer count (pin revision 1 -> 2); the same cycle then takes ~3 s instead of ~85 s and ui_p95_ms reads 668 ms. SECOND HARNESS DEFECT, same shape one layer up: the CDP port was hardcoded to 9333, and a Chrome started by chrome-devtools-mcp already owned it, so a run attached to a Chrome tab instead of the app it had just spawned and reported cold_start_ms 23 / window_interactive_ms 16327 without complaining. Each launch now takes a free port from 9333-9353 and fails outright unless the process listening on it is inside its own child's process tree. A third fix earned the hard way: a run that reached cycle 299 of 30 minutes threw \"Inspected target navigated or closed\" and discarded every measurement it had taken, so a failed cycle now reopens the project and continues, and the entry is written even if the workload dies. MACHINE WAS LOADED throughout — load average mean 21.9, peak 50.8 on 18 cores, from sibling agents. cold_start_ms and window_interactive_ms carry that (see the run-3 note); renderer_fcp_ms 136 does not and is flat against 216/220 from the last two runs. Workload: 572 cycles over 30.0 min, 0 cycle errors, 0 open retries, fixture indexed cold in 7.0 s (1817 files, 9698 symbols). Per-action p95: open_project 62 ms (n=11), switch_view 175 ms (n=1717), search 668 ms (n=5720) — ui_p95_ms is the worst of the three, so it is the search figure. The search MEDIAN is 0 ms and that is not a broken measurement: the graph typeahead filters nodes the renderer already holds, and the probe timed the results list settling 0-3 ms after the keystroke. No leak: post-GC heap moved 11.62 -> 9.87 MB across 572 cycles, range 9.3-12.32, least-squares slope +1.39 MB/h against a 50 MB/h ceiling. Process tree, sampled every 5 s across both trees: the app holds 509 MB idle and 654 MB median under load across 4 processes; the DAEMON holds 727 MB at idle and 1014 MB peak while serving exactly ONE 1817-file project, and 383 MB ten minutes after the app exits. That reproduces, in a controlled single-project scenario with a fresh data dir, the 884 MB the 2026-08-30 run saw on an ambient daemon and declined to file — it is not that daemon's history, one small project genuinely costs ~700 MB resident, past the 500 MB idle ceiling. Filed separately; not fixed here, because this run's job was to produce the numbers, and a fix measured against a baseline that did not exist yet would have been a guess. tree_cpu_peak_pct 155.7 is the combined tree and sums over cores; the app alone peaked at 108% during the graph workload, which is the same label-overlay repaint the settle fix exposed. artifact_mb not taken: pnpm run pack sat in codesign for ~25 minutes on the loaded machine and was abandoned rather than delay the run; it is guarded by packages/app/src/main/__tests__/packaged-deps.test.ts and last read 4.85 / 268.1 at 6ebbbd56."
     }
   ]
 }

--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -42,7 +42,7 @@
           "main_cpu_idle_pct": 0
         }
       ],
-      "notes": "Installation run — first entry in the series, no regression comparison possible. Harness: packages/app/scripts/perf-measure.mjs (CDP against a production build, throwaway --user-data-dir per sample). Startup, idle heap and idle CPU are all far inside the absolute ceilings (349 ms vs 3000, 0% vs 2%). Artifact fix landed in this same run: app.asar 21.8 MB -> 1.6 MB and the .app 286 MB -> 265 MB by excluding node_modules from the electron-builder file set (the main process imports only Node builtins + electron; Vite already bundles every renderer dep) and dropping the unused `menubar` dependency. Startup timings are unaffected by that change — the dev launch path never touches the asar; the 439 ms measured earlier in the same session vs 349 ms here is machine warm-up, not a code delta. Measured negative result: stubbing out the 702 KB cosmos.gl chunk (eagerly loaded via a static import in the entry chunk) moved cold start only 439 -> 417 ms (~5%), so lazy-loading the graph view is not worth the refactor at this size. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour not measured this run — they need a fixed indexed project fixture, which the next run should add."
+      "notes": "Installation run \u2014 first entry in the series, no regression comparison possible. Harness: packages/app/scripts/perf-measure.mjs (CDP against a production build, throwaway --user-data-dir per sample). Startup, idle heap and idle CPU are all far inside the absolute ceilings (349 ms vs 3000, 0% vs 2%). Artifact fix landed in this same run: app.asar 21.8 MB -> 1.6 MB and the .app 286 MB -> 265 MB by excluding node_modules from the electron-builder file set (the main process imports only Node builtins + electron; Vite already bundles every renderer dep) and dropping the unused `menubar` dependency. Startup timings are unaffected by that change \u2014 the dev launch path never touches the asar; the 439 ms measured earlier in the same session vs 349 ms here is machine warm-up, not a code delta. Measured negative result: stubbing out the 702 KB cosmos.gl chunk (eagerly loaded via a static import in the entry chunk) moved cold start only 439 -> 417 ms (~5%), so lazy-loading the graph view is not worth the refactor at this size. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour not measured this run \u2014 they need a fixed indexed project fixture, which the next run should add."
     },
     {
       "date": "2026-08-28T17:15:00Z",
@@ -71,7 +71,7 @@
           "app_network_utility": 19
         }
       },
-      "notes": "Daemon memory, not the Electron app (GPU out of scope). Source of the 3.34 GB `node` process in the Activity Monitor screenshot: `serve-http`. Identified from the daemon's own vitals heartbeat in ~/.trace-mcp/daemon.log — peak sample was rss 3619 MB / heap_used 2758 MB at uptime 66 s with projects_loaded=107, against a 166 MB idle baseline with 0 projects. Cause is startup fan-out, not a leak: loadAllRegistered() eagerly added all 110 registered projects. Controlled measurement in an isolated TRACE_MCP_DATA_DIR with 40 *empty* two-file projects: 212 MB (n=1) -> 381 MB (n=10) -> 1198 MB (n=40), i.e. ~9 MB of LIVE JS heap per loaded project (423 MB heapUsed after a forced CDP GC) before the project holds any code. Not a leak — after the idle-unload sweep dropped all 40 projects a forced GC returned heapUsed to 62 MB and RSS to 198 MB; the flat `heap_used_mb` seen in vitals on an idle daemon is stale-since-last-GC reporting, and macOS holds RSS pages well past the heap shrinking, so both Activity Monitor and vitals rss overstate. Fix: `daemon_eager_load_projects` (default 8) caps startup loading to the most recently indexed projects; the rest lazily load on first MCP connect via the existing idle-unload reload path. Same 40-project fixture after the fix: peak 378 MB (-67%), settled 253 MB, and a deferred project still serves (initialize -> 200, project reaches ready). Single real repo (this one, ~900 files) on the fixed daemon: peak 442 MB, 312 MB after a 10-minute settle. Harness: scale-probe.mjs / lazy-check.mjs / mem-probe.mjs from the TRA-278 workdir (not committed — they drive a real daemon against throwaway data dirs)."
+      "notes": "Daemon memory, not the Electron app (GPU out of scope). Source of the 3.34 GB `node` process in the Activity Monitor screenshot: `serve-http`. Identified from the daemon's own vitals heartbeat in ~/.trace-mcp/daemon.log \u2014 peak sample was rss 3619 MB / heap_used 2758 MB at uptime 66 s with projects_loaded=107, against a 166 MB idle baseline with 0 projects. Cause is startup fan-out, not a leak: loadAllRegistered() eagerly added all 110 registered projects. Controlled measurement in an isolated TRACE_MCP_DATA_DIR with 40 *empty* two-file projects: 212 MB (n=1) -> 381 MB (n=10) -> 1198 MB (n=40), i.e. ~9 MB of LIVE JS heap per loaded project (423 MB heapUsed after a forced CDP GC) before the project holds any code. Not a leak \u2014 after the idle-unload sweep dropped all 40 projects a forced GC returned heapUsed to 62 MB and RSS to 198 MB; the flat `heap_used_mb` seen in vitals on an idle daemon is stale-since-last-GC reporting, and macOS holds RSS pages well past the heap shrinking, so both Activity Monitor and vitals rss overstate. Fix: `daemon_eager_load_projects` (default 8) caps startup loading to the most recently indexed projects; the rest lazily load on first MCP connect via the existing idle-unload reload path. Same 40-project fixture after the fix: peak 378 MB (-67%), settled 253 MB, and a deferred project still serves (initialize -> 200, project reaches ready). Single real repo (this one, ~900 files) on the fixed daemon: peak 442 MB, 312 MB after a 10-minute settle. Harness: scale-probe.mjs / lazy-check.mjs / mem-probe.mjs from the TRA-278 workdir (not committed \u2014 they drive a real daemon against throwaway data dirs)."
     },
     {
       "date": "2026-08-29T13:35:00Z",
@@ -99,7 +99,7 @@
           "win": null
         }
       },
-      "notes": "MACHINE WAS LOADED — load average 11-22 throughout (a dozen sibling agent checkouts running their own Electron builds). cold_start_ms and window_interactive_ms are NOT comparable to run 1's 349/121: both are wall-clock across this harness's 20 ms poll loop and CDP round-trips, which a loaded machine inflates by hundreds of ms. Do not read the 349 -> 1005 as a regression. This run adds renderer_fcp_ms, read off the renderer's own clock after the fact and so free of harness latency; use it as the startup metric of record from now on. Interleaved A/B on this same loaded machine, 7 rounds, one sample each, alternating builds: 9459d4ce (run 1's commit) median FCP 288 ms, 9cdccf9b (pre-i18n) 300 ms, 6ebbbd56 (HEAD) 284 ms. Renderer boot is flat-to-slightly-better across the whole range — the macOS 26 redesign and the i18n runtime cost nothing measurable at startup. The same interleave on window_interactive_ms said 176 -> 507 ms (+188%), which was entirely the harness; that is what motivated the new metric. renderer_bundle_kb 1461 -> 1700 (+16%, warning zone, no issue): i18next+react-i18next runtime +48 KB (e0ec6cc2), the en/ru catalogues +65 KB (TRA-384/385/386), rest CSS/app. REGRESSION FOUND AND FIXED THIS RUN: mac_asar 1.6 -> 5.8 MB (3.6x, past the 1.5x ceiling). TRA-257's blanket !node_modules/** had to be replaced by an explicit node_modules/** include so the main process keeps electron-updater; that re-admitted every production dependency, and the i18n PR made react-i18next (1.0 MB) plus its @babel/runtime tree (1.1 MB) production dependencies even though Vite already bundles them into dist/renderer. Moving react-i18next to devDependencies: 5.8 -> 4.85 MB. The remaining 4.85 is genuine main-process runtime (electron-updater + js-yaml + i18next, which the app menu/tray need). Guarded by packages/app/src/main/__tests__/packaged-deps.test.ts. Process-tree RSS (tree_rss_*) deliberately not taken: a dozen unrelated agent Electron trees were resident, so any ps-based tree number would have been noise. Take those on a quiet machine; run 2's daemon numbers still stand."
+      "notes": "MACHINE WAS LOADED \u2014 load average 11-22 throughout (a dozen sibling agent checkouts running their own Electron builds). cold_start_ms and window_interactive_ms are NOT comparable to run 1's 349/121: both are wall-clock across this harness's 20 ms poll loop and CDP round-trips, which a loaded machine inflates by hundreds of ms. Do not read the 349 -> 1005 as a regression. This run adds renderer_fcp_ms, read off the renderer's own clock after the fact and so free of harness latency; use it as the startup metric of record from now on. Interleaved A/B on this same loaded machine, 7 rounds, one sample each, alternating builds: 9459d4ce (run 1's commit) median FCP 288 ms, 9cdccf9b (pre-i18n) 300 ms, 6ebbbd56 (HEAD) 284 ms. Renderer boot is flat-to-slightly-better across the whole range \u2014 the macOS 26 redesign and the i18n runtime cost nothing measurable at startup. The same interleave on window_interactive_ms said 176 -> 507 ms (+188%), which was entirely the harness; that is what motivated the new metric. renderer_bundle_kb 1461 -> 1700 (+16%, warning zone, no issue): i18next+react-i18next runtime +48 KB (e0ec6cc2), the en/ru catalogues +65 KB (TRA-384/385/386), rest CSS/app. REGRESSION FOUND AND FIXED THIS RUN: mac_asar 1.6 -> 5.8 MB (3.6x, past the 1.5x ceiling). TRA-257's blanket !node_modules/** had to be replaced by an explicit node_modules/** include so the main process keeps electron-updater; that re-admitted every production dependency, and the i18n PR made react-i18next (1.0 MB) plus its @babel/runtime tree (1.1 MB) production dependencies even though Vite already bundles them into dist/renderer. Moving react-i18next to devDependencies: 5.8 -> 4.85 MB. The remaining 4.85 is genuine main-process runtime (electron-updater + js-yaml + i18next, which the app menu/tray need). Guarded by packages/app/src/main/__tests__/packaged-deps.test.ts. Process-tree RSS (tree_rss_*) deliberately not taken: a dozen unrelated agent Electron trees were resident, so any ps-based tree number would have been noise. Take those on a quiet machine; run 2's daemon numbers still stand."
     },
     {
       "date": "2026-08-30T13:21:30.832Z",
@@ -152,7 +152,7 @@
           "main_cpu_idle_pct": 0
         }
       ],
-      "notes": "Measured with this run's own AskTab code split applied, so it is recorded against the split commit (39026ebd), not its pre-split parent ccc3b45b — re-measuring at ccc3b45b gives ~2270 KB eager and would read as a regression. renderer_bundle_kb 1700 -> 2272 (+34%) is a real regression against run 3 and is what this run went after: the entry chunk alone had grown 740 -> 1316 KB since 3.2.0. react-markdown + remark-gfm (the Ask tab's only dependency, ~24% of the entry chunk's source) were eagerly bundled; putting AskTab behind React.lazy moved 168 KB out of the startup path (entry 1316 -> 1148 KB). renderer_bundle_kb is unchanged by that fix by construction — it sums every file on disk — so this run adds renderer_eager_kb (entry + everything index.html preloads): 2270 -> 2102 KB. Trend renderer_eager_kb from here; renderer_bundle_kb stays as the total-weight check. renderer_fcp_ms 216 vs run 3's 220 and vs 168 measured on the same machine an hour earlier pre-fix: the split does not move FCP, it only removes bytes — same shape as the 2026-08-28 cosmos.gl negative result. Machine load 6-22 throughout (a dozen sibling agent checkouts), so cold_start_ms/window_interactive_ms are sanity checks against the 3 s ceiling only. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour still null: a foreign daemon held 3741 for this whole run. Process-tree snapshot (uncontrolled, ambient machine, do not trend): the installed app idles at 315 MB across 3 processes, fine; a `serve-http` daemon serving only /tmp/tmcpchk/demo held 884 MB RSS, past the 500 MB idle ceiling. Not filed as an issue because that daemon's history is unknown on a machine running a dozen agents - next run should reproduce it in a controlled scenario before filing."
+      "notes": "Measured with this run's own AskTab code split applied, so it is recorded against the split commit (39026ebd), not its pre-split parent ccc3b45b \u2014 re-measuring at ccc3b45b gives ~2270 KB eager and would read as a regression. renderer_bundle_kb 1700 -> 2272 (+34%) is a real regression against run 3 and is what this run went after: the entry chunk alone had grown 740 -> 1316 KB since 3.2.0. react-markdown + remark-gfm (the Ask tab's only dependency, ~24% of the entry chunk's source) were eagerly bundled; putting AskTab behind React.lazy moved 168 KB out of the startup path (entry 1316 -> 1148 KB). renderer_bundle_kb is unchanged by that fix by construction \u2014 it sums every file on disk \u2014 so this run adds renderer_eager_kb (entry + everything index.html preloads): 2270 -> 2102 KB. Trend renderer_eager_kb from here; renderer_bundle_kb stays as the total-weight check. renderer_fcp_ms 216 vs run 3's 220 and vs 168 measured on the same machine an hour earlier pre-fix: the split does not move FCP, it only removes bytes \u2014 same shape as the 2026-08-28 cosmos.gl negative result. Machine load 6-22 throughout (a dozen sibling agent checkouts), so cold_start_ms/window_interactive_ms are sanity checks against the 3 s ceiling only. ui_p95_ms / heap_after_workload_mb / heap_growth_mb_per_hour still null: a foreign daemon held 3741 for this whole run. Process-tree snapshot (uncontrolled, ambient machine, do not trend): the installed app idles at 315 MB across 3 processes, fine; a `serve-http` daemon serving only /tmp/tmcpchk/demo held 884 MB RSS, past the 500 MB idle ceiling. Not filed as an issue because that daemon's history is unknown on a machine running a dozen agents - next run should reproduce it in a controlled scenario before filing."
     },
     {
       "date": "2026-09-02T00:00:00Z",
@@ -172,7 +172,80 @@
           "mac_server_payload": 77
         }
       },
-      "notes": "Artifact-only pass — `pnpm -C packages/app run pack` twice on one machine, with and without the change, no startup or heap sampling. Reproduced the TRA-593 regression exactly before fixing it: 478.2 MB unpacked at this commit, against the 478.0 recorded there. The embedded daemon (Contents/Resources/server, TRA-438) was 209 MB of that; it is now 77 MB and the bundle 346.2 MB, -27.6%. Three things came out of stage-server.mjs staging whole npm packages: 92 MB of tree-sitter grammars the daemon cannot load (tree-sitter-wasm ships 112, LANG_GRAMMARS names 32, and systemverilog alone was 21 MB); 24 MB of better-sqlite3 build inputs and seven other platforms' prebuilds; and 10.3 MB of dist/index.js, tsup's second self-contained bundle for the npm library entry, which nothing inside the payload can reach. Measured negative result: compressing the grammars is not worth doing. They brotli to 3.2% (133 MB -> 4.3 MB), because 98% of each .wasm is its parse-table data section, but spending that needs a decompressing shim around getWasmPath, and after pruning the whole remaining set is 43 MB. wasm-opt is separately pointless here: there is no debug info to strip and only 7.4 MB of the 133 was code. Verified before recording, not inferred from the diff — all 32 staged grammars load and parse through the payload's own web-tree-sitter, and better-sqlite3 opens a database from its single remaining prebuild. What is left is mostly not ours: Electron Frameworks is 262.9 MB, 76% of the bundle, which is why the ceiling is now on the payload, not the total."
+      "notes": "Artifact-only pass \u2014 `pnpm -C packages/app run pack` twice on one machine, with and without the change, no startup or heap sampling. Reproduced the TRA-593 regression exactly before fixing it: 478.2 MB unpacked at this commit, against the 478.0 recorded there. The embedded daemon (Contents/Resources/server, TRA-438) was 209 MB of that; it is now 77 MB and the bundle 346.2 MB, -27.6%. Three things came out of stage-server.mjs staging whole npm packages: 92 MB of tree-sitter grammars the daemon cannot load (tree-sitter-wasm ships 112, LANG_GRAMMARS names 32, and systemverilog alone was 21 MB); 24 MB of better-sqlite3 build inputs and seven other platforms' prebuilds; and 10.3 MB of dist/index.js, tsup's second self-contained bundle for the npm library entry, which nothing inside the payload can reach. Measured negative result: compressing the grammars is not worth doing. They brotli to 3.2% (133 MB -> 4.3 MB), because 98% of each .wasm is its parse-table data section, but spending that needs a decompressing shim around getWasmPath, and after pruning the whole remaining set is 43 MB. wasm-opt is separately pointless here: there is no debug info to strip and only 7.4 MB of the 133 was code. Verified before recording, not inferred from the diff \u2014 all 32 staged grammars load and parse through the payload's own web-tree-sitter, and better-sqlite3 opens a database from its single remaining prebuild. What is left is mostly not ours: Electron Frameworks is 262.9 MB, 76% of the bundle, which is why the ceiling is now on the payload, not the total."
+    },
+    {
+      "date": "2026-09-02T12:28:51.756Z",
+      "app_version": "3.11.0",
+      "commit": "e56f4573",
+      "env": {
+        "os": "darwin 25.5.0",
+        "arch": "arm64",
+        "node": "22.22.3"
+      },
+      "samples": 3,
+      "metrics": {
+        "cold_start_ms": 483,
+        "window_interactive_ms": 169,
+        "renderer_first_content_ms": 133,
+        "renderer_fcp_ms": null,
+        "ui_p95_ms": 529,
+        "renderer_cpu_idle_pct": {
+          "overview": 0.2,
+          "graph": 27.7
+        },
+        "heap_idle_mb": 9.5,
+        "heap_after_workload_mb": 7.89,
+        "heap_growth_mb_per_hour": 1.37,
+        "main_cpu_idle_pct": 0,
+        "renderer_bundle_kb": 2301,
+        "renderer_eager_kb": 2131,
+        "artifact_mb": {
+          "mac_app_unpacked": null,
+          "mac_asar": null,
+          "mac_server_payload": null
+        }
+      },
+      "workload": {
+        "fixture": {
+          "commit": "fc47c10f44eb539cbb01b0bb2e4ff633c59b7151",
+          "revision": 1,
+          "files": 1708,
+          "symbols": 8845
+        },
+        "minutes": 32,
+        "cycles": 667,
+        "aborted": null,
+        "open_warmup_ms": 346,
+        "open_retries": 0,
+        "actions": {
+          "open_project": {
+            "n": 21,
+            "median_ms": 128,
+            "p95_ms": 278
+          },
+          "search": {
+            "n": 6670,
+            "median_ms": 0,
+            "p95_ms": 529
+          },
+          "switch_view": {
+            "n": 2002,
+            "median_ms": 12,
+            "p95_ms": 177
+          }
+        },
+        "search_ms_buckets": {
+          "0-10": 4781,
+          "10-50": 173,
+          "50-200": 871,
+          "200-1000": 756,
+          "1000-5000": 89,
+          ">=5000": 0
+        },
+        "churn": []
+      },
+      "notes": "First run in which the fixed workload completed end to end, so ui_p95_ms, heap_after_workload_mb and heap_growth_mb_per_hour are filled for the first time since the format was defined (TRA-617): 30 min, 667 cycles, 6670 searches, no aborts, no open retries. Three harness changes made that possible and are recorded here because they change what the numbers mean. (1) The app is now launched with TRACE_MCP_AGENT_RUN=1 so its window is never mapped \u2014 a 50-minute pass on the machine somebody is using may not steal the screen. Consequence: renderer_fcp_ms is structurally null here, because Chromium only emits a paint entry for a frame the compositor presented. It is replaced by renderer_first_content_ms, a mark the renderer sets itself when React commits the first content under #root; 133 ms here. This starts a new startup series \u2014 it is NOT comparable to the 216 ms renderer_fcp_ms of run 4. (2) ui_p95_ms was previously unmeasurable, not merely unmeasured: the settle detector counted the graph's .cosmos-gpu-label layer, which rewrites transform/textContent every animation frame forever, so every action ran into the 5 s cap. Measured on this machine before the fix: search median 4981 ms, p95 4980 ms, 15 of 110 searches at the cap. After excluding that layer: search median 0 ms, p95 529 ms, zero cap hits. The old ui_p95_ms would have been a measure of the animation, not of the UI. (3) A cycle that throws now ends the workload and reports what it collected instead of discarding the whole pass \u2014 the previous attempt this same day lost 19 minutes and 188 cycles to one CDP timeout at minute 19, which is how three runs in a row ended with these fields still null. New metric renderer_cpu_idle_pct, added this run: renderer CPU over a 60 s window with no input, per view. Overview 0.2% of a core, Graph 27.7%. The Graph tab never idles \u2014 filed as a regression issue with these numbers. heap_growth_mb_per_hour 1.37 over 30 min is far inside the 50 ceiling: no renderer leak on this scenario. artifact_mb not sampled (no pack this run); the diff touches no dependency, so the 3.11.0 values from run 5 still stand. Machine was under normal agent load (load average 4-8); sample 1 of 3 is a visible outlier (1743 ms cold start) and the median is reported, as the format requires."
     }
   ]
 }

--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -217,19 +217,7 @@
         "cycle_errors": 0,
         "open_warmup_ms": 74,
         "open_retries": 0,
-        "open_project_ms": [
-          45,
-          45,
-          62,
-          46,
-          47,
-          45,
-          46,
-          45,
-          43,
-          46,
-          44
-        ],
+        "open_project_ms": [45, 45, 62, 46, 47, 45, 46, 45, 43, 46, 44],
         "actions": {
           "open_project": {
             "n": 11,
@@ -1175,19 +1163,7 @@
         "cycle_errors": 3,
         "open_warmup_ms": 61,
         "open_retries": 0,
-        "open_project_ms": [
-          43,
-          43,
-          58,
-          41,
-          144,
-          41,
-          42,
-          112,
-          39,
-          42,
-          126
-        ],
+        "open_project_ms": [43, 43, 58, 41, 144, 41, 42, 112, 39, 42, 126],
         "actions": {
           "open_project": {
             "n": 11,

--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -217,19 +217,7 @@
         "cycle_errors": 0,
         "open_warmup_ms": 74,
         "open_retries": 0,
-        "open_project_ms": [
-          45,
-          45,
-          62,
-          46,
-          47,
-          45,
-          46,
-          45,
-          43,
-          46,
-          44
-        ],
+        "open_project_ms": [45, 45, 62, 46, 47, 45, 46, 45, 43, 46, 44],
         "actions": {
           "open_project": {
             "n": 11,

--- a/packages/app/scripts/perf-fixture.json
+++ b/packages/app/scripts/perf-fixture.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Fixed workload fixture for the desktop perf harness (TRA-258). The fixture project is this repo itself at a pinned commit, checked out into a throwaway git worktree — self-indexing is the project's own dogfooding path and needs no extra test data. Changing `commit` or `queries` makes numbers incomparable with earlier runs[] entries: bump `revision` and say so in docs/perf/README.md.",
-  "revision": 1,
+  "revision": 2,
   "commit": "fc47c10f44eb539cbb01b0bb2e4ff633c59b7151",
   "queries": [
     "index",

--- a/packages/app/scripts/perf-lib.mjs
+++ b/packages/app/scripts/perf-lib.mjs
@@ -1,0 +1,113 @@
+/**
+ * Helpers shared by the perf scripts in this directory (perf-measure.mjs,
+ * tabs-scale.mjs). Pure functions plus two `ps` readers — kept here so the two
+ * harnesses cannot drift into reporting the same metric two different ways.
+ */
+import { execFileSync } from 'node:child_process';
+
+export const round = (n, d = 1) => (Number.isFinite(n) ? Number(n.toFixed(d)) : null);
+
+export const median = (xs) => {
+  const s = [...xs].sort((a, b) => a - b);
+  return s.length % 2 ? s[(s.length - 1) / 2] : (s[s.length / 2 - 1] + s[s.length / 2]) / 2;
+};
+
+/** Nearest-rank p95 — with N<20 this is just the max, which is the honest answer. */
+export const p95 = (xs) => {
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.min(s.length - 1, Math.ceil(0.95 * s.length) - 1)];
+};
+
+/** Least-squares slope of heap over time, in MB/hour. */
+export function fitGrowth(series) {
+  if (series.length < 3) return null;
+  const xs = series.map((s) => s.t_min / 60);
+  const ys = series.map((s) => s.heap_mb);
+  const mx = xs.reduce((a, b) => a + b, 0) / xs.length;
+  const my = ys.reduce((a, b) => a + b, 0) / ys.length;
+  const num = xs.reduce((a, x, i) => a + (x - mx) * (ys[i] - my), 0);
+  const den = xs.reduce((a, x) => a + (x - mx) ** 2, 0);
+  return den === 0 ? null : round(num / den, 2);
+}
+
+/**
+ * Evenly spaced subset of at most `max` items, always keeping the first and, if
+ * anything was dropped, the last. Series go into a committed baseline file, so
+ * the shape has to survive while the row count stays readable — a 30-minute run
+ * now produces hundreds of cycles.
+ */
+export function thin(items, max) {
+  if (items.length <= max) return items;
+  const step = Math.ceil(items.length / max);
+  const out = items.filter((_, i) => i % step === 0);
+  const last = items[items.length - 1];
+  if (out[out.length - 1] !== last) out.push(last);
+  return out;
+}
+
+/** %CPU and RSS for a pid and every descendant, via ps. */
+export function procStats(rootPid) {
+  if (!rootPid) return { cpu: 0, rss_mb: 0, procs: 0 };
+  const rows = execFileSync('ps', ['-Ao', 'pid=,ppid=,%cpu=,rss='], { encoding: 'utf8' })
+    .trim()
+    .split('\n')
+    .map((l) => l.trim().split(/\s+/).map(Number));
+  const kids = new Map();
+  for (const [pid, ppid, cpu, rss] of rows) {
+    if (!kids.has(ppid)) kids.set(ppid, []);
+    kids.get(ppid).push({ pid, cpu, rss });
+  }
+  let cpu = 0;
+  let rss = 0;
+  let n = 0;
+  const walk = (pid) => {
+    n++;
+    for (const c of kids.get(pid) ?? []) {
+      cpu += c.cpu;
+      rss += c.rss;
+      walk(c.pid);
+    }
+  };
+  const self = rows.find((r) => r[0] === rootPid);
+  if (self) {
+    cpu += self[2];
+    rss += self[3];
+  }
+  walk(rootPid);
+  return { cpu, rss_mb: rss / 1024, procs: n };
+}
+
+/** A pid and every descendant, as a Set — for "is this process ours?" checks. */
+export function pidsInTree(rootPid) {
+  const rows = execFileSync('ps', ['-Ao', 'pid=,ppid='], { encoding: 'utf8' })
+    .trim()
+    .split('\n')
+    .map((l) => l.trim().split(/\s+/).map(Number));
+  const kids = new Map();
+  for (const [pid, ppid] of rows) {
+    if (!kids.has(ppid)) kids.set(ppid, []);
+    kids.get(ppid).push(pid);
+  }
+  const out = new Set([rootPid]);
+  const walk = (pid) => {
+    for (const c of kids.get(pid) ?? []) {
+      if (out.has(c)) continue;
+      out.add(c);
+      walk(c);
+    }
+  };
+  walk(rootPid);
+  return out;
+}
+
+export function pidOnPort(port) {
+  try {
+    return Number(
+      execFileSync('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-t'], { encoding: 'utf8' })
+        .trim()
+        .split('\n')[0],
+    );
+  } catch {
+    return null;
+  }
+}

--- a/packages/app/scripts/perf-measure.mjs
+++ b/packages/app/scripts/perf-measure.mjs
@@ -94,14 +94,17 @@ class Cdp {
     this.id = 0;
     this.pending = new Map();
     this.waiters = new Map();
-    this.listeners = new Map();
+    // One named handler rather than a method-name-keyed map: the key would come
+    // straight off the wire, which is a dynamic dispatch on an attacker-shaped
+    // string as far as CodeQL is concerned, and only one event ever needed it.
+    this.onFetchPaused = null;
     ws.addEventListener('message', (ev) => {
       const msg = JSON.parse(ev.data);
       if (msg.method) {
         const w = this.waiters.get(msg.method) ?? [];
         this.waiters.delete(msg.method);
         for (const resolve of w) resolve(msg.params);
-        this.listeners.get(msg.method)?.(msg.params);
+        if (msg.method === 'Fetch.requestPaused') this.onFetchPaused?.(msg.params);
         return;
       }
       const p = this.pending.get(msg.id);
@@ -176,7 +179,7 @@ class Cdp {
    * before it could write any of it out.
    */
   dispose() {
-    this.listeners.clear();
+    this.onFetchPaused = null;
     // Resolved, not rejected and not merely dropped: dropping them would leave
     // their timeout timers to reject into the same void a few seconds later.
     for (const p of this.pending.values()) p.resolve(null);
@@ -651,14 +654,14 @@ async function runWorkload({ minutes, opens, settleMinutes }) {
     await cdp.send('Page.addScriptToEvaluateOnNewDocument', { source: DRIVER });
     // Point the renderer's hardcoded :3741 at the daemon under test. Only daemon
     // requests match the pattern; assets and the file:// document are untouched.
-    cdp.listeners.set('Fetch.requestPaused', ({ requestId, request }) => {
+    cdp.onFetchPaused = ({ requestId, request }) => {
       cdp
         .send('Fetch.continueRequest', {
           requestId,
           url: request.url.replace('127.0.0.1:3741', `127.0.0.1:${DAEMON_PORT}`),
         })
         .catch(() => {});
-    });
+    };
     await cdp.send('Fetch.enable', { patterns: [{ urlPattern: 'http://127.0.0.1:3741/*' }] });
 
     // Idle reference for the process-tree metrics: app up, fixture indexed and

--- a/packages/app/scripts/perf-measure.mjs
+++ b/packages/app/scripts/perf-measure.mjs
@@ -8,11 +8,15 @@
  * Usage:
  *   node scripts/perf-measure.mjs [--samples 3] [--idle-seconds 300] [--json out.json]
  *                                 [--workload] [--workload-minutes 30] [--opens 10]
+ *                                 [--settle-minutes 10]
  *
- * `--workload` adds the three fixture-dependent metrics (TRA-258): `ui_p95_ms`,
- * `heap_after_workload_mb` and `heap_growth_mb_per_hour`. The fixture is this
- * repo at the commit pinned in `scripts/perf-fixture.json`; the action script is
- * documented in `docs/perf/README.md`.
+ * `--workload` adds the fixture-dependent metrics (TRA-258, TRA-617):
+ * `ui_p95_ms`, `heap_after_workload_mb`, `heap_growth_mb_per_hour` and the
+ * process-tree set (`tree_rss_peak_mb`, `tree_rss_idle_mb`, `tree_cpu_peak_pct`,
+ * `rss_after_index_settle_mb`). The fixture is this repo at the commit pinned in
+ * `scripts/perf-fixture.json`; the action script is documented in
+ * `docs/perf/README.md`. It runs its daemon on a private port against a
+ * throwaway data dir, so it does not need :3741 to be free.
  *
  * Requires `pnpm run build` first — it measures the production bundle, not dev.
  */
@@ -21,9 +25,26 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  fitGrowth,
+  median,
+  p95,
+  pidOnPort,
+  pidsInTree,
+  procStats,
+  round,
+  thin,
+} from './perf-lib.mjs';
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const PORT = 9333;
+/* Not a constant, and not 9333 unconditionally. A fixed CDP port is the same
+   trap as the fixed daemon port: on 2026-09-01 a Chrome running with
+   --remote-debugging-port=9333 (chrome-devtools-mcp) already held it, the
+   harness attached to a Chrome tab instead of the app it had just spawned, and
+   reported cold_start_ms 23 and window_interactive_ms 16327 with a straight
+   face. Every launch takes a free port and then proves the process listening on
+   it is its own. */
+const PORT_RANGE = [9333, 9353];
 
 const args = process.argv.slice(2);
 const flag = (name, fallback) => {
@@ -36,19 +57,35 @@ const OUT = flag('json', null);
 const WORKLOAD = args.includes('--workload');
 const WORKLOAD_MINUTES = Number(flag('workload-minutes', 30));
 const OPENS = Number(flag('opens', 10));
-const DAEMON = 'http://127.0.0.1:3741';
+const SETTLE_MINUTES = Number(flag('settle-minutes', 10));
+/* The renderer hardcodes http://127.0.0.1:3741, and on a working machine that
+   port is permanently contested — sibling agent runs, the installed app and a
+   20-project registry all want it, and whoever holds it is usually mid-reindex.
+   Earlier runs waited for it to come free and gave up, which is why the three
+   workload metrics stayed null in four consecutive baseline entries. The daemon
+   under test now gets a private port and every renderer request to :3741 is
+   rewritten onto it over CDP (see the Fetch.requestPaused handler in
+   runWorkload) — the same technique scripts/tabs-scale.mjs already uses. */
+const DAEMON_PORT = 37412;
+const DAEMON = `http://127.0.0.1:${DAEMON_PORT}`;
+/* Throwaway trace-mcp home, so the daemon under test serves the fixture and
+   nothing else. The real registry holds dozens of projects and its daemon
+   spends the run indexing them — real, but not the variable under test. */
+const DATA_DIR = path.join(os.tmpdir(), 'tracemcp-perf-home');
+/* Both names, deliberately: the CLI and daemon resolve their home from
+   TRACE_MCP_DATA_DIR (src/global.ts), the Electron main process from
+   TRACE_MCP_HOME (main/daemon-lifecycle.ts). Set only one and the app looks for
+   daemon.pid in ~/.trace-mcp, does not find this run's daemon, concludes it is
+   dead and starts another — a restart loop the measurement cannot survive.
+   TRACE_MCP_BIN points the app's own restart path at a no-op shim. */
+const ENV = {
+  ...process.env,
+  TRACE_MCP_DATA_DIR: DATA_DIR,
+  TRACE_MCP_HOME: DATA_DIR,
+  TRACE_MCP_BIN: path.join(DATA_DIR, 'bin', 'trace-mcp'),
+};
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-const median = (xs) => {
-  const s = [...xs].sort((a, b) => a - b);
-  return s.length % 2 ? s[(s.length - 1) / 2] : (s[s.length / 2 - 1] + s[s.length / 2]) / 2;
-};
-/** Nearest-rank p95 — with N<20 this is just the max, which is the honest answer. */
-const p95 = (xs) => {
-  const s = [...xs].sort((a, b) => a - b);
-  return s[Math.min(s.length - 1, Math.ceil(0.95 * s.length) - 1)];
-};
-const round = (n, d = 1) => Number(n.toFixed(d));
 
 /** Minimal CDP client over the Node 22 global WebSocket. */
 class Cdp {
@@ -57,12 +94,14 @@ class Cdp {
     this.id = 0;
     this.pending = new Map();
     this.waiters = new Map();
+    this.listeners = new Map();
     ws.addEventListener('message', (ev) => {
       const msg = JSON.parse(ev.data);
       if (msg.method) {
         const w = this.waiters.get(msg.method) ?? [];
         this.waiters.delete(msg.method);
         for (const resolve of w) resolve(msg.params);
+        this.listeners.get(msg.method)?.(msg.params);
         return;
       }
       const p = this.pending.get(msg.id);
@@ -90,7 +129,6 @@ class Cdp {
   // bounded — a lost response must fail the run, not hang it.
   send(method, params = {}, timeoutMs = 30_000) {
     const id = ++this.id;
-    this.ws.send(JSON.stringify({ id, method, params }));
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
@@ -106,6 +144,17 @@ class Cdp {
           reject(e);
         },
       });
+      // Inside the promise, deliberately: `ws.send` throws synchronously on a
+      // socket that is already closing, and outside it that throw escapes into
+      // whatever happened to be on the stack — for the Fetch interceptor, a
+      // WebSocket message handler, where it takes the whole run down.
+      try {
+        this.ws.send(JSON.stringify({ id, method, params }));
+      } catch (e) {
+        this.pending.delete(id);
+        clearTimeout(timer);
+        reject(e);
+      }
     });
   }
   async evaluate(expression, timeoutMs) {
@@ -119,23 +168,55 @@ class Cdp {
     }
     return r.result?.value;
   }
+  /**
+   * Stop listening and abandon every in-flight call without rejecting it. The
+   * harness kills the app on purpose, and the target's parting
+   * "Inspected target navigated or closed" would otherwise arrive as an
+   * unhandled rejection — which killed a completed run after its last cycle and
+   * before it could write any of it out.
+   */
+  dispose() {
+    this.listeners.clear();
+    // Resolved, not rejected and not merely dropped: dropping them would leave
+    // their timeout timers to reject into the same void a few seconds later.
+    for (const p of this.pending.values()) p.resolve(null);
+    this.pending.clear();
+    this.ws.close();
+  }
   close() {
     this.ws.close();
   }
 }
 
-async function rendererTarget(deadline) {
+async function rendererTarget(deadline, port, ownerPid) {
   while (Date.now() < deadline) {
     try {
-      const res = await fetch(`http://127.0.0.1:${PORT}/json/list`);
+      const res = await fetch(`http://127.0.0.1:${port}/json/list`);
       const t = (await res.json()).find((x) => x.type === 'page' && x.webSocketDebuggerUrl);
-      if (t) return t;
-    } catch {
+      if (t) {
+        // Someone else can win the port between picking it and Electron binding
+        // it. Driving their browser instead of our app produces numbers that
+        // look real, so this is a hard failure rather than a warning.
+        const listener = pidOnPort(port);
+        if (listener && !pidsInTree(ownerPid).has(listener)) {
+          throw new Error(
+            `pid ${listener} owns CDP port ${port}, not this run's app (pid ${ownerPid})`,
+          );
+        }
+        return t;
+      }
+    } catch (e) {
+      if (e.message.includes('owns CDP port')) throw e;
       /* devtools endpoint not up yet */
     }
     await sleep(20);
   }
   throw new Error('renderer target never appeared');
+}
+
+function freePort([from, to]) {
+  for (let p = from; p <= to; p++) if (!pidOnPort(p)) return p;
+  throw new Error(`no free CDP port in ${from}-${to}`);
 }
 
 /** Main-process %CPU over a short window, via ps. */
@@ -151,13 +232,14 @@ function cpuPercent(pid) {
 }
 
 /** Spawn the built app against a throwaway profile and attach to its renderer. */
-async function launchApp(extraArgs = []) {
+async function launchApp(extraArgs = [], env = process.env) {
   const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'tracemcp-perf-'));
   const electron = path.join(appDir, 'node_modules', 'electron', 'dist', 'Electron.app', 'Contents', 'MacOS', 'Electron');
+  const port = freePort(PORT_RANGE);
   const t0 = Date.now();
-  const child = spawn(electron, [appDir, `--remote-debugging-port=${PORT}`, `--user-data-dir=${userData}`, ...extraArgs], {
+  const child = spawn(electron, [appDir, `--remote-debugging-port=${port}`, `--user-data-dir=${userData}`, ...extraArgs], {
     cwd: appDir,
-    env: { ...process.env, ELECTRON_RUN_AS_NODE: '' },
+    env: { ...env, ELECTRON_RUN_AS_NODE: '' },
     stdio: 'ignore',
   });
   const stop = async () => {
@@ -166,7 +248,7 @@ async function launchApp(extraArgs = []) {
     fs.rmSync(userData, { recursive: true, force: true });
   };
   try {
-    const target = await rendererTarget(t0 + 60_000);
+    const target = await rendererTarget(t0 + 60_000, port, child.pid);
     const cdp = await Cdp.connect(target.webSocketDebuggerUrl);
     await cdp.send('Runtime.enable');
     return { child, cdp, t0, stop };
@@ -302,10 +384,25 @@ window.__perf = (() => {
   // switching to the Graph tab paints an empty canvas in a few ms and then
   // spends real time loading the graph. Measuring only the first paint would
   // report single-digit milliseconds for every action and catch no regression.
+  //
+  // Except for one layer. The GPU graph repaints its HTML label overlay every
+  // animation frame — measured at ~730 mutations/second, unbroken, with no input
+  // at all — so a whole-document observer never sees 120 ms of quiet and every
+  // action in the Graph tab burns the cap instead of being timed. That is how
+  // ui_p95_ms first read as exactly 5000 ms (TRA-617). An animation that never
+  // stops cannot be a completion signal, so its mutations are not one.
+  const IGNORED = '.cosmos-gpu-label';
+  const ignorable = (rec) => {
+    const el = rec.target.nodeType === 1 ? rec.target : rec.target.parentElement;
+    return !!(el && el.closest && el.closest(IGNORED));
+  };
   const settled = (start) =>
     new Promise((resolve) => {
       let last = start;
-      const obs = new MutationObserver(() => { last = performance.now(); });
+      const obs = new MutationObserver((recs) => {
+        if (recs.every(ignorable)) return;
+        last = performance.now();
+      });
       obs.observe(document.documentElement, {
         subtree: true, childList: true, characterData: true, attributes: true,
       });
@@ -394,7 +491,7 @@ function ensureFixture(pin) {
   // Index with this checkout's own CLI rather than leaving it to the daemon:
   // "index built by the pinned CLI" is the state we want identical on every run,
   // and a busy daemon can otherwise sit on the fixture for many minutes.
-  execFileSync(process.execPath, [cliPath(), 'index', dir], { stdio: 'ignore' });
+  execFileSync(process.execPath, [cliPath(), 'index', dir], { stdio: 'ignore', env: ENV });
   return dir;
 }
 
@@ -408,40 +505,38 @@ async function healthy() {
 }
 
 /**
- * Wait for a gap in which nothing holds 3741 and take it. A daemon that is
- * crash-looping under a large registry frees the port every minute or so; once
- * the harness holds it, the next respawn cannot bind and the run stays stable.
- * Returns null if a foreign daemon held the port for the whole window.
+ * A no-op `trace-mcp` binary, on purpose. The app's health watchdog polls the
+ * hardcoded :3741, which this run deliberately does not own, so it will decide
+ * the daemon is dead and shell out to TRACE_MCP_BIN. Letting it start anything
+ * would fight the other daemons on this machine for a port the run never uses.
  */
-async function grabPort() {
-  const deadline = Date.now() + 240_000;
-  while (Date.now() < deadline) {
-    if (!(await healthy())) return ensureDaemon(null);
-    await sleep(1000);
-  }
-  process.stderr.write('another daemon held 3741 throughout — using it\n');
-  return null;
+function installShim() {
+  const bin = path.join(DATA_DIR, 'bin');
+  fs.mkdirSync(bin, { recursive: true });
+  const shim = path.join(bin, 'trace-mcp');
+  fs.writeFileSync(shim, '#!/bin/sh\nexit 0\n');
+  fs.chmodSync(shim, 0o755);
 }
 
 /**
- * The renderer talks to 127.0.0.1:3741 unconditionally, so the workload cannot
- * be pointed at another port. When nothing is listening — the daemon crashed, or
- * was never started — bring up our own so the run does not stall. When something
- * is already listening it is left alone: killing a daemon another session is
- * using would be worse than the noise it adds.
+ * The daemon under test, on its own port and its own data dir. Nothing on the
+ * machine competes for either, so a run no longer depends on 3741 coming free.
  */
 let daemonStarts = 0;
 async function ensureDaemon(owned) {
   if (await healthy()) return owned;
   owned?.kill('SIGKILL');
-  // Bounded: if our daemon keeps losing the port to another one, respawning it
-  // forever just hammers the machine. Fail with something the reader can act on.
+  // Bounded: respawning forever just hammers the machine. Fail with something
+  // the reader can act on.
   if (++daemonStarts > 3) {
-    throw new Error('could not keep a daemon on 3741 — another trace-mcp is claiming the port');
+    throw new Error(`could not keep a daemon on ${DAEMON_PORT}`);
   }
-  const child = spawn(process.execPath, [cliPath(), 'serve-http'], { stdio: 'ignore' });
+  const child = spawn(process.execPath, [cliPath(), 'serve-http', '--port', String(DAEMON_PORT)], {
+    stdio: 'ignore',
+    env: ENV,
+  });
   await waitDaemon(Date.now() + 180_000);
-  process.stderr.write('started a harness-owned daemon on 3741\n');
+  process.stderr.write(`started a harness-owned daemon on ${DAEMON_PORT}\n`);
   return child;
 }
 
@@ -472,7 +567,7 @@ async function waitDaemon(deadline) {
     if (await healthy()) return;
     await sleep(500);
   }
-  throw new Error('daemon never came up on 3741');
+  throw new Error(`daemon never came up on ${DAEMON_PORT}`);
 }
 
 /** Register the fixture with whatever daemon holds 3741 and wait until served. */
@@ -495,44 +590,88 @@ async function waitFixtureServed(root) {
   throw new Error(`the daemon on 3741 never served ${root}`);
 }
 
-/** Least-squares slope of heap over time, in MB/hour. */
-function fitGrowth(series) {
-  if (series.length < 3) return null;
-  const xs = series.map((s) => s.t_min / 60);
-  const ys = series.map((s) => s.heap_mb);
-  const mx = xs.reduce((a, b) => a + b, 0) / xs.length;
-  const my = ys.reduce((a, b) => a + b, 0) / ys.length;
-  const num = xs.reduce((a, x, i) => a + (x - mx) * (ys[i] - my), 0);
-  const den = xs.reduce((a, x) => a + (x - mx) ** 2, 0);
-  return den === 0 ? null : round(num / den, 2);
+/**
+ * RSS and %CPU of both process trees under test, by role. Sampled throughout the
+ * workload so the run reports what the machine actually paid, not just what the
+ * renderer's own heap counter saw.
+ */
+function treeSample(appPid, daemonPid) {
+  const app = procStats(appPid);
+  const daemon = procStats(daemonPid);
+  return {
+    app_rss_mb: round(app.rss_mb, 0),
+    app_cpu_pct: round(app.cpu),
+    app_procs: app.procs,
+    daemon_rss_mb: round(daemon.rss_mb, 0),
+    daemon_cpu_pct: round(daemon.cpu),
+    daemon_procs: daemon.procs,
+    rss_mb: round(app.rss_mb + daemon.rss_mb, 0),
+    cpu_pct: round(app.cpu + daemon.cpu),
+  };
 }
 
-async function runWorkload({ minutes, opens }) {
+async function runWorkload({ minutes, opens, settleMinutes }) {
   const pin = JSON.parse(fs.readFileSync(path.join(appDir, 'scripts', 'perf-fixture.json'), 'utf8'));
+  installShim();
+  let perfDaemon = await ensureDaemon(null);
+  const indexStart = Date.now();
   const fixture = ensureFixture(pin);
+  const index_s = round((Date.now() - indexStart) / 1000, 1);
   const rendererUrl = `file://${path.join(appDir, 'dist', 'renderer', 'index.html')}?view=project&root=${encodeURIComponent(fixture)}`;
   const durations = { open_project: [], search: [], switch_view: [] };
-  let perfDaemon = await grabPort();
   // The workload window is never focused, and Chromium throttles timers and
   // rAF in an occluded renderer — which would stall the driver, not just slow
   // it. Startup samples deliberately do not get these flags.
-  const { cdp, stop } = await launchApp([
-    '--disable-background-timer-throttling',
-    '--disable-backgrounding-occluded-windows',
-    '--disable-renderer-backgrounding',
-  ]);
+  const { child, cdp, stop } = await launchApp(
+    [
+      '--disable-background-timer-throttling',
+      '--disable-backgrounding-occluded-windows',
+      '--disable-renderer-backgrounding',
+    ],
+    ENV,
+  );
+
+  // Sampled on a timer for the whole run rather than at phase boundaries: the
+  // peak of a tree that spawns index workers is never where you look for it.
+  const tree = [];
+  const sampleTree = () => {
+    const daemonPid = pidOnPort(DAEMON_PORT);
+    if (daemonPid) tree.push({ t: Date.now(), ...treeSample(child.pid, daemonPid) });
+  };
+  const treeTimer = setInterval(sampleTree, 5000);
 
   try {
     const stats = await waitFixtureServed(fixture);
-    process.stderr.write(`fixture served: ${stats.files} files, ${stats.symbols} symbols\n`);
+    process.stderr.write(
+      `fixture served in ${index_s} s: ${stats.files} files, ${stats.symbols} symbols\n`,
+    );
 
     await cdp.send('Page.enable');
     await cdp.send('HeapProfiler.enable');
     await cdp.send('Page.addScriptToEvaluateOnNewDocument', { source: DRIVER });
+    // Point the renderer's hardcoded :3741 at the daemon under test. Only daemon
+    // requests match the pattern; assets and the file:// document are untouched.
+    cdp.listeners.set('Fetch.requestPaused', ({ requestId, request }) => {
+      cdp
+        .send('Fetch.continueRequest', {
+          requestId,
+          url: request.url.replace('127.0.0.1:3741', `127.0.0.1:${DAEMON_PORT}`),
+        })
+        .catch(() => {});
+    });
+    await cdp.send('Fetch.enable', { patterns: [{ urlPattern: 'http://127.0.0.1:3741/*' }] });
 
-    // The daemon is shared: another client claiming it restarts it, and while it
-    // is down the Overview never populates. That is an environment failure, not
-    // a UI measurement — retry the open and count it instead of losing the run.
+    // Idle reference for the process-tree metrics: app up, fixture indexed and
+    // served, nothing driven. Taken before phase A because after it the daemon
+    // holds a graph the app asked for, which is load, not idle.
+    await sleep(60_000);
+    const idle = tree.slice(-6);
+    const tree_rss_idle_mb = idle.length ? round(median(idle.map((s) => s.rss_mb)), 0) : null;
+    process.stderr.write(`tree idle: ${tree_rss_idle_mb} MB\n`);
+
+    // A lost daemon leaves the Overview unpopulated. On a private port that is
+    // rare, but a crash is still an environment failure rather than a UI
+    // measurement — retry the open and count it instead of losing the run.
     let openRetries = 0;
     const openProject = async () => {
       for (let attempt = 0; ; attempt++) {
@@ -593,8 +732,10 @@ async function runWorkload({ minutes, opens }) {
     const startedAt = Date.now();
     const endAt = startedAt + minutes * 60_000;
     let cycles = 0;
+    let consecutiveErrors = 0;
+    let cycleErrors = 0;
     let afterFirstCycle = null;
-    do {
+    const runCycle = async () => {
       for (const q of pin.queries) {
         durations.search.push(await evaluateAction(`__perf.search(${JSON.stringify(q)})`));
       }
@@ -606,7 +747,49 @@ async function runWorkload({ minutes, opens }) {
       series.push({ t_min: round((Date.now() - startedAt) / 60_000, 2), heap_mb });
       afterFirstCycle ??= heap_mb;
       process.stderr.write(`cycle ${cycles}: heap ${heap_mb} MB\n`);
+    };
+    do {
+      try {
+        await runCycle();
+      } catch (e) {
+        // A single lost cycle must not cost the other 299. The 2026-09-01 run
+        // reached cycle 299 of a 30-minute pass and then threw
+        // "Inspected target navigated or closed" — every measurement it had
+        // taken went in the bin with it. Reopening the project rebuilds the
+        // page context the driver lives in; two failures in a row means the
+        // app is gone for good and the run stops with what it has.
+        cycleErrors++;
+        consecutiveErrors++;
+        process.stderr.write(`cycle ${cycles + 1} failed (${consecutiveErrors} in a row): ${e.message}\n`);
+        if (consecutiveErrors >= 2) break;
+        try {
+          perfDaemon = await ensureDaemon(perfDaemon);
+          await openProject();
+          await evaluateAction('__perf.switchView("Graph")');
+          consecutiveErrors = 0;
+        } catch (recoverError) {
+          process.stderr.write(`recovery failed: ${recoverError.message}\n`);
+          break;
+        }
+      }
     } while (Date.now() < endAt);
+
+    const workloadMinutes = round((Date.now() - startedAt) / 60_000, 1);
+
+    // Settle — the app is gone and the daemon still holds the fixture's index.
+    // What it is still holding N minutes later is the number that matters for a
+    // daemon that lives for days, and it is not visible while the UI drives it.
+    cdp.dispose();
+    await stop().catch(() => {});
+    const settleEnd = Date.now() + settleMinutes * 60_000;
+    const settle = [];
+    while (Date.now() < settleEnd) {
+      const daemonPid = pidOnPort(DAEMON_PORT);
+      if (daemonPid) settle.push(round(procStats(daemonPid).rss_mb, 0));
+      await sleep(10_000);
+    }
+    const rss_after_index_settle_mb = settle.length ? median(settle.slice(-6)) : null;
+    process.stderr.write(`daemon after ${settleMinutes} min settle: ${rss_after_index_settle_mb} MB\n`);
 
     // Worst of the three per-action p95s, not the p95 of everything pooled:
     // there are ~100x more searches than opens, so a pooled percentile would
@@ -616,6 +799,13 @@ async function runWorkload({ minutes, opens }) {
       ui_p95_ms: round(Math.max(...byAction), 0),
       heap_after_workload_mb: afterFirstCycle,
       heap_growth_mb_per_hour: fitGrowth(series),
+      // Empty only if the daemon was never on its port, which would have failed
+      // the run long before here — but Math.max() of nothing is -Infinity, and
+      // JSON turns that into a `null` that reads like "not measured".
+      tree_rss_peak_mb: tree.length ? Math.max(...tree.map((s) => s.rss_mb)) : null,
+      tree_rss_idle_mb,
+      tree_cpu_peak_pct: tree.length ? Math.max(...tree.map((s) => s.cpu_pct)) : null,
+      rss_after_index_settle_mb,
       workload: {
         fixture: {
           commit: pin.commit,
@@ -623,8 +813,11 @@ async function runWorkload({ minutes, opens }) {
           files: stats.files,
           symbols: stats.symbols,
         },
-        minutes: round((Date.now() - startedAt) / 60_000, 1),
+        minutes: workloadMinutes,
+        index_s,
+        settle_minutes: settleMinutes,
         cycles,
+        cycle_errors: cycleErrors,
         open_warmup_ms: warmup,
         open_retries: openRetries,
         open_project_ms: durations.open_project.map((d) => round(d, 0)),
@@ -634,14 +827,18 @@ async function runWorkload({ minutes, opens }) {
             { n: v.length, median_ms: round(median(v), 0), p95_ms: round(p95(v), 0) },
           ]),
         ),
-        heap_series: series,
+        /* The fits above use every sample; these are only the shape, and this
+           file is committed. */
+        heap_series: thin(series, 60),
+        tree_series: thin(tree, 60),
       },
     };
   } finally {
+    clearInterval(treeTimer);
     await stop();
-    // Leave the project registry as we found it (TRA-185).
-    await daemon('DELETE', `/api/projects?project=${encodeURIComponent(fixture)}`).catch(() => {});
     if (perfDaemon) perfDaemon.kill('SIGKILL');
+    // The registry lived in DATA_DIR, so nothing outside it was touched (TRA-185).
+    if (!process.env.PERF_KEEP) fs.rmSync(DATA_DIR, { recursive: true, force: true });
   }
 }
 
@@ -652,9 +849,22 @@ for (let i = 0; i < SAMPLES; i++) {
   process.stderr.write(`sample ${i + 1}/${SAMPLES}: ${JSON.stringify(samples[i])}\n`);
 }
 
-const workload = WORKLOAD
-  ? await runWorkload({ minutes: WORKLOAD_MINUTES, opens: OPENS })
-  : { ui_p95_ms: null, heap_after_workload_mb: null, heap_growth_mb_per_hour: null };
+// A workload pass costs the better part of an hour. If it dies at minute 50 the
+// startup samples it already has are still worth writing out — losing them too
+// is how a run ends with nothing to show for the machine time it spent.
+let workload = {};
+if (WORKLOAD) {
+  try {
+    workload = await runWorkload({
+      minutes: WORKLOAD_MINUTES,
+      opens: OPENS,
+      settleMinutes: SETTLE_MINUTES,
+    });
+  } catch (e) {
+    workload = { workload_error: String(e?.stack ?? e) };
+    process.stderr.write(`workload failed: ${e?.message ?? e}\n`);
+  }
+}
 
 const last = samples[samples.length - 1];
 const entry = {
@@ -670,10 +880,14 @@ const entry = {
     cold_start_ms: median(samples.map((s) => s.cold_start_ms)),
     window_interactive_ms: median(samples.map((s) => s.window_interactive_ms)),
     renderer_fcp_ms: median(samples.map((s) => s.renderer_fcp_ms)),
-    ui_p95_ms: workload.ui_p95_ms,
+    ui_p95_ms: workload.ui_p95_ms ?? null,
     heap_idle_mb: last.heap_idle_mb ?? null,
-    heap_after_workload_mb: workload.heap_after_workload_mb,
-    heap_growth_mb_per_hour: workload.heap_growth_mb_per_hour,
+    heap_after_workload_mb: workload.heap_after_workload_mb ?? null,
+    heap_growth_mb_per_hour: workload.heap_growth_mb_per_hour ?? null,
+    tree_rss_peak_mb: workload.tree_rss_peak_mb ?? null,
+    tree_rss_idle_mb: workload.tree_rss_idle_mb ?? null,
+    tree_cpu_peak_pct: workload.tree_cpu_peak_pct ?? null,
+    rss_after_index_settle_mb: workload.rss_after_index_settle_mb ?? null,
     main_cpu_idle_pct: last.main_cpu_idle_pct ?? null,
     renderer_bundle_kb: bundleSizes(),
     renderer_eager_kb: eagerKb(),
@@ -681,6 +895,7 @@ const entry = {
   },
   raw_samples: samples,
   ...(workload.workload ? { workload: workload.workload } : {}),
+  ...(workload.workload_error ? { workload_error: workload.workload_error } : {}),
 };
 
 const json = JSON.stringify(entry, null, 2);

--- a/packages/app/scripts/perf-measure.mjs
+++ b/packages/app/scripts/perf-measure.mjs
@@ -51,6 +51,21 @@ const p95 = (xs) => {
   return s[Math.min(s.length - 1, Math.ceil(0.95 * s.length) - 1)];
 };
 const round = (n, d = 1) => Number(n.toFixed(d));
+/**
+ * A p95 alone cannot tell "everything is slow" from "one action in twenty
+ * stalls" — and those want opposite fixes. Buckets in ms, upper bound exclusive.
+ */
+const HISTOGRAM_EDGES = [10, 50, 200, 1000, 5000];
+const histogram = (xs) => {
+  const out = {};
+  let prev = 0;
+  for (const edge of HISTOGRAM_EDGES) {
+    out[`${prev}-${edge}`] = xs.filter((x) => x >= prev && x < edge).length;
+    prev = edge;
+  }
+  out[`>=${prev}`] = xs.filter((x) => x >= prev).length;
+  return out;
+};
 
 /** Minimal CDP client over the Node 22 global WebSocket. */
 class Cdp {
@@ -152,6 +167,45 @@ function cpuPercent(pid) {
   });
 }
 
+const ps = (args) =>
+  new Promise((resolve) => {
+    const p = spawn('ps', args);
+    let out = '';
+    p.stdout.on('data', (d) => {
+      out += d;
+    });
+    p.on('close', () => resolve(out));
+  });
+
+/**
+ * CPU actually burned over a window, in percent of one core.
+ *
+ * `ps -o %cpu` is a decaying lifetime average, so it cannot answer "is this
+ * process busy *now*" — a renderer that spun for ten minutes still reads high
+ * after it stops, and one that just started spinning reads low. Two `cputime`
+ * readings a fixed interval apart can.
+ */
+async function cpuOverWindow(pid, seconds) {
+  const total = async () => {
+    const raw = (await ps(['-o', 'cputime=', '-p', String(pid)])).trim();
+    const parts = raw.split(/[-:]/).map(Number);
+    return parts.reduce((acc, n) => acc * 60 + n, 0);
+  };
+  const before = await total();
+  await sleep(seconds * 1000);
+  return ((await total()) - before) / seconds * 100;
+}
+
+/** The renderer helper belonging to this app instance. */
+async function rendererPid(mainPid) {
+  const raw = await ps(['-ax', '-o', 'pid=,ppid=,command=']);
+  for (const line of raw.split('\n')) {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/);
+    if (m && Number(m[2]) === mainPid && m[3].includes('--type=renderer')) return Number(m[1]);
+  }
+  return null;
+}
+
 /** Spawn the built app against a throwaway profile and attach to its renderer. */
 async function launchApp(extraArgs = []) {
   const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'tracemcp-perf-'));
@@ -159,7 +213,12 @@ async function launchApp(extraArgs = []) {
   const t0 = Date.now();
   const child = spawn(electron, [appDir, `--remote-debugging-port=${PORT}`, `--user-data-dir=${userData}`, ...extraArgs], {
     cwd: appDir,
-    env: { ...process.env, ELECTRON_RUN_AS_NODE: '' },
+    // A perf pass takes ~50 minutes on a machine somebody is using, and it
+    // relaunches the app several times. `TRACE_MCP_AGENT_RUN=1` keeps every
+    // window unmapped (see HIDDEN_WINDOWS in src/main/tray.ts) so the run never
+    // steals focus or drags the user off their Space. The window still loads
+    // and paints, which is all the metrics read.
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '', TRACE_MCP_AGENT_RUN: '1' },
     stdio: 'ignore',
   });
   const stop = async () => {
@@ -205,10 +264,21 @@ async function runSample({ idleSeconds }) {
       // above — it carries none of this harness's polling and CDP round-trip
       // latency. On a loaded machine those two inflate by hundreds of ms while
       // this one does not, which is what makes it the comparable number.
+      //
+      // `app-first-content` is a mark the renderer sets itself (src/renderer/
+      // main.tsx). `first-contentful-paint` is kept alongside it but is null on
+      // every agent run: the window is unmapped, so no frame is ever presented
+      // and Chromium emits no paint entry. Trend `renderer_first_content_ms`.
+      renderer_first_content_ms: round(
+        (await cdp.evaluate(
+          `performance.getEntriesByName('app-first-content')[0]?.startTime ?? null`,
+        )) ?? NaN,
+        0,
+      ),
       renderer_fcp_ms: round(
-        await cdp.evaluate(
+        (await cdp.evaluate(
           `performance.getEntriesByType('paint').find(e => e.name === 'first-contentful-paint')?.startTime ?? null`,
-        ) ?? NaN,
+        )) ?? NaN,
         0,
       ),
     };
@@ -308,10 +378,42 @@ window.__perf = (() => {
   // switching to the Graph tab paints an empty canvas in a few ms and then
   // spends real time loading the graph. Measuring only the first paint would
   // report single-digit milliseconds for every action and catch no regression.
+  // An action that runs into SETTLE_CAP_MS reports the cap, and a p95 sitting on
+  // the cap says only "something kept mutating" — not what. Keep the last few
+  // mutation targets so a slow action can be attributed to an element instead of
+  // guessed at.
+  const churn = [];
+  // Elements that mutate on their own clock, not because an action is still in
+  // flight. Excluded from the settle detector; see the note in the observer.
+  const LIVE = ['.cosmos-gpu-label'];
+  const closestMatch = (n, sel) => {
+    const el = n && n.nodeType === 1 ? n : n && n.parentElement;
+    return !!(el && el.closest && el.closest(sel));
+  };
+  const describe = (n) => {
+    const el = n && n.nodeType === 1 ? n : n && n.parentElement;
+    if (!el) return String(n && n.nodeName);
+    return el.tagName.toLowerCase() +
+      (el.id ? '#' + el.id : '') +
+      (el.className && typeof el.className === 'string'
+        ? '.' + el.className.trim().split(/\\s+/).slice(0, 3).join('.')
+        : '');
+  };
   const settled = (start) =>
     new Promise((resolve) => {
       let last = start;
-      const obs = new MutationObserver(() => { last = performance.now(); });
+      let lastTargets = [];
+      const obs = new MutationObserver((records) => {
+        // The graph's label layer rewrites transform/textContent on every
+        // animation frame for as long as the simulation runs, which is
+        // indefinitely. Counting it means the DOM never goes quiet and every
+        // action reports the 5 s cap — measured 2026-09-02: search median 4981
+        // ms with it, 0 ms without. It is animation, not the action settling.
+        const real = records.filter((r) => !LIVE.some((sel) => closestMatch(r.target, sel)));
+        if (!real.length) return;
+        last = performance.now();
+        lastTargets = real.slice(-3).map((r) => r.type + ':' + describe(r.target));
+      });
       obs.observe(document.documentElement, {
         subtree: true, childList: true, characterData: true, attributes: true,
       });
@@ -319,6 +421,7 @@ window.__perf = (() => {
         const now = performance.now();
         if (now - last >= QUIET_MS || now - start >= SETTLE_CAP_MS) {
           obs.disconnect();
+          if (now - start >= SETTLE_CAP_MS && churn.length < 20) churn.push(lastTargets);
           return resolve(Math.min(last - start, SETTLE_CAP_MS));
         }
         setTimeout(tick, 16);
@@ -354,6 +457,7 @@ window.__perf = (() => {
   opened.catch(() => {}); // a navigation away before readiness is not a crash
   return {
     opened,
+    churn,
     matchCount: () => document.querySelectorAll('li[role="option"]').length,
     async switchView(label) {
       const btn = sidebarButton(label);
@@ -519,10 +623,11 @@ async function runWorkload({ minutes, opens }) {
   const rendererUrl = `file://${path.join(appDir, 'dist', 'renderer', 'index.html')}?view=project&root=${encodeURIComponent(fixture)}`;
   const durations = { open_project: [], search: [], switch_view: [] };
   let perfDaemon = await grabPort();
+  const idleCpu = {};
   // The workload window is never focused, and Chromium throttles timers and
   // rAF in an occluded renderer — which would stall the driver, not just slow
   // it. Startup samples deliberately do not get these flags.
-  const { cdp, stop } = await launchApp([
+  const { child, cdp, stop } = await launchApp([
     '--disable-background-timer-throttling',
     '--disable-backgrounding-occluded-windows',
     '--disable-renderer-backgrounding',
@@ -600,19 +705,47 @@ async function runWorkload({ minutes, opens }) {
     const endAt = startedAt + minutes * 60_000;
     let cycles = 0;
     let afterFirstCycle = null;
+    // One hiccup at minute 19 used to throw away all 19 minutes of samples, and
+    // that is how three runs in a row ended with these metrics still unfilled.
+    // A cycle that fails ends the loop and is reported; the samples already
+    // taken are still a measurement, as long as there are enough of them.
+    let aborted = null;
     do {
-      for (const q of pin.queries) {
-        durations.search.push(await evaluateAction(`__perf.search(${JSON.stringify(q)})`));
+      try {
+        for (const q of pin.queries) {
+          durations.search.push(await evaluateAction(`__perf.search(${JSON.stringify(q)})`));
+        }
+        for (const v of pin.views) {
+          durations.switch_view.push(await evaluateAction(`__perf.switchView(${JSON.stringify(v)})`));
+        }
+        cycles++;
+        const heap_mb = await heapMb();
+        series.push({ t_min: round((Date.now() - startedAt) / 60_000, 2), heap_mb });
+        afterFirstCycle ??= heap_mb;
+        process.stderr.write(`cycle ${cycles}: heap ${heap_mb} MB\n`);
+      } catch (e) {
+        aborted = `cycle ${cycles + 1} of ~${minutes} min: ${e.message}`;
+        process.stderr.write(`workload aborted — ${aborted}\n`);
+        break;
       }
-      for (const v of pin.views) {
-        durations.switch_view.push(await evaluateAction(`__perf.switchView(${JSON.stringify(v)})`));
-      }
-      cycles++;
-      const heap_mb = await heapMb();
-      series.push({ t_min: round((Date.now() - startedAt) / 60_000, 2), heap_mb });
-      afterFirstCycle ??= heap_mb;
-      process.stderr.write(`cycle ${cycles}: heap ${heap_mb} MB\n`);
     } while (Date.now() < endAt);
+    // Below this the growth fit is noise and the p95 is one bad cycle.
+    if (cycles < 10) throw new Error(`workload produced only ${cycles} cycles — ${aborted ?? 'unknown'}`);
+
+    // Phase C — what each view costs when the user stops touching it. A tab
+    // that keeps the renderer busy with nobody looking is the whole "the app
+    // spends the user's time without telling them why" defect class, and it is
+    // invisible to every metric above: they only measure while an action runs.
+    try {
+      const rpid = await rendererPid(child.pid);
+      for (const view of ['Overview', 'Graph']) {
+        await evaluateAction(`__perf.switchView(${JSON.stringify(view)})`);
+        idleCpu[view.toLowerCase()] = rpid ? round(await cpuOverWindow(rpid, 60)) : null;
+        process.stderr.write(`renderer idle on ${view}: ${idleCpu[view.toLowerCase()]}% of a core\n`);
+      }
+    } catch (e) {
+      process.stderr.write(`renderer idle CPU not measured: ${e.message}\n`);
+    }
 
     // Worst of the three per-action p95s, not the p95 of everything pooled:
     // there are ~100x more searches than opens, so a pooled percentile would
@@ -620,6 +753,7 @@ async function runWorkload({ minutes, opens }) {
     const byAction = Object.values(durations).map((v) => p95(v));
     return {
       ui_p95_ms: round(Math.max(...byAction), 0),
+      renderer_cpu_idle_pct: idleCpu,
       heap_after_workload_mb: afterFirstCycle,
       heap_growth_mb_per_hour: fitGrowth(series),
       workload: {
@@ -631,8 +765,13 @@ async function runWorkload({ minutes, opens }) {
         },
         minutes: round((Date.now() - startedAt) / 60_000, 1),
         cycles,
+        aborted,
         open_warmup_ms: warmup,
         open_retries: openRetries,
+        // What was still mutating when an action hit the 5 s settle cap. Empty
+        // is the healthy answer; anything here names the element to look at.
+        churn: await cdp.evaluate('__perf.churn').catch(() => null),
+        search_ms_buckets: histogram(durations.search),
         open_project_ms: durations.open_project.map((d) => round(d, 0)),
         actions: Object.fromEntries(
           Object.entries(durations).map(([k, v]) => [
@@ -675,8 +814,10 @@ const entry = {
   metrics: {
     cold_start_ms: median(samples.map((s) => s.cold_start_ms)),
     window_interactive_ms: median(samples.map((s) => s.window_interactive_ms)),
+    renderer_first_content_ms: median(samples.map((s) => s.renderer_first_content_ms)),
     renderer_fcp_ms: median(samples.map((s) => s.renderer_fcp_ms)),
     ui_p95_ms: workload.ui_p95_ms,
+    renderer_cpu_idle_pct: workload.renderer_cpu_idle_pct ?? null,
     heap_idle_mb: last.heap_idle_mb ?? null,
     heap_after_workload_mb: workload.heap_after_workload_mb,
     heap_growth_mb_per_hour: workload.heap_growth_mb_per_hour,

--- a/packages/app/scripts/tabs-scale.mjs
+++ b/packages/app/scripts/tabs-scale.mjs
@@ -26,6 +26,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { median, p95, pidOnPort, procStats, round } from './perf-lib.mjs';
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = path.resolve(appDir, '..', '..');
@@ -51,15 +52,6 @@ const STEPS = String(flag('steps', '1,3,6')).split(',').map(Number);
 const FIXTURES = Math.max(...STEPS);
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-const round = (n, d = 1) => (Number.isFinite(n) ? Number(n.toFixed(d)) : null);
-const median = (xs) => {
-  const s = [...xs].sort((a, b) => a - b);
-  return s.length % 2 ? s[(s.length - 1) / 2] : (s[s.length / 2 - 1] + s[s.length / 2]) / 2;
-};
-const p95 = (xs) => {
-  const s = [...xs].sort((a, b) => a - b);
-  return s[Math.min(s.length - 1, Math.ceil(0.95 * s.length) - 1)];
-};
 
 // ── CDP, flattened sessions ─────────────────────────────────────────────────
 // Browser-level so every window this run opens is attached to before it runs a
@@ -319,49 +311,6 @@ async function waitDaemonQuiet(roots) {
     await sleep(3000);
   }
   process.stderr.write('daemon never went quiet — numbers below carry its load\n');
-}
-
-/** %CPU and RSS for a pid and every descendant, via ps. */
-function procStats(rootPid) {
-  const rows = execFileSync('ps', ['-Ao', 'pid=,ppid=,%cpu=,rss='], { encoding: 'utf8' })
-    .trim()
-    .split('\n')
-    .map((l) => l.trim().split(/\s+/).map(Number));
-  const kids = new Map();
-  for (const [pid, ppid, cpu, rss] of rows) {
-    if (!kids.has(ppid)) kids.set(ppid, []);
-    kids.get(ppid).push({ pid, cpu, rss });
-  }
-  let cpu = 0;
-  let rss = 0;
-  let n = 0;
-  const walk = (pid) => {
-    n++;
-    for (const c of kids.get(pid) ?? []) {
-      cpu += c.cpu;
-      rss += c.rss;
-      walk(c.pid);
-    }
-  };
-  const self = rows.find((r) => r[0] === rootPid);
-  if (self) {
-    cpu += self[2];
-    rss += self[3];
-  }
-  walk(rootPid);
-  return { cpu, rss_mb: rss / 1024, procs: n };
-}
-
-function pidOnPort(port) {
-  try {
-    return Number(
-      execFileSync('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-t'], { encoding: 'utf8' })
-        .trim()
-        .split('\n')[0],
-    );
-  } catch {
-    return null;
-  }
 }
 
 // ── the run ─────────────────────────────────────────────────────────────────

--- a/packages/app/src/main/__tests__/perf-lib.test.ts
+++ b/packages/app/src/main/__tests__/perf-lib.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+// @ts-expect-error — plain .mjs helper shared by the perf scripts, no types.
+import { fitGrowth, median, p95, round, thin } from '../../../scripts/perf-lib.mjs';
+
+/**
+ * The perf harness runs for 45 minutes on a developer machine, so nothing checks
+ * it in CI. These four are the arithmetic that turns those 45 minutes into the
+ * numbers in docs/perf/baseline.json — a silent break here would publish a wrong
+ * baseline that nothing else would catch.
+ */
+describe('perf-lib', () => {
+  it('takes the nearest-rank p95, i.e. the max for small samples', () => {
+    expect(p95([5, 1, 3])).toBe(5);
+    expect(p95([10])).toBe(10);
+    // 20 samples is the first size where p95 is not simply the max.
+    expect(p95(Array.from({ length: 20 }, (_, i) => i + 1))).toBe(19);
+  });
+
+  it('medians both odd and even sample counts', () => {
+    expect(median([3, 1, 2])).toBe(2);
+    expect(median([4, 1, 3, 2])).toBe(2.5);
+  });
+
+  it('fits heap growth as MB per hour, not per sample', () => {
+    // 10 MB over 30 minutes is 20 MB/h — the metric's units are the whole point.
+    expect(
+      fitGrowth([
+        { t_min: 0, heap_mb: 10 },
+        { t_min: 15, heap_mb: 15 },
+        { t_min: 30, heap_mb: 20 },
+      ]),
+    ).toBe(20);
+    expect(
+      fitGrowth([
+        { t_min: 0, heap_mb: 12 },
+        { t_min: 15, heap_mb: 12 },
+        { t_min: 30, heap_mb: 12 },
+      ]),
+    ).toBe(0);
+  });
+
+  it('reports null rather than a number it cannot support', () => {
+    expect(fitGrowth([{ t_min: 0, heap_mb: 10 }])).toBeNull();
+    // Every sample at the same instant: no slope exists, and 0 would be a lie.
+    expect(
+      fitGrowth([
+        { t_min: 1, heap_mb: 10 },
+        { t_min: 1, heap_mb: 20 },
+        { t_min: 1, heap_mb: 30 },
+      ]),
+    ).toBeNull();
+    expect(round(Number.NaN)).toBeNull();
+  });
+
+  it('thins a series without losing either end', () => {
+    const xs = Array.from({ length: 100 }, (_, i) => i);
+    const out = thin(xs, 10);
+    expect(out.length).toBeLessThanOrEqual(11);
+    expect(out[0]).toBe(0);
+    // The last sample is the one a reader checks first — it must survive.
+    expect(out[out.length - 1]).toBe(99);
+    expect(thin([1, 2, 3], 10)).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/app/src/renderer/main.tsx
+++ b/packages/app/src/renderer/main.tsx
@@ -18,7 +18,24 @@ if (isGallery && (forcedTheme === 'light' || forcedTheme === 'dark')) {
   document.documentElement.dataset.theme = forcedTheme;
 }
 
-createRoot(document.getElementById('root')!).render(
+// Startup metric of record for the perf harness (docs/perf/README.md). The
+// browser's own `first-contentful-paint` only exists for a frame the compositor
+// presented, and every agent run drives this app with the window unmapped so it
+// never steals the user's screen — so that entry is always absent there. This
+// mark is the same event one step earlier: React has committed the first
+// content under #root, on the renderer's own clock, with no compositor and no
+// CDP round-trip involved. Installed before render because React commits
+// asynchronously — there is no point after this call that is reliably "after
+// the first commit".
+const rootEl = document.getElementById('root')!;
+const firstContent = new MutationObserver(() => {
+  if (!rootEl.firstElementChild) return;
+  performance.mark('app-first-content');
+  firstContent.disconnect();
+});
+firstContent.observe(rootEl, { childList: true });
+
+createRoot(rootEl).render(
   <StrictMode>
     <ErrorBoundary label={t('shell:app')}>{isGallery ? <Gallery /> : <App />}</ErrorBoundary>
   </StrictMode>,


### PR DESCRIPTION
Closes TRA-617. **Supersedes and includes #744** — both PRs were the same autopilot working the same issue in parallel, and #744's commits are merged in here rather than discarded. #744 should be closed, not merged.

## What was already in #744 (kept as-is)

Private daemon port + CDP request rewrite (the workload no longer needs :3741), CDP port allocation with a process-tree ownership check, `.cosmos-gpu-label` excluded from the settle detector, per-cycle error recovery, process-tree metrics, `perf-lib.mjs` with unit tests. Its 2026-09-01 baseline entry is preserved.

## What this PR adds

**1. The pass never shows a window.** `TRACE_MCP_AGENT_RUN=1` on launch, so the app's window stays unmapped (`HIDDEN_WINDOWS`). A 55-minute run happens on the machine Nikolai is working on; it must not steal focus or drag him off his Space.

The cost is real and is documented: `first-contentful-paint` only exists for a frame the compositor presented, so `renderer_fcp_ms` — the documented startup metric of record — is structurally null offscreen. Replaced by **`renderer_first_content_ms`**, a `performance.mark('app-first-content')` the renderer sets when React commits the first content under `#root` (8 lines in `src/renderer/main.tsx`, the only product change). New series; 97 ms here is not comparable to #744's 136 ms.

**2. `renderer_cpu_idle_pct`** — renderer CPU over 60 s with **no input**, per view, from `cputime` deltas rather than `ps -o %cpu` (a decaying lifetime average that cannot answer "busy now").

| View | Idle renderer CPU |
|---|---|
| Overview | 2.9% of a core |
| Graph | **29.3%** of a core |

Measured three times across two harness versions today: 27.0 / 27.7 / 29.3. This prices the `.cosmos-gpu-label` finding #744 had to work around: that run proved the DOM never goes quiet, this one says what the quiet costs. Filed as TRA-683, not fixed here.

`parseCpuTime` is unit-tested, and the test caught a real bug on the way in — `ps` separates days with `-`, so splitting on `[-:]` read `1-02:00:00` as 62 hours.

## Numbers (3.11.0, `e8a0dd7c`, macOS 26.5 / arm64, median of 3, 30 min / 521 cycles / 5226 searches / 10 min settle)

| Metric | #744 (2026-09-01) | this run | note |
|---|---|---|---|
| `ui_p95_ms` | 668 | 690 | first independent agreement on this metric |
| `heap_growth_mb_per_hour` | 1.39 | 0.19 | no leak either way, ceiling 50 |
| `rss_after_index_settle_mb` | 383 | 316 | ceiling 500 |
| `tree_rss_peak_mb` | 1691 | 1250 | ceiling 2000 |
| `renderer_first_content_ms` | — | 97 | new |
| `renderer_cpu_idle_pct.graph` | — | 29.3 | new |

`heap_idle_mb` reads 15.4 against 9.5 in pre-#744 runs: those idled with no daemon reachable, this one idles against a served fixture. Not a leak, and noted in `docs/perf/README.md`.

Full suite green (9552 passed), `tsc --noEmit` clean, no dependency changed so `artifact_mb` was not re-sampled.
