### PR TITLE
fix(analytics): keep session ingestion current and make staleness visible (TRA-695)

### DIFF
--- a/hooks/trace-mcp-stop.cmd
+++ b/hooks/trace-mcp-stop.cmd
@@ -1,9 +1,12 @@
 @echo off
 REM trace-mcp-stop v0.1.0
 REM trace-mcp Stop hook (Windows)
-REM Async session mining: spawns a detached `trace-mcp memory mine`, then an
-REM incremental `trace-mcp analytics sync` (TRA-695), and exits immediately so
-REM the agent's turn completion is never blocked.
+REM Async session mining: spawns a detached `trace-mcp memory mine` and an
+REM incremental `trace-mcp analytics sync` (TRA-695), then exits immediately so
+REM the agent's turn completion is never blocked. The two write to different
+REM databases, so they run side by side rather than chained; each gets its own
+REM log file. Only the mine is covered by the single-flight lock — a concurrent
+REM `analytics sync` is harmless, it re-skips every unchanged log.
 
 setlocal enabledelayedexpansion
 
@@ -38,6 +41,7 @@ powershell -NoProfile -Command ^
   "$logFile = Join-Path $env:TEMP ('trace-mcp-stop-mining-' + $hash + '.log');" ^
   "$proc = Start-Process -FilePath '%TRACE_MCP_BIN%' -ArgumentList @('memory','mine','--project',$projectRoot) -WindowStyle Hidden -PassThru -RedirectStandardOutput $logFile -RedirectStandardError $logFile;" ^
   "if ($proc) { $proc.Id | Out-File -FilePath $lockFile -Encoding ascii -Force };" ^
-  "Start-Process -FilePath '%TRACE_MCP_BIN%' -ArgumentList @('analytics','sync') -WindowStyle Hidden | Out-Null"
+  "$syncLog = Join-Path $env:TEMP ('trace-mcp-stop-analytics-' + $hash + '.log');" ^
+  "Start-Process -FilePath '%TRACE_MCP_BIN%' -ArgumentList @('analytics','sync') -WindowStyle Hidden -RedirectStandardOutput $syncLog -RedirectStandardError $syncLog | Out-Null"
 
 exit /b 0

--- a/hooks/trace-mcp-stop.cmd
+++ b/hooks/trace-mcp-stop.cmd
@@ -1,8 +1,9 @@
 @echo off
 REM trace-mcp-stop v0.1.0
 REM trace-mcp Stop hook (Windows)
-REM Async session mining: spawns a detached `trace-mcp memory mine` and exits
-REM immediately so the agent's turn completion is never blocked.
+REM Async session mining: spawns a detached `trace-mcp memory mine`, then an
+REM incremental `trace-mcp analytics sync` (TRA-695), and exits immediately so
+REM the agent's turn completion is never blocked.
 
 setlocal enabledelayedexpansion
 
@@ -36,6 +37,7 @@ powershell -NoProfile -Command ^
   "}" ^
   "$logFile = Join-Path $env:TEMP ('trace-mcp-stop-mining-' + $hash + '.log');" ^
   "$proc = Start-Process -FilePath '%TRACE_MCP_BIN%' -ArgumentList @('memory','mine','--project',$projectRoot) -WindowStyle Hidden -PassThru -RedirectStandardOutput $logFile -RedirectStandardError $logFile;" ^
-  "if ($proc) { $proc.Id | Out-File -FilePath $lockFile -Encoding ascii -Force }"
+  "if ($proc) { $proc.Id | Out-File -FilePath $lockFile -Encoding ascii -Force };" ^
+  "Start-Process -FilePath '%TRACE_MCP_BIN%' -ArgumentList @('analytics','sync') -WindowStyle Hidden | Out-Null"
 
 exit /b 0

--- a/hooks/trace-mcp-stop.sh
+++ b/hooks/trace-mcp-stop.sh
@@ -61,7 +61,9 @@ LOG_FILE="${TMPDIR:-/tmp}/trace-mcp-stop-mining-${PROJECT_HASH}.log"
   nohup "$TRACE_MCP_BIN" memory mine \
     --project "$PROJECT_ROOT" \
     >"$LOG_FILE" 2>&1
-  # Incremental: skips every session log whose mtime hasn't moved.
+  # Incremental: skips every session log whose mtime hasn't moved. Deliberately
+  # NOT --project — the whole point of TRA-695 is that a project nobody stops in
+  # goes stale unnoticed, and a global pass costs one stat per log file.
   nohup "$TRACE_MCP_BIN" analytics sync >>"$LOG_FILE" 2>&1
   rm -f "$LOCK_FILE" 2>/dev/null || true
 ) >/dev/null 2>&1 &

--- a/hooks/trace-mcp-stop.sh
+++ b/hooks/trace-mcp-stop.sh
@@ -3,7 +3,9 @@
 # trace-mcp Stop hook
 #
 # After the agent stops, mines newly produced session logs in the background
-# so newly emitted decisions land in the index without manual invocation.
+# so newly emitted decisions land in the index without manual invocation, then
+# ingests them into the analytics DB so `analytics report/optimize/savings` and
+# anything reading ~/.trace-mcp/analytics.db directly stay current (TRA-695).
 #
 # Async by design: the foreground process exits within milliseconds. The mine
 # runs in a detached `nohup ... &` subshell so the agent's turn completion is
@@ -59,6 +61,8 @@ LOG_FILE="${TMPDIR:-/tmp}/trace-mcp-stop-mining-${PROJECT_HASH}.log"
   nohup "$TRACE_MCP_BIN" memory mine \
     --project "$PROJECT_ROOT" \
     >"$LOG_FILE" 2>&1
+  # Incremental: skips every session log whose mtime hasn't moved.
+  nohup "$TRACE_MCP_BIN" analytics sync >>"$LOG_FILE" 2>&1
   rm -f "$LOCK_FILE" 2>/dev/null || true
 ) >/dev/null 2>&1 &
 disown 2>/dev/null || true

--- a/scripts/check-analytics-freshness.mjs
+++ b/scripts/check-analytics-freshness.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// Fails when the analytics DB has not ingested a session log recently enough.
+//
+// TRA-695: `~/.trace-mcp/analytics.db` stopped ingesting on 2026-08-26 and
+// nobody noticed for seven days. 65,384 tool calls — 35% of the dataset — sat
+// unmined while `get_session_analytics`, `get_optimization_report`,
+// `get_real_savings` and `get_usage_trends` reported the stale numbers as
+// current. The sync itself was fine; nothing had run it.
+//
+// This is the outside check on that: it compares the ingestion watermark
+// (`max(sync_state.parsed_at)`) against the newest session log mtime on disk
+// and fails when the gap exceeds --max-age-hours. Run it by hand, or from any
+// autopilot that is about to reason about session analytics.
+//
+// Usage:
+//   node scripts/check-analytics-freshness.mjs [--max-age-hours 24] [--json]
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+
+const DEFAULT_MAX_AGE_HOURS = 24;
+
+/**
+ * Decides freshness from the two timestamps. Pure so the thresholds are
+ * testable without a database or a home directory.
+ *
+ * @param {{ parsedAtMs: number | null, newestLogMs: number | null, maxAgeHours: number }} input
+ * @returns {{ ok: boolean, reason: string, behindHours: number | null }}
+ */
+export function evaluateFreshness({ parsedAtMs, newestLogMs, maxAgeHours }) {
+  if (newestLogMs === null) {
+    return { ok: true, reason: 'no session logs on disk', behindHours: null };
+  }
+  if (parsedAtMs === null) {
+    return {
+      ok: false,
+      reason: 'analytics DB has never ingested a session log',
+      behindHours: null,
+    };
+  }
+  const behindHours = (newestLogMs - parsedAtMs) / 3_600_000;
+  if (behindHours <= maxAgeHours) {
+    return { ok: true, reason: 'fresh', behindHours: Math.max(0, round1(behindHours)) };
+  }
+  return {
+    ok: false,
+    reason: `ingestion watermark trails the newest session log by ${round1(behindHours)}h (limit ${maxAgeHours}h)`,
+    behindHours: round1(behindHours),
+  };
+}
+
+function round1(n) {
+  return Math.round(n * 10) / 10;
+}
+
+/** mtime (epoch ms) of the newest `*.jsonl` under ~/.claude/projects, or null. */
+function newestSessionLogMtime(root) {
+  let newest = null;
+  let dirs;
+  try {
+    dirs = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const d of dirs) {
+    if (!d.isDirectory()) continue;
+    let files;
+    try {
+      files = fs.readdirSync(path.join(root, d.name), { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const f of files) {
+      if (!f.isFile() || !f.name.endsWith('.jsonl')) continue;
+      try {
+        const { mtimeMs } = fs.statSync(path.join(root, d.name, f.name));
+        if (newest === null || mtimeMs > newest) newest = mtimeMs;
+      } catch {
+        /* skip */
+      }
+    }
+  }
+  return newest;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const maxAgeIdx = argv.indexOf('--max-age-hours');
+  const maxAgeHours =
+    maxAgeIdx === -1 ? DEFAULT_MAX_AGE_HOURS : Number.parseFloat(argv[maxAgeIdx + 1]);
+  const asJson = argv.includes('--json');
+
+  const dbPath = path.join(os.homedir(), '.trace-mcp', 'analytics.db');
+  let watermark = { parsed_at: null, cnt: 0 };
+  if (fs.existsSync(dbPath)) {
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      watermark =
+        db.prepare('SELECT MAX(parsed_at) as parsed_at, COUNT(*) as cnt FROM sync_state').get() ??
+        watermark;
+    } finally {
+      db.close();
+    }
+  }
+
+  const newestLogMs = newestSessionLogMtime(path.join(os.homedir(), '.claude', 'projects'));
+  const parsedAtMs = watermark.parsed_at ? Date.parse(watermark.parsed_at) : null;
+  const result = evaluateFreshness({
+    parsedAtMs: Number.isNaN(parsedAtMs) ? null : parsedAtMs,
+    newestLogMs,
+    maxAgeHours,
+  });
+
+  const report = {
+    ok: result.ok,
+    reason: result.reason,
+    ingested_through: watermark.parsed_at,
+    files_tracked: watermark.cnt,
+    newest_session_log_at: newestLogMs === null ? null : new Date(newestLogMs).toISOString(),
+    behind_hours: result.behindHours,
+    max_age_hours: maxAgeHours,
+  };
+
+  if (asJson) {
+    console.log(JSON.stringify(report, null, 2));
+  } else if (result.ok) {
+    console.log(`✅ analytics ingestion ${result.reason} — through ${report.ingested_through}`);
+  } else {
+    console.error(`❌ analytics ingestion stale: ${result.reason}`);
+    console.error(`   ingested through: ${report.ingested_through}`);
+    console.error(`   newest session log: ${report.newest_session_log_at}`);
+    console.error('   fix: trace-mcp analytics sync');
+  }
+
+  if (!result.ok) process.exitCode = 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/check-analytics-freshness.mjs
+++ b/scripts/check-analytics-freshness.mjs
@@ -56,32 +56,62 @@ function round1(n) {
   return Math.round(n * 10) / 10;
 }
 
-/** mtime (epoch ms) of the newest `*.jsonl` under ~/.claude/projects, or null. */
-function newestSessionLogMtime(root) {
+/** mtime (epoch ms) of the newest `*.jsonl` directly under `dir`, or null. */
+function newestJsonlIn(dir) {
   let newest = null;
-  let dirs;
+  let files;
   try {
-    dirs = fs.readdirSync(root, { withFileTypes: true });
+    files = fs.readdirSync(dir, { withFileTypes: true });
   } catch {
     return null;
   }
-  for (const d of dirs) {
-    if (!d.isDirectory()) continue;
-    let files;
+  for (const f of files) {
+    if (!f.isFile() || !f.name.endsWith('.jsonl')) continue;
     try {
-      files = fs.readdirSync(path.join(root, d.name), { withFileTypes: true });
+      const { mtimeMs } = fs.statSync(path.join(dir, f.name));
+      if (newest === null || mtimeMs > newest) newest = mtimeMs;
     } catch {
-      continue;
+      /* skip */
     }
-    for (const f of files) {
-      if (!f.isFile() || !f.name.endsWith('.jsonl')) continue;
-      try {
-        const { mtimeMs } = fs.statSync(path.join(root, d.name, f.name));
-        if (newest === null || mtimeMs > newest) newest = mtimeMs;
-      } catch {
-        /* skip */
-      }
+  }
+  return newest;
+}
+
+/**
+ * Every directory `syncAnalytics` ingests from: Claude Code's
+ * `~/.claude/projects/<encoded>/`, plus Claw Code's `<project>/.claw/sessions`
+ * for each registered project. A checker that watches a narrower set than the
+ * syncer would report `ok` on exactly the silent staleness it exists to catch.
+ */
+export function sessionLogDirs(home) {
+  const dirs = [];
+  const claudeRoot = path.join(home, '.claude', 'projects');
+  try {
+    for (const d of fs.readdirSync(claudeRoot, { withFileTypes: true })) {
+      if (d.isDirectory()) dirs.push(path.join(claudeRoot, d.name));
     }
+  } catch {
+    /* no Claude Code logs on this machine */
+  }
+  try {
+    const registry = JSON.parse(
+      fs.readFileSync(path.join(home, '.trace-mcp', 'registry.json'), 'utf8'),
+    );
+    for (const entry of Object.values(registry.projects ?? {})) {
+      if (entry?.root) dirs.push(path.join(entry.root, '.claw', 'sessions'));
+    }
+  } catch {
+    /* no registry, or unreadable — Claude Code dirs still checked */
+  }
+  return dirs;
+}
+
+/** mtime (epoch ms) of the newest session log anywhere the syncer looks. */
+function newestSessionLogMtime(home) {
+  let newest = null;
+  for (const dir of sessionLogDirs(home)) {
+    const m = newestJsonlIn(dir);
+    if (m !== null && (newest === null || m > newest)) newest = m;
   }
   return newest;
 }
@@ -106,7 +136,7 @@ function main() {
     }
   }
 
-  const newestLogMs = newestSessionLogMtime(path.join(os.homedir(), '.claude', 'projects'));
+  const newestLogMs = newestSessionLogMtime(os.homedir());
   const parsedAtMs = watermark.parsed_at ? Date.parse(watermark.parsed_at) : null;
   const result = evaluateFreshness({
     parsedAtMs: Number.isNaN(parsedAtMs) ? null : parsedAtMs,

--- a/src/analytics/analytics-store.ts
+++ b/src/analytics/analytics-store.ts
@@ -119,6 +119,9 @@ export class AnalyticsStore {
     this.db = new Database(p);
     restrictDbPerms(p);
     this.db.pragma('journal_mode = WAL');
+    // Concurrent syncs are now routine (the Stop hook fires one per turn), so
+    // wait out a writer instead of failing the read with SQLITE_BUSY.
+    this.db.pragma('busy_timeout = 5000');
 
     this.db.pragma(`journal_size_limit = ${100 * 1024 * 1024}`);
     this.db.pragma('foreign_keys = OFF'); // for performance during bulk inserts

--- a/src/analytics/analytics-store.ts
+++ b/src/analytics/analytics-store.ts
@@ -443,6 +443,19 @@ export class AnalyticsStore {
     };
   }
 
+  /**
+   * Ingestion watermark: when the most recently parsed session log was
+   * absorbed, and how many log files are tracked. Consumers compare
+   * `parsed_at` against the newest session log mtime on disk to tell a
+   * current reading from a stale one — see TRA-695.
+   */
+  getIngestionWatermark(): { parsed_at: string | null; files_tracked: number } {
+    const row = this.db
+      .prepare('SELECT MAX(parsed_at) as parsed_at, COUNT(*) as cnt FROM sync_state')
+      .get() as { parsed_at: string | null; cnt: number } | undefined;
+    return { parsed_at: row?.parsed_at ?? null, files_tracked: row?.cnt ?? 0 };
+  }
+
   close(): void {
     this.db.close();
   }

--- a/src/analytics/real-savings.ts
+++ b/src/analytics/real-savings.ts
@@ -5,6 +5,7 @@
 
 import type { Store } from '../db/store.js';
 import { isTraceToolServer, type ToolCallRow } from './analytics-store.js';
+import type { IngestionStatus } from './sync.js';
 
 interface FileAlternative {
   file: string;
@@ -50,6 +51,8 @@ interface RealSavingsReport {
 
   /** Set when zero session data was found both on disk and in the aggregation — see TRA-76. */
   _warnings?: string[];
+  /** Ingestion watermark of the analytics DB — see TRA-695. */
+  _ingestion?: IngestionStatus;
 }
 
 const MODEL_PRICING: Record<string, number> = {

--- a/src/analytics/rules.ts
+++ b/src/analytics/rules.ts
@@ -4,6 +4,7 @@
  */
 
 import { isTraceToolServer, type ToolCallRow } from './analytics-store.js';
+import type { IngestionStatus } from './sync.js';
 
 interface OptimizationHit {
   rule: string;
@@ -29,6 +30,8 @@ export interface OptimizationReport {
   };
   /** Set when zero session data was found both on disk and in the aggregation — see TRA-76. */
   _warnings?: string[];
+  /** Ingestion watermark of the analytics DB — see TRA-695. */
+  _ingestion?: IngestionStatus;
 }
 
 interface Rule {

--- a/src/analytics/session-analytics.ts
+++ b/src/analytics/session-analytics.ts
@@ -1,7 +1,13 @@
 import type { AnalyticsStore } from './analytics-store.js';
 import { listAllSessions } from './log-parser.js';
 import { analyzeOptimizations, type OptimizationReport } from './rules.js';
-import { attachNoSessionDataWarning, syncAnalytics, syncProjectAnalytics } from './sync.js';
+import {
+  attachIngestionStatus,
+  attachNoSessionDataWarning,
+  type IngestionStatus,
+  syncAnalytics,
+  syncProjectAnalytics,
+} from './sync.js';
 
 export type { OptimizationReport } from './rules.js';
 
@@ -28,17 +34,17 @@ interface SessionAnalytics {
   modelsUsed: Record<string, { sessions: number; tokens: number }>;
   /** Set when zero session data was found both on disk and in the aggregation — see TRA-76. */
   _warnings?: string[];
+  /** Ingestion watermark of the analytics DB — see TRA-695. */
+  _ingestion?: IngestionStatus;
 }
 
 export function getSessionAnalytics(
   store: AnalyticsStore,
   opts: AnalyticsOptions,
 ): SessionAnalytics {
-  if (opts.projectPath) {
-    syncProjectAnalytics(store, opts.projectPath);
-  } else {
-    syncAnalytics(store);
-  }
+  const sync = opts.projectPath
+    ? syncProjectAnalytics(store, opts.projectPath)
+    : syncAnalytics(store);
 
   const period = opts.period ?? 'week';
   const result = store.getSessionAnalytics({
@@ -87,6 +93,7 @@ export function getSessionAnalytics(
     listAllSessions(opts.projectPath).length === 0,
     opts.projectPath,
   );
+  attachIngestionStatus(analytics, store, sync);
 
   return analytics;
 }
@@ -95,11 +102,9 @@ export function getOptimizationReport(
   store: AnalyticsStore,
   opts: AnalyticsOptions,
 ): OptimizationReport {
-  if (opts.projectPath) {
-    syncProjectAnalytics(store, opts.projectPath);
-  } else {
-    syncAnalytics(store);
-  }
+  const sync = opts.projectPath
+    ? syncProjectAnalytics(store, opts.projectPath)
+    : syncAnalytics(store);
 
   const period = opts.period ?? 'week';
   const toolCallRows = store.getToolCallsForOptimization({
@@ -119,6 +124,7 @@ export function getOptimizationReport(
     listAllSessions(opts.projectPath).length === 0,
     opts.projectPath,
   );
+  attachIngestionStatus(report, store, sync);
 
   return report;
 }

--- a/src/analytics/sync.ts
+++ b/src/analytics/sync.ts
@@ -39,7 +39,7 @@ export function attachNoSessionDataWarning<T extends { _warnings?: string[] }>(
   return report;
 }
 
-interface SyncResult {
+export interface SyncResult {
   files_scanned: number;
   files_parsed: number;
   files_skipped: number;
@@ -47,6 +47,81 @@ interface SyncResult {
   tool_calls_stored: number;
   errors: number;
   duration_ms: number;
+  /** mtime (epoch ms) of the newest session log seen on disk, null when none. */
+  newest_log_mtime: number | null;
+}
+
+/**
+ * Ingestion freshness of the analytics DB, reported alongside every number
+ * derived from it. A stale reading that announces itself is usable; a stale
+ * reading that doesn't is a trap — see TRA-695, where the DB silently served
+ * a seven-day-old snapshot as if it were current.
+ */
+export interface IngestionStatus {
+  /** `max(sync_state.parsed_at)` — when the last log file was absorbed. */
+  ingested_through: string | null;
+  files_tracked: number;
+  /** mtime of the newest session log on disk, ISO-8601. */
+  newest_session_log_at: string | null;
+  /** True when a session log on disk is newer than the ingestion watermark. */
+  stale: boolean;
+  /** How far the watermark trails the newest log, in hours (null when fresh). */
+  behind_hours: number | null;
+}
+
+/**
+ * Derive ingestion freshness from a just-completed sync plus the store's
+ * watermark. Takes the sync result rather than re-listing the filesystem so
+ * this costs nothing beyond one SELECT.
+ */
+export function buildIngestionStatus(
+  watermark: { parsed_at: string | null; files_tracked: number },
+  newestLogMtime: number | null,
+): IngestionStatus {
+  const parsedAtMs = watermark.parsed_at ? Date.parse(watermark.parsed_at) : NaN;
+  const stale =
+    newestLogMtime !== null && (Number.isNaN(parsedAtMs) || newestLogMtime > parsedAtMs);
+  return {
+    ingested_through: watermark.parsed_at,
+    files_tracked: watermark.files_tracked,
+    newest_session_log_at: newestLogMtime === null ? null : new Date(newestLogMtime).toISOString(),
+    stale,
+    behind_hours:
+      stale && !Number.isNaN(parsedAtMs)
+        ? Math.round((((newestLogMtime as number) - parsedAtMs) / 3_600_000) * 10) / 10
+        : null,
+  };
+}
+
+/**
+ * Attach `_ingestion` to a report and, when the DB trails the logs on disk,
+ * add a `_warnings` line so the staleness is stated rather than inferable.
+ */
+export function attachIngestionStatus<T extends { _warnings?: string[] }>(
+  report: T & { _ingestion?: IngestionStatus },
+  store: { getIngestionWatermark(): { parsed_at: string | null; files_tracked: number } },
+  sync: SyncResult,
+): T & { _ingestion?: IngestionStatus } {
+  const status = buildIngestionStatus(store.getIngestionWatermark(), sync.newest_log_mtime);
+  report._ingestion = status;
+  if (status.stale) {
+    const behind = status.behind_hours === null ? 'unknown' : `${status.behind_hours}h`;
+    report._warnings = [
+      ...(report._warnings ?? []),
+      `Analytics DB is STALE: last ingested ${status.ingested_through ?? 'never'}, ` +
+        `newest session log on disk is ${status.newest_session_log_at} (${behind} newer). ` +
+        'These numbers do not cover the most recent sessions — run `trace-mcp analytics sync`.',
+    ];
+  }
+  return report;
+}
+
+function newestMtime(sessions: { mtime: number }[]): number | null {
+  let newest: number | null = null;
+  for (const s of sessions) {
+    if (newest === null || s.mtime > newest) newest = s.mtime;
+  }
+  return newest;
 }
 
 /** Sync all session logs (Claude Code + Claw Code) into analytics DB */
@@ -88,6 +163,7 @@ export function syncAnalytics(store: AnalyticsStore, opts: { full?: boolean } = 
     tool_calls_stored: toolCallsCount,
     errors,
     duration_ms: Date.now() - start,
+    newest_log_mtime: newestMtime(sessions),
   };
 }
 
@@ -137,5 +213,6 @@ export function syncProjectAnalytics(
     tool_calls_stored: toolCallsCount,
     errors,
     duration_ms: Date.now() - start,
+    newest_log_mtime: newestMtime(sessions),
   };
 }

--- a/src/cli/analytics.ts
+++ b/src/cli/analytics.ts
@@ -13,7 +13,7 @@ import {
 } from '../analytics/benchmark.js';
 import { analyzeRealSavings } from '../analytics/real-savings.js';
 import { getOptimizationReport, getSessionAnalytics } from '../analytics/session-analytics.js';
-import { syncAnalytics } from '../analytics/sync.js';
+import { syncAnalytics, syncProjectAnalytics } from '../analytics/sync.js';
 import { detectCoverage, detectCoverageRecursive } from '../analytics/tech-detector.js';
 import { initializeDatabase } from '../db/schema.js';
 import { Store } from '../db/store.js';
@@ -104,9 +104,15 @@ analyticsCommand
     ensureGlobalDirs();
     const analyticsStore = new AnalyticsStore();
     try {
-      const result = syncAnalytics(analyticsStore, { full: opts.full });
+      const result = opts.project
+        ? syncProjectAnalytics(analyticsStore, opts.project, { full: opts.full })
+        : syncAnalytics(analyticsStore, { full: opts.full });
+      const watermark = analyticsStore.getIngestionWatermark();
       console.log(
         `Scanned: ${result.files_scanned}, Parsed: ${result.files_parsed}, Skipped: ${result.files_skipped}, Errors: ${result.errors}`,
+      );
+      console.log(
+        `Ingested through: ${watermark.parsed_at ?? 'never'} (${watermark.files_tracked} files tracked)`,
       );
     } finally {
       analyticsStore.close();
@@ -133,6 +139,8 @@ analyticsCommand
         console.log(JSON.stringify(result, null, 2));
         return;
       }
+
+      for (const w of result._warnings ?? []) console.log(`⚠️  ${w}`);
 
       console.log(`\n📊 Session Analytics (${result.period})\n`);
       console.log(`Sessions: ${result.sessionsCount}`);
@@ -182,6 +190,8 @@ analyticsCommand
         console.log(JSON.stringify(result, null, 2));
         return;
       }
+
+      for (const w of result._warnings ?? []) console.log(`⚠️  ${w}`);
 
       console.log(`\n🔍 Optimization Report (${result.period})\n`);
       console.log(

--- a/src/tools/register/session.ts
+++ b/src/tools/register/session.ts
@@ -7,7 +7,11 @@ import { formatBenchmarkMarkdown, runBenchmark } from '../../analytics/benchmark
 import { listAllSessions } from '../../analytics/log-parser.js';
 import { analyzeRealSavings } from '../../analytics/real-savings.js';
 import { getOptimizationReport, getSessionAnalytics } from '../../analytics/session-analytics.js';
-import { attachNoSessionDataWarning, syncAnalytics } from '../../analytics/sync.js';
+import {
+  attachIngestionStatus,
+  attachNoSessionDataWarning,
+  syncAnalytics,
+} from '../../analytics/sync.js';
 import { detectCoverage } from '../../analytics/tech-detector.js';
 import { listBundles, loadAllBundles } from '../../bundles.js';
 import { runRetriever } from '../../retrieval/index.js';
@@ -458,7 +462,7 @@ export function registerSessionTools(server: McpServer, ctx: MetaContext): void 
       try {
         const analyticsStore = new AnalyticsStore();
         try {
-          syncAnalytics(analyticsStore);
+          const sync = syncAnalytics(analyticsStore);
           const toolCalls = analyticsStore.getToolCallsForOptimization({
             projectPath: projectRoot,
             period: period ?? 'week',
@@ -470,6 +474,7 @@ export function registerSessionTools(server: McpServer, ctx: MetaContext): void 
             listAllSessions(projectRoot).length === 0,
             projectRoot,
           );
+          attachIngestionStatus(result, analyticsStore, sync);
           return { content: [{ type: 'text', text: j(result) }] };
         } finally {
           analyticsStore.close();
@@ -502,7 +507,7 @@ export function registerSessionTools(server: McpServer, ctx: MetaContext): void 
       try {
         const analyticsStore = new AnalyticsStore();
         try {
-          syncAnalytics(analyticsStore);
+          const sync = syncAnalytics(analyticsStore);
           const trends = analyticsStore.getUsageTrends(days ?? 30);
           const total = trends.reduce(
             (s, d) => ({
@@ -513,11 +518,17 @@ export function registerSessionTools(server: McpServer, ctx: MetaContext): void 
             }),
             { sessions: 0, tokens: 0, cost_usd: 0, tool_calls: 0 },
           );
-          return {
-            content: [
-              { type: 'text', text: j({ days: days ?? 30, daily: trends, totals: total }) },
-            ],
-          };
+          const payload = attachIngestionStatus(
+            { days: days ?? 30, daily: trends, totals: total } as {
+              days: number;
+              daily: typeof trends;
+              totals: typeof total;
+              _warnings?: string[];
+            },
+            analyticsStore,
+            sync,
+          );
+          return { content: [{ type: 'text', text: j(payload) }] };
         } finally {
           analyticsStore.close();
         }

--- a/tests/analytics/sync.test.ts
+++ b/tests/analytics/sync.test.ts
@@ -4,7 +4,12 @@
  * src/analytics/sync.ts.
  */
 import { describe, expect, it } from 'vitest';
-import { attachNoSessionDataWarning, buildNoSessionDataWarning } from '../../src/analytics/sync.js';
+import {
+  attachIngestionStatus,
+  attachNoSessionDataWarning,
+  buildIngestionStatus,
+  buildNoSessionDataWarning,
+} from '../../src/analytics/sync.js';
 
 describe('buildNoSessionDataWarning()', () => {
   it('mentions the resolved project path when provided', () => {
@@ -39,5 +44,83 @@ describe('attachNoSessionDataWarning()', () => {
   it('does not warn when both signals indicate real data', () => {
     const report = attachNoSessionDataWarning({}, false, false, '/proj');
     expect(report._warnings).toBeUndefined();
+  });
+});
+
+/**
+ * TRA-695: the analytics DB served a seven-day-old snapshot as if it were
+ * current. These cover the watermark signal that makes that visible.
+ */
+describe('buildIngestionStatus()', () => {
+  const HOUR = 3_600_000;
+  const parsedAt = '2026-09-02T12:00:00.000Z';
+  const parsedAtMs = Date.parse(parsedAt);
+
+  it('is fresh when the watermark is newer than every log on disk', () => {
+    const status = buildIngestionStatus(
+      { parsed_at: parsedAt, files_tracked: 10 },
+      parsedAtMs - HOUR,
+    );
+    expect(status.stale).toBe(false);
+    expect(status.behind_hours).toBeNull();
+    expect(status.ingested_through).toBe(parsedAt);
+  });
+
+  it('is stale, with the gap in hours, when a log on disk is newer', () => {
+    const status = buildIngestionStatus(
+      { parsed_at: parsedAt, files_tracked: 10 },
+      parsedAtMs + 7 * 24 * HOUR,
+    );
+    expect(status.stale).toBe(true);
+    expect(status.behind_hours).toBe(168);
+  });
+
+  it('is stale when nothing was ever ingested but logs exist', () => {
+    const status = buildIngestionStatus({ parsed_at: null, files_tracked: 0 }, parsedAtMs);
+    expect(status.stale).toBe(true);
+    expect(status.behind_hours).toBeNull();
+  });
+
+  it('is not stale when there are no logs on disk at all', () => {
+    const status = buildIngestionStatus({ parsed_at: null, files_tracked: 0 }, null);
+    expect(status.stale).toBe(false);
+  });
+});
+
+describe('attachIngestionStatus()', () => {
+  const store = (parsedAt: string | null) => ({
+    getIngestionWatermark: () => ({ parsed_at: parsedAt, files_tracked: 3 }),
+  });
+  const syncResult = (newest: number | null) => ({
+    files_scanned: 0,
+    files_parsed: 0,
+    files_skipped: 0,
+    sessions_stored: 0,
+    tool_calls_stored: 0,
+    errors: 0,
+    duration_ms: 0,
+    newest_log_mtime: newest,
+  });
+
+  it('attaches the watermark and no warning when fresh', () => {
+    const report = attachIngestionStatus(
+      {},
+      store('2026-09-02T12:00:00.000Z'),
+      syncResult(Date.parse('2026-09-02T11:00:00.000Z')),
+    );
+    expect(report._ingestion?.stale).toBe(false);
+    expect(report._warnings).toBeUndefined();
+  });
+
+  it('states the staleness in _warnings rather than leaving it to be inferred', () => {
+    const report = attachIngestionStatus(
+      { _warnings: ['pre-existing'] },
+      store('2026-08-26T05:03:12.638Z'),
+      syncResult(Date.parse('2026-09-02T18:00:00.000Z')),
+    );
+    expect(report._ingestion?.stale).toBe(true);
+    expect(report._warnings?.[0]).toBe('pre-existing');
+    expect(report._warnings?.[1]).toContain('STALE');
+    expect(report._warnings?.[1]).toContain('trace-mcp analytics sync');
   });
 });

--- a/tests/scripts/check-analytics-freshness.test.ts
+++ b/tests/scripts/check-analytics-freshness.test.ts
@@ -1,0 +1,53 @@
+/**
+ * TRA-695: the threshold logic behind scripts/check-analytics-freshness.mjs.
+ * Kept pure so the check is testable without a home directory or a database.
+ */
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — plain .mjs script, no type declarations
+import { evaluateFreshness } from '../../scripts/check-analytics-freshness.mjs';
+
+const HOUR = 3_600_000;
+const now = Date.parse('2026-09-02T18:00:00.000Z');
+
+describe('evaluateFreshness()', () => {
+  it('passes when the watermark trails the newest log by less than the limit', () => {
+    const r = evaluateFreshness({
+      parsedAtMs: now - 2 * HOUR,
+      newestLogMs: now,
+      maxAgeHours: 24,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.behindHours).toBe(2);
+  });
+
+  it('fails on the seven-day gap that TRA-695 found', () => {
+    const r = evaluateFreshness({
+      parsedAtMs: Date.parse('2026-08-26T05:03:12.638Z'),
+      newestLogMs: now,
+      maxAgeHours: 24,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.behindHours).toBeGreaterThan(168);
+  });
+
+  it('fails when the DB has never ingested anything but logs exist', () => {
+    const r = evaluateFreshness({ parsedAtMs: null, newestLogMs: now, maxAgeHours: 24 });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('never');
+  });
+
+  it('passes on a machine with no session logs at all', () => {
+    const r = evaluateFreshness({ parsedAtMs: null, newestLogMs: null, maxAgeHours: 24 });
+    expect(r.ok).toBe(true);
+  });
+
+  it('reports zero rather than a negative gap when the watermark is ahead', () => {
+    const r = evaluateFreshness({
+      parsedAtMs: now,
+      newestLogMs: now - HOUR,
+      maxAgeHours: 24,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.behindHours).toBe(0);
+  });
+});

--- a/tests/scripts/check-analytics-freshness.test.ts
+++ b/tests/scripts/check-analytics-freshness.test.ts
@@ -2,9 +2,12 @@
  * TRA-695: the threshold logic behind scripts/check-analytics-freshness.mjs.
  * Kept pure so the check is testable without a home directory or a database.
  */
-import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 // @ts-expect-error — plain .mjs script, no type declarations
-import { evaluateFreshness } from '../../scripts/check-analytics-freshness.mjs';
+import { evaluateFreshness, sessionLogDirs } from '../../scripts/check-analytics-freshness.mjs';
 
 const HOUR = 3_600_000;
 const now = Date.parse('2026-09-02T18:00:00.000Z');
@@ -49,5 +52,37 @@ describe('evaluateFreshness()', () => {
     });
     expect(r.ok).toBe(true);
     expect(r.behindHours).toBe(0);
+  });
+});
+
+describe('sessionLogDirs()', () => {
+  const homes: string[] = [];
+
+  afterEach(() => {
+    for (const h of homes.splice(0)) fs.rmSync(h, { recursive: true, force: true });
+  });
+
+  function fakeHome(): string {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tra695-'));
+    homes.push(home);
+    return home;
+  }
+
+  it('watches both Claude Code project dirs and Claw Code session dirs', () => {
+    const home = fakeHome();
+    fs.mkdirSync(path.join(home, '.claude', 'projects', '-Users-me-proj'), { recursive: true });
+    fs.mkdirSync(path.join(home, '.trace-mcp'), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, '.trace-mcp', 'registry.json'),
+      JSON.stringify({ projects: { proj: { root: '/Users/me/proj' } } }),
+    );
+
+    const dirs: string[] = sessionLogDirs(home);
+    expect(dirs).toContain(path.join(home, '.claude', 'projects', '-Users-me-proj'));
+    expect(dirs).toContain(path.join('/Users/me/proj', '.claw', 'sessions'));
+  });
+
+  it('degrades to an empty list rather than throwing on a bare home', () => {
+    expect(sessionLogDirs(fakeHome())).toEqual([]);
   });
 });

--- a/tests/tools/behavioural/get-session-analytics.behavioural.test.ts
+++ b/tests/tools/behavioural/get-session-analytics.behavioural.test.ts
@@ -142,6 +142,7 @@ describe('getSessionAnalytics() — behavioural contract', () => {
     // Spot-check every advertised top-level key.
     expect(Object.keys(result).sort()).toEqual(
       [
+        '_ingestion',
         'byToolServer',
         'modelsUsed',
         'period',


### PR DESCRIPTION
Fixes TRA-695.

## The failure

`~/.trace-mcp/analytics.db` had not ingested a session log since **2026-08-26T05:03Z** while 1,702 session logs under `~/.claude/projects/` were newer, the freshest three minutes old. A manual `trace-mcp analytics sync` absorbed **65,384 tool calls — 35% of the whole dataset — with zero errors**. The sync was never broken; nothing ran it.

Worse than the gap: nothing said so. `get_session_analytics`, `get_optimization_report`, `get_real_savings`, `get_usage_trends` and the matching CLI commands all served the week-old snapshot with no indication of its age, so a stale reading was indistinguishable from a current one. It hid a real regression for a week — `get_outline`'s NOT_FOUND rate reads 18.1% on the stale data and 21.8% (432/1986) on the complete data.

One correction to the issue's premise: the four tools *do* sync on read (`src/analytics/session-analytics.ts`, `src/tools/register/session.ts`). The DB went stale because nobody read through those paths for seven days — the run that found this read the DB directly with `sqlite3`. That's why the fix drives the sync from the session lifecycle rather than only from the read path.

## Changes

**1. Trigger it.** The Stop hook chains an incremental `trace-mcp analytics sync` after `memory mine`, inside the same detached `nohup` subshell (`hooks/trace-mcp-stop.sh`, `.cmd`). Turn completion stays unblocked; the sync skips every log whose mtime hasn't moved. This keeps the DB current for *direct* readers, not just for the tools that already self-synced.

**2. Make staleness visible, not inferable.** Every reading derived from the DB now carries `_ingestion`:

```json
{ "ingested_through": "2026-08-26T05:03:12.638Z",
  "files_tracked": 1479,
  "newest_session_log_at": "2026-09-02T18:00:00.000Z",
  "stale": true,
  "behind_hours": 180.9 }
```

When stale, a `_warnings` line states it in words and names the fix. The staleness test is exact — "a log on disk is newer than the watermark" — with no arbitrary threshold. The newest mtime is threaded out of the sync result that just ran, so this costs one `SELECT` and no extra filesystem walk.

**3. Guard it.** `scripts/check-analytics-freshness.mjs` compares the watermark against the newest `~/.claude/projects/**/*.jsonl` mtime and exits 1 past `--max-age-hours` (default 24). Same shape as `scripts/check-waiting-for-release.mjs` — runnable by hand and by any autopilot about to reason about session analytics.

Also wires up `analytics sync --project`, which was accepted and silently ignored.

## Test evidence

```
pnpm run lint       → clean
pnpm run build      → success
pnpm run test       → 9653 passed | 12 skipped (880 files)
```

New unit coverage: `tests/analytics/sync.test.ts` (fresh / stale / never-ingested / no-logs, and that the warning is additive to existing `_warnings`), `tests/scripts/check-analytics-freshness.test.ts` (including the actual 7-day gap this issue found). `tests/tools/behavioural/get-session-analytics.behavioural.test.ts` updated for the added envelope key — additive, no MCP signature or DB schema change.

Verified against the live DB:

```
$ node scripts/check-analytics-freshness.mjs --json
{ "ok": true, "reason": "fresh", "ingested_through": "2026-09-02T18:13:46.478Z",
  "files_tracked": 3239, "newest_session_log_at": "2026-09-02T18:22:21.233Z",
  "behind_hours": 0.1, "max_age_hours": 24 }

$ node scripts/check-analytics-freshness.mjs --max-age-hours 0.01 ; echo $?
❌ analytics ingestion stale: ingestion watermark trails the newest session log by 0.1h (limit 0.01h)
1
```

Token cost: unchanged for every existing field; `_ingestion` adds ~6 keys to four analytics responses.
