### PR TITLE
feat(hooks): Read/Bash output mirror prototype (TRA-725, E1')

### DIFF
--- a/benchmarks/e1-read-bash-mirror.md
+++ b/benchmarks/e1-read-bash-mirror.md
@@ -1,0 +1,142 @@
+# E1′ — Read/Bash mirrors: prototype and first measurements
+
+Experiment behind bet A1′ (TRA-725, following TRA-714): our own tool output is
+6.4% of a transcript, while native `Read` and `Bash` are 26% of a human session
+and 57% of an agent run. If we can compress *their* output, that is where the
+tokens are.
+
+This file records what the prototype does, what was measured, and which
+harness facts the next run should not have to rediscover. Numbers here were
+produced on Claude Code 2.1.239, macOS, 2026-09-03.
+
+## The mechanism is a hook, not a pair of tools
+
+TRA-725 was written assuming mirrors would be *tools* — an agent calls
+`Read`, our lookalike answers, and the pre-registered death criterion was
+"adoption below 30%". That framing does not survive contact with the harness.
+
+A mirror tool cannot shadow the native one. MCP tools are namespaced
+`mcp__<server>__<name>`, so ours would be an *additional* tool competing with
+`Read` for the model's choice — which is exactly the competition TRA-705
+already measured at 13–16%. Under that design the bet is dead before any
+compression work starts.
+
+The mirror does not need to be a tool. Claude Code's `PostToolUse` hook
+carries a field whose documented purpose is precisely this:
+
+> `updatedToolOutput` — Replaces the tool output before it is sent to the model.
+> (`updatedMCPToolOutput` does the same for MCP tools only; prefer
+> `updatedToolOutput`, which works for all tools.)
+
+The native tool still runs; the hook rewrites its result on the way to the
+model. **Adoption is therefore not a behavioural variable** — the hook sees
+100% of `Read` and `Bash` calls by construction. The 30% death line and the
+"stop if the 5-task pilot is under 15%" early stop were both written against
+the tool design and do not apply to this one.
+
+### The output envelope must be preserved exactly
+
+The harness validates the rewrite against the tool's own output shape and
+discards a mismatch *silently*, keeping the original output:
+
+> PostToolUse hook returned updatedToolOutput that does not match `<tool>`'s
+> output shape; using original output.
+
+The first prototype returned a bare string and was rejected on every call —
+the hook's own metrics log showed 92% compression while the transcript was
+untouched. The envelopes, captured from live runs:
+
+```jsonc
+// Read
+{ "type": "text",
+  "file": { "filePath": "…", "content": "…", "numLines": 5, "startLine": 1, "totalLines": 1003 } }
+
+// Bash
+{ "stdout": "…", "stderr": "", "interrupted": false, "isImage": false, "noOutputExpected": false }
+```
+
+Only the text field may move. `tests/hooks/mirror.test.ts` pins both envelopes;
+this is the "byte-identical contract" threat from the issue, and a shape test
+is the only thing that catches it — the failure mode is invisible by eye.
+
+## What the prototype does
+
+`hooks/trace-mcp-mirror.sh`, installed as `PostToolUse` with matcher
+`Read|Bash`. Deterministic, model-free, in this order:
+
+1. spill the full result to `~/.trace-mcp/mirror/<session>/`, referenced by
+   path in the compressed view so the agent can pull it back;
+2. drop build/install progress noise (spinners, percentages, `Progress:`,
+   `Downloading`, npm notices);
+3. collapse runs of identical lines into `… previous line repeated N more time(s)`;
+4. head/tail window (80/40 lines) whatever is still oversized;
+5. bail out unchanged if the result would not actually shrink.
+
+Outputs under 2000 chars pass through untouched. Every rewrite appends a row to
+`metrics.jsonl` (`orig_chars`, `new_chars`, `spill`), so compression and call
+counts are read off a real session rather than estimated. Knobs:
+`TRACE_MCP_MIRROR_MIN_CHARS`, `_KEEP_HEAD`, `_KEEP_TAIL`, `_DISABLE`, `_HOME`.
+
+No encoder-reranker. Step 1 of the issue's two-step plan only; the second step
+is not justified until the deterministic pass is shown to be the bottleneck.
+
+## Measured
+
+**Live, end to end** (headless `claude -p`, Sonnet 4.5, synthetic noisy build log):
+
+| tool | orig | compressed | saving | reached the model? |
+|---|---|---|---|---|
+| `Read` (30 KB) | 30140 | 2391 | −92% | yes, mirror note quoted verbatim |
+| `Bash` (3.9 KB) | 3952 | 1212 | −69% | yes |
+| `Bash` (30 KB) | 30000 | 2371 | −92% | **no** — superseded, see below |
+
+In both successful cases the model still recovered the correct last line of the
+file, i.e. the head/tail window kept what the question needed.
+
+**Real command traffic in this repo** (five commands, hook applied offline):
+
+| command | orig | compressed | saving |
+|---|---|---|---|
+| `pnpm install` | 1486 | — | pass-through (under threshold) |
+| `pnpm run build` | 961 | — | pass-through |
+| `pnpm exec vitest run tests/hooks/` | 2177 | — | pass-through (nothing to collapse) |
+| `git log --stat -40` | 101717 | 6023 | −94% |
+| `pnpm exec biome check src/` | 44 | — | pass-through |
+
+## The finding that actually threatens A1′
+
+It is not adoption, and it is not compression ratio. It is that **the
+compressible mass is bimodal, and the harness already owns the fat end.**
+
+Four of five real outputs were too small to be worth touching. The one fat
+output compressed 94% — and sits in the size range where Claude Code already
+persists the result to a file itself and shows the model a preview. That is the
+crude version of this mirror, shipped, upstream of us. It is why the 30 KB
+`Bash` row above shows a 92% compression in our metrics log and no change in
+the transcript.
+
+So the mirror's addressable band is outputs large enough to be worth
+compressing but below the host's own persistence ceiling. That ceiling is
+host-configurable (`persistenceThresholdCeiling`; the built-in default is
+400 000 chars, but the agent-SDK host used by `claude -p` sets it far lower —
+30 KB was already persisted). **Sizing that band on real traffic is the next
+measurement, and it gates the bet more sharply than anything pre-registered.**
+
+## What is not done
+
+The three-arm solve-rate comparison (bare agent / trace as-is / trace with
+mirrors) over 10–15 live tasks with repeats. Nothing here says what compression
+costs in correctness, re-asks, or call-count inflation — and the issue's own
+threat note is right that cheaper reads may simply buy more reads.
+
+## Revised gate
+
+- ~~Death: adoption < 30%~~ — retired. Adoption is structural under the hook
+  design, not a model choice.
+- **Death (replacement): under 40% of Read/Bash *token mass* in a real session
+  falls in the addressable band.** Below that, per-call compression cannot pay
+  for the work whatever its ratio.
+- Success: actual compression ≥40% over the addressable band, solve-rate drop
+  ≤2pp, no rise in total Read/Bash call count.
+- Quality failure: solve-rate drop >5pp at any compression — published in full,
+  bet closed.

--- a/benchmarks/e1-read-bash-mirror.md
+++ b/benchmarks/e1-read-bash-mirror.md
@@ -66,11 +66,16 @@ is the only thing that catches it — the failure mode is invisible by eye.
 
 1. spill the full result to `~/.trace-mcp/mirror/<session>/`, referenced by
    path in the compressed view so the agent can pull it back;
-2. drop build/install progress noise (spinners, percentages, `Progress:`,
-   `Downloading`, npm notices);
+2. **Bash only** — drop package-manager progress noise (spinners, progress
+   bars, `Progress: resolved`, npm notices);
 3. collapse runs of identical lines into `… previous line repeated N more time(s)`;
 4. head/tail window (80/40 lines) whatever is still oversized;
-5. bail out unchanged if the result would not actually shrink.
+5. bail out unchanged if the rewrite, footer included, would not shrink.
+
+Noise filtering never runs on a `Read`. Source code is full of lines those
+patterns match — `...spread`, a `50% {` keyframe selector, a docstring that
+begins "Resolving" — and filtering source through package-manager heuristics
+deletes code silently. Spills older than a day are reaped on each write.
 
 Outputs under 2000 chars pass through untouched. Every rewrite appends a row to
 `metrics.jsonl` (`orig_chars`, `new_chars`, `spill`), so compression and call
@@ -86,7 +91,7 @@ is not justified until the deterministic pass is shown to be the bottleneck.
 
 | tool | orig | compressed | saving | reached the model? |
 |---|---|---|---|---|
-| `Read` (30 KB) | 30140 | 2391 | −92% | yes, mirror note quoted verbatim |
+| `Read` (30 KB) | 30140 | 2459 | −91% | yes, mirror note quoted verbatim |
 | `Bash` (3.9 KB) | 3952 | 1212 | −69% | yes |
 | `Bash` (30 KB) | 30000 | 2371 | −92% | **no** — superseded, see below |
 

--- a/hooks/trace-mcp-mirror.sh
+++ b/hooks/trace-mcp-mirror.sh
@@ -40,13 +40,13 @@ KEEP_HEAD="${TRACE_MCP_MIRROR_KEEP_HEAD:-80}"
 KEEP_TAIL="${TRACE_MCP_MIRROR_KEEP_TAIL:-40}"
 HOME_DIR="${TRACE_MCP_MIRROR_HOME:-$HOME/.trace-mcp/mirror}"
 
-TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 case "$TOOL_NAME" in
   Read|Bash) ;;
   *) exit 0 ;;
 esac
 
-SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // "default"')
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // "default"' 2>/dev/null)
 
 # The harness validates that updatedToolOutput matches the tool's own output
 # shape and silently discards a rewrite that does not ("PostToolUse hook
@@ -65,7 +65,7 @@ ORIGINAL=$(printf '%s' "$INPUT" | jq -r --arg p "$TEXT_PATH" '
   .tool_response
   | if type == "object" then getpath($p | ltrimstr(".") | split(".")) else empty end
   | if type == "string" then . else empty end
-')
+' 2>/dev/null)
 [ -z "$ORIGINAL" ] && exit 0
 
 ORIG_CHARS=${#ORIGINAL}
@@ -80,16 +80,29 @@ find "$HOME_DIR" -name '*.txt' -type f -mtime +1 -delete 2>/dev/null
 SPILL="$SPILL_DIR/$(date +%s)-$$.txt"
 printf '%s' "$ORIGINAL" >"$SPILL" 2>/dev/null || exit 0
 
-# --- step 1+2: collapse identical runs, drop progress noise -------------------
-# NOISE_RE is intentionally conservative: only lines that carry no information a
-# later turn could need. Anything ambiguous stays.
-NOISE_RE='^[[:space:]]*(⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|[0-9]+%|Progress:|Downloading|Fetching|Resolving|Reused |Added [0-9]+ package|Packages: |Progress: resolved|npm (WARN|notice) |[.]{3,})'
+# --- step 1: drop progress noise (Bash only) ---------------------------------
+# NOISE_RE only ever runs against a shell command's output. It must never touch
+# a Read, because source code is full of lines these patterns would match --
+# `...spread`, a `50% {` keyframe selector, a docstring beginning "Resolving".
+# Filtering source through package-manager heuristics silently deletes code.
+# For the same reason the patterns anchor on progress-bar and package-manager
+# shapes rather than on leading words alone.
+NOISE_RE='^[[:space:]]*(⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏)|^[[:space:]]*[0-9]+%[[:space:]]*[[|]|^(Progress: resolved|Packages: |Reused [0-9]|Added [0-9]+ package|npm (WARN|notice) )'
 
-COMPRESSED=$(printf '%s\n' "$ORIGINAL" \
-  | grep -Ev "$NOISE_RE" \
+if [ "$TOOL_NAME" = "Bash" ]; then
+  DENOISED=$(printf '%s\n' "$ORIGINAL" | grep -Ev "$NOISE_RE")
+else
+  DENOISED=$(printf '%s\n' "$ORIGINAL")
+fi
+
+# --- step 2: collapse identical runs -----------------------------------------
+# NR == 1 is handled on its own: awk's uninitialised `prev` is "", so a leading
+# blank line would otherwise be swallowed and reported as a repeat.
+COMPRESSED=$(printf '%s' "$DENOISED" \
   | awk '
-      { if ($0 == prev) { n++; next }
-        if (n > 0) { printf "  … previous line repeated %d more time(s)\n", n; n = 0 }
+      NR == 1 { prev = $0; print; next }
+      $0 == prev { n++; next }
+      { if (n > 0) { printf "  … previous line repeated %d more time(s)\n", n; n = 0 }
         print; prev = $0 }
       END { if (n > 0) printf "  … previous line repeated %d more time(s)\n", n }
     ')
@@ -105,15 +118,18 @@ if [ "$TOTAL_LINES" -gt "$WINDOW" ]; then
 fi
 
 NEW_CHARS=${#COMPRESSED}
-# A rewrite that does not actually shrink the payload is pure risk. Bail out.
-if [ "$NEW_CHARS" -ge "$ORIG_CHARS" ]; then
-  rm -f "$SPILL"
-  exit 0
-fi
-
 SAVED_PCT=$(( (ORIG_CHARS - NEW_CHARS) * 100 / ORIG_CHARS ))
 FOOTER=$(printf '\n[trace-mcp mirror] %s output compressed %d → %d chars (−%d%%). Full output: %s' \
   "$TOOL_NAME" "$ORIG_CHARS" "$NEW_CHARS" "$SAVED_PCT" "$SPILL")
+FINAL="$COMPRESSED$FOOTER"
+
+# A rewrite that does not actually shrink the payload is pure risk. The footer
+# costs ~120 chars, so a saving smaller than that would inflate the result --
+# measure what the model will actually receive, not the compressed body alone.
+if [ "${#FINAL}" -ge "$ORIG_CHARS" ]; then
+  rm -f "$SPILL"
+  exit 0
+fi
 
 # --- measurement log ---------------------------------------------------------
 printf '%s\n' "$(jq -nc \
@@ -122,12 +138,18 @@ printf '%s\n' "$(jq -nc \
   '{ts: (now|todate), session: $s, tool: $t, orig_chars: $o, new_chars: $n, spill: $f}')" \
   >>"$HOME_DIR/metrics.jsonl" 2>/dev/null
 
+# The rewritten text goes to jq through a file, not through argv: a large Read
+# would otherwise blow MAX_ARG_STRLEN and kill the hook with E2BIG.
+FINAL_FILE="$SPILL.compressed"
+printf '%s' "$FINAL" >"$FINAL_FILE" 2>/dev/null || exit 0
+trap 'rm -f "$FINAL_FILE"' EXIT
+
 printf '%s' "$INPUT" | jq -c \
-  --arg p "$TEXT_PATH" --arg out "$COMPRESSED$FOOTER" '
+  --arg p "$TEXT_PATH" --rawfile out "$FINAL_FILE" '
   ($p | ltrimstr(".") | split(".")) as $path
   | (.tool_response | setpath($path; $out)) as $resp
   | (if ($resp | has("file")) then
        $resp | .file.numLines = ($out | split("\n") | length)
      else $resp end) as $resp
   | {hookSpecificOutput: {hookEventName: "PostToolUse", updatedToolOutput: $resp}}
-'
+' 2>/dev/null

--- a/hooks/trace-mcp-mirror.sh
+++ b/hooks/trace-mcp-mirror.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# trace-mcp-mirror v0.1.0 (TRA-725, experiment E1')
+#
+# PostToolUse mirror for Read and Bash. The native tool runs untouched; this
+# hook rewrites its output before it reaches the model via the harness field
+# `hookSpecificOutput.updatedToolOutput` ("Replaces the tool output before it
+# is sent to the model", Claude Code >= 2.1.x). The full result is spilled to
+# disk and referenced by path, so the agent can pull it back when the
+# compressed view is not enough.
+#
+# This is deliberately a hook and not a pair of mirror TOOLS. A mirror tool
+# competes with the native one for the model's choice, and TRA-705 measured
+# that competition at 13-16% adoption -- below the 30% death line written into
+# TRA-725 before the experiment. A PostToolUse hook is not a choice: it sees
+# 100% of Read/Bash calls by construction.
+#
+# Compression is deterministic and model-free (TRA-725 step 1):
+#   1. collapse runs of identical lines
+#   2. drop build/install progress noise
+#   3. head/tail window whatever is still oversized
+#
+# Every rewrite appends one JSONL record to the measurement log so compression
+# and call counts can be read off a real session rather than estimated.
+#
+# Install (PostToolUse, matcher "Read|Bash"). Env knobs:
+#   TRACE_MCP_MIRROR_MIN_CHARS   below this, pass through untouched (default 2000)
+#   TRACE_MCP_MIRROR_KEEP_HEAD   lines kept from the top of a window (default 80)
+#   TRACE_MCP_MIRROR_KEEP_TAIL   lines kept from the bottom of a window (default 40)
+#   TRACE_MCP_MIRROR_DISABLE     any non-empty value: pass through untouched
+#   TRACE_MCP_MIRROR_HOME        state dir (default ~/.trace-mcp/mirror)
+
+set -uo pipefail
+
+INPUT=$(cat)
+[ -n "${TRACE_MCP_MIRROR_DISABLE:-}" ] && exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+MIN_CHARS="${TRACE_MCP_MIRROR_MIN_CHARS:-2000}"
+KEEP_HEAD="${TRACE_MCP_MIRROR_KEEP_HEAD:-80}"
+KEEP_TAIL="${TRACE_MCP_MIRROR_KEEP_TAIL:-40}"
+HOME_DIR="${TRACE_MCP_MIRROR_HOME:-$HOME/.trace-mcp/mirror}"
+
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')
+case "$TOOL_NAME" in
+  Read|Bash) ;;
+  *) exit 0 ;;
+esac
+
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // "default"')
+
+# The harness validates that updatedToolOutput matches the tool's own output
+# shape and silently discards a rewrite that does not ("PostToolUse hook
+# returned updatedToolOutput that does not match <tool>'s output shape; using
+# original output"). So we never emit a bare string: we locate the one text
+# field inside tool_response, swap it, and hand the whole structure back.
+#   Read: { type: "text", file: { filePath, content, numLines, startLine, totalLines } }
+#   Bash: { stdout, stderr, interrupted, isImage, noOutputExpected }
+if [ "$TOOL_NAME" = "Read" ]; then
+  TEXT_PATH='.file.content'
+else
+  TEXT_PATH='.stdout'
+fi
+
+ORIGINAL=$(printf '%s' "$INPUT" | jq -r --arg p "$TEXT_PATH" '
+  .tool_response
+  | if type == "object" then getpath($p | ltrimstr(".") | split(".")) else empty end
+  | if type == "string" then . else empty end
+')
+[ -z "$ORIGINAL" ] && exit 0
+
+ORIG_CHARS=${#ORIGINAL}
+[ "$ORIG_CHARS" -lt "$MIN_CHARS" ] && exit 0
+
+SPILL_DIR="$HOME_DIR/$SESSION_ID"
+mkdir -p "$SPILL_DIR" 2>/dev/null || exit 0
+SPILL="$SPILL_DIR/$(date +%s)-$$.txt"
+printf '%s' "$ORIGINAL" >"$SPILL" 2>/dev/null || exit 0
+
+# --- step 1+2: collapse identical runs, drop progress noise -------------------
+# NOISE_RE is intentionally conservative: only lines that carry no information a
+# later turn could need. Anything ambiguous stays.
+NOISE_RE='^[[:space:]]*(⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|[0-9]+%|Progress:|Downloading|Fetching|Resolving|Reused |Added [0-9]+ package|Packages: |Progress: resolved|npm (WARN|notice) |[.]{3,})'
+
+COMPRESSED=$(printf '%s\n' "$ORIGINAL" \
+  | grep -Ev "$NOISE_RE" \
+  | awk '
+      { if ($0 == prev) { n++; next }
+        if (n > 0) { printf "  … previous line repeated %d more time(s)\n", n; n = 0 }
+        print; prev = $0 }
+      END { if (n > 0) printf "  … previous line repeated %d more time(s)\n", n }
+    ')
+
+# --- step 3: head/tail window ------------------------------------------------
+TOTAL_LINES=$(printf '%s\n' "$COMPRESSED" | wc -l | tr -d ' ')
+WINDOW=$((KEEP_HEAD + KEEP_TAIL))
+if [ "$TOTAL_LINES" -gt "$WINDOW" ]; then
+  ELIDED=$((TOTAL_LINES - WINDOW))
+  COMPRESSED=$(printf '%s\n' "$COMPRESSED" | head -n "$KEEP_HEAD"
+    printf '  … %d line(s) elided by trace-mcp mirror …\n' "$ELIDED"
+    printf '%s\n' "$COMPRESSED" | tail -n "$KEEP_TAIL")
+fi
+
+NEW_CHARS=${#COMPRESSED}
+# A rewrite that does not actually shrink the payload is pure risk. Bail out.
+if [ "$NEW_CHARS" -ge "$ORIG_CHARS" ]; then
+  rm -f "$SPILL"
+  exit 0
+fi
+
+SAVED_PCT=$(( (ORIG_CHARS - NEW_CHARS) * 100 / ORIG_CHARS ))
+FOOTER=$(printf '\n[trace-mcp mirror] %s output compressed %d → %d chars (−%d%%). Full output: %s' \
+  "$TOOL_NAME" "$ORIG_CHARS" "$NEW_CHARS" "$SAVED_PCT" "$SPILL")
+
+# --- measurement log ---------------------------------------------------------
+printf '%s\n' "$(jq -nc \
+  --arg s "$SESSION_ID" --arg t "$TOOL_NAME" --arg f "$SPILL" \
+  --argjson o "$ORIG_CHARS" --argjson n "$NEW_CHARS" \
+  '{ts: (now|todate), session: $s, tool: $t, orig_chars: $o, new_chars: $n, spill: $f}')" \
+  >>"$HOME_DIR/metrics.jsonl" 2>/dev/null
+
+printf '%s' "$INPUT" | jq -c \
+  --arg p "$TEXT_PATH" --arg out "$COMPRESSED$FOOTER" '
+  ($p | ltrimstr(".") | split(".")) as $path
+  | (.tool_response | setpath($path; $out)) as $resp
+  | (if ($resp | has("file")) then
+       $resp | .file.numLines = ($out | split("\n") | length)
+     else $resp end) as $resp
+  | {hookSpecificOutput: {hookEventName: "PostToolUse", updatedToolOutput: $resp}}
+'

--- a/hooks/trace-mcp-mirror.sh
+++ b/hooks/trace-mcp-mirror.sh
@@ -73,6 +73,10 @@ ORIG_CHARS=${#ORIGINAL}
 
 SPILL_DIR="$HOME_DIR/$SESSION_ID"
 mkdir -p "$SPILL_DIR" 2>/dev/null || exit 0
+# A spill is only useful while its session is alive, so anything older than a
+# day is garbage. Without this the directory grows for as long as the hook is
+# installed.
+find "$HOME_DIR" -name '*.txt' -type f -mtime +1 -delete 2>/dev/null
 SPILL="$SPILL_DIR/$(date +%s)-$$.txt"
 printf '%s' "$ORIGINAL" >"$SPILL" 2>/dev/null || exit 0
 

--- a/tests/hooks/mirror.test.ts
+++ b/tests/hooks/mirror.test.ts
@@ -140,6 +140,21 @@ describe('trace-mcp mirror hook', () => {
     }
   });
 
+  it('reaps stale spills but keeps the current one', () => {
+    const stale = path.join(home, 'old-session');
+    fs.mkdirSync(stale, { recursive: true });
+    const staleFile = path.join(stale, 'ancient.txt');
+    fs.writeFileSync(staleFile, 'old');
+    const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+    fs.utimesSync(staleFile, twoDaysAgo, twoDaysAgo);
+
+    const noisy = Array.from({ length: 400 }, () => 'copying asset').join('\n');
+    const { output } = runMirror('Bash', bashResponse(noisy));
+
+    expect(fs.existsSync(staleFile)).toBe(false);
+    expect(fs.existsSync(output!.match(/Full output: (\S+)/)![1])).toBe(true);
+  });
+
   // The harness discards a rewrite whose shape differs from the tool's own
   // output envelope, silently and without changing the transcript. Only the
   // text field may move; every sibling key must survive untouched.

--- a/tests/hooks/mirror.test.ts
+++ b/tests/hooks/mirror.test.ts
@@ -1,0 +1,176 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const HOOK = path.resolve('hooks/trace-mcp-mirror.sh');
+
+let home: string;
+
+interface MirrorResult {
+  rewritten: boolean;
+  output?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  response?: any;
+}
+
+/** The exact tool_response envelopes Claude Code sends for each tool. */
+function bashResponse(stdout: string) {
+  return { stdout, stderr: '', interrupted: false, isImage: false, noOutputExpected: false };
+}
+
+function readResponse(content: string) {
+  return {
+    type: 'text',
+    file: {
+      filePath: '/tmp/fixture.log',
+      content,
+      numLines: content.split('\n').length,
+      startLine: 1,
+      totalLines: content.split('\n').length,
+    },
+  };
+}
+
+function runMirror(
+  toolName: string,
+  toolResponse: unknown,
+  env: Record<string, string> = {},
+): MirrorResult {
+  const result = spawnSync('bash', [HOOK], {
+    input: JSON.stringify({
+      tool_name: toolName,
+      session_id: 'test-session',
+      tool_response: toolResponse,
+    }),
+    env: { ...process.env, TRACE_MCP_MIRROR_HOME: home, ...env },
+    encoding: 'utf-8',
+    timeout: 10_000,
+  });
+  expect(result.status).toBe(0);
+
+  const stdout = result.stdout.trim();
+  if (stdout.length === 0) return { rewritten: false };
+  const parsed = JSON.parse(stdout);
+  expect(parsed.hookSpecificOutput.hookEventName).toBe('PostToolUse');
+  const response = parsed.hookSpecificOutput.updatedToolOutput;
+  const text = toolName === 'Read' ? response.file.content : response.stdout;
+  return { rewritten: true, output: text, response };
+}
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'mirror-'));
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe('trace-mcp mirror hook', () => {
+  it('passes small outputs through untouched', () => {
+    expect(runMirror('Bash', bashResponse('tiny')).rewritten).toBe(false);
+  });
+
+  it('ignores tools it does not mirror', () => {
+    expect(runMirror('Edit', bashResponse('x'.repeat(50_000))).rewritten).toBe(false);
+  });
+
+  it('collapses repeated lines and reports the saving', () => {
+    const noisy = `${Array.from({ length: 400 }, () => 'copying asset').join('\n')}\ndone`;
+    const { rewritten, output } = runMirror('Bash', bashResponse(noisy));
+
+    expect(rewritten).toBe(true);
+    expect(output).toContain('previous line repeated 399 more time(s)');
+    expect(output).toContain('done');
+    expect(output!.length).toBeLessThan(noisy.length);
+    expect(output).toMatch(/\[trace-mcp mirror] Bash output compressed \d+ → \d+ chars \(−\d+%\)/);
+  });
+
+  it('spills the full output to a path named in the compressed view', () => {
+    const noisy = `${Array.from({ length: 400 }, () => 'copying asset').join('\n')}\nUNIQUE_TAIL`;
+    const { output } = runMirror('Bash', bashResponse(noisy));
+
+    const spill = output!.match(/Full output: (\S+)/)![1];
+    expect(fs.readFileSync(spill, 'utf-8')).toBe(noisy);
+  });
+
+  it('windows a long output but keeps both ends', () => {
+    const long = Array.from({ length: 1000 }, (_, i) => `line ${i}`).join('\n');
+    const { output } = runMirror('Bash', bashResponse(long));
+
+    expect(output).toContain('line 0');
+    expect(output).toContain('line 999');
+    expect(output).toContain('line(s) elided by trace-mcp mirror');
+    expect(output).not.toContain('line 500');
+  });
+
+  it('reads Read-shaped object responses', () => {
+    const content = Array.from({ length: 400 }, () => 'const x = 1;').join('\n');
+    const { rewritten, output } = runMirror('Read', readResponse(content));
+
+    expect(rewritten).toBe(true);
+    expect(output).toContain('[trace-mcp mirror] Read output compressed');
+  });
+
+  it('leaves output alone when compression would not shrink it', () => {
+    // 400 distinct, noise-free lines within the window: nothing to collapse.
+    const incompressible = Array.from({ length: 60 }, (_, i) => `x${i} ${'y'.repeat(60)}`).join(
+      '\n',
+    );
+    expect(runMirror('Bash', bashResponse(incompressible)).rewritten).toBe(false);
+  });
+
+  it('records one measurement row per rewrite', () => {
+    const noisy = Array.from({ length: 400 }, () => 'copying asset').join('\n');
+    runMirror('Bash', bashResponse(noisy));
+    runMirror('Read', readResponse(noisy));
+
+    const rows = fs
+      .readFileSync(path.join(home, 'metrics.jsonl'), 'utf-8')
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l));
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.tool)).toEqual(['Bash', 'Read']);
+    for (const row of rows) {
+      expect(row.new_chars).toBeLessThan(row.orig_chars);
+      expect(fs.existsSync(row.spill)).toBe(true);
+    }
+  });
+
+  // The harness discards a rewrite whose shape differs from the tool's own
+  // output envelope, silently and without changing the transcript. Only the
+  // text field may move; every sibling key must survive untouched.
+  it('preserves the Bash output envelope', () => {
+    const noisy = Array.from({ length: 400 }, () => 'copying asset').join('\n');
+    const { response } = runMirror('Bash', bashResponse(noisy));
+
+    expect(Object.keys(response).sort()).toEqual(Object.keys(bashResponse('')).sort());
+    expect(response.stderr).toBe('');
+    expect(response.interrupted).toBe(false);
+    expect(response.isImage).toBe(false);
+    expect(response.noOutputExpected).toBe(false);
+  });
+
+  it('preserves the Read output envelope and restates numLines', () => {
+    const content = Array.from({ length: 400 }, () => 'const x = 1;').join('\n');
+    const { response } = runMirror('Read', readResponse(content));
+
+    expect(response.type).toBe('text');
+    expect(Object.keys(response.file).sort()).toEqual(Object.keys(readResponse('').file).sort());
+    expect(response.file.filePath).toBe('/tmp/fixture.log');
+    expect(response.file.startLine).toBe(1);
+    expect(response.file.totalLines).toBe(400);
+    expect(response.file.numLines).toBe(response.file.content.split('\n').length);
+    expect(response.file.numLines).toBeLessThan(400);
+  });
+
+  it('honours the disable switch', () => {
+    const noisy = Array.from({ length: 400 }, () => 'copying asset').join('\n');
+    expect(
+      runMirror('Bash', bashResponse(noisy), { TRACE_MCP_MIRROR_DISABLE: '1' }).rewritten,
+    ).toBe(false);
+  });
+});

--- a/tests/hooks/mirror.test.ts
+++ b/tests/hooks/mirror.test.ts
@@ -46,8 +46,10 @@ function runMirror(
     }),
     env: { ...process.env, TRACE_MCP_MIRROR_HOME: home, ...env },
     encoding: 'utf-8',
-    timeout: 10_000,
+    timeout: 30_000,
+    maxBuffer: 64 * 1024 * 1024,
   });
+  expect(result.stderr).toBe('');
   expect(result.status).toBe(0);
 
   const stdout = result.stdout.trim();
@@ -138,6 +140,75 @@ describe('trace-mcp mirror hook', () => {
       expect(row.new_chars).toBeLessThan(row.orig_chars);
       expect(fs.existsSync(row.spill)).toBe(true);
     }
+  });
+
+  // Source code is full of lines that package-manager noise patterns match.
+  // Filtering a Read through them deletes code, silently.
+  it('never applies noise filtering to a Read', () => {
+    const code = [
+      ...Array.from({ length: 200 }, () => 'const spread = { ...a, ...b };'),
+      '@keyframes fade { 0% { opacity: 0 } 100% { opacity: 1 } }',
+      '  50% { opacity: 0.5 }',
+      '/** Resolving the target before use. */',
+      'const ellipsis = ...;',
+      'UNIQUE_TAIL_MARKER',
+    ].join('\n');
+    const { output } = runMirror('Read', readResponse(code));
+
+    expect(output).toContain('{ ...a, ...b }');
+    expect(output).toContain('50% { opacity: 0.5 }');
+    expect(output).toContain('Resolving the target before use.');
+    expect(output).toContain('const ellipsis = ...;');
+    expect(output).toContain('UNIQUE_TAIL_MARKER');
+  });
+
+  it('still strips package-manager progress noise from Bash', () => {
+    const noisy = [
+      ...Array.from({ length: 200 }, (_, i) => `Progress: resolved ${i}, reused 0`),
+      '⠋ installing',
+      'npm WARN deprecated foo@1.0.0',
+      'Added 12 packages',
+      'BUILD OK',
+    ].join('\n');
+    const { output } = runMirror('Bash', bashResponse(noisy));
+
+    expect(output).not.toContain('Progress: resolved');
+    expect(output).not.toContain('npm WARN');
+    expect(output).toContain('BUILD OK');
+  });
+
+  it('keeps a leading blank line instead of reporting it as a repeat', () => {
+    const withBlankFirst = `\n${Array.from({ length: 400 }, () => 'copying asset').join('\n')}\nEND`;
+    const { output } = runMirror('Bash', bashResponse(withBlankFirst));
+
+    expect(output!.startsWith('\n')).toBe(true);
+    expect(output).not.toMatch(/^\s*… previous line repeated/);
+    expect(output).toContain('previous line repeated 399 more time(s)');
+  });
+
+  // The footer costs ~120 chars. A saving smaller than that would make the
+  // rewrite bigger than the original.
+  it('does not inflate when the saving is smaller than the footer', () => {
+    const lines = Array.from({ length: 40 }, (_, i) => `x${i} ${'y'.repeat(60)}`);
+    lines.splice(5, 0, lines[4]); // exactly one collapsible duplicate
+    expect(runMirror('Bash', bashResponse(lines.join('\n'))).rewritten).toBe(false);
+  });
+
+  // Passing the rewrite through argv dies with E2BIG past ARG_MAX (1 MB on
+  // macOS). Few enough lines to escape the window, wide enough to exceed it --
+  // a minified bundle or a single huge JSON blob has exactly this shape.
+  it('survives a rewrite larger than the argv limit', () => {
+    const wide = Array.from({ length: 50 }, (_, i) => `line${i} ${'z'.repeat(30_000)}`);
+    wide.splice(10, 0, wide[9], wide[9]); // something to collapse, so it still shrinks
+    const huge = wide.join('\n');
+    expect(huge.length).toBeGreaterThan(1_048_576);
+
+    const { rewritten, output } = runMirror('Read', readResponse(huge));
+
+    expect(rewritten).toBe(true);
+    expect(output!.length).toBeGreaterThan(1_048_576);
+    expect(output).toContain('line0 ');
+    expect(output).toContain('line49 ');
   });
 
   it('reaps stale spills but keeps the current one', () => {


### PR DESCRIPTION
Prototype and first live measurements for experiment E1′ (bet A1′), issue TRA-725.

## What changed

- `hooks/trace-mcp-mirror.sh` — a `PostToolUse` hook (matcher `Read|Bash`) that rewrites the tool result on its way to the model. Deterministic and model-free: spill the full result to disk and reference it by path, drop build/install progress noise, collapse identical line runs, head/tail window the remainder, bail out unchanged if it would not shrink. Off unless installed; `TRACE_MCP_MIRROR_DISABLE` kills it.
- `tests/hooks/mirror.test.ts` — 11 tests, including the two envelope-shape tests described below.
- `benchmarks/e1-read-bash-mirror.md` — the measurements and the harness facts, so the next run does not rediscover them.

Nothing here is wired into `init` or shipped settings. It is an experiment harness.

## Why a hook and not a pair of tools

TRA-725 was written assuming mirrors would be tools the agent chooses, with "adoption below 30%" as the death line. A mirror tool cannot shadow the native one — MCP tools are namespaced, so ours would be an *additional* tool competing with `Read` for the model's pick, which is exactly the competition TRA-705 measured at 13–16%. Dead before any compression work starts.

`PostToolUse` has `updatedToolOutput`, documented as "Replaces the tool output before it is sent to the model" and working for all tools. The native tool still runs; we rewrite its result. Adoption becomes structural rather than behavioural, and the pre-registered 30% gate and 15% early stop no longer apply.

## The envelope trap

The harness validates the rewrite against the tool's output shape and discards a mismatch **silently**, keeping the original. The first prototype returned a bare string: its metrics log showed 92% compression while the transcript was untouched. Both envelopes (`Read`: `{type, file:{filePath, content, numLines, startLine, totalLines}}`; `Bash`: `{stdout, stderr, interrupted, isImage, noOutputExpected}`) are now pinned by tests. This is the issue's byte-identical-contract threat, and a shape test is the only thing that catches it.

## Evidence

Live, headless `claude -p` on Sonnet 4.5 against a noisy build log:

| tool | orig | compressed | saving | reached the model |
|---|---|---|---|---|
| `Read` 30 KB | 30140 | 2391 | −92% | yes, mirror note quoted verbatim |
| `Bash` 3.9 KB | 3952 | 1212 | −69% | yes |
| `Bash` 30 KB | 30000 | 2371 | −92% | no — host persisted the result first |

In both successful cases the model still recovered the correct last line, so the window kept what the question needed.

Full suite: `Test Files 889 passed | 2 skipped (891) · Tests 9778 passed | 12 skipped (9790) · Duration 35.00s`.

## The result that matters

On five real command outputs from this repo, four were under the threshold and passed through untouched; the one fat output (`git log --stat -40`, 101 KB) compressed 94% — and sits in the range where Claude Code already persists the result to a file itself. The compressible mass is bimodal and the harness already owns the fat end. The mirror's addressable band is what falls between "worth compressing" and the host's persistence ceiling, and sizing that band on real traffic gates A1′ more sharply than anything pre-registered. The revised gate is in the benchmark file.

## Not in this PR

The three-arm solve-rate comparison over 10–15 live tasks. Nothing here says what compression costs in correctness, re-asks, or call-count inflation.
