### PR TITLE
fix(serve): move auto-update off the MCP initialize path (TRA-703)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -140,7 +140,7 @@ import { SubprojectManager } from './subproject/manager.js';
 import { buildGraphData, generateHtml } from './tools/analysis/visualize.js';
 import { scanCodeSmells } from './tools/quality/code-smells.js';
 import { TopologyStore } from './topology/topology-db.js';
-import { checkAndInstallUpdate, runPostUpdateMigrations } from './updater.js';
+import { checkAndInstallUpdate, scheduleBackgroundUpdate } from './updater.js';
 import { atomicWriteJson } from './utils/atomic-write.js';
 import { sqliteUtcToIso } from './utils/sqlite-time.js';
 
@@ -362,24 +362,18 @@ program
     installProcessSafetyNet('serve');
     const projectRoot = process.cwd();
 
-    // Auto-update: check if a newer trace-mcp version is available and install it.
+    // Auto-update + post-update migrations. TRA-703: both run in the background,
+    // never on the path to the `initialize` response — awaiting them here made
+    // the first session after every release time out and connect as `failed`.
     // Controlled by ~/.trace-mcp/.config.json: { "auto_update": true, "auto_update_check_interval_hours": 24 }
     const globalRaw = loadGlobalConfigRaw();
-    if (globalRaw.auto_update !== false) {
-      const intervalHours =
+    scheduleBackgroundUpdate({
+      checkIntervalHours:
         typeof globalRaw.auto_update_check_interval_hours === 'number'
           ? globalRaw.auto_update_check_interval_hours
-          : 12;
-      const updated = await checkAndInstallUpdate({ checkIntervalHours: intervalHours });
-      if (updated) {
-        // New version installed — exit cleanly. The MCP client will restart this
-        // process, which will now run the updated binary.
-        process.exit(0);
-      }
-    }
-
-    // Post-update migrations: hooks, CLAUDE.md, reindex — runs once after version change
-    await runPostUpdateMigrations();
+          : 12,
+      install: globalRaw.auto_update !== false,
+    });
 
     // Detect git linked worktrees so we share the main repo's index instead
     // of building a redundant copy.  projectRoot stays as the worktree path
@@ -552,19 +546,19 @@ program
     // the file naming a dead PID. isDaemonProcessAlive() then read "dead" while
     // a healthy daemon was serving, which disarmed the very guard that exists to
     // stop the restart war (measured: 724 restarts in 18.7h, peak 89/h).
-    // Auto-update (same logic as serve)
+    // Auto-update (same logic as serve). TRA-703: also off the startup path —
+    // a daemon stuck in `npm install` never binds its port, so every stdio
+    // client that auto-spawned it sits in tryAutoSpawnDaemon until timeout and
+    // only then answers `initialize`. The watchdog below picks up the installed
+    // version on its next tick and restarts the daemon between sessions.
     const globalRaw = loadGlobalConfigRaw();
-    if (globalRaw.auto_update !== false) {
-      const intervalHours =
+    scheduleBackgroundUpdate({
+      checkIntervalHours:
         typeof globalRaw.auto_update_check_interval_hours === 'number'
           ? globalRaw.auto_update_check_interval_hours
-          : 12;
-      const updated = await checkAndInstallUpdate({ checkIntervalHours: intervalHours });
-      if (updated) process.exit(0);
-    }
-
-    // Post-update migrations: hooks, CLAUDE.md, reindex — runs once after version change
-    await runPostUpdateMigrations();
+          : 12,
+      install: globalRaw.auto_update !== false,
+    });
 
     // Phase 5.1: defer registered-project loading until AFTER httpServer.listen
     // so the daemon is reachable from the first millisecond. Requests against
@@ -3071,7 +3065,7 @@ program
     }
 
     // ── Registry auto-update watchdog (TRA-180) ──────────────────
-    // checkAndInstallUpdate only runs once, at process startup. A daemon kept
+    // checkAndInstallUpdate otherwise runs once, shortly after startup. A daemon kept
     // alive for weeks by launchd/tray or a long-lived stdio client that never
     // reconnects therefore never re-hits the npm registry, so it can silently
     // sit on a stale version indefinitely (unlike the local-staleness check

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import fs from 'node:fs';
 import https from 'node:https';
 import path from 'node:path';
@@ -6,6 +6,36 @@ import { fileURLToPath } from 'node:url';
 import { ensureGlobalDirs, TRACE_MCP_HOME } from './global.js';
 import { logger } from './logger.js';
 import { atomicWriteJson } from './utils/atomic-write.js';
+
+/**
+ * Run a child process without blocking the event loop.
+ *
+ * TRA-703: this used to be `spawnSync`. On the MCP stdio path that froze the
+ * whole process — including the JSON-RPC stream — for as long as `npm install`
+ * took, so `initialize` never got answered and the client marked the server
+ * failed for the entire session.
+ */
+function run(
+  cmd: string,
+  args: string[],
+  timeoutMs: number,
+): Promise<{ status: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    execFile(
+      cmd,
+      args,
+      { encoding: 'utf-8', timeout: timeoutMs, maxBuffer: 8 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        const code = (err as (Error & { code?: number | string }) | null)?.code;
+        resolve({
+          status: err ? (typeof code === 'number' ? code : 1) : 0,
+          stdout: stdout ?? '',
+          stderr: stderr ?? '',
+        });
+      },
+    );
+  });
+}
 
 declare const PKG_VERSION_INJECTED: string;
 const CURRENT_VERSION =
@@ -92,14 +122,14 @@ const BACKUP_DIR_PREFIX = 'trace-mcp.tmcp-bak-';
  * Goes through a login shell so the GUI-launched daemon picks up the same
  * PATH (nvm/volta/homebrew) the user has in the terminal.
  */
-function resolveNpmRoot(): string | null {
+async function resolveNpmRoot(): Promise<string | null> {
   const shell = process.env.SHELL;
   const cmd = shell ? shell : 'npm';
   const args = shell ? ['-lc', 'npm root -g'] : ['root', '-g'];
   try {
-    const result = spawnSync(cmd, args, { encoding: 'utf-8', timeout: 30_000 });
+    const result = await run(cmd, args, 30_000);
     if (result.status !== 0) return null;
-    const line = (result.stdout ?? '').trim().split('\n').pop()?.trim() ?? '';
+    const line = result.stdout.trim().split('\n').pop()?.trim() ?? '';
     return line || null;
   } catch {
     return null;
@@ -361,27 +391,23 @@ export async function checkAndInstallUpdate(opts: AutoUpdateOptions = {}): Promi
   // Pre-flight: wipe any `.trace-mcp-<rand>` scratch dirs from prior interrupted
   // installs. `--force` swaps the package dir wholesale instead of relying on
   // npm's rename dance, which is the fragile step that fails with ENOTEMPTY.
-  const npmRoot = resolveNpmRoot();
+  const npmRoot = await resolveNpmRoot();
   if (npmRoot) {
     cleanStaleScratchDirs(npmRoot);
     reconcileStaleBackups(npmRoot);
   }
 
   const runInstall = () =>
-    spawnSync('npm', ['install', '-g', `trace-mcp@${latestVersion}`, '--force'], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 120_000,
-      encoding: 'utf-8',
-    });
+    run('npm', ['install', '-g', `trace-mcp@${latestVersion}`, '--force'], 120_000);
 
-  let result = runInstall();
+  let result = await runInstall();
 
   // ENOTEMPTY even after --force means the main `trace-mcp` dir itself is in a
   // corrupt half-extracted state. Atomic-rename it aside, retry once, and
   // rollback the rename if the retry also fails. NEVER destroy the package dir
   // outright — a second install failure (network blip, ENOSPC, registry hiccup)
   // would leave the user with no trace-mcp at all.
-  if (result.status !== 0 && /ENOTEMPTY/.test(result.stderr ?? '') && npmRoot) {
+  if (result.status !== 0 && /ENOTEMPTY/.test(result.stderr) && npmRoot) {
     logger.warn('Auto-update: ENOTEMPTY detected, backing up corrupt install dir and retrying');
     cleanStaleScratchDirs(npmRoot);
 
@@ -405,7 +431,7 @@ export async function checkAndInstallUpdate(opts: AutoUpdateOptions = {}): Promi
       }
     }
 
-    result = runInstall();
+    result = await runInstall();
 
     if (result.status === 0) {
       // Install succeeded — drop the backup.
@@ -454,7 +480,7 @@ export async function checkAndInstallUpdate(opts: AutoUpdateOptions = {}): Promi
 
   if (result.status !== 0) {
     logger.warn(
-      { stderr: (result.stderr ?? '').slice(-500), status: result.status },
+      { stderr: result.stderr.slice(-500), status: result.status },
       'Auto-update: npm install failed',
     );
     // Increment the consecutive-failure counter for this exact target.
@@ -486,8 +512,54 @@ export async function checkAndInstallUpdate(opts: AutoUpdateOptions = {}): Promi
   // (including the consecutive-failure counter — success resets the streak).
   writeCache({ lastChecked: now, latestVersion, installedVersion: latestVersion });
 
-  logger.info({ version: latestVersion }, 'Auto-update: installed successfully, restarting...');
+  logger.info(
+    { version: latestVersion },
+    'Auto-update: installed successfully — takes effect on the next start',
+  );
   return true;
+}
+
+/** How long to wait after startup before touching the registry (TRA-703). */
+export const BACKGROUND_UPDATE_DELAY_MS = 10_000;
+
+/**
+ * Kick off the update check + post-update migrations *off* the startup path.
+ *
+ * TRA-703: `serve` used to `await checkAndInstallUpdate()` before wiring the
+ * stdio transport, so the first session after any release spent its whole
+ * startup inside `npm install` and never answered `initialize` — the client
+ * marked the server failed for the entire session. Nothing here is awaited,
+ * and a successful install no longer exits the process: the new version is on
+ * disk and takes effect the next time the client starts the server, so a live
+ * session is never restarted underneath its client.
+ *
+ * Both are best-effort: a process that exits inside the delay window simply
+ * skips this round. Only the two long-lived serve paths call this, and the
+ * cache state they act on persists, so the next start picks the work back up.
+ *
+ * ponytail: no cross-process lock — concurrent sessions can race on the same
+ * `npm install -g`, exactly as they did before this change. Add a lockfile in
+ * TRACE_MCP_HOME if that race is ever observed to matter.
+ */
+export function scheduleBackgroundUpdate(
+  opts: AutoUpdateOptions & { delayMs?: number; install?: boolean } = {},
+): void {
+  const timer = setTimeout(() => {
+    void (async () => {
+      try {
+        // Migrations first: they compare the cache stamp against the version we
+        // are actually running, and the install below rewrites that stamp.
+        await runPostUpdateMigrations();
+        if (opts.install !== false) {
+          await checkAndInstallUpdate({ checkIntervalHours: opts.checkIntervalHours });
+        }
+      } catch (e) {
+        logger.debug({ error: e }, 'Auto-update: background update failed (non-fatal)');
+      }
+    })();
+  }, opts.delayMs ?? BACKGROUND_UPDATE_DELAY_MS);
+  // Never hold the process open just to run an update.
+  timer.unref();
 }
 
 /**

--- a/tests/updater-background.test.ts
+++ b/tests/updater-background.test.ts
@@ -1,0 +1,161 @@
+// TRA-703 regression: the auto-update must never sit on the startup path.
+//
+// Before this, `trace-mcp serve` awaited checkAndInstallUpdate() before wiring
+// the stdio transport. On the first session after any release that meant the
+// whole startup was spent inside `npm install`, the `initialize` request was
+// never answered, and the MCP client marked the server `failed` for the entire
+// session. These tests pin the two properties that fix depends on:
+//
+//   1. scheduleBackgroundUpdate() returns without doing any update work, so
+//      everything the caller does next (including answering `initialize`)
+//      happens first.
+//   2. A successful install does NOT exit the process — the new version takes
+//      effect on the next start, never mid-session.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
+vi.mock('node:https', () => ({ get: vi.fn() }));
+
+// Post-update migrations reach for these lazily; stub them so nothing reindexes.
+vi.mock('../src/config-jsonc.js', () => ({
+  migrateGlobalConfig: vi.fn(() => ({ changed: false, added: [] })),
+}));
+vi.mock('../src/init/detector.js', () => ({
+  detectGuardHook: vi.fn(() => ({ hasGuardHook: false, guardHookVersion: null })),
+}));
+vi.mock('../src/init/hooks.js', () => ({
+  installGuardHook: vi.fn(),
+  installReindexHook: vi.fn(),
+  installPrecompactHook: vi.fn(),
+  installWorktreeHook: vi.fn(),
+  migrateLegacyToolPrefix: vi.fn(() => []),
+}));
+vi.mock('../src/init/claude-md.js', () => ({ updateClaudeMd: vi.fn() }));
+vi.mock('../src/registry.js', () => ({
+  listProjects: vi.fn(() => []),
+  updateLastIndexed: vi.fn(),
+  markAllProjectsPendingReindex: vi.fn(() => 0),
+  clearPendingReindex: vi.fn(),
+  getProject: vi.fn(() => null),
+}));
+
+const HOME_REF = { current: '' };
+vi.mock('../src/global.js', () => ({
+  get TRACE_MCP_HOME() {
+    return HOME_REF.current;
+  },
+  ensureGlobalDirs: vi.fn(),
+  getDbPath: vi.fn((root: string) => path.join(root, '.trace-mcp.db')),
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+describe('scheduleBackgroundUpdate (TRA-703)', () => {
+  let tmpHome: string;
+  let scheduleBackgroundUpdate: typeof import('../src/updater.js').scheduleBackgroundUpdate;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tra703-'));
+    HOME_REF.current = tmpHome;
+    // A newer version is already known, so the updater goes straight to install.
+    // `installedVersion` differs from the running version so post-update
+    // migrations have real work to do as well.
+    fs.writeFileSync(
+      path.join(tmpHome, 'update-check.json'),
+      JSON.stringify({
+        lastChecked: Date.now(),
+        latestVersion: '2.0.0',
+        installedVersion: '0.9.0',
+      }),
+    );
+
+    (globalThis as Record<string, unknown>).PKG_VERSION_INJECTED = '1.0.0';
+    process.env.TRACE_MCP_FORCE_NOT_DEV_CHECKOUT = '1';
+    delete process.env.TRACE_MCP_NO_AUTO_UPDATE;
+
+    const { execFile } = await import('node:child_process');
+    vi.mocked(execFile).mockImplementation(((
+      _cmd: string,
+      _args: readonly string[],
+      _opts: unknown,
+      cb: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      cb(null, '', '');
+      return {} as ReturnType<typeof execFile>;
+    }) as unknown as typeof execFile);
+
+    scheduleBackgroundUpdate = (await import('../src/updater.js')).scheduleBackgroundUpdate;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    (globalThis as Record<string, unknown>).PKG_VERSION_INJECTED = undefined;
+    delete process.env.TRACE_MCP_FORCE_NOT_DEV_CHECKOUT;
+    try {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    } catch {}
+    vi.restoreAllMocks();
+  });
+
+  it('does no update work before the caller gets control back', async () => {
+    const { execFile } = await import('node:child_process');
+
+    scheduleBackgroundUpdate({ checkIntervalHours: 24 });
+
+    // This is the window in which `serve` wires the stdio transport and answers
+    // `initialize`. Nothing may have been spawned yet.
+    expect(vi.mocked(execFile)).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    const installCalls = vi
+      .mocked(execFile)
+      .mock.calls.filter((c) => Array.isArray(c[1]) && c[1].includes('install'));
+    expect(installCalls.length).toBeGreaterThan(0);
+  });
+
+  it('never exits the process when an install succeeds', async () => {
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+
+    scheduleBackgroundUpdate({ checkIntervalHours: 24 });
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // The install ran…
+    const written = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, 'update-check.json'), 'utf-8'),
+    ) as { installedVersion?: string };
+    expect(written.installedVersion).toBe('2.0.0');
+    // …and the live session survived it.
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('skips the registry install but still runs migrations when auto_update is off', async () => {
+    const { execFile } = await import('node:child_process');
+    const { updateClaudeMd } = await import('../src/init/claude-md.js');
+
+    scheduleBackgroundUpdate({ install: false });
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // Nothing was fetched or installed…
+    expect(vi.mocked(execFile)).not.toHaveBeenCalled();
+    // …but the post-update migrations still ran and stamped the new version.
+    expect(vi.mocked(updateClaudeMd)).toHaveBeenCalled();
+    const written = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, 'update-check.json'), 'utf-8'),
+    ) as { installedVersion?: string };
+    expect(written.installedVersion).toBe('1.0.0');
+  });
+
+  it('does not keep the process alive on its own', () => {
+    const spy = vi.spyOn(globalThis, 'setTimeout');
+    scheduleBackgroundUpdate({});
+    const timer = spy.mock.results[0]?.value as { hasRef?: () => boolean };
+    expect(timer.hasRef?.()).toBe(false);
+  });
+});

--- a/tests/updater-rollback.test.ts
+++ b/tests/updater-rollback.test.ts
@@ -10,7 +10,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('node:child_process', () => ({ spawnSync: vi.fn() }));
+vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
 vi.mock('node:https', () => ({ get: vi.fn() }));
 
 // Mock dynamic-import targets so post-update migrations never trigger here.
@@ -98,21 +98,20 @@ describe('checkAndInstallUpdate — backup + rollback', () => {
       JSON.stringify({ lastChecked: Date.now(), latestVersion: '2.0.0' }),
     );
 
-    const { spawnSync } = await import('node:child_process');
-    vi.mocked(spawnSync).mockImplementation(((cmd: string, args: readonly string[]) => {
+    const { execFile } = await import('node:child_process');
+    vi.mocked(execFile).mockImplementation(((
+      cmd: string,
+      args: readonly string[],
+      _opts: unknown,
+      cb: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
       const argList = Array.isArray(args) ? args : [];
       const isNpmRootProbe =
         (cmd === 'npm' && argList[0] === 'root' && argList[1] === '-g') ||
         argList.some((a) => typeof a === 'string' && a.includes('npm root -g'));
       if (isNpmRootProbe) {
-        return {
-          status: 0,
-          stdout: `${tmpRoot}\n`,
-          stderr: '',
-          pid: 0,
-          output: [],
-          signal: null,
-        } as unknown as ReturnType<typeof spawnSync>;
+        cb(null, `${tmpRoot}\n`, '');
+        return {} as ReturnType<typeof execFile>;
       }
       // Install call — pop the next staged result.
       const r =
@@ -121,15 +120,13 @@ describe('checkAndInstallUpdate — backup + rollback', () => {
         ({ status: 0, stderr: '' } as { status: number; stderr: string });
       installCallCount++;
       r.sideEffect?.();
-      return {
-        status: r.status,
-        stdout: '',
-        stderr: r.stderr,
-        pid: 0,
-        output: [],
-        signal: null,
-      } as unknown as ReturnType<typeof spawnSync>;
-    }) as typeof spawnSync);
+      cb(
+        r.status === 0 ? null : Object.assign(new Error('npm install failed'), { code: r.status }),
+        '',
+        r.stderr,
+      );
+      return {} as ReturnType<typeof execFile>;
+    }) as unknown as typeof execFile);
 
     (globalThis as Record<string, unknown>).PKG_VERSION_INJECTED = '1.0.0';
     // Bypass the `.git`-next-to-package-json dev-checkout guard — tests run

--- a/tests/updater.test.ts
+++ b/tests/updater.test.ts
@@ -1,6 +1,34 @@
+import type { execFile as ExecFile } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Stub `child_process.execFile` with a canned result per invocation.
+ * updater.ts shells out twice: `npm root -g` (or `$SHELL -lc 'npm root -g'`)
+ * and `npm install -g trace-mcp@<v> --force`.
+ */
+function stubExecFile(
+  execFileMock: typeof ExecFile,
+  impl: (cmd: string, args: string[]) => { status: number; stdout?: string; stderr?: string },
+): void {
+  vi.mocked(execFileMock).mockImplementation(((
+    cmd: string,
+    args: string[],
+    _opts: unknown,
+    cb: (err: Error | null, stdout: string, stderr: string) => void,
+  ) => {
+    const r = impl(cmd, args);
+    const err =
+      r.status === 0
+        ? null
+        : Object.assign(new Error('command failed'), {
+            code: r.status,
+          });
+    cb(err, r.stdout ?? '', r.stderr ?? '');
+    return {} as ReturnType<typeof ExecFile>;
+  }) as unknown as typeof ExecFile);
+}
 
 // Mock fs before importing the module under test
 vi.mock('node:fs');
@@ -288,21 +316,14 @@ describe('checkAndInstallUpdate', () => {
       lastFailedVersion: '2.0.0',
     });
 
-    const { spawnSync } = await import('node:child_process');
-    vi.mocked(spawnSync).mockReturnValue({
-      status: 0,
-      stdout: '',
-      stderr: '',
-      pid: 0,
-      output: [],
-      signal: null,
-    });
+    const { execFile } = await import('node:child_process');
+    stubExecFile(execFile, () => ({ status: 0 }));
 
     const result = await checkAndInstallUpdate({ checkIntervalHours: 24 });
     expect(result).toBe(false);
-    // Must NOT have attempted npm install (no spawnSync call for `npm install`).
+    // Must NOT have attempted npm install.
     const installCalls = vi
-      .mocked(spawnSync)
+      .mocked(execFile)
       .mock.calls.filter((c) => Array.isArray(c[1]) && c[1].includes('install'));
     expect(installCalls).toHaveLength(0);
   });
@@ -310,16 +331,9 @@ describe('checkAndInstallUpdate', () => {
   it('records lastFailedInstall when npm install fails', async () => {
     setupCache({ lastChecked: Date.now(), latestVersion: '2.0.0' });
 
-    const { spawnSync } = await import('node:child_process');
-    // Every spawnSync call (npm root probe + install attempts) returns failure.
-    vi.mocked(spawnSync).mockReturnValue({
-      status: 1,
-      stdout: '',
-      stderr: 'npm error something broke',
-      pid: 0,
-      output: [],
-      signal: null,
-    });
+    const { execFile } = await import('node:child_process');
+    // Every child process (npm root probe + install attempts) returns failure.
+    stubExecFile(execFile, () => ({ status: 1, stderr: 'npm error something broke' }));
 
     const result = await checkAndInstallUpdate({ checkIntervalHours: 24 });
     expect(result).toBe(false);
@@ -335,15 +349,8 @@ describe('checkAndInstallUpdate', () => {
     setupCache({ lastChecked: 0, latestVersion: '2.0.0' });
 
     // Mock npm install success
-    const { spawnSync } = await import('node:child_process');
-    vi.mocked(spawnSync).mockReturnValue({
-      status: 0,
-      stdout: '',
-      stderr: '',
-      pid: 0,
-      output: [],
-      signal: null,
-    });
+    const { execFile } = await import('node:child_process');
+    stubExecFile(execFile, () => ({ status: 0 }));
 
     // Mock fetchLatestVersion to return 2.0.0
     const https = await import('node:https');


### PR DESCRIPTION
Fixes TRA-703.

## Problem

`trace-mcp serve` awaited `checkAndInstallUpdate()` and `runPostUpdateMigrations()` **before** wiring the stdio transport. On the first session after any npm release, the whole startup was spent inside `npm install -g` — the client's `initialize` was never answered, and the server was marked `failed` for the rest of the session. TRA-696's A/B measured those sessions at a **median 3.1x token cost per task** versus a plain naive agent: the model burns turns hunting for MCP tools the prompt promised, then falls back to grep.

At 12 releases in a week, a daily-active install hits this almost daily.

## Fix

1. `src/updater.ts` shells out via `execFile` instead of `spawnSync`. No update step can freeze the event loop that carries the JSON-RPC stream. The ENOTEMPTY backup/retry/rollback logic is unchanged apart from `await`.
2. New `scheduleBackgroundUpdate()` runs post-update migrations + the registry check on an unref'd timer 10s after startup. `serve` and `serve-http` call it instead of awaiting.
   - `serve-http` matters too: a daemon stuck in `npm install` never binds its port, so every stdio client that auto-spawned it sat in `tryAutoSpawnDaemon` until timeout before answering `initialize`.
   - Migrations still run when `auto_update: false` — only the registry install is gated.
3. A successful install no longer calls `process.exit(0)`. The new version is on disk and takes effect at the next start, so **a live session is never restarted underneath its client**.

The daemon's TRA-180 registry watchdog and the 10-minute local-staleness timer are untouched, so a long-lived daemon still picks up an installed version and restarts between sessions.

## Test evidence

End-to-end, with a `npm` shim that blocks 20s and a seeded pending update, timing the `initialize` response of a real `dist/cli.js serve`:

| | time to `initialize` response |
|---|---|
| before | **21 910 ms** |
| after | **1 459 ms** |

Unit coverage — `tests/updater-background.test.ts` (new, 4 tests):
- no child process is spawned before the caller regains control (the window in which `serve` answers `initialize`), and the install does happen once the timer fires;
- a successful install never calls `process.exit`;
- `install: false` skips the registry but still runs migrations and stamps the version;
- the timer is unref'd.

`tests/updater.test.ts` and `tests/updater-rollback.test.ts` migrated from the `spawnSync` mock to `execFile`; all their assertions kept.

Full suite: **9669 passed, 12 skipped**. `tsc --noEmit` and `biome ci` clean.

Reviewed independently by a second model before opening; its one substantive finding (the `install: false` test asserted too little and its fixture short-circuited migrations) is fixed in this branch.

Agent: Lead Engineer


---

Follow-up to #805. That PR (TRA-704) takes the *daemon auto-spawn* wait off the handshake path; this one takes the *npm auto-update* wait off it. Different files, different blockers, same symptom — both are needed for `initialize` to be answered promptly on the first session after a release.
