### PR TITLE
docs: correct Multica agent mcp_config semantics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -790,15 +790,20 @@ with `mcp__trace__`.
 
 ### Multica workspace agents
 
-Multica agents don't run `trace-mcp init` — each agent's MCP wiring is set directly with `multica agent update --mcp-config-file <json>` (or `agent create --mcp-config-file` on first setup), scoped to that one agent. Every agent inherits a runtime-provided `trace-mcp` entry that runs the unconfigured default preset (`minimal`); to give a role its own preset, override the `trace-mcp` entry by name — the agent's own `mcp_config` always wins that collision:
+Multica agents don't run `trace-mcp init` — each agent's MCP wiring is set directly with `multica agent update --mcp-config-file <json>` (or `agent create --mcp-config-file` on first setup), scoped to that one agent. An agent with no `mcp_config` inherits the machine's own MCP setup, so its preset is whatever `tools.preset` says in `~/.trace-mcp/.config.json` (`standard` unless you changed it).
+
+Setting `mcp_config` does **not** override the inherited `trace-mcp` entry by name — Multica launches that agent with `--strict-mcp-config`, so it gets *only* the servers you list. Everything else the machine provides (user-scope servers, plugin servers, hosted connectors) disappears for that agent. List every server the role still needs, not just `trace-mcp`:
 
 ```json
 {
   "mcpServers": {
-    "trace-mcp": { "command": "trace-mcp", "args": ["--preset", "dev"] }
+    "trace-mcp": { "command": "trace-mcp", "args": ["serve", "--preset", "dev"] },
+    "context7": { "command": "context7-mcp", "args": [] }
   }
 }
 ```
+
+`--preset` is an option of the `serve` subcommand — `args` without `serve` starts nothing.
 
 ```bash
 multica agent update <agent-id> --mcp-config-file ./trace-mcp-dev.json
@@ -817,6 +822,8 @@ The role → preset matrix used in the trace-mcp workspace itself (adjust to you
 | Performance analysis | `perf` | `analyze_perf`, complexity/coupling trends, risk hotspots |
 
 `multica agent update --mcp-config*` **replaces** the agent's entire `mcp_config` — it does not merge. If the agent already has other private MCP servers configured, read them back first (only a workspace owner/admin can; `mcp_config` reads redacted for agent actors) and include them in the new payload, or the update will silently remove them.
+
+If you can't read it back (agent actors can't), you can still recover the *set* of servers a past run had from Claude Code's own connection logs on the machine that ran it — `~/Library/Caches/claude-cli-nodejs/<encoded-workdir>/mcp-logs-<server>/` has one directory per connected server. Under `--strict-mcp-config` that listing is exactly the config's server set; only each server's argv is still unknown.
 
 ---
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2085,15 +2085,20 @@ with `mcp__trace__`.
 
 ### Multica workspace agents
 
-Multica agents don't run `trace-mcp init` — each agent's MCP wiring is set directly with `multica agent update --mcp-config-file <json>` (or `agent create --mcp-config-file` on first setup), scoped to that one agent. Every agent inherits a runtime-provided `trace-mcp` entry that runs the unconfigured default preset (`minimal`); to give a role its own preset, override the `trace-mcp` entry by name — the agent's own `mcp_config` always wins that collision:
+Multica agents don't run `trace-mcp init` — each agent's MCP wiring is set directly with `multica agent update --mcp-config-file <json>` (or `agent create --mcp-config-file` on first setup), scoped to that one agent. An agent with no `mcp_config` inherits the machine's own MCP setup, so its preset is whatever `tools.preset` says in `~/.trace-mcp/.config.json` (`standard` unless you changed it).
+
+Setting `mcp_config` does **not** override the inherited `trace-mcp` entry by name — Multica launches that agent with `--strict-mcp-config`, so it gets *only* the servers you list. Everything else the machine provides (user-scope servers, plugin servers, hosted connectors) disappears for that agent. List every server the role still needs, not just `trace-mcp`:
 
 ```json
 {
   "mcpServers": {
-    "trace-mcp": { "command": "trace-mcp", "args": ["--preset", "dev"] }
+    "trace-mcp": { "command": "trace-mcp", "args": ["serve", "--preset", "dev"] },
+    "context7": { "command": "context7-mcp", "args": [] }
   }
 }
 ```
+
+`--preset` is an option of the `serve` subcommand — `args` without `serve` starts nothing.
 
 ```bash
 multica agent update <agent-id> --mcp-config-file ./trace-mcp-dev.json
@@ -2112,6 +2117,8 @@ The role → preset matrix used in the trace-mcp workspace itself (adjust to you
 | Performance analysis | `perf` | `analyze_perf`, complexity/coupling trends, risk hotspots |
 
 `multica agent update --mcp-config*` **replaces** the agent's entire `mcp_config` — it does not merge. If the agent already has other private MCP servers configured, read them back first (only a workspace owner/admin can; `mcp_config` reads redacted for agent actors) and include them in the new payload, or the update will silently remove them.
+
+If you can't read it back (agent actors can't), you can still recover the *set* of servers a past run had from Claude Code's own connection logs on the machine that ran it — `~/Library/Caches/claude-cli-nodejs/<encoded-workdir>/mcp-logs-<server>/` has one directory per connected server. Under `--strict-mcp-config` that listing is exactly the config's server set; only each server's argv is still unknown.
 
 ---
 


### PR DESCRIPTION
Follow-up to #747 (TRA-604).

Rolling the role presets out to the six workspace agents surfaced that the section merged in #747 is wrong on the mechanism, in a way that silently costs an agent its whole MCP surface:

- An agent-level `mcp_config` is **not** a by-name override of an inherited `trace-mcp` entry. Multica launches such an agent with `--strict-mcp-config`, so it gets *only* the listed servers — user-scope servers, plugin servers and hosted connectors all vanish. Verified against live runs: an agent with a config connected exactly its own six servers, an agent without one connected the machine's set plus plugins and connectors.
- `--preset` is an option of the `serve` subcommand; the old example (`args: ["--preset", "dev"]`) does not start a server.
- "unconfigured default preset (`minimal`)" is stale — the default now comes from `tools.preset` in `~/.trace-mcp/.config.json`, `standard` out of the box.
- Added how to recover the *set* of servers from a redacted `mcp_config` via Claude Code's `mcp-logs-*` directories, which is how the Design/UX Agent's config was reconstructed safely.

Markdown only, no code paths touched.