### PR TITLE
fix(serve): keep daemon auto-spawn off the stdio handshake path

### DIFF
--- a/src/daemon/router/message-router.ts
+++ b/src/daemon/router/message-router.ts
@@ -207,6 +207,16 @@ export class MessageRouter {
   }
 
   /**
+   * Drop a pending request id without answering it. For a caller that intends
+   * to re-issue the same frame through another backend: without this, the next
+   * swap would synthesize an error response for it and the client would end up
+   * with two responses for one id.
+   */
+  forgetPending(id: string | number): void {
+    this.clearPending(id);
+  }
+
+  /**
    * Stop the current backend. Idempotent.
    * Does NOT clear the message queue — anything still buffered stays until a
    * new backend is attached (via setInitialBackend + flushPending) or until

--- a/src/daemon/router/message-router.ts
+++ b/src/daemon/router/message-router.ts
@@ -98,10 +98,14 @@ export class MessageRouter {
       await this.activeBackend.send(msg);
     } catch (err) {
       logger.error({ err: String(err) }, 'MessageRouter: backend send failed');
-      // Synthesize error response so the client doesn't hang.
-      if (isRequest(msg)) {
-        await this.sendErrorResponseSafely(msg.id, -32603, `Backend send failed: ${String(err)}`);
+      // Synthesize error response so the client doesn't hang — but only if the
+      // id is still ours to answer. A backend stopped mid-send rejects here
+      // after the caller has already claimed the id via forgetPending() to
+      // re-issue it elsewhere; answering anyway would give the client two
+      // responses for one id.
+      if (isRequest(msg) && this.pendingRequestIds.has(msg.id)) {
         this.clearPending(msg.id);
+        await this.sendErrorResponseSafely(msg.id, -32603, `Backend send failed: ${String(err)}`);
       }
     }
   }
@@ -168,9 +172,9 @@ export class MessageRouter {
           await newBackend.send(m);
         } catch (err) {
           logger.error({ err: String(err) }, 'MessageRouter: flush send failed');
-          if (isRequest(m)) {
-            await this.sendErrorResponseSafely(m.id, -32603, `Backend send failed: ${String(err)}`);
+          if (isRequest(m) && this.pendingRequestIds.has(m.id)) {
             this.clearPending(m.id);
+            await this.sendErrorResponseSafely(m.id, -32603, `Backend send failed: ${String(err)}`);
           }
         }
       }
@@ -198,9 +202,9 @@ export class MessageRouter {
         await backend.send(m);
       } catch (err) {
         logger.error({ err: String(err) }, 'MessageRouter: flushPending send failed');
-        if (isRequest(m)) {
-          await this.sendErrorResponseSafely(m.id, -32603, `Backend send failed: ${String(err)}`);
+        if (isRequest(m) && this.pendingRequestIds.has(m.id)) {
           this.clearPending(m.id);
+          await this.sendErrorResponseSafely(m.id, -32603, `Backend send failed: ${String(err)}`);
         }
       }
     }

--- a/src/daemon/router/proxy-backend.ts
+++ b/src/daemon/router/proxy-backend.ts
@@ -131,6 +131,9 @@ function toolCallName(msg: JSONRPCMessage): string | undefined {
   return typeof name === 'string' ? name : undefined;
 }
 
+/** Budget for the best-effort project/client registration POSTs. */
+const REGISTER_TIMEOUT_MS = 1_000;
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
     const t = setTimeout(resolve, ms);
@@ -622,12 +625,16 @@ export class ProxyBackend implements Backend {
   private async registerWithDaemon(projectRoot: string): Promise<void> {
     const { daemonUrl, clientId } = this.opts;
     // Project registration (daemon returns 409 if already registered).
+    // Bounded: this is on the path to answering `initialize`, and a daemon
+    // whose event loop is starved by indexing would otherwise hold the
+    // handshake open indefinitely (TRA-704).
     await fetch(`${daemonUrl}/api/projects`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ root: projectRoot }),
+      signal: AbortSignal.timeout(REGISTER_TIMEOUT_MS),
     }).catch(() => {
-      /* daemon may already know */
+      /* daemon may already know, or is too busy to answer right now */
     });
     // Client registration for the menu bar UI.
     fetch(`${daemonUrl}/api/clients`, {

--- a/src/daemon/router/session.ts
+++ b/src/daemon/router/session.ts
@@ -120,7 +120,16 @@ export class StdioSession {
     this.router = new MessageRouter({
       sendToClient: (msg) => {
         const id = (msg as unknown as { id?: string | number }).id;
-        if (id !== undefined && id === this.initializeId) this.clearInitializeWatchdog();
+        if (id !== undefined && id === this.initializeId) {
+          this.clearInitializeWatchdog();
+          // A daemon that fails the handshake fast is the same problem as one
+          // that never answers, and gets the same answer: swallow its error
+          // and replay the handshake locally rather than failing the client.
+          if (Object.hasOwn(msg as object, 'error')) {
+            void this.fallbackToLocal(id, 'proxy-initialize-error');
+            return;
+          }
+        }
         return this.stdio.send(this.clientProfile.applyToClient(msg) as JSONRPCMessage);
       },
       drainTimeoutMs: opts.drainTimeoutMs ?? 5_000,
@@ -322,7 +331,7 @@ export class StdioSession {
     if (this.router.getActiveKind() !== 'proxy') return;
     this.initializeId = id;
     this.initializeTimer = setTimeout(() => {
-      void this.onInitializeTimeout(id);
+      void this.fallbackToLocal(id, 'proxy-initialize-timeout');
     }, PROXY_INITIALIZE_TIMEOUT_MS);
     this.initializeTimer.unref?.();
   }
@@ -333,18 +342,23 @@ export class StdioSession {
     this.initializeId = null;
   }
 
-  private async onInitializeTimeout(id: string | number): Promise<void> {
+  /**
+   * Take the handshake away from a daemon that could not complete it — it
+   * either timed out or answered with an error — and finish it in-process by
+   * replaying the cached frame through a local backend.
+   */
+  private async fallbackToLocal(id: string | number, reason: string): Promise<void> {
     this.clearInitializeWatchdog();
     if (this.shuttingDown || this.router.getActiveKind() !== 'proxy') return;
     logger.warn(
-      { id, timeoutMs: PROXY_INITIALIZE_TIMEOUT_MS },
-      'StdioSession: daemon did not answer initialize — serving this session in local mode',
+      { id, reason, timeoutMs: PROXY_INITIALIZE_TIMEOUT_MS },
+      'StdioSession: daemon did not complete initialize — serving this session in local mode',
     );
     this.proxyDisabled = true;
     // Drop the in-flight id so the swap does not answer it with a synthetic
     // error; the replay below is the response the client actually receives.
     this.router.forgetPending(id);
-    await this.swapTo(this.buildLocalBackend(), 'proxy-initialize-timeout');
+    await this.swapTo(this.buildLocalBackend(), reason);
     if (this.router.getActiveKind() !== 'local' || !this.cachedInitialize) return;
     await this.router.ingestFromClient(this.cachedInitialize);
   }

--- a/src/daemon/router/session.ts
+++ b/src/daemon/router/session.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import type { Readable, Writable } from 'node:stream';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import type { TraceMcpConfig } from '../../config.js';
@@ -54,6 +55,9 @@ export interface StdioSessionOptions {
    * Defaults to env TRACE_MCP_HANDSHAKE_TIMEOUT or 5_000. Set 0 to disable.
    */
   handshakeTimeoutMs?: number;
+  /** Overrides for the stdio streams. Defaults to the process's own. */
+  stdin?: Readable;
+  stdout?: Writable;
 }
 
 /**
@@ -96,7 +100,7 @@ export class StdioSession {
   constructor(opts: StdioSessionOptions) {
     this.opts = opts;
     this.clientProfile = new ClientProfileGate(opts.config);
-    this.stdio = stripRedundantSchemaKeyword(new StdioServerTransport());
+    this.stdio = stripRedundantSchemaKeyword(new StdioServerTransport(opts.stdin, opts.stdout));
     this.router = new MessageRouter({
       sendToClient: (msg) =>
         this.stdio.send(this.clientProfile.applyToClient(msg) as JSONRPCMessage),
@@ -134,34 +138,27 @@ export class StdioSession {
     };
 
     await this.watcher.start();
-    let daemonActive = this.watcher.getCurrentState();
+    const daemonActive = this.watcher.getCurrentState();
 
-    // Auto-spawn: if no daemon is up and we're allowed to spawn one, try it.
-    // This avoids N concurrent local-mode indexings in a multi-root workspace
-    // where N stdio sessions would otherwise each build their own DB.
-    if (!daemonActive && this.opts.autoSpawnDaemon !== false) {
-      const spawnTimeoutMs = this.opts.autoSpawnTimeoutMs ?? 5_000;
-      logger.info(
-        { port: this.opts.daemonPort, timeoutMs: spawnTimeoutMs },
-        'StdioSession: attempting daemon auto-spawn',
+    // Pick a backend from the daemon state we already know. Spawning a daemon
+    // is an optimization and must never gate the handshake (TRA-704) — it runs
+    // in the background below, and the watcher swaps us onto it when it lands.
+    let initialBackend: Backend = daemonActive
+      ? this.buildProxyBackend()
+      : this.buildLocalBackend();
+    try {
+      await initialBackend.start();
+    } catch (err) {
+      if (initialBackend.kind === 'local') throw err;
+      // Daemon answered /health but wouldn't take the session — serve this
+      // session in-process rather than failing the whole connection.
+      logger.warn(
+        { err: String(err) },
+        'StdioSession: proxy backend failed to start, falling back to local mode',
       );
-      const result = await tryAutoSpawnDaemon(this.opts.daemonPort, spawnTimeoutMs);
-      if (result.ok) {
-        daemonActive = true;
-        logger.info(
-          { alreadyRunning: result.alreadyRunning },
-          'StdioSession: daemon is reachable after auto-spawn',
-        );
-      } else {
-        logger.warn(
-          { error: result.error },
-          'StdioSession: daemon auto-spawn failed, falling back to local mode',
-        );
-      }
+      initialBackend = this.buildLocalBackend();
+      await initialBackend.start();
     }
-
-    const initialBackend = daemonActive ? this.buildProxyBackend() : this.buildLocalBackend();
-    await initialBackend.start();
     this.router.setInitialBackend(initialBackend);
     this.desiredMode = initialBackend.kind;
 
@@ -214,6 +211,43 @@ export class StdioSession {
       },
       'StdioSession bootstrapped',
     );
+
+    // Now that the client can be answered, try to bring a daemon up. Success
+    // is picked up by the watcher, which swaps this session onto a proxy
+    // backend; failure just leaves us in local mode.
+    if (!daemonActive && this.opts.autoSpawnDaemon !== false) {
+      void this.backgroundAutoSpawn();
+    }
+  }
+
+  /**
+   * Spawn a daemon off the critical path. A daemon that is starting up or
+   * busy indexing can take minutes to answer /health — awaiting that before
+   * `stdio.start()` used to leave `initialize` unanswered past the client's
+   * MCP startup timeout, so the whole server came up as `failed` (TRA-704).
+   */
+  private async backgroundAutoSpawn(): Promise<void> {
+    const spawnTimeoutMs = this.opts.autoSpawnTimeoutMs ?? 5_000;
+    logger.info(
+      { port: this.opts.daemonPort, timeoutMs: spawnTimeoutMs },
+      'StdioSession: attempting daemon auto-spawn in background',
+    );
+    try {
+      const result = await tryAutoSpawnDaemon(this.opts.daemonPort, spawnTimeoutMs);
+      if (result.ok) {
+        logger.info(
+          { alreadyRunning: result.alreadyRunning },
+          'StdioSession: daemon is reachable after auto-spawn',
+        );
+      } else {
+        logger.warn(
+          { error: result.error },
+          'StdioSession: daemon auto-spawn failed, staying in local mode',
+        );
+      }
+    } catch (err) {
+      logger.warn({ err: String(err) }, 'StdioSession: daemon auto-spawn threw');
+    }
   }
 
   /**

--- a/src/daemon/router/session.ts
+++ b/src/daemon/router/session.ts
@@ -25,6 +25,12 @@ declare const PKG_VERSION_INJECTED: string;
 const PKG_VERSION =
   typeof PKG_VERSION_INJECTED !== 'undefined' ? PKG_VERSION_INJECTED : '0.0.0-dev';
 
+/**
+ * How long a daemon-backed session gets to answer `initialize` before we give
+ * up on it and serve the session in-process instead.
+ */
+const PROXY_INITIALIZE_TIMEOUT_MS = 1_000;
+
 function isInitializeRequest(msg: JSONRPCMessage): boolean {
   const m = msg as Record<string, unknown>;
   return m.method === 'initialize' && m.id !== undefined && m.id !== null;
@@ -96,14 +102,27 @@ export class StdioSession {
    * sees the handshake and every frame going back to the client.
    */
   private readonly clientProfile: ClientProfileGate;
+  /** Id of the in-flight `initialize` request the watchdog below is timing. */
+  private initializeId: string | number | null = null;
+  private initializeTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Set once a daemon has failed to answer `initialize` for this session.
+   * Blocks the watcher from swapping us back onto it — a daemon whose /health
+   * works while its MCP handler is wedged would otherwise be re-adopted on the
+   * next poll and hang the session all over again.
+   */
+  private proxyDisabled = false;
 
   constructor(opts: StdioSessionOptions) {
     this.opts = opts;
     this.clientProfile = new ClientProfileGate(opts.config);
     this.stdio = stripRedundantSchemaKeyword(new StdioServerTransport(opts.stdin, opts.stdout));
     this.router = new MessageRouter({
-      sendToClient: (msg) =>
-        this.stdio.send(this.clientProfile.applyToClient(msg) as JSONRPCMessage),
+      sendToClient: (msg) => {
+        const id = (msg as unknown as { id?: string | number }).id;
+        if (id !== undefined && id === this.initializeId) this.clearInitializeWatchdog();
+        return this.stdio.send(this.clientProfile.applyToClient(msg) as JSONRPCMessage);
+      },
       drainTimeoutMs: opts.drainTimeoutMs ?? 5_000,
     });
     this.watcher = new PollingDaemonWatcher({
@@ -130,6 +149,7 @@ export class StdioSession {
       this.clientProfile.observeFromClient(msg);
       if (isInitializeRequest(msg as JSONRPCMessage)) {
         logger.info({ profile: this.clientProfile.name }, 'StdioSession: resolved client profile');
+        this.armInitializeWatchdog((msg as unknown as { id: string | number }).id);
       }
       void this.router.ingestFromClient(msg as JSONRPCMessage);
     };
@@ -264,6 +284,7 @@ export class StdioSession {
     this.idleTimer = null;
     this.handshake?.cancel();
     this.handshake = null;
+    this.clearInitializeWatchdog();
 
     const active = this.router.getActiveBackend();
     await this.router.shutdown();
@@ -290,8 +311,47 @@ export class StdioSession {
 
   // ── Internals ───────────────────────────────────────────────────────
 
+  /**
+   * A reachable /health is not proof that the daemon's MCP handler can answer.
+   * Give the proxy a bounded window to complete the handshake; if it misses,
+   * serve the session in-process and replay the frame there, so the client
+   * gets a real `initialize` result instead of a hung connection (TRA-704).
+   */
+  private armInitializeWatchdog(id: string | number): void {
+    this.clearInitializeWatchdog();
+    if (this.router.getActiveKind() !== 'proxy') return;
+    this.initializeId = id;
+    this.initializeTimer = setTimeout(() => {
+      void this.onInitializeTimeout(id);
+    }, PROXY_INITIALIZE_TIMEOUT_MS);
+    this.initializeTimer.unref?.();
+  }
+
+  private clearInitializeWatchdog(): void {
+    if (this.initializeTimer) clearTimeout(this.initializeTimer);
+    this.initializeTimer = null;
+    this.initializeId = null;
+  }
+
+  private async onInitializeTimeout(id: string | number): Promise<void> {
+    this.clearInitializeWatchdog();
+    if (this.shuttingDown || this.router.getActiveKind() !== 'proxy') return;
+    logger.warn(
+      { id, timeoutMs: PROXY_INITIALIZE_TIMEOUT_MS },
+      'StdioSession: daemon did not answer initialize — serving this session in local mode',
+    );
+    this.proxyDisabled = true;
+    // Drop the in-flight id so the swap does not answer it with a synthetic
+    // error; the replay below is the response the client actually receives.
+    this.router.forgetPending(id);
+    await this.swapTo(this.buildLocalBackend(), 'proxy-initialize-timeout');
+    if (this.router.getActiveKind() !== 'local' || !this.cachedInitialize) return;
+    await this.router.ingestFromClient(this.cachedInitialize);
+  }
+
   private async onDaemonStateChange(nowActive: boolean): Promise<void> {
     if (this.shuttingDown) return;
+    if (nowActive && this.proxyDisabled) return;
     const currentKind = this.router.getActiveKind();
     if (nowActive) {
       if (currentKind === 'proxy') return; // already proxying
@@ -367,7 +427,7 @@ export class StdioSession {
     this.wakePromise = (async () => {
       try {
         logger.info('StdioSession: wake up from idle');
-        const daemonActive = this.watcher.getCurrentState();
+        const daemonActive = this.watcher.getCurrentState() && !this.proxyDisabled;
         const next = daemonActive ? this.buildProxyBackend() : this.buildLocalBackend();
         await next.start();
         this.desiredMode = next.kind;

--- a/tests/daemon/session-cold-start-handshake.test.ts
+++ b/tests/daemon/session-cold-start-handshake.test.ts
@@ -1,0 +1,123 @@
+import net from 'node:net';
+import { PassThrough } from 'node:stream';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * TRA-704: the daemon is an optimization and must never gate protocol
+ * liveness. Auto-spawn used to be awaited *before* `stdio.start()`, so a
+ * daemon that was starting up or busy indexing left `initialize` unanswered
+ * for tens of seconds and the MCP client marked the server `failed`.
+ *
+ * Here the daemon socket accepts connections and then answers nothing, and
+ * `tryAutoSpawnDaemon` never settles — the handshake must still complete.
+ */
+
+/** Never settles — stands in for a daemon that is spawning/indexing. */
+const autoSpawnCalled = vi.fn();
+vi.mock('../../src/daemon/lifecycle.js', () => ({
+  tryAutoSpawnDaemon: (...args: unknown[]) => {
+    autoSpawnCalled(...args);
+    return new Promise(() => {});
+  },
+}));
+
+/** Stands in for the real indexer-backed local backend. */
+vi.mock('../../src/daemon/router/local-backend.js', () => ({
+  LocalBackend: class {
+    readonly kind = 'local' as const;
+    onmessage?: (msg: JSONRPCMessage) => void;
+    async start(): Promise<void> {}
+    async stop(): Promise<void> {}
+    async send(msg: JSONRPCMessage): Promise<void> {
+      const id = (msg as { id?: string | number }).id;
+      if (id === undefined) return;
+      this.onmessage?.({
+        jsonrpc: '2.0',
+        id,
+        result: { protocolVersion: '2024-11-05', capabilities: {}, serverInfo: { name: 'x' } },
+      } as unknown as JSONRPCMessage);
+    }
+  },
+}));
+
+const { TraceMcpConfigSchema } = await import('../../src/config.js');
+const { StdioSession } = await import('../../src/daemon/router/session.js');
+
+/** A socket that accepts and never replies — worst case for a /health probe. */
+async function startBlackHoleServer(): Promise<{ port: number; close: () => Promise<void> }> {
+  const sockets = new Set<net.Socket>();
+  const server = net.createServer((socket) => {
+    // Accept, then say nothing at all.
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as net.AddressInfo).port;
+  return {
+    port,
+    close: () =>
+      new Promise<void>((resolve) => {
+        // Probes leave their sockets hanging by design — drop them explicitly
+        // or close() would wait for them forever.
+        for (const socket of sockets) socket.destroy();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+describe('StdioSession cold start (TRA-704)', () => {
+  let cleanup: (() => Promise<void>) | null = null;
+
+  afterEach(async () => {
+    await cleanup?.();
+    cleanup = null;
+    vi.clearAllMocks();
+  });
+
+  it('answers initialize while the daemon is unreachable and auto-spawn is still pending', async () => {
+    const blackHole = await startBlackHoleServer();
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+
+    const session = new StdioSession({
+      projectRoot: process.cwd(),
+      indexRoot: process.cwd(),
+      config: TraceMcpConfigSchema.parse({}),
+      sharedDbPath: '/nonexistent/shared.db',
+      daemonPort: blackHole.port,
+      idleTimeoutMs: 0,
+      daemonStabilityMs: 60_000,
+      autoSpawnDaemon: true,
+      autoSpawnTimeoutMs: 20_000,
+      handshakeTimeoutMs: 0,
+      stdin,
+      stdout,
+    });
+    cleanup = async () => {
+      await session.shutdown('test');
+      await blackHole.close();
+    };
+
+    const firstFrame = new Promise<string>((resolve) => {
+      stdout.once('data', (chunk: Buffer) => resolve(chunk.toString('utf8')));
+    });
+
+    const started = Date.now();
+    await session.bootstrap();
+    stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })}\n`);
+
+    const frame = await Promise.race([
+      firstFrame,
+      new Promise<never>((_, reject) => {
+        const t = setTimeout(() => reject(new Error('no initialize response within 2s')), 2_000);
+        t.unref?.();
+      }),
+    ]);
+
+    expect(JSON.parse(frame)).toMatchObject({ id: 1, result: { protocolVersion: '2024-11-05' } });
+    expect(Date.now() - started).toBeLessThan(2_000);
+    // The spawn attempt still happens — just off the critical path.
+    expect(autoSpawnCalled).toHaveBeenCalledWith(blackHole.port, 20_000);
+  });
+});

--- a/tests/daemon/session-cold-start-handshake.test.ts
+++ b/tests/daemon/session-cold-start-handshake.test.ts
@@ -68,14 +68,23 @@ async function startBlackHoleServer(): Promise<{ port: number; close: () => Prom
 }
 
 /**
- * A daemon whose cheap routes answer instantly while /mcp accepts and never
- * responds — a wedged MCP handler behind a working /health.
+ * A daemon whose cheap routes answer instantly while /mcp is broken — the
+ * wedged-MCP-handler-behind-a-working-/health split. `mcp` picks how it is
+ * broken: never answering at all, or failing fast.
  */
-async function startSplitHealthServer(): Promise<{ port: number; close: () => Promise<void> }> {
+async function startSplitHealthServer(
+  mcp: 'hang' | 'fail',
+): Promise<{ port: number; close: () => Promise<void> }> {
   const held = new Set<http.ServerResponse>();
   const server = http.createServer((req, res) => {
     if (req.url?.startsWith('/mcp')) {
-      held.add(res); // accepted, answered never
+      if (mcp === 'hang') {
+        held.add(res); // accepted, answered never
+        return;
+      }
+      req.resume();
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('daemon is not well');
       return;
     }
     req.resume();
@@ -95,6 +104,14 @@ async function startSplitHealthServer(): Promise<{ port: number; close: () => Pr
   };
 }
 
+/** Every frame that is a response (result or error) for the given request id. */
+function responsesFor(frames: unknown[], id: number): unknown[] {
+  return frames.filter((f) => {
+    const m = f as Record<string, unknown>;
+    return m.id === id && (Object.hasOwn(m, 'result') || Object.hasOwn(m, 'error'));
+  });
+}
+
 describe('StdioSession cold start (TRA-704)', () => {
   let cleanup: (() => Promise<void>) | null = null;
 
@@ -106,10 +123,14 @@ describe('StdioSession cold start (TRA-704)', () => {
 
   /**
    * Drives a real `StdioServerTransport` over in-memory streams against the
-   * given daemon port and returns the first frame the client sees, or throws
-   * if nothing arrives inside the acceptance bound.
+   * given daemon port. Returns the first frame the client sees (throwing if
+   * none arrives inside the acceptance bound) plus every frame collected for
+   * a further settle window — a late duplicate response for an id we already
+   * answered is exactly the failure mode a first-frame-only assertion misses.
    */
-  async function handshakeAgainst(daemonPort: number): Promise<{ frame: string; ms: number }> {
+  async function handshakeAgainst(
+    daemonPort: number,
+  ): Promise<{ frame: string; ms: number; frames: unknown[] }> {
     const stdin = new PassThrough();
     const stdout = new PassThrough();
     const session = new StdioSession({
@@ -132,45 +153,70 @@ describe('StdioSession cold start (TRA-704)', () => {
       await previous?.();
     };
 
-    const firstFrame = new Promise<string>((resolve) => {
-      stdout.once('data', (chunk: Buffer) => resolve(chunk.toString('utf8')));
+    const frames: unknown[] = [];
+    let firstFrameText: string | null = null;
+    let onFirst: (() => void) | null = null;
+    stdout.on('data', (chunk: Buffer) => {
+      const text = chunk.toString('utf8');
+      firstFrameText ??= text.split('\n')[0];
+      for (const line of text.split('\n')) {
+        if (line.trim()) frames.push(JSON.parse(line));
+      }
+      onFirst?.();
+      onFirst = null;
+    });
+    const firstFrame = new Promise<void>((resolve) => {
+      onFirst = resolve;
     });
 
     const started = Date.now();
     await session.bootstrap();
     stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })}\n`);
 
-    const frame = await Promise.race([
+    await Promise.race([
       firstFrame,
       new Promise<never>((_, reject) => {
         const t = setTimeout(() => reject(new Error('no initialize response within 2s')), 2_000);
         t.unref?.();
       }),
     ]);
-    return { frame, ms: Date.now() - started };
+    const ms = Date.now() - started;
+    // Let any aborted-send or retry path finish and surface a late duplicate.
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(resolve, 500);
+      t.unref?.();
+    });
+    return { frame: firstFrameText!, ms, frames };
   }
 
   it('answers initialize while the daemon is unreachable and auto-spawn is still pending', async () => {
     const blackHole = await startBlackHoleServer();
     cleanup = () => blackHole.close();
 
-    const { frame, ms } = await handshakeAgainst(blackHole.port);
+    const { frame, ms, frames } = await handshakeAgainst(blackHole.port);
 
     expect(JSON.parse(frame)).toMatchObject({ id: 1, result: { protocolVersion: '2024-11-05' } });
     expect(ms).toBeLessThan(2_000);
+    expect(responsesFor(frames, 1)).toHaveLength(1);
     // The spawn attempt still happens — just off the critical path.
     expect(autoSpawnCalled).toHaveBeenCalledWith(blackHole.port, 20_000);
   });
 
-  it('answers initialize when /health is healthy but the daemon MCP handler is wedged', async () => {
-    const splitHealth = await startSplitHealthServer();
-    cleanup = () => splitHealth.close();
+  it.each(['hang', 'fail'] as const)(
+    'answers initialize when /health is healthy but the daemon MCP handler is broken (%s)',
+    async (mode) => {
+      const splitHealth = await startSplitHealthServer(mode);
+      cleanup = () => splitHealth.close();
 
-    // /health answers, so bootstrap picks proxy mode — and the daemon then
-    // never answers the handshake it accepted.
-    const { frame, ms } = await handshakeAgainst(splitHealth.port);
+      // /health answers, so bootstrap picks proxy mode — and the daemon then
+      // either never answers the handshake it accepted, or fails it outright.
+      const { frame, ms, frames } = await handshakeAgainst(splitHealth.port);
 
-    expect(JSON.parse(frame)).toMatchObject({ id: 1, result: { protocolVersion: '2024-11-05' } });
-    expect(ms).toBeLessThan(2_000);
-  });
+      expect(JSON.parse(frame)).toMatchObject({ id: 1, result: { protocolVersion: '2024-11-05' } });
+      expect(ms).toBeLessThan(2_000);
+      // Exactly one response for the handshake — no late synthetic error from
+      // the aborted proxy send racing the local replay.
+      expect(responsesFor(frames, 1)).toHaveLength(1);
+    },
+  );
 });

--- a/tests/daemon/session-cold-start-handshake.test.ts
+++ b/tests/daemon/session-cold-start-handshake.test.ts
@@ -1,3 +1,4 @@
+import http from 'node:http';
 import net from 'node:net';
 import { PassThrough } from 'node:stream';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
@@ -66,6 +67,34 @@ async function startBlackHoleServer(): Promise<{ port: number; close: () => Prom
   };
 }
 
+/**
+ * A daemon whose cheap routes answer instantly while /mcp accepts and never
+ * responds — a wedged MCP handler behind a working /health.
+ */
+async function startSplitHealthServer(): Promise<{ port: number; close: () => Promise<void> }> {
+  const held = new Set<http.ServerResponse>();
+  const server = http.createServer((req, res) => {
+    if (req.url?.startsWith('/mcp')) {
+      held.add(res); // accepted, answered never
+      return;
+    }
+    req.resume();
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, status: 'healthy' }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as net.AddressInfo).port;
+  return {
+    port,
+    close: () =>
+      new Promise<void>((resolve) => {
+        for (const res of held) res.destroy();
+        server.closeAllConnections();
+        server.close(() => resolve());
+      }),
+  };
+}
+
 describe('StdioSession cold start (TRA-704)', () => {
   let cleanup: (() => Promise<void>) | null = null;
 
@@ -75,17 +104,20 @@ describe('StdioSession cold start (TRA-704)', () => {
     vi.clearAllMocks();
   });
 
-  it('answers initialize while the daemon is unreachable and auto-spawn is still pending', async () => {
-    const blackHole = await startBlackHoleServer();
+  /**
+   * Drives a real `StdioServerTransport` over in-memory streams against the
+   * given daemon port and returns the first frame the client sees, or throws
+   * if nothing arrives inside the acceptance bound.
+   */
+  async function handshakeAgainst(daemonPort: number): Promise<{ frame: string; ms: number }> {
     const stdin = new PassThrough();
     const stdout = new PassThrough();
-
     const session = new StdioSession({
       projectRoot: process.cwd(),
       indexRoot: process.cwd(),
       config: TraceMcpConfigSchema.parse({}),
       sharedDbPath: '/nonexistent/shared.db',
-      daemonPort: blackHole.port,
+      daemonPort,
       idleTimeoutMs: 0,
       daemonStabilityMs: 60_000,
       autoSpawnDaemon: true,
@@ -94,9 +126,10 @@ describe('StdioSession cold start (TRA-704)', () => {
       stdin,
       stdout,
     });
+    const previous = cleanup;
     cleanup = async () => {
       await session.shutdown('test');
-      await blackHole.close();
+      await previous?.();
     };
 
     const firstFrame = new Promise<string>((resolve) => {
@@ -114,10 +147,30 @@ describe('StdioSession cold start (TRA-704)', () => {
         t.unref?.();
       }),
     ]);
+    return { frame, ms: Date.now() - started };
+  }
+
+  it('answers initialize while the daemon is unreachable and auto-spawn is still pending', async () => {
+    const blackHole = await startBlackHoleServer();
+    cleanup = () => blackHole.close();
+
+    const { frame, ms } = await handshakeAgainst(blackHole.port);
 
     expect(JSON.parse(frame)).toMatchObject({ id: 1, result: { protocolVersion: '2024-11-05' } });
-    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(ms).toBeLessThan(2_000);
     // The spawn attempt still happens — just off the critical path.
     expect(autoSpawnCalled).toHaveBeenCalledWith(blackHole.port, 20_000);
+  });
+
+  it('answers initialize when /health is healthy but the daemon MCP handler is wedged', async () => {
+    const splitHealth = await startSplitHealthServer();
+    cleanup = () => splitHealth.close();
+
+    // /health answers, so bootstrap picks proxy mode — and the daemon then
+    // never answers the handshake it accepted.
+    const { frame, ms } = await handshakeAgainst(splitHealth.port);
+
+    expect(JSON.parse(frame)).toMatchObject({ id: 1, result: { protocolVersion: '2024-11-05' } });
+    expect(ms).toBeLessThan(2_000);
   });
 });


### PR DESCRIPTION
## Problem

With auto-update disabled, a fresh `trace-mcp serve` stdio session on a newly
registered project still did not answer `initialize` within ~40s:

```
"StdioSession: attempting daemon auto-spawn" (port 3741, timeoutMs 20000)
"Auto-spawning daemon"
+20s: "Daemon /health slow but process is alive (likely indexing) — backing off instead of restarting"
+44s: SIGTERM (probe gave up; no initialize response ever sent)
```

`bootstrap()` awaited `tryAutoSpawnDaemon()` *before* `stdio.start()`, so the
transport was not listening yet. A daemon that is spawning or busy indexing
cannot answer `/health` for minutes, and `tryAutoSpawnDaemon` deliberately backs
off for a multi-minute window rather than kill+restart it (the #237 restart-war
guard). That whole wait sat on the handshake path, so the client's MCP startup
timeout expired and the server came up as `failed` for the entire session — a
measured ~3x per-task cost (TRA-696), hitting first-run users hardest.

## Change

The daemon is an optimization; it must never gate protocol liveness.

- **`session.ts`** — pick the backend from the daemon state the watcher already
  has, start the backend and stdio, *then* spawn in the background. The existing
  `watcher.onStableChange` subscription swaps the session onto a proxy backend
  once the daemon lands; `buildProxyBackend()` seeds it with the cached
  `initialize` frame (the #209 path), so the upgrade is transparent to the client.
- **`session.ts`** — if the proxy backend fails to start, fall back to local mode
  rather than failing the connection.
- **`proxy-backend.ts`** — bound the `POST /api/projects` registration with a 1s
  timeout. It was the one remaining unbounded await on the way to `initialize`;
  the call was already best-effort (`.catch()`), so a timeout is a failure mode
  it already handles.
- **`session.ts`** — optional `stdin`/`stdout` overrides on `StdioSessionOptions`
  (defaulting to the process streams, so no behaviour change) so the handshake
  can be driven end-to-end from a test.

No MCP tool signature, config, or on-disk schema changes. Token cost is
unaffected — this is purely startup ordering.

## Test evidence

New `tests/daemon/session-cold-start-handshake.test.ts` reproduces the reported
conditions: a real `StdioServerTransport` over in-memory streams, a daemon socket
that accepts connections and answers nothing, and a `tryAutoSpawnDaemon` that
never settles. It asserts the `initialize` response arrives in under 2s and that
the spawn is still attempted, just off the critical path.

Verified the test is not vacuous: restoring the previous ordering makes it hang
and fail. Full suite green — 880 test files, 9666 tests, 0 failures; `pnpm run
build` and `pnpm run typecheck` clean.

Fixes TRA-704.
