### PR TITLE
fix(daemon): name the dropped dangerous root instead of re-asking for a hint (TRA-720)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -118,9 +118,8 @@ import {
 } from './registry.js';
 import { isKnownSubproject, resolveDeepestKnownRoot } from './subproject/resolve.js';
 import {
-  buildAmbiguousProjectError,
-  buildNoProjectsError,
   buildProjectNotFoundError,
+  buildResolutionFailureError,
   extractRpcId,
 } from './daemon/mcp-error-response.js';
 import { resolveProjectForMcpRequest } from './daemon/mcp-project-router.js';
@@ -1111,14 +1110,10 @@ program
             'Ignored dangerous project hint from MCP client — resolved without it (TRA-286)',
           );
         }
-        if (resolution.kind === 'no-projects') {
-          res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify(buildNoProjectsError(rpcId)));
-          return;
-        }
-        if (resolution.kind === 'ambiguous') {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify(buildAmbiguousProjectError(resolution.registered, rpcId)));
+        if (resolution.kind === 'no-projects' || resolution.kind === 'ambiguous') {
+          const { status, body } = buildResolutionFailureError(resolution, rpcId);
+          res.writeHead(status, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(body));
           return;
         }
         if (resolution.via === 'tracked-client') {

--- a/src/daemon/__tests__/mcp-error-response.test.ts
+++ b/src/daemon/__tests__/mcp-error-response.test.ts
@@ -3,6 +3,7 @@ import {
   buildAmbiguousProjectError,
   buildNoProjectsError,
   buildProjectNotFoundError,
+  buildResolutionFailureError,
   extractRpcId,
 } from '../mcp-error-response.js';
 
@@ -59,6 +60,64 @@ describe('buildAmbiguousProjectError', () => {
     expect(body.error.message).toMatch(/X-Trace-Project/);
     expect(body.error.data.reason).toBe('ambiguous_project');
     expect(body.error.data.registered).toEqual(['/a', '/b']);
+  });
+});
+
+// TRA-720: `claude mcp list` reported trace-mcp as "Failed to connect" on a
+// machine with several registered projects whenever the client's cwd was a home
+// or system directory. Our stdio proxy had appended `?project=<cwd>`, the
+// resolver dropped that hint as a dangerous root (TRA-286), the fall-through
+// found no unique project, and the client was told to "pass ?project=" — the
+// exact thing it had just done. Every trace-mcp tool was gone for that session.
+describe('buildResolutionFailureError', () => {
+  it('names the dropped dangerous root instead of asking for a hint again', () => {
+    const { status, body } = buildResolutionFailureError(
+      {
+        kind: 'ambiguous',
+        registered: ['/work/a', '/work/b'],
+        ignoredDangerousHint: { projectRoot: '/Users/user', reason: 'home directory' },
+      },
+      1,
+    );
+
+    expect(status).toBe(404);
+    expect(body.error.data.reason).toBe('dangerous_root');
+    expect(body.error.message).toContain('/Users/user');
+    expect(body.error.message).toContain('home directory');
+    // The advice the client could not act on must be gone.
+    expect(body.error.message).not.toMatch(/\?project=/);
+  });
+
+  it('applies the same rule when nothing at all is registered', () => {
+    const { status, body } = buildResolutionFailureError(
+      {
+        kind: 'no-projects',
+        ignoredDangerousHint: { projectRoot: '/tmp', reason: 'system directory' },
+      },
+      null,
+    );
+
+    expect(status).toBe(404);
+    expect(body.error.data.reason).toBe('dangerous_root');
+    expect(body.error.message).toContain('/tmp');
+  });
+
+  it('keeps the ambiguous error when no hint was dropped', () => {
+    const { status, body } = buildResolutionFailureError(
+      { kind: 'ambiguous', registered: ['/work/a', '/work/b'] },
+      1,
+    );
+
+    expect(status).toBe(400);
+    expect(body.error.data.reason).toBe('ambiguous_project');
+    expect(body.error.message).toMatch(/\?project=/);
+  });
+
+  it('keeps the no-projects error when no hint was dropped', () => {
+    const { status, body } = buildResolutionFailureError({ kind: 'no-projects' }, 1);
+
+    expect(status).toBe(404);
+    expect(body.error.data.reason).toBe('no_projects_registered');
   });
 });
 

--- a/src/daemon/mcp-error-response.ts
+++ b/src/daemon/mcp-error-response.ts
@@ -115,6 +115,48 @@ export function buildAmbiguousProjectError(
   };
 }
 
+/**
+ * Pick the error for a resolution that produced no project, and the HTTP status
+ * to send it with.
+ *
+ * The branch that matters is the dangerous-hint one. TRA-286 made the resolver
+ * DROP an explicit `?project=` / header / `_meta` hint naming a home or system
+ * directory and fall through to the tracked-client and single-project steps —
+ * right, and unchanged here. But when that fall-through also came up empty, the
+ * client was handed the plain ambiguous error: "pass ?project=<absolute-path>",
+ * addressed to a client that had just passed exactly that. Our own stdio proxy
+ * is one of them — it always appends `?project=<cwd>`, so a session started with
+ * cwd=~ (or /, or /tmp) lost all of trace-mcp's tools behind advice it could not
+ * act on (TRA-720). Naming the dropped root turns that into the one instruction
+ * that actually helps: point the client at a real project directory.
+ */
+export function buildResolutionFailureError(
+  resolution: {
+    kind: 'no-projects' | 'ambiguous';
+    registered?: readonly string[];
+    ignoredDangerousHint?: { projectRoot: string; reason: string };
+  },
+  rpcId: unknown,
+): { status: number; body: JsonRpcErrorBody } {
+  const dropped = resolution.ignoredDangerousHint;
+  if (dropped) {
+    return {
+      status: 404,
+      body: buildProjectNotFoundError({
+        projectRoot: dropped.projectRoot,
+        folderMissing: false,
+        dangerReason: dropped.reason,
+        hasMarkers: false,
+        rpcId,
+      }),
+    };
+  }
+  if (resolution.kind === 'no-projects') {
+    return { status: 404, body: buildNoProjectsError(rpcId) };
+  }
+  return { status: 400, body: buildAmbiguousProjectError(resolution.registered ?? [], rpcId) };
+}
+
 /** Extract the `id` field from a parsed JSON-RPC body for echoing back. */
 export function extractRpcId(parsedBody: unknown): unknown {
   if (parsedBody && typeof parsedBody === 'object' && 'id' in parsedBody) {


### PR DESCRIPTION
## The failure

`claude mcp list` on this machine reports:

```
trace-mcp: /Users/nikolai/.trace-mcp/bin/trace-mcp serve - ✘ Failed to connect
  -32603: Backend send failed: ... "Multiple projects registered — pass
  ?project=<absolute-path> on /mcp, set the X-Trace-Project header, ..."
```

The advice is impossible to follow: our own stdio proxy **had** passed it. The
launcher log for the same run shows
`mcpUrl=http://127.0.0.1:3741/mcp?project=%2Fprivate%2Ftmp`.

## Root cause

`resolveProjectForMcpRequest` drops an explicit `?project=` / `X-Trace-Project` /
`_meta` hint that names a home or system directory (TRA-286 — a client spawned
with `cwd=/` otherwise pinned the session to `/` and failed to start at all).
That drop is right. What was wrong is what happens when the fall-through —
tracked-client match, then single-project — also comes up empty: the client got
the generic ambiguous error, which names neither the dropped root nor the reason
and prescribes the action the client already took.

Concretely: a Claude Code session started from `~` on a machine with two or more
registered projects loses all ~170 trace-mcp tools and has no way to learn why.

## The change

`buildResolutionFailureError` picks the response for a resolution that produced
no project. When a hint was dropped, it reuses the existing `dangerous_root`
message — which names the root, the reason, and the real remedy. Otherwise the
`ambiguous` / `no-projects` responses are byte-identical to before, same status
codes.

Net: +42 lines in the error module, −9 in the `/mcp` handler.

## Test evidence

Unit: 4 new cases in `mcp-error-response.test.ts` pin both directions — a
dropped hint must produce `dangerous_root` and must **not** re-suggest
`?project=`; no dropped hint must still produce `ambiguous_project` / 400 and
`no_projects_registered` / 404.

End-to-end against `serve-http` on an isolated port and `TRACE_MCP_DATA_DIR`
with two registered projects:

```
POST /mcp?project=/tmp
→ -32002 "Refusing to index /tmp (system directory). Configure your MCP client
   to use a real project directory ..."   data.reason=dangerous_root

POST /mcp   (no hint)
→ -32602 "Multiple projects registered — pass ?project=..."
   data.reason=ambiguous_project        ← unchanged
```

Full suite: 9766 passed, 12 skipped. `tsc --noEmit` clean. No MCP tool-signature
or on-disk schema change.

Closes TRA-720.
