### PR TITLE
feat(app): detect a second installed trace-mcp.app bundle (TRA-692)

### DIFF
--- a/packages/app/src/main/__tests__/update-state.test.ts
+++ b/packages/app/src/main/__tests__/update-state.test.ts
@@ -253,14 +253,16 @@ describe('scanAppBundles', () => {
 });
 
 describe('runningAppBundle', () => {
+  // Built with path.join so the separator matches the one the helper looks for
+  // on whatever platform a contributor runs the suite from.
+  const bundle = path.join(path.sep, 'Applications', 'trace-mcp.app');
+
   it('walks back from the executable to the bundle', () => {
-    expect(runningAppBundle('/Applications/trace-mcp.app/Contents/MacOS/trace-mcp')).toBe(
-      '/Applications/trace-mcp.app',
-    );
+    expect(runningAppBundle(path.join(bundle, 'Contents', 'MacOS', 'trace-mcp'))).toBe(bundle);
   });
 
   it('returns null for a process not running out of a bundle', () => {
-    expect(runningAppBundle('/usr/local/bin/electron')).toBeNull();
+    expect(runningAppBundle(path.join(path.sep, 'usr', 'local', 'bin', 'electron'))).toBeNull();
   });
 });
 

--- a/packages/app/src/main/__tests__/update-state.test.ts
+++ b/packages/app/src/main/__tests__/update-state.test.ts
@@ -11,7 +11,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   findStaleRoots,
   type GlobalInstall,
+  readAppLocationMarker,
   readLauncherCliPath,
+  runningAppBundle,
+  scanAppBundles,
   scanGlobalInstalls,
   staleRootInUse,
 } from '../update-state';
@@ -188,5 +191,99 @@ describe('staleRootInUse', () => {
     fs.mkdirSync(linkRoot);
     fs.symlinkSync(path.join(stale, 'trace-mcp'), path.join(linkRoot, 'trace-mcp'), 'dir');
     expect(staleRootInUse([{ root: stale, version: '3.0.0' }], cli(linkRoot))?.root).toBe(stale);
+  });
+});
+
+/* TRA-692: two installed bundles, only the running one gets updated. The scan is
+   what makes the other copy visible at all. */
+describe('scanAppBundles', () => {
+  let tmp: string;
+
+  const makeBundle = (dir: string, version?: string): string => {
+    const appPath = path.join(tmp, dir, 'trace-mcp.app');
+    fs.mkdirSync(path.join(appPath, 'Contents', 'MacOS'), { recursive: true });
+    if (version !== undefined) {
+      fs.writeFileSync(
+        path.join(appPath, 'Contents', 'Info.plist'),
+        `<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0"><dict>\n<key>CFBundleIdentifier</key>\n<string>com.trace-mcp.app</string>\n<key>CFBundleShortVersionString</key>\n<string>${version}</string>\n</dict></plist>\n`,
+      );
+    }
+    return appPath;
+  };
+  const exec = (appPath: string): string => path.join(appPath, 'Contents', 'MacOS', 'trace-mcp');
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-bundles-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('reports both bundles and their versions, marking the running one', () => {
+    const system = makeBundle('Applications', '3.10.0');
+    const user = makeBundle('home-apps', '3.11.0');
+    expect(scanAppBundles([system, user], runningAppBundle(exec(user)))).toEqual([
+      { path: system, version: '3.10.0', running: false },
+      { path: user, version: '3.11.0', running: true },
+    ]);
+  });
+
+  it('reports the single install on a normal machine — the caller gates on length', () => {
+    const only = makeBundle('Applications', '3.11.0');
+    expect(
+      scanAppBundles(
+        [only, null, path.join(tmp, 'gone', 'trace-mcp.app')],
+        runningAppBundle(exec(only)),
+      ),
+    ).toEqual([{ path: only, version: '3.11.0', running: true }]);
+  });
+
+  it('counts a path reached twice — marker and directory — once', () => {
+    const only = makeBundle('Applications', '3.11.0');
+    const viaLink = path.join(tmp, 'link.app');
+    fs.symlinkSync(only, viaLink, 'dir');
+    expect(scanAppBundles([only, viaLink], null)).toHaveLength(1);
+  });
+
+  it('skips a build output and a bundle with no readable version', () => {
+    const built = makeBundle(path.join('checkout', 'packages', 'app', 'release'), '3.11.0');
+    const versionless = makeBundle('Applications');
+    expect(scanAppBundles([built, versionless], null)).toEqual([]);
+  });
+});
+
+describe('runningAppBundle', () => {
+  it('walks back from the executable to the bundle', () => {
+    expect(runningAppBundle('/Applications/trace-mcp.app/Contents/MacOS/trace-mcp')).toBe(
+      '/Applications/trace-mcp.app',
+    );
+  });
+
+  it('returns null for a process not running out of a bundle', () => {
+    expect(runningAppBundle('/usr/local/bin/electron')).toBeNull();
+  });
+});
+
+describe('readAppLocationMarker', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-marker-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('reads the recorded appPath', () => {
+    const marker = path.join(tmp, 'app-location.json');
+    fs.writeFileSync(marker, JSON.stringify({ appPath: '/Applications/trace-mcp.app' }));
+    expect(readAppLocationMarker(marker)).toBe('/Applications/trace-mcp.app');
+  });
+
+  it('returns null when the marker is absent or malformed', () => {
+    expect(readAppLocationMarker(path.join(tmp, 'absent.json'))).toBeNull();
+    const broken = path.join(tmp, 'broken.json');
+    fs.writeFileSync(broken, '{ not json');
+    expect(readAppLocationMarker(broken)).toBeNull();
   });
 });

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -177,9 +177,14 @@ import {
   unloadModel as ollamaUnload,
 } from './ollama-control';
 import {
+  type AppBundle,
+  APP_BUNDLE_NAME,
   findStaleRoots,
   type GlobalInstall,
+  readAppLocationMarker,
   readLauncherCliPath,
+  runningAppBundle,
+  scanAppBundles,
   scanGlobalInstalls,
   staleRootInUse,
 } from './update-state';
@@ -657,7 +662,14 @@ ipcMain.handle('check-for-update', async () => {
   // in because the user's own npm may own a root the static scan never guesses.
   const { configRoot, binRoot } = await resolveNpmRoots();
   const staleRoots = staleRootClientsUse(configRoot, binRoot);
-  return staleRoots.length > 0 ? { ...result, staleRoots } : result;
+  // Same rationale for a second installed .app bundle: the update applies to the
+  // copy that is running and says nothing about the copy launched tomorrow.
+  const duplicateApps = duplicateAppInstalls();
+  return {
+    ...result,
+    ...(staleRoots.length > 0 ? { staleRoots } : {}),
+    ...(duplicateApps.length > 0 ? { duplicateApps } : {}),
+  };
 });
 
 async function checkForUpdate() {
@@ -848,6 +860,27 @@ function staleGlobalRoots(...extraRoots: (string | null | undefined)[]): GlobalI
 function staleRootClientsUse(...extraRoots: (string | null | undefined)[]): GlobalInstall[] {
   const inUse = staleRootInUse(staleGlobalRoots(...extraRoots), readLauncherCliPath());
   return inUse ? [inUse] : [];
+}
+
+/**
+ * Installed `.app` bundles when there is more than one, empty otherwise.
+ *
+ * The two conventional install directories plus whatever the location marker
+ * records — the same set every other resolver of "where is the app" considers,
+ * minus Spotlight, which needs a subprocess and adds nothing on the machines
+ * this happens on. Empty on the normal single-install machine (TRA-692).
+ */
+function duplicateAppInstalls(): AppBundle[] {
+  if (process.platform !== 'darwin') return [];
+  const bundles = scanAppBundles(
+    [
+      path.join('/Applications', APP_BUNDLE_NAME),
+      path.join(os.homedir(), 'Applications', APP_BUNDLE_NAME),
+      readAppLocationMarker(),
+    ],
+    runningAppBundle(process.execPath),
+  );
+  return bundles.length > 1 ? bundles : [];
 }
 
 async function resolveNpmBin(): Promise<string | null> {

--- a/packages/app/src/main/preload.ts
+++ b/packages/app/src/main/preload.ts
@@ -97,6 +97,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     error?: string;
     /** Global npm roots holding an older trace-mcp than the newest install on this machine. */
     staleRoots?: { root: string; version: string }[];
+    /** Installed `.app` bundles when this machine holds more than one (TRA-692). */
+    duplicateApps?: { path: string; version: string; running: boolean }[];
   }> => ipcRenderer.invoke('check-for-update'),
   /** `percent` is only present while a download is still in flight. */
   checkPendingUpdate: (): Promise<{ pending: boolean; version?: string; percent?: number }> =>

--- a/packages/app/src/main/update-state.ts
+++ b/packages/app/src/main/update-state.ts
@@ -17,6 +17,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { isPlausibleInstallPath } from './install-path';
 import { getLauncherDir } from './trace-home';
 
 /** A global npm root that currently holds a `trace-mcp` install. */
@@ -147,4 +148,106 @@ export function staleRootInUse(
     }
   }
   return null;
+}
+
+// --- Installed .app bundles --------------------------------------------------
+//
+// The same shape one layer up from the npm roots above: electron-updater updates
+// the bundle it is *running from*, so a machine carrying two installed copies
+// (`/Applications` and `~/Applications`, the second dragged in later) keeps the
+// other frozen at whatever version it arrived at — and whichever copy launches
+// next decides the version the user gets. `app-location.json` records one
+// location and validates it (TRA-357); a second plausible bundle elsewhere is
+// invisible to every check we have (TRA-692).
+
+/** The bundle filename we install under. Mirrors `scripts/locate-app.mjs`. */
+export const APP_BUNDLE_NAME = 'trace-mcp.app';
+
+/** An installed `trace-mcp.app` found on disk. */
+export interface AppBundle {
+  /** Absolute path to the `.app` bundle. */
+  path: string;
+  /** `CFBundleShortVersionString`, without a leading `v`. */
+  version: string;
+  /** True for the bundle this process is running from. */
+  running: boolean;
+}
+
+/**
+ * The version a bundle claims, from `Contents/Info.plist`.
+ *
+ * Mirrors `readBundleVersion` in `scripts/locate-app.mjs` — same regex over the
+ * XML plist, no `PlistBuddy` subprocess. The plist is the only honest answer to
+ * "what is installed here": sidecar markers record what a swap intended and part
+ * company with the bundle whenever one is replaced out-of-band (TRA-443).
+ */
+export function readBundleVersion(appPath: string): string | undefined {
+  try {
+    const raw = fs.readFileSync(path.join(appPath, 'Contents', 'Info.plist'), 'utf-8');
+    const m = raw.match(/<key>CFBundleShortVersionString<\/key>\s*<string>([^<]+)<\/string>/);
+    return m?.[1]?.trim().replace(/^v/, '') || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The `.app` bundle an Electron main process runs from, or null when it does not
+ * run out of one (`electron .` during development, Windows, Linux).
+ */
+export function runningAppBundle(execPath: string): string | null {
+  const marker = `.app${path.sep}Contents${path.sep}MacOS${path.sep}`;
+  const at = execPath.indexOf(marker);
+  return at < 0 ? null : execPath.slice(0, at + '.app'.length);
+}
+
+/** The bundle path `app-location.json` records, or null. */
+export function readAppLocationMarker(
+  markerPath: string = path.join(getLauncherDir(), 'app-location.json'),
+): string | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(markerPath, 'utf-8')) as { appPath?: unknown };
+    return typeof parsed.appPath === 'string' ? parsed.appPath : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Every installed bundle among `candidates`, with the running one marked.
+ *
+ * Deduplicated by realpath, so a path reached twice (the marker and the
+ * conventional directory it already names) counts once. Build outputs are
+ * skipped by the same gate the location marker uses — a bundle inside a checkout
+ * is not an install and must not raise a duplicate warning on a dev machine.
+ */
+export function scanAppBundles(
+  candidates: readonly (string | null | undefined)[],
+  runningPath: string | null,
+): AppBundle[] {
+  let running: string | null = null;
+  if (runningPath) {
+    try {
+      running = fs.realpathSync(runningPath);
+    } catch {
+      running = runningPath;
+    }
+  }
+  const seen = new Set<string>();
+  const found: AppBundle[] = [];
+  for (const candidate of candidates) {
+    if (!candidate || !isPlausibleInstallPath(candidate)) continue;
+    let real: string;
+    try {
+      real = fs.realpathSync(candidate);
+    } catch {
+      continue; // Nothing at that path.
+    }
+    if (seen.has(real)) continue;
+    seen.add(real);
+    const version = readBundleVersion(candidate);
+    if (!version) continue; // Not one of ours, or half-swapped.
+    found.push({ path: candidate, version, running: real === running });
+  }
+  return found;
 }

--- a/packages/app/src/renderer/electron.d.ts
+++ b/packages/app/src/renderer/electron.d.ts
@@ -66,6 +66,8 @@ declare global {
         error?: string;
         /** Global npm roots holding an older trace-mcp than the newest install on this machine. */
         staleRoots?: { root: string; version: string }[];
+        /** Installed `.app` bundles when this machine holds more than one (TRA-692). */
+        duplicateApps?: { path: string; version: string; running: boolean }[];
       }>;
       /** `percent` is only present while a download is still in flight. */
       checkPendingUpdate: () => Promise<{ pending: boolean; version?: string; percent?: number }>;

--- a/packages/app/src/renderer/update-check.ts
+++ b/packages/app/src/renderer/update-check.ts
@@ -23,6 +23,8 @@ export type UpdateState = {
   lastChecked?: number;
   error?: string;
   staleRoots?: { root: string; version: string }[];
+  /** Installed `.app` bundles when this machine holds more than one (TRA-692). */
+  duplicateApps?: { path: string; version: string; running: boolean }[];
 };
 
 /**


### PR DESCRIPTION
Closes TRA-692.

## Problem

`electron-updater` updates the bundle it is *running from*. On a machine with two installed copies — `/Applications/trace-mcp.app` and `~/Applications/trace-mcp.app`, as on Nikolai's — the other stays behind silently, and whichever one launches next decides the version the user gets.

Nothing enumerated the bundles on disk: `app-location.json` records **one** location and validates it is plausible (TRA-357), so a second plausible bundle elsewhere was invisible to every check we have. The version the UI reports is true of the copy you launched and says nothing about the copy you might launch tomorrow — the TRA-364/TRA-377 stale-npm-root shape one layer up.

## Change

`packages/app/src/main/update-state.ts`, next to the npm-root inspection it mirrors:

- `readBundleVersion()` — `CFBundleShortVersionString` from `Contents/Info.plist`, same regex as `scripts/locate-app.mjs` (no `PlistBuddy` subprocess).
- `runningAppBundle(execPath)` — walks back from the executable to the `.app`, null when not running out of a bundle.
- `readAppLocationMarker()` — the path `app-location.json` records.
- `scanAppBundles(candidates, runningPath)` — dedupes by realpath, skips build outputs via `isPlausibleInstallPath` (a bundle in a checkout is not an install), returns `{ path, version, running }` per bundle.

`duplicateAppInstalls()` in `index.ts` scans `/Applications`, `~/Applications` and the marker path, and returns the bundles only when there is more than one. It rides along with the existing update check as a `duplicateApps` payload, exactly like `staleRoots` — empty on a normal single-install machine, so nothing new renders there. macOS only.

Surfacing (Settings → Updates App row, menu header) belongs to TRA-686 and is not in this PR; the IPC contract types are declared so that half is a UI-only change.

## Acceptance

- Two bundles at different versions → both paths and versions reported, running one marked (`update-state.test.ts` "reports both bundles and their versions, marking the running one").
- Single install → one entry from the scan, `duplicateAppInstalls()` gates it to an empty payload.
- Deleting the duplicate → the path no longer resolves and drops out on the next check (covered by the absent-path case).

## Tests

`pnpm test` in `packages/app`: 62 files, 609 tests, all passing (22 in `update-state.test.ts`, 10 of them new). `tsc -p tsconfig.main.json --noEmit` and `tsc --noEmit` clean.
