### PR TITLE
fix(launcher): resolve node from a prefix only pkg_roots knows (TRA-742)

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.4.0 (Windows)
+REM trace-mcp-launcher v0.5.0 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.4.0 (Windows)
+# trace-mcp-launcher v0.5.0 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.
@@ -143,6 +143,20 @@ function Get-NodeCandidates {
 function Find-Node {
     $candidates = @(Get-NodeCandidates)
     if ($candidates.Count -gt 0) { return $candidates[0] }
+    # Last resort: node shipped inside a prefix we only know about because our
+    # package lives there - a bundled runtime, or a corporate
+    # `npm config set prefix`. Get-PkgRoots already enumerates those roots for
+    # the cli.js lookup; the node beside one of them is the pair
+    # `trace-mcp init` recorded. Without this a machine whose ONLY node is such
+    # a runtime dies with "node binary not found" while a working node.exe and
+    # cli.js sit on disk.
+    foreach ($r in @(Get-PkgRoots $null)) {
+        # <prefix>\node_modules and <prefix>\lib\node_modules are both in use.
+        foreach ($rel in @('..\node.exe', '..\..\node.exe')) {
+            $c = Join-Path $r $rel
+            if (Test-NodeBinary $c) { return (Resolve-Path -LiteralPath $c).Path }
+        }
+    }
     return $null
 }
 

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.4.0
+# trace-mcp-launcher v0.5.0
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -134,6 +134,27 @@ node_from_nvm_tree() {
   return 1
 }
 
+# Node shipped inside a prefix we only know about because our package lives
+# there: a bundled runtime (Hermes, Antigravity) or a corporate
+# `npm config set prefix`. pkg_roots() already enumerates those roots for the
+# cli.js lookup; the node beside one of them is exactly the pair
+# `trace-mcp init` recorded. Without this, a machine whose ONLY node is such a
+# runtime dies with "node binary not found" while a working node + cli.js sit
+# on disk — the mirror image of the prefix-pairing bug fixed in v0.4.0.
+node_from_pkg_roots() {
+  local root candidate
+  while IFS= read -r root; do
+    [ -n "$root" ] || continue
+    # <prefix>/lib/node_modules → <prefix>/bin/node
+    candidate="$root/../../bin/node"
+    if [ -x "$candidate" ]; then
+      normalise_path "$candidate"
+      return 0
+    fi
+  done <<< "$(pkg_roots)"
+  return 1
+}
+
 probe_node() {
   # 4a. System-wide stable paths (Homebrew, /usr/local)
   for candidate in /opt/homebrew/bin/node /usr/local/bin/node; do
@@ -165,6 +186,9 @@ probe_node() {
       return 0
     fi
   done
+
+  # 4f. Last resort: a prefix that only pkg_roots knows about.
+  if node_from_pkg_roots; then return 0; fi
 
   return 1
 }

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -99,4 +99,7 @@ export const SESSION_START_HOOK_VERSION = '0.2.0';
 export const USER_PROMPT_SUBMIT_HOOK_VERSION = '0.3.0'; // nosemgrep: ajinabraham.njsscan.generic.hardcoded_secrets.node_username -- the constant name contains "USER", which the "username" secret heuristic matches; the value is a hook script version.
 export const STOP_HOOK_VERSION = '0.2.0';
 export const SESSION_END_HOOK_VERSION = '0.2.0';
-export const LAUNCHER_VERSION = '0.4.0';
+// 0.5.0 (TRA-742): probe_node falls back to the node beside a recorded package
+// root, so a machine whose only node is a bundled runtime or a custom npm
+// prefix no longer dies with "node binary not found".
+export const LAUNCHER_VERSION = '0.5.0';

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -352,6 +352,112 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
     });
   });
 
+  // TRA-742: the mirror of TRA-701. `pkg_roots` learned about bundled runtimes
+  // and custom npm prefixes, but `probe_node` never did — so a machine whose
+  // ONLY node lives in such a prefix died with "node binary not found" while a
+  // working node and cli.js sat right next to each other on disk.
+  //
+  // The two system paths the probe tries before anything under HOME are
+  // absolute, so a runner that has Homebrew/system node installed resolves at
+  // step 4a and never reaches the fallback under test.
+  const HAS_SYSTEM_NODE =
+    fs.existsSync('/opt/homebrew/bin/node') || fs.existsSync('/usr/local/bin/node');
+
+  describe.skipIf(HAS_SYSTEM_NODE)('node resolves from a prefix only pkg_roots knows', () => {
+    /** Plants a working node + package inside `prefix`, returns both realpaths. */
+    function plantPrefix(prefix: string): { node: string; cli: string } {
+      fs.mkdirSync(path.join(prefix, 'bin'), { recursive: true });
+      const node = path.join(prefix, 'bin', 'node');
+      fs.writeFileSync(node, '#!/bin/bash\necho "NODE_ARGS:$*"\n', { mode: 0o755 });
+      const dist = path.join(prefix, 'lib', 'node_modules', 'trace-mcp', 'dist');
+      fs.mkdirSync(dist, { recursive: true });
+      const cli = path.join(dist, 'cli.js');
+      fs.writeFileSync(cli, '// bundled cli\n');
+      return { node: fs.realpathSync(node), cli: fs.realpathSync(cli) };
+    }
+
+    it('uses the node recorded in pkg-roots when no standard node exists', () => {
+      const { home, traceHome } = setupFakeHome();
+      const prefix = path.join(home, 'some-bundled-runtime', 'node');
+      const { cli } = plantPrefix(prefix);
+      fs.writeFileSync(
+        path.join(traceHome, 'pkg-roots'),
+        `${path.join(prefix, 'lib', 'node_modules')}\n`,
+      );
+      writeConfig(traceHome, '/nonexistent/node', '/nonexistent/cli.js');
+
+      const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+    });
+
+    it('uses the node bundled by Hermes when no standard node exists', () => {
+      const { home, traceHome } = setupFakeHome();
+      const { node, cli } = plantPrefix(path.join(home, '.hermes', 'node'));
+      writeConfig(traceHome, '/nonexistent/node', '/nonexistent/cli.js');
+
+      const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+      // And the healed config pins the pair, so the next start is a fast path.
+      const cfg = fs.readFileSync(path.join(traceHome, 'launcher.env'), 'utf-8');
+      expect(cfg).toContain(`TRACE_MCP_NODE="${node}"`);
+    });
+
+    it('uses the node under a custom npm prefix from ~/.npmrc', () => {
+      const { home, traceHome } = setupFakeHome();
+      const prefix = path.join(home, 'custom-prefix');
+      const { cli } = plantPrefix(prefix);
+      fs.writeFileSync(path.join(home, '.npmrc'), `prefix=${prefix}\n`);
+      writeConfig(traceHome, '/nonexistent/node', '/nonexistent/cli.js');
+
+      const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+    });
+
+    it('still exits 127 when no prefix holds a node', () => {
+      const { home, traceHome } = setupFakeHome();
+      fs.writeFileSync(path.join(traceHome, 'pkg-roots'), `${path.join(home, 'gone')}\n`);
+      const { status, stderr } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(status).toBe(127);
+      expect(stderr).toContain('node binary not found');
+    });
+  });
+
+  // A standard node must keep winning: the fallback is a last resort, not a
+  // reordering of the probe.
+  it('prefers an nvm default node over one found via pkg-roots', () => {
+    const { home, traceHome } = setupFakeHome();
+    const nvmBin = path.join(home, '.nvm', 'versions', 'node', 'v22.22.2', 'bin');
+    fs.mkdirSync(nvmBin, { recursive: true });
+    fs.writeFileSync(path.join(nvmBin, 'node'), '#!/bin/bash\necho "NVM_NODE:$*"\n', {
+      mode: 0o755,
+    });
+    fs.mkdirSync(path.join(home, '.nvm', 'alias'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.nvm', 'alias', 'default'), 'v22.22.2\n');
+
+    const bundled = path.join(home, '.hermes', 'node');
+    fs.mkdirSync(path.join(bundled, 'bin'), { recursive: true });
+    fs.writeFileSync(path.join(bundled, 'bin', 'node'), '#!/bin/bash\necho "BUNDLED:$*"\n', {
+      mode: 0o755,
+    });
+    const dist = path.join(bundled, 'lib', 'node_modules', 'trace-mcp', 'dist');
+    fs.mkdirSync(dist, { recursive: true });
+    fs.writeFileSync(path.join(dist, 'cli.js'), '// bundled cli\n');
+    writeConfig(traceHome, '/nonexistent/node', '/nonexistent/cli.js');
+
+    const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+    expect(status).toBe(0);
+    // Whichever standard node the probe picked, it is not the bundled one.
+    expect(stdout).not.toContain('BUNDLED:');
+  });
+
   it('stale config (broken paths) falls through to probe and still errors cleanly', () => {
     const { home, traceHome } = setupFakeHome();
     writeConfig(traceHome, '/nonexistent/node', '/nonexistent/cli.js');


### PR DESCRIPTION
## The failure

`v0.4.0` (TRA-701) fixed one half of the prefix-pairing failure: `cli.js` is now
looked for in **every** known npm prefix instead of only next to the selected node.

The other half stayed broken. `probe_node()` knows Homebrew, `/usr/local`, Volta,
nvm, Herd and fnm — and nothing else. `pkg_roots()`, by contrast, additionally
knows the roots each install records (`~/.trace/pkg-roots`), `~/.hermes/node`, and
a custom `npm config set prefix`.

So on a machine whose **only** node is a bundled runtime (Hermes, Antigravity) or a
corporate prefix, a stale `launcher.env` is fatal: `exit 127`,
`node binary not found` — while a working node and a working `cli.js` sit next to
each other on disk. The client loses all ~170 tools for the rest of the session
and never retries.

Reproduced before the fix:

```
$ HOME=$R TRACE_MCP_HOME=$R $R/bin/trace serve
trace-mcp launcher: node binary not found — install Node.js (...)
rc=127
```

…with `$R/.hermes/node/bin/node` and `$R/.hermes/node/lib/node_modules/trace-mcp/dist/cli.js`
both present and both recorded in `pkg-roots`. After the fix the same fixture execs
cleanly (`rc=0`).

## The fix

`pkg_roots()` already enumerates exactly the prefixes `probe_node()` is missing.
Reuse it as the **last** probe step — the node beside a recorded package root is
the pair `trace-mcp init` wrote. Appended after every existing step, so a machine
with a standard node resolves exactly as before.

Same asymmetry existed in the PowerShell shim (`Find-Node` ignored `Get-PkgRoots`);
fixed there too. Launcher version `0.4.0 → 0.5.0` so existing installs get the new
shim on their next `trace init`.

## Tests

Four new integration tests for the new fallback (pkg-roots prefix, Hermes prefix,
`~/.npmrc` prefix, and the still-fails-cleanly case), plus one asserting the probe
order did **not** change — a standard nvm node still beats the bundled one. The
new suite is skipped where `/opt/homebrew/bin/node` or `/usr/local/bin/node`
exists, since those absolute paths short-circuit the probe before the fallback is
reachable; the order test runs everywhere.

`pnpm test`: 9804 passed | 12 skipped. Build and `tsc --noEmit` clean.

Closes TRA-742.

Agent: Lead Engineer
