### PR TITLE
fix(app): clamp the setup sheet to the window so its actions stay reachable (TRA-794)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1182,6 +1182,25 @@ belongs to the window: the application menu, a context menu at the cursor.
 Sidebar collapsed, sidebar at 180 and at 320, and the 640px window minimum are four
 different pane boxes. Check the overlay in all of them, not just the one you developed in.
 
+### A sheet is clamped by the window, and its list scrolls — not the sheet
+
+`.lx-sheet-scrim` is `position: fixed`, so it cannot scroll: whatever part of a sheet falls
+past the window edge is gone, not merely below the fold. And the part that falls off is
+always the bottom, which is where the actions are. TRA-794 shipped that — with ten MCP
+clients detected, the first-run wizard's sheet measured 753px in a 700px window and both
+`Skip for now` and `Connect selected` sat at y 732. A new user got a list and no way
+forward; only Esc, which means "skip".
+
+So: `.lx-sheet` is `max-height: calc(100vh - 24px)` and a flex column, and `.lx-sheet-body`
+is `min-height: 0; overflow-y: auto` — the safety net that no step can outgrow. A step whose
+content is a list does better than the net: the list takes the leftover height
+(`flex-1 min-h-0` on the card, `overflow-y-auto` on the rows) so the title, the subtitle and
+the actions never move. One scroll container, and it is the list.
+
+Any content whose length comes from the user's machine — detected clients, projects,
+sessions — is unbounded. Check the sheet at the 640×420 window minimum with that content at
+its longest, not with the two rows your dev machine happens to have.
+
 ---
 
 ## 7. Accessibility

--- a/packages/app/src/renderer/app.css
+++ b/packages/app/src/renderer/app.css
@@ -193,7 +193,13 @@ body {
 
 .lx-sheet {
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
   width: min(440px, calc(100vw - 32px));
+  /* The scrim is `position: fixed` and cannot scroll, so a sheet taller than the
+     window loses its bottom — which is where the actions are (TRA-794). Clamp it
+     to the window and let the body scroll instead. */
+  max-height: calc(100vh - 24px);
   padding: 20px;
   background: var(--surface);
   border: 0.5px solid var(--separator);
@@ -218,8 +224,13 @@ body {
 }
 .lx-sheet-body {
   display: flex;
+  flex: 1 1 auto;
   flex-direction: column;
   gap: 12px;
+  /* Safety net: a step whose content outgrows the window scrolls here. Steps
+     with a long list scroll inside the list instead, so their actions stay put. */
+  min-height: 0;
+  overflow-y: auto;
 }
 .lx-sheet-text {
   margin: 0;
@@ -276,6 +287,7 @@ body {
 
 .lx-sheet-actions {
   display: flex;
+  flex: none;
   justify-content: flex-end;
   gap: 8px;
   margin-top: 4px;

--- a/packages/app/src/renderer/components/SetupWizard.tsx
+++ b/packages/app/src/renderer/components/SetupWizard.tsx
@@ -419,7 +419,11 @@ export function SetupWizard({ onClose, initialStep }: SetupWizardProps) {
   } else if (step === 'clients') {
     title = t('guard:wizard.clients.title');
     body = (
-      <div className="flex flex-col gap-4">
+      // The list is the only unbounded content in the wizard: with 15 detected
+      // clients it used to push the actions past the window (TRA-794). It takes
+      // the leftover height and scrolls inside itself, so the subtitle and the
+      // two buttons stay where they are.
+      <div className="flex flex-col gap-4 flex-1 min-h-0">
         <p className="lx-sheet-text" style={{ margin: 0 }}>
           {t('guard:wizard.clients.subtitle')}
         </p>
@@ -436,8 +440,11 @@ export function SetupWizard({ onClose, initialStep }: SetupWizardProps) {
             {t('guard:wizard.clients.none')}
           </p>
         ) : (
-          <Card>
-            <div className="flex flex-col divide-y divide-[var(--separator)]">
+          <Card className="flex-1 min-h-0 flex flex-col">
+            <div
+              data-scroll="clients"
+              className="flex flex-col divide-y divide-[var(--separator)] min-h-0 overflow-y-auto"
+            >
               {clients.map((row) => {
                 const displayName = MCP_CLIENT_DISPLAY_NAMES[row.client.name] ?? row.client.name;
                 const isManual = row.client.name === 'warp' || row.client.name === 'jetbrains-ai';

--- a/packages/app/src/renderer/components/__tests__/SetupWizard.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/SetupWizard.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import { SetupWizard, isOnboardingDone } from '../SetupWizard';
@@ -233,6 +234,32 @@ it('dismisses on Escape and remembers completion', async () => {
 
   expect(onClose).toHaveBeenCalledTimes(1);
   expect(isOnboardingDone()).toBe(true);
+});
+
+// TRA-794: the sheet used to be as tall as its content, so 15 detected clients
+// pushed "Skip for now" / "Connect selected" below the window edge — with a
+// fixed, unscrollable scrim there was no way forward left on screen. jsdom does
+// not apply app.css, so this checks both halves of the chain by source: the
+// sheet's ceiling in CSS, and the shrink/scroll classes on the list.
+it('keeps the client list scrolling inside the sheet, not past the window', async () => {
+  const css = readFileSync('src/renderer/app.css', 'utf8');
+  const sheetRule = css.slice(css.indexOf('.lx-sheet {'), css.indexOf('@keyframes lx-sheet-in'));
+  expect(sheetRule).toMatch(/max-height:/);
+  const bodyRule = css.slice(css.indexOf('.lx-sheet-body {'));
+  expect(bodyRule.slice(0, bodyRule.indexOf('}'))).toMatch(/overflow-y:\s*auto/);
+
+  stubElectronApi();
+  render(<SetupWizard onClose={() => {}} initialStep="clients" />);
+  await screen.findByText('Connect coding assistants');
+
+  const list = document.querySelector('[data-scroll="clients"]') as HTMLElement;
+  expect(list.className).toContain('overflow-y-auto');
+
+  // Every box between the scroll area and the sheet body must be allowed to
+  // shrink, or the list just grows and takes the actions off screen again.
+  for (let el = list.parentElement; el && !el.classList.contains('lx-sheet-body'); el = el.parentElement) {
+    expect(el.className).toContain('min-h-0');
+  }
 });
 
 it('traps Tab focus inside the sheet', async () => {


### PR DESCRIPTION
Closes TRA-794.

## The problem

The first-run wizard's **Connect coding assistants** step renders a sheet as tall as its
content. `.lx-sheet-scrim` is `position: fixed` and nothing below it scrolls, so whatever
falls past the window edge is unreachable — and what falls off is the bottom, where the
actions are. A new user is shown a list of clients and no way forward; only Esc, which
means "skip".

Measured on the running renderer (`electron-cdp.mjs`, 10 MCP clients detected on this
machine, dev build of 3.16.0):

| | before | after |
|---|---|---|
| 960×700 — sheet height | 753 (window 700) | 676 |
| 960×700 — actions bottom edge | y 732 — off screen | y 656 |
| 640×420 (window minimum) — sheet height | 753 | 396 |
| 640×420 — actions bottom edge | y 732 — off screen | y 376 |
| list scrolls | no | yes |

## The fix

- `.lx-sheet` — `max-height: calc(100vh - 24px)` and a flex column, so a sheet can never
  exceed the window.
- `.lx-sheet-body` — `min-height: 0; overflow-y: auto`. The safety net for every step,
  including long translated copy at the window minimum.
- `.lx-sheet-actions` — `flex: none`, so the button row is never the thing that compresses.
- Clients step — the list card takes the leftover height (`flex-1 min-h-0`) and its rows
  scroll (`overflow-y-auto`). One scroll container, and it is the list: the title, subtitle
  and both buttons stay put.

## Verification

Screenshots before/after in light and dark and at the 640×420 minimum are attached to
TRA-794. `pnpm test` in `packages/app`: 65 files, 657 tests, all passing; `typecheck` clean.
The new test in `SetupWizard.test.tsx` fails if either half of the chain is dropped — the
CSS ceiling or the shrink/scroll classes on the list.

DESIGN.md §6 gains the general rule, since the missing ceiling was house-wide and not
specific to this step.
