### PR TITLE
fix(app): clamp the sheet to the window so the first-run actions stay reachable (TRA-794)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1182,6 +1182,26 @@ belongs to the window: the application menu, a context menu at the cursor.
 Sidebar collapsed, sidebar at 180 and at 320, and the 640px window minimum are four
 different pane boxes. Check the overlay in all of them, not just the one you developed in.
 
+### A sheet is clamped by the window, and the unbounded thing inside it is what scrolls
+
+The scrim is `position: fixed; inset: 0`, which is a box that cannot scroll. So a sheet
+without a height ceiling is not a tall sheet — it is a sheet whose bottom is **cut off and
+unreachable**, by the pointer and by the keyboard alike. `.lx-sheet` caps at
+`calc(100vh - 24px)` and is a flex column; `.lx-sheet-body` carries `min-height: 0;
+overflow-y: auto` as the floor no step can fall through.
+
+That floor is the fallback, not the design. A step with one unbounded region — a list, a
+log, a diff — names *that* region as the scroller (`flex-1 min-h-0` down the chain,
+`overflow-y-auto` on the list itself) so the title, the explanation and the buttons never
+move. One scroll container, and the primary action is never something you have to go
+looking for.
+
+TRA-794 is what this is written from: the setup wizard's clients step measured 753px in the
+700px default window with fifteen clients detected, and the 53px it lost were `Skip for now`
+and `Connect selected` — the entire first-run flow, with no way forward and no way back
+except an `Esc` nobody was told about. **A sheet's action row is the one part of it that may
+never depend on how much content is above it.**
+
 ---
 
 ## 7. Accessibility
@@ -1596,6 +1616,7 @@ new evidence.
 | The last tile still hand-rolling its material is the one nobody looks at | The sidebar's update card kept `--fill-tertiary` at an 8px radius and a private `.btn-prominent` through the whole TRA-290 migration, because it only appears when there is an update — so every review of the sidebar was a review of a sidebar without it. When a migration says "every surface", enumerate the surfaces that are conditionally rendered too. |
 | A seam you cannot see is a seam you do not have | The workspace table's frozen columns declared a `-1px 0 0 var(--separator)` hairline on the pinned cells from the day they landed, and Chromium had been discarding it the whole time — `box-shadow` does not paint on cells under `border-collapse: collapse`. Nobody noticed, because the failure mode of a missing seam is a table that looks finished. Check a decorative declaration renders; only a screenshot or `getComputedStyle` on the running renderer can tell you it did. |
 | A row label never repeats its own control's verb | "Temporary pause" beside a "Pause for 10 minutes" button wrapped to two lines at the 640px minimum and added no meaning. The label names the subject ("Enforcement"), the control names the action. |
+| A layer with no ceiling does not overflow — it truncates, silently | `.lx-sheet` had `width: min(440px, 100vw - 32px)` and nothing at all on the vertical axis, for as long as the sheet has existed. It never showed, because every sheet in the app is short — until `detectMcpClients` returned fifteen on a real machine and the first-run wizard grew to 753px inside a 700px window. A `position: fixed` scrim does not scroll, so the missing 53px were not below the fold, they were gone: the two buttons that are the entire point of the step. The tell is that the failure mode looks like a finished screen. Any axis a layer does not constrain, check against the window minimum with the most content the data can actually produce, not with the fixture. |
 | A baseline is taken from a reading the app **has**, and never from an empty one | The KPI effect guarded on `metricsLoading` alone, which `Workspace.tsx` passes as `false` the moment the request *fails* and which says nothing about the project list two tiles are derived from. One launch with the daemon down stored all zeros, and the dashboard then reported the whole workspace — "↑ +53 projects, ↑ +656.2k symbols vs 5 hours ago" — as this afternoon's growth for the next 24 hours. A comparison drawn against zero is the value repeated with an arrow on it, which is the bare number §7 asks a comparison line to replace — so an empty snapshot is refused on the way in *and* on the way out, which is also what heals the users already carrying one. When a component distinguishes four data states, a side effect that writes persistent state has to respect all four. |
 
 ---

--- a/packages/app/src/renderer/app.css
+++ b/packages/app/src/renderer/app.css
@@ -191,9 +191,19 @@ body {
   }
 }
 
+/* A sheet is clamped by the window it hangs from (TRA-794). Without the
+   ceiling its height is whatever its content is, and the scrim is
+   `position: fixed` — so the overflow is not scrolled, it is cut off. The
+   clients step of the setup wizard was 753px in the 700px default window, and
+   the 53px that went missing were its two buttons: a first-run user saw a list
+   and no way forward. The 24px it gives back keeps the bottom edge and its 12px
+   corners clear of the window sill, so it still reads as a sheet. */
 .lx-sheet {
   box-sizing: border-box;
   width: min(440px, calc(100vw - 32px));
+  max-height: calc(100vh - 24px);
+  display: flex;
+  flex-direction: column;
   padding: 20px;
   background: var(--surface);
   border: 0.5px solid var(--separator);
@@ -216,10 +226,16 @@ body {
   font: var(--weight-semibold) var(--text-title-2) / var(--leading-title-2) var(--font-ui);
   color: var(--label);
 }
+/* `min-height: 0` so the body can shrink below its content inside the clamped
+   sheet, and `overflow-y: auto` as the last resort for a step that has no
+   scroll region of its own — long copy at the 640x420 window minimum. A step
+   that names its own scroller (the clients list) never reaches this. */
 .lx-sheet-body {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  min-height: 0;
+  overflow-y: auto;
 }
 .lx-sheet-text {
   margin: 0;

--- a/packages/app/src/renderer/components/SetupWizard.tsx
+++ b/packages/app/src/renderer/components/SetupWizard.tsx
@@ -419,7 +419,12 @@ export function SetupWizard({ onClose, initialStep }: SetupWizardProps) {
   } else if (step === 'clients') {
     title = t('guard:wizard.clients.title');
     body = (
-      <div className="flex flex-col gap-4">
+      /* The list is the one thing here without a ceiling — fifteen detected
+         clients is 600px of rows — so it is the one that scrolls, and the
+         subtitle and the two buttons stay where they are (TRA-794). `min-h-0`
+         on every link of the chain, or a flex item refuses to shrink below its
+         content and the sheet grows past the window again. */
+      <div className="flex flex-col gap-4 flex-1 min-h-0">
         <p className="lx-sheet-text" style={{ margin: 0 }}>
           {t('guard:wizard.clients.subtitle')}
         </p>
@@ -436,8 +441,8 @@ export function SetupWizard({ onClose, initialStep }: SetupWizardProps) {
             {t('guard:wizard.clients.none')}
           </p>
         ) : (
-          <Card>
-            <div className="flex flex-col divide-y divide-[var(--separator)]">
+          <Card className="flex flex-col min-h-0">
+            <div className="flex flex-col divide-y divide-[var(--separator)] min-h-0 overflow-y-auto">
               {clients.map((row) => {
                 const displayName = MCP_CLIENT_DISPLAY_NAMES[row.client.name] ?? row.client.name;
                 const isManual = row.client.name === 'warp' || row.client.name === 'jetbrains-ai';

--- a/packages/app/src/renderer/components/__tests__/SetupWizard.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/SetupWizard.test.tsx
@@ -112,6 +112,26 @@ it('renders pre-checked checkboxes for detected MCP clients with config paths', 
   expect(screen.getByText('/Users/test/.cursor/mcp.json')).toBeTruthy();
 });
 
+/* TRA-794. jsdom has no layout, so what is asserted here is the structure that
+   makes the layout possible: the client list is the one scroll container, and
+   the buttons sit outside it. With fifteen clients detected the sheet was 753px
+   in a 700px window and the action row was at y=704 — off screen, and with no
+   scrollable ancestor to bring it back. */
+it('scrolls the client list, not the sheet, so the actions stay in view', async () => {
+  stubElectronApi();
+  const { container } = render(<SetupWizard onClose={() => {}} initialStep="clients" />);
+
+  await screen.findByText('Connect coding assistants');
+
+  const scroller = container.querySelector('.overflow-y-auto');
+  expect(scroller).toBeTruthy();
+  expect(scroller!.textContent).toContain('Cursor');
+
+  const actions = container.querySelector('.lx-sheet-actions');
+  expect(actions).toBeTruthy();
+  expect(scroller!.contains(actions!)).toBe(false);
+});
+
 it('connects selected clients and advances to project step on confirmation', async () => {
   stubElectronApi();
   render(<SetupWizard onClose={() => {}} initialStep="clients" />);


### PR DESCRIPTION
## The defect

On first run the setup wizard's **Connect coding assistants** step rendered a sheet taller than
the window, and the window clipped it. The clipped part was the action row — so a new user was
shown a list of assistants and **no way to go forward**.

Measured on the running Electron renderer (`electron-cdp.mjs launch`, viewport 960×700 — the
app's default size — with fifteen MCP clients detected):

| | before | after |
|---|---|---|
| `.lx-sheet` height | **753px** in a 700px window | 676px |
| `Skip for now` / `Connect selected`, bottom edge | **y 732** — off screen | y 656 |
| same at the 640×420 window minimum | 5 of 15 rows, nothing below them | y 376, both buttons visible |

`.lx-sheet-scrim` is `position: fixed; inset: 0` and nothing in the chain had `overflow: auto`,
so those 53px were not below the fold — they were unreachable, by pointer and by keyboard alike.
`Esc` still dismissed the sheet, which was the only exit, and it means *skip*.

`.lx-sheet` has had a width ceiling (`min(440px, 100vw - 32px)`) and nothing at all on the
vertical axis since it was written. It never showed because every sheet in the app is short —
until `detectMcpClients` returned fifteen on a real machine.

## The fix

- `.lx-sheet`: `max-height: calc(100vh - 24px)`, flex column. The 24px keeps the bottom edge and
  its 12px corners clear of the sill, so it still reads as a sheet.
- `.lx-sheet-body`: `min-height: 0; overflow-y: auto` — the floor no step can fall through,
  including long German copy at the window minimum.
- Clients step: names its own scroller rather than relying on that floor. The list `Card` absorbs
  the overflow (`flex-1 min-h-0` down the chain, `overflow-y-auto` on the list), so the title, the
  explanation and the two buttons never move. One scroll container per DESIGN.md §6, and the
  primary action does not depend on how much content sits above it.

## Verification

Screenshots from the real Electron window (not a browser): default 960×700 dark, the 640×420
minimum in light, and light with Reduce Transparency + Increase Contrast. The other three wizard
steps re-measured unchanged — `daemon`, `project` (312px, actions at y 291) and `complete` never
reach the body's overflow floor.

`packages/app`: typecheck clean, 657/657 tests pass, including a new one that fails if the scroll
chain is dropped (jsdom has no layout, so it asserts the structure that makes the layout possible:
the list is the scroller and the actions are outside it).

DESIGN.md §6 gets the rule — *a sheet is clamped by the window, and the unbounded thing inside it
is what scrolls* — and §11 the decision: a layer with no ceiling does not overflow, it truncates,
and the failure mode looks like a finished screen.

Closes TRA-794.
