### PR TITLE
feat(app): WindowTabBar becomes a real tab bar (TRA-700)

### DIFF
--- a/packages/app/src/main/__tests__/menu.test.ts
+++ b/packages/app/src/main/__tests__/menu.test.ts
@@ -95,9 +95,32 @@ describe('application menu', () => {
     expect(keys.get('Quick open…')).toBe('CmdOrCtrl+Shift+O');
     expect(keys.get('Open project…')).toBe('CmdOrCtrl+O');
     expect(keys.get('New window')).toBe('CmdOrCtrl+N');
-    expect(keys.get('Close tab')).toBe('CmdOrCtrl+W');
     expect(keys.get('Close window')).toBe('CmdOrCtrl+Shift+W');
     expect(keys.get('Reload')).toBe('CmdOrCtrl+R');
+  });
+
+  /* TRA-700: one BrowserWindow for the whole app now, so `role: 'close'` on
+     CmdOrCtrl+W would close the app's only window instead of a tab. The
+     renderer's own keydown handler (App.tsx) owns CmdOrCtrl+W and
+     CmdOrCtrl+1…9 outright — nothing here may accelerate either, or the two
+     handlers would double-fire on the same keypress. */
+  it('leaves CmdOrCtrl+W and CmdOrCtrl+1…9 unaccelerated — the renderer owns them', () => {
+    setWindowSections(1, [
+      { id: 'overview', label: 'Overview' },
+      { id: 'ask', label: 'Ask' },
+      { id: 'graph', label: 'Graph' },
+    ]);
+    buildAppMenu();
+    const keys = accelerators();
+    expect(keys.get('Close tab')).toBeUndefined();
+    for (const value of keys.values()) {
+      expect(value).not.toMatch(/^CmdOrCtrl\+[1-9]$/);
+    }
+  });
+
+  it('still lets a mouse close the active tab, routed through app-command', () => {
+    click(menu('File'), 'Close tab');
+    expect(sent).toEqual([{ command: 'close-tab' }]);
   });
 
   /* TRA-363: the sidebar's app menu offers the same four actions. Both lists
@@ -133,7 +156,11 @@ describe('application menu', () => {
     expect(sent).toEqual([{ command: 'toggle-sidebar' }, { command: 'find' }]);
   });
 
-  it('numbers the focused window’s own sections ⌘1…⌘n', () => {
+  /* TRA-700: the View menu still lists the focused window's own sections by
+     name — clicking one still works — it just no longer carries a ⌘-number
+     of its own. Selecting a tab's section by number is now the renderer's
+     CmdOrCtrl+1…9 keydown handler (App.tsx), covered in tab-shell.test.tsx. */
+  it('lists the focused window’s own sections, by label, still clickable', () => {
     setWindowSections(1, [
       { id: 'overview', label: 'Overview' },
       { id: 'ask', label: 'Ask' },
@@ -141,21 +168,11 @@ describe('application menu', () => {
     ]);
     buildAppMenu();
     const view = menu('View');
-    expect(view.find((i) => i.label === 'Overview')?.accelerator).toBe('CmdOrCtrl+1');
-    expect(view.find((i) => i.label === 'Graph')?.accelerator).toBe('CmdOrCtrl+3');
+    expect(view.find((i) => i.label === 'Overview')).toBeTruthy();
+    expect(view.find((i) => i.label === 'Graph')).toBeTruthy();
 
     click(view, 'Graph');
     expect(sent).toEqual([{ command: 'select-section', arg: 3 }]);
-  });
-
-  it('caps the section list at the nine keys that exist', () => {
-    setWindowSections(
-      1,
-      Array.from({ length: 12 }, (_, i) => ({ id: `s${i}`, label: `Section ${i}` })),
-    );
-    buildAppMenu();
-    const numbered = menu('View').filter((i) => /^CmdOrCtrl\+\d$/.test(i.accelerator ?? ''));
-    expect(numbered).toHaveLength(9);
   });
 
   it('shows no section items for a window that never reported any', () => {

--- a/packages/app/src/main/menu.ts
+++ b/packages/app/src/main/menu.ts
@@ -85,12 +85,14 @@ function actionItem(id: GlobalActionId): MenuItemConstructorOptions {
       };
 }
 
+/* No accelerator here: CmdOrCtrl+1…9 belongs to the renderer's tab strip now
+   (App.tsx) — one BrowserWindow, several tabs, and the combo picks a tab, not
+   a section (TRA-700). These stay mouse-clickable, just unaccelerated. */
 function sectionItems(): MenuItemConstructorOptions[] {
   const focused = BrowserWindow.getFocusedWindow();
   const sections = focused ? (sectionsByWebContents.get(focused.webContents.id) ?? []) : [];
   return sections.map((section, i) => ({
     label: section.label,
-    accelerator: `CmdOrCtrl+${i + 1}`,
     click: () => send('select-section', i + 1),
   }));
 }
@@ -140,7 +142,12 @@ export function buildAppMenu(): Menu {
         click: () => send('quick-open'),
       },
       { type: 'separator' },
-      { label: t('menu:closeTab'), accelerator: 'CmdOrCtrl+W', role: 'close' },
+      /* No accelerator: CmdOrCtrl+W is the renderer's own keydown handler now
+         (App.tsx) — the old `role: 'close'` closed the focused window, which
+         under the single-window architecture is the app's ONLY window, not a
+         tab (TRA-700). Still clickable from the menu, routed through the
+         same app-command channel the renderer already listens on. */
+      { label: t('menu:closeTab'), click: () => send('close-tab') },
       { label: t('menu:closeWindow'), accelerator: 'CmdOrCtrl+Shift+W', click: closeWindowGroup },
       ...(isMac
         ? []

--- a/packages/app/src/main/preload.ts
+++ b/packages/app/src/main/preload.ts
@@ -62,7 +62,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('update-mcp-clients', clientNames),
   openProjectTab: (root: string): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('open-project-tab', root),
-  closeCurrentTab: (): Promise<{ ok: boolean }> => ipcRenderer.invoke('close-current-tab'),
   onFullscreenChanged: (callback: (isFullscreen: boolean) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, isFullscreen: boolean) =>
       callback(isFullscreen);
@@ -155,19 +154,29 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.removeListener('app-command', handler);
     };
   },
-  // Tab management (Windows custom tab bar)
+  // Tab bar: the renderer owns the tab list (App.tsx); main only pushes
+  // lifecycle events for it to fold in (TRA-700).
   getPlatform: (): Promise<string> => ipcRenderer.invoke('get-platform'),
-  focusTab: (tabId: string): Promise<{ ok: boolean }> => ipcRenderer.invoke('focus-tab', tabId),
-  onTabListChanged: (
-    callback: (tabs: { id: string; title: string; type: string; active: boolean }[]) => void,
-  ) => {
-    const handler = (
-      _event: Electron.IpcRendererEvent,
-      tabs: { id: string; title: string; type: string; active: boolean }[],
-    ) => callback(tabs);
-    ipcRenderer.on('tab-list-changed', handler);
+  onOpenTab: (callback: (payload: { root: string }) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, payload: { root: string }) =>
+      callback(payload);
+    ipcRenderer.on('open-tab', handler);
     return () => {
-      ipcRenderer.removeListener('tab-list-changed', handler);
+      ipcRenderer.removeListener('open-tab', handler);
+    };
+  },
+  onNewTab: (callback: () => void): (() => void) => {
+    const handler = () => callback();
+    ipcRenderer.on('new-tab', handler);
+    return () => {
+      ipcRenderer.removeListener('new-tab', handler);
+    };
+  },
+  onFocusTab: (callback: (tabId: string) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, tabId: string) => callback(tabId);
+    ipcRenderer.on('focus-tab', handler);
+    return () => {
+      ipcRenderer.removeListener('focus-tab', handler);
     };
   },
   // trace-mcp guard control: read project status + toggle per-project mode.

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -5,7 +5,7 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { GuardOnboarding, isOnboardingDone } from './components/GuardOnboarding';
 import { QuickOpen, type QuickOpenItem } from './components/QuickOpen';
 import { SidebarRow } from './components/SidebarRow';
-import { WindowTabBar } from './components/WindowTabBar';
+import { type TabInfo, WindowTabBar } from './components/WindowTabBar';
 import { DAEMON_FETCH_TIMEOUT_MS } from './hooks/useDaemon';
 import { t } from './i18n';
 import { formatNumber } from './i18n/format';
@@ -714,17 +714,174 @@ function ProjectContent({
 }
 
 // ── Main App ──────────────────────────────────────────────────
+/** Basename of a project root, used as the tab title. */
+function basename(root: string): string {
+  const sep = root.includes('\\') && !root.includes('/') ? '\\' : '/';
+  return root.split(sep).filter(Boolean).pop() || root;
+}
+
+function newMenuTab(): TabInfo {
+  return { id: 'menu', kind: 'menu', title: t('shell:menuWindow'), active: true };
+}
+
+function activateTab(tabs: TabInfo[], id: string): TabInfo[] {
+  return tabs.map((tab) => ({ ...tab, active: tab.id === id }));
+}
+
+/**
+ * The window shell: owns the tab list and switches which tab's `AppTabView`
+ * is visible. There is exactly one `BrowserWindow` for the whole app
+ * (TRA-699) — a "tab" is renderer state here, not a window, so switching is
+ * a local state update instead of an IPC round trip to focus a window.
+ * Inactive tabs stay mounted (hidden via `display:none`) rather than
+ * unmounting, so switching back doesn't re-run their indexing queries.
+ */
 export function App() {
+  const [initialParams] = useState(getUrlParams);
+  const firstTabId = initialParams.view === 'project' && initialParams.root
+    ? initialParams.root
+    : 'menu';
+  const [tabs, setTabs] = useState<TabInfo[]>(() =>
+    initialParams.view === 'project' && initialParams.root
+      ? [
+          {
+            id: initialParams.root,
+            kind: 'project' as const,
+            root: initialParams.root,
+            title: basename(initialParams.root),
+            active: true,
+          },
+        ]
+      : [newMenuTab()],
+  );
+  const { theme } = useTheme();
+
+  const openOrFocusProjectTab = useCallback((root: string) => {
+    setTabs((prev) => {
+      const existing = prev.find((tab) => tab.kind === 'project' && tab.root === root);
+      if (existing) return activateTab(prev, existing.id);
+      const next: TabInfo = { id: root, kind: 'project', root, title: basename(root), active: true };
+      return [...prev.map((tab) => ({ ...tab, active: false })), next];
+    });
+  }, []);
+
+  const openOrFocusMenuTab = useCallback(() => {
+    setTabs((prev) => {
+      const existing = prev.find((tab) => tab.kind === 'menu');
+      if (existing) return activateTab(prev, existing.id);
+      return [...prev.map((tab) => ({ ...tab, active: false })), newMenuTab()];
+    });
+  }, []);
+
+  const selectTab = useCallback((id: string) => {
+    setTabs((prev) => activateTab(prev, id));
+  }, []);
+
+  const cycleTab = useCallback((direction: 1 | -1) => {
+    setTabs((prev) => {
+      if (prev.length <= 1) return prev;
+      const from = prev.findIndex((tab) => tab.active);
+      const to = (from + direction + prev.length) % prev.length;
+      return activateTab(prev, prev[to].id);
+    });
+  }, []);
+
+  /* Closing the active tab falls back to the menu tab (creating one if it
+     isn't open) rather than leaving the window with nothing to show — there
+     is always at least one tab mounted. */
+  const closeTab = useCallback((id: string) => {
+    if (id === 'menu') return;
+    setTabs((prev) => {
+      const wasActive = prev.find((tab) => tab.id === id)?.active ?? false;
+      const rest = prev.filter((tab) => tab.id !== id);
+      if (rest.length === 0) return [newMenuTab()];
+      if (!wasActive) return rest;
+      const fallback = rest.find((tab) => tab.kind === 'menu') ?? rest[rest.length - 1];
+      return activateTab(rest, fallback.id);
+    });
+  }, []);
+
+  useEffect(() => {
+    const api = window.electronAPI;
+    if (!api?.onOpenTab) return;
+    return api.onOpenTab(({ root }) => openOrFocusProjectTab(root));
+  }, [openOrFocusProjectTab]);
+
+  useEffect(() => {
+    const api = window.electronAPI;
+    if (!api?.onNewTab) return;
+    return api.onNewTab(() => openOrFocusMenuTab());
+  }, [openOrFocusMenuTab]);
+
+  useEffect(() => {
+    const api = window.electronAPI;
+    if (!api?.onFocusTab) return;
+    return api.onFocusTab((tabId) => selectTab(tabId));
+  }, [selectTab]);
+
+  /* Cmd/Ctrl+T new tab, Ctrl+Tab / Ctrl+Shift+Tab cycle. Cmd/Ctrl+W (close tab)
+     and Cmd/Ctrl+1…9 (select tab by index) are deliberately NOT bound here:
+     the native View menu already owns CmdOrCtrl+1…9 for section switching and
+     CmdOrCtrl+W for `role: 'close'` (main/menu.ts), which now closes the
+     app's only window instead of a tab. Binding the same combo again here
+     would fire both handlers on every press. Repointing those accelerators
+     needs a main/menu.ts change, out of this issue's renderer-only scope. */
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const primary = e.metaKey || e.ctrlKey;
+      if (primary && !e.altKey && !e.shiftKey && (e.key === 't' || e.key === 'T')) {
+        e.preventDefault();
+        openOrFocusMenuTab();
+        return;
+      }
+      if (e.ctrlKey && !e.metaKey && !e.altKey && e.key === 'Tab') {
+        e.preventDefault();
+        cycleTab(e.shiftKey ? -1 : 1);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [openOrFocusMenuTab, cycleTab]);
+
+  return (
+    <div
+      className="ws-stage flex flex-col h-screen"
+      data-mode={theme}
+      data-platform={hasInsetTitleBar() ? 'mac' : 'other'}
+      data-tabbar={tabs.length > 1 ? 'on' : 'off'}
+    >
+      <WindowTabBar tabs={tabs} onSelect={selectTab} onClose={closeTab} />
+      {tabs.map((tab) => (
+        <AppTabView
+          key={tab.id}
+          tab={tab}
+          isActive={tab.active}
+          initialGlobalTab={tab.id === firstTabId ? initialParams.tab : undefined}
+        />
+      ))}
+    </div>
+  );
+}
+
+function AppTabView({
+  tab,
+  isActive,
+  initialGlobalTab,
+}: {
+  tab: TabInfo;
+  isActive: boolean;
+  initialGlobalTab?: string | null;
+}) {
   const { t } = useTranslation('shell');
-  const { view, tab, root } = getUrlParams();
-  const isProject = view === 'project' && root !== null;
-  const { theme, appearance, setAppearance } = useTheme();
+  const isProject = tab.kind === 'project';
+  const root = tab.root ?? null;
+  const { appearance, setAppearance } = useTheme();
   /* One owner of update state for the whole window: the app menu's header
      reports it, the card acts on it, and "Check for updates…" — from the
      application menu or from the app menu — drives the same check (TRA-363). */
   const update = useUpdateCheck();
 
-  const [globalTab, setGlobalTab] = useState<GlobalTab>(normalizeGlobalTab(tab));
+  const [globalTab, setGlobalTab] = useState<GlobalTab>(normalizeGlobalTab(initialGlobalTab));
   const [projectTab, setProjectTab] = useState<ProjectTab>('overview');
   const [sidebarWidth, setSidebarWidth] = useState(readSidebarWidth);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(readSidebarCollapsed);
@@ -745,7 +902,7 @@ export function App() {
   // window. Project sub-windows skip it; the wizard belongs in the place
   // where the user manages projects.
   const [showOnboarding, setShowOnboarding] = useState(
-    !isProject && view === 'menu' && !isOnboardingDone(),
+    tab.kind === 'menu' && !isOnboardingDone(),
   );
 
   const onGraphGpuSettingsChange = useCallback((patch: Partial<GraphGPUSettings>) => {
@@ -885,11 +1042,18 @@ export function App() {
      this is the single renderer-side handler — ⌘P below is the one exception,
      because Electron allows a menu item only one accelerator. */
   useEffect(() => {
+    // Only the active tab may claim the window's ⌘1…⌘9 section labels — an
+    // inactive tab mounting in the background must not steal them.
+    if (!isActive) return;
     const api = window.electronAPI;
     api?.setWindowSections?.(sectionList.map((t) => ({ id: t.id, label: t.label })));
-  }, [sectionList]);
+  }, [sectionList, isActive]);
 
   useEffect(() => {
+    // app-command is one page-wide IPC channel now (single window, several
+    // mounted tabs) — only the active tab may act on it, or every mounted
+    // tab would react to the same keypress at once.
+    if (!isActive) return;
     const api = window.electronAPI;
     if (!api?.onAppCommand) return;
     return api.onAppCommand((command, arg) => {
@@ -917,10 +1081,11 @@ export function App() {
           break;
       }
     });
-  }, [toggleSidebar, selectSection, focusSearch, openSettings, pickProject, update.check]);
+  }, [isActive, toggleSidebar, selectSection, focusSearch, openSettings, pickProject, update.check]);
 
   // ⌘P — the second quick-open key. Not in the menu (one accelerator per item).
   useEffect(() => {
+    if (!isActive) return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
       if (e.key !== 'p' && e.key !== 'P') return;
@@ -929,7 +1094,7 @@ export function App() {
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, []);
+  }, [isActive]);
 
   /* Quick-open's file list. Fetched when the panel opens rather than on mount:
      it is a bigger page than the sidebar's 30 rows and nobody pays for it
@@ -1026,24 +1191,10 @@ export function App() {
   );
   const toggleLivesInSidebar = !sidebarCollapsed && hasInsetTitleBar();
 
-  const [tabCount, setTabCount] = useState<number>(0);
-
-  useEffect(() => {
-    const api = window.electronAPI;
-    if (!api?.onTabListChanged) return;
-    return api.onTabListChanged((tabs) => setTabCount(tabs.length));
-  }, []);
-
   return (
-    <div
-      className="ws-stage flex flex-col h-screen"
-      data-mode={theme}
-      data-platform={hasInsetTitleBar() ? 'mac' : 'other'}
-      data-tabbar={tabCount > 1 ? 'on' : 'off'}
-    >
+    <div style={{ display: isActive ? 'contents' : 'none' }}>
       {showOnboarding && <GuardOnboarding onClose={() => setShowOnboarding(false)} />}
       {quickOpen && <QuickOpen items={quickOpenItems()} onClose={() => setQuickOpen(false)} />}
-      <WindowTabBar />
 
       <div className={`ws-shell${sidebarCollapsed ? ' is-collapsed' : ''}`}>
         {!sidebarCollapsed && (

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -755,6 +755,11 @@ export function App() {
       : [newMenuTab()],
   );
   const { theme } = useTheme();
+  /* Hoisted here, not inside AppTabView: one owner of update state for the
+     whole window, not one per mounted tab. AppTabView used to call
+     useUpdateCheck() itself, so every kept-alive tab started its own
+     10-minute poll and its own update-progress subscription. */
+  const update = useUpdateCheck();
 
   const openOrFocusProjectTab = useCallback((root: string) => {
     setTabs((prev) => {
@@ -819,20 +824,32 @@ export function App() {
     return api.onFocusTab((tabId) => selectTab(tabId));
   }, [selectTab]);
 
-  /* Cmd/Ctrl+T new tab, Ctrl+Tab / Ctrl+Shift+Tab cycle. Cmd/Ctrl+W (close tab)
-     and Cmd/Ctrl+1…9 (select tab by index) are deliberately NOT bound here:
-     the native View menu already owns CmdOrCtrl+1…9 for section switching and
-     CmdOrCtrl+W for `role: 'close'` (main/menu.ts), which now closes the
-     app's only window instead of a tab. Binding the same combo again here
-     would fire both handlers on every press. Repointing those accelerators
-     needs a main/menu.ts change, out of this issue's renderer-only scope. */
+  /* Cmd/Ctrl+T new tab, Cmd/Ctrl+W close active tab, Cmd/Ctrl+1…9 select tab
+     by index, Ctrl+Tab / Ctrl+Shift+Tab cycle. These own CmdOrCtrl+W and
+     CmdOrCtrl+1…9 outright — main/menu.ts no longer registers accelerators
+     for them (see menu.ts sectionItems / the "Close tab" item), so there is
+     nothing left to double-fire against. */
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       const primary = e.metaKey || e.ctrlKey;
-      if (primary && !e.altKey && !e.shiftKey && (e.key === 't' || e.key === 'T')) {
-        e.preventDefault();
-        openOrFocusMenuTab();
-        return;
+      if (primary && !e.altKey && !e.shiftKey) {
+        if (e.key === 't' || e.key === 'T') {
+          e.preventDefault();
+          openOrFocusMenuTab();
+          return;
+        }
+        if (e.key === 'w' || e.key === 'W') {
+          e.preventDefault();
+          const active = tabs.find((tab) => tab.active);
+          if (active) closeTab(active.id);
+          return;
+        }
+        if (e.key >= '1' && e.key <= '9') {
+          e.preventDefault();
+          const target = tabs[Number(e.key) - 1];
+          if (target) selectTab(target.id);
+          return;
+        }
       }
       if (e.ctrlKey && !e.metaKey && !e.altKey && e.key === 'Tab') {
         e.preventDefault();
@@ -841,7 +858,7 @@ export function App() {
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [openOrFocusMenuTab, cycleTab]);
+  }, [openOrFocusMenuTab, cycleTab, closeTab, selectTab, tabs]);
 
   return (
     <div
@@ -857,6 +874,8 @@ export function App() {
           tab={tab}
           isActive={tab.active}
           initialGlobalTab={tab.id === firstTabId ? initialParams.tab : undefined}
+          update={update}
+          onCloseSelf={() => closeTab(tab.id)}
         />
       ))}
     </div>
@@ -867,19 +886,19 @@ function AppTabView({
   tab,
   isActive,
   initialGlobalTab,
+  update,
+  onCloseSelf,
 }: {
   tab: TabInfo;
   isActive: boolean;
   initialGlobalTab?: string | null;
+  update: UpdateCheck;
+  onCloseSelf: () => void;
 }) {
   const { t } = useTranslation('shell');
   const isProject = tab.kind === 'project';
   const root = tab.root ?? null;
   const { appearance, setAppearance } = useTheme();
-  /* One owner of update state for the whole window: the app menu's header
-     reports it, the card acts on it, and "Check for updates…" — from the
-     application menu or from the app menu — drives the same check (TRA-363). */
-  const update = useUpdateCheck();
 
   const [globalTab, setGlobalTab] = useState<GlobalTab>(normalizeGlobalTab(initialGlobalTab));
   const [projectTab, setProjectTab] = useState<ProjectTab>('overview');
@@ -1079,9 +1098,21 @@ function AppTabView({
         case 'check-for-update':
           update.check();
           break;
+        case 'close-tab':
+          onCloseSelf();
+          break;
       }
     });
-  }, [isActive, toggleSidebar, selectSection, focusSearch, openSettings, pickProject, update.check]);
+  }, [
+    isActive,
+    toggleSidebar,
+    selectSection,
+    focusSearch,
+    openSettings,
+    pickProject,
+    update.check,
+    onCloseSelf,
+  ]);
 
   // ⌘P — the second quick-open key. Not in the menu (one accelerator per item).
   useEffect(() => {

--- a/packages/app/src/renderer/__tests__/tab-shell.test.tsx
+++ b/packages/app/src/renderer/__tests__/tab-shell.test.tsx
@@ -220,4 +220,75 @@ describe('tab bar ownership', () => {
 
     expect(visibleText('.ws-sidebar')).toContain('Workspace');
   });
+
+  /* main/menu.ts no longer accelerates CmdOrCtrl+W or CmdOrCtrl+1…9 — this
+     handler owns both outright now (TRA-700 review). */
+  it('Cmd/Ctrl+W closes the active project tab, falling back to the menu tab', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+    await act(async () => emitOpenTab('/projects/assetfeed'));
+    expect(screen.getByTitle('/projects/assetfeed')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: 'w', metaKey: true });
+    });
+
+    expect(screen.queryByTitle('/projects/assetfeed')).toBeNull();
+    expect(visibleText('.ws-sidebar')).toContain('Workspace');
+  });
+
+  it('Cmd/Ctrl+W on the menu tab is a no-op — the menu tab is never closable', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: 'w', metaKey: true });
+    });
+
+    expect(document.querySelector('.ws-sidebar')).not.toBeNull();
+  });
+
+  it('Cmd/Ctrl+1…9 selects a tab by position', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+    await act(async () => emitOpenTab('/projects/assetfeed'));
+    // Opening activated the project tab (position 2); ⌘1 should hand focus
+    // back to the menu tab at position 1.
+    expect(visibleText('.ws-sidebar')).not.toContain('Workspace');
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: '1', metaKey: true });
+    });
+
+    expect(visibleText('.ws-sidebar')).toContain('Workspace');
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: '2', metaKey: true });
+    });
+
+    expect(screen.getByTitle('/projects/assetfeed')).toBeTruthy();
+    expect(visibleText('.ws-sidebar')).not.toContain('Workspace');
+  });
+
+  /* Regression for the review finding on #807: useUpdateCheck() used to live
+     inside AppTabView, so every kept-alive tab started its own poller and
+     update-progress subscription — N mounted tabs, N update checks. It now
+     lives in the shell and is passed down, so opening a second tab must not
+     trigger a second check. */
+  it('shares one update check across every mounted tab, not one per tab', async () => {
+    const api = window.electronAPI as unknown as { checkForUpdate: ReturnType<typeof vi.fn> };
+    await renderApp('/?view=menu&tab=workspace');
+    expect(api.checkForUpdate).toHaveBeenCalledTimes(1);
+
+    await act(async () => emitOpenTab('/projects/assetfeed'));
+
+    expect(api.checkForUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('Cmd/Ctrl+N (beyond the open tab count) is a no-op', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: '2', metaKey: true });
+    });
+
+    expect(document.querySelector('[data-tabbar]')?.getAttribute('data-tabbar')).toBe('off');
+  });
 });

--- a/packages/app/src/renderer/__tests__/tab-shell.test.tsx
+++ b/packages/app/src/renderer/__tests__/tab-shell.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+/* TRA-700 — App.tsx owns the tab list and switches the mounted view in
+   place. There is one BrowserWindow for the whole app (TRA-699): opening a
+   project is a local state update fed by `open-tab` / `new-tab` / `focus-tab`
+   IPC from main, not a window focus round trip. */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { App } from '../App';
+
+type OpenTabHandler = (payload: { root: string }) => void;
+type VoidHandler = () => void;
+type FocusTabHandler = (tabId: string) => void;
+
+let openTabHandlers: OpenTabHandler[] = [];
+let newTabHandlers: VoidHandler[] = [];
+let focusTabHandlers: FocusTabHandler[] = [];
+
+const emitOpenTab = (root: string) => {
+  for (const h of openTabHandlers) h({ root });
+};
+const emitNewTab = () => {
+  for (const h of newTabHandlers) h();
+};
+const emitFocusTab = (tabId: string) => {
+  for (const h of focusTabHandlers) h(tabId);
+};
+
+beforeEach(() => {
+  openTabHandlers = [];
+  newTabHandlers = [];
+  focusTabHandlers = [];
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    getPlatform: vi.fn(async () => 'darwin'),
+    onOpenTab: (cb: OpenTabHandler) => {
+      openTabHandlers.push(cb);
+      return () => {
+        openTabHandlers = openTabHandlers.filter((h) => h !== cb);
+      };
+    },
+    onNewTab: (cb: VoidHandler) => {
+      newTabHandlers.push(cb);
+      return () => {
+        newTabHandlers = newTabHandlers.filter((h) => h !== cb);
+      };
+    },
+    onFocusTab: (cb: FocusTabHandler) => {
+      focusTabHandlers.push(cb);
+      return () => {
+        focusTabHandlers = focusTabHandlers.filter((h) => h !== cb);
+      };
+    },
+    setWindowSections: vi.fn(),
+    onAppCommand: vi.fn(() => () => {}),
+    openProjectTab: vi.fn(),
+    openSettings: vi.fn(),
+    selectFolder: vi.fn(async () => null),
+    syncSidebarWidth: vi.fn(),
+    onSidebarWidthChanged: vi.fn(() => () => {}),
+    onFullscreenChanged: vi.fn(() => () => {}),
+    checkForUpdate: vi.fn(async () => ({ available: false })),
+    checkPendingUpdate: vi.fn(async () => ({ pending: false })),
+    openInEditor: vi.fn(),
+    guard: {
+      checkCliVersion: vi.fn(async () => ({
+        current: '2.1.0',
+        required: '2.1.0',
+        ok: true,
+        needsUpgrade: false,
+        notInstalled: false,
+      })),
+      installStatus: vi.fn(async () => ({ claudeDetected: false, installed: false })),
+    },
+  };
+  localStorage.clear();
+  localStorage.setItem('trace-mcp.onboarded.v1', '1');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(JSON.stringify({ projects: [], files: [] }), { status: 200 })),
+  );
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })),
+  );
+  vi.stubGlobal(
+    'EventSource',
+    class {
+      close() {}
+    },
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function renderApp(search: string): Promise<void> {
+  window.history.replaceState({}, '', search);
+  await act(async () => {
+    render(<App />);
+  });
+}
+
+/* Inactive tabs stay mounted (hidden via `display:none`), so a plain
+   `document.querySelector('.ws-sb-row.is-selected')` can match a hidden
+   tab's row instead of the visible one — walk up for an inline
+   `display:none` ancestor to find the row that is actually on screen. */
+function isHidden(el: Element | null): boolean {
+  for (let node = el; node; node = node.parentElement) {
+    if (node instanceof HTMLElement && node.style.display === 'none') return true;
+  }
+  return false;
+}
+
+function visibleText(selector: string): string | null {
+  const els = document.querySelectorAll<HTMLElement>(selector);
+  return Array.from(els).find((el) => !isHidden(el))?.textContent ?? null;
+}
+
+describe('tab bar ownership', () => {
+  it('starts with no strip for a single tab', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+    expect(document.querySelector('[data-tabbar]')?.getAttribute('data-tabbar')).toBe('off');
+  });
+
+  it('mounts a new tab locally when main sends open-tab, no window focus IPC involved', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+
+    await act(async () => emitOpenTab('/projects/assetfeed'));
+
+    expect(screen.getByTitle('/projects/assetfeed')).toBeTruthy();
+    expect(document.querySelector('[data-tabbar]')?.getAttribute('data-tabbar')).toBe('on');
+  });
+
+  it('re-focuses an already-open project tab instead of duplicating it', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+
+    await act(async () => emitOpenTab('/projects/assetfeed'));
+    await act(async () => emitOpenTab('/projects/assetfeed'));
+
+    expect(screen.getAllByTitle('/projects/assetfeed')).toHaveLength(1);
+  });
+
+  it('new-tab from main opens (or focuses) the menu tab', async () => {
+    await renderApp('/?view=project&root=/projects/assetfeed');
+
+    await act(async () => emitNewTab());
+
+    expect(screen.getByTitle('Menu')).toBeTruthy();
+    expect(visibleText('.ws-sb-row.is-selected')).toContain('Workspace');
+  });
+
+  it('focus-tab from main switches the active tab locally', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+    await act(async () => emitOpenTab('/projects/assetfeed'));
+
+    // Opening activated the project tab; focus-tab('menu') should hand it back.
+    await act(async () => emitFocusTab('menu'));
+
+    expect(visibleText('.ws-sidebar')).toContain('Workspace');
+  });
+
+  it('switching tabs keeps each tab’s own state alive instead of resetting it', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+
+    // Change the menu tab's own section before a second tab exists.
+    fireEvent.click(screen.getByText('MCP Clients'));
+    expect(visibleText('.ws-sb-row.is-selected')).toContain('MCP Clients');
+
+    // Opening a project tab mounts a second tab and activates it — the menu
+    // tab is now hidden, not unmounted.
+    await act(async () => emitOpenTab('/projects/assetfeed'));
+
+    // Switch back to the menu tab via the strip.
+    fireEvent.click(screen.getByTitle('Menu'));
+
+    expect(visibleText('.ws-sb-row.is-selected')).toContain('MCP Clients');
+  });
+
+  it('closing the only project tab falls back to the menu view', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+    await act(async () => emitOpenTab('/projects/assetfeed'));
+    expect(screen.getByTitle('/projects/assetfeed')).toBeTruthy();
+
+    const closeBtn = screen.getByRole('button', { name: /close/i });
+    await act(async () => fireEvent.click(closeBtn));
+
+    expect(screen.queryByTitle('/projects/assetfeed')).toBeNull();
+    expect(visibleText('.ws-sidebar')).toContain('Workspace');
+  });
+
+  it('Cmd/Ctrl+T opens (or focuses) the menu tab', async () => {
+    await renderApp('/?view=project&root=/projects/assetfeed');
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: 't', metaKey: true });
+    });
+
+    expect(screen.getByTitle('Menu')).toBeTruthy();
+    expect(visibleText('.ws-sb-row.is-selected')).toContain('Workspace');
+  });
+
+  it('Ctrl+Tab cycles the active tab', async () => {
+    await renderApp('/?view=menu&tab=workspace');
+    await act(async () => emitOpenTab('/projects/assetfeed'));
+
+    // Opening the project tab activated it; Ctrl+Tab should cycle back to menu.
+    await act(async () => {
+      fireEvent.keyDown(window, { key: 'Tab', ctrlKey: true });
+    });
+
+    expect(visibleText('.ws-sidebar')).toContain('Workspace');
+  });
+});

--- a/packages/app/src/renderer/components/WindowTabBar.tsx
+++ b/packages/app/src/renderer/components/WindowTabBar.tsx
@@ -2,9 +2,11 @@
  * Custom tab bar for every platform, macOS included (the native AppKit tabs
  * were removed in PR 708).
  *
- * Displays a horizontal strip of tabs at the top of each window.
- * Each tab represents an open window (Menu + project windows).
- * Clicking a tab sends IPC to focus that window.
+ * Displays a horizontal strip of tabs at the top of the window — the menu tab
+ * plus one per open project. The tab list is owned by the app shell
+ * (App.tsx); this component is a plain controlled view over it. Clicking a
+ * tab switches the mounted view in place — no IPC round trip to main, since
+ * there is only one window to begin with (TRA-698/TRA-700).
  *
  * On macOS this strip is the topmost band, so the system traffic lights are
  * drawn INSIDE it. Its height is therefore TOP_BAND_H — the same number the
@@ -16,16 +18,23 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TOP_BAND_H } from '../../shared/chrome-metrics.js';
 
-interface TabInfo {
+export interface TabInfo {
   id: string;
+  kind: 'menu' | 'project';
+  /** Present for `kind === 'project'`; equals `id`. */
+  root?: string;
   title: string;
-  type: string;
   active: boolean;
 }
 
-export function WindowTabBar() {
+interface WindowTabBarProps {
+  tabs: TabInfo[];
+  onSelect: (tabId: string) => void;
+  onClose: (tabId: string) => void;
+}
+
+export function WindowTabBar({ tabs, onSelect, onClose }: WindowTabBarProps) {
   const { t } = useTranslation('shell');
-  const [tabs, setTabs] = useState<TabInfo[]>([]);
   const [platform, setPlatform] = useState<string>('');
 
   useEffect(() => {
@@ -34,30 +43,14 @@ export function WindowTabBar() {
     api.getPlatform().then((p: string) => setPlatform(p));
   }, []);
 
-  useEffect(() => {
-    const api = window.electronAPI;
-    if (!api?.onTabListChanged) return;
-    return api.onTabListChanged((newTabs: TabInfo[]) => setTabs(newTabs));
-  }, []);
-
   // Don't render if only 1 tab (no strip needed)
   if (tabs.length <= 1) return null;
 
-  const handleTabClick = (tabId: string) => {
-    const api = window.electronAPI;
-    api?.focusTab(tabId);
-  };
-
-  const handleCloseTab = (e: React.MouseEvent, tabId: string) => {
+  const handleCloseTab = (e: React.MouseEvent | React.KeyboardEvent, tabId: string) => {
     e.stopPropagation();
-    // Closing a non-active tab: just tell main to close that window
-    // For simplicity, we only allow closing project tabs (not the menu tab)
+    // Only project tabs are closable — the menu tab is always available.
     if (tabId === 'menu') return;
-    const api = window.electronAPI;
-    // Focus the tab first, then close it
-    api?.focusTab(tabId).then(() => {
-      api?.closeCurrentTab();
-    });
+    onClose(tabId);
   };
 
   return (
@@ -82,7 +75,7 @@ export function WindowTabBar() {
         <button
           type="button"
           key={tab.id}
-          onClick={() => handleTabClick(tab.id)}
+          onClick={() => onSelect(tab.id)}
           style={
             {
               display: 'flex',
@@ -109,7 +102,7 @@ export function WindowTabBar() {
           title={tab.id === 'menu' ? t('menuWindow') : tab.id}
         >
           <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{tab.title}</span>
-          {tab.type === 'project' && (
+          {tab.kind === 'project' && (
             <span
               role="button"
               tabIndex={0}
@@ -119,7 +112,7 @@ export function WindowTabBar() {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
                   e.stopPropagation();
-                  handleCloseTab(e as unknown as React.MouseEvent<HTMLSpanElement>, tab.id);
+                  handleCloseTab(e, tab.id);
                 }
               }}
               style={{

--- a/packages/app/src/renderer/components/__tests__/WindowTabBar.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/WindowTabBar.test.tsx
@@ -1,37 +1,15 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TOP_BAND_H, trafficLightCentreY } from '../../../shared/chrome-metrics.js';
-import { WindowTabBar } from '../WindowTabBar';
+import { type TabInfo, WindowTabBar } from '../WindowTabBar';
 
-interface TabInfo {
-  id: string;
-  title: string;
-  type: string;
-  active: boolean;
-}
-
-function stubElectronAPI(platform = 'darwin', initialTabs: TabInfo[] = []) {
-  let tabCallback: ((tabs: TabInfo[]) => void) | null = null;
-
+function stubElectronAPI(platform = 'darwin') {
   const api = {
     getPlatform: vi.fn(async () => platform),
-    onTabListChanged: vi.fn((cb: (tabs: TabInfo[]) => void) => {
-      tabCallback = cb;
-      cb(initialTabs);
-      return () => {
-        tabCallback = null;
-      };
-    }),
-    focusTab: vi.fn(async (_id: string) => ({ ok: true })),
-    closeCurrentTab: vi.fn(async () => ({ ok: true })),
   };
-
   (window as unknown as { electronAPI: typeof api }).electronAPI = api;
-  return {
-    api,
-    emitTabs: (tabs: TabInfo[]) => tabCallback?.(tabs),
-  };
+  return { api };
 }
 
 afterEach(() => {
@@ -41,24 +19,25 @@ afterEach(() => {
 
 describe('WindowTabBar', () => {
   it('renders nothing when only 1 tab exists', async () => {
-    const { container } = render(<WindowTabBar />);
-    stubElectronAPI('darwin', [
-      { id: 'menu', title: 'Workspace', type: 'menu', active: true },
-    ]);
-
-    await waitFor(() => {
-      expect(container.firstChild).toBeNull();
-    });
+    stubElectronAPI();
+    const { container } = render(
+      <WindowTabBar
+        tabs={[{ id: 'menu', kind: 'menu', title: 'Workspace', active: true }]}
+        onSelect={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
   });
 
   it('renders tab strip on macOS with 78px padding for traffic lights', async () => {
+    stubElectronAPI('darwin');
     const tabs: TabInfo[] = [
-      { id: 'menu', title: 'Workspace', type: 'menu', active: true },
-      { id: '/projects/assetfeed', title: 'assetfeed', type: 'project', active: false },
+      { id: 'menu', kind: 'menu', title: 'Workspace', active: true },
+      { id: '/projects/assetfeed', kind: 'project', root: '/projects/assetfeed', title: 'assetfeed', active: false },
     ];
-    stubElectronAPI('darwin', tabs);
 
-    const { container } = render(<WindowTabBar />);
+    const { container } = render(<WindowTabBar tabs={tabs} onSelect={() => {}} onClose={() => {}} />);
 
     await screen.findByText('Workspace');
     expect(screen.getByText('assetfeed')).toBeTruthy();
@@ -73,13 +52,13 @@ describe('WindowTabBar', () => {
      TOP_BAND_H — lights centred at 22 in a strip centred at 18. Assert the tie,
      not the number: if either side moves alone, this fails. */
   it('sizes the strip so the traffic lights land on its centre line', async () => {
+    stubElectronAPI('darwin');
     const tabs: TabInfo[] = [
-      { id: 'menu', title: 'Workspace', type: 'menu', active: true },
-      { id: '/projects/assetfeed', title: 'assetfeed', type: 'project', active: false },
+      { id: 'menu', kind: 'menu', title: 'Workspace', active: true },
+      { id: '/projects/assetfeed', kind: 'project', root: '/projects/assetfeed', title: 'assetfeed', active: false },
     ];
-    stubElectronAPI('darwin', tabs);
 
-    const { container } = render(<WindowTabBar />);
+    const { container } = render(<WindowTabBar tabs={tabs} onSelect={() => {}} onClose={() => {}} />);
     await screen.findByText('Workspace');
 
     const bar = container.firstChild as HTMLElement;
@@ -88,49 +67,64 @@ describe('WindowTabBar', () => {
   });
 
   it('renders tab strip on Windows/Linux with 4px padding', async () => {
+    stubElectronAPI('win32');
     const tabs: TabInfo[] = [
-      { id: 'menu', title: 'Workspace', type: 'menu', active: true },
-      { id: '/projects/thewed', title: 'thewed', type: 'project', active: false },
+      { id: 'menu', kind: 'menu', title: 'Workspace', active: true },
+      { id: '/projects/thewed', kind: 'project', root: '/projects/thewed', title: 'thewed', active: false },
     ];
-    stubElectronAPI('win32', tabs);
 
-    const { container } = render(<WindowTabBar />);
+    const { container } = render(<WindowTabBar tabs={tabs} onSelect={() => {}} onClose={() => {}} />);
 
     await screen.findByText('Workspace');
     const bar = container.firstChild as HTMLElement;
     expect(bar.style.paddingLeft).toBe('4px');
   });
 
-  it('switches tab on click', async () => {
+  it('calls onSelect with the clicked tab id — no IPC, purely local', async () => {
+    stubElectronAPI('darwin');
     const tabs: TabInfo[] = [
-      { id: 'menu', title: 'Workspace', type: 'menu', active: true },
-      { id: '/projects/assetfeed', title: 'assetfeed', type: 'project', active: false },
+      { id: 'menu', kind: 'menu', title: 'Workspace', active: true },
+      { id: '/projects/assetfeed', kind: 'project', root: '/projects/assetfeed', title: 'assetfeed', active: false },
     ];
-    const { api } = stubElectronAPI('darwin', tabs);
+    const onSelect = vi.fn();
 
-    render(<WindowTabBar />);
+    render(<WindowTabBar tabs={tabs} onSelect={onSelect} onClose={() => {}} />);
 
     const projectTab = await screen.findByText('assetfeed');
     fireEvent.click(projectTab);
 
-    expect(api.focusTab).toHaveBeenCalledWith('/projects/assetfeed');
+    expect(onSelect).toHaveBeenCalledWith('/projects/assetfeed');
   });
 
-  it('closes a project tab on close button click', async () => {
+  it('calls onClose with the tab id when its close button is clicked', async () => {
+    stubElectronAPI('darwin');
     const tabs: TabInfo[] = [
-      { id: 'menu', title: 'Workspace', type: 'menu', active: true },
-      { id: '/projects/assetfeed', title: 'assetfeed', type: 'project', active: false },
+      { id: 'menu', kind: 'menu', title: 'Workspace', active: true },
+      { id: '/projects/assetfeed', kind: 'project', root: '/projects/assetfeed', title: 'assetfeed', active: false },
     ];
-    const { api } = stubElectronAPI('darwin', tabs);
+    const onClose = vi.fn();
+    const onSelect = vi.fn();
 
-    render(<WindowTabBar />);
+    render(<WindowTabBar tabs={tabs} onSelect={onSelect} onClose={onClose} />);
 
     const closeBtn = await screen.findByRole('button', { name: /close/i });
     fireEvent.click(closeBtn);
 
-    expect(api.focusTab).toHaveBeenCalledWith('/projects/assetfeed');
-    await waitFor(() => {
-      expect(api.closeCurrentTab).toHaveBeenCalled();
-    });
+    expect(onClose).toHaveBeenCalledWith('/projects/assetfeed');
+    // The close (×) click must not also select the tab it's closing.
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('never offers a close button on the menu tab', async () => {
+    stubElectronAPI('darwin');
+    const tabs: TabInfo[] = [
+      { id: 'menu', kind: 'menu', title: 'Workspace', active: true },
+      { id: '/projects/assetfeed', kind: 'project', root: '/projects/assetfeed', title: 'assetfeed', active: false },
+    ];
+
+    render(<WindowTabBar tabs={tabs} onSelect={() => {}} onClose={() => {}} />);
+    await screen.findByText('Workspace');
+
+    expect(screen.getAllByRole('button', { name: /close/i })).toHaveLength(1);
   });
 });

--- a/packages/app/src/renderer/electron.d.ts
+++ b/packages/app/src/renderer/electron.d.ts
@@ -54,7 +54,6 @@ declare global {
       /** Repair drifted entries. Setup asks for an enforcement level; this never does. */
       updateMcpClients: (clientNames: string[]) => Promise<{ ok: boolean; error?: string }>;
       openProjectTab: (root: string) => Promise<{ ok: boolean }>;
-      closeCurrentTab: () => Promise<{ ok: boolean }>;
       onFullscreenChanged: (callback: (isFullscreen: boolean) => void) => () => void;
       setAppearance: (appearance: 'auto' | 'light' | 'dark') => void;
       setLocale: (locale: string) => void;
@@ -96,12 +95,11 @@ declare global {
       // Application menu ↔ renderer (TRA-297)
       setWindowSections: (sections: { id: string; label: string }[]) => void;
       onAppCommand: (callback: (command: string, arg?: unknown) => void) => () => void;
-      // Tab management (Windows custom tab bar)
+      // Tab bar: the renderer owns the tab list; main only pushes lifecycle events.
       getPlatform: () => Promise<string>;
-      focusTab: (tabId: string) => Promise<{ ok: boolean }>;
-      onTabListChanged: (
-        callback: (tabs: { id: string; title: string; type: string; active: boolean }[]) => void,
-      ) => () => void;
+      onOpenTab: (callback: (payload: { root: string }) => void) => () => void;
+      onNewTab: (callback: () => void) => () => void;
+      onFocusTab: (callback: (tabId: string) => void) => () => void;
       guard: {
         status: (projectRoot: string) => Promise<{
           health: 'ok' | 'stalled' | 'down' | 'unknown';


### PR DESCRIPTION
Follow-up to #803 (TRA-699, main-process half of the same single-window rework — coordinated, not duplicate work).

## Summary

Part 2 of the single-window rework (parent: TRA-698).

- `App.tsx` now owns the tab list (`{ id, kind: 'menu' | 'project', root, title, active }`) and mounts one `AppTabView` per tab, keeping inactive tabs mounted (`display:none`) instead of unmounting them — switching tabs no longer re-runs a project's indexing queries.
- `WindowTabBar` is now a plain controlled component (`tabs`, `onSelect`, `onClose` props) — clicking a tab is a local React state update, no IPC round trip to focus a window.
- Keyboard: Cmd/Ctrl+T (new/focus menu tab), Cmd/Ctrl+W (close active tab, falls back to the menu tab), Cmd/Ctrl+1…9 (select tab by position), Ctrl+Tab / Ctrl+Shift+Tab (cycle). `main/menu.ts` no longer accelerates CmdOrCtrl+W or CmdOrCtrl+1…9 (they used to mean "close window" and "select section", which conflict under one window) — both menu items stay clickable, just unaccelerated; the renderer's keydown handler owns the combos outright.
- `preload.ts` / `electron.d.ts`: replaced `focusTab` / `closeCurrentTab` / `onTabListChanged` with `onOpenTab` / `onNewTab` / `onFocusTab`, matching the `open-tab` / `new-tab` / `focus-tab` IPC #803 sends from the single `BrowserWindow`.
- `useUpdateCheck()` moved out of the per-tab view into the shell and is passed down, so there's one update poller for the window instead of one per kept-alive tab.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run build` (renderer + main) — clean
- [x] `pnpm run test` — 626/626 passing: rewritten `WindowTabBar.test.tsx` (controlled-component API), `tab-shell.test.tsx` (tab open/focus/dedup via IPC, per-tab state surviving a switch, close-falls-back-to-menu, Cmd/Ctrl+T, Cmd/Ctrl+W incl. the menu-tab-is-never-closable case, Cmd/Ctrl+1…9, Ctrl+Tab, and a regression test pinning the single shared update poller), and updated `menu.test.ts` (no accelerator on CmdOrCtrl+W/1…9, "Close tab" still clickable via app-command).
