### PR TITLE
fix(app): the theme switcher applies without a restart (TRA-754)

### DIFF
--- a/packages/app/src/renderer/__tests__/theme.test.tsx
+++ b/packages/app/src/renderer/__tests__/theme.test.tsx
@@ -132,16 +132,37 @@ describe('useTheme', () => {
     expect(() => renderHook(() => useTheme())).not.toThrow();
   });
 
+  /* A real `storage` event fires AFTER the other window's write landed, so the
+     test has to move localStorage too — the event is the nudge, not the value. */
   it('syncs from another window, including a clear back to Auto', () => {
     const { result } = renderHook(() => useTheme());
     act(() => {
+      localStorage.setItem(THEME_KEY, 'dark');
       window.dispatchEvent(new StorageEvent('storage', { key: THEME_KEY, newValue: 'dark' }));
     });
     expect(result.current.appearance).toBe('dark');
 
     act(() => {
+      localStorage.removeItem(THEME_KEY);
       window.dispatchEvent(new StorageEvent('storage', { key: THEME_KEY, newValue: null }));
     });
     expect(result.current.appearance).toBe('auto');
+  });
+
+  /* TRA-754. TRA-700 split the single useTheme() call into two — the window
+     shell keeps `theme` for .ws-stage[data-mode], the tab view keeps
+     setAppearance for the toggle — and per-hook useState let them disagree:
+     the click moved [data-theme] and localStorage but not [data-mode], so the
+     app only picked up the new theme on the next launch. */
+  it('every instance in the window sees the same choice', () => {
+    const shell = renderHook(() => useTheme());
+    const tab = renderHook(() => useTheme());
+
+    act(() => tab.result.current.setAppearance('dark'));
+    expect(shell.result.current.appearance).toBe('dark');
+    expect(shell.result.current.theme).toBe('dark');
+
+    act(() => tab.result.current.setAppearance('auto'));
+    expect(shell.result.current.appearance).toBe('auto');
   });
 });

--- a/packages/app/src/renderer/theme.ts
+++ b/packages/app/src/renderer/theme.ts
@@ -6,13 +6,19 @@
    Picking Auto REMOVES the key — absence of a stored value is what Auto means,
    so there is no third value to write and no way to get stuck on an override.
 
-   Cross-window: when the menu and a project window are both open, a `storage`
-   event syncs them (a cleared key arrives as newValue === null).
+   localStorage IS the store, not a mirror of per-hook state: every useTheme()
+   in the window reads the same snapshot and re-renders together. It has to be —
+   the window shell puts [data-mode] on .ws-stage while the tab view owns the
+   toggle, two separate calls, and per-hook useState let them disagree until a
+   restart (TRA-754).
+
+   Cross-window: when two windows are open, a `storage` event re-reads the
+   snapshot (a cleared key means Auto).
 
    Lives outside App.tsx so it is testable without pulling in the whole
    renderer — same reason sidebar-prefs.ts and recent-projects.ts do. */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState, useSyncExternalStore } from 'react';
 import { t } from './i18n';
 
 export const THEME_KEY = 'trace-mcp-theme';
@@ -49,6 +55,31 @@ export function readStoredAppearance(): Appearance {
   }
 }
 
+/* Same-window subscribers. A `storage` event only reaches OTHER windows, so the
+   writer has to tell its own siblings; by then localStorage already holds the
+   new value, which is why both paths just re-read the snapshot. */
+const listeners = new Set<() => void>();
+
+function subscribeAppearance(onChange: () => void): () => void {
+  listeners.add(onChange);
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === THEME_KEY) onChange();
+  };
+  window.addEventListener('storage', onStorage);
+  return () => {
+    listeners.delete(onChange);
+    window.removeEventListener('storage', onStorage);
+  };
+}
+
+function setStoredAppearance(next: Appearance): void {
+  try {
+    if (next === 'auto') localStorage.removeItem(THEME_KEY);
+    else localStorage.setItem(THEME_KEY, next);
+  } catch {}
+  for (const notify of [...listeners]) notify();
+}
+
 export function systemTheme(): Theme {
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
@@ -58,7 +89,11 @@ export function useTheme(): {
   appearance: Appearance;
   setAppearance: (next: Appearance) => void;
 } {
-  const [appearance, setStored] = useState<Appearance>(() => readStoredAppearance());
+  const appearance = useSyncExternalStore(
+    subscribeAppearance,
+    readStoredAppearance,
+    readStoredAppearance,
+  );
   const [system, setSystem] = useState<Theme>(() => systemTheme());
 
   // Apply / remove the data-theme attribute on every change, and mirror the
@@ -80,22 +115,11 @@ export function useTheme(): {
     return () => mq.removeEventListener('change', handler);
   }, []);
 
-  useEffect(() => {
-    const onStorage = (e: StorageEvent) => {
-      if (e.key !== THEME_KEY) return;
-      setStored(e.newValue === 'light' || e.newValue === 'dark' ? e.newValue : 'auto');
-    };
-    window.addEventListener('storage', onStorage);
-    return () => window.removeEventListener('storage', onStorage);
-  }, []);
-
-  const setAppearance = useCallback((next: Appearance) => {
-    try {
-      if (next === 'auto') localStorage.removeItem(THEME_KEY);
-      else localStorage.setItem(THEME_KEY, next);
-    } catch {}
-    setStored(next);
-  }, []);
-
-  return { theme: appearance === 'auto' ? system : appearance, appearance, setAppearance };
+  // Not a useCallback: the store is the module, so the setter already is one
+  // stable reference for every caller in the window.
+  return {
+    theme: appearance === 'auto' ? system : appearance,
+    appearance,
+    setAppearance: setStoredAppearance,
+  };
 }


### PR DESCRIPTION
Fixes the Appearance control, which since #807 only took effect on the next launch.

## What broke

TRA-700 split the window's single `useTheme()` call in two:

- `App` (the window shell) keeps `theme` for `data-mode` on `.ws-stage`
- `AppTabView` (one per tab) keeps `appearance`/`setAppearance` for the toggle

Each call owned a private `useState`. Clicking the toggle moved the tab view's copy and wrote localStorage, so `<html data-theme>` flipped — but the shell's copy never heard about it and `.ws-stage[data-mode]` stayed on its mount-time value. `tokens.css` defines the palette on **both** scopes (`:root[data-theme="dark"], .ws-stage[data-mode="dark"]`), and everything visible lives inside `.ws-stage`, so the stale one won. On the next launch both instances re-read localStorage and agreed — which is why the choice "worked after a restart".

## The fix

Make localStorage the store instead of a mirror of per-hook state. `useTheme()` reads it through `useSyncExternalStore`, so every instance in the window renders the same snapshot; the setter notifies same-window subscribers (a `storage` event only ever reaches *other* windows). Cross-window sync now re-reads the snapshot on that event rather than trusting `newValue`, which is what a real `storage` event means anyway.

This addresses the class rather than the two call sites — a third `useTheme()` cannot drift from the others either. Net: `theme.ts` loses the local `useState`, the storage-listener effect, and the write path inside `setAppearance`; it gains a small module-level subscriber set.

## Tests

New regression test in `packages/app/src/renderer/__tests__/theme.test.tsx` — two `useTheme()` instances, set the appearance on one, assert the other sees it. Verified it fails on the parent commit (`× every instance in the window sees the same choice`) and passes with the fix.

The existing cross-window test now moves localStorage before dispatching the synthetic `StorageEvent`, matching what a browser actually does: the write lands first, the event is the nudge and not the value.

`pnpm test` in `packages/app`: 63 files, 627 tests passed. `pnpm typecheck`: clean.

No MCP tool-signature, schema, or token-budget impact — renderer only.

Agent: Lead Engineer
