### PR TITLE
fix(migration): copy files byte-for-byte, not through a UTF-8 string (TRA-732)

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -73,9 +73,20 @@ function migrateLegacyHomeDir(target: string, legacy: string): boolean {
       /* best-effort — worst case a later run just doesn't retry the symlink */
     }
     return true;
-  } catch {
-    // No legacy dir (ENOENT) or a rename failure (cross-device, permissions)
-    // — fall through and let ensureGlobalDirs() create `target` fresh.
+  } catch (err) {
+    // ENOENT means there is no legacy dir at all — a clean install, nothing to
+    // say. Anything else (cross-device rename on a mounted $HOME, permissions)
+    // means the data IS there and we are about to start from an empty home
+    // instead: indistinguishable from a fresh install unless we say so. The
+    // old directory is left untouched, so the fix is a manual move (TRA-732).
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.warn(
+        `[trace] Could not migrate "${legacy}" to "${target}": ${(err as Error).message}\n` +
+          `[trace] Starting with an empty "${target}". Your existing projects, decision ` +
+          `memory and indexes are still in "${legacy}" — move that directory to ` +
+          `"${target}" manually to keep them.`,
+      );
+    }
     return false;
   }
 }

--- a/src/utils/atomic-write.ts
+++ b/src/utils/atomic-write.ts
@@ -49,6 +49,25 @@ export function atomicWriteString(
   opts: AtomicWriteOptions = {},
 ): void {
   const trailingNewline = opts.trailingNewline ?? true;
+  const body = trailingNewline && !payload.endsWith('\n') ? `${payload}\n` : payload;
+  atomicWriteBuffer(targetPath, Buffer.from(body, 'utf-8'), opts);
+}
+
+/**
+ * Atomically write raw bytes to disk — same tmp + O_EXCL + fsync + rename and
+ * the same symlink rejection as {@link atomicWriteString}, minus the UTF-8
+ * round-trip. Use this for anything that is not text: SQLite databases and
+ * their WAL/SHM sidecars, binaries, archives. Passing such content through
+ * `atomicWriteString` replaces every non-UTF-8 byte with U+FFFD, which for a
+ * database is silent, unrecoverable corruption (TRA-732).
+ *
+ * `trailingNewline` is ignored here — bytes are written verbatim.
+ */
+export function atomicWriteBuffer(
+  targetPath: string,
+  payload: Buffer,
+  opts: AtomicWriteOptions = {},
+): void {
   const rejectSymlinks = opts.rejectSymlinks ?? true;
 
   let linkStat: fs.Stats | null = null;
@@ -80,14 +99,12 @@ export function atomicWriteString(
   const rand = randomBytes(6).toString('hex');
   const tmp = path.join(dir, `.${base}.tmp.${process.pid}.${rand}`);
 
-  const body = trailingNewline && !payload.endsWith('\n') ? `${payload}\n` : payload;
-
   let fd: number | null = null;
   try {
     // O_EXCL prevents accidental clobber of a same-pid+rand collision. mode
     // is applied at create time (before any data is visible at the target).
     fd = fs.openSync(tmp, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, mode);
-    fs.writeFileSync(fd, body);
+    fs.writeFileSync(fd, payload);
     // fsync: ensure data is on disk before the rename publishes it. Best-effort
     // — some filesystems (network, fuse) may not honour this, but POSIX rename
     // is still atomic at the directory entry level.

--- a/src/utils/path-migration.ts
+++ b/src/utils/path-migration.ts
@@ -21,7 +21,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { atomicWriteString } from './atomic-write.js';
+import { atomicWriteBuffer, atomicWriteString } from './atomic-write.js';
 import { restrictDbPerms } from '../shared/db-perms.js';
 import { readIfExists } from './safe-fs.js';
 import type { InitStepResult } from '../init/types.js';
@@ -244,7 +244,7 @@ export function migrateDirectorySafely(
                 const sStat = fs.lstatSync(sidecarSrc);
                 if (sStat.isFile() && !sStat.isSymbolicLink()) {
                   copyFileAtomic(sidecarSrc, sidecarDest, mode);
-                  restrictDbPerms(destItem);
+                  restrictDbPerms(sidecarDest);
                   processedSidecars.add(sidecarSrc);
                 }
               } catch {
@@ -298,11 +298,9 @@ function copyFileAtomic(source: string, destination: string, mode: number): void
   if (!fs.existsSync(destDir)) {
     fs.mkdirSync(destDir, { recursive: true });
   }
-  atomicWriteString(destination, content.toString('utf-8'), {
-    mode,
-    rejectSymlinks: true,
-    trailingNewline: false,
-  });
+  // Bytes, not text: this copies SQLite databases and bin/ shims. Going
+  // through a UTF-8 string would map every invalid byte to U+FFFD (TRA-732).
+  atomicWriteBuffer(destination, content, { mode, rejectSymlinks: true });
 }
 
 /**

--- a/tests/utils/atomic-write.test.ts
+++ b/tests/utils/atomic-write.test.ts
@@ -10,7 +10,46 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { atomicWriteJson, atomicWriteString } from '../../src/utils/atomic-write.js';
+import {
+  atomicWriteBuffer,
+  atomicWriteJson,
+  atomicWriteString,
+} from '../../src/utils/atomic-write.js';
+
+describe('atomicWriteBuffer', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'trace-atomic-buf-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes non-UTF-8 bytes verbatim and appends nothing', () => {
+    const target = join(dir, 'blob.bin');
+    const bytes = Buffer.from([0x00, 0xff, 0xfe, 0x80, 0x81, 0x0a, 0x7f]);
+    atomicWriteBuffer(target, bytes);
+    expect(readFileSync(target)).toEqual(bytes);
+  });
+
+  it('applies the requested mode', () => {
+    if (process.platform === 'win32') return;
+    const target = join(dir, 'secret.bin');
+    atomicWriteBuffer(target, Buffer.from([0x01]), { mode: 0o600 });
+    expect(statSync(target).mode & 0o777).toBe(0o600);
+  });
+
+  it('refuses to write through a symlink', () => {
+    const real = join(dir, 'real.bin');
+    const link = join(dir, 'link.bin');
+    writeFileSync(real, 'untouched');
+    symlinkSync(real, link);
+
+    expect(() => atomicWriteBuffer(link, Buffer.from([0xff]))).toThrow(/symlink/);
+    expect(readFileSync(real, 'utf8')).toBe('untouched');
+  });
+});
 
 describe('atomicWriteString', () => {
   let dir: string;

--- a/tests/utils/path-migration.test.ts
+++ b/tests/utils/path-migration.test.ts
@@ -180,6 +180,35 @@ describe('Path and Directory Migration Security', () => {
         expect(statSync(join(destDir, 'decisions.db-shm')).mode & 0o777).toBe(0o600);
       }
     });
+
+    // TRA-732: the copy path used to round-trip through a UTF-8 string, which
+    // maps every invalid byte to U+FFFD (1 byte in, 3 out). The five tests
+    // above all pass on a file corrupted that way because their fixtures are
+    // ASCII. A real database is not.
+    it('copies a database and its sidecars byte-for-byte', () => {
+      const dbBytes = Buffer.concat([
+        Buffer.from('SQLite format 3\0', 'binary'),
+        Buffer.from([0x10, 0x00, 0x01, 0x01, 0x00, 0x40, 0x20, 0x20, 0xff, 0xfe, 0x80, 0x81]),
+      ]);
+      const walBytes = Buffer.from([0x37, 0x7f, 0x06, 0x82, 0xff, 0xc0, 0x00, 0xed]);
+      writeFileSync(join(srcDir, 'state.db'), dbBytes);
+      writeFileSync(join(srcDir, 'state.db-wal'), walBytes);
+
+      const result = migrateDirectorySafely(srcDir, destDir);
+      expect(result.success).toBe(true);
+
+      expect(readFileSync(join(destDir, 'state.db'))).toEqual(dbBytes);
+      expect(readFileSync(join(destDir, 'state.db-wal'))).toEqual(walBytes);
+    });
+
+    it('copies a non-database binary file without appending a newline', () => {
+      const blob = Buffer.from([0x00, 0xff, 0x0a, 0x80, 0x7f]);
+      writeFileSync(join(srcDir, 'cache.bin'), blob);
+
+      const result = migrateDirectorySafely(srcDir, destDir);
+      expect(result.success).toBe(true);
+      expect(readFileSync(join(destDir, 'cache.bin'))).toEqual(blob);
+    });
   });
 
   describe('Project Config (.trace-mcp.json -> .trace.json) Migration', () => {


### PR DESCRIPTION
Fixes TRA-732.

## The bug

`migrateDirectorySafely()` (`src/utils/path-migration.ts`) documents *"SQLite Database Integrity (CWE-362): Atomically migrates database files together with their WAL/SHM sidecars"* and specifically recognises `.db` plus `-wal` / `-shm` / `-journal`. Its copy helper then did this:

```ts
const content = fs.readFileSync(source);                            // Buffer
atomicWriteString(destination, content.toString('utf-8'), { ... }); // string
```

`atomicWriteString` writes UTF-8. Every byte that is not valid UTF-8 becomes U+FFFD — one byte in, three bytes out. The result is not a database.

**No user data has been corrupted:** `migrateDirectorySafely` has zero production callers today; `src/global.ts` inlines its own `renameSync` migration. The risk is the first caller. `migrateLegacyHomeDir` returns `false` on a cross-device rename (container / mounted `$HOME` — `TRACE_MCP_DATA_DIR` is documented as the Docker-volume knob), and the obvious next step is "use the copying fallback on cross-device". That fallback is written, looks tested, and corrupts every database it touches. The existing five tests all use ASCII fixtures, so it passes them.

## Changes

1. **`atomicWriteBuffer()`** next to `atomicWriteString()` in `src/utils/atomic-write.ts` — same tmp + `O_EXCL` + symlink rejection + fsync + rename, payload written verbatim. `atomicWriteString()` now applies `trailingNewline` and delegates, so the write guarantees live in one place.
2. **`copyFileAtomic()`** uses it.
3. **Sidecar perms typo**: the sidecar loop called `restrictDbPerms(destItem)` — hardening the parent `.db` a second time instead of the sidecar. Not exploitable (perms already arrive via `mode` at create time), but a copy-paste slip in a file whose purpose is being safe.
4. **`migrateLegacyHomeDir()`** no longer starts from an empty `~/.trace` in silence when the rename fails. Starting empty is indistinguishable from a clean install; it now names both paths and says the data is still in the old directory. `ENOENT` (no legacy dir at all) stays quiet.

I did **not** add a copying fallback to `migrateLegacyHomeDir` — that is a separate decision, and the warning makes today's live behaviour honest either way. Whoever adds it now inherits a correct helper.

## Test evidence

New in `tests/utils/path-migration.test.ts`: a real SQLite header plus invalid-UTF-8 bytes copied as a `.db` with a `-wal` sidecar, and a plain binary file (also guards against a stray trailing newline). New in `tests/utils/atomic-write.test.ts`: direct `atomicWriteBuffer` coverage for byte fidelity, mode, and symlink rejection.

Both new migration tests fail against the previous implementation — verified by reverting the one-line change and re-running:

```
× copies a database and its sidecars byte-for-byte
× copies a non-database binary file without appending a newline
Tests  2 failed | 22 passed (24)
```

Full suite green: `Test Files 889 passed | 2 skipped`, `Tests 9789 passed | 12 skipped`. `pnpm run build` and `pnpm run lint` clean.

Agent: Lead Engineer
