### PR TITLE
perf(app): let the Graph tab go quiet when nobody is watching (TRA-683)

### DIFF
--- a/packages/app/src/renderer/tabs/GraphExplorerGPU.tsx
+++ b/packages/app/src/renderer/tabs/GraphExplorerGPU.tsx
@@ -32,6 +32,7 @@ import {
   useMenuAnchor,
 } from '../lattice/ui';
 import { userFacingError } from './graph-error';
+import { breathAction } from './graph-idle';
 
 const BASE = 'http://127.0.0.1:3741';
 
@@ -824,6 +825,10 @@ export const GraphExplorerGPU = forwardRef<GraphExplorerGPUHandle, Props>(functi
   // clearHighlight restores from this instead of a flat theme-default color.
   const defaultLinkColorsRef = useRef<Float32Array | null>(null);
   const rafLabelRef = useRef<number | null>(null);
+  // Last frame's label-input fingerprint (camera, hover, selection, data).
+  // While the solver is stopped nothing moves on its own, so an unchanged
+  // fingerprint means the whole label + halo pass can be skipped.
+  const lastLabelSigRef = useRef<string>('');
   // Throttles per-tick camera refit during simulation (see onSimulationTick).
   const lastTickFitRef = useRef<number>(0);
   // Whether we've already frozen the layout on this render cycle. Set true
@@ -1392,6 +1397,17 @@ export const GraphExplorerGPU = forwardRef<GraphExplorerGPUHandle, Props>(functi
     if (!graph || !layer) return;
 
     const zoom = graph.getZoomLevel();
+    // Idle short-circuit (TRA-683). Point positions only move while the
+    // solver runs; everything else that can move a label is in this
+    // fingerprint. The origin's screen position covers pan and zoom in one
+    // call. Without this the pass rewrote textContent/transform on every
+    // label, plus repainted the halo canvas, 30×/s forever.
+    const origin = graph.spaceToScreenPosition([0, 0]);
+    const sig = `${origin[0]}|${origin[1]}|${zoom}|${hovered?.id ?? ''}|${selected?.id ?? ''}|${
+      highlightedDepthRef.current?.size ?? -1
+    }|${selectedIndicesRef.current?.size ?? -1}|${showLabelsRef.current}|${nodesRef.current.length}`;
+    if (!graph.isSimulationRunning && sig === lastLabelSigRef.current) return;
+    lastLabelSigRef.current = sig;
     // Labels toggle is the master switch — when off, wipe any existing labels
     // and bail before re-adding any. Reading via ref avoids any stale-closure
     // risk if the RAF loop outlives a dep change.
@@ -1761,6 +1777,9 @@ export const GraphExplorerGPU = forwardRef<GraphExplorerGPUHandle, Props>(functi
       // its one initial fit-view pass.
       frozenRef.current = false;
       userInteractedRef.current = false;
+      // Fresh data — force the next label pass to run even if the camera and
+      // node count happen to match the previous render.
+      lastLabelSigRef.current = '';
 
       const prevGraph = graphRef.current;
       let carryPositions: number[] | Float32Array | null = null;
@@ -2709,6 +2728,39 @@ export const GraphExplorerGPU = forwardRef<GraphExplorerGPUHandle, Props>(functi
     };
   }, [live]);
 
+  // ── Idle wake-up ──────────────────────────────────────────────
+  // Any pointer, wheel or click over the pane counts as "someone is looking".
+  // The breathing interval below reads this to decide whether to keep
+  // re-heating the solver; when it has already let the solver stop, the next
+  // event here restarts it immediately instead of waiting up to 2.5 s.
+  const lastInteractionRef = useRef<number>(performance.now());
+  const idlePausedRef = useRef(false);
+  useEffect(() => {
+    // The whole pane, not just the canvas — toolbar clicks (Fit, search,
+    // filters) are the user looking at the graph too.
+    const pane = paneRef.current;
+    if (!pane) return;
+    const events = ['pointerdown', 'pointermove', 'wheel'] as const;
+    const wake = () => {
+      lastInteractionRef.current = performance.now();
+      if (!idlePausedRef.current) return;
+      idlePausedRef.current = false;
+      const g = graphRef.current;
+      if (!g || !liveRef.current || offscreenPausedRef.current) return;
+      try {
+        g.unpause();
+        g.start(0.15);
+        setSimRunning(true);
+      } catch {
+        /* graph destroyed between events — the interval will re-arm */
+      }
+    };
+    for (const ev of events) pane.addEventListener(ev, wake, { passive: true });
+    return () => {
+      for (const ev of events) pane.removeEventListener(ev, wake);
+    };
+  }, []);
+
   // ── Breathing interval ────────────────────────────────────────
   // Wall-clock re-heat: every 2.5 s, if the user hasn't paused via Live,
   // bump alpha back up with `graph.start(0.15)`. This has to be a plain
@@ -2717,13 +2769,29 @@ export const GraphExplorerGPU = forwardRef<GraphExplorerGPUHandle, Props>(functi
   // (0.001), so a tick-driven re-heat can never recover from full decay.
   // `isSimulationRunning`-guarded unpause handles the "resumed from a full
   // stop" case that pause/unpause alone can't restart.
+  //
+  // Breathing stops on its own once the pane has been idle (TRA-683):
+  // cosmos.gl's frame loop only keeps running while the simulation is, so
+  // pausing it takes the tab's idle cost to ~nothing. The Live dot goes
+  // amber, which is what it already means — live, but not currently solving.
   useEffect(() => {
     if (!live) return;
     const id = window.setInterval(() => {
       const g = graphRef.current;
       if (!g) return;
       if (!liveRef.current) return;
+      const action = breathAction(
+        performance.now() - lastInteractionRef.current,
+        idlePausedRef.current,
+      );
+      if (action === 'stay-paused') return;
       try {
+        if (action === 'pause') {
+          g.pause();
+          idlePausedRef.current = true;
+          if (simRunning) setSimRunning(false);
+          return;
+        }
         g.start(0.15);
         if (!simRunning) setSimRunning(true);
       } catch {
@@ -2742,6 +2810,10 @@ export const GraphExplorerGPU = forwardRef<GraphExplorerGPUHandle, Props>(functi
     const graph = graphRef.current;
     if (!graph) return;
     if (live) {
+      // Flipping the toggle is an interaction — clear any idle pause so the
+      // breathing interval doesn't stop the solver again on its next tick.
+      lastInteractionRef.current = performance.now();
+      idlePausedRef.current = false;
       // If alpha has decayed past the re-heat threshold and the sim has
       // naturally stopped, bump it back up so the toggle takes visible
       // effect. Otherwise a simple unpause is enough.

--- a/packages/app/src/renderer/tabs/GraphExplorerGPU.tsx
+++ b/packages/app/src/renderer/tabs/GraphExplorerGPU.tsx
@@ -829,6 +829,12 @@ export const GraphExplorerGPU = forwardRef<GraphExplorerGPUHandle, Props>(functi
   // While the solver is stopped nothing moves on its own, so an unchanged
   // fingerprint means the whole label + halo pass can be skipped.
   const lastLabelSigRef = useRef<string>('');
+  // Identity of the highlight map / selection set the last pass ran against —
+  // both are replaced wholesale by every writer, never mutated in place.
+  const lastLabelDepsRef = useRef<{
+    highlight: Map<number, number> | null;
+    selection: Set<number> | null;
+  }>({ highlight: null, selection: null });
   // Throttles per-tick camera refit during simulation (see onSimulationTick).
   const lastTickFitRef = useRef<number>(0);
   // Whether we've already frozen the layout on this render cycle. Set true
@@ -1402,12 +1408,27 @@ export const GraphExplorerGPU = forwardRef<GraphExplorerGPUHandle, Props>(functi
     // fingerprint. The origin's screen position covers pan and zoom in one
     // call. Without this the pass rewrote textContent/transform on every
     // label, plus repainted the halo canvas, 30×/s forever.
+    // The highlight map and the selection set are compared by identity, not by
+    // size: every writer replaces them with a fresh Map/Set, and two different
+    // selections of the same size are exactly the case a size check misses.
     const origin = graph.spaceToScreenPosition([0, 0]);
-    const sig = `${origin[0]}|${origin[1]}|${zoom}|${hovered?.id ?? ''}|${selected?.id ?? ''}|${
-      highlightedDepthRef.current?.size ?? -1
-    }|${selectedIndicesRef.current?.size ?? -1}|${showLabelsRef.current}|${nodesRef.current.length}`;
-    if (!graph.isSimulationRunning && sig === lastLabelSigRef.current) return;
+    const cw = containerRef.current?.clientWidth ?? 0;
+    const ch = containerRef.current?.clientHeight ?? 0;
+    const sig = `${origin[0]}|${origin[1]}|${zoom}|${hovered?.id ?? ''}|${selected?.id ?? ''}|${showLabelsRef.current}|${nodes.length}|${cw}x${ch}`;
+    const deps = lastLabelDepsRef.current;
+    if (
+      !graph.isSimulationRunning &&
+      sig === lastLabelSigRef.current &&
+      deps.highlight === highlightedDepthRef.current &&
+      deps.selection === selectedIndicesRef.current
+    ) {
+      return;
+    }
     lastLabelSigRef.current = sig;
+    lastLabelDepsRef.current = {
+      highlight: highlightedDepthRef.current,
+      selection: selectedIndicesRef.current,
+    };
     // Labels toggle is the master switch — when off, wipe any existing labels
     // and bail before re-adding any. Reading via ref avoids any stale-closure
     // risk if the RAF loop outlives a dep change.
@@ -1431,8 +1452,6 @@ export const GraphExplorerGPU = forwardRef<GraphExplorerGPUHandle, Props>(functi
     const indices = new Set<number>();
     const highlightedDepth = highlightedDepthRef.current;
     const highlightActive = highlightedDepth != null && highlightedDepth.size > 0;
-    const cw = containerRef.current?.clientWidth ?? 0;
-    const ch = containerRef.current?.clientHeight ?? 0;
     const HARD_CAP = 80;
     const placed: LabelBox[] = [];
     const screenOf = (idx: number): [number, number] | null => {

--- a/packages/app/src/renderer/tabs/__tests__/graph-idle.test.ts
+++ b/packages/app/src/renderer/tabs/__tests__/graph-idle.test.ts
@@ -1,0 +1,24 @@
+/* TRA-683 — the Graph tab burned 27.7% of a core with no user input because
+   the breathing interval re-heated the solver unconditionally. */
+
+import { describe, expect, it } from 'vitest';
+import { breathAction, IDLE_BREATH_MS } from '../graph-idle';
+
+describe('breathAction', () => {
+  it('breathes while the pane is being used', () => {
+    expect(breathAction(0, false)).toBe('breathe');
+    expect(breathAction(IDLE_BREATH_MS, false)).toBe('breathe');
+  });
+
+  it('stops the solver once the pane goes untouched', () => {
+    expect(breathAction(IDLE_BREATH_MS + 1, false)).toBe('pause');
+  });
+
+  it('does not re-pause an already stopped solver', () => {
+    expect(breathAction(IDLE_BREATH_MS + 60_000, true)).toBe('stay-paused');
+  });
+
+  it('breathes again as soon as an interaction resets the clock', () => {
+    expect(breathAction(0, true)).toBe('breathe');
+  });
+});

--- a/packages/app/src/renderer/tabs/graph-idle.ts
+++ b/packages/app/src/renderer/tabs/graph-idle.ts
@@ -1,0 +1,26 @@
+/* TRA-683 — the Graph tab used to breathe forever: a wall-clock interval
+   re-heated the solver every 2.5 s whether or not anyone was watching, which
+   measured at 27.7% of a core on an idle tab (Overview: 0.2%). Breathing is
+   for a user who is looking at it, so after this long without pointer, wheel
+   or click input we stop the solver and let cosmos.gl's frame loop end; the
+   next interaction unpauses and re-heats it. */
+
+/** How long the view may sit untouched before the solver is allowed to stop. */
+export const IDLE_BREATH_MS = 10_000;
+
+export type BreathAction =
+  /** Re-heat alpha — someone is (or just was) watching. */
+  | 'breathe'
+  /** Nobody has touched the view in a while — stop the solver. */
+  | 'pause'
+  /** Already stopped; nothing to do until the next interaction. */
+  | 'stay-paused';
+
+export function breathAction(
+  msSinceInteraction: number,
+  paused: boolean,
+  idleMs: number = IDLE_BREATH_MS,
+): BreathAction {
+  if (msSinceInteraction <= idleMs) return 'breathe';
+  return paused ? 'stay-paused' : 'pause';
+}


### PR DESCRIPTION
Closes TRA-683.

## What burned the CPU

Two loops, both unconditional:

1. **Breathing.** `GraphExplorerGPU.tsx` runs a wall-clock `setInterval` that calls
   `graph.start(0.15)` every 2.5 s while Live is on, so the force simulation never cools.
2. **Labels.** A 30 fps RAF loop rewrites `textContent`, `dataset.kind`, `style.transform`
   and `dataset.state` on every `.cosmos-gpu-label`, reads `getPointPositions()` (a
   WebGL→JS buffer copy) and repaints the halo canvas — every frame, forever.

Neither had an "is anyone watching?" condition. The tab's only quiet path was the
existing offscreen guard (IntersectionObserver + Page Visibility), which never fires
while the tab is the one on screen.

## The change

- **`graph-idle.ts`** — `breathAction(msSinceInteraction, paused)`: breathe, pause, or
  stay paused. One pure function, unit-tested.
- **Breathing** stops after 10 s with no `pointerdown` / `pointermove` / `wheel` over the
  pane, by calling `graph.pause()`. cosmos.gl's own `shouldKeepRendering()` returns false
  once `isSimulationRunning` is false and no transition/zoom/drag/hover work is pending,
  so pausing genuinely ends its frame loop — this is the same mechanism the offscreen
  guard already relies on. The Live dot goes amber, which is what it already means.
- **Wake-up** on the next pointer/wheel event over the pane (or the Live toggle):
  `unpause()` + `start(0.15)`, so motion resumes immediately rather than on the next
  2.5 s tick.
- **Label pass** short-circuits when the solver is stopped *and* its inputs are unchanged.
  The fingerprint is the origin's screen position (covers pan and zoom in one call), zoom,
  hovered/selected id, highlight and selection sizes, the labels toggle and node count.
  While the solver runs the pass always executes, because positions move without changing
  any of those.

Nothing about the interactive behaviour changes: any interaction re-arms both loops, and
a running solver is never short-circuited.

## Test evidence

- `packages/app/src/renderer/tabs/__tests__/graph-idle.test.ts` — the four states of the
  breathing decision.
- `pnpm --dir packages/app exec vitest run` — 60 files, 588 tests, green.
- `pnpm test` (root, quiet) — 872 files, 9601 tests, green.
- `pnpm --dir packages/app exec tsc --noEmit` — clean.

## What I could not verify locally, and why

The acceptance metric is `renderer_cpu_idle_pct.graph` from Phase C of
`packages/app/scripts/perf-measure.mjs`. That instrumentation is **not on master** — it
lives in #781, which is open with one failing check, so I did not build on it.

I wrote a standalone CDP probe instead (pinned perf fixture, Graph tab, 60 s with no
input, `cputime` deltas per process). It cannot reproduce the defect: this workspace's
rules forbid putting a window on the machine owner's screen, and a never-shown
`BrowserWindow` reports `document.hidden === true`, so the tab's *existing* offscreen
guard pauses the simulation before the idle path is ever reached. Both runs — with and
without this change — measured a fully loaded Graph tab (2 canvases, 15–21 labels) at
**0.1–0.3% renderer CPU over 30–60 s**. Neutralising the visibility guard in-page to
force the visible code path made the app fail to reach readiness, and I stopped there
rather than keep hacking at the probe.

That number is still useful as a floor: it is what this exact tab costs once
`graph.pause()` has taken effect, which is the state this change now reaches on idle. The
real before/after belongs to the next baseline pass under #781.
