### PR TITLE
fix(navigation): resolve cwd-relative paths to the indexed file (TRA-693)

### DIFF
--- a/src/db/repositories/file-repository.ts
+++ b/src/db/repositories/file-repository.ts
@@ -69,6 +69,29 @@ export class FileRepository {
     return this._stmts.getFile.get(path) as FileRow | undefined;
   }
 
+  /**
+   * Read-side lookup: exact path, else a *unique* suffix match.
+   *
+   * Agents run with cwd inside a subdirectory of the indexed root (a Laravel app
+   * under a monorepo, a checkout under a workspace dir) and pass paths relative
+   * to that cwd. Exact matching then misses a file the index actually holds, and
+   * the agent burns a round-trip on NOT_FOUND plus another on the search() it
+   * falls back to. Only an unambiguous match is accepted — two candidates mean
+   * we cannot know which one was meant, so it stays a miss.
+   *
+   * Never use this on the indexer write path: inserts must stay exact.
+   */
+  resolveFile(path: string): FileRow | undefined {
+    const exact = this._stmts.getFile.get(path) as FileRow | undefined;
+    if (exact) return exact;
+    const normalized = path.replace(/^\.?\//, '');
+    if (!normalized) return undefined;
+    const rows = this.db
+      .prepare('SELECT * FROM files WHERE path = ? OR path LIKE ? ESCAPE ? LIMIT 2')
+      .all(normalized, `%/${normalized.replace(/([%_\\])/g, '\\$1')}`, '\\') as FileRow[];
+    return rows.length === 1 ? rows[0] : undefined;
+  }
+
   getFileById(id: number): FileRow | undefined {
     return this._stmts.getFileById.get(id) as FileRow | undefined;
   }

--- a/src/db/repositories/file-repository.ts
+++ b/src/db/repositories/file-repository.ts
@@ -5,6 +5,7 @@ export class FileRepository {
   private readonly _stmts: {
     insertFile: Database.Statement;
     getFile: Database.Statement;
+    resolveSuffix: Database.Statement;
     getFileById: Database.Statement;
     updateFileHash: Database.Statement;
     updateFileMtime: Database.Statement;
@@ -29,6 +30,7 @@ export class FileRepository {
          RETURNING id`,
       ),
       getFile: db.prepare('SELECT * FROM files WHERE path = ?'),
+      resolveSuffix: db.prepare('SELECT * FROM files WHERE path LIKE ? ESCAPE ? LIMIT 2'),
       getFileById: db.prepare('SELECT * FROM files WHERE id = ?'),
       updateFileHash: db.prepare(
         "UPDATE files SET content_hash = ?, byte_length = ?, mtime_ms = ?, indexed_at = datetime('now') WHERE id = ?",
@@ -86,9 +88,17 @@ export class FileRepository {
     if (exact) return exact;
     const normalized = path.replace(/^\.?\//, '');
     if (!normalized) return undefined;
-    const rows = this.db
-      .prepare('SELECT * FROM files WHERE path = ? OR path LIKE ? ESCAPE ? LIMIT 2')
-      .all(normalized, `%/${normalized.replace(/([%_\\])/g, '\\$1')}`, '\\') as FileRow[];
+    if (normalized !== path) {
+      // An exact hit on the normalized spelling is still exact — it must not be
+      // put up against suffix candidates, or a same-named file in some
+      // subdirectory would make it look ambiguous.
+      const normalizedExact = this._stmts.getFile.get(normalized) as FileRow | undefined;
+      if (normalizedExact) return normalizedExact;
+    }
+    const rows = this._stmts.resolveSuffix.all(
+      `%/${normalized.replace(/([%_\\])/g, '\\$1')}`,
+      '\\',
+    ) as FileRow[];
     return rows.length === 1 ? rows[0] : undefined;
   }
 

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -54,6 +54,11 @@ export class Store {
     return this.files.getFile(path);
   }
 
+  /** Read-side path lookup with a unique-suffix fallback. See FileRepository.resolveFile. */
+  resolveFile(path: string): FileRow | undefined {
+    return this.files.resolveFile(path);
+  }
+
   getFileById(id: number): FileRow | undefined {
     return this.files.getFileById(id);
   }

--- a/src/tools/navigation/navigation.ts
+++ b/src/tools/navigation/navigation.ts
@@ -1147,7 +1147,7 @@ export async function getFileOutline(
   filePath: string,
   opts: GetFileOutlineOptions = {},
 ): Promise<TraceMcpResult<FileOutlineResult>> {
-  const file = store.getFile(filePath);
+  const file = store.resolveFile(filePath);
   if (!file) {
     return err(notFound(filePath));
   }

--- a/src/tools/register/navigation/lookup-tools.ts
+++ b/src/tools/register/navigation/lookup-tools.ts
@@ -230,6 +230,9 @@ export function registerLookupTools(server: McpServer, ctx: ServerContext): void
         };
       }
       markExplored(filePath);
+      // A suffix-resolved path was consulted under its canonical name too, so a
+      // follow-up Read of either spelling counts as consulted.
+      if (result.value.path !== filePath) markExplored(result.value.path);
       const fileRow = store.getFile(result.value.path);
       const freshness = fileRow ? computeFileFreshness(projectRoot, fileRow) : 'fresh';
       const summary = aggregateFreshness([freshness]);

--- a/tests/db/resolve-file-suffix.test.ts
+++ b/tests/db/resolve-file-suffix.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Store.resolveFile — unique-suffix fallback for read-side path lookups.
+ *
+ * Regression guard for the NOT_FOUND round-trip waste measured in TRA-693:
+ * agents whose cwd is a subdirectory of the indexed root pass paths relative to
+ * that cwd, and every such call used to cost a failed call plus a search()
+ * recovery. 42 of 56 mappable NOT_FOUND failures in the local session history
+ * were resolvable by a unique suffix match in the very database that was queried.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Store } from '../../src/db/store.js';
+import { createTestStore } from '../test-utils.js';
+
+function seed(store: Store, paths: string[]): void {
+  for (const p of paths) store.insertFile(p, 'php', null, null);
+}
+
+describe('Store.resolveFile', () => {
+  it('returns the exact match when one exists', () => {
+    const store = createTestStore();
+    seed(store, ['app/Models/City.php', 'sub/app/Models/City.php']);
+    expect(store.resolveFile('app/Models/City.php')?.path).toBe('app/Models/City.php');
+  });
+
+  it('resolves a cwd-relative path to the single indexed file that ends with it', () => {
+    const store = createTestStore();
+    seed(store, ['thewed-laravel/app/Http/Controllers/SitemapController.php', 'other/Readme.php']);
+    expect(store.resolveFile('app/Http/Controllers/SitemapController.php')?.path).toBe(
+      'thewed-laravel/app/Http/Controllers/SitemapController.php',
+    );
+  });
+
+  it('strips a leading ./ or /', () => {
+    const store = createTestStore();
+    seed(store, ['pkg/app/Models/City.php']);
+    expect(store.resolveFile('./app/Models/City.php')?.path).toBe('pkg/app/Models/City.php');
+    expect(store.resolveFile('/app/Models/City.php')?.path).toBe('pkg/app/Models/City.php');
+  });
+
+  it('refuses to guess when the suffix is ambiguous', () => {
+    const store = createTestStore();
+    seed(store, ['a/app/Models/City.php', 'b/app/Models/City.php']);
+    expect(store.resolveFile('app/Models/City.php')).toBeUndefined();
+  });
+
+  it('does not match a partial path segment', () => {
+    const store = createTestStore();
+    seed(store, ['app/Models/BigCity.php']);
+    expect(store.resolveFile('City.php')).toBeUndefined();
+  });
+
+  it('treats LIKE wildcards in the query as literal characters', () => {
+    const store = createTestStore();
+    seed(store, ['app/Models/City.php', 'app/Models/Town.php']);
+    // '%' and '_' must not turn into wildcards and match both rows.
+    expect(store.resolveFile('app/Models/%.php')).toBeUndefined();
+    expect(store.resolveFile('app/Models/Cit_.php')).toBeUndefined();
+  });
+
+  it('still misses genuinely unknown files', () => {
+    const store = createTestStore();
+    seed(store, ['app/Models/City.php']);
+    expect(store.resolveFile('app/Models/Ghost.php')).toBeUndefined();
+  });
+});

--- a/tests/db/resolve-file-suffix.test.ts
+++ b/tests/db/resolve-file-suffix.test.ts
@@ -37,6 +37,15 @@ describe('Store.resolveFile', () => {
     expect(store.resolveFile('/app/Models/City.php')?.path).toBe('pkg/app/Models/City.php');
   });
 
+  it('prefers the normalized exact match over suffix candidates', () => {
+    const store = createTestStore();
+    seed(store, ['app/Models/City.php', 'sub/app/Models/City.php']);
+    // './' spelling must resolve to the root file, not be rejected as ambiguous
+    // just because a subdirectory holds a file with the same suffix.
+    expect(store.resolveFile('./app/Models/City.php')?.path).toBe('app/Models/City.php');
+    expect(store.resolveFile('/app/Models/City.php')?.path).toBe('app/Models/City.php');
+  });
+
   it('refuses to guess when the suffix is ambiguous', () => {
     const store = createTestStore();
     seed(store, ['a/app/Models/City.php', 'b/app/Models/City.php']);


### PR DESCRIPTION
## Problem

`get_outline` is the worst-failing trace-mcp tool in the local session history: **287 errors on 1586 calls (18.1%)**, measured from `~/.trace-mcp/analytics.db` (123,229 tool calls, 1,389 sessions, 2026-03-29 → 2026-08-26).

The dominant error is `NOT_FOUND` — and it is not a missing file. Agents run with cwd inside a subdirectory of the indexed root and pass paths relative to *that* cwd:

```
get_outline { path: "app/Http/Controllers/FrontendApi/SitemapController.php" }
→ {"error":{"code":"NOT_FOUND","reason":"not_found",
   "help":"No file exists at this path. Use search() to locate the correct path."}}
```

The file is indexed. It is stored as `thewed-laravel/app/Http/Controllers/FrontendApi/SitemapController.php`, in the same database that was queried.

## The number

Replayed every `NOT_FOUND` in `~/.claude/projects/**/*.jsonl` against the registry:

| | count |
|---|---|
| `not_found` failures with a resolvable project | 56 |
| **resolvable by a unique suffix match in the queried DB** | **42 (75%)** |
| genuinely absent / ambiguous | 14 |

Each of those 42 cost two round-trips: the failed call, plus the `search()` the tool's own help text tells the agent to make. Under a subscription the binding limit is requests, not output tokens — so a wasted round-trip costs a whole context re-read, not 40 tokens of error JSON.

## The change

`Store.resolveFile(path)` — exact match, else a *unique* suffix match. Read side only; the indexer write path keeps exact matching (`store.getFile`) untouched, since an insert must never land on a near-match. Ambiguous suffix (two candidates) stays a miss — guessing between them would be worse than failing.

`getFileOutline` uses it, and already returns `file.path` (the canonical indexed path), so the agent learns the correct prefix for its next call instead of repeating the mistake.

## Verification

Against the production index of the worst-affected project (`~/.trace-mcp/index/thewed-2f9565b74fb5.db`), on the five paths that actually failed in the logs:

```
exact hits: 0    resolveFile hits: 5
app/Http/Controllers/FrontendApi/SitemapController.php -> thewed-laravel/app/Http/Controllers/FrontendApi/SitemapController.php
app/Http/Controllers/SitemapController.php             -> thewed-laravel/app/Http/Controllers/SitemapController.php
app/Traits/InteractsWithPublicCache.php                -> thewed-laravel/app/Traits/InteractsWithPublicCache.php
app/Models/City.php                                    -> thewed-laravel/app/Models/City.php
tests/Unit/Models/SubscribersRelationshipTest.php      -> thewed-laravel/tests/Unit/Models/SubscribersRelationshipTest.php
```

Regression guard: `tests/db/resolve-file-suffix.test.ts` (7 cases) covers exact-wins, suffix hit, `./` and `/` prefixes, ambiguity refusal, no partial-segment match, LIKE wildcards (`%`, `_`) treated literally, and genuine misses.

Full suite green: 9647 passed / 14 skipped. `tsc --noEmit` clean, build clean.

## Trade-offs

- One extra SQL statement, only on the miss path. Exact hits keep the prepared-statement fast path.
- No change to the MCP tool contract; no change to response size.

Closes TRA-693 (partially — this is the measured fix from this run).

Agent: Performance Agent