### PR TITLE
fix(doctor): stop flagging trace-mcp's own tool names as competitor directives

### DIFF
--- a/src/init/conflict-detector.ts
+++ b/src/init/conflict-detector.ts
@@ -114,13 +114,14 @@ const COMPETING_CLAUDE_MD_PATTERNS: { pattern: RegExp; competitor: string; marke
   },
   { pattern: /<!-- ?code-index:start ?-->/i, competitor: 'code-index', marker: 'code-index:start' },
   // jcodemunch — tool name references (distinctive API surface)
+  //
+  // Only names jcodemunch does NOT share with trace-mcp belong here. get_context_bundle,
+  // embed_repo, get_session_stats and suggest_queries are trace-mcp's own tools, so
+  // matching them flagged every file that documents trace-mcp itself — including this
+  // repo's CLAUDE.md (TRA-746).
   { pattern: /jcodemunch|jCodeMunch/i, competitor: 'jcodemunch-mcp' },
   {
-    pattern: /get_file_outline|get_symbol_source|get_context_bundle|get_ranked_context/i,
-    competitor: 'jcodemunch-mcp',
-  },
-  {
-    pattern: /embed_repo|get_blast_radius|get_session_stats|suggest_queries/i,
+    pattern: /get_file_outline|get_symbol_source|get_ranked_context|get_blast_radius/i,
     competitor: 'jcodemunch-mcp',
   },
   // repomix

--- a/tests/init/conflict-detector.test.ts
+++ b/tests/init/conflict-detector.test.ts
@@ -208,6 +208,33 @@ describe('detectConflicts', () => {
     expect(jcm!.severity).toBe('critical');
   });
 
+  it('does not flag a CLAUDE.md that documents trace-mcp own tools', () => {
+    // TRA-746: these names belong to trace-mcp, not to any competitor.
+    const root = fixture({
+      'CLAUDE.md':
+        '# Project\n\n' +
+        '- `get_context_bundle({ symbol_id: "..." })` returns symbol + imports\n' +
+        '- `embed_repo` precomputes embeddings\n' +
+        '- `get_session_stats` reports token savings\n' +
+        '- `suggest_queries` lists example calls\n',
+    });
+
+    const report = detectConflicts(root);
+    const claudeConflicts = report.conflicts.filter(
+      (c) => c.category === 'claude_md' && c.target.startsWith(root),
+    );
+    expect(claudeConflicts).toHaveLength(0);
+  });
+
+  it("does not flag this repo's own CLAUDE.md", () => {
+    // TRA-746: the reported false positive, guarded against the real file.
+    const root = process.cwd();
+    const claudeConflicts = detectConflicts(root).conflicts.filter(
+      (c) => c.category === 'claude_md' && c.target.startsWith(root),
+    );
+    expect(claudeConflicts).toEqual([]);
+  });
+
   it('does not flag clean CLAUDE.md', () => {
     const root = fixture({
       'CLAUDE.md': '# Project\n\nUse trace-mcp tools for code navigation.\n',


### PR DESCRIPTION
Fixes TRA-746.

## Problem

`trace-mcp doctor` reported this repository's own `CLAUDE.md` (plus two files under `~/.claude/projects/`) as containing "jcodemunch-mcp directives" and offered `--fix` to rewrite them. The file has zero literal occurrences of `jcodemunch`.

Cause is in `COMPETING_CLAUDE_MD_PATTERNS` (`src/init/conflict-detector.ts`): two of the "distinctive jcodemunch API surface" patterns listed **trace-mcp's own tool names** —

- `get_context_bundle`, `embed_repo`, `get_session_stats`, `suggest_queries`

So any file that documents trace-mcp's tool routing matched. `isNegatedMention` doesn't save it: our CLAUDE.md mentions these tools affirmatively (`get_context_bundle({ symbol_id: ... })`), which is exactly right — they're ours.

Impact was real, not cosmetic: the finding is `fixable: true`, so a user or agent trusting the warning would have run `--fix` and let the resolver comment out live trace-mcp routing instructions in files that needed no change.

## Fix

Drop the four shared names. Kept the ones jcodemunch does not share with us: `get_file_outline`, `get_symbol_source`, `get_ranked_context`, `get_blast_radius`. Genuine jcodemunch detection (marker blocks, the `jcodemunch` name itself, config files, MCP server entries, hooks) is untouched.

## Test evidence

Two regression tests in `tests/init/conflict-detector.test.ts`:

1. a fixture CLAUDE.md documenting the four trace-mcp tools — must yield no `claude_md` conflict;
2. the reported file itself — `detectConflicts(process.cwd())` must report no `claude_md` conflict for this repo.

Both fail on `main` (verified: `expected [ { …(9) } ] to have a length of +0`) and pass with the fix.

Real repro re-run against the rebuilt CLI: `node dist/cli.js doctor` → "No competing tools or conflicting configurations detected." All three reported false positives gone.

Full suite: 9791 passed / 12 skipped, build and biome clean.

No MCP tool-signature or on-disk schema change; no token-cost impact.

Agent: Lead Engineer