### PR TITLE
feat(analytics): publish the client-reporting gate in adoption.yml (TRA-748)

### DIFF
--- a/scripts/ga4-funnel.d.mts
+++ b/scripts/ga4-funnel.d.mts
@@ -17,3 +17,21 @@ export function activation(rows: FunnelRow[] | undefined | null): Activation;
 
 /** Percentage, or null when the denominator is missing. */
 export function share(part: number, whole: number): number | null;
+
+export interface ClientReporting {
+  fix_version: string;
+  at_or_above: number;
+  below: number;
+  unknown: number;
+  pct: number | null;
+  readable: boolean | null;
+}
+
+/** First version whose ping reports its client correctly. */
+export const CLIENT_FIX_VERSION: string;
+
+/** Share of `customEvent:version` rows able to report a client (TRA-748). */
+export function clientReporting(
+  rows: FunnelRow[] | undefined | null,
+  floor?: string,
+): ClientReporting;

--- a/scripts/ga4-funnel.mjs
+++ b/scripts/ga4-funnel.mjs
@@ -165,3 +165,71 @@ export function usageByClient(rows) {
 export function share(part, whole) {
   return whole > 0 ? Math.round((part / whole) * 100) : null;
 }
+
+/**
+ * First version whose ping reports its client correctly (TRA-643, `be1fb536`).
+ * Before it, the ping's final `saveState` wrote a snapshot taken before the HTTP
+ * request and erased the client name the request had just recorded, so those
+ * installs report `unknown` no matter which client they run.
+ */
+export const CLIENT_FIX_VERSION = '3.12.0';
+
+/** Semver compare on the numeric release triple; a prerelease suffix is ignored. */
+function cmpVersion(a, b) {
+  // `Number('')` is 0, so an empty segment has to be rejected before the parse —
+  // otherwise `(not set)`'s empty string parses as 0.0.0 and lands below the
+  // floor, which is exactly the unknown-counted-as-evidence bug this guards.
+  const parts = (v) =>
+    String(v)
+      .split('-')[0]
+      .split('.')
+      .map((n) => (n.trim() === '' ? Number.NaN : Number(n)));
+  const [x, y] = [parts(a), parts(b)];
+  if (x.some((n) => !Number.isFinite(n)) || y.some((n) => !Number.isFinite(n))) return null;
+  for (let i = 0; i < 3; i++) if ((x[i] ?? 0) !== (y[i] ?? 0)) return (x[i] ?? 0) - (y[i] ?? 0);
+  return 0;
+}
+
+/**
+ * How much of the field runs a version that can report its client at all
+ * (TRA-748) — the gate on whether `by_client` and `by_client_used_pct` mean
+ * anything yet.
+ *
+ * `by_client_used_pct` becomes non-empty the moment `calls` is registered in the
+ * property, and it decides distribution strategy — but a split computed over a
+ * population that is nine-tenths client-blind cannot answer "does use hold
+ * across clients" in either direction. Nineteen hours after v3.12.0 shipped,
+ * versions carrying the fix were 10% of the rows. Publishing the share here is
+ * the difference between a caveat that travels with the data and a caveat in an
+ * issue nobody re-reads.
+ *
+ * `pct` is over placed rows only, the same denominator discipline as everything
+ * above: GA4's `(not set)` version is not evidence of an old install.
+ *
+ * @param rows GA4 `runReport` rows, dimension `customEvent:version`, metric
+ *   `activeUsers`.
+ */
+export function clientReporting(rows, floor = CLIENT_FIX_VERSION) {
+  let at_or_above = 0;
+  let below = 0;
+  let unknown = 0;
+  for (const row of rows ?? []) {
+    const users = Number(row.metricValues?.[0]?.value ?? 0);
+    if (!Number.isFinite(users) || users <= 0) continue;
+    const c = cmpVersion(row.dimensionValues?.[0]?.value ?? '', floor);
+    if (c === null) unknown += users;
+    else if (c >= 0) at_or_above += users;
+    else below += users;
+  }
+  const pct = share(at_or_above, at_or_above + below);
+  return {
+    fix_version: floor,
+    at_or_above,
+    below,
+    unknown,
+    pct,
+    // The gate itself, as a value rather than something to re-derive: below half
+    // the field on a fix-carrying version, re-read and record — do not conclude.
+    readable: pct === null ? null : pct >= 50,
+  };
+}

--- a/scripts/ga4-snapshot.mjs
+++ b/scripts/ga4-snapshot.mjs
@@ -22,7 +22,7 @@
  */
 import crypto from 'node:crypto';
 import fs from 'node:fs';
-import { activation, share, usage, usageByClient } from './ga4-funnel.mjs';
+import { activation, clientReporting, share, usage, usageByClient } from './ga4-funnel.mjs';
 import { PRICE_MODEL, PRICE_PER_TOKEN, sanitizedTokens, usd } from './ga4-savings.mjs';
 
 const OUT = 'docs/_data/adoption.yml';
@@ -313,6 +313,7 @@ const yaml = (obj, indent = 2) =>
 const act = activation(indexed?.rows);
 const use = usage(called?.rows);
 const useByClient = usageByClient(calledByClient?.rows);
+const clientFix = clientReporting(versions?.rows);
 const newInstalls = installs ? (breakdown(installs).new ?? 0) : 0;
 const yamlNum = (v) => (v === null || v === undefined ? 'null' : v);
 /** An `error:` line when a source failed, nothing when it did not. */
@@ -420,7 +421,9 @@ ${yaml(act.buckets, 4)}
 # hook — is Claude Code only, and session mining has providers for two clients.
 # If use holds across clients, reach work goes wide; if it collapses without a
 # hook, our addressable market is clients that can enforce routing. Read it
-# beside \`by_client_installs\`: single-digit denominators conclude nothing.
+# beside \`by_client_installs\`: single-digit denominators conclude nothing — and
+# beside \`client_reporting\` further down, which says whether the population
+# being split can report a client at all yet (TRA-748).
 #
 # Empty until \`calls\` is registered as an event-scoped custom dimension in the
 # property; GA4 does not backfill, so values start at registration.
@@ -449,6 +452,28 @@ installs_28d:
 ${yaml(installs ? breakdown(installs) : {})}
 by_version:
 ${yaml(breakdown(versions))}
+
+# Whether \`by_client\` below — and \`by_client_used_pct\` above — can be read at
+# all yet (TRA-748). Derived from \`by_version\`, not sent by the client.
+#
+# Installs older than \`fix_version\` report their client as \`unknown\` whatever
+# client they run: the ping's final \`saveState\` persisted a snapshot taken
+# before the HTTP request and erased the name the request had just recorded
+# (fixed in TRA-643). So a client split over a mostly-\`below\` population cannot
+# say whether tool use holds across clients — in either direction.
+#
+#   pct         share of placed rows on a version that reports a client
+#   readable    that share past half; until then, re-read and record, do not
+#               conclude. \`null\` means no version rows at all.
+#   unknown     rows whose version GA4 has no value for — not evidence of an
+#               old install, so kept out of \`pct\` entirely.
+client_reporting:
+  fix_version: "${clientFix.fix_version}"
+  at_or_above: ${clientFix.at_or_above}
+  below: ${clientFix.below}
+  unknown: ${clientFix.unknown}
+  pct: ${yamlNum(clientFix.pct)}
+  readable: ${yamlNum(clientFix.readable)}
 
 # Which tool preset installs actually run, and how many tools that surface
 # advertises (TRA-643). \`preset-surface-budget.test.ts\` measures the same basis

--- a/tests/scripts/ga4-funnel.test.ts
+++ b/tests/scripts/ga4-funnel.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { activation, share, usage, usageByClient } from '../../scripts/ga4-funnel.mjs';
+import {
+  activation,
+  clientReporting,
+  share,
+  usage,
+  usageByClient,
+} from '../../scripts/ga4-funnel.mjs';
 
 /** One GA4 row: a `repos_indexed` value and how many active installs reported it. */
 const row = (value: string, users: number) => ({
@@ -116,6 +122,66 @@ describe('usageByClient', () => {
     expect(result.installs.__proto__).toBe(7);
     expect(result.used_pct.__proto__).toBe(100);
     expect({}.hasOwnProperty).toBeTypeOf('function'); // nothing polluted globally
+  });
+});
+
+describe('clientReporting', () => {
+  it('reads the real 2026-09-03 by_version as not yet readable', () => {
+    // The snapshot that raised TRA-748: 12 of 120 rows on a version carrying the
+    // TRA-643 client fix, nineteen hours after v3.12.0 shipped. A client split
+    // over this population says nothing, and `readable` is what says so.
+    const result = clientReporting([
+      row('(not set)', 36),
+      row('3.10.0', 26),
+      row('3.11.0', 23),
+      row('3.8.0', 19),
+      row('3.14.0', 10),
+      row('3.7.0', 2),
+      row('3.12.0', 1),
+      row('3.13.0', 1),
+      row('3.5.2', 1),
+      row('3.6.0', 1),
+    ]);
+
+    expect(result).toEqual({
+      fix_version: '3.12.0',
+      at_or_above: 12,
+      below: 72,
+      unknown: 36,
+      // Over placed rows only — `(not set)` is not evidence of an old install.
+      pct: 14,
+      readable: false,
+    });
+  });
+
+  it('opens the gate once past half the placed field', () => {
+    expect(clientReporting([row('3.12.0', 6), row('3.8.0', 4)])).toMatchObject({
+      pct: 60,
+      readable: true,
+    });
+  });
+
+  it('compares release numbers, not strings', () => {
+    // '3.9.0' > '3.12.0' lexicographically; below the floor numerically.
+    const result = clientReporting([row('3.9.0', 5), row('3.100.0', 5)]);
+
+    expect(result.below).toBe(5);
+    expect(result.at_or_above).toBe(5);
+  });
+
+  it('counts a prerelease of the fix as carrying it', () => {
+    expect(clientReporting([row('3.12.0-rc.1', 3)]).at_or_above).toBe(3);
+  });
+
+  it('reports no version rows as null, not as an unreadable field', () => {
+    expect(clientReporting([]).readable).toBeNull();
+    expect(clientReporting(undefined).pct).toBeNull();
+  });
+
+  it('keeps unparseable versions out of both sides', () => {
+    const result = clientReporting([row('dev', 4), row('', 2), row('3.14.0', 1)]);
+
+    expect(result).toMatchObject({ unknown: 6, at_or_above: 1, below: 0, pct: 100 });
   });
 });
 


### PR DESCRIPTION
`by_client_used_pct` is the number `adoption.yml` calls "the one that decides distribution strategy", and it becomes non-empty the moment `calls` is registered in the property (TRA-747) — computed over a population that mostly cannot report a client at all.

Installs older than **v3.12.0** report their client as `unknown` whatever client they run: the ping's final `saveState` persisted a snapshot taken before the HTTP request and erased the name `recordUsagePingClient` had just written. Fixed in TRA-643 / #748 (`be1fb536`), first shipped in v3.12.0 on 2026-09-02.

This publishes the gate instead of remembering it. `scripts/ga4-snapshot.mjs` already fetches `by_version`; one derived block now says whether the client split is worth reading:

```yaml
client_reporting:
  fix_version: "3.12.0"
  at_or_above: 12
  below: 72
  unknown: 36
  pct: 14
  readable: false
```

Those are today's real numbers (`origin/adoption-data`, snapshot 2026-09-03 06:41 UTC), and they are the test fixture.

Note the denominator: TRA-748 quotes **10% (12 of 120)**. `pct` here is **14%**, over placed rows only — `(not set)` versions are counted in `unknown` and kept out of both sides, following the same rule `activation`/`usage` already use. GA4 having no version for a row is not evidence of an old install. Either way the gate is shut.

`readable` is the boolean the issue asks for: below half the placed field, re-read and record, do not conclude.

## Test evidence

`tests/scripts/ga4-funnel.test.ts` — 19 passed, including the 2026-09-03 fixture, numeric (not lexicographic) version compare (`3.9.0` < `3.12.0` < `3.100.0`), prereleases of the fix, unparseable versions landing in `unknown`, and no rows → `null` rather than "unreadable". `tsc --noEmit` clean.

## Not in scope

- The `by_client` reading itself lives in #824 (`ops/user-signal.md`), still open — untouched here to avoid a conflict.
- `3.9.0` missing from `by_version` while 3.8.0 holds 19 installs belongs with the upgrade path (TRA-566), not here.

Closes TRA-748.

Agent: Lead Engineer

---

Related: #826 — docs-only, and not a duplicate. That PR corrects the `docs/ROADMAP.md` wording for registering `calls` (TRA-747); this one derives the readability gate for the split that registration will expose (TRA-748). The two land in different files and the duplicate-work guard matches on the shared `TRA-747` mention.
