### PR TITLE
feat(site): red means danger, not brand — monochrome CTA and chrome (TRA-739)

### DIFF
--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -61,7 +61,8 @@ ratios intact; `--accent-solid`, whose only job was the red CTA fill, is gone.
 Two surfaces implement these: `docs/index.html` (landing, inline `<style>`) and
 `docs/assets/css/docs.css` (every documentation page). The values must match.
 A token that exists in only one of them is a component token and must say so
-here — otherwise it reads as drift. There is exactly one: `--accent-solid`.
+here — otherwise it reads as drift. There are none: `--accent-solid` was the
+only one, and §0 removed it.
 
 Surfaces — a text token has to clear its ratio against **every** one of these
 it is painted on, because all three are in use on the same page:

--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -16,8 +16,43 @@ deliberately different — the app is native to macOS, the site is Nothing.
 Never port a decision from one to the other, and never "unify" them.
 
 The site's aesthetic is **Nothing**: monospaced caps for service labels, a dot
-lattice, near-monochrome, red as the single accent, generous air, no gradients,
-no shadows.
+lattice, monochrome, generous air, no gradients, no shadows.
+
+---
+
+## 0. Red means something is wrong. Nothing else.
+
+Nikolai's decision, 2026-09-03. It overrides the earlier "red is the single
+accent" rule that the rest of this file was written under, and it overrides the
+`nothing-design` skill where the two disagree. The copy in the agent brief and
+the copy here are the same rule; change one, change both.
+
+Red on our surfaces says **error, regression, degradation, or "here is what it
+costs without trace-mcp"**. Nothing else.
+
+Not allowed:
+
+- a red fill on the primary CTA, or on any button meant to be pressed;
+- red as a brand accent — dots, chips, outlines, underlines, hover states,
+  bullets, glyphs, icons;
+- red as decoration in banners, logo lockups, and social previews.
+
+The reason is not taste. Red reads as a warning: a download button in red asks
+the reader to be careful rather than to download, and next to an honest
+`without trace-mcp — 13,595 tok` — where red is right — one hue is saying two
+opposite things on one screen.
+
+What replaces it: the base stays monochrome. An element that needs an accent
+takes it from an accent palette recorded in this file, and red is not in that
+palette. **No palette has been chosen yet**, so until one is, the answer is
+monochrome at maximum contrast and more air — not "some other colour".
+
+Landing and doc pages carry **zero** red as of TRA-739: the CTA is a full
+inversion (`--text-display` fill, `--black` label, 21:1 both themes), the nav
+liveness dot, the problem-list bullets and the category dot are
+`--text-display`, and a doc-page link is `--text-display` plus its underline.
+`--accent` stays defined in both files as the reserved danger colour with its
+ratios intact; `--accent-solid`, whose only job was the red CTA fill, is gone.
 
 ---
 
@@ -63,18 +98,18 @@ contrast sweep below is what keeps it that way. Raising the red further to
 clear `#1A1A1A` too would push it to roughly `#EA5057`, which reads pink
 rather than red, and red being *this* red is not negotiable.
 
-**`--accent-solid` `#D71921` is not in the table above and is not a shared
-token.** It is the brand red as a **fill** — the landing's primary button —
-so it is never a foreground and has no ratio against a surface. The only
-ratio it has is white text on it: **5.18**. It lives in `docs/index.html`
-alone and is deliberately absent from `docs/assets/css/docs.css`, which has
-no filled-red component; adding it there would be a dead token. If a doc page
-ever grows one, define it there in the same PR.
+**`--accent` is the danger colour and nothing else** (§0). It is currently
+painted on no element of either surface; it stays defined, with its ratios,
+because the next genuine failure state must not have to re-derive a red that
+clears AA. It is lighter in dark and darker in light because a foreground has
+to fight its background. Never use it as a fill under white text — `#E54047`
+behind white is 4.07 and fails.
 
-`--accent` (link/glyph red) is lighter in dark and darker in light because a
-foreground has to fight its background; a fill does not. Never use
-`--accent-solid` as a text colour, and never use `--accent` as a fill under
-white text — `#E54047` behind white is 4.07 and fails.
+**`--accent-solid` `#D71921` no longer exists.** It was the brand red as a
+**fill**, and its only consumer was the landing's primary button, which §0
+removed in TRA-739. Do not reintroduce it: a red fill has no remaining job
+here, and a fill red that no element uses is how the CTA got red back the
+last time.
 
 **Compute a ratio against the surface the text actually sits on, in both
 themes.** `#FFFFFF` in light and `#000000` in dark are the most forgiving
@@ -170,8 +205,12 @@ Order: sticky header (brand + theme toggle) → `h1` → prose → `Last updated
   the `h2` drops its own — never two hairlines around an empty band.
 - `h4`–`h6` are Space Mono 11px caps at `--text-secondary`, not scaled-down
   headings.
-- Links are `--accent` with a 40%-opacity underline that goes solid on hover.
-  Red is the only chrome colour on a doc page.
+- Links are `--text-display` with a 40%-opacity underline of the same colour
+  that goes solid on hover. **A doc page has no chrome colour at all** (§0):
+  the link is the brightest text in its paragraph *and* the only underlined
+  one, so the affordance survives greyscale and colour blindness, which the
+  old red-plus-underline never needed to. Blockquotes take
+  `--border-visible`, not red.
 - Tables: **no zebra striping.** Rows separate on a `--border` hairline; the
   head is a Space Mono 10px caps label, not a bold band. Every table is
   wrapped in a focusable `.table-scroll` region by the layout script, so a
@@ -275,9 +314,13 @@ WebP conversion.
 - Toast popups — use inline `[SAVED]` / `[ERROR: …]`.
 - Filled or multi-colour icons, emoji as UI — including `✅` / `❌` / `⚠️`
   as capability marks in a table.
-- A second accent colour. Red is the only one. `--accent` and `--accent-solid`
-  are two lightnesses of the same red for two jobs (§1), not two accents.
-- `--accent` as a fill under white text, or `--accent-solid` as a text colour.
+- **Red on anything that is not a failure, a regression, or a cost** (§0):
+  no red CTA, dot, chip, bullet, outline, underline, hover, icon, banner or
+  social preview. This overrides the old "red is the single accent" rule.
+- Reintroducing `--accent-solid`, or any red fill.
+- A second accent colour. There is no first one — the base is monochrome and
+  no accent palette has been chosen yet (§0).
+- `--accent` as a fill under white text.
 - Red text on `--surface-raised` in dark — 4.27:1, the one gap in §1.
 - A colour value recorded with a ratio against a background it is not painted
   on. Quote the worst of the three surfaces, in both themes.
@@ -362,6 +405,18 @@ appearance without a screenshot or a measurement is not a finding.
       wrapper *and* every `pre` *and* the landing page's `.terminal-body`.
       Code blocks and the landing terminal were each read out of this line
       once and shipped clipped and unlabelled for months.
+
+**Colour**
+- [ ] No red outside a failure state. Not a claim — a command:
+
+      ```
+      grep -ni 'var(--accent)\|#D71921\|#E54047\|#B3151C' \
+        docs/index.html docs/assets/css/docs.css
+      ```
+
+      Every hit must be either a token definition or an element that means
+      something is wrong (§0). Today the correct output is the two token
+      definitions per file and nothing else.
 
 **Type & spacing**
 - [ ] Within the 2 families / 3 sizes / 2 weights budget.
@@ -463,8 +518,12 @@ left, with the whole right half empty is not asymmetry, it is a page that
 started and gave up. `.hero { text-align: center }` plus `margin: 0 auto` on
 `.hero-headline` (900px) and `.hero-desc` (660px).
 
-**One action. The button.** `.btn .btn-primary .btn-lg`, the one red on the
-screen. It ships labelled `Download` pointing at `/releases/latest` so it works
+**One action. The button.** `.btn .btn-primary .btn-lg` — a full inversion,
+`--text-display` fill under a `--black` label, 21:1 in both themes. It is the
+loudest thing a monochrome page has, and on a page whose base is near-black or
+near-white nothing else competes with a solid block of the opposite end. It
+shipped red until TRA-739; §0 is why it is not red now, and the inversion is
+what a primary CTA looks like here from now on. It ships labelled `Download` pointing at `/releases/latest` so it works
 without JS (TRA-440), and `resolveDownload()` narrows it to a single file and
 renames it only once it has found that file in the release JSON. The label names
 the exact machine — `Download for Mac (Apple Silicon)`, `Download for Mac
@@ -499,7 +558,9 @@ no focus ring and nothing for a screen reader; the `$` is `aria-hidden`, the
 `copy` label is `aria-live="polite"` so `copied` is announced. It keeps its
 technical 8px box on `--surface` — but side by side with the red pill that box
 read as a second button of equal weight, which is what this hero keeps being
-pulled back into, so it is a full row down instead. Off macOS and Windows it
+pulled back into, so it is a full row down instead. That verdict predates the
+inversion and survives it: an outlined box next to a solid block of the
+opposite end still reads as a second button when the two sit side by side. Off macOS and Windows it
 gains `.is-primary` and is the hero's only action.
 
 **The headline is measured, not guessed.** `clamp(36px, 5.2vw, 60px)` over

--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -69,8 +69,7 @@
   --text-secondary: #999999;
   --text-primary: #e8e8e8;
   --text-display: #ffffff;
-  --accent: #e54047; /* 5.16 page / 4.64 surface / 4.27 raised — no red text on raised, see DESIGN-WEB.md #1 */
-  --accent-subtle: rgba(229, 64, 71, 0.15);
+  --accent: #e54047; /* danger only — failure, regression, cost. Never chrome. 5.16 page / 4.64 surface / 4.27 raised — no red text on raised, see DESIGN-WEB.md #1 */
 
   --nav-bg: rgba(0, 0, 0, 0.85);
   --dot-color: var(--border);
@@ -92,8 +91,7 @@
   --text-secondary: #595959;
   --text-primary: #1a1a1a;
   --text-display: #000000;
-  --accent: #b3151c; /* 6.33 page / 6.91 surface / 6.06 raised (governs) */
-  --accent-subtle: rgba(179, 21, 28, 0.12);
+  --accent: #b3151c; /* danger only — failure, regression, cost. Never chrome. 6.33 page / 6.91 surface / 6.06 raised (governs) */
 
   --nav-bg: rgba(245, 245, 245, 0.85);
   --dot-color: var(--border-visible);
@@ -182,7 +180,7 @@ body::before {
   color: var(--text-disabled);
 }
 .nav-brand:hover .bracket {
-  color: var(--accent);
+  color: var(--text-display);
 }
 
 .container {
@@ -338,16 +336,19 @@ main {
   font-style: italic;
 }
 
+/* A link is the brightest text in the paragraph plus a rule under it — the
+   underline is what carries the affordance, so it survives greyscale and
+   colour blindness alike. Red would say "this link is a problem". */
 .prose a {
-  color: var(--accent);
+  color: var(--text-display);
   text-decoration: underline;
   text-underline-offset: 3px;
   text-decoration-thickness: 1px;
-  text-decoration-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  text-decoration-color: color-mix(in srgb, var(--text-display) 40%, transparent);
   transition: text-decoration-color 150ms var(--ease);
 }
 .prose a:hover {
-  text-decoration-color: var(--accent);
+  text-decoration-color: var(--text-display);
 }
 /* Scroll regions are tab stops too. Left out, they fall through to Chrome's
    own ring — blue in the light theme, which is a second accent colour. */
@@ -496,7 +497,7 @@ main {
 
 .prose blockquote {
   padding-left: 20px;
-  border-left: 1px solid var(--accent);
+  border-left: 1px solid var(--border-visible);
   color: var(--text-secondary);
 }
 .prose hr {
@@ -546,7 +547,7 @@ svg {
   text-decoration: none;
 }
 .docs-footer a:hover {
-  color: var(--accent);
+  color: var(--text-display);
 }
 /* One cell per link. `auto-fill` rather than a fixed count so the column
    number falls out of the width — 4 at 1440px, 1 below 600px — and no label

--- a/docs/index.html
+++ b/docs/index.html
@@ -279,9 +279,7 @@ layout: null
       --text-secondary: #999999;
       --text-primary: #E8E8E8;
       --text-display: #FFFFFF;
-      --accent: #E54047; /* 5.16 page / 4.64 surface / 4.27 raised — no red text on raised, see DESIGN-WEB.md #1 */
-      --accent-subtle: rgba(229, 64, 71, 0.15);
-      --accent-solid: #D71921; /* landing-only fill under white text: 5.18:1 with #FFFFFF */
+      --accent: #E54047; /* danger only — failure, regression, cost. Never chrome. 5.16 page / 4.64 surface / 4.27 raised — no red text on raised, see DESIGN-WEB.md #1 */
       --success: #4A9E5C;
       --warning: #D4A843;
 
@@ -305,9 +303,7 @@ layout: null
       --text-secondary: #595959;
       --text-primary: #1A1A1A;
       --text-display: #000000;
-      --accent: #B3151C; /* 6.33 page / 6.91 surface / 6.06 raised (governs) */
-      --accent-subtle: rgba(179, 21, 28, 0.12);
-      --accent-solid: #D71921; /* landing-only fill under white text: 5.18:1 with #FFFFFF */
+      --accent: #B3151C; /* danger only — failure, regression, cost. Never chrome. 6.33 page / 6.91 surface / 6.06 raised (governs) */
       --success: #2E7D3E;
       --warning: #A8822E;
 
@@ -363,7 +359,6 @@ layout: null
     .label-display { color: var(--text-display); }
     .label-disabled { color: var(--text-disabled); }
     .label-success { color: var(--success); }
-    .label-accent { color: var(--accent); }
 
     /* ── Nav ── */
     nav {
@@ -397,10 +392,11 @@ layout: null
       color: var(--text-disabled);
       text-transform: uppercase;
     }
+    /* Monochrome: red on this site means something is wrong, and "online" is
+       not wrong. The pulse carries the liveness, not the hue. */
     .status-dot {
       width: 6px; height: 6px; border-radius: 50%;
-      background: var(--accent);
-      box-shadow: 0 0 8px var(--accent);
+      background: var(--text-display);
       animation: pulse 2s ease-in-out infinite;
     }
     @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
@@ -496,17 +492,20 @@ layout: null
       min-height: 44px;
       white-space: nowrap;
     }
+    /* The one action on the page, drawn in the loudest thing a monochrome
+       page has: full inversion. 21:1 either way. A red fill here asked the
+       reader to be careful instead of to download. */
     .btn-primary {
-      background: var(--accent-solid);
-      color: #FFFFFF;
-      box-shadow: 0 0 0 0 rgba(215, 25, 33, 0.4);
+      background: var(--text-display);
+      color: var(--black);
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--text-display) 40%, transparent);
       transition: background-color 200ms cubic-bezier(0.25, 0.1, 0.25, 1),
                   box-shadow 200ms cubic-bezier(0.25, 0.1, 0.25, 1),
                   transform 200ms cubic-bezier(0.25, 0.1, 0.25, 1);
     }
     .btn-primary:hover {
-      background: #B21218;
-      box-shadow: 0 0 0 4px rgba(215, 25, 33, 0.18);
+      background: var(--text-primary);
+      box-shadow: 0 0 0 4px color-mix(in srgb, var(--text-display) 18%, transparent);
     }
     .btn-secondary {
       background: transparent;
@@ -1597,9 +1596,8 @@ layout: null
     .pain-num::before {
       content: '';
       width: 8px; height: 8px;
-      background: var(--accent);
+      background: var(--text-display);
       border-radius: 50%;
-      box-shadow: 0 0 12px color-mix(in srgb, var(--accent) 45%, transparent);
       flex-shrink: 0;
     }
     .pain-text {
@@ -1626,7 +1624,7 @@ layout: null
       content: '/';
       position: absolute;
       left: 64px; top: 2px;
-      color: var(--accent);
+      color: var(--text-disabled);
       font-family: var(--font-mono);
       font-size: 22px;
       line-height: 1;
@@ -1863,12 +1861,6 @@ layout: null
       color: var(--text-display);
       overflow-wrap: break-word;
     }
-    .diff-quote .neg {
-      color: var(--text-disabled);
-      text-decoration: line-through;
-      text-decoration-thickness: 1px;
-      text-decoration-color: var(--accent);
-    }
     .diff-quote .pos {
       color: var(--text-display);
       font-weight: 700;
@@ -1953,8 +1945,7 @@ layout: null
       transform: translateY(-50%);
       width: 8px; height: 8px;
       border-radius: 50%;
-      background: var(--accent);
-      box-shadow: 0 0 14px var(--accent);
+      background: var(--text-display);
     }
     .category-headline {
       font-family: var(--font-body);


### PR DESCRIPTION
## What

Red on trace-mcp.com now means exactly one thing: something is wrong. Nikolai's decision of 2026-09-03 — it was recorded in the agent brief but not in `docs/DESIGN-WEB.md`, and the site contradicted it in seven places, starting with a red download button.

## Why it matters

A red primary CTA asks the reader to be careful, not to download. And next to an honest "without trace-mcp — 13,595 tok", one hue ends up saying two opposite things on one screen.

## Landing — `docs/index.html`

| Element | Before | After |
|---|---|---|
| `.btn-primary` | `--accent-solid` `#D71921` fill, white label | `--text-display` fill, `--black` label — 21:1 in both themes |
| `.status-dot` (nav "online") | red + 8px glow | `--text-display`, no glow; the pulse still carries liveness |
| `.pain-num::before` (problem bullets) | red + 12px glow | `--text-display` |
| `.category-tag::before` | red + 14px glow | `--text-display` |
| `.pain-punchline::before` `/` | red | `--text-disabled` — same voice as `/ The Category` |
| `.label-accent`, `.diff-quote .neg`, `--accent-subtle` | dead rules | removed |
| `--accent-solid` | landing-only red fill token | removed — its only consumer was the CTA |

The glows went with the colour: a glow is a shadow, which §4 already banned.

## Doc pages — `docs/assets/css/docs.css`

Links are `--text-display` plus their 40% underline instead of red. The underline is what carries the affordance, so it survives greyscale and colour blindness — the red version never had to. Blockquote rule → `--border-visible`; brand-bracket hover and footer-link hover → `--text-display`. `--accent-subtle` removed.

`--accent` stays defined in both files, with its contrast ratios intact, as the reserved danger colour. No element paints it today, and the next real failure state should not have to re-derive a red that clears AA.

## `docs/DESIGN-WEB.md`

New **§0 — Red means something is wrong. Nothing else.** carries the rule verbatim, states that it overrides both the old "red is the single accent" line and the `nothing-design` skill, and records that no accent palette has been chosen yet — so until one is, the answer is monochrome at maximum contrast and more air, not "some other colour". §1, §2, §4, §5 and §8 are brought into line. §5 gains a gate that is a command, not a sentence:

```
grep -ni 'var(--accent)\|#D71921\|#E54047\|#B3151C' docs/index.html docs/assets/css/docs.css
```

Every hit must be a token definition or an element that means failure. Today: two definitions per file, nothing else.

## Verification

- Headless Chrome (`--headless`, throwaway profile — Nikolai's screen untouched), 1440px and 390px, dark and light, landing and `comparisons.html`. The 390px layout is identical to the live page apart from the colour.
- `node scripts/contrast-sweep.mjs` — 28 pages × 2 themes, **0 failing elements**.

## Not in scope

The YC badge's `#FF6600` is a third-party brand mark, not our accent, and stays. `og-image.png` was checked and carries no red.
