### PR TITLE
docs(seo): link source files by GitHub URL instead of paths that 404 on the site

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,7 +169,7 @@ Two different things can leave a folder out of the index — check which one app
    }
    ```
 
-   `include` in a per-project config file **replaces** the built-in list rather than adding to it (config merge is shallow) — copy the defaults from [`src/config.ts`](../src/config.ts) alongside your addition if you still want the rest of the project indexed.
+   `include` in a per-project config file **replaces** the built-in list rather than adding to it (config merge is shallow) — copy the defaults from [`src/config.ts`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/src/config.ts) alongside your addition if you still want the rest of the project indexed.
 
 ---
 

--- a/docs/decision-memory.md
+++ b/docs/decision-memory.md
@@ -132,7 +132,7 @@ The score that drives the review queue combines a base prior with multiplicative
 
 For mined decisions, the pattern's intrinsic confidence (see [Extraction patterns](#extraction-patterns)) is additionally multiplied by `1 + 0.05 × n` where `n` is the number of context boosters (`because`, `reason`, `pros and cons`, `alternative`, `architecture`, `design decision`) found in the surrounding turn.
 
-The implementation lives in [`src/memory/decision-confidence.ts`](../src/memory/decision-confidence.ts).
+The implementation lives in [`src/memory/decision-confidence.ts`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/src/memory/decision-confidence.ts).
 
 ## MCP tools
 
@@ -259,7 +259,7 @@ The mining pipeline also filters non-user content before it reaches the store. B
 | `<task-notification>…</task-notification>` | Autonomous protocol payloads from background agents |
 | `<local-command-stdout>…</local-command-stdout>` | Captured shell output (may contain secrets) |
 
-`<command-message>` and `<command-name>` are kept — those wrap real user slash-commands and are part of the conversation. Implementation: `stripPrivacyTags` in [`src/memory/conversation-miner.ts`](../src/memory/conversation-miner.ts).
+`<command-message>` and `<command-name>` are kept — those wrap real user slash-commands and are part of the conversation. Implementation: `stripPrivacyTags` in [`src/memory/conversation-miner.ts`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/src/memory/conversation-miner.ts).
 
 ## CLI
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -177,7 +177,7 @@ trace-mcp ci-report --base main --head HEAD --format markdown --output report.md
 trace-mcp ci-report --base main --head HEAD --fail-on high
 ```
 
-Generates a change impact report with blast radius, risk scores, test coverage gaps, architecture violations, and dead code. See [README](../README.md#cipr-change-impact-reports) for GitHub Action setup.
+Generates a change impact report with blast radius, risk scores, test coverage gaps, architecture violations, and dead code. See [README](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/README.md#cipr-change-impact-reports) for GitHub Action setup.
 
 ## Security context export (CLI)
 
@@ -1464,7 +1464,7 @@ Two different things can leave a folder out of the index — check which one app
    }
    ```
 
-   `include` in a per-project config file **replaces** the built-in list rather than adding to it (config merge is shallow) — copy the defaults from [`src/config.ts`](../src/config.ts) alongside your addition if you still want the rest of the project indexed.
+   `include` in a per-project config file **replaces** the built-in list rather than adding to it (config merge is shallow) — copy the defaults from [`src/config.ts`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/src/config.ts) alongside your addition if you still want the rest of the project indexed.
 
 ---
 
@@ -3242,8 +3242,8 @@ are deeply nested and small.
 
 ## Methodology
 
-- Script: [`scripts/bench-toon.ts`](../scripts/bench-toon.ts) for the
-  per-tool numbers; [`scripts/toon-diagnostic-2.ts`](../scripts/toon-diagnostic-2.ts)
+- Script: [`scripts/bench-toon.ts`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/scripts/bench-toon.ts) for the
+  per-tool numbers; [`scripts/toon-diagnostic-2.ts`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/scripts/toon-diagnostic-2.ts)
   for the table-vs-list-mode curve.
 - Invocation pattern: each registered MCP tool's closure is captured via a
   fake `server.tool(...)`. This bypasses the MCP transport but exercises the
@@ -3516,7 +3516,7 @@ The score that drives the review queue combines a base prior with multiplicative
 
 For mined decisions, the pattern's intrinsic confidence (see [Extraction patterns](#extraction-patterns)) is additionally multiplied by `1 + 0.05 × n` where `n` is the number of context boosters (`because`, `reason`, `pros and cons`, `alternative`, `architecture`, `design decision`) found in the surrounding turn.
 
-The implementation lives in [`src/memory/decision-confidence.ts`](../src/memory/decision-confidence.ts).
+The implementation lives in [`src/memory/decision-confidence.ts`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/src/memory/decision-confidence.ts).
 
 ## MCP tools
 
@@ -3643,7 +3643,7 @@ The mining pipeline also filters non-user content before it reaches the store. B
 | `<task-notification>…</task-notification>` | Autonomous protocol payloads from background agents |
 | `<local-command-stdout>…</local-command-stdout>` | Captured shell output (may contain secrets) |
 
-`<command-message>` and `<command-name>` are kept — those wrap real user slash-commands and are part of the conversation. Implementation: `stripPrivacyTags` in [`src/memory/conversation-miner.ts`](../src/memory/conversation-miner.ts).
+`<command-message>` and `<command-name>` are kept — those wrap real user slash-commands and are part of the conversation. Implementation: `stripPrivacyTags` in [`src/memory/conversation-miner.ts`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/src/memory/conversation-miner.ts).
 
 ## CLI
 

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -187,7 +187,7 @@ processes; worker *threads* are counted inside their host process's RSS by `ps`)
 `workload.tree_series` keeps every fifth sample, so the shape over the run survives in
 `baseline.json` without carrying 500 rows.
 
-The harness ([`packages/app/scripts/perf-measure.mjs`](../../packages/app/scripts/perf-measure.mjs))
+The harness ([`packages/app/scripts/perf-measure.mjs`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/packages/app/scripts/perf-measure.mjs))
 launches the built app against a throwaway `--user-data-dir`, drives it over CDP, and
 prints a ready-to-paste `runs[]` entry. `cold_start_ms` is process spawn → `#root` has
 painted real content; `window_interactive_ms` is the renderer's own share of that.
@@ -197,7 +197,7 @@ painted real content; `window_interactive_ms` is the renderer's own share of tha
 The three workload metrics are only comparable if the scenario is byte-identical
 between runs, so the harness does not improvise one. It checks this repo out into a
 detached git worktree at the commit pinned in
-[`packages/app/scripts/perf-fixture.json`](../../packages/app/scripts/perf-fixture.json),
+[`packages/app/scripts/perf-fixture.json`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/packages/app/scripts/perf-fixture.json),
 indexes it with this checkout's own `dist/cli.js`, registers it with the daemon, drives
 it, and unregisters it again at the end. The worktree lives at
 `~/.trace/perf-fixture/<commit12>` — deliberately outside any checkout, because the

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -194,7 +194,7 @@ trace-mcp ci-report --base main --head HEAD --format markdown --output report.md
 trace-mcp ci-report --base main --head HEAD --fail-on high
 ```
 
-Generates a change impact report with blast radius, risk scores, test coverage gaps, architecture violations, and dead code. See [README](../README.md#cipr-change-impact-reports) for GitHub Action setup.
+Generates a change impact report with blast radius, risk scores, test coverage gaps, architecture violations, and dead code. See [README](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/README.md#cipr-change-impact-reports) for GitHub Action setup.
 
 ## Security context export (CLI)
 

--- a/docs/toon-savings.md
+++ b/docs/toon-savings.md
@@ -114,8 +114,8 @@ are deeply nested and small.
 
 ## Methodology
 
-- Script: [`scripts/bench-toon.ts`](../scripts/bench-toon.ts) for the
-  per-tool numbers; [`scripts/toon-diagnostic-2.ts`](../scripts/toon-diagnostic-2.ts)
+- Script: [`scripts/bench-toon.ts`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/scripts/bench-toon.ts) for the
+  per-tool numbers; [`scripts/toon-diagnostic-2.ts`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/scripts/toon-diagnostic-2.ts)
   for the table-vs-list-mode curve.
 - Invocation pattern: each registered MCP tool's closure is captured via a
   fake `server.tool(...)`. This bypasses the MCP transport but exercises the

--- a/tests/docs/internal-links.test.ts
+++ b/tests/docs/internal-links.test.ts
@@ -256,6 +256,30 @@ describe('docs footer nav covers every indexed page', () => {
     ).toEqual([]);
   });
 
+  /**
+   * docs/ is the site root, so a link written for the repo checkout — `../src/config.ts`,
+   * `../README.md` — resolves to https://trace-mcp.com/src/config.ts and 404s. Eight of
+   * them were live across five pages, each verified 404 on 2026-09-02. Source files get
+   * a GitHub blob URL instead; a `../` that stays inside docs/ still resolves and passes.
+   */
+  it('no docs page links out of the site root with a relative path', () => {
+    const escaping = readdirSync(DOCS, { recursive: true, encoding: 'utf-8' })
+      .map((f) => f.replace(/\\/g, '/'))
+      .filter((f) => f.endsWith('.md') && !f.startsWith('_'))
+      .flatMap((f) => {
+        const dir = f.includes('/') ? f.replace(/\/[^/]*$/, '') : '.';
+        const body = readFileSync(join(DOCS, f), 'utf-8').replace(/^```[\s\S]*?^```/gm, '');
+        return [...body.matchAll(/\[[^\]]*\]\(\s*(\.\.\/[^)\s]+)/g)]
+          .map(([, href]) => href)
+          .filter((href) => join(dir, href).startsWith('..'))
+          .map((href) => `${f} -> ${href}`);
+      });
+    expect(
+      escaping,
+      `docs links that escape docs/ and 404 on the live site — use a https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/ URL: ${escaping.join(', ')}`,
+    ).toEqual([]);
+  });
+
   // The matcher above decides whether a page counts as a dead end, so its two
   // failure directions are worth pinning down. A false positive is the costly
   // one — it reports a dead end as linked and the guard goes quiet — so an


### PR DESCRIPTION
Eight documentation links written for the repo checkout resolve against `docs/` as the site root, so each one returns 404 on trace-mcp.com. Verified live on 2026-09-02:

```
https://trace-mcp.com/src/config.ts        -> 404
https://trace-mcp.com/scripts/bench-toon.ts -> 404
https://trace-mcp.com/README.md            -> 404
```

Affected: `docs/configuration.md`, `docs/decision-memory.md` (x2), `docs/toon-savings.md` (x2), `docs/tools-reference.md`, `docs/perf/README.md` (x2).

They now point at `https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/...` — the convention `docs/ROADMAP.md` already uses. All 8 targets verified 200.

A guard in `tests/docs/internal-links.test.ts` fails on any markdown link whose relative path escapes `docs/`, so this cannot ship again. `docs/llms-full.txt` regenerated via `pnpm docs:sitemap` (it embeds the page text).

`pnpm test --run tests/docs/`: 11 files, 150 passed. `pnpm run format:check`: clean.

Agent: SEO Agent