### PR TITLE
perf(hooks): detach the reindex dispatch so an edit never waits on the daemon (TRA-694)

### DIFF
--- a/hooks/trace-mcp-reindex.sh
+++ b/hooks/trace-mcp-reindex.sh
@@ -1,9 +1,24 @@
 #!/usr/bin/env bash
-# trace-mcp-reindex v0.4.1
+# trace-mcp-reindex v0.5.0
 # trace-mcp PostToolUse auto-reindex hook
 # Daemon-first: posts to the running daemon's /api/projects/reindex-file
 # endpoint via curl (no Node startup). Falls back to a cold subprocess
 # only when the daemon is unreachable.
+#
+# v0.5 changes (TRA-694 — the dispatch no longer blocks the agent):
+#   - Notifying the daemon that a file changed is fire-and-forget: reindexing
+#     is asynchronous on the daemon side and nothing here consumes the result.
+#     Yet the curl ran in the foreground, so every edit paid its round trip —
+#     p50 372 ms on the happy path, and the full `--max-time 2` ceiling
+#     whenever the daemon was up but not answering. Measured over 16,440
+#     recorded runs: 12,215 s (3 h 24 min) of agent wall clock, 70% of it on
+#     timeouts. The whole dispatch is now detached; the hook returns in ~5 ms.
+#   - Fixed the failure classification. `curl -w '%{http_code}'` prints "000"
+#     itself on connection failure AND exits non-zero, so the old
+#     `|| echo "000"` appended a second one: HTTP_CODE became "000000", which
+#     matched no case arm and was recorded as `other`. Every connection
+#     failure in the history is mislabelled, and `no-daemon` — which the tests
+#     believed they covered — never occurred once in 16,440 lines.
 
 set -euo pipefail
 
@@ -122,46 +137,61 @@ write_stat() {
       "$ts" "$path_kind" "$reason" "$wall_ms" >> "$STATS_FILE" ) 2>/dev/null || true
 }
 
-# Wallclock for the dispatch attempt.
-START_MS=$(now_ms)
+dispatch() {
+  # Wallclock for the dispatch attempt.
+  local START_MS END_MS WALL_MS HTTP_CODE REASON
+  START_MS=$(now_ms)
 
-# Try daemon first — single curl, ~5 ms RTT. No Node startup.
-HTTP_CODE=$(curl -sS --max-time 2 -o /dev/null -w '%{http_code}' -X POST \
-    -H 'Content-Type: application/json' \
-    -d "$(jq -n --arg p "$PROJECT_ROOT" --arg f "$FILE_PATH" '{project:$p,path:$f}')" \
-    "http://127.0.0.1:${PORT}/api/projects/reindex-file" 2>/dev/null || echo "000")
+  # Try daemon first — single curl, ~5 ms RTT. No Node startup.
+  # `-w '%{http_code}'` yields "000" on any pre-HTTP failure (refused,
+  # timeout, DNS). curl's exit status is deliberately ignored: the code it
+  # printed is the whole signal, and `|| echo` here corrupts it (see v0.5).
+  HTTP_CODE=$(curl -sS --max-time 2 -o /dev/null -w '%{http_code}' -X POST \
+      -H 'Content-Type: application/json' \
+      -d "$(jq -n --arg p "$PROJECT_ROOT" --arg f "$FILE_PATH" '{project:$p,path:$f}')" \
+      "http://127.0.0.1:${PORT}/api/projects/reindex-file" 2>/dev/null) || true
+  # Empty means curl is missing or died before writing anything — same
+  # observable state as a refused connection.
+  [[ -z "$HTTP_CODE" ]] && HTTP_CODE="000"
 
-END_MS=$(now_ms)
-WALL_MS=$((END_MS - START_MS))
+  END_MS=$(now_ms)
+  WALL_MS=$((END_MS - START_MS))
 
-if [[ "$HTTP_CODE" =~ ^2[0-9][0-9]$ ]]; then
-  write_stat "daemon" "ok" "$WALL_MS" "$END_MS"
-  exit 0
-fi
+  if [[ "$HTTP_CODE" =~ ^2[0-9][0-9]$ ]]; then
+    write_stat "daemon" "ok" "$WALL_MS" "$END_MS"
+    return 0
+  fi
 
-# Classify failure for stats. 000 = no daemon / connection refused / timeout
-# (curl exits before HTTP). Distinguish timeout via curl exit code is fiddly
-# under set -e; we collapse "couldn't connect" into no-daemon.
-case "$HTTP_CODE" in
-  400) REASON="400" ;;
-  404) REASON="404" ;;
-  503) REASON="503" ;;
-  5*)  REASON="5xx" ;;
-  000) REASON="no-daemon" ;;
-  *)   REASON="other" ;;
-esac
+  # Classify failure for stats. 000 = no daemon / connection refused / timeout
+  # (curl exits before HTTP). Distinguish timeout via curl exit code is fiddly
+  # under set -e; we collapse "couldn't connect" into no-daemon.
+  case "$HTTP_CODE" in
+    400) REASON="400" ;;
+    404) REASON="404" ;;
+    503) REASON="503" ;;
+    5*)  REASON="5xx" ;;
+    000) REASON="no-daemon" ;;
+    *)   REASON="other" ;;
+  esac
 
-# Fallback: cold spawn (legacy behavior). Only hit when daemon is down.
-# Phase 5+7 audit fix: `nohup ... &` returns immediately after fork, so any
-# duration we measure post-fork is just the spawn cost — NOT the cold CLI
-# reindex duration the user actually pays. Record only the curl wallclock so
-# `daemon stats` shows the cost of *detecting* the daemon is down, not a
-# misleading fake reindex time.
-if command -v trace-mcp >/dev/null 2>&1; then
-  nohup trace-mcp index-file "$FILE_PATH" >/dev/null 2>&1 &
-  write_stat "cli" "$REASON" "$WALL_MS" "$END_MS"
-else
-  write_stat "skipped" "$REASON" "$WALL_MS" "$END_MS"
-fi
+  # Fallback: cold spawn (legacy behavior). Only hit when daemon is down.
+  # Phase 5+7 audit fix: `nohup ... &` returns immediately after fork, so any
+  # duration we measure post-fork is just the spawn cost — NOT the cold CLI
+  # reindex duration the user actually pays. Record only the curl wallclock so
+  # `daemon stats` shows the cost of *detecting* the daemon is down, not a
+  # misleading fake reindex time.
+  if command -v trace-mcp >/dev/null 2>&1; then
+    nohup trace-mcp index-file "$FILE_PATH" >/dev/null 2>&1 &
+    write_stat "cli" "$REASON" "$WALL_MS" "$END_MS"
+  else
+    write_stat "skipped" "$REASON" "$WALL_MS" "$END_MS"
+  fi
+}
+
+# Detach. Redirecting all three fds is not cosmetic: a background job that
+# keeps the hook's stdout open makes the caller block reading that pipe until
+# the job ends, which would reinstate exactly the wait we are removing.
+dispatch </dev/null >/dev/null 2>&1 &
+disown 2>/dev/null || true
 
 exit 0

--- a/src/cli/daemon-stats.ts
+++ b/src/cli/daemon-stats.ts
@@ -141,6 +141,10 @@ export function renderHookStats(agg: HookAggregate, windowLabel: string): string
   lines.push(fmt('daemon path  ', agg.daemon));
   lines.push(fmt('cli fallback ', agg.cli));
   lines.push(fmt('skipped      ', agg.skipped));
+  // Since reindex hook v0.5 the dispatch is detached, so these durations are
+  // daemon round-trip time, not time the agent waited. Saying so here because
+  // reading them as agent cost is what produced TRA-694.
+  lines.push('  (durations are daemon round-trip; the hook does not wait on them)');
   const reasonKeys = Object.keys(agg.reasons).sort();
   if (reasonKeys.length > 0) {
     const parts = reasonKeys.map((k) => `"${k}": ${agg.reasons[k]}`);

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -89,7 +89,10 @@ export interface InitReport {
 // `cmd /c`. The bump makes `trace-mcp init` treat existing installs as
 // outdated and rewrite the registered command + install the hidden-run shim.
 export const GUARD_HOOK_VERSION = '0.12.0';
-export const REINDEX_HOOK_VERSION = '0.4.0';
+// 0.5.0 (TRA-694): the reindex dispatch is detached, so an edit no longer
+// blocks the agent on the daemon round trip. Existing installs must be
+// rewritten to pick it up.
+export const REINDEX_HOOK_VERSION = '0.5.0';
 export const PRECOMPACT_HOOK_VERSION = '0.3.0';
 export const WORKTREE_HOOK_VERSION = '0.3.0';
 export const SESSION_START_HOOK_VERSION = '0.2.0';

--- a/tests/hooks/stats-write.test.ts
+++ b/tests/hooks/stats-write.test.ts
@@ -96,18 +96,52 @@ exit 0
   return stubPath;
 }
 
-function makeFailingCurlStub(stubDir: string): string {
+/**
+ * Real curl under `-w '%{http_code}'` PRINTS "000" and THEN exits non-zero on
+ * a refused connection. The original stub only did the second half, so the
+ * hook's old `|| echo "000"` looked correct in tests while producing "000000"
+ * — and therefore `reason: "other"` — against the real binary. TRA-694 found
+ * `no-daemon` had never once been recorded in 16,440 production lines.
+ */
+function makeFailingCurlStub(stubDir: string, printsCode = true): string {
   fs.mkdirSync(stubDir, { recursive: true });
   const stubPath = path.join(stubDir, 'curl');
-  // Mimics curl's connection-refused behavior: writes nothing useful to
-  // stdout and exits non-zero. The hook's "|| echo 000" branch then
-  // substitutes the missing HTTP code.
   const body = `#!/usr/bin/env bash
+${printsCode ? 'echo "000"' : ':'}
 exit 7
 `;
   fs.writeFileSync(stubPath, body);
   fs.chmodSync(stubPath, 0o755);
   return stubPath;
+}
+
+/** Stub curl that never answers, to prove the hook does not wait on it. */
+function makeHangingCurlStub(stubDir: string, seconds: number): string {
+  fs.mkdirSync(stubDir, { recursive: true });
+  const stubPath = path.join(stubDir, 'curl');
+  fs.writeFileSync(stubPath, `#!/usr/bin/env bash\nsleep ${seconds}\necho "000"\nexit 28\n`);
+  fs.chmodSync(stubPath, 0o755);
+  return stubPath;
+}
+
+/**
+ * The dispatch is detached (TRA-694), so the stats line lands after the hook
+ * has already exited. Poll for it instead of reading once.
+ */
+function readLastStat(traceHome: string, timeoutMs = 10_000): Record<string, unknown> {
+  const statsFile = path.join(traceHome, 'hook-stats.jsonl');
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (fs.existsSync(statsFile)) {
+      const lines = fs
+        .readFileSync(statsFile, 'utf-8')
+        .split('\n')
+        .filter((l) => l.length > 0);
+      if (lines.length > 0) return JSON.parse(lines[lines.length - 1]) as Record<string, unknown>;
+    }
+    if (Date.now() > deadline) throw new Error(`no stats line written to ${statsFile}`);
+    execSync('sleep 0.05');
+  }
 }
 
 function makeTraceMcpStub(stubDir: string): string {
@@ -149,14 +183,7 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-reindex.sh stats writer
     const res = runHook({ cwd: projectDir, stubDir, traceHome, stdin });
     expectCleanExit(res);
 
-    const statsFile = path.join(traceHome, 'hook-stats.jsonl');
-    expect(fs.existsSync(statsFile)).toBe(true);
-    const lines = fs
-      .readFileSync(statsFile, 'utf-8')
-      .split('\n')
-      .filter((l) => l.length > 0);
-    expect(lines).toHaveLength(1);
-    const parsed = JSON.parse(lines[0]) as Record<string, unknown>;
+    const parsed = readLastStat(traceHome);
     expect(parsed.path).toBe('daemon');
     expect(parsed.reason).toBe('ok');
     expect(typeof parsed.ts).toBe('number');
@@ -174,10 +201,7 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-reindex.sh stats writer
     const res = runHook({ cwd: projectDir, stubDir, traceHome, stdin });
     expectCleanExit(res);
 
-    const statsFile = path.join(traceHome, 'hook-stats.jsonl');
-    const parsed = JSON.parse(
-      fs.readFileSync(statsFile, 'utf-8').trim().split('\n').pop() as string,
-    ) as Record<string, unknown>;
+    const parsed = readLastStat(traceHome);
     expect(parsed.path).toBe('cli');
     expect(parsed.reason).toBe('no-daemon');
   });
@@ -194,10 +218,7 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-reindex.sh stats writer
     const res = runHook({ cwd: projectDir, stubDir, traceHome, stdin, sanitizePath: true });
     expectCleanExit(res);
 
-    const statsFile = path.join(traceHome, 'hook-stats.jsonl');
-    const parsed = JSON.parse(
-      fs.readFileSync(statsFile, 'utf-8').trim().split('\n').pop() as string,
-    ) as Record<string, unknown>;
+    const parsed = readLastStat(traceHome);
     expect(parsed.path).toBe('skipped');
     expect(parsed.reason).toBe('no-daemon');
   });
@@ -213,12 +234,48 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-reindex.sh stats writer
     const res = runHook({ cwd: projectDir, stubDir, traceHome, stdin });
     expectCleanExit(res);
 
-    const statsFile = path.join(traceHome, 'hook-stats.jsonl');
-    const parsed = JSON.parse(
-      fs.readFileSync(statsFile, 'utf-8').trim().split('\n').pop() as string,
-    ) as Record<string, unknown>;
+    const parsed = readLastStat(traceHome);
     expect(parsed.path).toBe('cli');
     expect(parsed.reason).toBe('404');
+  });
+
+  it('classifies a curl that prints 000 and exits non-zero as no-daemon', () => {
+    // Guards the v0.5 fix: the old `|| echo "000"` turned this — real curl's
+    // actual connection-refused behavior — into "000000" → reason "other".
+    makeFailingCurlStub(stubDir, true);
+    makeTraceMcpStub(stubDir);
+    const filePath = path.join(projectDir, 'src', 'foo.ts');
+    const res = runHook({
+      cwd: projectDir,
+      stubDir,
+      traceHome,
+      stdin: JSON.stringify({ tool_name: 'Edit', tool_input: { file_path: filePath } }),
+    });
+    expectCleanExit(res);
+
+    const parsed = readLastStat(traceHome);
+    expect(parsed.reason).toBe('no-daemon');
+  });
+
+  it('returns without waiting for the daemon round trip', () => {
+    // TRA-694: the dispatch is fire-and-forget. A daemon that accepts the
+    // connection and never answers must cost the agent nothing — that case
+    // alone burned 8,547 s of the 12,215 s measured before this fix.
+    makeHangingCurlStub(stubDir, 10);
+    makeTraceMcpStub(stubDir);
+    const filePath = path.join(projectDir, 'src', 'foo.ts');
+    const started = Date.now();
+    const res = runHook({
+      cwd: projectDir,
+      stubDir,
+      traceHome,
+      stdin: JSON.stringify({ tool_name: 'Edit', tool_input: { file_path: filePath } }),
+    });
+    const elapsed = Date.now() - started;
+    expectCleanExit(res);
+    // Loose bound: the hook itself spawns several subprocesses and CI is slow.
+    // Anything under the stub's 10 s sleep proves it did not block on curl.
+    expect(elapsed, `hook blocked for ${elapsed} ms on a hanging curl`).toBeLessThan(5_000);
   });
 
   it('does not error when stats home is read-only — best-effort write', () => {


### PR DESCRIPTION
Fixes the latency measured in TRA-694 — though not via the mechanism the issue proposed, because that mechanism does not hold up.

## What the issue said, and what the data says

TRA-694 attributes 12,215 s of wall clock to the **PreToolUse guard hook** falling back to a cold CLI spawn whenever the daemon 404s on an unregistered ephemeral workdir. Three parts of that are wrong:

1. `~/.trace-mcp/hook-stats.jsonl` is written by `hooks/trace-mcp-reindex.sh` (PostToolUse on `Edit|Write|MultiEdit`), not by the guard. It runs on code-file edits, not on every tool call.
2. The `cli` path does **not** measure a CLI spawn. The fallback is `nohup … &`, which returns after the fork; the recorded `wallclock_ms` is the curl round trip only. The script says so in a comment.
3. The 404 path is the **cheapest** branch, not the expensive one. Measured live against the running daemon for this very unregistered workdir: `404` in 2.6 ms. Across the whole file `cli/404` is 6,213 rows at p50 38 ms — 815 s, 6.7% of the total.

Re-aggregated by `path`/`reason`:

| path/reason | n | p50 | max | total | ≥1900 ms |
|---|---|---|---|---|---|
| `cli/other` | 4,046 | **2,050 ms** | 20,906 ms | **8,133 s** | 3,913 |
| `daemon/ok` | 5,156 | 372 ms | 2,046 ms | 2,740 s | 315 |
| `cli/404` | 6,213 | 38 ms | 2,035 ms | 815 s | 18 |
| `skipped/other` | 212 | 2,046 ms | 2,072 ms | 414 s | 202 |
| `cli/503` | 668 | 38 ms | 2,006 ms | 85 s | 1 |
| `no-daemon` (any) | **0** | — | — | — | — |

70% of the cost is `reason: "other"` sitting on the 2 s `--max-time` ceiling, and `no-daemon` — the reason that is supposed to cover exactly that — has never been recorded once.

## Two defects

**1. The dispatch blocked on a result nobody reads.** Reindexing is asynchronous on the daemon side; the hook's exit status does not depend on it. Yet every edit paid the round trip: 372 ms at p50 even when the daemon answered, and the full 2 s whenever it accepted the connection without replying.

The dispatch is now detached. All three fds are redirected — not cosmetic: a background job holding the hook's stdout open makes the caller block reading that pipe until the job ends, which would silently reinstate the wait.

Measured against a listener that accepts and never replies:

```
old hook: 2103.4 ms/run
new hook:   31.9 ms/run
```

**2. `no-daemon` was unreachable.** `curl -w '%{http_code}'` prints `000` itself on a pre-HTTP failure *and* exits non-zero, so `|| echo "000"` appended a second one. Reproduced:

```
$ curl -sS --max-time 2 -o /dev/null -w '%{http_code}' http://127.0.0.1:59999/x || echo "000"
000000        # matches no case arm -> reason "other"
```

The test stub emulated only curl's non-zero exit, not the `000` it prints, which is why the suite believed the branch was covered. Both the stub and the hook are fixed.

## Regression guards

Two new tests, each verified to fail against the pre-change hook:

- `returns without waiting for the daemon round trip` — a curl stub that sleeps 10 s. Old hook: **blocked for 10,732 ms**. New: passes.
- `classifies a curl that prints 000 and exits non-zero as no-daemon` — old hook: **`other`**. New: `no-daemon`.

The existing stats assertions now poll, since the line lands after the hook exits.

`renderHookStats` gains one line stating that its durations are daemon round-trip time and not time the agent waited — reading them as agent cost is what produced this issue in the first place.

`REINDEX_HOOK_VERSION` → `0.5.0` so existing installs get rewritten by `trace-mcp init`. (The constant was `0.4.0` while the script header already said `0.4.1`; that drift is corrected too.)

## Not done here

The issue's lever 3 — registering ephemeral workdirs, or resolving a workdir to its parent project — is a **correctness** matter (PR #800's mis-resolved project root), not a latency one: those 404s cost 2.6 ms and still spawn the CLI fallback that does the indexing. Worth doing on its own merits, not as a fix for this.

## Test evidence

```
Test Files  877 passed | 2 skipped (879)
Tests  9644 passed | 12 skipped (9656)
```

`pnpm run build` and `pnpm run lint` (`tsc --noEmit`) clean.

Agent: Lead Engineer
