### PR TITLE
fix(docs): regenerate stale sitemap lastmod (TRA-795)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 ---
 title: "Architecture — indexing pipeline, storage, and MCP server internals"
 description: "How trace-mcp indexes a codebase into a queryable graph: tree-sitter parsing, SQLite + FTS5 storage, optional LSP enrichment, and the MCP server on top."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # Architecture

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: "Configuration Reference — all config options (works with none)"
 description: "Every trace-mcp option in .trace-mcp.json — indexing, quality gates, LSP enrichment, TOON output, telemetry. All optional: it works out of the box."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # Configuration

--- a/docs/daemon-memory.md
+++ b/docs/daemon-memory.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Daemon memory: what it costs and what caps it"
 description: Measured resident-set attribution for the trace-mcp daemon — what each region holds and which config knob bounds it.
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # Daemon memory: what it costs and what caps it

--- a/docs/decision-memory.md
+++ b/docs/decision-memory.md
@@ -1,7 +1,7 @@
 ---
 title: "Decision Memory — a persistent knowledge graph for architectural decisions"
 description: "trace-mcp's decision graph captures architectural decisions, tech choices, bug root causes and conventions — each linked to the code it is about."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # Decision memory

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,7 +1,7 @@
 ---
 title: "Contributing to trace-mcp — local setup, build, and test"
 description: "How to set up trace-mcp for local development: install, build, run the test suite, and the conventions to follow before opening a PR."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # Development

--- a/docs/pr-context-benchmark.md
+++ b/docs/pr-context-benchmark.md
@@ -1,7 +1,7 @@
 ---
 title: "PR Review Context Benchmark — Measured Input-Token Cost on Real Pull Requests"
 description: "Reproducible measurement of the input tokens trace-mcp context saves over naive file loading when reviewing real merged pull requests in open-source repos."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # PR Review Context Benchmark

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,7 +1,7 @@
 ---
 title: "Quality Gates — configure trace-mcp's thresholds"
 description: "The eight quality_gates.rules keys trace-mcp checks, which three run by default, and how this project calibrated its own thresholds as a worked example."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # Quality gates — configuring thresholds

--- a/docs/reduce-claude-code-token-usage.md
+++ b/docs/reduce-claude-code-token-usage.md
@@ -1,7 +1,7 @@
 ---
 title: "How to Reduce Claude Code Token Usage — 7 measured tactics"
 description: "Seven ways to cut token usage in Claude Code, ordered by measured impact: stop full-file reads, trim your MCP tool surface, pick the output format."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # How to reduce Claude Code token usage

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://trace-mcp.com/</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -26,61 +26,61 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/repomix.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/serena.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/codebase-memory-mcp.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/codegraph.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/context-mode.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/repomix-vs-codegraph.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/reduce-claude-code-token-usage.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/configuration.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/architecture.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/supported-frameworks.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -92,19 +92,19 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/pr-context-benchmark.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/toon-savings.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/decision-memory.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -116,31 +116,31 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/daemon-memory.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/telemetry.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/quality-gates.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/tweakcc.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/development.html</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/docs/supported-frameworks.md
+++ b/docs/supported-frameworks.md
@@ -1,7 +1,7 @@
 ---
 title: "Supported Languages & Frameworks — 81 languages, 87 framework integrations"
 description: "Full list of languages and frameworks trace-mcp understands out of the box — web frameworks, ORMs, UI libraries, and tooling, across 81 languages."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # Supported frameworks & languages

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,7 +1,7 @@
 ---
 title: "Telemetry & Observability — OpenTelemetry spans for every MCP tool call"
 description: "trace-mcp's pluggable observability bridge emits OpenTelemetry-compatible spans for every AI provider call and every MCP tool call."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # Telemetry & Observability

--- a/docs/toon-savings.md
+++ b/docs/toon-savings.md
@@ -1,7 +1,7 @@
 ---
 title: "TOON Output Format — Measured Token Savings on Real Tool Calls"
 description: "Real-world token measurements for trace-mcp's TOON (Token-Oriented Object Notation) output format across tabular MCP tool responses."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # TOON Token Savings — Measured

--- a/docs/tweakcc.md
+++ b/docs/tweakcc.md
@@ -1,7 +1,7 @@
 ---
 title: "System Prompt Routing via tweakcc — pairing trace-mcp with Claude Code"
 description: "How to pair trace-mcp with tweakcc to patch Claude Code's system prompts and route tool selection toward trace-mcp instead of native file reads."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # System Prompt Routing via tweakcc

--- a/docs/vs/codebase-memory-mcp.md
+++ b/docs/vs/codebase-memory-mcp.md
@@ -1,7 +1,7 @@
 ---
 title: "codebase-memory-mcp Alternative: trace-mcp vs codebase-memory-mcp"
 description: "Both build a persistent code knowledge graph for AI agents. Head-to-head on language coverage, tool cost, framework awareness, refactoring and security."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # codebase-memory-mcp alternative: trace-mcp vs codebase-memory-mcp

--- a/docs/vs/codegraph.md
+++ b/docs/vs/codegraph.md
@@ -1,7 +1,7 @@
 ---
 title: "CodeGraph MCP Alternative: trace-mcp vs codegraph for AI coding agents"
 description: "codegraph ships one orientation tool; trace-mcp ships a broad graph with refactoring, security and memory. Head-to-head on tools, coverage, benchmarks."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # CodeGraph MCP alternative: trace-mcp vs codegraph

--- a/docs/vs/context-mode.md
+++ b/docs/vs/context-mode.md
@@ -1,7 +1,7 @@
 ---
 title: "Context Mode alternative? trace-mcp vs Context Mode for AI coding agents"
 description: "Context Mode keeps raw tool output out of the context window; trace-mcp makes questions about your code cheap to ask. Head-to-head — and why run both."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # trace-mcp vs Context Mode

--- a/docs/vs/repomix-vs-codegraph.md
+++ b/docs/vs/repomix-vs-codegraph.md
@@ -1,7 +1,7 @@
 ---
 title: "Repomix vs codegraph: packing a repo vs indexing it for AI agents"
 description: "Repomix packs a repo into one file an agent reads; codegraph indexes it into a graph an agent queries. Head-to-head on cost, freshness and benchmarks."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # Repomix vs codegraph

--- a/docs/vs/repomix.md
+++ b/docs/vs/repomix.md
@@ -1,7 +1,7 @@
 ---
 title: "Repomix Alternative: trace-mcp vs Repomix for AI code context"
 description: "Repomix packs your repository into one prompt; trace-mcp indexes it into a queryable graph. Head-to-head on token cost, freshness, search, refactoring."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # Repomix alternative: trace-mcp vs Repomix

--- a/docs/vs/serena.md
+++ b/docs/vs/serena.md
@@ -1,7 +1,7 @@
 ---
 title: "Serena MCP Alternative: trace-mcp vs Serena for agent code navigation"
 description: "Serena drives a live language server; trace-mcp precomputes a framework-aware code graph. Head-to-head on precision, startup cost, refactoring, memory."
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # Serena MCP alternative: trace-mcp vs Serena


### PR DESCRIPTION
## Summary
- Measured master's CI health: 7 failures / 100 recent `ci.yml` runs (20 more were pre-emption cancels, not failures). All 7 trace back to two causes:
  1. `tests/docs/internal-links.test.ts` — `docs/sitemap.xml` drifted out of sync with edited docs pages (5-6 of the 7). Reproduced locally on master: `pnpm docs:sitemap` still finds 19 stale `<lastmod>` entries, less than a day after the last manual fix (#850).
  2. `tests/hooks/mirror.test.ts` Windows CRLF assertion (1 of the 7) — already fixed by `TRA-743` / #822 before this PR started; the failing sample just predates that merge. No action needed here.
- Regenerates `docs/sitemap.xml` / doc `updated:` front matter now to unblock the board.

## Scope note
An earlier revision of this PR also wired `pnpm run docs:sitemap` into `lint-staged` as a pre-commit auto-fix, to stop this from recurring. Dropped after two rounds of review (thank you @Code Reviewer) surfaced real correctness bugs in that mechanism: (1) `gitDate()` read `git log -1`, which at pre-commit time still points at the *previous* commit, so the hook stamped a stale date for the very edit it was dating; (2) even after fixing that, the hook's generators scan the whole working tree, so an unrelated *unstaged* docs edit could leak into the staged `llms-full.txt`, producing a commit whose generated artifact doesn't match a clean checkout. Both are real, reproducible bugs in a "prevent recurrence" convenience layer for a mechanism that (separately) doesn't even run in Multica's own agent checkouts, since `simple-git-hooks` fails to install hooks when `.git` is a worktree pointer file (`ENOTDIR`). Filing the "how do we actually prevent recurrence" question as its own issue rather than keep patching a client-side hook two rounds deep — the reviewer's own recommendation was that CI should stay the authoritative backstop regardless.

## Test plan
- [x] `pnpm run docs:sitemap` then `pnpm vitest run tests/docs/` — 15 files / 211 tests pass (was previously red on `internal-links.test.ts`)
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `pnpm run biome:ci`
- [x] `pnpm test` — full suite, 895 files / 9920 tests pass