### PR TITLE
docs(roadmap): calls is a GA4 custom dimension, not a metric

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -413,8 +413,12 @@ currently pointed at installs that will never reach value. Those are opposite
 strategies and we cannot presently tell them apart.
 
 **One dependency, and it is the same one three other items are waiting on.**
-`calls` needs registering in GA4 as an event-scoped custom metric, exactly like
-`repos_indexed` / `preset` / `tools_advertised` need registering as dimensions.
+`calls` needs registering in GA4 as an event-scoped custom **dimension**, exactly
+like `repos_indexed` / `preset` / `tools_advertised` — not a metric, as an earlier
+revision of this line said. `scripts/ga4-snapshot.mjs` queries `customEvent:calls`
+in the `dimensions` array (once alone, once crossed with `client`), and GA4 will
+not serve a metric registration to a dimension slot: registering it as a metric
+leaves `usage` and `by_client_used_pct` exactly as blank as they are now.
 GA4 does not backfill any of them. That makes four fields in one admin session
 rather than four separate asks — bundle it.
 


### PR DESCRIPTION
`scripts/ga4-snapshot.mjs` queries `customEvent:calls` in the **dimensions** array — once alone (`usage`, line 274) and once crossed with `client` (`by_client_used_pct`, line 289). `docs/ROADMAP.md` told the reader to register it as a custom **metric**.

GA4 does not serve a metric registration into a dimension slot, and it does not backfill. Following the old line would have cost an admin session and left `usage` / `by_client_used_pct` exactly as blank as they are today, with the failure only visible a day later in the next snapshot.

Verified against `origin/master`:
- client sends `calls` in `app_open` params — `src/telemetry/usage-ping.ts:319`
- snapshot reads it as a dimension — `scripts/ga4-snapshot.mjs:274`, `:289`

Docs only, no code change. Refs TRA-747.
