### PR TITLE
fix(docs): correct the stale tool/resource counts in the README diagram (TRA-608)

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ Source files (PHP, TS, Vue, Python, Go, Java, Kotlin, Ruby, HTML, CSS, Blade)
                      │
                      ▼
          MCP server (stdio or HTTP/SSE)
-         169 tools · 9 resources
+         177 tools · 10 resources
 ```
 
 **Incremental by default** — files are content-hashed; unchanged files are skipped on re-index.

--- a/tests/docs/readme-claims.test.ts
+++ b/tests/docs/readme-claims.test.ts
@@ -67,22 +67,6 @@ interface Claim {
   description: string;
 }
 
-/**
- * Pull the first occurrence of each `<NUMBER> <unit>` claim out of README.
- * Picks the first hit so duplicate claims (e.g. "138 tools" appearing in
- * both intro and table-of-contents) only need to be updated once.
- */
-function findClaim(unit: RegExp, readme: string, description: string): Claim | null {
-  const lines = readme.split('\n');
-  for (const line of lines) {
-    const m = line.match(new RegExp(`(\\d+)\\s+${unit.source}`));
-    if (m) {
-      return { count: Number.parseInt(m[1], 10), rawLine: line.trim(), description };
-    }
-  }
-  return null;
-}
-
 function within(actual: number, claim: number, tolerance: number): boolean {
   return Math.abs(actual - claim) <= tolerance;
 }
@@ -155,15 +139,31 @@ describe('README numeric claims', () => {
     }
   });
 
-  it('MCP tool count in README matches the source of truth (±5)', () => {
-    const claim = findClaim(/tools?/, readme, 'tool count');
-    expect(claim, 'no "X tools" claim found in README').not.toBeNull();
-    if (!claim) return;
-    if (!within(toolCount, claim.count, 5)) {
-      throw new Error(
-        `README claims ${claim.count} tools; src/tools/register/ registers ${toolCount} ` +
-          `framework-agnostic tools. Update README.md line: "${claim.rawLine}"`,
-      );
+  it('every MCP tool count in README matches the source of truth (±5)', () => {
+    // TRA-608: first-match-only left "169 tools · 9 resources" in the
+    // architecture diagram for months while the intro above it said 177 —
+    // the same gap TRA-272 already closed for languages and frameworks.
+    const claims = findAllClaims(/tools?/, readme);
+    expect(claims.length, 'no "X tools" claim found in README').toBeGreaterThan(0);
+    for (const claim of claims) {
+      if (!within(toolCount, claim.count, 5)) {
+        throw new Error(
+          `README claims ${claim.count} tools; src/tools/register/ registers ${toolCount} ` +
+            `framework-agnostic tools. Update README.md line: "${claim.rawLine}"`,
+        );
+      }
+    }
+  });
+
+  it('every resource count in README matches the source of truth (±2)', () => {
+    for (const claim of findAllClaims(/resources?/, readme)) {
+      if (!within(countServerResourceCalls(), claim.count, 2)) {
+        throw new Error(
+          `README claims ${claim.count} resources; src/tools/register/ contains ` +
+            `${countServerResourceCalls()} server.resource(...) registrations. ` +
+            `Update README.md line: "${claim.rawLine}"`,
+        );
+      }
     }
   });
 


### PR DESCRIPTION
The README's architecture diagram claimed `169 tools · 9 resources`; the intro says `177 tools`, and `src/tools/register/` registers 177 tools / 10 resources.

`tests/docs/readme-claims.test.ts` could not catch it: the tool check used `findClaim`, which stops at the first match, so it only ever verified the intro line. That is the same first-match-only gap TRA-272 already closed for the languages and frameworks checks. This PR:

- fixes the diagram line to `177 tools · 10 resources`;
- switches the tool check to `findAllClaims` so every occurrence is verified;
- adds the equivalent resources check (±2, matching the llms.txt/tools-reference check);
- drops `findClaim`, now unused.

Verified: `pnpm vitest run tests/docs/readme-claims.test.ts` → 67 passed. Reverting the README number back to `169 tools · 9 resources` makes the new check fail with `README claims 169 tools; src/tools/register/ registers 177`, so the guard is real.

Closes the last open item of TRA-608 ("проверить, чтобы все цифры соответствовали данным из `docs/_data/counts.yml`") — the structural README redesign itself landed in #819 (TRA-738), and #788 was closed in its favour.
