### PR TITLE
fix(daemon): report cleanup-tier failures on project removal (TRA-559)

### DIFF
--- a/packages/app/src/main/api-client.ts
+++ b/packages/app/src/main/api-client.ts
@@ -95,8 +95,12 @@ export class DaemonClient {
   }
 
   // DELETE /api/projects?project=<root>
-  async removeProject(root: string): Promise<{ status: string; project: string }> {
-    return this.delete<{ status: string; project: string }>(
+  async removeProject(root: string): Promise<{
+    status: string;
+    project: string;
+    failures: { tier: string; error: string }[];
+  }> {
+    return this.delete<{ status: string; project: string; failures: { tier: string; error: string }[] }>(
       `/api/projects?project=${encodeURIComponent(root)}`,
     );
   }

--- a/packages/app/src/renderer/hooks/useDaemon.ts
+++ b/packages/app/src/renderer/hooks/useDaemon.ts
@@ -393,11 +393,23 @@ export function useDaemon() {
   }, []);
 
   const removeProject = useCallback(async (root: string) => {
+    let res: Response;
     try {
-      await fetch(`${BASE}/api/projects?project=${encodeURIComponent(root)}`, { method: 'DELETE' });
-      setProjects((prev) => prev.filter((p) => p.root !== root));
+      res = await fetch(`${BASE}/api/projects?project=${encodeURIComponent(root)}`, {
+        method: 'DELETE',
+      });
     } catch {
       // SSE will reconcile
+      return;
+    }
+    setProjects((prev) => prev.filter((p) => p.root !== root));
+    const body = (await res.json().catch(() => ({}))) as {
+      failures?: { tier: string; error: string }[];
+    };
+    if (body.failures?.length) {
+      throw new Error(
+        `Cleanup incomplete for ${root}: ${body.failures.map((f) => f.tier).join(', ')}`,
+      );
     }
   }, []);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2409,6 +2409,7 @@ program
             freedBytes: artifacts.freedBytes,
             topology: artifacts.topology,
             decisions: artifacts.decisions,
+            failures: artifacts.failures,
           }),
         );
         return;

--- a/src/daemon/__tests__/project-artifacts-failures.test.ts
+++ b/src/daemon/__tests__/project-artifacts-failures.test.ts
@@ -1,0 +1,107 @@
+/**
+ * TRA-559: a cleanup tier that throws must be reported as failed, not read
+ * back as "found nothing to do". Before this, every one of these catch sites
+ * logged a warning and returned a zero/empty value indistinguishable from a
+ * project that genuinely had nothing left to clean up — which is exactly how
+ * TRA-542's `dropDecisionRows` crash (a bare `require('better-sqlite3')`
+ * throwing "Database is not a constructor" on every shipped build) went
+ * unnoticed: the removal path answered `decisions: {0,0,0,0}` and both the
+ * API response and the desktop app read it as a clean removal.
+ */
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function mkdirp(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function makeGitRepo(root: string): void {
+  mkdirp(path.join(root, '.git'));
+  fs.writeFileSync(path.join(root, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+  fs.writeFileSync(path.join(root, 'package.json'), '{"name":"fixture","version":"0.0.0"}\n');
+}
+
+describe('removeProjectArtifacts — failure reporting (TRA-559)', () => {
+  let tmpHome: string;
+  let tmpProjects: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-artifacts-failures-home-'));
+    tmpProjects = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-artifacts-failures-projects-'));
+    vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    fs.rmSync(tmpProjects, { recursive: true, force: true });
+  });
+
+  it('reports an unlink failure as a failure, not a silent skip', async () => {
+    const root = path.join(tmpProjects, 'run-1');
+    makeGitRepo(root);
+
+    const registry = await import('../../registry.js');
+    const entry = registry.registerProject(root);
+    mkdirp(path.dirname(entry.dbPath));
+    fs.writeFileSync(entry.dbPath, '');
+
+    const realUnlinkSync = fs.unlinkSync;
+    vi.spyOn(fs, 'unlinkSync').mockImplementation((target) => {
+      if (target === entry.dbPath) {
+        throw Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+      }
+      return realUnlinkSync(target);
+    });
+
+    const { removeProjectArtifacts } = await import('../project-artifacts.js');
+    const result = removeProjectArtifacts(root);
+
+    // The old behaviour: file just doesn't show up in `deleted`, indistinguishable
+    // from "there was nothing to delete".
+    expect(result.deleted).not.toContain(entry.dbPath);
+    // The fix: the failure is visible instead of silently folded into a zero.
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ tier: 'index_db', error: expect.stringContaining('EACCES') }),
+    );
+    expect(fs.existsSync(entry.dbPath)).toBe(true);
+  });
+
+  it('reports a decision-table delete failure instead of reading it as zero rows dropped', async () => {
+    const root = path.join(tmpProjects, 'run-1');
+
+    const { DECISIONS_DB_PATH, ensureGlobalDirs } = await import('../../global.js');
+    ensureGlobalDirs();
+    const db = new Database(DECISIONS_DB_PATH);
+    try {
+      // Missing `project_root` column: the DELETE below throws "no such column",
+      // a real failure distinct from the "no such table" case the code already
+      // treats as a legitimate no-op on older DBs.
+      db.exec('CREATE TABLE decisions (id INTEGER PRIMARY KEY)');
+      db.exec('CREATE TABLE session_chunks (project_root TEXT NOT NULL)');
+      db.exec('CREATE TABLE decision_clusters (project_root TEXT NOT NULL)');
+      db.exec('CREATE TABLE project_memos (project_root TEXT NOT NULL)');
+    } finally {
+      db.close();
+    }
+
+    const { removeProjectArtifacts } = await import('../project-artifacts.js');
+    const result = removeProjectArtifacts(root);
+
+    // The old behaviour: this table's count stays 0, same as "nothing to drop".
+    expect(result.decisions.decisions).toBe(0);
+    // The fix: the failure is visible instead of a silent zero.
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({
+        tier: 'decisions.decisions',
+        error: expect.stringContaining('no such column'),
+      }),
+    );
+  });
+});

--- a/src/daemon/project-artifacts.ts
+++ b/src/daemon/project-artifacts.ts
@@ -24,6 +24,14 @@ import { logger } from '../logger.js';
 import { getProject, isEphemeralProjectRoot, listProjects } from '../registry.js';
 import { INDEX_DIR } from '../shared/paths.js';
 
+/** A tier that failed outright (as opposed to finding nothing to clean up). */
+export interface ArtifactFailure {
+  /** Which cleanup tier failed, e.g. "index_db", "topology", "decisions.session_chunks". */
+  tier: string;
+  /** The underlying error, stringified. */
+  error: string;
+}
+
 /** Result of a project artifact cleanup pass. */
 export interface RemoveArtifactsResult {
   /** Absolute paths that were deleted. */
@@ -36,6 +44,12 @@ export interface RemoveArtifactsResult {
   topology: { subprojects: number; services: number };
   /** Decision-store rows dropped for this project_root, if any. */
   decisions: { decisions: number; chunks: number; clusters: number; memos: number };
+  /**
+   * Tiers that threw instead of completing, distinct from a tier that ran
+   * and genuinely found nothing to do. A zero count next to a failures entry
+   * for the same tier means "the driver wouldn't load", not "nothing here".
+   */
+  failures: ArtifactFailure[];
 }
 
 /** Options for {@link removeProjectArtifacts}. */
@@ -48,44 +62,47 @@ export interface RemoveArtifactsOptions {
 /** SQLite sidecars that may exist next to a `.db` file. */
 const SQLITE_SIDECARS = ['', '-wal', '-shm', '-journal'] as const;
 
-function tryUnlink(file: string): { deleted: boolean; bytes: number } {
+function tryUnlink(file: string): { deleted: boolean; bytes: number; error?: string } {
   try {
     const stat = fs.statSync(file);
     fs.unlinkSync(file);
     return { deleted: true, bytes: stat.size };
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
-    if (code !== 'ENOENT') {
-      logger.warn({ file, err }, 'project-artifacts: unlink failed');
-    }
-    return { deleted: false, bytes: 0 };
+    if (code === 'ENOENT') return { deleted: false, bytes: 0 };
+    logger.error({ file, err }, 'project-artifacts: unlink failed');
+    return { deleted: false, bytes: 0, error: String(err) };
   }
 }
 
-function deleteDbWithSidecars(basePath: string, result: RemoveArtifactsResult): void {
+function deleteDbWithSidecars(basePath: string, result: RemoveArtifactsResult, tier: string): void {
   for (const suffix of SQLITE_SIDECARS) {
     const full = basePath + suffix;
-    const { deleted, bytes } = tryUnlink(full);
+    const { deleted, bytes, error } = tryUnlink(full);
     if (deleted) {
       result.deleted.push(full);
       result.freedBytes += bytes;
     }
+    if (error) result.failures.push({ tier, error: `${full}: ${error}` });
   }
 }
 
-function listIndexDirFiles(): string[] {
+function listIndexDirFiles(result: RemoveArtifactsResult): string[] {
   try {
     return fs.readdirSync(INDEX_DIR);
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
-    if (code !== 'ENOENT') {
-      logger.warn({ err }, 'project-artifacts: failed to list INDEX_DIR');
-    }
+    if (code === 'ENOENT') return [];
+    logger.error({ err }, 'project-artifacts: failed to list INDEX_DIR');
+    result.failures.push({ tier: 'index_dir_list', error: String(err) });
     return [];
   }
 }
 
-function dropTopologyRows(root: string): { subprojects: number; services: number } {
+function dropTopologyRows(
+  root: string,
+  result: RemoveArtifactsResult,
+): { subprojects: number; services: number } {
   if (!fs.existsSync(TOPOLOGY_DB_PATH)) return { subprojects: 0, services: 0 };
   try {
     // Lazy import to avoid pulling better-sqlite3 unless a topology DB exists.
@@ -100,7 +117,8 @@ function dropTopologyRows(root: string): { subprojects: number; services: number
       store.close();
     }
   } catch (err) {
-    logger.warn({ err, root }, 'project-artifacts: topology cleanup failed (non-fatal)');
+    logger.error({ err, root }, 'project-artifacts: topology cleanup failed');
+    result.failures.push({ tier: 'topology', error: String(err) });
     return { subprojects: 0, services: 0 };
   }
 }
@@ -132,7 +150,7 @@ export async function sweepEphemeralTopology(): Promise<string[]> {
       store.close();
     }
   } catch (err) {
-    logger.warn({ err }, 'project-artifacts: ephemeral topology sweep failed (non-fatal)');
+    logger.error({ err }, 'project-artifacts: ephemeral topology sweep failed');
   }
   return dropped;
 }
@@ -144,7 +162,7 @@ interface DecisionDeleteCounts {
   memos: number;
 }
 
-function dropDecisionRows(root: string): DecisionDeleteCounts {
+function dropDecisionRows(root: string, result: RemoveArtifactsResult): DecisionDeleteCounts {
   const empty: DecisionDeleteCounts = { decisions: 0, chunks: 0, clusters: 0, memos: 0 };
   if (!fs.existsSync(DECISIONS_DB_PATH)) return empty;
   try {
@@ -175,7 +193,8 @@ function dropDecisionRows(root: string): DecisionDeleteCounts {
           // Table may not exist on older DBs — ignore.
           const msg = (err as Error)?.message ?? '';
           if (!/no such table/i.test(msg)) {
-            logger.warn({ err, table, root }, 'project-artifacts: decision table delete failed');
+            logger.error({ err, table, root }, 'project-artifacts: decision table delete failed');
+            result.failures.push({ tier: `decisions.${table}`, error: String(err) });
           }
         }
       }
@@ -184,7 +203,8 @@ function dropDecisionRows(root: string): DecisionDeleteCounts {
       db.close();
     }
   } catch (err) {
-    logger.warn({ err, root }, 'project-artifacts: decision cleanup failed (non-fatal)');
+    logger.error({ err, root }, 'project-artifacts: decision cleanup failed');
+    result.failures.push({ tier: 'decisions', error: String(err) });
     return empty;
   }
 }
@@ -212,6 +232,7 @@ export function removeProjectArtifacts(
     freedBytes: 0,
     topology: { subprojects: 0, services: 0 },
     decisions: { decisions: 0, chunks: 0, clusters: 0, memos: 0 },
+    failures: [],
   };
 
   // TRA-38: use the registry's own recorded dbPath, not a fresh
@@ -251,7 +272,7 @@ export function removeProjectArtifacts(
     }
   } else {
     // 1. Index DB + WAL/SHM/journal sidecars
-    deleteDbWithSidecars(indexDbBase, result);
+    deleteDbWithSidecars(indexDbBase, result, 'index_db');
     // Nothing holds a DB that no longer exists.
     removeHoldersDir(indexDbBase);
   }
@@ -266,7 +287,7 @@ export function removeProjectArtifacts(
     const taskCacheSuffix = `-${hash}.db`;
     const taskCachePrefix = 'daemon-task-cache-';
     const seenBases = new Set<string>();
-    for (const file of listIndexDirFiles()) {
+    for (const file of listIndexDirFiles(result)) {
       let base: string | null = null;
       if (file.startsWith(sessionPrefix) && /\.db(-wal|-shm|-journal)?$/.test(file)) {
         base = file.replace(/(-wal|-shm|-journal)$/, '');
@@ -279,15 +300,15 @@ export function removeProjectArtifacts(
       }
       if (!base || seenBases.has(base)) continue;
       seenBases.add(base);
-      deleteDbWithSidecars(path.join(INDEX_DIR, base), result);
+      deleteDbWithSidecars(path.join(INDEX_DIR, base), result, 'session_task_cache_db');
     }
   }
 
   // 4. Topology rows
-  result.topology = dropTopologyRows(absRoot);
+  result.topology = dropTopologyRows(absRoot, result);
 
   // 5. Decisions DB project-scoped rows
-  result.decisions = dropDecisionRows(absRoot);
+  result.decisions = dropDecisionRows(absRoot, result);
 
   logger.info(
     {
@@ -297,8 +318,11 @@ export function removeProjectArtifacts(
       freedBytes: result.freedBytes,
       topology: result.topology,
       decisions: result.decisions,
+      failures: result.failures,
     },
-    'project-artifacts: cleanup complete',
+    result.failures.length > 0
+      ? 'project-artifacts: cleanup completed with failures'
+      : 'project-artifacts: cleanup complete',
   );
 
   return result;

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -955,6 +955,7 @@ export class ProjectManager {
         freedBytes: 0,
         topology: { subprojects: 0, services: 0 },
         decisions: { decisions: 0, chunks: 0, clusters: 0, memos: 0 },
+        failures: [{ tier: 'artifacts', error: String(err) }],
       };
     }
     unregisterProject(root);
@@ -968,6 +969,7 @@ export class ProjectManager {
         projectRoot: root,
         deletedFiles: artifacts.deleted.length,
         freedBytes: artifacts.freedBytes,
+        failures: artifacts.failures,
       },
       'Project removed from daemon',
     );


### PR DESCRIPTION
## Summary
- `removeProjectArtifacts` treated every one of six failing cleanup tiers (index DB unlink, `INDEX_DIR` listing, topology rows, topology sweep, decision-table deletes, decision cleanup) the same as "found nothing to clean up" — logging a `warn` and returning a zero/empty value. This is the exact mechanism that hid TRA-542's `dropDecisionRows` crash across every shipped build.
- Adds a `failures: { tier, error }[]` field to `RemoveArtifactsResult`, populated at each of those six sites instead of being silently swallowed. Log level for a genuine failure is now `error`, not `warn`.
- Surfaces `failures` in the `DELETE /api/projects` response (`src/cli.ts`) and in the fallback result `ProjectManager.removeProject` builds when `removeProjectArtifacts` throws outright.
- Desktop app: `useDaemon.ts`'s `removeProject` now reads the response body and throws when `failures` is non-empty, so the existing `Promise.allSettled` bulk-remove path in `useWorkspaceProjects.ts` surfaces it through the inline error banner it already has (no new UI plumbing). `api-client.ts`'s typed `DaemonClient.removeProject` return type updated to match.
- No new error framework — just a field on the existing result object, as scoped in the issue.

## Test plan
- [x] New regression test `src/daemon/__tests__/project-artifacts-failures.test.ts`: forces an unlink failure (index DB tier) and a decision-table delete failure, asserts both show up in `result.failures` instead of reading as zero rows dropped — the exact TRA-542 reproduction shape.
- [x] `pnpm run build` — clean
- [x] `pnpm run typecheck` (root + `packages/app`) — clean
- [x] `pnpm run biome:ci` — clean, no fixes needed
- [x] `pnpm test` — 9633 passed, 12 skipped, no regressions
- [x] `packages/app` test suite — 597 passed