### PR TITLE
fix(search): honor glob wildcards in search's file_pattern filter (TRA-676)

### DIFF
--- a/src/db/fts.ts
+++ b/src/db/fts.ts
@@ -53,7 +53,7 @@ export function searchFts(
   }
   if (filters?.filePattern) {
     conditions.push('f.path LIKE ?');
-    params.push(`%${filters.filePattern}%`);
+    params.push(filePatternToLike(filters.filePattern));
   }
 
   // Default-exclusion guard: drop markdown headings/tags from generic
@@ -98,6 +98,17 @@ export function searchFts(
 
   params.push(limit, offset);
   return db.prepare(sql).all(...params) as FtsResult[];
+}
+
+/**
+ * Convert a `file_pattern` filter into a SQL LIKE pattern. Glob wildcards
+ * (`*`, `?`) map to their LIKE equivalents (`%`, `_`); a pattern with no
+ * wildcards keeps the pre-existing substring-match behavior so plain
+ * filenames like `tool-filter.ts` still match anywhere in the path.
+ */
+export function filePatternToLike(pattern: string): string {
+  if (!/[*?]/.test(pattern)) return `%${pattern}%`;
+  return pattern.replace(/\*/g, '%').replace(/\?/g, '_');
 }
 
 export function escapeFtsQuery(query: string): string {

--- a/src/db/fuzzy.ts
+++ b/src/db/fuzzy.ts
@@ -1,5 +1,6 @@
 import type Database from 'better-sqlite3';
 import { distance as levenshtein } from 'fastest-levenshtein';
+import { filePatternToLike } from './fts.js';
 
 // ─── Trigram utilities ─────────────────────────────────────
 
@@ -127,7 +128,7 @@ export function fuzzySearch(
     }
     if (filePattern) {
       filterConditions.push('f.path LIKE ?');
-      filterParams.push(`%${filePattern}%`);
+      filterParams.push(filePatternToLike(filePattern));
     }
   }
 

--- a/tests/db/fts-filters.test.ts
+++ b/tests/db/fts-filters.test.ts
@@ -7,7 +7,7 @@
 import path from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
 import type { TraceMcpConfig } from '../../src/config.js';
-import { escapeFtsQuery, searchFts } from '../../src/db/fts.js';
+import { escapeFtsQuery, filePatternToLike, searchFts } from '../../src/db/fts.js';
 import type { Store } from '../../src/db/store.js';
 import { IndexingPipeline } from '../../src/indexer/pipeline.js';
 import { PhpLanguagePlugin } from '../../src/indexer/plugins/language/php/index.js';
@@ -81,6 +81,39 @@ describe('searchFts filter push-down', () => {
       const sym = store.getSymbolBySymbolId(r.symbolIdStr);
       const file = store.getFileById(sym!.file_id);
       expect(file?.path).toContain('app/');
+    }
+  });
+
+  // TRA-676: file_pattern used to be spliced straight into a `%...%` LIKE
+  // clause, so glob wildcards (`*`) were matched as literal characters and
+  // any glob-style pattern silently returned zero rows.
+  it('filePattern filter accepts a glob wildcard (*.ts)', () => {
+    const results = searchFts(store.db, 'add', 50, 0, { filePattern: '*.ts' });
+    expect(results.length).toBeGreaterThan(0);
+    for (const r of results) {
+      const sym = store.getSymbolBySymbolId(r.symbolIdStr);
+      const file = store.getFileById(sym!.file_id);
+      expect(file?.path.endsWith('.ts')).toBe(true);
+    }
+  });
+
+  it('filePattern filter accepts a directory glob (src/**)', () => {
+    const results = searchFts(store.db, 'add', 50, 0, { filePattern: 'src/**' });
+    expect(results.length).toBeGreaterThan(0);
+    for (const r of results) {
+      const sym = store.getSymbolBySymbolId(r.symbolIdStr);
+      const file = store.getFileById(sym!.file_id);
+      expect(file?.path.startsWith('src/')).toBe(true);
+    }
+  });
+
+  it('filePattern filter accepts a leading-** glob (**/*.ts)', () => {
+    const results = searchFts(store.db, 'add', 50, 0, { filePattern: '**/*.ts' });
+    expect(results.length).toBeGreaterThan(0);
+    for (const r of results) {
+      const sym = store.getSymbolBySymbolId(r.symbolIdStr);
+      const file = store.getFileById(sym!.file_id);
+      expect(file?.path.endsWith('.ts')).toBe(true);
     }
   });
 
@@ -173,5 +206,27 @@ describe('escapeFtsQuery', () => {
 
   it('handles query that is only boolean operators', () => {
     expect(escapeFtsQuery('OR AND NOT')).toBe('');
+  });
+});
+
+describe('filePatternToLike', () => {
+  it('converts * to the SQL wildcard %', () => {
+    expect(filePatternToLike('*.ts')).toBe('%.ts');
+  });
+
+  it('converts ? to the SQL single-char wildcard _', () => {
+    expect(filePatternToLike('file?.ts')).toBe('file_.ts');
+  });
+
+  it('converts ** to consecutive %% — equivalent to a single % in SQL LIKE', () => {
+    expect(filePatternToLike('src/**')).toBe('src/%%');
+  });
+
+  it('handles a leading-** glob', () => {
+    expect(filePatternToLike('**/*.ts')).toBe('%%/%.ts');
+  });
+
+  it('wraps a plain pattern (no wildcards) in % for substring matching', () => {
+    expect(filePatternToLike('src/index.ts')).toBe('%src/index.ts%');
   });
 });

--- a/tests/db/fuzzy.test.ts
+++ b/tests/db/fuzzy.test.ts
@@ -182,6 +182,25 @@ describe('Fuzzy search', () => {
       expect(results.length).toBe(0);
     });
 
+    it('filePattern glob (*.py) matches only python file symbols', () => {
+      const results = fuzzySearch(db, 'formatCurrencyy', {
+        filePattern: '*.py',
+        threshold: 0.1,
+        maxEditDistance: 5,
+      });
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((r) => r.name.startsWith('format'))).toBe(true);
+    });
+
+    it('filePattern glob (*.ts) excludes symbols from non-matching files', () => {
+      const results = fuzzySearch(db, 'formatCurrencyy', {
+        filePattern: '*.ts',
+        threshold: 0.1,
+        maxEditDistance: 5,
+      });
+      expect(results.length).toBe(0);
+    });
+
     it('handles multiple results without N+1', () => {
       // fuzzySearch uses batch SQL — single candidate query + batch metadata
       const results = fuzzySearch(db, 'formatCurrencyy', {

--- a/tests/e2e/mcp-tools-e2e.test.ts
+++ b/tests/e2e/mcp-tools-e2e.test.ts
@@ -226,9 +226,13 @@ describe('MCP Tools E2E — Search scoring', () => {
   it('search with file pattern filter narrows results', async () => {
     const all = await search(store, 'User', {}, 100, 0, {});
     const filtered = await search(store, 'User', { filePattern: '**/Models/**' }, 100, 0, {});
+    // TRA-676 regression guard: a glob file_pattern must actually filter,
+    // not silently return zero rows (which used to also satisfy the <=
+    // assertion below).
+    expect(filtered.items.length).toBeGreaterThan(0);
     expect(filtered.items.length).toBeLessThanOrEqual(all.items.length);
     for (const item of filtered.items) {
-      expect(item.symbol.file).toContain('Models');
+      expect(item.file.path).toContain('Models');
     }
   });
 });


### PR DESCRIPTION
## Summary
- `search`'s `file_pattern` filter was spliced straight into a `%...%` SQL LIKE clause. Glob wildcards (`*`, `**`, `?`) were matched as literal characters, so any glob-style pattern (`*.ts`, `src/**`, `**/*.ts`) silently returned zero results while the same query with no `file_pattern` matched fine.
- Added `filePatternToLike()` in `src/db/fts.ts` that converts `*`->`%`, `?`->`_`; patterns with no wildcards keep the previous substring-match behavior (`%pattern%`) for backward compatibility. Applied in both `searchFts` (backs single/tiered/drill/flat/fusion modes) and `fuzzySearch` (backs `fuzzy=true` and the automatic zero-result fallback).
- Fixing this unmasked a latent test bug in `tests/e2e/mcp-tools-e2e.test.ts`: the file_pattern regression test asserted on `item.symbol.file` (does not exist on the row shape) instead of `item.file.path`. The glob pattern used there always returned 0 rows before this fix, so that loop body never actually ran. Fixed the assertion and added a `toBeGreaterThan(0)` guard.
- Added direct regression coverage: `filePatternToLike` unit tests, `searchFts` glob-pattern integration tests, and `fuzzySearch` glob-pattern tests.

## Test plan
- [x] pnpm run typecheck
- [x] pnpm run test - 9611 passed, 10 skipped, 0 failed
- [x] pnpm run build
- [x] pnpm run biome:ci on changed files
