### PR TITLE
ci: make the audit gate depend on advisories, not on npm's uptime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,22 +256,14 @@ jobs:
       # hour; because `audit` is a required check on master, every PR in the repo
       # was unmergeable for as long as somebody else's service was down. The gate
       # promises "0 known vulnerabilities in prod", and a 503 says nothing about
-      # that either way — so a transport failure warns and passes, while a real
-      # advisory still fails. `pnpm audit` exits non-zero for both, hence the grep.
+      # that either way. `--ignore-registry-errors` is pnpm's own switch for
+      # exactly this — it decides on the response, not on the report text, so an
+      # advisory that happens to mention ECONNRESET in its title still fails.
       - name: pnpm audit (production dependencies)
         env:
           npm_config_fetch_timeout: '300000'
           npm_config_fetch_retries: '0'
-        run: |
-          set +e
-          out=$(pnpm audit --prod --audit-level=moderate 2>&1)
-          code=$?
-          printf '%s\n' "$out"
-          if [ "$code" -ne 0 ] && printf '%s' "$out" | grep -qE 'ERR_PNPM_AUDIT_BAD_RESPONSE|ERR_PNPM_FETCH|ERR_SOCKET_TIMEOUT|ENOTFOUND|ECONNRESET|ETIMEDOUT'; then
-            echo "::warning title=Audit inconclusive::npm advisory endpoint unreachable — the audit did not run. Not failing the gate on somebody else's outage."
-            exit 0
-          fi
-          exit "$code"
+        run: pnpm audit --prod --audit-level=moderate --ignore-registry-errors
 
   no-ai-marks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,9 +244,16 @@ jobs:
       # pnpm kills its own request and retries: 60s + 10s + 60s + 60s ~= 190s,
       # measured, which alone overran the job. Three slow attempts are strictly
       # worse than one patient one — the answer is the same either way.
+      #
+      # `fetch-retries: 0` is what actually makes it one attempt. pnpm keeps its
+      # default of 2 retries unless this is set separately, so the timeout alone
+      # bought a worst case of 3 x 300s plus 10s and 60s of backoff — about
+      # 16m10s, which does not fit the 15-minute job cap the timeout was sized
+      # against. Retrying an advisory lookup does not change its answer.
       - name: pnpm audit (production dependencies)
         env:
           npm_config_fetch_timeout: '300000'
+          npm_config_fetch_retries: '0'
         run: pnpm audit --prod --audit-level=moderate
 
   no-ai-marks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,11 +250,28 @@ jobs:
       # bought a worst case of 3 x 300s plus 10s and 60s of backoff — about
       # 16m10s, which does not fit the 15-minute job cap the timeout was sized
       # against. Retrying an advisory lookup does not change its answer.
+      #
+      # An unreachable advisory endpoint is not an advisory. On 2026-09-04 npm
+      # answered both audit endpoints with `503 Service Unavailable` for over an
+      # hour; because `audit` is a required check on master, every PR in the repo
+      # was unmergeable for as long as somebody else's service was down. The gate
+      # promises "0 known vulnerabilities in prod", and a 503 says nothing about
+      # that either way — so a transport failure warns and passes, while a real
+      # advisory still fails. `pnpm audit` exits non-zero for both, hence the grep.
       - name: pnpm audit (production dependencies)
         env:
           npm_config_fetch_timeout: '300000'
           npm_config_fetch_retries: '0'
-        run: pnpm audit --prod --audit-level=moderate
+        run: |
+          set +e
+          out=$(pnpm audit --prod --audit-level=moderate 2>&1)
+          code=$?
+          printf '%s\n' "$out"
+          if [ "$code" -ne 0 ] && printf '%s' "$out" | grep -qE 'ERR_PNPM_AUDIT_BAD_RESPONSE|ERR_PNPM_FETCH|ERR_SOCKET_TIMEOUT|ENOTFOUND|ECONNRESET|ETIMEDOUT'; then
+            echo "::warning title=Audit inconclusive::npm advisory endpoint unreachable — the audit did not run. Not failing the gate on somebody else's outage."
+            exit 0
+          fi
+          exit "$code"
 
   no-ai-marks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to #850, which was merged 14 seconds before its second-model
review landed. The review found the arithmetic in that PR's own comment
does not hold: pnpm keeps `fetch-retries: 2` unless it is set separately,
so `npm_config_fetch_timeout=300000` bought a worst case of three 300s
attempts plus 10s and 60s of backoff — about 16m10s for the advisory
lookup alone, against a 15-minute job cap. `audit` is a required check on
master, so that is the same class of failure #850 set out to remove: the
gate cancelled without ever producing an advisory result.

`npm_config_fetch_retries=0` is what makes it the single patient request
the comment describes. Verified locally:

  npm_config_fetch_retries=0 pnpm config get fetch-retries  -> 0
  npm_config_fetch_timeout=300000 pnpm config get fetch-timeout -> 300000

Nothing else changes: same command, same pins, still not continue-on-error.

Reported by Code Reviewer on TRA-785 as a post-merge MEDIUM finding against #850.