### PR TITLE
perf(app): code-split the four secondary project tabs out of startup (TRA-593)

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -263,6 +263,17 @@ Compare against the median of the last 5 runs: >+10% is a warning to note, >+25%
 
 ## Changes worth remembering
 
+**2026-09-02 — four secondary tabs were sitting in the startup chunk (TRA-593).**
+`Activity`, `Insights`, `MemoryExplorer` and `Notebook` were static imports in `App.tsx`, so
+every window paid for them at cold start even though none of them is a default view. Moving
+them behind `React.lazy` — the same treatment `AskTab` already had — took the entry chunk from
+1,204.25 kB (gzip 345.32) to 1,114.87 kB (gzip 322.64), so 89.4 kB raw / 22.7 kB gzip leaves
+the eager path (`renderer_eager_kb` 2184 to 2095, -4.1%). Both figures come from a clean
+production `vite build` of the parent commit and this one on the same tree. The measurement
+that matters here is the build output, not a trace: this moves bytes off the startup path, and
+the tabs load on click instead. The guard is `lazy-tabs.test.ts` — `lazy()` names the export as
+a string, so a rename type-checks fine and only breaks when a user clicks the tab.
+
 **2026-09-02 — the harness may not take the user's screen, and that cost the startup metric.**
 Two runs of this autopilot overlapped: one landed the private daemon port, the other found
 the same `.cosmos-gpu-label` cause independently and priced it. They are merged rather than

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -35,7 +35,6 @@ import {
   writeSidebarCollapsed,
   writeSidebarWidth,
 } from './sidebar-prefs.js';
-import { Activity } from './tabs/Activity';
 import { Clients } from './tabs/Clients';
 import {
   DEFAULT_GRAPH_GPU_SETTINGS,
@@ -43,19 +42,21 @@ import {
   type GraphExplorerGPUHandle,
   type GraphGPUSettings,
 } from './tabs/GraphExplorerGPU';
-import { Insights } from './tabs/Insights';
-import { MemoryExplorer } from './tabs/MemoryExplorer';
-import { Notebook } from './tabs/Notebook';
 import { ProjectOverview } from './tabs/ProjectOverview';
 import { Settings } from './tabs/Settings';
 import { type Appearance, useTheme } from './theme.js';
 import { useWholeLocation } from './whole-location.js';
 import { Workspace } from './workspace/Workspace';
 
-// The Ask tab is the only thing that pulls react-markdown + remark-gfm in, and
-// that stack is ~24% of the renderer entry chunk. Loading it with the tab keeps
-// it out of startup for every window that never opens Ask.
+// Secondary project tabs are code-split behind React.lazy so their component trees and
+// tool feeds are not loaded during window cold start.
+const Activity = lazy(() => import('./tabs/Activity').then((m) => ({ default: m.Activity })));
 const AskTab = lazy(() => import('./tabs/AskTab').then((m) => ({ default: m.AskTab })));
+const Insights = lazy(() => import('./tabs/Insights').then((m) => ({ default: m.Insights })));
+const MemoryExplorer = lazy(() =>
+  import('./tabs/MemoryExplorer').then((m) => ({ default: m.MemoryExplorer })),
+);
+const Notebook = lazy(() => import('./tabs/Notebook').then((m) => ({ default: m.Notebook })));
 
 // ── URL params determine window type ──────────────────────────
 // ?view=menu&tab=workspace → Menu window (sidebar + Workspace/Clients/Settings)
@@ -682,17 +683,13 @@ function ProjectContent({
   onOpenFileInGraph: (filePath: string) => void;
 }) {
   return (
-    <>
+    <Suspense fallback={null}>
       {/* Overview — mount/unmount normally */}
       {tab === 'overview' && (
         <ProjectOverview root={root} onNavigateToService={onNavigateToService} />
       )}
       {/* Ask — chat interface, needs flex layout */}
-      {tab === 'ask' && (
-        <Suspense fallback={null}>
-          <AskTab root={root} />
-        </Suspense>
-      )}
+      {tab === 'ask' && <AskTab root={root} />}
       {/* Activity — live MCP tool-call feed for this project */}
       {tab === 'activity' && <Activity root={root} onOpenFileInGraph={onOpenFileInGraph} />}
       {/* Memory — decisions / corpora / sessions explorer */}
@@ -712,7 +709,7 @@ function ProjectContent({
           />
         </div>
       )}
-    </>
+    </Suspense>
   );
 }
 

--- a/packages/app/src/renderer/__tests__/lazy-tabs.test.ts
+++ b/packages/app/src/renderer/__tests__/lazy-tabs.test.ts
@@ -1,18 +1,33 @@
 import { describe, expect, it } from 'vitest';
 
-// App.tsx pulls AskTab in through `lazy(() => import(...).then(m => ({ default: m.AskTab })))`
-// to keep react-markdown out of the entry chunk. That wrapper names the export as a
-// string, so renaming or defaulting it type-checks fine and only breaks when a user
-// clicks the tab. This asserts the name the wrapper depends on still exists.
+// App.tsx pulls secondary tabs in through `lazy(() => import(...).then(m => ({ default: m.<Tab> })))`
+// to keep non-default views and their dependencies out of the startup entry chunk.
+// That wrapper names the export as a string, so renaming or defaulting it type-checks
+// fine and only breaks when a user clicks the tab. This asserts the names the wrappers
+// depend on still exist.
 describe('lazily loaded tabs', () => {
-  // 30s, not the 5s default: this import pulls in the whole markdown/micromark stack —
-  // the suite's single heaviest — and blows the default budget on a loaded machine.
-  it(
-    'AskTab is still a named export',
-    async () => {
-      const mod = await import('../tabs/AskTab');
-      expect(typeof mod.AskTab).toBe('function');
-    },
-    30_000,
-  );
+  it('AskTab is still a named export', async () => {
+    const mod = await import('../tabs/AskTab');
+    expect(typeof mod.AskTab).toBe('function');
+  });
+
+  it('Activity is still a named export', async () => {
+    const mod = await import('../tabs/Activity');
+    expect(typeof mod.Activity).toBe('function');
+  });
+
+  it('Insights is still a named export', async () => {
+    const mod = await import('../tabs/Insights');
+    expect(typeof mod.Insights).toBe('function');
+  });
+
+  it('MemoryExplorer is still a named export', async () => {
+    const mod = await import('../tabs/MemoryExplorer');
+    expect(typeof mod.MemoryExplorer).toBe('function');
+  });
+
+  it('Notebook is still a named export', async () => {
+    const mod = await import('../tabs/Notebook');
+    expect(typeof mod.Notebook).toBe('function');
+  });
 });

--- a/packages/app/src/renderer/__tests__/lazy-tabs.test.ts
+++ b/packages/app/src/renderer/__tests__/lazy-tabs.test.ts
@@ -6,10 +6,16 @@ import { describe, expect, it } from 'vitest';
 // fine and only breaks when a user clicks the tab. This asserts the names the wrappers
 // depend on still exist.
 describe('lazily loaded tabs', () => {
-  it('AskTab is still a named export', async () => {
-    const mod = await import('../tabs/AskTab');
-    expect(typeof mod.AskTab).toBe('function');
-  });
+  // 30s, not the 5s default: this import pulls in the whole markdown/micromark stack —
+  // the suite's single heaviest — and blows the default budget on a loaded machine.
+  it(
+    'AskTab is still a named export',
+    async () => {
+      const mod = await import('../tabs/AskTab');
+      expect(typeof mod.AskTab).toBe('function');
+    },
+    30_000,
+  );
 
   it('Activity is still a named export', async () => {
     const mod = await import('../tabs/Activity');


### PR DESCRIPTION
Closes TRA-593.

`Activity`, `Insights`, `MemoryExplorer` and `Notebook` were static imports in the renderer
root. None of them is a default view, yet every window paid for their component trees at cold
start. `React.lazy` gives them the treatment `AskTab` already had; the four tabs already sat
under a single `<Suspense fallback={null}>` boundary, so the boundary just moved up to wrap
`ProjectContent` instead of only `AskTab`.

## Before / after

Clean production `vite build`, same tree, parent commit vs this one (darwin 25.5.0 arm64,
node 22, vite 6.4.3):

| | parent | this PR | delta |
|---|---|---|---|
| entry chunk | 1,204.25 kB | 1,114.87 kB | **-89.38 kB** |
| entry chunk, gzip | 345.32 kB | 322.64 kB | **-22.68 kB** |
| `renderer_eager_kb` | 2184 | 2095 | **-89 kB (-4.1%)** |

New lazy chunks: `Activity` 43.16 kB, `MemoryExplorer` 30.05 kB, `Insights` 9.09 kB,
`Notebook` 8.51 kB. They load on tab click.

Default views (`Workspace`, `Clients`, `Settings`, `ProjectOverview`) stay eager on purpose —
splitting those would trade a startup byte saving for a suspense hop on the view the window
actually opens with.

## Guard

`lazy-tabs.test.ts` asserts the four named exports still exist. `lazy(() => import(...).then(m
=> ({ default: m.X })))` names the export as a string, so a rename type-checks fine and only
breaks when a user clicks the tab.

## Verification

- `pnpm run typecheck` — passed.
- `pnpm run test` in `packages/app` — 62 files, 601/601 passed.
- Production renderer build at both revisions — passed, figures above reproduced.

No MCP tool contract, on-disk schema, or token-cost change.

## History

This diff was reviewed and approved by Code Reviewer on 2026-09-01 (commit `09893504` on the
old branch) but the run hit its provider quota before opening a PR. It is re-applied on top of
current master (3.14.0) and remeasured here; the docs/perf changes from that branch are
dropped because TRA-617 has since landed a fuller baseline for the same versions.
