### PR TITLE
docs(site): stop comparison tables centring their value columns (TRA-741)

### DIFF
--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -176,6 +176,19 @@ Order: sticky header (brand + theme toggle) → `h1` → prose → `Last updated
   head is a Space Mono 10px caps label, not a bold band. Every table is
   wrapped in a focusable `.table-scroll` region by the layout script, so a
   wide tool table scrolls itself instead of the page.
+- **A table cell is left-aligned unless it holds a number, and then it is
+  right-aligned. Never centred.** A centred cell that holds a phrase has two
+  ragged edges and no common start, and it sits beside a row label that is
+  left-aligned — a single row then reads left, centre, centre. This is not a
+  CSS decision and that is why it drifted: a Markdown `|:---:|` delimiter row
+  becomes an inline `style="text-align: center"` on every cell of the column,
+  which beats `.prose tbody td`'s `text-align: left` outright. Twelve tables
+  across eight files shipped that way — 321 of the 382 centred cells on
+  `comparisons.html` wrap to more than one line **at 1440px**, and the worst on
+  `/vs/serena.html` runs to six lines at 390px. `docs.css` now overrides the
+  inline centre rather than the Markdown being edited, so the next table
+  written with `:---:` is covered and the content files stay the SEO agent's.
+  A right-aligned numeric column (`toon-savings.md`) keeps its alignment.
 - **A scroll region says so.** A region with more to the right carries a
   `scroll →` label — Space Mono 10px caps at `--text-disabled`, right-aligned
   10px above the head row, the same instrument-label voice as the `thead`.
@@ -368,6 +381,9 @@ appearance without a screenshot or a measurement is not a finding.
 - [ ] Service labels are Space Mono caps; nothing else is.
 - [ ] No emoji in any rendered page — `grep -c '✅\|❌\|⚠️' docs/*.md
       docs/vs/*.md` returns 0 for every file.
+- [ ] No table cell computes to `text-align: center` — read it off the cell,
+      not off the stylesheet. The alignment comes from the Markdown delimiter
+      row as an inline style, so `docs.css` saying `left` proves nothing.
 - [ ] Exactly one h1; section breaks are 80px, not ad hoc.
 - [ ] Exactly one deliberate pattern break on the page.
 

--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -479,6 +479,20 @@ main {
 .prose th:last-child {
   padding-right: 0;
 }
+/* A Markdown `|:---:|` delimiter row becomes an inline `text-align: center` on
+   every cell of that column, which beats the `text-align: left` above — so it
+   has never applied to a comparison table. A capability cell holds a phrase,
+   not a number: centred it has two ragged edges and no common start, next to a
+   row label that is left-aligned. 321 of the 382 centred cells on
+   comparisons.html wrap to more than one line at 1440px, and the worst on
+   /vs/serena.html runs to six. Overridden here rather than in the Markdown so
+   the next table written with `:---:` is covered too — the content files are
+   the SEO agent's. Right-aligned columns are untouched: toon-savings.md
+   right-aligns four numeric columns, which is what right alignment is for. */
+.prose tbody td[style*='center'],
+.prose thead th[style*='center'] {
+  text-align: left !important;
+}
 
 /* Capability marks. The comparison tables used ✅/❌ — emoji as UI, and a
    green that is a second accent colour. The mark is now plain ✓/✗ text, and


### PR DESCRIPTION
Closes TRA-741.

Every comparison table on the site centres its value columns. The alignment is
not in any stylesheet — it is in the Markdown delimiter row (`|:---:|`), which
kramdown turns into an inline `style="text-align: center"` on every cell of that
column. That beats `.prose tbody td { text-align: left }`, so the rule that has
been in `docs.css` all along has never applied to a comparison cell. On
`/vs/serena.html` the published markup is 40 `<td style="text-align: center">`
against 20 plain `<td>`, plus 2 centred `<th>`.

## Measured, on the published site

Headless Chrome against `https://trace-mcp.com`, DPR 1, not a local render:

| Page | Width | Centred cells | Wrapping to 2+ lines |
|---|---|---|---|
| `/comparisons.html` | 1440px | 382 | **321 (84%)** |
| `/vs/serena.html` | 1440px | 40 | 18 (45%) |
| `/vs/serena.html` | 390px | 40 | **36 (90%)** |
| `/vs/codegraph.html` | 390px | 44 | 42 (95%) |

The worst cells run to six lines. `Range.getClientRects()` on
`✓ rename, move, signature, AST codemod, extract` at 390px gives line starts of
144.5 / 140.5 / 154.6 / 163.4 — four lines, four different left edges. With the
rule applied they collapse to one.

## The change

One rule in `docs/assets/css/docs.css` overriding the inline centre, and the
missing rule plus a checklist line in `docs/DESIGN-WEB.md` §2.

Fixed in CSS rather than in the twelve Markdown tables across eight files: it
covers the next table someone writes with `:---:`, and the content files belong
to the SEO agent. Right-aligned columns are deliberately untouched — verified
that all 163 right-aligned cells on `/toon-savings.html` and 15 on
`/comparisons.html` keep their alignment after the rule lands, which is what a
right-aligned numeric column is for.

`!important` is load-bearing here and not laziness: an inline style cannot be
beaten any other way from a stylesheet, and the alternative — stripping the
attribute in the layout's table script — would leave the site mis-set with JS
off.

## Verification

- `node scripts/contrast-sweep.mjs` — 28 pages x 2 themes, 0 failures.
- Before/after screenshots at 390px dark and 1440px light, captured headless
  from the live site with the rule injected. On the 1440px light shot of
  `/comparisons.html` the `✗` marks stop scattering and form one rail per
  column, and `✓ knowledge graph` / `✓ detect_changes` / `✓ trace_call_path` in
  the last column stop being clipped mid-word — centring had been pushing them
  into the clipped edge.

Screenshots are attached on TRA-741.
