### PR TITLE
fix(hooks): strip CRLF from mirror hook output on Windows (TRA-743)

### DIFF
--- a/hooks/trace-mcp-mirror.sh
+++ b/hooks/trace-mcp-mirror.sh
@@ -61,11 +61,14 @@ else
   TEXT_PATH='.stdout'
 fi
 
+# jq's Windows build writes stdout in CRT text mode, which turns every LF it
+# emits into CRLF -- the CR never came from the tool output itself, so strip
+# it here rather than let it leak into the spill file and the compressed view.
 ORIGINAL=$(printf '%s' "$INPUT" | jq -r --arg p "$TEXT_PATH" '
   .tool_response
   | if type == "object" then getpath($p | ltrimstr(".") | split(".")) else empty end
   | if type == "string" then . else empty end
-' 2>/dev/null)
+' 2>/dev/null | tr -d '\r')
 [ -z "$ORIGINAL" ] && exit 0
 
 ORIG_CHARS=${#ORIGINAL}


### PR DESCRIPTION
## Summary
- `jq`'s Windows build writes stdout in CRT text mode, turning every LF it emits into CRLF when extracting the tool-response text field.
- That CR never came from the actual tool output — it leaked into the spill file and the compressed view, failing `tests/hooks/mirror.test.ts` on `windows-latest` in CI (blocking release PR #796).
- Strip `\r` right after the `jq -r` extraction so Windows behavior matches Unix.

## Test plan
- [x] `npx vitest run tests/hooks/mirror.test.ts` — 17/17 pass locally (macOS)
- [ ] CI `cross-platform-test (windows-latest)` green