### PR TITLE
fix(launcher): stop the legacy bin path freezing at its install-time shim (TRA-716)

### DIFF
--- a/src/init/launcher.ts
+++ b/src/init/launcher.ts
@@ -256,16 +256,61 @@ function isOwnedShim(file: string): boolean {
 }
 
 /**
+ * Body of the Windows compat shim. Windows symlinks need privileges the
+ * installer usually lacks, so the legacy `.cmd` delegates by exec instead —
+ * which tracks launcher upgrades just as a symlink would, since it resolves
+ * the current shim at run time rather than copying it.
+ */
+export function legacyCompatCmdBody(currentLauncher: string): string {
+  return [
+    '@echo off',
+    `REM trace-mcp-launcher v${LAUNCHER_VERSION} compat shim — do not edit by hand.`,
+    'REM Delegates to the current launcher so this path tracks every upgrade.',
+    `"${currentLauncher}" %*`,
+    '',
+  ].join('\r\n');
+}
+
+/**
+ * Point `legacyPath` at `current` without ever leaving the legacy path missing.
+ *
+ * The old path is what a registered MCP client spawns, so it must survive a
+ * failed replacement: unlinking first and then failing to create the
+ * replacement would take the client's launcher away entirely — worse than the
+ * stale shim we set out to fix. Both branches build the new entry beside the
+ * old one and swap it in with a single rename.
+ */
+function writeLegacyCompat(legacyPath: string, current: string): void {
+  const tmp = `${legacyPath}.tmp.${process.pid}`;
+  try {
+    if (IS_WINDOWS) {
+      fs.writeFileSync(tmp, legacyCompatCmdBody(current), { mode: 0o755 });
+    } else {
+      fs.symlinkSync(current, tmp);
+    }
+    fs.renameSync(tmp, legacyPath);
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* nothing to clean up */
+    }
+    throw err;
+  }
+}
+
+/**
  * Keep `~/.trace-mcp/bin/trace-mcp` (`trace-mcp.cmd` on Windows) pointing at the
  * current `~/.trace/bin/trace` shim, so a client still registered at the
  * pre-TRA-611 absolute path keeps working after the rename.
  *
- * The legacy path must be a *symlink*, not a copy. A pre-rename install left a
+ * The legacy path must *delegate*, not be a copy. A pre-rename install left a
  * real shim file there, and `installLauncher` only ever writes into the current
  * launcher dir — so a client spawning the legacy path stayed frozen on whatever
  * launcher version happened to be on disk at migration time, and no later
  * launcher fix could reach it (TRA-716). Replacing that stale file with a
- * symlink is what makes the legacy path track every future upgrade.
+ * symlink (or a delegating `.cmd` on Windows) is what makes the legacy path
+ * track every future upgrade.
  *
  * Acts when either signal says a legacy path may still be registered:
  * LEGACY_MIGRATION_MARKER (a durable file left in the new home the moment the
@@ -278,9 +323,10 @@ function isOwnedShim(file: string): boolean {
 function installLegacyBinCompat(): void {
   const legacyDir = path.join(os.homedir(), '.trace-mcp', 'bin');
   const legacyPath = path.join(legacyDir, LEGACY_PRIMARY_DEST);
+  const current = getLauncherPath();
   // When the legacy home *is* the launcher home, the real shim already lives at
-  // this path; symlinking it would point it at itself.
-  if (path.resolve(legacyPath) === path.resolve(getLauncherPath())) return;
+  // this path; delegating it would point it at itself.
+  if (path.resolve(legacyPath) === path.resolve(current)) return;
   try {
     if (isSymlink(legacyPath)) return; // already delegating to the current shim
     const exists = fs.existsSync(legacyPath);
@@ -291,14 +337,13 @@ function installLegacyBinCompat(): void {
     ) {
       return;
     }
-    if (exists) {
-      if (!isOwnedShim(legacyPath)) return;
-      fs.unlinkSync(legacyPath);
-    }
+    // Anything we did not write is the user's own wrapper — leave it alone.
+    if (exists && !isOwnedShim(legacyPath)) return;
     ensureDir(legacyDir);
-    fs.symlinkSync(getLauncherPath(), legacyPath);
+    writeLegacyCompat(legacyPath, current);
   } catch {
-    /* best-effort — the durable signals mean the next `trace init` retries */
+    /* best-effort — the durable signals mean the next `trace init` retries,
+       and the legacy path is left exactly as it was found */
   }
 }
 
@@ -316,6 +361,11 @@ export function installLauncher(opts: InstallLauncherOpts): InitStepResult {
   const isCurrent = installedVersion === LAUNCHER_VERSION;
 
   if (isCurrent && !opts.force) {
+    // The shim in the current home is up to date, but the legacy compat path is
+    // a separate file that may still hold a stale pre-rename shim — and this is
+    // the branch an ordinary `trace upgrade` takes, so skipping the repair here
+    // would leave every affected client unfixed (TRA-716).
+    if (!dryRun) installLegacyBinCompat();
     return {
       target: dest,
       action: 'already_configured',

--- a/src/init/launcher.ts
+++ b/src/init/launcher.ts
@@ -236,27 +236,69 @@ export interface InstallLauncherOpts {
   force?: boolean;
 }
 
+/** Header line every shim we ship carries — `# trace-mcp-launcher v0.4.0`. */
+const LAUNCHER_HEADER_RE = /trace-mcp-launcher v[0-9]+\.[0-9]+\.[0-9]+/;
+
+/** True only for a shim this project wrote, so we never clobber a user's file. */
+function isOwnedShim(file: string): boolean {
+  try {
+    const fd = fs.openSync(file, 'r');
+    try {
+      const buf = Buffer.alloc(256);
+      fs.readSync(fd, buf, 0, 256, 0);
+      return LAUNCHER_HEADER_RE.test(buf.toString('utf-8'));
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Preserve `~/.trace-mcp/bin/trace-mcp` (`trace-mcp.cmd` on Windows) as a
- * symlink to the new `~/.trace/bin/trace` shim, so a client or script still
- * pointed at the pre-TRA-611 absolute path keeps working after the rename.
- * Gated on LEGACY_MIGRATION_MARKER (a durable file left in the new home the
- * moment the rename succeeds) rather than the one-shot
- * TRACE_MCP_HOME_MIGRATED flag: that flag is only true for the single process
- * that performed the rename, so a symlink failure there (permissions,
- * dry-run) would otherwise never get a second chance. The marker survives
- * restarts, so every later `trace init`/`upgrade` retries until it succeeds.
+ * Keep `~/.trace-mcp/bin/trace-mcp` (`trace-mcp.cmd` on Windows) pointing at the
+ * current `~/.trace/bin/trace` shim, so a client still registered at the
+ * pre-TRA-611 absolute path keeps working after the rename.
+ *
+ * The legacy path must be a *symlink*, not a copy. A pre-rename install left a
+ * real shim file there, and `installLauncher` only ever writes into the current
+ * launcher dir — so a client spawning the legacy path stayed frozen on whatever
+ * launcher version happened to be on disk at migration time, and no later
+ * launcher fix could reach it (TRA-716). Replacing that stale file with a
+ * symlink is what makes the legacy path track every future upgrade.
+ *
+ * Acts when either signal says a legacy path may still be registered:
+ * LEGACY_MIGRATION_MARKER (a durable file left in the new home the moment the
+ * rename succeeds — durable rather than the one-shot TRACE_MCP_HOME_MIGRATED
+ * flag, so a failure here gets retried by every later `trace init`), or a
+ * surviving `~/.trace-mcp/bin` directory, which only a pre-rename install has.
+ * Without either we create nothing: a fresh install has no legacy path to
+ * preserve, and inventing one would just be litter.
  */
 function installLegacyBinCompat(): void {
-  if (!fs.existsSync(path.join(TRACE_MCP_HOME, LEGACY_MIGRATION_MARKER))) return;
   const legacyDir = path.join(os.homedir(), '.trace-mcp', 'bin');
   const legacyPath = path.join(legacyDir, LEGACY_PRIMARY_DEST);
+  // When the legacy home *is* the launcher home, the real shim already lives at
+  // this path; symlinking it would point it at itself.
+  if (path.resolve(legacyPath) === path.resolve(getLauncherPath())) return;
   try {
-    if (isSymlink(legacyPath) || fs.existsSync(legacyPath)) return;
+    if (isSymlink(legacyPath)) return; // already delegating to the current shim
+    const exists = fs.existsSync(legacyPath);
+    if (
+      !exists &&
+      !fs.existsSync(legacyDir) &&
+      !fs.existsSync(path.join(TRACE_MCP_HOME, LEGACY_MIGRATION_MARKER))
+    ) {
+      return;
+    }
+    if (exists) {
+      if (!isOwnedShim(legacyPath)) return;
+      fs.unlinkSync(legacyPath);
+    }
     ensureDir(legacyDir);
     fs.symlinkSync(getLauncherPath(), legacyPath);
   } catch {
-    /* best-effort — the durable marker means the next `trace init` retries */
+    /* best-effort — the durable signals mean the next `trace init` retries */
   }
 }
 

--- a/tests/init/launcher-legacy-compat.test.ts
+++ b/tests/init/launcher-legacy-compat.test.ts
@@ -9,11 +9,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  getLauncherPath,
-  installLauncher,
-  legacyCompatCmdBody,
-} from '../../src/init/launcher.js';
+import { getLauncherPath, installLauncher, legacyCompatCmdBody } from '../../src/init/launcher.js';
 import { LAUNCHER_VERSION } from '../../src/init/types.js';
 
 const STALE_SHIM = '#!/bin/bash\n# trace-mcp-launcher v0.3.0\nexit 127\n';

--- a/tests/init/launcher-legacy-compat.test.ts
+++ b/tests/init/launcher-legacy-compat.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The pre-TRA-611 launcher path `~/.trace-mcp/bin/trace-mcp` stays registered in
+ * MCP client configs long after the home directory was renamed to `~/.trace`.
+ * Whatever sits at that path is what the client actually spawns, so it must not
+ * be allowed to freeze at the launcher version that happened to be on disk when
+ * the rename ran — every later launcher fix would miss those clients entirely.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getLauncherPath, installLauncher } from '../../src/init/launcher.js';
+import { LAUNCHER_VERSION } from '../../src/init/types.js';
+
+const STALE_SHIM = '#!/bin/bash\n# trace-mcp-launcher v0.3.0\nexit 127\n';
+
+describe.skipIf(process.platform === 'win32')('legacy bin compat', () => {
+  let home: string;
+  let legacyPath: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-legacy-'));
+    vi.spyOn(os, 'homedir').mockReturnValue(home);
+    legacyPath = path.join(home, '.trace-mcp', 'bin', 'trace-mcp');
+    // The launcher installs into ~/.trace; leaving TRACE_MCP_HOME unset keeps
+    // the legacy and current homes distinct, as they are on a migrated machine.
+    delete process.env.TRACE_MCP_HOME;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  function writeLegacy(content: string): void {
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    fs.writeFileSync(legacyPath, content, { mode: 0o755 });
+  }
+
+  it('repoints a stale trace-mcp-owned shim at the current launcher', () => {
+    writeLegacy(STALE_SHIM);
+
+    installLauncher({ force: true });
+
+    expect(fs.lstatSync(legacyPath).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(legacyPath)).toBe(fs.realpathSync(getLauncherPath()));
+    // What a client spawning the legacy path now actually runs.
+    expect(fs.readFileSync(legacyPath, 'utf-8')).toContain(
+      `trace-mcp-launcher v${LAUNCHER_VERSION}`,
+    );
+  });
+
+  it('creates the compat symlink when the legacy bin dir survives but the shim is gone', () => {
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+
+    installLauncher({ force: true });
+
+    expect(fs.lstatSync(legacyPath).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(legacyPath)).toBe(fs.realpathSync(getLauncherPath()));
+  });
+
+  it('creates nothing for a fresh install with no legacy path', () => {
+    installLauncher({ force: true });
+
+    expect(fs.existsSync(path.join(home, '.trace-mcp'))).toBe(false);
+  });
+
+  it('leaves an existing symlink alone', () => {
+    writeLegacy(STALE_SHIM);
+    installLauncher({ force: true });
+    const before = fs.readlinkSync(legacyPath);
+
+    installLauncher({ force: true });
+
+    expect(fs.readlinkSync(legacyPath)).toBe(before);
+  });
+
+  it('never clobbers a file we do not own', () => {
+    const foreign = '#!/bin/bash\n# hand-rolled wrapper\nexec my-thing "$@"\n';
+    writeLegacy(foreign);
+
+    installLauncher({ force: true });
+
+    expect(fs.lstatSync(legacyPath).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(legacyPath, 'utf-8')).toBe(foreign);
+  });
+
+  it('does not link the legacy path to itself when it is the launcher home', () => {
+    process.env.TRACE_MCP_HOME = path.join(home, '.trace-mcp');
+    try {
+      installLauncher({ force: true });
+      // The real shim lives here now; replacing it with a self-symlink would
+      // leave the client executing a loop.
+      expect(fs.lstatSync(getLauncherPath()).isSymbolicLink()).toBe(false);
+    } finally {
+      delete process.env.TRACE_MCP_HOME;
+    }
+  });
+});

--- a/tests/init/launcher-legacy-compat.test.ts
+++ b/tests/init/launcher-legacy-compat.test.ts
@@ -9,10 +9,35 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getLauncherPath, installLauncher } from '../../src/init/launcher.js';
+import {
+  getLauncherPath,
+  installLauncher,
+  legacyCompatCmdBody,
+} from '../../src/init/launcher.js';
 import { LAUNCHER_VERSION } from '../../src/init/types.js';
 
 const STALE_SHIM = '#!/bin/bash\n# trace-mcp-launcher v0.3.0\nexit 127\n';
+
+// Windows cannot use a symlink here without privileges the installer usually
+// lacks, so the legacy .cmd delegates by exec. Asserted on every platform:
+// the Windows CI job is conditional, and this is the shim clients would spawn.
+describe('windows legacy compat shim', () => {
+  const body = legacyCompatCmdBody('C:\\Users\\x\\.trace\\bin\\trace.cmd');
+
+  it('delegates to the current launcher and forwards all arguments', () => {
+    expect(body).toContain('"C:\\Users\\x\\.trace\\bin\\trace.cmd" %*');
+  });
+
+  it('carries the launcher header so a later run recognises it as ours', () => {
+    expect(body).toMatch(/trace-mcp-launcher v[0-9]+\.[0-9]+\.[0-9]+/);
+    expect(body.split(/\r?\n/)[0]).toBe('@echo off');
+  });
+
+  it('uses CRLF line endings', () => {
+    expect(body).toContain('\r\n');
+    expect(body).not.toMatch(/[^\r]\n/);
+  });
+});
 
 describe.skipIf(process.platform === 'win32')('legacy bin compat', () => {
   let home: string;
@@ -83,6 +108,44 @@ describe.skipIf(process.platform === 'win32')('legacy bin compat', () => {
 
     expect(fs.lstatSync(legacyPath).isSymbolicLink()).toBe(false);
     expect(fs.readFileSync(legacyPath, 'utf-8')).toBe(foreign);
+  });
+
+  // The branch an ordinary `trace upgrade` takes once the current shim is
+  // already at LAUNCHER_VERSION. Passing force:true masks this entirely.
+  it('repairs the legacy path on the already-current upgrade path', () => {
+    installLauncher({ force: true }); // current shim in place, legacy dir absent
+    writeLegacy(STALE_SHIM); // client still pointed at a pre-rename shim
+
+    const step = installLauncher({});
+
+    expect(step.action).toBe('already_configured');
+    expect(fs.lstatSync(legacyPath).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(legacyPath)).toBe(fs.realpathSync(getLauncherPath()));
+  });
+
+  it('leaves the legacy path untouched when a dry run reports it as current', () => {
+    installLauncher({ force: true });
+    writeLegacy(STALE_SHIM);
+
+    installLauncher({ dryRun: true });
+
+    expect(fs.lstatSync(legacyPath).isSymbolicLink()).toBe(false);
+  });
+
+  // The legacy path is what a registered client spawns. Removing it before the
+  // replacement exists would take the launcher away entirely on any failure —
+  // routine on Windows, where symlinks need privileges.
+  it('preserves the working shim when the replacement cannot be created', () => {
+    writeLegacy(STALE_SHIM);
+    vi.spyOn(fs, 'symlinkSync').mockImplementation(() => {
+      throw Object.assign(new Error('operation not permitted'), { code: 'EPERM' });
+    });
+
+    installLauncher({ force: true });
+
+    expect(fs.existsSync(legacyPath)).toBe(true);
+    expect(fs.readFileSync(legacyPath, 'utf-8')).toBe(STALE_SHIM);
+    expect(fs.readdirSync(path.dirname(legacyPath))).toEqual(['trace-mcp']);
   });
 
   it('does not link the legacy path to itself when it is the launcher home', () => {


### PR DESCRIPTION
## Problem

MCP clients registered before TRA-611 still spawn `~/.trace-mcp/bin/trace-mcp`. That path was frozen at whatever launcher version happened to be on disk when the home directory was renamed, and nothing could ever update it:

- `installLauncher` only writes artifacts into the *current* launcher dir (`~/.trace/bin/trace`).
- `installLegacyBinCompat` bailed on `isSymlink(legacyPath) || fs.existsSync(legacyPath)` — and a pre-rename install left a **real shim file** at the legacy path, so the symlink was never created.

Net effect: every launcher fix lands in `~/.trace/bin/trace` and never reaches the path the client actually executes.

## Evidence

On a live machine, `claude mcp list` shows the client registered at the legacy path:

```
trace-mcp: /Users/nikolai/.trace-mcp/bin/trace-mcp serve - ✔ Connected
```

That file was launcher **v0.3.0** while **v0.4.0** was already in the tree, and `~/.trace-mcp/launcher.log` still recorded session kills that v0.4.0 (TRA-701) fixes:

```
[2026-09-02T19:54:46Z] ERROR: trace-mcp package not found next to node=/Users/nikolai/.hermes/node/bin/node
[2026-09-02T19:58:01Z] ERROR: ...
[2026-09-02T19:59:13Z] ERROR: ...
[2026-09-02T20:00:55Z] ERROR: ...
```

Four killed sessions in 24h — each one an agent silently losing all ~170 tools. The fix for them was merged; it just had no route to the binary being run.

`installLegacyBinCompat` had **zero test coverage**.

## Fix

Replace a stale trace-mcp-owned shim at the legacy path with a symlink to the current launcher, so it tracks every later upgrade. Guards:

- A file **without** our `trace-mcp-launcher v...` header is left untouched — we never clobber a user's own wrapper.
- An existing symlink is left alone.
- The compat link is only *created* when a legacy path plausibly exists (migration marker, or a surviving `~/.trace-mcp/bin`); a fresh install gets nothing rather than a litter directory.
- No self-symlink when the legacy home *is* the launcher home.

## Tests

New `tests/init/launcher-legacy-compat.test.ts` — 6 cases covering all of the above. Three of them fail on `main` and pass here.

No MCP tool signature, schema, or token-budget changes.

```
tests/init/     232 passed | 3 skipped
full suite      9716 passed | 12 skipped (888 files)
pnpm run build  ✓
pnpm run lint   ✓
```

Verified on the live machine: legacy path repointed, `claude mcp list` still reports `✔ Connected`, and `~/.trace-mcp/bin/trace-mcp --version` → `3.14.0`.

Closes TRA-716.

---

**Not a duplicate.** Follow-up to #806 (TRA-701), which fixed the launcher this PR makes reachable, and to #717 — the TRA-611 transition whose compat path this repairs. The duplicate-work guard matched on the bare `TRA-611` key that both descriptions cite as background; neither PR touches `installLegacyBinCompat`.
