### PR TITLE
fix(web): sweep the scroll hint, the one label nothing measured (TRA-564)

### DIFF
--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -92,6 +92,19 @@ error has now shipped twice:
   `SCROLL →`, `LICENSE`, and the terminal's comment lines. The "no" answer in
   our own comparison table was the least readable text on the site.
 
+**Raising `--text-disabled` did not flatten the ramp — measured, not assumed.**
+The objection to raising it was that `#848484` and `--text-secondary` `#999999`
+sit 21 hex steps apart and would stop reading as two levels, trading a contrast
+failure for a hierarchy failure. In CIE L\* — which is what the eye separates on,
+not hex distance — the four dark levels land at 55.1 / 63.2 / 92.0 / 100.0, and
+the four light ones at 46.0 / 37.8 / 9.3 / 0.0. Both ramps step
+**8 / 29 / 8**: the disabled-to-secondary gap is 8.1 in dark and 8.2 in light.
+Light has always shipped that separation and has always read as four levels, so
+dark now reads as four levels for the same reason. Neither of the alternatives —
+pushing `--text-secondary` up to keep the gap, or dropping dark to three levels —
+is needed. Compare greys in L\*, not in hex; hex distance is not perception, and
+it is what made this look like a trade-off.
+
 Dark mode is the default. Light is opt-in and equally first-class — never
 ship a change checked in one mode only.
 
@@ -321,8 +334,18 @@ appearance without a screenshot or a measurement is not a finding.
       alongside the doc pages because it carries its own copy of the tokens
       (§7) and has drifted from this table before.
 - [ ] A new `aria-hidden` on anything the sweep now skips is deliberate
-      decoration, not a way to silence a failure. Only two exist: the YC badge
-      mark and the landing's 400px ghost `94%`.
+      decoration, not a way to silence a failure. `aria-hidden` means "not for
+      the AT tree"; it does not exempt painted text from 1.4.3, and the two are
+      not the same axis. `scroll →` is the case that proves it — correctly
+      `aria-hidden` (a screen reader navigates the region directly and never
+      scrolls it) yet visible functional text, and on top of that `display:none`
+      until the region actually overflows. Both of the sweep's skips dropped it,
+      so the one label §2 argues hardest for was the one label nothing measured:
+      44 of them on `/` and `/configuration.html` alone. The sweep now reveals
+      every `.scroll-hint` and checks it despite `aria-hidden`. Anything else
+      given `aria-hidden` must be decoration you would not mind being illegible
+      — currently the YC badge mark, the `MIT` and licence badge marks, the
+      terminal's `$` prompt, and the landing's 400px ghost `94%`.
 
 **Widths**
 - [ ] Desktop (1440px) and narrow (≤500px) both screenshotted.

--- a/scripts/contrast-sweep.mjs
+++ b/scripts/contrast-sweep.mjs
@@ -294,10 +294,20 @@ const EVAL_SCRIPT = String.raw`
       return false;
     }
 
+    // The scroll hint is visible text that has to be read, and it is the one
+    // element the sweep could never see: it is aria-hidden (correct — a screen
+    // reader navigates the region directly and does not scroll it) and it is
+    // display:none until the region actually overflows. Both skips below would
+    // drop it, so reveal it and exempt it. aria-hidden marks decoration for the
+    // AT tree; it does not exempt painted text from 1.4.3.
+    for (const hint of document.querySelectorAll('.scroll-hint')) {
+      hint.classList.add('is-visible');
+    }
+
     const results = [];
     const allElements = Array.from(document.querySelectorAll('*'));
     for (const el of allElements) {
-      if (isAriaHidden(el)) continue;
+      if (isAriaHidden(el) && !el.classList.contains('scroll-hint')) continue;
       if (el.tagName === 'SCRIPT' || el.tagName === 'STYLE' || el.tagName === 'NOSCRIPT' || el.tagName === 'SVG' || el.tagName === 'HEAD' || el.tagName === 'HTML') continue;
 
       let hasDirectText = false;


### PR DESCRIPTION
Closes TRA-564.

## What this actually found

TRA-564 opened against dark `--text-disabled: #666666` (3.03–3.66:1). That token was already raised to `#848484` by TRA-539 / #719 before this run started, so the arithmetic half is done. What was *not* done is the thing TRA-564 asked for and TRA-539 could not have given it: the functional-vs-decorative audit, measured by walking the rendered DOM rather than reading the token table.

Doing that audit surfaced a hole in the gate itself.

**The `scroll →` hint was invisible to the contrast sweep.** Twice over:

1. It carries `aria-hidden="true"` — and the sweep skips `aria-hidden` subtrees as decoration.
2. It is `display:none` until the region actually overflows — and the sweep skips `display:none`.

So the single element TRA-564 names as its sharpest case — "functional text, not decoration", the label `DESIGN-WEB` §2 argues at length is better than a fade — was the one label nothing measured. 44 of them on `/` and `/configuration.html` alone.

The `aria-hidden` is correct and stays: a screen reader navigates the region directly and never scrolls it, and the region already carries `role="group"` + `aria-label`. The bug is that the sweep treats `aria-hidden` as "exempt from contrast". Those are two different axes — `aria-hidden` means "not for the AT tree", not "not painted", and WCAG 1.4.3 applies to painted text either way.

## The change

Eleven lines in `scripts/contrast-sweep.mjs`: reveal every `.scroll-hint` before measuring, and exempt it from the `aria-hidden` skip.

**Verified the gate actually bites**, rather than just going green:

| | `/` | `/configuration.html` |
|---|---|---|
| Elements checked, before | 441 | 1359 |
| Elements checked, after | 442 | 1402 |

And with dark `--text-disabled` temporarily reverted to its old `#666666`, the sweep reports `43x #666666 on #000000 (div.scroll-hint.is-visible)` on `/configuration.html` — where it previously reported zero. Full sweep at the shipped tokens: 27 pages × 2 themes, **0 failures**.

## The ramp question, answered with a measurement

TRA-564 argued raising the token was a trade — `#848484` and `--text-secondary` `#999999` are 21 hex steps apart and would "stop reading as two distinct levels" — and listed three options for buying the contrast back without flattening the dark ramp.

None of them is needed, and hex distance is why it looked otherwise. In CIE L\*, which is what the eye separates on:

| | disabled | secondary | primary | display |
|---|---|---|---|---|
| Dark | 55.1 | 63.2 | 92.0 | 100.0 |
| Light | 46.0 | 37.8 | 9.3 | 0.0 |

Both ramps step **8 / 29 / 8**. The disabled-to-secondary gap is 8.1 in dark and 8.2 in light — light has always shipped that separation and has always read as four levels, so dark reads as four levels for the same reason. Recorded in `DESIGN-WEB.md` §1 so the next run does not re-litigate it.

## Docs

- §1 gains the L\* note above.
- §5's checklist line claimed "Only two `aria-hidden` exist: the YC badge mark and the landing's ghost `94%`." That was wrong — there are five in `index.html` plus one injected per scrollable region. Corrected, with the `aria-hidden` ≠ decoration distinction spelled out, since that conflation is what hid this for months.

No token values changed. No visual change to the site.
