### PR TITLE
feat(tools): ship the router preset and make batch-as-door deliberate (TRA-675)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -443,7 +443,7 @@ The `tools.*` section controls what the MCP server injects into every session �
 ```jsonc
 {
   "tools": {
-    "preset": "standard",                // "full" | "standard" | "minimal" | "review" | "architecture" | "dev" | "security" | "design" | "perf"
+    "preset": "standard",                // "full" | "standard" | "minimal" | "review" | "architecture" | "dev" | "security" | "design" | "perf" | "router"
     "description_verbosity": "full",     // "full" | "minimal" | "none"
     "instructions_verbosity": "full",    // "full" | "minimal" | "none" — controls the tool-routing block
     "client_profile": "auto",            // "auto" | "off" | "claude-code" | "codex" | "cursor" | "vscode" | "generic"
@@ -456,7 +456,7 @@ The `tools.*` section controls what the MCP server injects into every session �
 
 | Option | Default | Description |
 |---|---|---|
-| `tools.preset` | `"minimal"` | Tool preset — the number is the upper bound on the tool surface; framework-gated tools only appear when the framework is detected. `minimal` (28 tools, default), `standard` (60 tools — covers >99% of real-world tool calls per session-log mining), `review` (32 tools), `architecture` (41 tools), `dev` (42 tools), `security` (35 tools), `design` (26 tools), `perf` (31 tools), or `full` (every registered tool, opt-in). A preset is a *deferral*, not a restriction: everything outside it is registered but hidden, and `load_tools` pulls any of it in mid-session. `tools.exclude` remains a hard restriction that `load_tools` cannot undo. |
+| `tools.preset` | `"minimal"` | Tool preset — the number is the upper bound on the tool surface; framework-gated tools only appear when the framework is detected. `minimal` (28 tools, default), `standard` (60 tools — covers >99% of real-world tool calls per session-log mining), `review` (32 tools), `architecture` (41 tools), `dev` (42 tools), `security` (35 tools), `design` (26 tools), `perf` (31 tools), `router` (10 tools — see [The router preset](#the-router-preset)), or `full` (every registered tool, opt-in). A preset is a *deferral*, not a restriction: everything outside it is registered but hidden, and `load_tools` pulls any of it in mid-session. `tools.exclude` remains a hard restriction that `load_tools` cannot undo. |
 | `tools.include` | — | Whitelist specific tools by name |
 | `tools.exclude` | — | Blacklist specific tools by name |
 | `tools.description_verbosity` | `"full"` | Per-tool description length. `minimal` = first sentence. `none` = empty |
@@ -498,6 +498,14 @@ returns each loaded tool's full JSON schema in its response, and the loaded tool
 is immediately reachable through `batch` — `batch({ calls: [{ tool, args }] })`
 — which is in every preset.
 
+`batch` dispatches by name against the whole registry, deferred tools included,
+so a deferred tool is callable through it *without* loading it first. That is
+deliberate (it is what the `router` preset below is built on), and the price is
+one round-trip's worth of schema you never see: you have to know the tool's
+arguments, or read them from `load_tools`. `tools.exclude` is not reachable this
+way — the exclusion is checked on the inner call names too, on both the local
+and the daemon-backed path.
+
 What escalation cannot do is widen `tools.exclude`. Exclusion stays a hard
 restriction; `load_tools` reports those names under `blocked` and leaves them
 off. If you want a tool gone, exclude it — don't rely on the preset.
@@ -509,13 +517,38 @@ in a flag set to save tokens into a 36.3k-token surface instead of a 7.8k one.
 Failing toward the cheap surface costs at most one `load_tools` round-trip.
 
 Measured `tools/list` cost of each preset on this repo (serialized chars, then
-o200k tokens, 2026-09-01): `design` 21.9k / 5.0k, `perf` 32.3k / 7.5k, `minimal`
+o200k tokens, 2026-09-01; `router` added 2026-09-02): `router` 7.1k / 1.6k,
+`design` 21.9k / 5.0k, `perf` 32.3k / 7.5k, `minimal`
 34.0k / 7.8k, `review` 37.3k / 8.6k, `security` 41.5k / 9.6k, `architecture`
 44.3k / 10.2k, `dev` 51.3k / 11.9k, `standard` 64.6k / 14.9k, `full` 157.7k /
 36.3k. Against `full`, that is a 67% cut on the widest role preset (`dev`) and
 86% on the narrowest (`design`) — framework-gated tools are excluded, so a
 project that detects the matching framework pays more.
 `load_tools` itself is 0.9k of that — the price of making the other 123k optional.
+
+### The router preset
+
+`"preset": "router"` advertises **no** code-intelligence tools at all — only the
+session meta-tools that are never gated, `load_tools` and `batch` among them. Ten
+tools, 1.6k tokens, 95.6% below `full` and 79.2% below the `minimal` default.
+
+It is usable rather than crippled because the two halves cover each other:
+`load_tools()` names the ~150 deferred tools (names only — the schemas are what
+you are not paying for), and `batch` calls any of them directly. So the session
+pays for a catalog instead of a surface, and there is no escalation round-trip
+unless you want the schemas.
+
+```jsonc
+{ "tools": { "preset": "router" } }      // or: trace-mcp --preset router
+```
+
+It is **opt-in and will not become the default.** On a host that already defers
+tool schemas itself — Claude Code's ToolSearch, which keeps only the 15
+`ALWAYS_LOAD_TOOLS` eagerly loaded — `router` saves ~2.9k tokens and takes away
+exactly the first-five-minutes tools that stamp exists to protect. On a host
+without such a mechanism it saves ~6.2k per session, every session. Take it if
+your client has no tool deferral of its own, or if you are running many short
+sessions where the surface is most of what you pay.
 
 ### Client profiles
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1736,7 +1736,7 @@ The `tools.*` section controls what the MCP server injects into every session �
 ```jsonc
 {
   "tools": {
-    "preset": "standard",                // "full" | "standard" | "minimal" | "review" | "architecture" | "dev" | "security" | "design" | "perf"
+    "preset": "standard",                // "full" | "standard" | "minimal" | "review" | "architecture" | "dev" | "security" | "design" | "perf" | "router"
     "description_verbosity": "full",     // "full" | "minimal" | "none"
     "instructions_verbosity": "full",    // "full" | "minimal" | "none" — controls the tool-routing block
     "client_profile": "auto",            // "auto" | "off" | "claude-code" | "codex" | "cursor" | "vscode" | "generic"
@@ -1749,7 +1749,7 @@ The `tools.*` section controls what the MCP server injects into every session �
 
 | Option | Default | Description |
 |---|---|---|
-| `tools.preset` | `"minimal"` | Tool preset — the number is the upper bound on the tool surface; framework-gated tools only appear when the framework is detected. `minimal` (28 tools, default), `standard` (60 tools — covers >99% of real-world tool calls per session-log mining), `review` (32 tools), `architecture` (41 tools), `dev` (42 tools), `security` (35 tools), `design` (26 tools), `perf` (31 tools), or `full` (every registered tool, opt-in). A preset is a *deferral*, not a restriction: everything outside it is registered but hidden, and `load_tools` pulls any of it in mid-session. `tools.exclude` remains a hard restriction that `load_tools` cannot undo. |
+| `tools.preset` | `"minimal"` | Tool preset — the number is the upper bound on the tool surface; framework-gated tools only appear when the framework is detected. `minimal` (28 tools, default), `standard` (60 tools — covers >99% of real-world tool calls per session-log mining), `review` (32 tools), `architecture` (41 tools), `dev` (42 tools), `security` (35 tools), `design` (26 tools), `perf` (31 tools), `router` (10 tools — see [The router preset](#the-router-preset)), or `full` (every registered tool, opt-in). A preset is a *deferral*, not a restriction: everything outside it is registered but hidden, and `load_tools` pulls any of it in mid-session. `tools.exclude` remains a hard restriction that `load_tools` cannot undo. |
 | `tools.include` | — | Whitelist specific tools by name |
 | `tools.exclude` | — | Blacklist specific tools by name |
 | `tools.description_verbosity` | `"full"` | Per-tool description length. `minimal` = first sentence. `none` = empty |
@@ -1791,6 +1791,14 @@ returns each loaded tool's full JSON schema in its response, and the loaded tool
 is immediately reachable through `batch` — `batch({ calls: [{ tool, args }] })`
 — which is in every preset.
 
+`batch` dispatches by name against the whole registry, deferred tools included,
+so a deferred tool is callable through it *without* loading it first. That is
+deliberate (it is what the `router` preset below is built on), and the price is
+one round-trip's worth of schema you never see: you have to know the tool's
+arguments, or read them from `load_tools`. `tools.exclude` is not reachable this
+way — the exclusion is checked on the inner call names too, on both the local
+and the daemon-backed path.
+
 What escalation cannot do is widen `tools.exclude`. Exclusion stays a hard
 restriction; `load_tools` reports those names under `blocked` and leaves them
 off. If you want a tool gone, exclude it — don't rely on the preset.
@@ -1802,13 +1810,38 @@ in a flag set to save tokens into a 36.3k-token surface instead of a 7.8k one.
 Failing toward the cheap surface costs at most one `load_tools` round-trip.
 
 Measured `tools/list` cost of each preset on this repo (serialized chars, then
-o200k tokens, 2026-09-01): `design` 21.9k / 5.0k, `perf` 32.3k / 7.5k, `minimal`
+o200k tokens, 2026-09-01; `router` added 2026-09-02): `router` 7.1k / 1.6k,
+`design` 21.9k / 5.0k, `perf` 32.3k / 7.5k, `minimal`
 34.0k / 7.8k, `review` 37.3k / 8.6k, `security` 41.5k / 9.6k, `architecture`
 44.3k / 10.2k, `dev` 51.3k / 11.9k, `standard` 64.6k / 14.9k, `full` 157.7k /
 36.3k. Against `full`, that is a 67% cut on the widest role preset (`dev`) and
 86% on the narrowest (`design`) — framework-gated tools are excluded, so a
 project that detects the matching framework pays more.
 `load_tools` itself is 0.9k of that — the price of making the other 123k optional.
+
+### The router preset
+
+`"preset": "router"` advertises **no** code-intelligence tools at all — only the
+session meta-tools that are never gated, `load_tools` and `batch` among them. Ten
+tools, 1.6k tokens, 95.6% below `full` and 79.2% below the `minimal` default.
+
+It is usable rather than crippled because the two halves cover each other:
+`load_tools()` names the ~150 deferred tools (names only — the schemas are what
+you are not paying for), and `batch` calls any of them directly. So the session
+pays for a catalog instead of a surface, and there is no escalation round-trip
+unless you want the schemas.
+
+```jsonc
+{ "tools": { "preset": "router" } }      // or: trace-mcp --preset router
+```
+
+It is **opt-in and will not become the default.** On a host that already defers
+tool schemas itself — Claude Code's ToolSearch, which keeps only the 15
+`ALWAYS_LOAD_TOOLS` eagerly loaded — `router` saves ~2.9k tokens and takes away
+exactly the first-five-minutes tools that stamp exists to protect. On a host
+without such a mechanism it saves ~6.2k per session, every session. Take it if
+your client has no tool deferral of its own, or if you are running many short
+sessions where the surface is most of what you pay.
 
 ### Client profiles
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -350,7 +350,7 @@ program
   .description('Start MCP server (stdio transport)')
   .option(
     '--preset <name>',
-    'Tool preset (e.g. minimal, review, dev, security, design, perf, architecture, standard, full)',
+    'Tool preset (e.g. router, minimal, review, dev, security, design, perf, architecture, standard, full)',
   )
   .action(async (opts: { preset?: string } = {}) => {
     if (opts.preset) {
@@ -528,7 +528,7 @@ program
   )
   .option(
     '--preset <name>',
-    'Default tool preset for daemon sessions (e.g. minimal, review, dev, security, design, perf, architecture, standard, full)',
+    'Default tool preset for daemon sessions (e.g. router, minimal, review, dev, security, design, perf, architecture, standard, full)',
   )
   .action(async (opts: { port: string; host: string; allowRemote?: boolean; preset?: string }) => {
     if (opts.preset) {

--- a/src/daemon/router/__tests__/proxy-tool-preset.test.ts
+++ b/src/daemon/router/__tests__/proxy-tool-preset.test.ts
@@ -353,6 +353,18 @@ describe('daemon proxy answers load_tools locally (TRA-402)', () => {
     expect(await p.listTools()).not.toContain('get_pagerank');
   });
 
+  it('lists the deferred surface even when no tools/list came through this backend', async () => {
+    // The swap case (session starts local, router moves it to the proxy): the
+    // client already listed tools through the *other* backend, so the proxy
+    // never saw a tools/list and reported an empty catalog — the discovery half
+    // of progressive disclosure silently gone (TRA-675). It primes itself now.
+    const p = await startEscalatingProxy(minimalConfig);
+    const result = (await p.loadTools({})) as { deferred_tools: string[] };
+    expect(result.deferred_tools.length).toBeGreaterThan(100);
+    expect(result.deferred_tools).toContain('get_pagerank');
+    expect(result.deferred_tools).not.toContain('search');
+  });
+
   it('passes toolSurface when constructing ProxyBackend, or escalation is dead on the shipped path', () => {
     const src = readFileSync(fileURLToPath(new URL('../session.ts', import.meta.url)), 'utf8');
     const ctor = src.slice(src.indexOf('new ProxyBackend('));
@@ -372,6 +384,79 @@ describe('StdioSession wires the filter into every proxy backend (TRA-250)', () 
     expect(ctor.slice(0, ctor.indexOf('});')), 'session.ts must pass toolFilter').toContain(
       'toolFilter:',
     );
+  });
+});
+
+describe('the router preset and batch-as-door (TRA-675)', () => {
+  const routerConfig = { tools: { preset: 'router' } } as TraceMcpConfig;
+
+  it('advertises exactly the ungated meta-tools and nothing else', async () => {
+    const names = await proxiedToolNames(routerConfig);
+    expect([...names].sort()).toEqual([...UNGATED_META_TOOLS].sort());
+  });
+
+  it('forwards a batch whose inner call is outside the preset', async () => {
+    // This is what makes an empty preset usable rather than crippled: the
+    // filter applies to the outer tool name, so `batch` reaches the daemon's
+    // full registry with no escalation round-trip. Deliberate, not accidental.
+    const { backend, transport, toClient } = await startProxy(routerConfig);
+    await backend.send({
+      jsonrpc: '2.0',
+      id: 42,
+      method: 'tools/call',
+      params: { name: 'batch', arguments: { calls: [{ tool: 'get_circular_imports', args: {} }] } },
+    } as unknown as JSONRPCMessage);
+    expect(
+      transport.forwarded.some((m) => (m as { method?: string }).method === 'tools/call'),
+    ).toBe(true);
+    expect((toClient.at(-1) as { error?: unknown }).error).toBeUndefined();
+  });
+
+  it('rejects a batch whose inner call is excluded by config, without forwarding it', async () => {
+    // A preset is a deferral; `tools.exclude` is a restriction. It has to hold
+    // through every door, so the proxy reads the inner names for this one case.
+    const transport = new FakeDaemonTransport(DAEMON_TOOLS);
+    const toClient: JSONRPCMessage[] = [];
+    const config = {
+      tools: { preset: 'router', exclude: ['get_circular_imports'] },
+    } as TraceMcpConfig;
+    const backend = new ProxyBackend({
+      daemonUrl: 'http://127.0.0.1:0',
+      projectRoot: '/nonexistent/fake-project',
+      clientId: 'tra-675-test',
+      toolFilter: createToolFilter(config),
+      toolSurface: {
+        isExcluded: (name) => (config.tools?.exclude ?? []).includes(name),
+        load: () => undefined,
+      },
+      transportFactory: () => transport,
+    });
+    backend.onmessage = (m) => toClient.push(m);
+    backends.push(backend);
+    await backend.start();
+
+    await backend.send({
+      jsonrpc: '2.0',
+      id: 43,
+      method: 'tools/call',
+      params: {
+        name: 'batch',
+        arguments: {
+          calls: [
+            { tool: 'search', args: { query: 'x' } },
+            { tool: 'get_circular_imports', args: {} },
+          ],
+        },
+      },
+    } as unknown as JSONRPCMessage);
+
+    const reply = toClient.at(-1) as { id?: unknown; error?: { code: number; message: string } };
+    expect(reply.id).toBe(43);
+    expect(reply.error?.message).toContain('get_circular_imports');
+    expect(
+      transport.forwarded.some((m) => (m as { method?: string }).method === 'tools/call'),
+      'an excluded tool must never reach the daemon, not even wrapped in a batch',
+    ).toBe(false);
   });
 });
 

--- a/src/daemon/router/__tests__/proxy-tool-preset.test.ts
+++ b/src/daemon/router/__tests__/proxy-tool-preset.test.ts
@@ -365,6 +365,27 @@ describe('daemon proxy answers load_tools locally (TRA-402)', () => {
     expect(result.deferred_tools).not.toContain('search');
   });
 
+  it('swallows a prime reply that arrives after its own timeout', async () => {
+    // The prime is answered on a race with a 5s timeout. A reply that loses
+    // that race still arrives eventually, and the client never sent the
+    // request it answers — forwarding it hands the MCP host a response with an
+    // id it cannot match. Recognised by id prefix, not by a live pending entry.
+    const p = await startEscalatingProxy(minimalConfig);
+    await p.loadTools({});
+    const primeId = p.transport.forwarded
+      .map((m) => (m as { id?: unknown }).id)
+      .find((id) => typeof id === 'string' && id.startsWith('__trace_prime_tools_list_'));
+    expect(primeId, 'the proxy should have primed itself').toBeDefined();
+
+    const before = p.toClient.length;
+    p.transport.onmessage?.({
+      jsonrpc: '2.0',
+      id: primeId,
+      result: { tools: [{ name: 'search' }] },
+    } as unknown as JSONRPCMessage);
+    expect(p.toClient.length, 'a late prime reply must not reach the client').toBe(before);
+  });
+
   it('passes toolSurface when constructing ProxyBackend, or escalation is dead on the shipped path', () => {
     const src = readFileSync(fileURLToPath(new URL('../session.ts', import.meta.url)), 'utf8');
     const ctor = src.slice(src.indexOf('new ProxyBackend('));

--- a/src/daemon/router/proxy-backend.ts
+++ b/src/daemon/router/proxy-backend.ts
@@ -77,6 +77,14 @@ const REINIT_TIMEOUT_MS = 10_000;
 const PRIME_TIMEOUT_MS = 5_000;
 
 /**
+ * Id prefix for those internal requests. Recognising a prime by its id rather
+ * than by a live entry in `pendingPrimeIds` is what keeps a *late* reply — one
+ * that lost the timeout race — from falling through to the client as a response
+ * to a request it never made.
+ */
+const PRIME_ID_PREFIX = '__trace_prime_tools_list_';
+
+/**
  * How many reinitialize+retry attempts to make on a lost session before giving
  * up and letting the error propagate (so the watcher can fall back to local
  * mode). Greater than 1 because the daemon can restart *again* in the narrow
@@ -397,7 +405,7 @@ export class ProxyBackend implements Backend {
   private primeDaemonTools(): Promise<void> {
     if (this.daemonTools.length > 0 || !this.httpTransport) return Promise.resolve();
     if (this.priming) return this.priming;
-    const id = `__trace_prime_tools_list_${++this.primeSeq}`;
+    const id = `${PRIME_ID_PREFIX}${++this.primeSeq}`;
     this.priming = (async () => {
       try {
         const done = new Promise<void>((resolve) => {
@@ -530,15 +538,18 @@ export class ProxyBackend implements Backend {
         return;
       }
       // An internal tools/list prime: record the daemon's surface, tell nobody.
+      // Matched on the id prefix, so a reply that arrived after its timeout is
+      // still swallowed instead of reaching the client as a response to a
+      // request the client never sent.
       const primeId = messageId(msg);
-      const resolvePrime =
-        typeof primeId === 'string' ? this.pendingPrimeIds.get(primeId) : undefined;
-      if (resolvePrime) {
+      if (typeof primeId === 'string' && primeId.startsWith(PRIME_ID_PREFIX)) {
         const tools = ((msg as Record<string, unknown>).result as { tools?: unknown })?.tools;
         if (Array.isArray(tools)) {
           this.daemonTools = tools as typeof this.daemonTools;
         }
-        resolvePrime();
+        const resolvePrime = this.pendingPrimeIds.get(primeId);
+        this.pendingPrimeIds.delete(primeId);
+        resolvePrime?.();
         return;
       }
       this.onmessage?.(this.filterToolsListResponse(msg));

--- a/src/daemon/router/proxy-backend.ts
+++ b/src/daemon/router/proxy-backend.ts
@@ -70,6 +70,13 @@ export interface ProxyBackendOptions {
 const REINIT_TIMEOUT_MS = 10_000;
 
 /**
+ * Max wall-clock to wait for the internal `tools/list` that primes the deferred
+ * catalog. Shorter than the reinit budget: this only decorates a `load_tools`
+ * reply, so timing out costs an empty catalog, not a broken session.
+ */
+const PRIME_TIMEOUT_MS = 5_000;
+
+/**
  * How many reinitialize+retry attempts to make on a lost session before giving
  * up and letting the error propagate (so the watcher can fall back to local
  * mode). Greater than 1 because the daemon can restart *again* in the narrow
@@ -166,6 +173,10 @@ export class ProxyBackend implements Backend {
    * of the schemas `load_tools` echoes back (TRA-402).
    */
   private daemonTools: Array<{ name: string; description?: string; inputSchema?: unknown }> = [];
+  /** Ids of internal `tools/list` primes, whose responses never reach the client. */
+  private readonly pendingPrimeIds = new Map<string, () => void>();
+  private priming: Promise<void> | null = null;
+  private primeSeq = 0;
 
   constructor(opts: ProxyBackendOptions) {
     this.opts = opts;
@@ -212,7 +223,26 @@ export class ProxyBackend implements Backend {
       const id = messageId(msg);
       const called = toolCallName(msg);
       if (called === 'load_tools' && this.opts.toolSurface && id !== undefined) {
-        this.handleLoadTools(msg, id);
+        await this.handleLoadTools(msg, id);
+        return;
+      }
+      // `batch` dispatches by name on the daemon side, past this filter — that
+      // is deliberate (TRA-675: it is what makes the `router` preset usable
+      // without an escalation round-trip). `tools.exclude` is the exception:
+      // it is a hard restriction, so it has to be enforced on the inner names
+      // too, not just the outer `batch`.
+      const excludedInBatch = called === 'batch' ? this.excludedBatchCall(msg) : undefined;
+      if (excludedInBatch !== undefined) {
+        if (id !== undefined) {
+          this.onmessage?.({
+            jsonrpc: '2.0',
+            id,
+            error: {
+              code: METHOD_NOT_FOUND,
+              message: `Tool "${excludedInBatch}" is excluded by config and cannot be called through batch.`,
+            },
+          } as unknown as JSONRPCMessage);
+        }
         return;
       }
       // A filtered-out tool must be genuinely uncallable, not merely hidden
@@ -340,7 +370,58 @@ export class ProxyBackend implements Backend {
    * still gets the loaded tools' schemas in the reply and can drive them
    * through `batch`.
    */
-  private handleLoadTools(msg: JSONRPCMessage, id: string | number): void {
+  /**
+   * First `tools.exclude`d name inside a `batch` call, or undefined if there is
+   * none (or this isn't a shape we can read).
+   */
+  private excludedBatchCall(msg: JSONRPCMessage): string | undefined {
+    const isExcluded = this.opts.toolSurface?.isExcluded;
+    if (!isExcluded) return undefined;
+    const args = ((msg as Record<string, unknown>).params as Record<string, unknown> | undefined)
+      ?.arguments as { calls?: Array<{ tool?: unknown }> } | undefined;
+    if (!Array.isArray(args?.calls)) return undefined;
+    return args.calls.find((c) => typeof c?.tool === 'string' && isExcluded(c.tool as string))
+      ?.tool as string | undefined;
+  }
+
+  /**
+   * Make sure `daemonTools` is populated before answering `load_tools`.
+   *
+   * It is normally filled as a side effect of the client's own `tools/list`,
+   * but that only happens if a list passed through *this* backend — which it
+   * does not when the session started on the local backend and was swapped to
+   * the proxy afterwards. On that path `load_tools()` reported an empty
+   * catalog: the discovery half of progressive disclosure silently gone
+   * (TRA-675). So ask the daemon ourselves and swallow the reply.
+   */
+  private primeDaemonTools(): Promise<void> {
+    if (this.daemonTools.length > 0 || !this.httpTransport) return Promise.resolve();
+    if (this.priming) return this.priming;
+    const id = `__trace_prime_tools_list_${++this.primeSeq}`;
+    this.priming = (async () => {
+      try {
+        const done = new Promise<void>((resolve) => {
+          this.pendingPrimeIds.set(id, resolve);
+        });
+        await this.httpTransport!.send({
+          jsonrpc: '2.0',
+          id,
+          method: 'tools/list',
+          params: {},
+        } as unknown as JSONRPCMessage);
+        await Promise.race([done, delay(PRIME_TIMEOUT_MS)]);
+      } catch (err) {
+        logger.debug({ err: String(err) }, 'ProxyBackend: tools/list prime failed');
+      } finally {
+        this.pendingPrimeIds.delete(id);
+        this.priming = null;
+      }
+    })();
+    return this.priming;
+  }
+
+  private async handleLoadTools(msg: JSONRPCMessage, id: string | number): Promise<void> {
+    await this.primeDaemonTools();
     const surface = this.opts.toolSurface!;
     const filter = this.opts.toolFilter!;
     const args = ((msg as Record<string, unknown>).params as Record<string, unknown> | undefined)
@@ -446,6 +527,18 @@ export class ProxyBackend implements Backend {
       // one during its original handshake; a duplicate would corrupt its state.
       if (this.pendingReinitId !== null && messageId(msg) === this.pendingReinitId) {
         this.resolveReinit?.();
+        return;
+      }
+      // An internal tools/list prime: record the daemon's surface, tell nobody.
+      const primeId = messageId(msg);
+      const resolvePrime =
+        typeof primeId === 'string' ? this.pendingPrimeIds.get(primeId) : undefined;
+      if (resolvePrime) {
+        const tools = ((msg as Record<string, unknown>).result as { tools?: unknown })?.tools;
+        if (Array.isArray(tools)) {
+          this.daemonTools = tools as typeof this.daemonTools;
+        }
+        resolvePrime();
         return;
       }
       this.onmessage?.(this.filterToolsListResponse(msg));

--- a/src/tools/project/presets.ts
+++ b/src/tools/project/presets.ts
@@ -6,6 +6,18 @@
  */
 
 export const TOOL_PRESETS: Record<string, string[] | 'all'> = {
+  // The router surface (TRA-675): membership is deliberately empty, so a
+  // session advertises only UNGATED_META_TOOLS — 10 tools, 1,604 tokens, 95.6%
+  // below `full` and 79.2% below the shipped `minimal` default. It is usable
+  // rather than crippled because `batch` dispatches any non-excluded tool by
+  // name, including ones this preset defers (see the `batch` description), so
+  // there is no escalation round-trip: `load_tools()` names the catalog and
+  // `batch` calls it. Opt-in, never the default — on a host that already defers
+  // tool schemas itself (Claude Code's ToolSearch) it buys ~2.9k tokens while
+  // taking away the first-five-minutes tools `ALWAYS_LOAD_TOOLS` protects; on a
+  // host without one it buys ~6.2k per session.
+  router: [],
+
   // The default surface (TRA-402). Membership is ALWAYS_LOAD_TOOLS — the
   // first-five-minutes set below — plus the decision-memory quartet. Those two
   // lists used to disagree: `minimal` omitted get_task_context, get_call_graph

--- a/src/tools/register/__tests__/batch-door.test.ts
+++ b/src/tools/register/__tests__/batch-door.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `batch` is the door for preset-deferred tools (TRA-675).
+ *
+ * The daemon-backed path has always behaved this way — the proxy filters on the
+ * outer tool name only, so an inner call reaches the daemon's full registry —
+ * while the local path answered "Unknown tool" for the same call, because a
+ * deferred tool is registered-but-disabled and never lands in `toolHandlers`.
+ * The `router` preset (empty membership) depends on that door, so this pins the
+ * behaviour on the local half; proxy-tool-preset.test.ts pins the other half.
+ *
+ * `tools.exclude` is the one thing that must not pass through it: a preset is a
+ * deferral, an exclusion is a restriction.
+ */
+import type { z } from 'zod';
+import { describe, expect, it } from 'vitest';
+import type { MetaContext } from '../../../server/types.js';
+import { registerSessionTools } from '../session.js';
+import { metaCtx } from './_capture-tools.js';
+
+type Handler = (args: Record<string, unknown>) => Promise<{
+  content?: Array<{ type: string; text: string }>;
+}>;
+
+/** Register the session tools and hand back `batch`'s callback. */
+function buildBatch(opts: { loaded?: string[]; deferred?: string[]; exclude?: string[] }): Handler {
+  const handlers = new Map<string, Handler>();
+  const server = {
+    tool: () => undefined,
+    resource: () => undefined,
+    prompt: () => undefined,
+  };
+  const ctx = metaCtx({
+    config: { tools: { exclude: opts.exclude } },
+    savings: { recordCall: () => undefined },
+  }) as unknown as Record<string, unknown>;
+  const stub =
+    (name: string): Handler =>
+    async () => ({
+      content: [{ type: 'text', text: JSON.stringify({ ran: name }) }],
+    });
+  ctx._originalTool = (
+    name: string,
+    _description: string,
+    _shape: Record<string, z.ZodTypeAny>,
+    handler: Handler,
+  ) => {
+    handlers.set(name, handler);
+  };
+  ctx.toolHandlers = new Map((opts.loaded ?? []).map((n) => [n, stub(n)]));
+  ctx.deferredTools = new Map(
+    (opts.deferred ?? []).map((n) => [n, { registered: { enabled: false }, handler: stub(n) }]),
+  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerSessionTools(server as any, ctx as unknown as MetaContext);
+  const batch = handlers.get('batch');
+  if (!batch) throw new Error('batch was not registered');
+  return batch;
+}
+
+async function runBatch(
+  handler: Handler,
+  tools: string[],
+): Promise<Array<{ tool: string; result?: unknown; error?: string }>> {
+  const response = await handler({ calls: tools.map((tool) => ({ tool, args: {} })) });
+  return JSON.parse(response.content?.[0]?.text ?? '{}').batch_results;
+}
+
+describe('batch dispatches past the preset, but never past tools.exclude (TRA-675)', () => {
+  it('runs a tool the session preset deferred', async () => {
+    const batch = buildBatch({ loaded: ['search'], deferred: ['get_pagerank'] });
+    const [result] = await runBatch(batch, ['get_pagerank']);
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual({ ran: 'get_pagerank' });
+  });
+
+  it('refuses a tools.exclude entry even though it is registered', async () => {
+    const batch = buildBatch({
+      loaded: ['search'],
+      deferred: ['get_pagerank'],
+      exclude: ['get_pagerank'],
+    });
+    const [result] = await runBatch(batch, ['get_pagerank']);
+    expect(result.result).toBeUndefined();
+    expect(result.error).toContain('excluded');
+  });
+
+  it('refuses an excluded tool that is otherwise fully loaded', async () => {
+    // The exclusion has to be checked before the handler lookup, not as a
+    // side effect of the tool being absent from the map.
+    const batch = buildBatch({ loaded: ['search'], exclude: ['search'] });
+    const [result] = await runBatch(batch, ['search']);
+    expect(result.error).toContain('excluded');
+  });
+
+  it('still reports a genuinely unknown tool', async () => {
+    const batch = buildBatch({ loaded: ['search'] });
+    const [result] = await runBatch(batch, ['no_such_tool']);
+    expect(result.error).toContain('Unknown tool');
+  });
+});

--- a/src/tools/register/__tests__/preset-surface-budget.test.ts
+++ b/src/tools/register/__tests__/preset-surface-budget.test.ts
@@ -62,6 +62,12 @@ function presetPayloadChars(preset: string): { chars: number; tools: number } {
  * enough to hide a preset drifting back toward the full surface.
  */
 const PRESET_CHAR_CEILINGS: Record<string, number> = {
+  // TRA-675. Membership is empty, so this is exactly UNGATED_META_TOOLS:
+  // 10 tools / 7,120 chars / 1,604 tok against this reconstruction — 95.6%
+  // below `full` (161,652 / 37,145) and 79.2% below the `minimal` default
+  // (34,207 / 7,838). The ceiling leaves room for a meta-tool or two and none
+  // for the preset quietly acquiring members.
+  router: 8_000,
   minimal: 38_000,
   review: 42_000,
   dev: 58_000,

--- a/src/tools/register/session.ts
+++ b/src/tools/register/session.ts
@@ -819,7 +819,7 @@ export function registerSessionTools(server: McpServer, ctx: MetaContext): void 
   // --- Batch API: multiple tool calls in one MCP request ---
   _originalTool(
     'batch',
-    'Execute multiple trace-mcp tools in a single MCP request. Returns results for all calls. Use to reduce round-trips when you need several independent queries (e.g., get_outline for 3 files, or search + get_symbol together). Read-only (delegates to other tools). Returns JSON: { batch_results: [{ tool, result }], total }.',
+    "Execute multiple trace-mcp tools in a single MCP request. Dispatches any registered tool by name, including tools this session's preset defers — so a deferred tool is callable here without a load_tools round-trip (tools.exclude stays a hard restriction). Use to reduce round-trips when you need several independent queries (e.g., get_outline for 3 files, or search + get_symbol together). Read-only (delegates to other tools). Returns JSON: { batch_results: [{ tool, result }], total }.",
     {
       calls: z
         .array(
@@ -834,8 +834,19 @@ export function registerSessionTools(server: McpServer, ctx: MetaContext): void 
     },
     async ({ calls }) => {
       const results: { tool: string; result?: unknown; error?: string }[] = [];
+      const excluded = new Set(config.tools?.exclude ?? []);
       for (const call of calls) {
-        const handler = toolHandlers.get(call.tool);
+        // `tools.exclude` is the one hard restriction — a tool excluded by
+        // config must be unreachable through every door, including this one.
+        if (excluded.has(call.tool)) {
+          results.push({ tool: call.tool, error: `Tool "${call.tool}" is excluded by config` });
+          continue;
+        }
+        // Preset-deferred tools are dispatchable here on purpose (TRA-675):
+        // the daemon-backed path has always behaved this way, and the `router`
+        // preset depends on it. Falling back to `deferredTools` keeps the local
+        // path identical instead of answering "Unknown tool" for the same call.
+        const handler = toolHandlers.get(call.tool) ?? deferredTools.get(call.tool)?.handler;
         if (!handler) {
           results.push({ tool: call.tool, error: `Unknown tool: ${call.tool}` });
           continue;

--- a/tests/tools/tool-config.test.ts
+++ b/tests/tools/tool-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { TraceMcpConfigSchema } from '../../src/config.js';
+import { UNGATED_META_TOOLS } from '../../src/server/tool-filter.js';
 import { resolvePreset, TOOL_PRESETS } from '../../src/tools/project/presets.js';
 
 describe('Tool config schema', () => {
@@ -19,6 +20,15 @@ describe('Tool config schema', () => {
   it('every non-full preset carries core infra tools (search, get_symbol, register_edit, batch)', () => {
     for (const [name, tools] of Object.entries(TOOL_PRESETS)) {
       if (tools === 'all') continue;
+      // `router` is the deliberate exception (TRA-675): its membership is empty
+      // and its usability comes from `batch`, which every session gets through
+      // UNGATED_META_TOOLS rather than through preset membership. Asserted
+      // instead by proxy-tool-preset.test.ts (the advertised surface) and
+      // batch-door.test.ts (deferred tools stay dispatchable).
+      if (tools.length === 0) {
+        expect(UNGATED_META_TOOLS.has('batch'), `preset "${name}" has no door`).toBe(true);
+        continue;
+      }
       expect(tools, `preset "${name}" is missing search`).toContain('search');
       expect(tools, `preset "${name}" is missing get_symbol`).toContain('get_symbol');
       expect(tools, `preset "${name}" is missing register_edit`).toContain('register_edit');


### PR DESCRIPTION
Ships `"preset": "router"` (TRA-675) and turns the `batch` escape hatch it depends on from an accident into a documented, tested contract.

## The preset

Membership is empty, so a session advertises only `UNGATED_META_TOOLS`.

| preset | tools | chars | o200k tokens |
|---|---|---|---|
| **router** | **10** | **7,120** | **1,604** |
| minimal (default) | 28 | 34,207 | 7,838 |
| design | 21 | 22,077 | 5,074 |
| full | 158 | 161,652 | 37,145 |

95.6% below `full`, 79.2% below the shipped default. Measured with the same reconstruction `preset-surface-budget.test.ts` uses (name + description + JSON-Schema, gpt-tokenizer/o200k) on this branch; the issue's 6,954 / 1,572 was the same measurement before this PR widened `batch`'s own description by 166 chars.

Opt-in, and it stays opt-in: on Claude Code the host's ToolSearch already defers everything but the 15 `ALWAYS_LOAD_TOOLS`, so `router` buys ~2.9k there while removing exactly the first-five-minutes tools that stamp exists to protect. On a client without tool deferral it buys ~6.2k per session.

## batch-as-door, decided on purpose

`batch` dispatches by name against the whole registry — including tools the session's preset defers. That is what makes an empty preset usable with **zero** escalation round-trips, and it was previously (a) undocumented, (b) contradicted by the comment two lines above the proxy filter, and (c) true on the daemon path only. Now:

- documented in `batch`'s own description and in `docs/configuration.md`;
- the **local** path matches: `batch` falls back to `deferredTools` instead of answering `Unknown tool`;
- `tools.exclude` stays a hard restriction through the door — checked before the handler lookup locally, and against the inner call names in the proxy, so an excluded tool never reaches the daemon even wrapped in a `batch`.

## load_tools discovery on the proxy path

`load_tools()` with no args returned an empty catalog on the daemon path whenever no `tools/list` had passed through *that* backend — which is the swap case (session starts local, router moves it to the proxy). The proxy now primes itself with an internal `tools/list` whose reply is swallowed before it reaches the client. 5s budget; timing out costs an empty catalog, not a session.

## Guards

- `preset-surface-budget.test.ts`: `router` ceiling at 8,000 chars.
- `batch-door.test.ts` (new): local path — deferred tool dispatches, excluded tool refused (both when deferred and when loaded), unknown tool still unknown.
- `proxy-tool-preset.test.ts`: proxy path — `router` advertises exactly `UNGATED_META_TOOLS`; a batch with a deferred inner call is forwarded; a batch with an excluded inner call is rejected and never forwarded; `load_tools()` returns a non-empty catalog with no prior `tools/list`.

Verified the new guards fail without the fix: 3/4 in `batch-door.test.ts` with `session.ts` stashed, 2 in `proxy-tool-preset.test.ts` with `proxy-backend.ts` stashed.

No existing preset's advertised surface changes. `tool-config.test.ts`'s "every non-full preset carries core infra" invariant gained an explicit, commented exception for a zero-membership preset — `router` carries `batch` through `UNGATED_META_TOOLS`, not through membership.

Full suite: 9,612 passed, 8 skipped, 0 failed. Build + biome + tsc clean.

Closes TRA-675.

Agent: Performance Agent
