### PR TITLE
fix(launcher): resolve cli.js independently of the selected node (TRA-701)

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.3.0 (Windows)
+REM trace-mcp-launcher v0.4.0 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -153,6 +153,16 @@ function Get-PkgRoots {
         # Unix-style layout (some cross-platform setups)
         $roots += (Join-Path $dir '..\lib\node_modules')
     }
+    # Roots recorded by past installs (mirrors src/init/launcher.ts::recordPkgRoot).
+    # This is how a prefix we cannot name in advance becomes findable without
+    # asking npm at runtime. Values are opaque paths, never evaluated.
+    $rootsFile = Join-Path $TraceHome 'pkg-roots'
+    if (Test-Path -LiteralPath $rootsFile -PathType Leaf) {
+        foreach ($line in [System.IO.File]::ReadAllLines($rootsFile)) {
+            $t = $line.Trim()
+            if ($t -and -not $t.StartsWith('#')) { $roots += $t }
+        }
+    }
     # Volta keeps each global package under its own image directory.
     if ($env:LOCALAPPDATA) {
         $roots += (Join-Path $env:LOCALAPPDATA 'Volta\tools\image\packages\trace-mcp\lib\node_modules')

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -153,6 +153,30 @@ function Get-PkgRoots {
         # Unix-style layout (some cross-platform setups)
         $roots += (Join-Path $dir '..\lib\node_modules')
     }
+    # Volta keeps each global package under its own image directory.
+    if ($env:LOCALAPPDATA) {
+        $roots += (Join-Path $env:LOCALAPPDATA 'Volta\tools\image\packages\trace-mcp\lib\node_modules')
+    }
+    # Custom prefixes (`npm config set prefix`). Read from config files, never
+    # by spawning npm: the shim inherits the MCP client's PATH, which in
+    # a project directory can contain a repository-controlled `node_modules\.bin`,
+    # so spawning a PATH-resolved npm would turn a stale config into code
+    # execution from the opened repository.
+    $prefix = $env:NPM_CONFIG_PREFIX
+    if (-not $prefix -and $env:USERPROFILE) {
+        $npmrc = Join-Path $env:USERPROFILE '.npmrc'
+        if (Test-Path -LiteralPath $npmrc -PathType Leaf) {
+            foreach ($line in [System.IO.File]::ReadAllLines($npmrc)) {
+                if ($line -match '^\s*prefix\s*=\s*(.+?)\s*$') {
+                    $prefix = $Matches[1].Trim('"').Trim("'")
+                }
+            }
+        }
+    }
+    if ($prefix) {
+        $roots += (Join-Path $prefix 'node_modules')
+        $roots += (Join-Path $prefix 'lib\node_modules')
+    }
     return ($roots | Select-Object -Unique)
 }
 
@@ -188,6 +212,9 @@ function Save-LauncherConfig {
     # The parser strips exactly one pair of quotes and never expands; a literal
     # quote in a path would corrupt the file, so skip rather than mangle.
     if ($NodeExe.Contains('"') -or $Cli.Contains('"')) { return }
+    # Never pin the config to a swap-window backup: that directory is about to
+    # be deleted, so the "fast path" it buys would be a dangling one.
+    if ($Cli -match 'trace-mcp\.tmcp-bak-' -or $Cli -match '[\\/]\.trace-mcp-') { return }
     try {
         if (-not (Test-Path -LiteralPath $TraceHome -PathType Container)) {
             New-Item -ItemType Directory -Path $TraceHome -Force -ErrorAction Stop | Out-Null

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.3.0 (Windows)
+# trace-mcp-launcher v0.4.0 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.
@@ -33,6 +33,7 @@ function Die {
 # --- 1. Parse config safely (no Invoke-Expression, whitelist keys) ---
 $NodePath = ''
 $CliPath  = ''
+$UsingOverride = $false
 
 if (Test-Path -LiteralPath $ConfigPath -PathType Leaf) {
     foreach ($line in [System.IO.File]::ReadAllLines($ConfigPath)) {
@@ -55,8 +56,8 @@ if (Test-Path -LiteralPath $ConfigPath -PathType Leaf) {
 }
 
 # --- 2. Env overrides ---
-if ($env:TRACE_MCP_NODE_OVERRIDE) { $NodePath = $env:TRACE_MCP_NODE_OVERRIDE }
-if ($env:TRACE_MCP_CLI_OVERRIDE)  { $CliPath  = $env:TRACE_MCP_CLI_OVERRIDE }
+if ($env:TRACE_MCP_NODE_OVERRIDE) { $NodePath = $env:TRACE_MCP_NODE_OVERRIDE; $UsingOverride = $true }
+if ($env:TRACE_MCP_CLI_OVERRIDE)  { $CliPath  = $env:TRACE_MCP_CLI_OVERRIDE;  $UsingOverride = $true }
 
 function Test-NodeBinary {
     param([string]$Path)
@@ -80,7 +81,10 @@ if ((Test-NodeBinary $NodePath) -and (Test-CliFile $CliPath)) {
 
 # --- 4. Probe fallback (stable sources only) ---
 
-function Find-Node {
+function Get-NodeCandidates {
+    # Every node.exe we know how to locate, most-preferred first.
+    $found = @()
+
     # 4a. System-wide official installer
     $candidates = @(
         (Join-Path $env:ProgramFiles 'nodejs\node.exe'),
@@ -88,17 +92,17 @@ function Find-Node {
         (Join-Path $env:LOCALAPPDATA 'Programs\nodejs\node.exe')
     )
     foreach ($c in $candidates) {
-        if ($c -and (Test-NodeBinary $c)) { return $c }
+        if ($c -and (Test-NodeBinary $c)) { $found += $c }
     }
 
     # 4b. Volta (stable shim dir)
     $volta = Join-Path $env:USERPROFILE '.volta\bin\node.exe'
-    if (Test-NodeBinary $volta) { return $volta }
+    if (Test-NodeBinary $volta) { $found += $volta }
 
     # 4c. nvm-windows: $APPDATA\nvm\<ver>\node.exe; active one symlinked via %NVM_SYMLINK%
     if ($env:NVM_SYMLINK) {
         $nvmActive = Join-Path $env:NVM_SYMLINK 'node.exe'
-        if (Test-NodeBinary $nvmActive) { return $nvmActive }
+        if (Test-NodeBinary $nvmActive) { $found += $nvmActive }
     }
     $nvmRoot = Join-Path $env:APPDATA 'nvm'
     if (Test-Path -LiteralPath $nvmRoot -PathType Container) {
@@ -108,7 +112,7 @@ function Find-Node {
                   Select-Object -First 1
         if ($latest) {
             $candidate = Join-Path $latest.FullName 'node.exe'
-            if (Test-NodeBinary $candidate) { return $candidate }
+            if (Test-NodeBinary $candidate) { $found += $candidate }
         }
     }
 
@@ -117,29 +121,96 @@ function Find-Node {
     if (Test-Path -LiteralPath $nvsDefault -PathType Container) {
         $nodeExe = Get-ChildItem -LiteralPath $nvsDefault -Recurse -Filter 'node.exe' -ErrorAction SilentlyContinue |
                    Select-Object -First 1
-        if ($nodeExe) { return $nodeExe.FullName }
+        if ($nodeExe) { $found += $nodeExe.FullName }
     }
 
+    return $found
+}
+
+function Find-Node {
+    $candidates = @(Get-NodeCandidates)
+    if ($candidates.Count -gt 0) { return $candidates[0] }
     return $null
+}
+
+# Every global node_modules root worth searching, most-likely-first.
+#
+# Node and cli.js are resolved INDEPENDENTLY on purpose: any working node can
+# run any cli.js. Tying the package lookup to the prefix of the selected node
+# killed the server whenever the two lived in different prefixes.
+function Get-PkgRoots {
+    param([string]$NodeExe)
+    $roots = @()
+    # npm-global layout on Windows places global modules in %APPDATA%\npm\node_modules\.
+    if ($env:APPDATA) { $roots += (Join-Path $env:APPDATA 'npm\node_modules') }
+    $nodes = @()
+    if ($NodeExe) { $nodes += $NodeExe }
+    $nodes += (Get-NodeCandidates)
+    foreach ($n in $nodes) {
+        if (-not $n) { continue }
+        $dir = Split-Path -Parent $n
+        $roots += (Join-Path $dir 'node_modules')
+        # Unix-style layout (some cross-platform setups)
+        $roots += (Join-Path $dir '..\lib\node_modules')
+    }
+    return ($roots | Select-Object -Unique)
 }
 
 function Find-Cli {
     param([string]$NodeExe)
-    # npm-global layout on Windows places global modules in %APPDATA%\npm\node_modules\,
-    # not next to node.exe. Check both layouts for robustness.
-    $candidates = @(
-        (Join-Path $env:APPDATA 'npm\node_modules\trace-mcp\dist\cli.js'),
-        (Join-Path (Split-Path -Parent $NodeExe) 'node_modules\trace-mcp\dist\cli.js'),
-        # Unix-style layout (some cross-platform setups)
-        (Join-Path (Split-Path -Parent $NodeExe) '..\lib\node_modules\trace-mcp\dist\cli.js')
-    )
-    foreach ($c in $candidates) {
+    $roots = @(Get-PkgRoots $NodeExe)
+    foreach ($r in $roots) {
+        $c = Join-Path $r 'trace-mcp\dist\cli.js'
         if (Test-Path -LiteralPath $c -PathType Leaf) {
             return (Resolve-Path -LiteralPath $c).Path
         }
     }
+    # Last resort: an update is swapping the package right this second. npm and
+    # our own updater both rename the live directory aside before unpacking the
+    # new one, so a stale-but-working copy is on disk for the length of the
+    # window. Serving the previous version beats losing every tool for the rest
+    # of the client's session.
+    foreach ($r in $roots) {
+        if (-not (Test-Path -LiteralPath $r -PathType Container)) { continue }
+        $bak = Get-ChildItem -LiteralPath $r -Directory -ErrorAction SilentlyContinue |
+               Where-Object { $_.Name -like 'trace-mcp.tmcp-bak-*' -or $_.Name -like '.trace-mcp-*' } |
+               ForEach-Object { Join-Path $_.FullName 'dist\cli.js' } |
+               Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
+               Select-Object -First 1
+        if ($bak) { return (Resolve-Path -LiteralPath $bak).Path }
+    }
     return $null
 }
+
+# Persist a freshly probed pair so the next start takes the fast path.
+function Save-LauncherConfig {
+    param([string]$NodeExe, [string]$Cli)
+    # The parser strips exactly one pair of quotes and never expands; a literal
+    # quote in a path would corrupt the file, so skip rather than mangle.
+    if ($NodeExe.Contains('"') -or $Cli.Contains('"')) { return }
+    try {
+        if (-not (Test-Path -LiteralPath $TraceHome -PathType Container)) {
+            New-Item -ItemType Directory -Path $TraceHome -Force -ErrorAction Stop | Out-Null
+        }
+        $lines = @(
+            '# Managed by trace-mcp - do not edit by hand.',
+            '# Rewritten by the launcher after a successful probe.',
+            ('TRACE_MCP_NODE="{0}"' -f $NodeExe),
+            # TRACE_MCP_VERSION is deliberately dropped: the probed cli.js may be
+            # a different build than the one the stale config described, and a
+            # wrong version is worse than none. `trace-mcp init` restores it.
+            ('TRACE_MCP_CLI="{0}"' -f ($Cli -replace '\\', '/'))
+        )
+        $tmp = "$ConfigPath.tmp.$PID"
+        [System.IO.File]::WriteAllLines($tmp, $lines)
+        Move-Item -LiteralPath $tmp -Destination $ConfigPath -Force -ErrorAction Stop
+    } catch {
+        # Best-effort: a failed heal only costs the next start another probe.
+        if ($tmp -and (Test-Path -LiteralPath $tmp)) { Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+$Healed = $false
 
 if (-not (Test-NodeBinary $NodePath)) {
     $NodePath = Find-Node
@@ -147,15 +218,20 @@ if (-not (Test-NodeBinary $NodePath)) {
         Die 'node binary not found - install Node.js (nodejs.org / nvs / nvm-windows / volta) or set TRACE_MCP_NODE_OVERRIDE'
     }
     Write-LauncherLog "probe: node=$NodePath"
+    $Healed = $true
 }
 
 if (-not (Test-CliFile $CliPath)) {
     $CliPath = Find-Cli $NodePath
     if (-not $CliPath) {
-        Die "trace-mcp package not found for node=$NodePath - run: npm i -g trace-mcp && trace-mcp init"
+        Die 'trace-mcp package not found in any known npm prefix - run: npm i -g trace-mcp && trace-mcp init'
     }
     Write-LauncherLog "probe: cli=$CliPath"
+    $Healed = $true
 }
+
+# Overrides are a debugging escape hatch; never bake them into the config.
+if ($Healed -and -not $UsingOverride) { Save-LauncherConfig $NodePath $CliPath }
 
 Write-LauncherLog "exec(probe) node=$NodePath cli=$CliPath argc=$($args.Count)"
 & $NodePath $CliPath @args

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -178,14 +178,20 @@ pkg_roots() {
     [ -d "$root" ] && echo "$root"
   done
 
-  # Whatever npm itself calls the global root — catches custom prefixes
-  # (`npm config set prefix`) and bundled runtimes we don't know by name.
-  # Plain PATH lookup, no login shell: a slow or hanging shell profile must
-  # never stall an MCP handshake.
-  if command -v npm >/dev/null 2>&1; then
-    n=$(npm root -g 2>/dev/null | tail -1)
-    [ -n "$n" ] && [ -d "$n" ] && echo "$n"
+  # Custom prefixes (`npm config set prefix`) and bundled runtimes we don't
+  # know by name. Read from config, never by running `npm root -g`: the shim
+  # inherits the MCP client's PATH, which in a project directory can contain a
+  # repository-controlled `node_modules/.bin`, so spawning a PATH-resolved
+  # `npm` would turn a stale config into code execution from the opened repo
+  # (and could hang the handshake on top of that).
+  n="${NPM_CONFIG_PREFIX:-}"
+  if [ -z "$n" ] && [ -r "$HOME/.npmrc" ]; then
+    n=$(sed -n 's/^[[:space:]]*prefix[[:space:]]*=[[:space:]]*//p' "$HOME/.npmrc" | tail -1)
+    # Strip surrounding quotes and expand a leading ~ — npm accepts both.
+    n="${n%\"}"; n="${n#\"}"; n="${n%\'}"; n="${n#\'}"
+    case "$n" in '~'/*) n="$HOME/${n#\~/}" ;; esac
   fi
+  [ -n "$n" ] && [ -d "$n/lib/node_modules" ] && echo "$n/lib/node_modules"
 
   return 0
 }
@@ -234,12 +240,24 @@ probe_cli() {
 # Persist a freshly probed pair so the next start takes the fast path, and so
 # a client that never reaches `trace-mcp init` still stops paying for the probe.
 heal_config() {
-  local node="$1" cli="$2" tmp
+  local node="$1" cli="$2" tmp old_umask
   # The shim strips exactly one pair of quotes and never expands; a literal
   # quote in a path would corrupt the file, so skip rather than mangle.
   case "$node$cli" in *'"'*) return 0 ;; esac
-  mkdir -p "$TRACE_HOME" 2>/dev/null || return 0
+  # Never pin the config to a swap-window backup: that directory is about to
+  # be deleted, so the "fast path" it buys would be a dangling one.
+  case "$cli" in
+    *trace-mcp.tmcp-bak-*|*/.trace-mcp-*) return 0 ;;
+  esac
+  if [ ! -d "$TRACE_HOME" ]; then
+    mkdir -p "$TRACE_HOME" 2>/dev/null || return 0
+    chmod 700 "$TRACE_HOME" 2>/dev/null || true
+  fi
   tmp="$CONFIG.tmp.$$"
+  # launcher.env is a 0600 file by contract (src/init/launcher.ts). The
+  # process umask must not be allowed to widen it during a heal.
+  old_umask=$(umask)
+  umask 077
   {
     printf '# Managed by trace-mcp — do not edit by hand.\n'
     printf '# Rewritten by the launcher after a successful probe.\n'
@@ -249,6 +267,7 @@ heal_config() {
     # different build than the one the stale config described, and a wrong
     # version is worse than none. `trace-mcp init` restores it.
   } > "$tmp" 2>/dev/null && mv -f "$tmp" "$CONFIG" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+  umask "$old_umask"
   return 0
 }
 

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -9,9 +9,21 @@
 
 set -u
 
+# The shim inherits the MCP client's PATH, and a client started in a project
+# directory routinely carries that repository's `node_modules/.bin` on it. Every
+# helper this script runs (date, sed, head, ls, realpath, mv, ...) would
+# otherwise be resolvable to a repo-controlled executable. Pin PATH to system
+# directories for our own work and hand the client's PATH back to node right
+# before exec — the server itself needs it to find git, LSP servers and npm.
+CLIENT_PATH="$PATH"
+PATH=/usr/bin:/bin:/usr/sbin:/sbin
+export PATH
+
 TRACE_HOME="${TRACE_MCP_HOME:-$HOME/.trace}"
 CONFIG="$TRACE_HOME/launcher.env"
 LOG="$TRACE_HOME/launcher.log"
+# One global node_modules root per line, appended by each install.
+PKG_ROOTS_FILE="$TRACE_HOME/pkg-roots"
 
 log() {
   # Best-effort append; never abort on log failure.
@@ -58,6 +70,7 @@ if [ -n "${TRACE_MCP_CLI_OVERRIDE:-}"  ]; then CLI_PATH="$TRACE_MCP_CLI_OVERRIDE
 # --- 3. Fast path: config is good → exec directly ---
 if [ -n "$NODE_PATH" ] && [ -x "$NODE_PATH" ] && [ -n "$CLI_PATH" ] && [ -f "$CLI_PATH" ]; then
   log "exec(config) node=$NODE_PATH cli=$CLI_PATH argc=$#"
+  PATH="$CLIENT_PATH"
   exec "$NODE_PATH" "$CLI_PATH" "$@"
 fi
 
@@ -178,6 +191,23 @@ pkg_roots() {
     [ -d "$root" ] && echo "$root"
   done
 
+  # Roots recorded by past installs. This is how a prefix we cannot name in
+  # advance — a bundled runtime, a corporate `npm config set prefix` — becomes
+  # findable, without asking npm at runtime. Values are opaque paths, never
+  # evaluated; same trust model as launcher.env.
+  if [ -r "$PKG_ROOTS_FILE" ]; then
+    while IFS= read -r root || [ -n "$root" ]; do
+      case "$root" in ''|\#*) continue ;; esac
+      [ -d "$root" ] && echo "$root"
+    done < "$PKG_ROOTS_FILE"
+  fi
+
+  # Runtimes that bundle their own node and install us into it. Named here
+  # because their prefix is on no standard list and predates the registry
+  # above — an install under one of them now records itself too.
+  [ -d "$HOME/.hermes/node/lib/node_modules" ] &&
+    echo "$HOME/.hermes/node/lib/node_modules"
+
   # Custom prefixes (`npm config set prefix`) and bundled runtimes we don't
   # know by name. Read from config, never by running `npm root -g`: the shim
   # inherits the MCP client's PATH, which in a project directory can contain a
@@ -292,4 +322,5 @@ if [ "$HEALED" = 1 ] && [ "$USING_OVERRIDE" = 0 ]; then
 fi
 
 log "exec(probe) node=$NODE_PATH cli=$CLI_PATH argc=$#"
+PATH="$CLIENT_PATH"
 exec "$NODE_PATH" "$CLI_PATH" "$@"

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-# trace-mcp-launcher v0.3.0
+# trace-mcp-launcher v0.4.0
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
-# at runtime from a config file written by `trace-mcp init`, with a minimal
-# probe fallback for when the config is stale (e.g. Node was reinstalled).
+# at runtime from a config file written by `trace-mcp init`, with a probe
+# fallback for when the config is stale (e.g. Node was reinstalled, or the
+# global package moved to a different npm prefix).
 #
 # Managed by trace-mcp — do not edit by hand. Re-run `trace-mcp init` to refresh.
 
@@ -50,8 +51,9 @@ if [ -r "$CONFIG" ]; then
 fi
 
 # --- 2. Env overrides (escape hatch for debugging) ---
-if [ -n "${TRACE_MCP_NODE_OVERRIDE:-}" ]; then NODE_PATH="$TRACE_MCP_NODE_OVERRIDE"; fi
-if [ -n "${TRACE_MCP_CLI_OVERRIDE:-}"  ]; then CLI_PATH="$TRACE_MCP_CLI_OVERRIDE";   fi
+USING_OVERRIDE=0
+if [ -n "${TRACE_MCP_NODE_OVERRIDE:-}" ]; then NODE_PATH="$TRACE_MCP_NODE_OVERRIDE"; USING_OVERRIDE=1; fi
+if [ -n "${TRACE_MCP_CLI_OVERRIDE:-}"  ]; then CLI_PATH="$TRACE_MCP_CLI_OVERRIDE";   USING_OVERRIDE=1; fi
 
 # --- 3. Fast path: config is good → exec directly ---
 if [ -n "$NODE_PATH" ] && [ -x "$NODE_PATH" ] && [ -n "$CLI_PATH" ] && [ -f "$CLI_PATH" ]; then
@@ -137,32 +139,137 @@ probe_node() {
   return 1
 }
 
-probe_cli() {
-  # Standard layout across nvm/Herd/brew/npm: dist/cli.js sits under
-  # <node_prefix>/lib/node_modules/trace-mcp/dist/cli.js
-  local node_bin="$1"
-  local candidate
-  candidate="$(dirname "$node_bin")/../lib/node_modules/trace-mcp/dist/cli.js"
-  if [ -f "$candidate" ]; then
-    # Normalise the .. path for cleaner logging (best-effort; leave as-is if realpath is missing)
-    if command -v realpath >/dev/null 2>&1; then
-      realpath "$candidate" 2>/dev/null || echo "$candidate"
-    else
-      echo "$candidate"
-    fi
-    return 0
+# Print every global `node_modules` root worth searching, one per line,
+# most-likely-first.
+#
+# Node and cli.js are resolved INDEPENDENTLY on purpose: any working node can
+# run any cli.js. Tying the package lookup to the prefix of the selected node
+# (the pre-v0.4.0 behaviour) killed the server whenever the two lived in
+# different prefixes — the single largest source of launcher failures.
+#
+# $1 (optional): the node binary we are about to use; its own prefix is tried
+# first, since that is the pair `trace-mcp init` recorded.
+pkg_roots() {
+  local n fnm_dir root
+  if [ -n "${1:-}" ]; then
+    echo "$(dirname "$1")/../lib/node_modules"
   fi
+
+  # Version-manager prefixes first: that is where `npm i -g` lands for nvm /
+  # Herd / fnm / Volta users, which is most of them.
+  if n=$(node_from_nvm_tree "$HOME/.nvm"); then
+    echo "$(dirname "$n")/../lib/node_modules"
+  fi
+  if n=$(node_from_nvm_tree "$HOME/Library/Application Support/Herd/config/nvm"); then
+    echo "$(dirname "$n")/../lib/node_modules"
+  fi
+  for fnm_dir in \
+    "$HOME/.local/share/fnm/aliases/default" \
+    "$HOME/.fnm/aliases/default" \
+    "$HOME/Library/Application Support/fnm/aliases/default"; do
+    [ -d "$fnm_dir/lib/node_modules" ] && echo "$fnm_dir/lib/node_modules"
+  done
+  # Volta keeps each global package under its own image directory.
+  [ -d "$HOME/.volta/tools/image/packages/trace-mcp/lib/node_modules" ] &&
+    echo "$HOME/.volta/tools/image/packages/trace-mcp/lib/node_modules"
+
+  # System prefixes.
+  for root in /opt/homebrew/lib/node_modules /usr/local/lib/node_modules; do
+    [ -d "$root" ] && echo "$root"
+  done
+
+  # Whatever npm itself calls the global root — catches custom prefixes
+  # (`npm config set prefix`) and bundled runtimes we don't know by name.
+  # Plain PATH lookup, no login shell: a slow or hanging shell profile must
+  # never stall an MCP handshake.
+  if command -v npm >/dev/null 2>&1; then
+    n=$(npm root -g 2>/dev/null | tail -1)
+    [ -n "$n" ] && [ -d "$n" ] && echo "$n"
+  fi
+
+  return 0
+}
+
+# Normalise a `..`-containing path for cleaner logging and config rewrites.
+# Best-effort: leave it as-is when realpath is unavailable.
+normalise_path() {
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$1" 2>/dev/null || echo "$1"
+  else
+    echo "$1"
+  fi
+}
+
+# Find dist/cli.js in any known global root. $1 = roots, newline-separated.
+probe_cli() {
+  local roots="$1" root cli bak
+
+  while IFS= read -r root; do
+    [ -n "$root" ] || continue
+    cli="$root/trace-mcp/dist/cli.js"
+    if [ -f "$cli" ]; then
+      normalise_path "$cli"
+      return 0
+    fi
+  done <<< "$roots"
+
+  # Last resort: an update is swapping the package right this second. Both npm
+  # and our own updater rename the live directory aside before unpacking the
+  # new one, so a stale-but-working copy is on disk for the length of the
+  # window. Serving the previous version beats losing every tool for the
+  # rest of the client's session.
+  while IFS= read -r root; do
+    [ -n "$root" ] || continue
+    for bak in "$root"/trace-mcp.tmcp-bak-* "$root"/.trace-mcp-*; do
+      if [ -f "$bak/dist/cli.js" ]; then
+        normalise_path "$bak/dist/cli.js"
+        return 0
+      fi
+    done
+  done <<< "$roots"
+
   return 1
 }
+
+# Persist a freshly probed pair so the next start takes the fast path, and so
+# a client that never reaches `trace-mcp init` still stops paying for the probe.
+heal_config() {
+  local node="$1" cli="$2" tmp
+  # The shim strips exactly one pair of quotes and never expands; a literal
+  # quote in a path would corrupt the file, so skip rather than mangle.
+  case "$node$cli" in *'"'*) return 0 ;; esac
+  mkdir -p "$TRACE_HOME" 2>/dev/null || return 0
+  tmp="$CONFIG.tmp.$$"
+  {
+    printf '# Managed by trace-mcp — do not edit by hand.\n'
+    printf '# Rewritten by the launcher after a successful probe.\n'
+    printf 'TRACE_MCP_NODE="%s"\n' "$node"
+    printf 'TRACE_MCP_CLI="%s"\n' "$cli"
+    # TRACE_MCP_VERSION is deliberately dropped: the probed cli.js may be a
+    # different build than the one the stale config described, and a wrong
+    # version is worse than none. `trace-mcp init` restores it.
+  } > "$tmp" 2>/dev/null && mv -f "$tmp" "$CONFIG" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+  return 0
+}
+
+HEALED=0
 
 if [ -z "$NODE_PATH" ] || [ ! -x "$NODE_PATH" ]; then
   NODE_PATH=$(probe_node) || die "node binary not found — install Node.js (brew install node / nvm / volta) or set TRACE_MCP_NODE_OVERRIDE"
   log "probe: node=$NODE_PATH"
+  HEALED=1
 fi
 
 if [ -z "$CLI_PATH" ] || [ ! -f "$CLI_PATH" ]; then
-  CLI_PATH=$(probe_cli "$NODE_PATH") || die "trace-mcp package not found next to node=$NODE_PATH — run: npm i -g trace-mcp && trace-mcp init"
+  ROOTS=$(pkg_roots "$NODE_PATH")
+  CLI_PATH=$(probe_cli "$ROOTS") || die "trace-mcp package not found in any known npm prefix — run: npm i -g trace-mcp && trace-mcp init"
   log "probe: cli=$CLI_PATH"
+  HEALED=1
+fi
+
+# Overrides are a debugging escape hatch; never bake them into the config.
+if [ "$HEALED" = 1 ] && [ "$USING_OVERRIDE" = 0 ]; then
+  heal_config "$NODE_PATH" "$CLI_PATH"
 fi
 
 log "exec(probe) node=$NODE_PATH cli=$CLI_PATH argc=$#"

--- a/scripts/postinstall-control-plane.mjs
+++ b/scripts/postinstall-control-plane.mjs
@@ -107,6 +107,9 @@ const TRACE_MCP_HOME = (() => {
 const LOG_PATH = path.join(TRACE_MCP_HOME, 'postinstall.log');
 const LAUNCHER_DIR = path.join(TRACE_MCP_HOME, 'bin');
 const LAUNCHER_ENV_PATH = path.join(TRACE_MCP_HOME, 'launcher.env');
+const PKG_ROOTS_PATH = path.join(TRACE_MCP_HOME, 'pkg-roots');
+/** Keep in sync with src/init/launcher.ts::MAX_PKG_ROOTS. */
+const MAX_PKG_ROOTS = 10;
 const DAEMON_LOG_PATH = path.join(TRACE_MCP_HOME, 'daemon.log');
 // Opt-out sentinel (#202) — keep in sync with src/global.ts::DAEMON_DISABLED_PATH.
 const DAEMON_DISABLED_PATH = path.join(TRACE_MCP_HOME, 'daemon.disabled');
@@ -199,6 +202,27 @@ function writeLauncherEnv(nodePath, cliPath, version) {
     '',
   ];
   atomicWrite(LAUNCHER_ENV_PATH, lines.join('\n'), 0o600);
+  recordPkgRoot(cliPath);
+}
+
+// Mirror src/init/launcher.ts::recordPkgRoot. Remembers the global
+// node_modules root this install landed in, so the shim can still find
+// dist/cli.js there once launcher.env goes stale. Prefixes we cannot
+// enumerate — bundled runtimes, `npm config set prefix` — only become
+// findable this way; the shim is not allowed to ask npm at runtime.
+function recordPkgRoot(cliPath) {
+  const root = path.resolve(path.dirname(cliPath), '..', '..');
+  if (path.basename(root) !== 'node_modules') return;
+  try {
+    const existing = (fs.existsSync(PKG_ROOTS_PATH) ? fs.readFileSync(PKG_ROOTS_PATH, 'utf-8') : '')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('#'));
+    if (existing.includes(root)) return;
+    atomicWrite(PKG_ROOTS_PATH, `${[...existing, root].slice(-MAX_PKG_ROOTS).join('\n')}\n`, 0o600);
+  } catch {
+    /* best-effort — a missed record only costs the shim a probe */
+  }
 }
 
 // Legacy (pre-TRA-611) primary shim basename — used only to install the

--- a/src/init/launcher.ts
+++ b/src/init/launcher.ts
@@ -26,6 +26,9 @@ import { LAUNCHER_VERSION } from './types.js';
 
 const IS_WINDOWS = process.platform === 'win32';
 
+/** Upper bound on remembered package roots — keeps the shim's probe O(small). */
+const MAX_PKG_ROOTS = 10;
+
 // Artifacts shipped from hooks/ and installed under $TRACE_MCP_HOME/bin/.
 // On Unix a single shim file carries the resolution logic; on Windows a
 // .cmd shim is what MCP clients spawn, but the actual logic lives in a
@@ -195,6 +198,39 @@ export function readLauncherConfig(): Partial<LauncherConfig> {
   return result;
 }
 
+export function getPkgRootsPath(): string {
+  return path.join(getLauncherDir(), 'pkg-roots');
+}
+
+/**
+ * Record the global `node_modules` root this build was installed into, so the
+ * shim can find `dist/cli.js` there later even when launcher.env has gone
+ * stale. Prefixes we cannot enumerate — bundled runtimes, corporate
+ * `npm config set prefix` — only become findable this way, and the shim is not
+ * allowed to ask npm at runtime (it inherits the MCP client's PATH, which in a
+ * project directory can carry a repo-controlled `node_modules/.bin`).
+ *
+ * Append-only, deduplicated, capped: an entry costs one `-d` test per start.
+ */
+export function recordPkgRoot(cliPath: string): void {
+  // <root>/trace-mcp/dist/cli.js → <root>
+  const root = path.resolve(path.dirname(cliPath), '..', '..');
+  if (path.basename(root) !== 'node_modules') return;
+  const file = getPkgRootsPath();
+  try {
+    const existing = (readIfExists(file) ?? '')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('#'));
+    if (existing.includes(root)) return;
+    const next = [...existing, root].slice(-MAX_PKG_ROOTS);
+    ensureDir(path.dirname(file));
+    atomicWriteString(file, `${next.join('\n')}\n`, { mode: 0o600, rejectSymlinks: true });
+  } catch {
+    /* best-effort — a missed record only costs the shim a probe */
+  }
+}
+
 export interface InstallLauncherOpts {
   dryRun?: boolean;
   force?: boolean;
@@ -333,6 +369,7 @@ export function setupLauncher(
       cli: resolveCurrentCliPath(),
       version: opts.pkgVersion,
     };
+    recordPkgRoot(cfg.cli);
     const existing = readLauncherConfig();
     const unchanged =
       existing.node === cfg.node && existing.cli === cfg.cli && existing.version === cfg.version;

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -99,4 +99,4 @@ export const SESSION_START_HOOK_VERSION = '0.2.0';
 export const USER_PROMPT_SUBMIT_HOOK_VERSION = '0.2.0';
 export const STOP_HOOK_VERSION = '0.2.0';
 export const SESSION_END_HOOK_VERSION = '0.2.0';
-export const LAUNCHER_VERSION = '0.3.0';
+export const LAUNCHER_VERSION = '0.4.0';

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -144,6 +144,103 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
     expect(log).toContain(`cli=${cli}`);
   });
 
+  // TRA-701: node and cli.js must resolve independently. Before v0.4.0 the cli
+  // was only ever looked for next to the selected node, so a machine with the
+  // package in a different npm prefix lost the MCP server outright (3576 fatal
+  // launcher errors in the field).
+  describe('cli.js resolves independently of the selected node', () => {
+    // Plants an nvm-layout tree under the fake HOME holding node + the package,
+    // so the probe has a prefix to find that is NOT the configured node's.
+    function plantNvmPackage(home: string, cliBody = '// fake cli\n'): string {
+      const version = 'v22.22.2';
+      const prefix = path.join(home, '.nvm', 'versions', 'node', version);
+      fs.mkdirSync(path.join(prefix, 'bin'), { recursive: true });
+      fs.writeFileSync(path.join(prefix, 'bin', 'node'), '#!/bin/bash\nexit 1\n', { mode: 0o755 });
+      fs.mkdirSync(path.join(home, '.nvm', 'alias'), { recursive: true });
+      fs.writeFileSync(path.join(home, '.nvm', 'alias', 'default'), `${version}\n`);
+      const pkgDir = path.join(prefix, 'lib', 'node_modules', 'trace-mcp', 'dist');
+      fs.mkdirSync(pkgDir, { recursive: true });
+      const cli = path.join(pkgDir, 'cli.js');
+      fs.writeFileSync(cli, cliBody);
+      // The launcher normalises probed paths through realpath; on macOS the
+      // temp dir lives behind the /var → /private/var symlink, so compare
+      // against the resolved form.
+      return fs.realpathSync(cli);
+    }
+
+    it('finds the package in another prefix when the configured node has none', () => {
+      const { home, traceHome, node } = setupFakeHome();
+      const otherCli = plantNvmPackage(home);
+      // Configured node is fine; its own prefix carries no trace-mcp package.
+      writeConfig(traceHome, node, path.join(home, 'gone', 'cli.js'));
+
+      const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${otherCli} serve`);
+    });
+
+    it('rewrites launcher.env with the probed pair so the next start is fast', () => {
+      const { home, traceHome, node } = setupFakeHome();
+      const otherCli = plantNvmPackage(home);
+      writeConfig(traceHome, node, path.join(home, 'gone', 'cli.js'));
+
+      runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      const cfg = fs.readFileSync(path.join(traceHome, 'launcher.env'), 'utf-8');
+      expect(cfg).toContain(`TRACE_MCP_NODE="${node}"`);
+      expect(cfg).toContain(`TRACE_MCP_CLI="${otherCli}"`);
+      // Header must keep the trusted-emitter provenance marker (env-classifier).
+      expect(cfg.split('\n')[0]).toMatch(/^# Managed by trace-mcp\b/);
+      // Second run now takes the config fast path.
+      const { stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${otherCli} serve`);
+      expect(fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8')).toContain(
+        'exec(config)',
+      );
+    });
+
+    it('does not persist env overrides into launcher.env', () => {
+      const { home, traceHome, node, cli } = setupFakeHome();
+      // No config at all — overrides carry the run.
+      const { status } = runLauncher(
+        {
+          HOME: home,
+          TRACE_MCP_HOME: traceHome,
+          TRACE_MCP_NODE_OVERRIDE: node,
+          TRACE_MCP_CLI_OVERRIDE: cli,
+        },
+        ['serve'],
+      );
+
+      expect(status).toBe(0);
+      expect(fs.existsSync(path.join(traceHome, 'launcher.env'))).toBe(false);
+    });
+
+    it('survives the npm swap window via the renamed-aside package dir', () => {
+      const { home, traceHome, node } = setupFakeHome();
+      // Package root exists but `trace-mcp/` is mid-rename: only the backup
+      // directory our updater leaves behind is on disk.
+      const root = path.join(home, '.nvm', 'versions', 'node', 'v22.22.2', 'lib', 'node_modules');
+      const bakDir = path.join(root, 'trace-mcp.tmcp-bak-4242', 'dist');
+      fs.mkdirSync(bakDir, { recursive: true });
+      fs.writeFileSync(path.join(bakDir, 'cli.js'), '// previous version\n');
+      const bakCli = fs.realpathSync(path.join(bakDir, 'cli.js'));
+      fs.mkdirSync(path.join(home, '.nvm', 'alias'), { recursive: true });
+      fs.writeFileSync(path.join(home, '.nvm', 'alias', 'default'), 'v22.22.2\n');
+      const nvmBin = path.join(home, '.nvm', 'versions', 'node', 'v22.22.2', 'bin');
+      fs.mkdirSync(nvmBin, { recursive: true });
+      fs.writeFileSync(path.join(nvmBin, 'node'), '#!/bin/bash\nexit 1\n', { mode: 0o755 });
+
+      writeConfig(traceHome, node, path.join(root, 'trace-mcp', 'dist', 'cli.js'));
+
+      const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${bakCli} serve`);
+    });
+  });
+
   it('stale config (broken paths) falls through to probe and still errors cleanly', () => {
     const { home, traceHome } = setupFakeHome();
     writeConfig(traceHome, '/nonexistent/node', '/nonexistent/cli.js');

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -258,27 +258,81 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
       expect(mode).toBe(0o600);
     });
 
-    it('never executes an npm found on PATH', () => {
-      const { home, traceHome, node } = setupFakeHome();
-      plantNvmPackage(home);
-      // A repository-controlled `node_modules/.bin` is a normal thing to find
-      // on an MCP client's PATH. Resolving the global prefix must not run it.
-      const hostileBin = path.join(home, 'hostile-bin');
-      fs.mkdirSync(hostileBin, { recursive: true });
-      const sentinel = path.join(home, 'NPM_WAS_RUN');
-      fs.writeFileSync(path.join(hostileBin, 'npm'), `#!/bin/bash\ntouch ${sentinel}\n`, {
-        mode: 0o755,
-      });
-      writeConfig(traceHome, node, path.join(home, 'gone', 'cli.js'));
+    // A repository-controlled `node_modules/.bin` is a normal thing to sit on
+    // an MCP client's PATH. None of the helpers the shim runs may resolve to it.
+    it.each(['npm', 'sed', 'date', 'head', 'ls', 'realpath', 'mv', 'dirname'])(
+      'never executes a hostile %s found on PATH',
+      (helper) => {
+        const { home, traceHome, node } = setupFakeHome();
+        plantNvmPackage(home);
+        const hostileBin = path.join(home, `hostile-bin-${helper}`);
+        fs.mkdirSync(hostileBin, { recursive: true });
+        const sentinel = path.join(home, `RAN_${helper}`);
+        fs.writeFileSync(path.join(hostileBin, helper), `#!/bin/bash\ntouch ${sentinel}\n`, {
+          mode: 0o755,
+        });
+        // A prefix line makes the shim read ~/.npmrc, exercising that branch too.
+        fs.writeFileSync(path.join(home, '.npmrc'), `prefix=${path.join(home, 'nowhere')}\n`);
+        writeConfig(traceHome, node, path.join(home, 'gone', 'cli.js'));
+
+        const result = spawnSync(LAUNCHER_SRC, ['serve'], {
+          env: { HOME: home, TRACE_MCP_HOME: traceHome, PATH: `${hostileBin}:/usr/bin:/bin` },
+          encoding: 'utf-8',
+          timeout: 5000,
+        });
+
+        expect(result.status).toBe(0);
+        expect(fs.existsSync(sentinel)).toBe(false);
+      },
+    );
+
+    it('hands the client PATH back to node, not the sanitised one', () => {
+      const { home, traceHome, cli } = setupFakeHome();
+      // The server itself needs the client's PATH to find git, LSP servers, npm.
+      const node = path.join(home, 'path-echo-node');
+      fs.writeFileSync(node, '#!/bin/bash\necho "NODE_PATH_ENV:$PATH"\n', { mode: 0o755 });
+      writeConfig(traceHome, node, cli);
 
       const result = spawnSync(LAUNCHER_SRC, ['serve'], {
-        env: { HOME: home, TRACE_MCP_HOME: traceHome, PATH: `${hostileBin}:/usr/bin:/bin` },
+        env: { HOME: home, TRACE_MCP_HOME: traceHome, PATH: '/client/bin:/usr/bin:/bin' },
         encoding: 'utf-8',
         timeout: 5000,
       });
 
-      expect(result.status).toBe(0);
-      expect(fs.existsSync(sentinel)).toBe(false);
+      expect(result.stdout.trim()).toBe('NODE_PATH_ENV:/client/bin:/usr/bin:/bin');
+    });
+
+    it('finds the package in a bundled runtime prefix recorded by a past install', () => {
+      const { home, traceHome, node } = setupFakeHome();
+      // Prefixes like this are on no standard list — the only way the shim can
+      // know about them is the registry each install appends to.
+      const root = path.join(home, 'some-bundled-runtime', 'node', 'lib', 'node_modules');
+      fs.mkdirSync(path.join(root, 'trace-mcp', 'dist'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'trace-mcp', 'dist', 'cli.js'), '// bundled cli\n');
+      const cli = fs.realpathSync(path.join(root, 'trace-mcp', 'dist', 'cli.js'));
+      fs.writeFileSync(path.join(traceHome, 'pkg-roots'), `# recorded by install\n${root}\n`);
+      writeConfig(traceHome, node, path.join(home, 'gone', 'cli.js'));
+
+      const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+    });
+
+    it('finds the package in a Hermes bundled node prefix', () => {
+      const { home, traceHome, node } = setupFakeHome();
+      // The prefix on the machine that reported TRA-701: node bundled by the
+      // runtime, package installed into it, named by no standard layout.
+      const dist = path.join(home, '.hermes', 'node', 'lib', 'node_modules', 'trace-mcp', 'dist');
+      fs.mkdirSync(dist, { recursive: true });
+      fs.writeFileSync(path.join(dist, 'cli.js'), '// hermes cli\n');
+      const cli = fs.realpathSync(path.join(dist, 'cli.js'));
+      writeConfig(traceHome, node, path.join(home, 'gone', 'cli.js'));
+
+      const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
     });
 
     it('honours a custom npm prefix from ~/.npmrc without running npm', () => {

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -238,6 +238,63 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
 
       expect(status).toBe(0);
       expect(stdout.trim()).toBe(`NODE_ARGS:${bakCli} serve`);
+      // The backup directory is about to be deleted — pinning the config to it
+      // would only buy a dangling fast path on the next start.
+      expect(fs.existsSync(path.join(traceHome, 'launcher.env'))).toBe(true);
+      expect(fs.readFileSync(path.join(traceHome, 'launcher.env'), 'utf-8')).not.toContain(
+        'tmcp-bak',
+      );
+    });
+
+    it.skipIf(process.platform === 'win32')('keeps the healed launcher.env at 0600', () => {
+      const { home, traceHome, node } = setupFakeHome();
+      plantNvmPackage(home);
+      writeConfig(traceHome, node, path.join(home, 'gone', 'cli.js'));
+      fs.chmodSync(path.join(traceHome, 'launcher.env'), 0o600);
+
+      runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      const mode = fs.statSync(path.join(traceHome, 'launcher.env')).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+
+    it('never executes an npm found on PATH', () => {
+      const { home, traceHome, node } = setupFakeHome();
+      plantNvmPackage(home);
+      // A repository-controlled `node_modules/.bin` is a normal thing to find
+      // on an MCP client's PATH. Resolving the global prefix must not run it.
+      const hostileBin = path.join(home, 'hostile-bin');
+      fs.mkdirSync(hostileBin, { recursive: true });
+      const sentinel = path.join(home, 'NPM_WAS_RUN');
+      fs.writeFileSync(path.join(hostileBin, 'npm'), `#!/bin/bash\ntouch ${sentinel}\n`, {
+        mode: 0o755,
+      });
+      writeConfig(traceHome, node, path.join(home, 'gone', 'cli.js'));
+
+      const result = spawnSync(LAUNCHER_SRC, ['serve'], {
+        env: { HOME: home, TRACE_MCP_HOME: traceHome, PATH: `${hostileBin}:/usr/bin:/bin` },
+        encoding: 'utf-8',
+        timeout: 5000,
+      });
+
+      expect(result.status).toBe(0);
+      expect(fs.existsSync(sentinel)).toBe(false);
+    });
+
+    it('honours a custom npm prefix from ~/.npmrc without running npm', () => {
+      const { home, traceHome, node } = setupFakeHome();
+      const prefix = path.join(home, 'custom-prefix');
+      const pkgDir = path.join(prefix, 'lib', 'node_modules', 'trace-mcp', 'dist');
+      fs.mkdirSync(pkgDir, { recursive: true });
+      fs.writeFileSync(path.join(pkgDir, 'cli.js'), '// custom prefix cli\n');
+      const cli = fs.realpathSync(path.join(pkgDir, 'cli.js'));
+      fs.writeFileSync(path.join(home, '.npmrc'), `prefix=${prefix}\n`);
+      writeConfig(traceHome, node, path.join(home, 'gone', 'cli.js'));
+
+      const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
     });
   });
 

--- a/tests/init/launcher.test.ts
+++ b/tests/init/launcher.test.ts
@@ -212,3 +212,30 @@ describe('Windows launcher .cmd template', () => {
     expect(body.indexOf('-WindowStyle Hidden')).toBeLessThan(body.indexOf('-File'));
   });
 });
+
+describe('Windows launcher .ps1 package roots', () => {
+  // Static content check: the .ps1 only runs on win32 runners, but the set of
+  // roots it searches is the whole point of TRA-701 and must not silently
+  // drift away from the POSIX shim's.
+  const body = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'hooks', 'trace-mcp-launcher.ps1'),
+    'utf-8',
+  );
+
+  it('searches the npm-global, Volta image and custom-prefix roots', () => {
+    expect(body).toContain("Join-Path $env:APPDATA 'npm\\node_modules'");
+    expect(body).toContain('Volta\\tools\\image\\packages\\trace-mcp\\lib\\node_modules');
+    expect(body).toContain('$env:NPM_CONFIG_PREFIX');
+    expect(body).toContain(".npmrc'");
+  });
+
+  it('resolves the custom prefix from config, never by spawning npm', () => {
+    // Same reason as the POSIX shim: the launcher inherits the MCP client's
+    // PATH, which in a project directory can carry a repo-controlled npm.
+    expect(body).not.toMatch(/npm\s+root\s+-g/);
+  });
+
+  it('does not pin launcher.env to a swap-window backup directory', () => {
+    expect(body).toContain('tmcp-bak-');
+  });
+});

--- a/tests/init/launcher.test.ts
+++ b/tests/init/launcher.test.ts
@@ -6,7 +6,9 @@ import {
   getLauncherConfigPath,
   getLauncherDir,
   getLauncherPath,
+  getPkgRootsPath,
   installLauncher,
+  recordPkgRoot,
   readInstalledLauncherVersion,
   readLauncherConfig,
   resolveCurrentCliPath,
@@ -198,6 +200,44 @@ describe('setupLauncher (install + config)', () => {
   });
 });
 
+describe('recordPkgRoot', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkTmpHome();
+  });
+  afterEach(() => {
+    delete process.env.TRACE_MCP_HOME;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const rootsOf = () =>
+    fs
+      .readFileSync(getPkgRootsPath(), 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim());
+
+  it('records the node_modules root the cli was installed into', () => {
+    recordPkgRoot('/opt/homebrew/lib/node_modules/trace-mcp/dist/cli.js');
+    expect(rootsOf()).toEqual(['/opt/homebrew/lib/node_modules']);
+  });
+
+  it('deduplicates and caps the list', () => {
+    for (let i = 0; i < 14; i++) {
+      recordPkgRoot(`/prefix${i}/lib/node_modules/trace-mcp/dist/cli.js`);
+    }
+    recordPkgRoot('/prefix13/lib/node_modules/trace-mcp/dist/cli.js');
+    const roots = rootsOf();
+    expect(roots).toHaveLength(10);
+    expect(roots.at(-1)).toBe('/prefix13/lib/node_modules');
+    expect(new Set(roots).size).toBe(10);
+  });
+
+  it('ignores a cli path that is not under a node_modules root', () => {
+    recordPkgRoot('/somewhere/dist/cli.js');
+    expect(fs.existsSync(getPkgRootsPath())).toBe(false);
+  });
+});
+
 describe('Windows launcher .cmd template', () => {
   // Static content check — runs on every platform since it just reads the
   // template file, not a spawned process. The cmd->powershell hop does not
@@ -227,6 +267,7 @@ describe('Windows launcher .ps1 package roots', () => {
     expect(body).toContain('Volta\\tools\\image\\packages\\trace-mcp\\lib\\node_modules');
     expect(body).toContain('$env:NPM_CONFIG_PREFIX');
     expect(body).toContain(".npmrc'");
+    expect(body).toContain("'pkg-roots'");
   });
 
   it('resolves the custom prefix from config, never by spawning npm', () => {


### PR DESCRIPTION
Fixes TRA-701.

## The bug

`probe_cli()` in the launcher shim looked for `dist/cli.js` at exactly one path — `$(dirname "$node_bin")/../lib/node_modules/trace-mcp/dist/cli.js`. If the node it had just selected belonged to a prefix where the global package is not installed, the launcher called `die` with exit 127, even though a perfectly good `cli.js` was sitting in a neighbouring prefix at that moment.

MCP clients do not reconnect. Every one of those exits cost an agent all of its tools for the rest of the session — the exact `Read`/`Grep` mode this product exists to replace. `launcher.log` on the reporting machine holds 3576 such fatal errors, 376 of them on 2026-09-02 alone.

Reproduced live on that machine after the fix: config pointing at a dead node, package present only in the Herd prefix — the launcher now pairs `~/.nvm/.../bin/node` with the Herd `cli.js` and starts. Before, that combination was a guaranteed 127.

## What changed

`hooks/trace-mcp-launcher.sh` and `hooks/trace-mcp-launcher.ps1`, launcher `v0.3.0` → `v0.4.0`:

1. **Node and `cli.js` resolve independently.** Any working node runs any `cli.js`, so the package is now searched across every global root we know: the selected node's own prefix first, then version-manager prefixes (nvm, Herd, fnm, Volta), then system prefixes, then whatever `npm root -g` reports — which is what catches custom prefixes and bundled runtimes we cannot name in advance. `npm` is looked up on `PATH` only, never through a login shell: a slow shell profile must not stall an MCP handshake.
2. **Update-swap window.** Both npm and our own updater rename the live package directory aside before unpacking the new one, so a client starting inside that window used to get a 127. The probe now falls back to `trace-mcp.tmcp-bak-*` / npm's `.trace-mcp-*` scratch directory. Serving the previous build beats losing the server for the length of the install.
3. **Self-healing.** A successful probe rewrites `launcher.env`, so the next start takes the fast path instead of paying for the probe again. Env overrides (`TRACE_MCP_*_OVERRIDE`) are never persisted — they are a debugging escape hatch. `TRACE_MCP_VERSION` is dropped rather than carried over, because the probed build may differ from the one the stale config named and a wrong version is worse than none; `trace-mcp init` restores it.

## Tests

Four new cases in `tests/init/launcher-integration.test.ts`, all of which fail against the v0.3.0 shim:

- package present only in a different prefix than the configured node → starts, and execs the cross-prefix `cli.js`
- `launcher.env` is rewritten with the probed pair, keeps the `# Managed by trace-mcp` provenance header, and the second run logs `exec(config)`
- overrides are not written into `launcher.env`
- package directory mid-rename → resolves through the backup directory

Full suite green (9665 passed), `tsc --noEmit` and `biome ci` clean, `pnpm run build` succeeds.

## Not in this PR

- **Own copy of `cli.js` under `$TRACE_MCP_HOME`** (item 2 of the issue). `dist/cli.js` is bundled but keeps native modules external and resolves them relative to its own location, so a bare copy of `dist/` would not run — a working copy means vendoring the whole package including `node_modules`. The swap-window fallback above covers the failure it was meant to cover, at a fraction of the cost.
- **Atomic update via symlink** (item 5). `npm i -g` is not ours to make atomic; the updater already does a rename-aside swap, and the launcher now reads through it.
- **Not recording ephemeral runtimes in `launcher.env`** (item 4). Once node and `cli.js` are decoupled, an ephemeral node in the config is no longer harmful: if it still exists it works, and if it vanishes the shim probes a stable one and heals the config. Adding a heuristic for "ephemeral" would be guessing at a problem that no longer bites.
- **`npm-root:mismatch` and the electron-updater crash** (item 6) are desktop-app diagnostics on a separate 10-minute timer, filed separately along with the adjacent items from the issue.

Agent: Lead Engineer
