### PR TITLE
docs(app): warn app builds <=3.10.0 they must reinstall (TRA-687)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,22 @@ jobs:
           ```
           UPGRADE
           )
-          gh release edit "$TAG" --repo "${{ github.repository }}" --notes "${BODY}${FOOTER}"
+          # TRA-687: app builds <=3.10.0 (macOS/Windows) can't self-update, and
+          # the fix ships inside the very updater those builds can't run. Their
+          # only surface onto a live page is "View changelog", which opens
+          # /releases — so the recovery note has to live in every release's
+          # notes, not just the one that shipped the fix, for it to ever reach
+          # them. Same append mechanism as the Upgrade footer above.
+          RECOVERY=$(cat <<'RECOVERY'
+
+          ---
+
+          ### In-app updater stuck?
+
+          App builds 3.10.0 and earlier on macOS/Windows can't update themselves — "Check for updates…" shows `Cannot set properties of undefined (setting 'autoDownload')` and does nothing. Reinstall by hand: [download the .dmg](https://trace-mcp.com/) (macOS), grab the `.exe` installer from this page (Windows), or run `trace-mcp install-app` if you have the CLI.
+          RECOVERY
+          )
+          gh release edit "$TAG" --repo "${{ github.repository }}" --notes "${BODY}${FOOTER}${RECOVERY}"
 
   # Gate between the app builds and npm, and the one place that can take a
   # release back out of `latest`. The release exists the moment the tag is cut,

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ trace-mcp ships with an optional Electron desktop app (`packages/app`) that give
 
 **Install on Windows:** run `trace-mcp.Setup.<version>.exe` from [Releases](https://github.com/nikolai-vysotskyi/trace-mcp/releases/latest).
 
+**In-app updater stuck on an old build?** App versions 3.10.0 and earlier on macOS/Windows can't update themselves — "Check for updates…" shows `Cannot set properties of undefined (setting 'autoDownload')` and does nothing, a bug fixed in 3.11.0 that the affected builds can't fetch their own way out of. Reinstall by hand: [download the .dmg](https://trace-mcp.com/) (macOS) or grab the latest `trace-mcp.Setup.<version>.exe` from [Releases](https://github.com/nikolai-vysotskyi/trace-mcp/releases/latest) (Windows) — or, if you have the CLI installed, run `trace-mcp install-app`.
+
 The app talks to the same `trace-mcp` daemon (`http://127.0.0.1:3741`) that MCP clients use, so anything you index from the app is immediately available to Claude Code / Cursor / etc. If you only want the MCP server and the CLI, you do not need the app at all — [`npm install -g trace-mcp`](#quick-start) is the whole install.
 
 ---

--- a/packages/app/src/main/__tests__/autoupdater-interop.test.ts
+++ b/packages/app/src/main/__tests__/autoupdater-interop.test.ts
@@ -1,0 +1,25 @@
+import type { AppUpdater } from 'electron-updater';
+import { describe, expect, it } from 'vitest';
+import { resolveAutoUpdaterExport } from '../autoupdater-interop';
+
+describe('resolveAutoUpdaterExport', () => {
+  it('reads autoUpdater off the module namespace', () => {
+    const autoUpdater = {} as AppUpdater;
+    expect(resolveAutoUpdaterExport({ autoUpdater })).toBe(autoUpdater);
+  });
+
+  it('falls back to the default namespace when interop lands it there', () => {
+    const autoUpdater = {} as AppUpdater;
+    expect(resolveAutoUpdaterExport({ default: { autoUpdater } })).toBe(autoUpdater);
+  });
+
+  // TRA-687: builds <=3.10.0 called `.autoDownload` on `undefined` here
+  // instead of failing loudly — this pins the throw so a future interop
+  // shift breaks a test, not a shipped menu.
+  it('throws instead of silently returning undefined', () => {
+    expect(() => resolveAutoUpdaterExport({})).toThrow('electron-updater did not export autoUpdater');
+    expect(() => resolveAutoUpdaterExport({ default: {} })).toThrow(
+      'electron-updater did not export autoUpdater',
+    );
+  });
+});

--- a/packages/app/src/main/autoupdater-interop.ts
+++ b/packages/app/src/main/autoupdater-interop.ts
@@ -1,0 +1,20 @@
+import type { AppUpdater } from 'electron-updater';
+
+/**
+ * electron-updater's dynamic-import interop sometimes lands the named
+ * `autoUpdater` export under `.default` instead of on the module namespace
+ * directly (bundler-dependent). Missing that shape used to throw
+ * `Cannot set properties of undefined (setting 'autoDownload')` deep inside
+ * the update flow instead of here, at the one place that actually knows what
+ * shape it expected (TRA-687, fixed by #707).
+ */
+export function resolveAutoUpdaterExport(mod: {
+  autoUpdater?: AppUpdater;
+  default?: { autoUpdater?: AppUpdater };
+}): AppUpdater {
+  const autoUpdater = mod.autoUpdater ?? mod.default?.autoUpdater;
+  if (!autoUpdater) {
+    throw new Error('electron-updater did not export autoUpdater');
+  }
+  return autoUpdater;
+}

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -3,6 +3,7 @@ import { execFile, spawn } from 'child_process';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
+import { resolveAutoUpdaterExport } from './autoupdater-interop';
 import { t } from './i18n';
 import { registerAppMenu } from './menu';
 import { getLauncherDir } from './trace-home';
@@ -622,10 +623,7 @@ async function getAutoUpdater() {
     throw new Error(`electron-updater is not the update channel on ${process.platform}`);
   }
   const mod = await import('electron-updater');
-  const autoUpdater = mod.autoUpdater ?? mod.default?.autoUpdater;
-  if (!autoUpdater) {
-    throw new Error('electron-updater did not export autoUpdater');
-  }
+  const autoUpdater = resolveAutoUpdaterExport(mod);
   // Download only when the user asks: the renderer's Update button drives the
   // whole flow, so a silent background download would fight the UI's state.
   autoUpdater.autoDownload = false;


### PR DESCRIPTION
## Summary
- Documents the recovery path for app builds ≤3.10.0 (macOS/Windows) stuck with a broken in-app updater (`Cannot set properties of undefined (setting 'autoDownload')`), since the fix (#707, shipped in 3.11.0) lives inside the very updater those builds can't run.
- Pins the interop fix with a real regression test: extracts `resolveAutoUpdaterExport()` from `getAutoUpdater()` into its own module (`autoupdater-interop.ts`) so the throw-on-missing-export branch is exercised directly, instead of relying on `packaged-deps.test.ts`'s incidental check of the real package's current shape.
- Investigated whether any surface a stuck ≤3.10.0 build still fetches (update-check response, changelog view) could carry a "reinstall to recover" hint — see the linked issue comment for why the answer is no.

## Test plan
- [x] `pnpm --dir packages/app run typecheck`
- [x] `pnpm --dir packages/app run test -- --run` — 597/597 passed (incl. 3 new tests)
- [x] `pnpm run test -- --run` (root suite, covers `tests/docs/readme-claims.test.ts`) — 9601/9611 passed, 10 skipped (pre-existing)

Closes TRA-687.