### PR TITLE
docs(state): say that trace_state_* is off the default surface (TRA-723)

### DIFF
--- a/docs/SKILL_STATE.md
+++ b/docs/SKILL_STATE.md
@@ -63,13 +63,32 @@ measures task success — we have no Pass@1 evidence, only prompt cost.
 
 ---
 
+## Availability: not on the default surface
+
+The `trace_state_*` tools are always registered, but they are **not advertised by
+the default `tools.preset` (`minimal`)** — they are members of the `state` and
+`full` presets only (`src/tools/project/presets.ts`). On a default install
+`tools/list` does not contain them, and the recipe below will not run as written
+until you do one of:
+
+- call them through `batch`, which dispatches any registered tool by name,
+  including ones the active preset defers;
+- `load_tools({ tools: ["trace_state_init", ...] })` to advertise them for the
+  session (`get_preset_info` lists what is deferred);
+- set `tools.preset` to `state` or `full` in config, or `TRACE_MCP_PRESET`.
+
+Keeping them off `minimal` is deliberate: the measurement above puts the win on
+long sessions, and the one short session in the set lost. Until the crossover is
+located, paying schema tokens for these seven tools in every session — most of
+which are short — is not justified by anything measured.
+
 ## MCP Tools Suite
 
 | Tool | Purpose |
 |------|---------|
 | `trace_state_init` | Initialize a new task state with goal & initial plan steps |
 | `trace_state_patch` | Apply an atomic RFC 7396 JSON Merge Patch to update state |
-| `trace_state_get` | Retrieve state as compact Markdown (~150 tokens) or JSON |
+| `trace_state_get` | Retrieve state as compact Markdown (343 tokens at the replay median) or JSON |
 | `trace_state_checkpoint` | Create a named snapshot checkpoint for rollback |
 | `trace_state_rollback` | Restore state to a saved checkpoint |
 | `trace_state_add_dead_end` | Fast shortcut to record failed approaches and prevent repetition |


### PR DESCRIPTION
Driver run on the SKILL.state epic (TRA-596). Phases 1–4 are all `done` and released; #715 and #765 merged. What the sweep turned up is not a code defect but a documentation one, and it is reproducible.

## The problem

`docs/SKILL_STATE.md` ends with an "Agent Two-Phase Loop Recipe" that calls `trace_state_init` directly. On a default install that call is not available:

- `src/tools/project/presets.ts:124-138` — the seven `trace_state_*` tools are members of the `state` and `full` presets only.
- `src/config.ts:226` — `tools.preset` defaults to `minimal`.

So `tools/list` on a stock install does not contain them. The tools *are* registered unconditionally (`src/server/server.ts:648-651`, `src/tools/register/state.ts:16`), so they stay reachable through `batch`, `load_tools`, or a preset switch — but the page never said which.

Second, the page contradicted itself: the tool table advertised a "~150 tokens" state block two sections after the measurement section put the replayed median at **343**.

## The change

Docs only. Adds an "Availability" section naming the three reachability paths, and states why `minimal` deliberately excludes them — #765 measured the win on long sessions and saw the one sub-30-turn session lose, so paying seven tool schemas in every session is not justified by anything measured yet. Fixes 150 → 343.

No code, no MCP tool signature, no schema touched.

Agent: Lead Engineer