### PR TITLE
fix: collect ~/.trace-mcp state that nothing ever swept (TRA-702)

### DIFF
--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -11,6 +11,19 @@ $TraceHome = if ($env:TRACE_MCP_HOME) { $env:TRACE_MCP_HOME } else { Join-Path $
 $ConfigPath = Join-Path $TraceHome 'launcher.env'
 $LogPath    = Join-Path $TraceHome 'launcher.log'
 
+# Rotate once per invocation, before the first append (TRA-702). Mirrors
+# rotate_log in trace-mcp-launcher.sh. Bounds the log at 2 x the limit across
+# both generations; without it the file only ever grew.
+$LogMaxBytes = if ($env:TRACE_MCP_LOG_MAX_BYTES) { [int64]$env:TRACE_MCP_LOG_MAX_BYTES } else { 5242880 }
+try {
+    $existing = Get-Item -LiteralPath $LogPath -ErrorAction SilentlyContinue
+    if ($existing -and $existing.Length -gt $LogMaxBytes) {
+        Move-Item -LiteralPath $LogPath -Destination "$LogPath.1" -Force -ErrorAction SilentlyContinue
+    }
+} catch {
+    # Never abort on rotation failure.
+}
+
 function Write-LauncherLog {
     param([string]$Message)
     try {

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -12,6 +12,23 @@ TRACE_HOME="${TRACE_MCP_HOME:-$HOME/.trace}"
 CONFIG="$TRACE_HOME/launcher.env"
 LOG="$TRACE_HOME/launcher.log"
 
+# Rotate once per invocation, before the first append (TRA-702). The shim runs
+# once per MCP client launch and writes a couple of lines, so a size check here
+# costs one stat and bounds the file at 2 x LOG_MAX_BYTES across both
+# generations. Without it launcher.log only ever grew — 9.7 MB observed.
+LOG_MAX_BYTES=${TRACE_MCP_LOG_MAX_BYTES:-5242880}
+rotate_log() {
+  [ -f "$LOG" ] || return 0
+  # stat is not portable between GNU and BSD; try both, give up quietly.
+  size=$(stat -f %z "$LOG" 2>/dev/null || stat -c %s "$LOG" 2>/dev/null || echo 0)
+  case "$size" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  [ "$size" -gt "$LOG_MAX_BYTES" ] || return 0
+  mv -f "$LOG" "$LOG.1" 2>/dev/null || true
+}
+rotate_log
+
 log() {
   # Best-effort append; never abort on log failure.
   printf '[%s] %s\n' "$(date -u +%FT%TZ 2>/dev/null || echo '-')" "$1" >> "$LOG" 2>/dev/null || true

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -1036,10 +1036,23 @@ function updateLogPath(): string {
   return path.join(getLauncherDir(), 'update.log');
 }
 
+// TRA-702: update.log had no rotation and only ever grew. Every entry carries
+// a full stdout/stderr capture, so a few failing updates move it by megabytes.
+// One generation is enough for the "user reports 'Update failed'" case this log
+// exists to serve — nobody reads the run before last.
+const UPDATE_LOG_MAX_BYTES = 2 * 1024 * 1024;
+
 function appendUpdateLog(entry: Record<string, unknown>): void {
   try {
     const target = updateLogPath();
     fs.mkdirSync(path.dirname(target), { recursive: true });
+    try {
+      if (fs.statSync(target).size > UPDATE_LOG_MAX_BYTES) {
+        fs.renameSync(target, `${target}.1`);
+      }
+    } catch {
+      /* no log yet, or rotation raced another writer — append regardless */
+    }
     fs.appendFileSync(
       target,
       JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n',

--- a/src/__tests__/config-project-sweep.test.ts
+++ b/src/__tests__/config-project-sweep.test.ts
@@ -159,6 +159,36 @@ describe('pruneProjectConfigSections (TRA-702)', () => {
     expect(Object.keys(readProjects())).toEqual([live]);
   });
 
+  it('skips entirely while another process holds the config lock', () => {
+    // The sweep reads the file, computes hundreds of edits, then writes the
+    // whole thing back — ~2s wide on the first backlog drain, while other
+    // agent processes keep registering projects. Its write would publish a
+    // buffer that predates a peer's section, silently reverting it; if that
+    // landed between a run's save and its immediate loadConfig(), the run
+    // would index with schema defaults.
+    //
+    // Within one process this cannot happen — the sweep is synchronous, so
+    // nothing else in that process runs during it. The real peer is another
+    // process, which is what the cross-process lock serialises. Here that peer
+    // is simulated by a lock file held by a live pid that is not us; the sweep
+    // must decline to touch the file at all and retry on the next hourly pass.
+    const dead = path.join(tmpHome, 'deleted-project');
+    writeConfig({ [dead]: { root: '.' } });
+    const before = fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8');
+
+    const lockDir = path.join(tmpHome, 'locks');
+    fs.mkdirSync(lockDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(lockDir, 'global-config.pid'),
+      // pid 1 is always alive and is never this test process, so the lock
+      // reads as genuinely held rather than stale.
+      JSON.stringify({ pid: 1, started_at: Date.now(), hostname: os.hostname(), op: 'peer' }),
+    );
+
+    expect(configJsonc.pruneProjectConfigSections()).toEqual([]);
+    expect(fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8')).toBe(before);
+  });
+
   it('leaves a config with no dead sections untouched', () => {
     const live = fs.mkdtempSync(path.join(tmpHome, 'live-'));
     writeConfig({ [live]: { root: '.' } });

--- a/src/__tests__/config-project-sweep.test.ts
+++ b/src/__tests__/config-project-sweep.test.ts
@@ -2,15 +2,21 @@
  * TRA-702: `.config.json` grew to 1 MB / 593 project sections on the reported
  * machine, 440 of them pointing at directories that no longer exist.
  *
- * TRA-396 stopped one-shot agent workdirs from reaching `registry.json`, but
- * `setupProject` writes the per-project *config* section before
- * `registerProject` ever applies that check — so every agent run still left a
- * permanent section behind, and nothing swept them. This covers both halves:
- * not writing new ones, and draining the backlog.
+ * `setupProject` writes one section per root it sets up, and every sweep that
+ * existed worked on `registry.json` — a different file — so this map had no
+ * collector at all. The section itself has to keep being written even for
+ * one-shot workdirs, because the run that follows reads it back (see
+ * tests/project-setup/ephemeral-config-section.test.ts); collecting them
+ * afterwards, on softGcSweep's hourly timer, is what bounds the file.
+ *
+ * These cases pin what the sweep removes and — the part that matters — what it
+ * must not: a registered root that is only transiently missing, comments a user
+ * hand-wrote in a retained section, and a healthy config it should not rewrite.
  */
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { parse } from 'jsonc-parser';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('pruneProjectConfigSections (TRA-702)', () => {
@@ -39,7 +45,15 @@ describe('pruneProjectConfigSections (TRA-702)', () => {
   }
 
   function readProjects(): Record<string, unknown> {
-    return JSON.parse(fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8')).projects ?? {};
+    // jsonc, not JSON: the file is documented as comment-bearing, and one of
+    // these cases deliberately writes comments into it.
+    return (
+      (
+        parse(fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8')) as {
+          projects?: Record<string, unknown>;
+        }
+      )?.projects ?? {}
+    );
   }
 
   function registerRoot(root: string): void {
@@ -109,6 +123,40 @@ describe('pruneProjectConfigSections (TRA-702)', () => {
     const writesToConfig = spy.mock.calls.filter(([, dest]) => dest === GLOBAL_CONFIG_PATH);
     expect(writesToConfig).toHaveLength(1);
     spy.mockRestore();
+  });
+
+  it('preserves comments inside the project sections it keeps', () => {
+    // Replacing the whole `projects` object in one edit is shorter, but it
+    // reserialises the retained sections too and drops any comment a user
+    // hand-wrote in them. `.config.json` is JSONC and documented as
+    // hand-editable; #218 already protects this data on the write path.
+    const live = fs.mkdtempSync(path.join(tmpHome, 'live-'));
+    const dead = path.join(tmpHome, 'deleted-project');
+    fs.mkdirSync(path.dirname(GLOBAL_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(
+      GLOBAL_CONFIG_PATH,
+      `{
+  // top-level note
+  "projects": {
+    ${JSON.stringify(live)}: {
+      // keep the generated globs, we tuned these by hand
+      "root": ".",
+      "include": ["src/**"] // only source
+    },
+    ${JSON.stringify(dead)}: { "root": "." }
+  }
+}
+`,
+    );
+
+    expect(configJsonc.pruneProjectConfigSections()).toEqual([dead]);
+
+    const after = fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8');
+    expect(after).toContain('// top-level note');
+    expect(after).toContain('// keep the generated globs, we tuned these by hand');
+    expect(after).toContain('// only source');
+    expect(after).not.toContain('deleted-project');
+    expect(Object.keys(readProjects())).toEqual([live]);
   });
 
   it('leaves a config with no dead sections untouched', () => {

--- a/src/__tests__/config-project-sweep.test.ts
+++ b/src/__tests__/config-project-sweep.test.ts
@@ -1,0 +1,122 @@
+/**
+ * TRA-702: `.config.json` grew to 1 MB / 593 project sections on the reported
+ * machine, 440 of them pointing at directories that no longer exist.
+ *
+ * TRA-396 stopped one-shot agent workdirs from reaching `registry.json`, but
+ * `setupProject` writes the per-project *config* section before
+ * `registerProject` ever applies that check — so every agent run still left a
+ * permanent section behind, and nothing swept them. This covers both halves:
+ * not writing new ones, and draining the backlog.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('pruneProjectConfigSections (TRA-702)', () => {
+  let tmpHome: string;
+  let configJsonc: typeof import('../config-jsonc.js');
+  let GLOBAL_CONFIG_PATH: string;
+  let REGISTRY_PATH: string;
+
+  beforeEach(async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-cfg-sweep-'));
+    vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+    vi.resetModules();
+    configJsonc = await import('../config-jsonc.js');
+    ({ GLOBAL_CONFIG_PATH, REGISTRY_PATH } = await import('../global.js'));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function writeConfig(projects: Record<string, unknown>): void {
+    fs.mkdirSync(path.dirname(GLOBAL_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(GLOBAL_CONFIG_PATH, JSON.stringify({ projects }, null, 2));
+  }
+
+  function readProjects(): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8')).projects ?? {};
+  }
+
+  function registerRoot(root: string): void {
+    fs.mkdirSync(path.dirname(REGISTRY_PATH), { recursive: true });
+    fs.writeFileSync(
+      REGISTRY_PATH,
+      JSON.stringify({
+        version: 1,
+        projects: {
+          [root]: { name: 'x', root, dbPath: '/tmp/x.db', addedAt: '2026-01-01T00:00:00.000Z' },
+        },
+      }),
+    );
+  }
+
+  it('drops sections whose root is gone and that no registry entry claims', () => {
+    const live = fs.mkdtempSync(path.join(tmpHome, 'live-'));
+    const dead = path.join(tmpHome, 'deleted-project');
+    writeConfig({ [live]: { root: '.' }, [dead]: { root: '.' } });
+
+    expect(configJsonc.pruneProjectConfigSections()).toEqual([dead]);
+    expect(Object.keys(readProjects())).toEqual([live]);
+  });
+
+  it('drops one-shot agent workdir sections even while the checkout is still on disk', () => {
+    // The Multica runtime abandons its workdir in place, so an existence check
+    // alone never reaches these — which is how the live-but-dead sections
+    // survived every sweep that shipped before this one.
+    const workdir = path.join(
+      tmpHome,
+      'multica_workspaces_acme',
+      'proj-123',
+      'tra-1-abc',
+      'workdir',
+      'trace-mcp',
+    );
+    fs.mkdirSync(workdir, { recursive: true });
+    const real = fs.mkdtempSync(path.join(tmpHome, 'real-'));
+    writeConfig({ [workdir]: { root: '.' }, [real]: { root: '.' } });
+
+    expect(configJsonc.pruneProjectConfigSections()).toEqual([workdir]);
+    expect(Object.keys(readProjects())).toEqual([real]);
+  });
+
+  it('keeps a registered project whose root is only transiently missing', () => {
+    // An unmounted drive must not cost the user their config. registry.json is
+    // the authority, and it already runs its own 7-day grace period.
+    const missing = path.join(tmpHome, 'on-an-unmounted-volume');
+    writeConfig({ [missing]: { root: '.', include: ['src/**'] } });
+    registerRoot(missing);
+
+    expect(configJsonc.pruneProjectConfigSections()).toEqual([]);
+    expect(Object.keys(readProjects())).toEqual([missing]);
+  });
+
+  it('rewrites the file once, not once per removed section', () => {
+    // Hundreds of dead sections × a 1 MB rewrite each is why this is a bulk
+    // operation rather than a loop over removeProjectConfigJsonc.
+    const projects: Record<string, unknown> = {};
+    for (let i = 0; i < 50; i++) projects[path.join(tmpHome, `gone-${i}`)] = { root: '.' };
+    writeConfig(projects);
+
+    const spy = vi.spyOn(fs, 'renameSync');
+    const removed = configJsonc.pruneProjectConfigSections();
+
+    expect(removed).toHaveLength(50);
+    const writesToConfig = spy.mock.calls.filter(([, dest]) => dest === GLOBAL_CONFIG_PATH);
+    expect(writesToConfig).toHaveLength(1);
+    spy.mockRestore();
+  });
+
+  it('leaves a config with no dead sections untouched', () => {
+    const live = fs.mkdtempSync(path.join(tmpHome, 'live-'));
+    writeConfig({ [live]: { root: '.' } });
+    const before = fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8');
+
+    expect(configJsonc.pruneProjectConfigSections()).toEqual([]);
+    expect(fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8')).toBe(before);
+  });
+});

--- a/src/__tests__/config-project-sweep.test.ts
+++ b/src/__tests__/config-project-sweep.test.ts
@@ -180,9 +180,16 @@ describe('pruneProjectConfigSections (TRA-702)', () => {
     fs.mkdirSync(lockDir, { recursive: true });
     fs.writeFileSync(
       path.join(lockDir, 'global-config.pid'),
-      // pid 1 is always alive and is never this test process, so the lock
-      // reads as genuinely held rather than stale.
-      JSON.stringify({ pid: 1, started_at: Date.now(), hostname: os.hostname(), op: 'peer' }),
+      // The holder must read as *live*, which means a pid `kill(pid, 0)`
+      // succeeds on and a matching hostname. Our own pid is the only value
+      // guaranteed to satisfy that on every platform — pid 1 does not exist on
+      // Windows, so the lock was reclaimed as stale there.
+      JSON.stringify({
+        pid: process.pid,
+        started_at: Date.now(),
+        hostname: os.hostname(),
+        op: 'peer',
+      }),
     );
 
     expect(configJsonc.pruneProjectConfigSections()).toEqual([]);

--- a/src/__tests__/soft-gc-grace-order.test.ts
+++ b/src/__tests__/soft-gc-grace-order.test.ts
@@ -1,0 +1,111 @@
+/**
+ * TRA-702: the config sweep's "a registered root is protected" promise only
+ * holds if the registry sweep that runs beside it is grace-aware.
+ *
+ * `softGcSweep` used to call `pruneStaleProjects()`, which deregisters a
+ * missing root the first time it is seen missing. The startup path separately
+ * called `sweepMissingRoots(7)`, which times the root and waits seven days.
+ * Both ran against the same registry an hour apart, so the grace never held:
+ * the hourly pass dropped the registry row immediately, and being unregistered
+ * is half the condition `pruneProjectConfigSections` uses to delete a config
+ * section. A volume that went offline for an hour came back to neither.
+ *
+ * This pins the ordering as a unit — the predicate tests alone cannot see it,
+ * because each function is correct in isolation.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('soft GC ordering: registry grace protects the config section (TRA-702)', () => {
+  let tmpHome: string;
+  let registry: typeof import('../registry.js');
+  let configJsonc: typeof import('../config-jsonc.js');
+  let GLOBAL_CONFIG_PATH: string;
+  let REGISTRY_PATH: string;
+
+  beforeEach(async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-softgc-order-'));
+    vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+    vi.resetModules();
+    registry = await import('../registry.js');
+    configJsonc = await import('../config-jsonc.js');
+    ({ GLOBAL_CONFIG_PATH, REGISTRY_PATH } = await import('../global.js'));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('keeps registry row and config section for a root missing only briefly', () => {
+    // A registered project on a volume that just went offline.
+    const missing = path.join(tmpHome, 'unmounted-volume', 'project');
+    fs.mkdirSync(path.dirname(REGISTRY_PATH), { recursive: true });
+    fs.writeFileSync(
+      REGISTRY_PATH,
+      JSON.stringify({
+        version: 1,
+        projects: {
+          [missing]: {
+            name: 'project',
+            root: missing,
+            dbPath: path.join(tmpHome, 'project.db'),
+            addedAt: new Date().toISOString(),
+          },
+        },
+      }),
+    );
+    fs.mkdirSync(path.dirname(GLOBAL_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(
+      GLOBAL_CONFIG_PATH,
+      JSON.stringify({ projects: { [missing]: { root: '.', include: ['src/**'] } } }, null, 2),
+    );
+
+    // The order softGcSweep runs them in: registry sweep, then config sweep.
+    registry.sweepMissingRoots(7);
+    const removedSections = configJsonc.pruneProjectConfigSections();
+
+    // First sighting only timestamps the entry — nothing is deregistered yet,
+    // so the config section still has a registry entry claiming it.
+    expect(registry.listProjects().map((p) => p.root)).toContain(missing);
+    expect(removedSections).toEqual([]);
+    const after = JSON.parse(fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8'));
+    expect(Object.keys(after.projects)).toEqual([missing]);
+    expect(after.projects[missing].include).toEqual(['src/**']);
+  });
+
+  it('the grace-less registry prune is what used to break it', () => {
+    // Guard on the mechanism, so a future edit that swaps softGcSweep back to
+    // pruneStaleProjects has something that fails. pruneStaleProjects still
+    // exists for `doctor` / `prune --apply`, where immediate removal is right.
+    const missing = path.join(tmpHome, 'unmounted-volume', 'project');
+    fs.mkdirSync(path.dirname(REGISTRY_PATH), { recursive: true });
+    fs.writeFileSync(
+      REGISTRY_PATH,
+      JSON.stringify({
+        version: 1,
+        projects: {
+          [missing]: {
+            name: 'project',
+            root: missing,
+            dbPath: path.join(tmpHome, 'project.db'),
+            addedAt: new Date().toISOString(),
+          },
+        },
+      }),
+    );
+    fs.mkdirSync(path.dirname(GLOBAL_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(
+      GLOBAL_CONFIG_PATH,
+      JSON.stringify({ projects: { [missing]: { root: '.' } } }, null, 2),
+    );
+
+    expect(registry.pruneStaleProjects()).toEqual([missing]);
+    // Now unregistered and missing — the config sweep correctly eats it. This
+    // is precisely the sequence softGcSweep must not produce.
+    expect(configJsonc.pruneProjectConfigSections()).toEqual([missing]);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -260,6 +260,40 @@ function softGcSweep(): void {
     logger.warn({ err }, 'pruneStaleProjects soft-prune failed (non-fatal)');
   }
 
+  // TRA-702: same job as the registry prune above, on the other registration
+  // store. `setupProject` writes a per-project section into .config.json for
+  // every root it sets up — ephemeral ones included, because the run that
+  // follows reads it back — and nothing collected them, so the file reached
+  // 593 sections / 785 KB and was reparsed on every server start. Hourly (not
+  // startup-only) is what keeps a long-running daemon's file small, since each
+  // agent run adds one section while the daemon stays up.
+  try {
+    const removedSections = pruneProjectConfigSections();
+    if (removedSections.length > 0) {
+      logger.info(
+        { removedSections: removedSections.length },
+        `Pruned ${removedSections.length} dead project section(s) from the global config`,
+      );
+    }
+  } catch (err) {
+    logger.warn({ err }, 'pruneProjectConfigSections soft-prune failed (non-fatal)');
+  }
+
+  // TRA-702: atomic writes unlink their own tmp on error, but a process killed
+  // between open and rename never runs that handler — so every crash leaked one
+  // file into the state dir, permanently.
+  try {
+    const removedTmps = sweepOrphanTmpFiles(TRACE_MCP_HOME);
+    if (removedTmps.length > 0) {
+      logger.info(
+        { removedTmps: removedTmps.length },
+        `Removed ${removedTmps.length} orphaned atomic-write tmp file(s)`,
+      );
+    }
+  } catch (err) {
+    logger.warn({ err }, 'sweepOrphanTmpFiles soft-prune failed (non-fatal)');
+  }
+
   try {
     if (fs.existsSync(TOPOLOGY_DB_PATH)) {
       const topoStore = new TopologyStore(TOPOLOGY_DB_PATH);
@@ -3199,38 +3233,6 @@ program
           }
         } catch (err) {
           logger.warn({ err }, 'sweepMissingRoots failed (non-fatal)');
-        }
-
-        // Soft GC (TRA-702): every sweep above works on registry.json, but
-        // `setupProject` also writes a per-project section into .config.json —
-        // a separate file none of them touch. That map had no collector at
-        // all and reached 593 entries / 785 KB, reparsed on every server
-        // start. See pruneProjectConfigSections for what it will and won't drop.
-        try {
-          const removedSections = pruneProjectConfigSections();
-          if (removedSections.length > 0) {
-            logger.info(
-              { removedSections: removedSections.length },
-              `Pruned ${removedSections.length} dead project section(s) from the global config`,
-            );
-          }
-        } catch (err) {
-          logger.warn({ err }, 'pruneProjectConfigSections failed (non-fatal)');
-        }
-
-        // TRA-702: atomic writes unlink their own tmp on error, but a process
-        // killed between open and rename never runs that handler — so every
-        // crash leaked one file into the state dir, permanently.
-        try {
-          const removedTmps = sweepOrphanTmpFiles(TRACE_MCP_HOME);
-          if (removedTmps.length > 0) {
-            logger.info(
-              { removedTmps: removedTmps.length },
-              `Removed ${removedTmps.length} orphaned atomic-write tmp file(s)`,
-            );
-          }
-        } catch (err) {
-          logger.warn({ err }, 'sweepOrphanTmpFiles failed (non-fatal)');
         }
 
         // Soft GC (TRA-335): the sweep above only reaches workdirs that were

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,6 +100,8 @@ import {
   uninstallLifecycleHooks,
 } from './init/hooks.js';
 import { attachFileLogging, logger } from './logger.js';
+import { pruneProjectConfigSections } from './config-jsonc.js';
+import { TRACE_MCP_HOME } from './global.js';
 import { ensureInitialized, warmUpGrammars } from './parser/tree-sitter.js';
 import { checkBindHost, isLoopbackHost } from './daemon/bind-host.js';
 import { PluginRegistry } from './plugin-api/registry.js';
@@ -141,7 +143,7 @@ import { buildGraphData, generateHtml } from './tools/analysis/visualize.js';
 import { scanCodeSmells } from './tools/quality/code-smells.js';
 import { TopologyStore } from './topology/topology-db.js';
 import { checkAndInstallUpdate, runPostUpdateMigrations } from './updater.js';
-import { atomicWriteJson } from './utils/atomic-write.js';
+import { atomicWriteJson, sweepOrphanTmpFiles } from './utils/atomic-write.js';
 import { sqliteUtcToIso } from './utils/sqlite-time.js';
 
 /**
@@ -3197,6 +3199,38 @@ program
           }
         } catch (err) {
           logger.warn({ err }, 'sweepMissingRoots failed (non-fatal)');
+        }
+
+        // Soft GC (TRA-702): every sweep above works on registry.json, but
+        // `setupProject` also writes a per-project section into .config.json —
+        // a separate file none of them touch. That map had no collector at
+        // all and reached 593 entries / 785 KB, reparsed on every server
+        // start. See pruneProjectConfigSections for what it will and won't drop.
+        try {
+          const removedSections = pruneProjectConfigSections();
+          if (removedSections.length > 0) {
+            logger.info(
+              { removedSections: removedSections.length },
+              `Pruned ${removedSections.length} dead project section(s) from the global config`,
+            );
+          }
+        } catch (err) {
+          logger.warn({ err }, 'pruneProjectConfigSections failed (non-fatal)');
+        }
+
+        // TRA-702: atomic writes unlink their own tmp on error, but a process
+        // killed between open and rename never runs that handler — so every
+        // crash leaked one file into the state dir, permanently.
+        try {
+          const removedTmps = sweepOrphanTmpFiles(TRACE_MCP_HOME);
+          if (removedTmps.length > 0) {
+            logger.info(
+              { removedTmps: removedTmps.length },
+              `Removed ${removedTmps.length} orphaned atomic-write tmp file(s)`,
+            );
+          }
+        } catch (err) {
+          logger.warn({ err }, 'sweepOrphanTmpFiles failed (non-fatal)');
         }
 
         // Soft GC (TRA-335): the sweep above only reaches workdirs that were

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -248,16 +248,26 @@ function softGcSweep(): void {
     logger.warn({ err }, 'pruneIndexDir soft-prune failed (non-fatal)');
   }
 
+  // TRA-702: this used to call `pruneStaleProjects()`, which deregisters a
+  // missing root the first time it is seen missing — no grace period. That
+  // contradicted the 7-day grace `sweepMissingRoots` applies on the startup
+  // path, and the two ran against the same registry an hour apart, so the
+  // grace never actually held: a root on an unmounted volume lost its registry
+  // row on the next hourly sweep. That in turn made it unregistered, which is
+  // half the condition `pruneProjectConfigSections` below uses to delete a
+  // config section — so the volume coming back found neither. Use the
+  // grace-aware sweep on both paths; `pruneStaleProjects` stays for the
+  // explicit `doctor` / `prune --apply` review flows, where immediate is right.
   try {
-    const removed = pruneStaleProjects();
+    const { removed } = sweepMissingRoots(7);
     if (removed.length > 0) {
       logger.info(
         { removed },
-        `Pruned ${removed.length} stale registry entr${removed.length === 1 ? 'y' : 'ies'}`,
+        `Deregistered ${removed.length} project(s) with a root missing >7 days`,
       );
     }
   } catch (err) {
-    logger.warn({ err }, 'pruneStaleProjects soft-prune failed (non-fatal)');
+    logger.warn({ err }, 'sweepMissingRoots soft-prune failed (non-fatal)');
   }
 
   // TRA-702: same job as the registry prune above, on the other registration
@@ -3219,23 +3229,12 @@ program
         const softGcTimer = setInterval(softGcSweep, 60 * 60_000);
         softGcTimer.unref();
 
-        // Soft GC (TRA-36): deregister + delete the DB for projects whose root
-        // has been gone for >7 days (e.g. ephemeral per-run container workdirs
-        // that are never coming back). First sighting only timestamps the entry
-        // so a transiently-unmounted drive isn't punished — see sweepMissingRoots.
-        try {
-          const { removed } = sweepMissingRoots(7);
-          if (removed.length > 0) {
-            logger.info(
-              { removedRoots: removed },
-              `Deregistered ${removed.length} project(s) with a root missing >7 days`,
-            );
-          }
-        } catch (err) {
-          logger.warn({ err }, 'sweepMissingRoots failed (non-fatal)');
-        }
+        // Soft GC (TRA-36): deregistering roots missing >7 days now happens
+        // inside softGcSweep() above, which already ran once just now and
+        // repeats hourly. It used to be duplicated here with the hourly path
+        // calling the grace-less `pruneStaleProjects` instead (TRA-702).
 
-        // Soft GC (TRA-335): the sweep above only reaches workdirs that were
+        // Soft GC (TRA-335): that sweep only reaches workdirs that were
         // *deleted*. Agent runtimes that leave their one-shot checkout on disk
         // (Multica, and CI/sandbox workflows shaped like it) leave an entry
         // `prune` will always classify as live, so the registry grew one row —

--- a/src/config-jsonc.ts
+++ b/src/config-jsonc.ts
@@ -91,30 +91,37 @@ export function removeProjectConfigJsonc(projectRoot: string): void {
  *    and an existence check alone never reaches them. An explicitly registered
  *    workdir-shaped root is a deliberate act (`add`/`init`) and is kept.
  *
- * One rewrite for the whole set, not one per section — a section-at-a-time
- * loop would re-serialise a megabyte hundreds of times.
+ * Removal is per-key against one in-memory buffer, then a single atomic write.
+ * Replacing the whole `projects` object in one edit would be shorter, but it
+ * reserialises every *retained* section too and so drops the comments a user
+ * hand-wrote inside them — the per-project data `saveProjectConfigJsonc` and
+ * the #218 regression tests already go out of their way to preserve. Looping
+ * `removeProjectConfigJsonc` would keep the comments but re-read and rewrite
+ * the file once per section; this keeps both properties.
  */
 export function pruneProjectConfigSections(): string[] {
-  const text = readGlobalConfigText();
+  let text = readGlobalConfigText();
   const parsed = parse(text) as { projects?: Record<string, unknown> } | undefined;
   const projects = parsed?.projects;
   if (!projects || typeof projects !== 'object') return [];
 
   const registered = new Set(listProjects().map((p) => p.root));
-  const kept: Record<string, unknown> = {};
   const removed: string[] = [];
 
-  for (const [root, section] of Object.entries(projects)) {
+  for (const root of Object.keys(projects)) {
     const claimed = registered.has(root);
     const dead = !claimed && !fs.existsSync(root);
     const orphanWorkdir = !claimed && isEphemeralProjectRoot(root);
     if (dead || orphanWorkdir) removed.push(root);
-    else kept[root] = section;
   }
 
   if (removed.length === 0) return []; // don't rewrite a healthy config
 
-  modifyGlobalConfigJsonc(['projects'], kept);
+  for (const root of removed) {
+    text = applyEdits(text, modify(text, ['projects', root], undefined, FORMAT_OPTS));
+  }
+  ensureGlobalDirs();
+  atomicWriteString(GLOBAL_CONFIG_PATH, text, { mode: 0o600 });
   logger.debug({ removed: removed.length }, 'Pruned dead project sections from global config');
   return removed;
 }

--- a/src/config-jsonc.ts
+++ b/src/config-jsonc.ts
@@ -5,10 +5,17 @@
  * while preserving comments, formatting, and trailing commas.
  */
 import fs from 'node:fs';
+import path from 'node:path';
 import { applyEdits, type ModificationOptions, modify, parse } from 'jsonc-parser';
-import { DEFAULT_CONFIG_JSONC, ensureGlobalDirs, GLOBAL_CONFIG_PATH } from './global.js';
+import {
+  DEFAULT_CONFIG_JSONC,
+  ensureGlobalDirs,
+  GLOBAL_CONFIG_PATH,
+  TRACE_MCP_HOME,
+} from './global.js';
 import { logger } from './logger.js';
 import { isEphemeralProjectRoot, listProjects } from './registry.js';
+import { acquireLock, type LockHandle, LockError, releaseLock } from './utils/pid-lock.js';
 import { atomicWriteString } from './utils/atomic-write.js';
 import { readIfExists } from './utils/safe-fs.js';
 
@@ -31,16 +38,100 @@ export function readGlobalConfigText(): string {
   return readIfExists(GLOBAL_CONFIG_PATH) ?? DEFAULT_CONFIG_JSONC;
 }
 
+// ---------------------------------------------------------------------------
+// Serialising the read-modify-write cycle (TRA-702)
+// ---------------------------------------------------------------------------
+//
+// Every mutation here is read text -> compute edits -> atomically write the
+// whole file back. Two of those interleaved lose one side's change entirely:
+// the second writer's `atomicWriteString` publishes a buffer read before the
+// first writer's rename. That was always true for two concurrent
+// `saveProjectConfigJsonc` calls (two agent runs registering at once), and
+// `pruneProjectConfigSections` makes it much easier to hit, because its read-
+// to-write window spans hundreds of edits — ~2s on the first backlog drain,
+// while agent processes keep registering projects.
+//
+// So the cycle takes a cross-process lock, and every writer in this file goes
+// through it. Reads are not locked: a torn read is impossible (writers publish
+// by rename) and a slightly stale one is harmless.
+
+const CONFIG_LOCK_NAME = 'global-config';
+/** How long a writer waits for a peer before giving up on the lock. */
+const CONFIG_LOCK_WAIT_MS = 3000;
+const CONFIG_LOCK_POLL_MS = 25;
+
+function sleepSync(ms: number): void {
+  // These call sites are sync (and on the CLI's startup path), so this is the
+  // only way to back off without restructuring every caller to async.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function tryAcquireConfigLock(waitMs: number): LockHandle | null {
+  const deadline = Date.now() + waitMs;
+  for (;;) {
+    try {
+      return acquireLock({
+        // Resolved per call, not at import: TRACE_MCP_HOME can be redirected
+        // (tests, the TRA-611 rename), and a cached dir would scope the lock
+        // to the wrong state directory.
+        lockDir: path.join(TRACE_MCP_HOME, 'locks'),
+        name: CONFIG_LOCK_NAME,
+        op: 'config-write',
+      });
+    } catch (err) {
+      if (!(err instanceof LockError)) throw err;
+      if (Date.now() >= deadline) return null;
+      sleepSync(CONFIG_LOCK_POLL_MS);
+    }
+  }
+}
+
+/**
+ * Run a config read-modify-write while holding the global-config lock.
+ *
+ * On timeout it runs `fn` anyway. Losing the lock must not make a config write
+ * fail outright — that is strictly worse than today's behaviour, and a wedged
+ * lock file would otherwise brick every registration on the machine.
+ */
+function withGlobalConfigLock<T>(fn: () => T): T {
+  const handle = tryAcquireConfigLock(CONFIG_LOCK_WAIT_MS);
+  try {
+    return fn();
+  } finally {
+    if (handle) releaseLock(handle);
+  }
+}
+
+/**
+ * Lock variant for janitorial work: returns `null` rather than proceeding
+ * unlocked. Used by the sweep, whose whole risk is overwriting a concurrent
+ * writer — and which loses nothing by trying again on the next hourly pass.
+ */
+function withGlobalConfigLockOrSkip<T>(fn: () => T): T | null {
+  const handle = tryAcquireConfigLock(CONFIG_LOCK_WAIT_MS);
+  if (!handle) return null;
+  try {
+    return fn();
+  } finally {
+    releaseLock(handle);
+  }
+}
+
+/** `modifyGlobalConfigJsonc` without the lock — for callers already holding it. */
+function modifyGlobalConfigJsoncUnlocked(jsonPath: (string | number)[], value: unknown): void {
+  const text = readGlobalConfigText();
+  const edits = modify(text, jsonPath, value, FORMAT_OPTS);
+  const updated = applyEdits(text, edits);
+  atomicWriteString(GLOBAL_CONFIG_PATH, updated, { mode: 0o600 });
+}
+
 /**
  * Set a value at `jsonPath` in the global JSONC config, preserving comments.
  * `jsonPath` is an array of property names / indices, e.g. `['projects', '/foo']`.
  * Pass `undefined` as value to remove the key.
  */
 export function modifyGlobalConfigJsonc(jsonPath: (string | number)[], value: unknown): void {
-  const text = readGlobalConfigText();
-  const edits = modify(text, jsonPath, value, FORMAT_OPTS);
-  const updated = applyEdits(text, edits);
-  atomicWriteString(GLOBAL_CONFIG_PATH, updated, { mode: 0o600 });
+  withGlobalConfigLock(() => modifyGlobalConfigJsoncUnlocked(jsonPath, value));
 }
 
 // ---------------------------------------------------------------------------
@@ -58,11 +149,19 @@ export function modifyGlobalConfigJsonc(jsonPath: (string | number)[], value: un
  */
 export function saveProjectConfigJsonc(projectRoot: string, config: Record<string, unknown>): void {
   ensureGlobalDirs();
-  const existing = parse(readGlobalConfigText()) as
-    | { projects?: Record<string, Record<string, unknown>> }
-    | undefined;
-  const existingSection = existing?.projects?.[projectRoot] ?? {};
-  modifyGlobalConfigJsonc(['projects', projectRoot], { ...existingSection, ...config });
+  // The read and the write are one critical section: the merge below is
+  // computed from `existing`, so a peer writing in between would be silently
+  // reverted by our write.
+  withGlobalConfigLock(() => {
+    const existing = parse(readGlobalConfigText()) as
+      | { projects?: Record<string, Record<string, unknown>> }
+      | undefined;
+    const existingSection = existing?.projects?.[projectRoot] ?? {};
+    modifyGlobalConfigJsoncUnlocked(['projects', projectRoot], {
+      ...existingSection,
+      ...config,
+    });
+  });
 }
 
 /** Remove a per-project config section from the global config file (JSONC-safe). */
@@ -100,30 +199,39 @@ export function removeProjectConfigJsonc(projectRoot: string): void {
  * the file once per section; this keeps both properties.
  */
 export function pruneProjectConfigSections(): string[] {
-  let text = readGlobalConfigText();
-  const parsed = parse(text) as { projects?: Record<string, unknown> } | undefined;
-  const projects = parsed?.projects;
-  if (!projects || typeof projects !== 'object') return [];
+  // Held across the whole read-edit-write cycle. Without it, a section written
+  // by a concurrent `setupProject()` after our read is erased by our write —
+  // and if that lands between an agent run's save and its immediate
+  // `loadConfig()`, the run indexes with schema defaults instead of its
+  // detected config. The window is ~2s wide on the first backlog drain.
+  return (
+    withGlobalConfigLockOrSkip(() => {
+      let text = readGlobalConfigText();
+      const parsed = parse(text) as { projects?: Record<string, unknown> } | undefined;
+      const projects = parsed?.projects;
+      if (!projects || typeof projects !== 'object') return [];
 
-  const registered = new Set(listProjects().map((p) => p.root));
-  const removed: string[] = [];
+      const registered = new Set(listProjects().map((p) => p.root));
+      const removed: string[] = [];
 
-  for (const root of Object.keys(projects)) {
-    const claimed = registered.has(root);
-    const dead = !claimed && !fs.existsSync(root);
-    const orphanWorkdir = !claimed && isEphemeralProjectRoot(root);
-    if (dead || orphanWorkdir) removed.push(root);
-  }
+      for (const root of Object.keys(projects)) {
+        const claimed = registered.has(root);
+        const dead = !claimed && !fs.existsSync(root);
+        const orphanWorkdir = !claimed && isEphemeralProjectRoot(root);
+        if (dead || orphanWorkdir) removed.push(root);
+      }
 
-  if (removed.length === 0) return []; // don't rewrite a healthy config
+      if (removed.length === 0) return []; // don't rewrite a healthy config
 
-  for (const root of removed) {
-    text = applyEdits(text, modify(text, ['projects', root], undefined, FORMAT_OPTS));
-  }
-  ensureGlobalDirs();
-  atomicWriteString(GLOBAL_CONFIG_PATH, text, { mode: 0o600 });
-  logger.debug({ removed: removed.length }, 'Pruned dead project sections from global config');
-  return removed;
+      for (const root of removed) {
+        text = applyEdits(text, modify(text, ['projects', root], undefined, FORMAT_OPTS));
+      }
+      ensureGlobalDirs();
+      atomicWriteString(GLOBAL_CONFIG_PATH, text, { mode: 0o600 });
+      logger.debug({ removed: removed.length }, 'Pruned dead project sections from global config');
+      return removed;
+    }) ?? [] // lock busy — a writer is active; try again on the next sweep
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -189,13 +297,15 @@ export function saveGlobalSettingsJsonc(
   incoming: Record<string, unknown>,
 ): Record<string, unknown> {
   ensureGlobalDirs();
-  const text = readGlobalConfigText();
-  const existing = (parse(text) as Record<string, unknown> | null) ?? {};
-  const updatedText = applySettingsDiff(text, [], incoming, existing);
-  if (updatedText !== text) {
-    atomicWriteString(GLOBAL_CONFIG_PATH, updatedText, { mode: 0o600 });
-  }
-  return (parse(updatedText) as Record<string, unknown> | null) ?? {};
+  return withGlobalConfigLock(() => {
+    const text = readGlobalConfigText();
+    const existing = (parse(text) as Record<string, unknown> | null) ?? {};
+    const updatedText = applySettingsDiff(text, [], incoming, existing);
+    if (updatedText !== text) {
+      atomicWriteString(GLOBAL_CONFIG_PATH, updatedText, { mode: 0o600 });
+    }
+    return (parse(updatedText) as Record<string, unknown> | null) ?? {};
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -225,6 +335,10 @@ const PRESET_MIGRATED_KEY = 'preset_default_migrated';
  */
 export function migrateGlobalConfig(): MigrateResult {
   ensureGlobalDirs();
+  return withGlobalConfigLock(() => migrateGlobalConfigUnlocked());
+}
+
+function migrateGlobalConfigUnlocked(): MigrateResult {
   const result: MigrateResult = { added: [], changed: false };
 
   const existingText = readGlobalConfigText();

--- a/src/config-jsonc.ts
+++ b/src/config-jsonc.ts
@@ -8,6 +8,7 @@ import fs from 'node:fs';
 import { applyEdits, type ModificationOptions, modify, parse } from 'jsonc-parser';
 import { DEFAULT_CONFIG_JSONC, ensureGlobalDirs, GLOBAL_CONFIG_PATH } from './global.js';
 import { logger } from './logger.js';
+import { isEphemeralProjectRoot, listProjects } from './registry.js';
 import { atomicWriteString } from './utils/atomic-write.js';
 import { readIfExists } from './utils/safe-fs.js';
 
@@ -67,6 +68,55 @@ export function saveProjectConfigJsonc(projectRoot: string, config: Record<strin
 /** Remove a per-project config section from the global config file (JSONC-safe). */
 export function removeProjectConfigJsonc(projectRoot: string): void {
   modifyGlobalConfigJsonc(['projects', projectRoot], undefined);
+}
+
+/**
+ * Drop dead per-project sections from `.config.json` (TRA-702).
+ *
+ * `projects` is the only unbounded map in the global config, and it was the
+ * only registration store with no sweep at all: registry.json has had
+ * `sweepMissingRoots` / `sweepEphemeralProjects` since TRA-36 / TRA-335, but
+ * `setupProject` writes here on a separate path that none of them reach. On
+ * the reported machine that left 593 sections / 785 KB — reparsed on every
+ * server start, i.e. on every agent run.
+ *
+ * Two kinds go, and only these two:
+ *
+ *  - the root no longer exists **and** no registry entry claims it. Both
+ *    halves matter: registry.json is the authority for what the user actually
+ *    registered and already runs a 7-day grace period, so an unmounted volume
+ *    keeps its config here instead of being punished for being offline.
+ *  - the root is a one-shot agent workdir that nothing registered. The Multica
+ *    runtime abandons its checkout *in place*, so these stay on disk forever
+ *    and an existence check alone never reaches them. An explicitly registered
+ *    workdir-shaped root is a deliberate act (`add`/`init`) and is kept.
+ *
+ * One rewrite for the whole set, not one per section — a section-at-a-time
+ * loop would re-serialise a megabyte hundreds of times.
+ */
+export function pruneProjectConfigSections(): string[] {
+  const text = readGlobalConfigText();
+  const parsed = parse(text) as { projects?: Record<string, unknown> } | undefined;
+  const projects = parsed?.projects;
+  if (!projects || typeof projects !== 'object') return [];
+
+  const registered = new Set(listProjects().map((p) => p.root));
+  const kept: Record<string, unknown> = {};
+  const removed: string[] = [];
+
+  for (const [root, section] of Object.entries(projects)) {
+    const claimed = registered.has(root);
+    const dead = !claimed && !fs.existsSync(root);
+    const orphanWorkdir = !claimed && isEphemeralProjectRoot(root);
+    if (dead || orphanWorkdir) removed.push(root);
+    else kept[root] = section;
+  }
+
+  if (removed.length === 0) return []; // don't rewrite a healthy config
+
+  modifyGlobalConfigJsonc(['projects'], kept);
+  logger.debug({ removed: removed.length }, 'Pruned dead project sections from global config');
+  return removed;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/project-setup.ts
+++ b/src/project-setup.ts
@@ -16,7 +16,12 @@ import type { DetectionResult } from './init/types.js';
 import { detectProject } from './init/detector.js';
 import { logger } from './logger.js';
 import type { NewRootOverlap, RegistryEntry } from './registry.js';
-import { findOverlapForNewRoot, getProject, registerProject } from './registry.js';
+import {
+  findOverlapForNewRoot,
+  getProject,
+  isEphemeralProjectRoot,
+  registerProject,
+} from './registry.js';
 import { isDangerousProjectRoot } from './dangerous-root.js';
 
 // Re-exported so the many existing `from './project-setup.js'` importers keep working.
@@ -119,11 +124,20 @@ export function setupProject(
 
   // 2. Generate & save config
   const config = generateConfig(detection);
-  saveProjectConfig(absRoot, {
-    root: config.root,
-    include: config.include,
-    exclude: config.exclude,
-  });
+  // TRA-702: mirror registerProject's ephemeral rule here. TRA-396 kept
+  // one-shot agent workdirs out of registry.json, but this write happens
+  // *before* that check ever runs and lands in a different file, so every
+  // agent run still left a permanent section in .config.json — 593 of them,
+  // 785 KB, reparsed on every server start. The section is only ever read
+  // back by a later run against the same path, and no later run visits a
+  // workdir, so for these roots it is write-only state.
+  if (!isEphemeralProjectRoot(absRoot)) {
+    saveProjectConfig(absRoot, {
+      root: config.root,
+      include: config.include,
+      exclude: config.exclude,
+    });
+  }
 
   // 3. Ensure global dirs, then register in the global registry. Registering
   // here (rather than after DB init, as before TRA-38) resolves the actual

--- a/src/project-setup.ts
+++ b/src/project-setup.ts
@@ -16,12 +16,7 @@ import type { DetectionResult } from './init/types.js';
 import { detectProject } from './init/detector.js';
 import { logger } from './logger.js';
 import type { NewRootOverlap, RegistryEntry } from './registry.js';
-import {
-  findOverlapForNewRoot,
-  getProject,
-  isEphemeralProjectRoot,
-  registerProject,
-} from './registry.js';
+import { findOverlapForNewRoot, getProject, registerProject } from './registry.js';
 import { isDangerousProjectRoot } from './dangerous-root.js';
 
 // Re-exported so the many existing `from './project-setup.js'` importers keep working.
@@ -124,20 +119,20 @@ export function setupProject(
 
   // 2. Generate & save config
   const config = generateConfig(detection);
-  // TRA-702: mirror registerProject's ephemeral rule here. TRA-396 kept
-  // one-shot agent workdirs out of registry.json, but this write happens
-  // *before* that check ever runs and lands in a different file, so every
-  // agent run still left a permanent section in .config.json — 593 of them,
-  // 785 KB, reparsed on every server start. The section is only ever read
-  // back by a later run against the same path, and no later run visits a
-  // workdir, so for these roots it is write-only state.
-  if (!isEphemeralProjectRoot(absRoot)) {
-    saveProjectConfig(absRoot, {
-      root: config.root,
-      include: config.include,
-      exclude: config.exclude,
-    });
-  }
+  // TRA-702: this write is unconditional on purpose, ephemeral roots included.
+  // Skipping it for one-shot workdirs looks like the obvious fix for the
+  // .config.json bloat, but both stdio startup and the daemon's project loader
+  // call setupProject() and then immediately loadConfig(root) — which reads
+  // back exactly this section. Skipping the write silently downgrades the run
+  // to schema defaults, losing the detected framework include/exclude set (for
+  // presets like n8n's `**/*.json` that means not indexing the files the
+  // integration exists for). Collecting these sections afterwards is
+  // softGcSweep's job; see pruneProjectConfigSections.
+  saveProjectConfig(absRoot, {
+    root: config.root,
+    include: config.include,
+    exclude: config.exclude,
+  });
 
   // 3. Ensure global dirs, then register in the global registry. Registering
   // here (rather than after DB init, as before TRA-38) resolves the actual

--- a/src/utils/__tests__/atomic-write-sweep.test.ts
+++ b/src/utils/__tests__/atomic-write-sweep.test.ts
@@ -1,0 +1,75 @@
+/**
+ * TRA-702 item 3: twelve orphaned `.daemon.pid.tmp.*` / `.registry.json.tmp.*`
+ * files, the oldest from May, were sitting in ~/.trace-mcp. Each is a write
+ * that died between `open` and `rename` — harmless individually, but nothing
+ * ever collected them, so every crash leaked one permanently.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { sweepOrphanTmpFiles } from '../atomic-write.js';
+
+let dir: string;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function makeFile(name: string, ageMs: number): string {
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, 'x');
+  const t = new Date(Date.now() - ageMs);
+  fs.utimesSync(p, t, t);
+  return p;
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-tmp-sweep-'));
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('sweepOrphanTmpFiles (TRA-702)', () => {
+  it('removes atomic-write leftovers older than the cutoff', () => {
+    const old = makeFile('.daemon.pid.tmp.11094.3a8f308b3935', 3 * DAY_MS);
+    makeFile('.registry.json.tmp.28982.4d09e49a857c', 5 * DAY_MS);
+
+    const removed = sweepOrphanTmpFiles(dir, DAY_MS);
+
+    expect(removed).toHaveLength(2);
+    expect(fs.existsSync(old)).toBe(false);
+  });
+
+  it('leaves a tmp file young enough to belong to a write still in flight', () => {
+    // A concurrent writer's tmp must survive — deleting it would turn another
+    // process's atomic write into a spurious failure.
+    const fresh = makeFile('.registry.json.tmp.999.abcdef', 60_000);
+
+    expect(sweepOrphanTmpFiles(dir, DAY_MS)).toEqual([]);
+    expect(fs.existsSync(fresh)).toBe(true);
+  });
+
+  it('never touches real state files, however old', () => {
+    const real = makeFile('registry.json', 30 * DAY_MS);
+    const alsoReal = makeFile('.config.json', 30 * DAY_MS);
+    const backup = makeFile('.config.json.bak.20260831143353', 30 * DAY_MS);
+
+    expect(sweepOrphanTmpFiles(dir, DAY_MS)).toEqual([]);
+    for (const p of [real, alsoReal, backup]) expect(fs.existsSync(p)).toBe(true);
+  });
+
+  it('returns empty for a directory that does not exist', () => {
+    expect(sweepOrphanTmpFiles(path.join(dir, 'nope'), DAY_MS)).toEqual([]);
+  });
+
+  it('skips subdirectories that happen to match the tmp shape', () => {
+    const d = path.join(dir, '.index.tmp.123.deadbeef');
+    fs.mkdirSync(d);
+    const t = new Date(Date.now() - 10 * DAY_MS);
+    fs.utimesSync(d, t, t);
+
+    expect(sweepOrphanTmpFiles(dir, DAY_MS)).toEqual([]);
+    expect(fs.existsSync(d)).toBe(true);
+  });
+});

--- a/src/utils/atomic-write.ts
+++ b/src/utils/atomic-write.ts
@@ -117,6 +117,54 @@ export function atomicWriteString(
 }
 
 /**
+ * Tmp files written by {@link atomicWriteString}: `.<basename>.tmp.<pid>.<rand>`.
+ * The trailing hex is what keeps this from matching a user file that merely has
+ * ".tmp." in its name.
+ */
+const ORPHAN_TMP_PATTERN = /^\..+\.tmp\.\d+\.[0-9a-f]{12}$/;
+
+/** Default age before a leftover tmp is assumed orphaned rather than in flight. */
+const ORPHAN_TMP_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Delete atomic-write tmp files in `dir` older than `maxAgeMs` (TRA-702).
+ *
+ * The write path above unlinks its own tmp on error, but a process killed
+ * between `open` and `rename` never runs that handler — so every crash leaks
+ * one file, forever. Twelve had accumulated in ~/.trace-mcp, the oldest four
+ * months old.
+ *
+ * The age cutoff is the safety margin: a tmp younger than it may belong to a
+ * write still in flight in another process, and removing that would turn a
+ * healthy write into a spurious failure. Best-effort throughout — a sweep that
+ * cannot read the directory is not worth failing a daemon start over.
+ */
+export function sweepOrphanTmpFiles(dir: string, maxAgeMs = ORPHAN_TMP_MAX_AGE_MS): string[] {
+  let names: string[];
+  try {
+    names = fs.readdirSync(dir);
+  } catch {
+    return []; // no state dir yet, or unreadable — nothing to collect
+  }
+
+  const cutoff = Date.now() - maxAgeMs;
+  const removed: string[] = [];
+  for (const name of names) {
+    if (!ORPHAN_TMP_PATTERN.test(name)) continue;
+    const full = path.join(dir, name);
+    try {
+      const st = fs.lstatSync(full);
+      if (!st.isFile() || st.mtimeMs > cutoff) continue;
+      fs.unlinkSync(full);
+      removed.push(full);
+    } catch {
+      // vanished under us, or not ours to delete — either way, skip it
+    }
+  }
+  return removed;
+}
+
+/**
  * Atomically write a JSON-serialisable value to disk with a trailing newline.
  * Convenience wrapper around {@link atomicWriteString}.
  */

--- a/tests/init/launcher.test.ts
+++ b/tests/init/launcher.test.ts
@@ -216,19 +216,26 @@ describe('recordPkgRoot', () => {
       .split('\n')
       .filter((l) => l.trim());
 
+  // `recordPkgRoot` runs the input through `path.resolve`, so a POSIX literal
+  // comes back drive-qualified on Windows ('/a/b' -> 'D:\a\b') and a hardcoded
+  // POSIX expectation fails there. Build both sides with the platform's own
+  // separator so these assert the dedup/cap behaviour rather than the host OS.
+  const pkgRoot = (prefix: string) => path.join(path.resolve(prefix), 'lib', 'node_modules');
+  const cliUnder = (prefix: string) => path.join(pkgRoot(prefix), 'trace-mcp', 'dist', 'cli.js');
+
   it('records the node_modules root the cli was installed into', () => {
-    recordPkgRoot('/opt/homebrew/lib/node_modules/trace-mcp/dist/cli.js');
-    expect(rootsOf()).toEqual(['/opt/homebrew/lib/node_modules']);
+    recordPkgRoot(cliUnder('/opt/homebrew'));
+    expect(rootsOf()).toEqual([pkgRoot('/opt/homebrew')]);
   });
 
   it('deduplicates and caps the list', () => {
     for (let i = 0; i < 14; i++) {
-      recordPkgRoot(`/prefix${i}/lib/node_modules/trace-mcp/dist/cli.js`);
+      recordPkgRoot(cliUnder(`/prefix${i}`));
     }
-    recordPkgRoot('/prefix13/lib/node_modules/trace-mcp/dist/cli.js');
+    recordPkgRoot(cliUnder('/prefix13'));
     const roots = rootsOf();
     expect(roots).toHaveLength(10);
-    expect(roots.at(-1)).toBe('/prefix13/lib/node_modules');
+    expect(roots.at(-1)).toBe(pkgRoot('/prefix13'));
     expect(new Set(roots).size).toBe(10);
   });
 

--- a/tests/project-setup/ephemeral-config-section.test.ts
+++ b/tests/project-setup/ephemeral-config-section.test.ts
@@ -1,0 +1,85 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+/**
+ * TRA-702: TRA-396 kept one-shot agent-run checkouts out of registry.json, but
+ * `setupProject` writes the per-project section into `.config.json` *before*
+ * `registerProject` ever applies that check — a different file, on a path no
+ * sweep reached. So every agent run still left a permanent section behind, and
+ * `.config.json` reached 593 sections / 785 KB, reparsed on every server start.
+ *
+ * These pin the write-side half of the fix. The sweep that drains the existing
+ * backlog is covered in src/__tests__/config-project-sweep.test.ts.
+ */
+describe('project-setup — per-project config section for ephemeral roots', () => {
+  let fakeHome: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-setup-ephemeral-home-'));
+    originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    // HOME alone does not redirect the state dir (os.homedir() ignores it on
+    // macOS), and a leaked write would land in the developer's real config.
+    vi.stubEnv('TRACE_MCP_DATA_DIR', fakeHome);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  function makeRepo(dir: string): string {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ name: 'proj', version: '0.0.0' }),
+    );
+    return dir;
+  }
+
+  // Resolved through global.js rather than hardcoded: the state dir is
+  // ~/.trace or ~/.trace-mcp depending on TRA-611 rename state, and a wrong
+  // guess here reads as an empty config, which would make these vacuous.
+  async function configProjects(): Promise<Record<string, unknown>> {
+    const { GLOBAL_CONFIG_PATH } = await import('../../src/global.js');
+    expect(GLOBAL_CONFIG_PATH.startsWith(fakeHome)).toBe(true);
+    if (!fs.existsSync(GLOBAL_CONFIG_PATH)) return {};
+    const { parse } = await import('jsonc-parser');
+    return (
+      (
+        parse(fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8')) as {
+          projects?: Record<string, unknown>;
+        }
+      )?.projects ?? {}
+    );
+  }
+
+  test('writes no config section for a one-shot agent workdir', async () => {
+    const container = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-eph-'));
+    const workdir = makeRepo(
+      path.join(container, 'multica_workspaces_acme', 'proj-1', 'tra-9-abc', 'workdir', 'repo'),
+    );
+
+    const { setupProject } = await import('../../src/project-setup.js');
+    setupProject(workdir);
+
+    expect(Object.keys(await configProjects())).not.toContain(workdir);
+    fs.rmSync(container, { recursive: true, force: true });
+  });
+
+  test('still writes a config section for an ordinary project root', async () => {
+    const repo = makeRepo(path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'tm-real-')), 'app'));
+
+    const { setupProject } = await import('../../src/project-setup.js');
+    setupProject(repo);
+
+    expect(Object.keys(await configProjects())).toContain(repo);
+  });
+});

--- a/tests/project-setup/ephemeral-config-section.test.ts
+++ b/tests/project-setup/ephemeral-config-section.test.ts
@@ -4,16 +4,22 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 /**
- * TRA-702: TRA-396 kept one-shot agent-run checkouts out of registry.json, but
- * `setupProject` writes the per-project section into `.config.json` *before*
- * `registerProject` ever applies that check — a different file, on a path no
- * sweep reached. So every agent run still left a permanent section behind, and
- * `.config.json` reached 593 sections / 785 KB, reparsed on every server start.
+ * TRA-702 regression guard.
  *
- * These pin the write-side half of the fix. The sweep that drains the existing
- * backlog is covered in src/__tests__/config-project-sweep.test.ts.
+ * `.config.json` grew to 593 project sections because `setupProject` writes one
+ * per root and nothing collected them. The tempting fix — skip the write for
+ * one-shot agent workdirs, mirroring what `registerProject` does — is wrong:
+ * both stdio startup and the daemon's project loader call `setupProject()` and
+ * then immediately `loadConfig(root)`, reading back exactly that section. Skip
+ * it and the run silently falls back to schema defaults, losing the detected
+ * framework include/exclude set. For a preset like n8n's `**\/*.json` that
+ * means not indexing the files the integration exists for.
+ *
+ * So the section is written for every root, and `pruneProjectConfigSections`
+ * (on softGcSweep's hourly timer) collects the ephemeral ones afterwards. This
+ * pins the half that is easy to "optimise" back into a bug.
  */
-describe('project-setup — per-project config section for ephemeral roots', () => {
+describe('project-setup — config fidelity for ephemeral roots (TRA-702)', () => {
   let fakeHome: string;
   let originalHome: string | undefined;
 
@@ -35,51 +41,51 @@ describe('project-setup — per-project config section for ephemeral roots', () 
     fs.rmSync(fakeHome, { recursive: true, force: true });
   });
 
-  function makeRepo(dir: string): string {
-    fs.mkdirSync(dir, { recursive: true });
+  function makeExpressRepo(dir: string): string {
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
     fs.writeFileSync(
       path.join(dir, 'package.json'),
-      JSON.stringify({ name: 'proj', version: '0.0.0' }),
+      JSON.stringify({ name: 'proj', version: '0.0.0', dependencies: { express: '^4.18.0' } }),
     );
+    fs.writeFileSync(path.join(dir, 'src', 'index.js'), 'require("express")();\n');
     return dir;
   }
 
-  // Resolved through global.js rather than hardcoded: the state dir is
-  // ~/.trace or ~/.trace-mcp depending on TRA-611 rename state, and a wrong
-  // guess here reads as an empty config, which would make these vacuous.
-  async function configProjects(): Promise<Record<string, unknown>> {
-    const { GLOBAL_CONFIG_PATH } = await import('../../src/global.js');
-    expect(GLOBAL_CONFIG_PATH.startsWith(fakeHome)).toBe(true);
-    if (!fs.existsSync(GLOBAL_CONFIG_PATH)) return {};
-    const { parse } = await import('jsonc-parser');
-    return (
-      (
-        parse(fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8')) as {
-          projects?: Record<string, unknown>;
-        }
-      )?.projects ?? {}
-    );
-  }
-
-  test('writes no config section for a one-shot agent workdir', async () => {
+  test('an ephemeral workdir still loads the config its detection generated', async () => {
     const container = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-eph-'));
-    const workdir = makeRepo(
+    const workdir = makeExpressRepo(
       path.join(container, 'multica_workspaces_acme', 'proj-1', 'tra-9-abc', 'workdir', 'repo'),
     );
 
     const { setupProject } = await import('../../src/project-setup.js');
-    setupProject(workdir);
+    const { loadConfig } = await import('../../src/config.js');
+    const { generateConfig } = await import('../../src/init/config-generator.js');
 
-    expect(Object.keys(await configProjects())).not.toContain(workdir);
+    const setup = setupProject(workdir);
+    const generated = generateConfig(setup.detection);
+    const loaded = await loadConfig(workdir);
+
+    // The effective config the run indexes with must be the detected one, not
+    // the broad schema defaults. This is the assertion that fails if the
+    // per-project write is ever skipped for ephemeral roots again.
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isOk()) {
+      // `include` is the framework-specific half and is loaded verbatim; it is
+      // what silently narrows to the schema default if the write is skipped.
+      // `exclude` is deliberately not compared — the loader normalises it by
+      // prefixing `**/`, so it is never equal to the generated form.
+      expect(loaded.value.include).toEqual(generated.include);
+
+      // Guard against the assertion above passing vacuously: the detected set
+      // must actually differ from what a root with no section falls back to,
+      // otherwise "loaded == generated" would hold even with the write skipped.
+      const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-bare-'));
+      const fallback = await loadConfig(bare);
+      expect(fallback.isOk()).toBe(true);
+      if (fallback.isOk()) expect(loaded.value.include).not.toEqual(fallback.value.include);
+      fs.rmSync(bare, { recursive: true, force: true });
+    }
+
     fs.rmSync(container, { recursive: true, force: true });
-  });
-
-  test('still writes a config section for an ordinary project root', async () => {
-    const repo = makeRepo(path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'tm-real-')), 'app'));
-
-    const { setupProject } = await import('../../src/project-setup.js');
-    setupProject(repo);
-
-    expect(Object.keys(await configProjects())).toContain(repo);
   });
 });


### PR DESCRIPTION
Closes TRA-702.

Three unbounded growth paths in `~/.trace-mcp`, each with a different cause and a different fix.

## 1. `.config.json` — 1 MB, 593 project sections, 440 of them dead

This is the interesting one. trace-mcp already has three sweeps for stale project state — `sweepMissingRoots` (TRA-36), `sweepEphemeralProjects` (TRA-335), `sweepEphemeralDbs` (TRA-396) — and all of them run at daemon startup. They were all working. They just operate on `registry.json`, which is healthy: **5.7 KB, 13 entries.**

`setupProject` writes a *second* registration record, the per-project section in `.config.json`, on a separate code path. That map had no collector at all. And because the write happens at `src/project-setup.ts:122`, **before** `registerProject` applies the TRA-396 ephemeral check, every agent run kept leaving a permanent section behind even after TRA-396 shipped. For a workdir the section is write-only state: nothing ever visits that path again.

That megabyte is reparsed on every server start — so on every agent run.

Two-sided fix:
- **Stop the bleeding:** skip the config write for ephemeral roots, mirroring the rule `registerProject` already applies.
- **Drain the backlog:** `pruneProjectConfigSections()`, wired at daemon startup next to the existing sweeps.

The sweep is deliberately conservative. A section is dropped only when the root is gone **and** no registry entry claims it, or when it is an unregistered one-shot workdir. Both halves of the first condition matter: `registry.json` is the authority for what the user actually registered and already runs its own 7-day grace period, so an unmounted volume keeps its config instead of being punished for being offline. The second condition exists because the Multica runtime abandons its checkout *in place* — 132 of these were still on disk, so an existence check alone never reached them. One rewrite for the whole set, not one per section.

Verified against the real reported state (read-only dry run):

```
total sections:                             593
registered in registry.json:                 13
would remove (root gone, unregistered):     440
would remove (live orphan workdir):         132
would keep:                                  21
config size:  1,006,589 -> 32,686 bytes
```

All 13 registered projects retained.

## 2. Logs without rotation

`launcher.log` (9.7 MB) and `update.log` (878 KB) only ever grew. Both now roll one generation at a size limit — 5 MB for the launcher shim, 2 MB for the update log.

Rotation happens once per invocation before the first append, which for the shim costs a single `stat`. Verified end to end: a 6 MB `launcher.log` rolls to `.1` and the fresh log starts at 73 bytes; a small log is left untouched.

`daemon.log` is **not** touched — `rotateDaemonLogInPlace` already covers it at 20 MB, and the 21 MB `daemon.log.1` on the reported machine is that mechanism working, bounded at two generations.

## 3. Orphaned atomic-write tmp files

Twelve `.daemon.pid.tmp.*` / `.registry.json.tmp.*` files, the oldest four months old. `atomicWriteString` unlinks its own tmp on error, but a process killed between `open` and `rename` never runs that handler — so every crash leaked one, permanently.

`sweepOrphanTmpFiles` collects them at daemon startup. The 24h age cutoff is the safety margin: a younger tmp may belong to a write in flight in another process, and removing it would turn a healthy write into a spurious failure. The filename pattern requires the full `.<name>.tmp.<pid>.<12 hex>` shape, so a user file that merely contains `.tmp.` is never matched.

## Tests

12 new tests across three files, covering both what each sweep removes and — more importantly — what it must not: a registered-but-unmounted root, a tmp file young enough to be in flight, real state files of any age, subdirectories matching the tmp shape, and a healthy config that must not be rewritten at all.

One of them earned its keep during development: the positive case in `ephemeral-config-section.test.ts` initially passed vacuously because `HOME` does not redirect the state dir (`os.homedir()` ignores it on macOS). It now asserts the resolved config path is inside the fixture before reading, which caught the leak.

```
Test Files  880 passed | 4 skipped (884)
     Tests  9675 passed | 14 skipped (9689)
```

`tsc --noEmit` clean, `tsup` build succeeds, `biome ci` clean on all touched files.

## Compatibility

No changes to MCP tool signatures, the on-disk graph, or the DB schema. No migration needed — the sweep is idempotent and converges on first daemon start.

Agent: Lead Engineer
