### PR TITLE
docs: refresh the tools-reference lastmod that master is red on

### DIFF
--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -8,7 +8,7 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/tools-reference.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -1,7 +1,7 @@
 ---
 title: "MCP Tools Reference — code-intelligence tools by task and framework"
 description: "The trace-mcp MCP tools you reach for most, grouped by task — navigation, refactoring, impact analysis, security, and framework-aware queries. Every tool is listed in the tool index."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # Tools reference


### PR DESCRIPTION
`master` is red, and has been since the last docs commit landed. Two cases in `tests/docs/internal-links.test.ts` fail on `master` itself (run `33831305841`), which blocks every open PR:

```
FAIL tests/docs/internal-links.test.ts > every lastmod is at least the source page last commit date
FAIL tests/docs/internal-links.test.ts > regenerating never moves a committed date backwards
```

`docs/tools-reference.md` was last committed on 2026-09-04; `docs/sitemap.xml` still claimed `2026-09-03`. This is the output of `pnpm docs:sitemap`, nothing hand-edited — two date lines.

`npx vitest run tests/docs/internal-links.test.ts` → 23 passed.

**Worth a follow-up, not fixed here:** this will happen again. The check compares committed data against `git log`, so any commit that touches a docs page after the sitemap's date rolls over turns `master` red until someone notices and regenerates. Either the generator should run in CI, or the test should tell you to run `pnpm docs:sitemap` instead of asserting a date. I'd rather file that than widen this PR while the board is blocked.
