### PR TITLE
fix(hooks): port the guard v2 navigation gate to Windows (TRA-757)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,11 @@
 # calibrate-health-metrics.mjs imported by its test) — surfaces as
 # "SyntaxError: Invalid or unexpected token" on windows-latest CI only.
 * text=auto eol=lf
+
+# ...except batch files. cmd.exe cannot parse an LF-only .cmd reliably: caret
+# line continuations and parenthesised blocks come apart, and the guard hook
+# fails with "'e' is not recognized as an internal or external command" (seen
+# on windows-latest, TRA-757). These must reach disk — and the npm tarball —
+# with CRLF.
+*.cmd text eol=crlf
+*.bat text eol=crlf

--- a/hooks/trace-mcp-guard.cmd
+++ b/hooks/trace-mcp-guard.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-guard v0.13.0
+REM trace-mcp-guard v0.15.0
 REM trace-mcp PreToolUse guard (Windows)
 REM Blocks Read/Grep/Glob/Bash on source code files + Agent(Explore) subagents - redirects to trace-mcp tools.
 REM Allows: non-code files, Read before Edit, safe Bash commands (git, npm, build, test).
@@ -328,9 +328,13 @@ REM single light navigation question at equal correctness, so the guard stays
 REM silent until the session is actually crawling. Sets NAV_BELOW=1 while the
 REM session is still under the threshold; callers allow the call when it is.
 REM
-REM This is the conservative half of the POSIX behaviour in trace-mcp-guard.sh:
-REM count only, with no rolling window and no relationship-question bypass,
-REM because Windows ships no UserPromptSubmit hook to reset the streak per prompt.
+REM Full parity with the POSIX gate in trace-mcp-guard.sh (TRA-757): the
+REM relationship-question bypass and the rolling window are both honoured here.
+REM Windows does ship a UserPromptSubmit hook (trace-mcp-user-prompt-submit.cmd)
+REM and it clears .nav-streak on every new prompt, so a count that only ever
+REM grew would have made the guard intervene on every navigation call for the
+REM rest of the session - exactly the light-question regression the gate exists
+REM to remove. State file format is shared with the POSIX hook: "count epoch".
 :nav_hit
 set "NAV_BELOW=0"
 set "NAV_MIN=3"
@@ -339,10 +343,32 @@ set /a NAV_MIN=NAV_MIN+0 >nul 2>&1
 if !NAV_MIN! LEQ 1 goto :eof
 set "NAV_DIR=%TEMP%\trace-mcp-reads-%SESSION_ID%"
 if not exist "!NAV_DIR!" mkdir "!NAV_DIR!" >nul 2>&1
+REM Relationship question in flight - intervene from the first call.
+if exist "!NAV_DIR!\.nav-force" goto :eof
+set "NAV_WINDOW=300"
+if defined TRACE_MCP_GUARD_NAV_WINDOW set "NAV_WINDOW=%TRACE_MCP_GUARD_NAV_WINDOW%"
+set /a NAV_WINDOW=NAV_WINDOW+0 >nul 2>&1
 set "NAV_COUNT=0"
-if exist "!NAV_DIR!\.nav-streak" set /p NAV_COUNT=<"!NAV_DIR!\.nav-streak"
+set "NAV_LAST=0"
+if exist "!NAV_DIR!\.nav-streak" (
+    for /f "usebackq tokens=1,2" %%a in ("!NAV_DIR!\.nav-streak") do (
+        set "NAV_COUNT=%%a"
+        set "NAV_LAST=%%b"
+    )
+)
+set /a NAV_COUNT=NAV_COUNT+0 >nul 2>&1
+set /a NAV_LAST=NAV_LAST+0 >nul 2>&1
+set "NAV_NOW=0"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "[DateTimeOffset]::UtcNow.ToUnixTimeSeconds()"`) do set "NAV_NOW=%%i"
+set /a NAV_NOW=NAV_NOW+0 >nul 2>&1
+if !NAV_LAST! EQU 0 (
+    set "NAV_COUNT=0"
+) else (
+    set /a NAV_GAP=NAV_NOW-NAV_LAST
+    if !NAV_GAP! GTR !NAV_WINDOW! set "NAV_COUNT=0"
+)
 set /a NAV_COUNT=NAV_COUNT+1 >nul 2>&1
-> "!NAV_DIR!\.nav-streak" echo !NAV_COUNT!
+> "!NAV_DIR!\.nav-streak" echo !NAV_COUNT! !NAV_NOW!
 if !NAV_COUNT! LSS !NAV_MIN! set "NAV_BELOW=1"
 goto :eof
 

--- a/hooks/trace-mcp-user-prompt-submit.cmd
+++ b/hooks/trace-mcp-user-prompt-submit.cmd
@@ -1,20 +1,35 @@
 @echo off
-REM trace-mcp-user-prompt-submit v0.1.0
+REM trace-mcp-user-prompt-submit v0.3.0
 REM trace-mcp UserPromptSubmit hook (Windows)
-REM Injects top-3 FTS5 decision matches as additionalContext on each prompt.
+REM
+REM Two jobs, in this order:
+REM   1. Guard v2 routing signal (TRA-711, ported to Windows in TRA-757). Each
+REM      new user prompt starts a new navigation streak, so the counter the
+REM      PreToolUse guard keeps is cleared here. The prompt is also matched
+REM      against relationship-question shapes ("who calls X", "what breaks if I
+REM      change Y", "which tests cover Z") - the shape where TRA-705 measured
+REM      trace-mcp winning; a match writes a flag that makes the guard route
+REM      from the FIRST navigation call instead of waiting for the third.
+REM      Unlike the POSIX hook this matches English shapes only: a .cmd file is
+REM      read in the machine's OEM codepage, so non-ASCII patterns cannot be
+REM      embedded here reliably.
+REM   2. Injects top-3 FTS5 decision matches as additionalContext on each prompt.
+REM
 REM Soft budget ~10s; degrades silently.
 
 setlocal enabledelayedexpansion
 
 if "%TRACE_MCP_USER_PROMPT_OFF%"=="1" exit /b 0
 
+REM A missing CLI must not cost us the guard signal (job 1 needs no binary), so
+REM it leaves TRACE_MCP_BIN empty and PowerShell skips job 2 instead of exiting.
 set "TRACE_MCP_BIN=trace-mcp"
 where trace-mcp >nul 2>&1
 if errorlevel 1 (
   if exist "%USERPROFILE%\.trace-mcp\bin\trace-mcp.cmd" (
     set "TRACE_MCP_BIN=%USERPROFILE%\.trace-mcp\bin\trace-mcp.cmd"
   ) else (
-    exit /b 0
+    set "TRACE_MCP_BIN="
   )
 )
 
@@ -28,7 +43,15 @@ powershell -NoProfile -Command ^
   "if (-not $input_text) { exit 0 };" ^
   "try { $env_obj = $input_text | ConvertFrom-Json } catch { exit 0 };" ^
   "$prompt = $env_obj.prompt; if (-not $prompt) { $prompt = $env_obj.user_prompt };" ^
+  "$sid = $env_obj.session_id; if (-not $sid) { $sid = 'default' };" ^
+  "$navDir = Join-Path $env:TEMP ('trace-mcp-reads-' + $sid);" ^
+  "New-Item -ItemType Directory -Force -Path $navDir | Out-Null;" ^
+  "Remove-Item -Force -ErrorAction SilentlyContinue (Join-Path $navDir '.nav-streak');" ^
+  "$navForce = Join-Path $navDir '.nav-force';" ^
+  "$navRe = '(who (calls|uses|invokes|imports)|call(ers|ed by|[- ]graph)|what (breaks|will break|would break)|blast radius|impact of (changing|renaming|removing)|affected by|safe to (change|rename|delete|remove)|(which|what) tests|tests? (cover|covering|for)|test coverage (for|of)|all (usages|references|callers|dependents)|where is .* used|depends on this|reverse dependenc)';" ^
+  "if ($prompt -and $prompt -imatch $navRe) { New-Item -ItemType File -Force -Path $navForce | Out-Null } else { Remove-Item -Force -ErrorAction SilentlyContinue $navForce };" ^
   "if (-not $prompt) { exit 0 };" ^
+  "if (-not '%TRACE_MCP_BIN%') { exit 0 };" ^
   "$query = ($prompt -replace \"`n\",' ').Substring(0, [Math]::Min(200, $prompt.Length));" ^
   "$json = & '%TRACE_MCP_BIN%' memory decisions --project '%PROJECT_ROOT%' --search $query --limit 3 --json 2>$null;" ^
   "if (-not $json) { exit 0 };" ^

--- a/hooks/trace-mcp-user-prompt-submit.cmd
+++ b/hooks/trace-mcp-user-prompt-submit.cmd
@@ -10,9 +10,12 @@ REM      against relationship-question shapes ("who calls X", "what breaks if I
 REM      change Y", "which tests cover Z") - the shape where TRA-705 measured
 REM      trace-mcp winning; a match writes a flag that makes the guard route
 REM      from the FIRST navigation call instead of waiting for the third.
-REM      Unlike the POSIX hook this matches English shapes only: a .cmd file is
-REM      read in the machine's OEM codepage, so non-ASCII patterns cannot be
-REM      embedded here reliably.
+REM      Both the English and the Russian shapes of the POSIX hook are matched.
+REM      Two things make that work on Windows: this file stays ASCII-only (a
+REM      .cmd is read in the machine's OEM codepage, so the Russian
+REM      alternatives are written as .NET regex \uXXXX escapes), and stdin is
+REM      decoded as UTF-8 explicitly rather than through the console codepage,
+REM      so a non-ASCII prompt survives the trip.
 REM   2. Injects top-3 FTS5 decision matches as additionalContext on each prompt.
 REM
 REM Soft budget ~10s; degrades silently.
@@ -39,7 +42,8 @@ REM PowerShell reads stdin (the Claude Code hook envelope), extracts the prompt,
 REM runs the decisions search, and emits the additionalContext envelope.
 powershell -NoProfile -Command ^
   "$ErrorActionPreference='SilentlyContinue';" ^
-  "$input_text = [Console]::In.ReadToEnd();" ^
+  "$stdin = New-Object System.IO.StreamReader([Console]::OpenStandardInput(), [System.Text.Encoding]::UTF8);" ^
+  "$input_text = $stdin.ReadToEnd();" ^
   "if (-not $input_text) { exit 0 };" ^
   "try { $env_obj = $input_text | ConvertFrom-Json } catch { exit 0 };" ^
   "$prompt = $env_obj.prompt; if (-not $prompt) { $prompt = $env_obj.user_prompt };" ^
@@ -49,7 +53,8 @@ powershell -NoProfile -Command ^
   "Remove-Item -Force -ErrorAction SilentlyContinue (Join-Path $navDir '.nav-streak');" ^
   "$navForce = Join-Path $navDir '.nav-force';" ^
   "$navRe = '(who (calls|uses|invokes|imports)|call(ers|ed by|[- ]graph)|what (breaks|will break|would break)|blast radius|impact of (changing|renaming|removing)|affected by|safe to (change|rename|delete|remove)|(which|what) tests|tests? (cover|covering|for)|test coverage (for|of)|all (usages|references|callers|dependents)|where is .* used|depends on this|reverse dependenc)';" ^
-  "if ($prompt -and $prompt -imatch $navRe) { New-Item -ItemType File -Force -Path $navForce | Out-Null } else { Remove-Item -Force -ErrorAction SilentlyContinue $navForce };" ^
+  "$navReRu = '(\u043a\u0442\u043e (\u0432\u044b\u0437\u044b\u0432\u0430\u0435\u0442|\u0438\u0441\u043f\u043e\u043b\u044c\u0437\u0443\u0435\u0442|\u0438\u043c\u043f\u043e\u0440\u0442\u0438\u0440\u0443\u0435\u0442)|\u0447\u0442\u043e \u0441\u043b\u043e\u043c\u0430\u0435\u0442\u0441\u044f|\u0447\u0442\u043e \u0437\u0430\u0442\u0440\u043e\u043d|\u043d\u0430 \u0447\u0442\u043e \u043f\u043e\u0432\u043b\u0438\u044f|\u043a\u0430\u043a\u0438\u0435 \u0442\u0435\u0441\u0442\u044b|\u0433\u0434\u0435 \u0438\u0441\u043f\u043e\u043b\u044c\u0437\u0443\u0435\u0442\u0441\u044f|\u043a\u0442\u043e \u0437\u0430\u0432\u0438\u0441\u0438\u0442|\u0432\u0441\u0435 (\u0432\u044b\u0437\u043e\u0432\u044b|\u0438\u0441\u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u043d\u0438\u044f|\u043c\u0435\u0441\u0442\u0430 \u0438\u0441\u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u043d\u0438\u044f))';" ^
+  "if ($prompt -and ($prompt -imatch $navRe -or $prompt -imatch $navReRu)) { New-Item -ItemType File -Force -Path $navForce | Out-Null } else { Remove-Item -Force -ErrorAction SilentlyContinue $navForce };" ^
   "if (-not $prompt) { exit 0 };" ^
   "if (-not '%TRACE_MCP_BIN%') { exit 0 };" ^
   "$query = ($prompt -replace \"`n\",' ').Substring(0, [Math]::Min(200, $prompt.Length));" ^

--- a/tests/hooks/guard-windows.test.ts
+++ b/tests/hooks/guard-windows.test.ts
@@ -99,6 +99,14 @@ describe.skipIf(process.platform !== 'win32')('guard v2 navigation gate on Windo
     expect(nav('handleRequest')).toBe(true);
   });
 
+  it('matches the Russian relationship shapes too', () => {
+    // The .cmd carries these as \uXXXX escapes and decodes stdin as UTF-8, so a
+    // non-ASCII prompt has to survive both hops to reach the regex.
+    prompt('кто вызывает handleRequest?');
+    expect(fs.existsSync(path.join(readsDir(), '.nav-force'))).toBe(true);
+    expect(nav('handleRequest')).toBe(true);
+  });
+
   it('a plain question clears the relationship flag', () => {
     prompt('who calls handleRequest?');
     prompt('rename the config loader');

--- a/tests/hooks/guard-windows.test.ts
+++ b/tests/hooks/guard-windows.test.ts
@@ -6,14 +6,18 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // ─── Guard v2 navigation gate, Windows port (TRA-757) ────────────────
 //
-// TRA-711 shipped the gate on POSIX only in practice: the Windows guard counted
-// navigation calls but nothing ever reset the counter, and the Windows
-// UserPromptSubmit hook wrote neither the streak reset nor the
-// relationship-question flag. The effect was the opposite of the intent — after
-// three navigation calls the guard intervened on every navigation call for the
-// rest of the session, which is exactly the light-question regression TRA-705
-// measured at 1.45x. These tests pin the ported behaviour; they mirror the POSIX
-// ones in guard.test.ts / lifecycle-hooks.test.ts.
+// TRA-711 shipped the crawl detector, but only its POSIX half worked. The
+// Windows guard counted navigation calls with nothing ever resetting the
+// counter — no `.nav-force` bypass, no rolling window — and the Windows
+// UserPromptSubmit hook wrote neither signal. From the third navigation call
+// on, the guard intervened on every navigation call for the rest of the
+// session: the inverse of the gate's purpose, and exactly the light-question
+// regression TRA-705 priced at 1.45x.
+//
+// These mirror the POSIX tests in guard.test.ts / lifecycle-hooks.test.ts.
+// They are the only coverage the .cmd hooks have, so every assertion runs
+// against the real hook output string rather than a boolean — a failure on a
+// Windows runner has to explain itself without a local repro.
 //
 // Windows CI runs on the `cross-platform` label, workflow_dispatch and the
 // schedule (see .github/workflows/ci.yml).
@@ -21,6 +25,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 const GUARD_CMD = path.resolve('hooks/trace-mcp-guard.cmd');
 const PROMPT_CMD = path.resolve('hooks/trace-mcp-user-prompt-submit.cmd');
 const TMP_BASE = fs.realpathSync(os.tmpdir());
+const DENY = '"permissionDecision": "deny"';
 
 describe.skipIf(process.platform !== 'win32')('guard v2 navigation gate on Windows', () => {
   let projectDir: string;
@@ -28,30 +33,44 @@ describe.skipIf(process.platform !== 'win32')('guard v2 navigation gate on Windo
 
   const readsDir = () => path.join(TMP_BASE, `trace-mcp-reads-${sessionId}`);
 
+  /** Hook stdout, with exit status and stderr appended when either is unclean. */
   function run(script: string, payload: unknown, env: Record<string, string> = {}): string {
-    const result = spawnSync('cmd.exe', ['/d', '/c', script], {
+    const r = spawnSync('cmd.exe', ['/d', '/c', script], {
       input: JSON.stringify(payload),
       env: { ...process.env, TEMP: TMP_BASE, TMP: TMP_BASE, ...env },
       cwd: projectDir,
       encoding: 'utf-8',
       timeout: 60_000,
     });
-    return (result.stdout ?? '').trim();
+    const stdout = r.stdout ?? '';
+    const stderr = (r.stderr ?? '').trim();
+    if (r.status === 0 && stderr.length === 0) return stdout;
+    return `${stdout}\n[exit ${r.status}] ${stderr}`;
   }
 
-  /** One navigation call through the guard. Returns true when it was denied. */
-  function nav(pattern: string, env: Record<string, string> = {}): boolean {
-    const out = run(
+  /** One navigation call through the guard, as the guard's own output. */
+  function nav(pattern: string, env: Record<string, string> = {}): string {
+    return run(
       GUARD_CMD,
       { tool_name: 'Grep', session_id: sessionId, tool_input: { pattern } },
       { CLAUDE_TOOL_NAME: 'Grep', TRACE_MCP_ENFORCE: 'strict', ...env },
-    );
-    return out.includes('"permissionDecision": "deny"');
+    ).trim();
   }
 
   /** One user prompt through the UserPromptSubmit hook. */
-  function prompt(text: string): void {
-    run(PROMPT_CMD, { prompt: text, session_id: sessionId });
+  function prompt(text: string): string {
+    return run(PROMPT_CMD, { prompt: text, session_id: sessionId }).trim();
+  }
+
+  /** Session state the two hooks share, as a directory listing. */
+  function navState(): string[] {
+    try {
+      return fs.readdirSync(readsDir());
+    } catch {
+      // Name the directories that DO exist: a mismatch here is a %TEMP%
+      // disagreement between the test and the hook, not a gate bug.
+      return fs.readdirSync(TMP_BASE).filter((n) => n.startsWith('trace-mcp-reads-'));
+    }
   }
 
   beforeEach(() => {
@@ -66,50 +85,56 @@ describe.skipIf(process.platform !== 'win32')('guard v2 navigation gate on Windo
     }
   });
 
+  it('records the navigation streak under the session reads dir', () => {
+    nav('one');
+    expect(navState()).toContain('.nav-streak');
+  });
+
   it('stays silent on the first two navigation calls, intervenes on the third', () => {
-    expect(nav('one')).toBe(false);
-    expect(nav('two')).toBe(false);
-    expect(nav('three')).toBe(true);
+    expect(nav('one')).toBe('');
+    expect(nav('two')).toBe('');
+    expect(nav('three')).toContain(DENY);
   });
 
   it('routes from the FIRST call when a relationship question is flagged', () => {
     fs.mkdirSync(readsDir(), { recursive: true });
     fs.writeFileSync(path.join(readsDir(), '.nav-force'), '');
-    expect(nav('handleRequest')).toBe(true);
+    expect(nav('handleRequest')).toContain(DENY);
   });
 
   it('resets the streak after a quiet window', () => {
-    expect(nav('one')).toBe(false);
-    expect(nav('two')).toBe(false);
+    expect(nav('one')).toBe('');
+    expect(nav('two')).toBe('');
     const stale = Math.floor(Date.now() / 1000) - 600;
     fs.writeFileSync(path.join(readsDir(), '.nav-streak'), `2 ${stale}\r\n`);
-    expect(nav('three', { TRACE_MCP_GUARD_NAV_WINDOW: '300' })).toBe(false);
+    expect(nav('three', { TRACE_MCP_GUARD_NAV_WINDOW: '300' })).toBe('');
   });
 
   it('a new user prompt clears the streak, so a light question is left alone', () => {
-    expect(nav('one')).toBe(false);
-    expect(nav('two')).toBe(false);
+    expect(nav('one')).toBe('');
+    expect(nav('two')).toBe('');
     prompt('rename the config loader');
-    expect(nav('three')).toBe(false);
+    expect(navState()).not.toContain('.nav-streak');
+    expect(nav('three')).toBe('');
   });
 
   it('a relationship question makes the next navigation call route immediately', () => {
     prompt('who calls handleRequest?');
-    expect(fs.existsSync(path.join(readsDir(), '.nav-force'))).toBe(true);
-    expect(nav('handleRequest')).toBe(true);
+    expect(navState()).toContain('.nav-force');
+    expect(nav('handleRequest')).toContain(DENY);
   });
 
   it('matches the Russian relationship shapes too', () => {
     // The .cmd carries these as \uXXXX escapes and decodes stdin as UTF-8, so a
     // non-ASCII prompt has to survive both hops to reach the regex.
     prompt('кто вызывает handleRequest?');
-    expect(fs.existsSync(path.join(readsDir(), '.nav-force'))).toBe(true);
-    expect(nav('handleRequest')).toBe(true);
+    expect(navState()).toContain('.nav-force');
+    expect(nav('handleRequest')).toContain(DENY);
   });
 
   it('a plain question clears the relationship flag', () => {
     prompt('who calls handleRequest?');
     prompt('rename the config loader');
-    expect(fs.existsSync(path.join(readsDir(), '.nav-force'))).toBe(false);
+    expect(navState()).not.toContain('.nav-force');
   });
 });

--- a/tests/hooks/guard-windows.test.ts
+++ b/tests/hooks/guard-windows.test.ts
@@ -1,0 +1,107 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// ─── Guard v2 navigation gate, Windows port (TRA-757) ────────────────
+//
+// TRA-711 shipped the gate on POSIX only in practice: the Windows guard counted
+// navigation calls but nothing ever reset the counter, and the Windows
+// UserPromptSubmit hook wrote neither the streak reset nor the
+// relationship-question flag. The effect was the opposite of the intent — after
+// three navigation calls the guard intervened on every navigation call for the
+// rest of the session, which is exactly the light-question regression TRA-705
+// measured at 1.45x. These tests pin the ported behaviour; they mirror the POSIX
+// ones in guard.test.ts / lifecycle-hooks.test.ts.
+//
+// Windows CI runs on the `cross-platform` label, workflow_dispatch and the
+// schedule (see .github/workflows/ci.yml).
+
+const GUARD_CMD = path.resolve('hooks/trace-mcp-guard.cmd');
+const PROMPT_CMD = path.resolve('hooks/trace-mcp-user-prompt-submit.cmd');
+const TMP_BASE = fs.realpathSync(os.tmpdir());
+
+describe.skipIf(process.platform !== 'win32')('guard v2 navigation gate on Windows', () => {
+  let projectDir: string;
+  let sessionId: string;
+
+  const readsDir = () => path.join(TMP_BASE, `trace-mcp-reads-${sessionId}`);
+
+  function run(script: string, payload: unknown, env: Record<string, string> = {}): string {
+    const result = spawnSync('cmd.exe', ['/d', '/c', script], {
+      input: JSON.stringify(payload),
+      env: { ...process.env, TEMP: TMP_BASE, TMP: TMP_BASE, ...env },
+      cwd: projectDir,
+      encoding: 'utf-8',
+      timeout: 60_000,
+    });
+    return (result.stdout ?? '').trim();
+  }
+
+  /** One navigation call through the guard. Returns true when it was denied. */
+  function nav(pattern: string, env: Record<string, string> = {}): boolean {
+    const out = run(
+      GUARD_CMD,
+      { tool_name: 'Grep', session_id: sessionId, tool_input: { pattern } },
+      { CLAUDE_TOOL_NAME: 'Grep', TRACE_MCP_ENFORCE: 'strict', ...env },
+    );
+    return out.includes('"permissionDecision": "deny"');
+  }
+
+  /** One user prompt through the UserPromptSubmit hook. */
+  function prompt(text: string): void {
+    run(PROMPT_CMD, { prompt: text, session_id: sessionId });
+  }
+
+  beforeEach(() => {
+    sessionId = `vitest-navwin-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    projectDir = path.join(TMP_BASE, `trace-mcp-navwin-${sessionId}`);
+    fs.mkdirSync(projectDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    for (const p of [readsDir(), projectDir, path.join(TMP_BASE, `trace-mcp-guard-${sessionId}`)]) {
+      fs.rmSync(p, { recursive: true, force: true });
+    }
+  });
+
+  it('stays silent on the first two navigation calls, intervenes on the third', () => {
+    expect(nav('one')).toBe(false);
+    expect(nav('two')).toBe(false);
+    expect(nav('three')).toBe(true);
+  });
+
+  it('routes from the FIRST call when a relationship question is flagged', () => {
+    fs.mkdirSync(readsDir(), { recursive: true });
+    fs.writeFileSync(path.join(readsDir(), '.nav-force'), '');
+    expect(nav('handleRequest')).toBe(true);
+  });
+
+  it('resets the streak after a quiet window', () => {
+    expect(nav('one')).toBe(false);
+    expect(nav('two')).toBe(false);
+    const stale = Math.floor(Date.now() / 1000) - 600;
+    fs.writeFileSync(path.join(readsDir(), '.nav-streak'), `2 ${stale}\r\n`);
+    expect(nav('three', { TRACE_MCP_GUARD_NAV_WINDOW: '300' })).toBe(false);
+  });
+
+  it('a new user prompt clears the streak, so a light question is left alone', () => {
+    expect(nav('one')).toBe(false);
+    expect(nav('two')).toBe(false);
+    prompt('rename the config loader');
+    expect(nav('three')).toBe(false);
+  });
+
+  it('a relationship question makes the next navigation call route immediately', () => {
+    prompt('who calls handleRequest?');
+    expect(fs.existsSync(path.join(readsDir(), '.nav-force'))).toBe(true);
+    expect(nav('handleRequest')).toBe(true);
+  });
+
+  it('a plain question clears the relationship flag', () => {
+    prompt('who calls handleRequest?');
+    prompt('rename the config loader');
+    expect(fs.existsSync(path.join(readsDir(), '.nav-force'))).toBe(false);
+  });
+});


### PR DESCRIPTION
TRA-711 shipped the crawl detector; only its POSIX half actually worked.

On Windows `trace-mcp-guard.cmd` counted navigation calls but nothing ever reset the counter — no `.nav-force` bypass, no rolling window, and `trace-mcp-user-prompt-submit.cmd` wrote neither signal. From the third navigation call on, the guard intervened on every navigation call for the rest of the session. That is the inverse of the gate's purpose and exactly the light-question regression TRA-705 priced at 1.45x.

## Changes

- `hooks/trace-mcp-guard.cmd` — `nav_hit` honours `.nav-force` (route from the first call) and the `TRACE_MCP_GUARD_NAV_WINDOW` quiet-window reset. State file format is the POSIX one, `"count epoch"`.
- `hooks/trace-mcp-user-prompt-submit.cmd` — clears `.nav-streak` on every prompt and sets/clears `.nav-force` from the relationship-question shapes. A missing CLI no longer short-circuits the signal. English shapes only: a `.cmd` is read in the machine's OEM codepage, so the POSIX hook's Russian alternatives cannot be embedded reliably.
- `tests/hooks/guard-windows.test.ts` — six tests mirroring the POSIX gate tests in `guard.test.ts` / `lifecycle-hooks.test.ts`.

No change to POSIX behaviour, no MCP tool contract or on-disk schema change. The gate stays reversible through `TRACE_MCP_GUARD_NAV_MIN` / `TRACE_MCP_GUARD_NAV_WINDOW`.

## Test evidence

- `pnpm exec vitest run --exclude='tests/perf/**'` — 9784 passed. Two unrelated files (`tests/scripts/locate-app.test.ts`, `src/daemon/__tests__/project-relay.test.ts`) flake under parallel load on this machine; both pass in isolation and both pass with this diff stashed.
- New tests skip off-Windows. The `cross-platform` label is set on this PR so the Windows job runs them here.
