### PR TITLE
fix(server): the client-profile notice was an instruction, not a note (TRA-796)

### DIFF
--- a/src/daemon/router/__tests__/list-changed-debt.test.ts
+++ b/src/daemon/router/__tests__/list-changed-debt.test.ts
@@ -1,0 +1,59 @@
+/**
+ * One `tools/list_changed` per profile reinstatement, never two (TRA-796).
+ *
+ * A profile-suppressed tool is registered on the server and hidden only on the
+ * wire, so `load_tools` answers `already_loaded` and notifies nothing — the
+ * session has to. But the same call can also load a preset-deferred tool, and
+ * that path notifies on its own. Two notifications means a compliant host
+ * re-reads the whole advertised surface twice, which is the cost this layer
+ * exists to avoid.
+ *
+ * The three cases below are the shapes actually seen in the field: the
+ * `search_text` escalation the suppression notice provokes, a suppressed tool
+ * that is also outside the preset (`discover_hermes_sessions`), and a blanket
+ * `preset: "full"`.
+ */
+import { describe, expect, it } from 'vitest';
+import { ListChangedDebt } from '../session.js';
+
+const LIST_CHANGED = 'notifications/tools/list_changed';
+
+/** Frames the session sends back for one request, in order. */
+function emissions(owedId: string | number | undefined, outbound: object[]): number {
+  const debt = new ListChangedDebt();
+  debt.owe(owedId);
+  return outbound.filter((f) => debt.settle(f)).length;
+}
+
+describe('ListChangedDebt', () => {
+  it('pays for a reinstatement the backend did not notify about', () => {
+    // `search_text` is inside every role preset, so load_tools has nothing to
+    // load and sends only its result.
+    expect(emissions(7, [{ id: 7, result: { content: [] } }])).toBe(1);
+  });
+
+  it('does not pay when the backend already notified', () => {
+    // `discover_hermes_sessions` is suppressed *and* outside the preset, so
+    // load_tools loads it and fires its own notification before answering.
+    expect(emissions(7, [{ method: LIST_CHANGED }, { id: 7, result: { content: [] } }])).toBe(0);
+  });
+
+  it('does not pay for preset: "full", which always loads something', () => {
+    expect(emissions(9, [{ method: LIST_CHANGED }, { id: 9, result: { content: [] } }])).toBe(0);
+  });
+
+  it('pays once, for the request that owed it', () => {
+    const debt = new ListChangedDebt();
+    debt.owe(1);
+    expect(debt.settle({ id: 2 })).toBe(false);
+    expect(debt.settle({ id: 1 })).toBe(true);
+    expect(debt.settle({ id: 1 })).toBe(false);
+  });
+
+  it('owes nothing until a reinstatement happens', () => {
+    const debt = new ListChangedDebt();
+    expect(debt.settle({ id: 1 })).toBe(false);
+    debt.owe(undefined);
+    expect(debt.settle({ id: 1 })).toBe(false);
+  });
+});

--- a/src/daemon/router/session.ts
+++ b/src/daemon/router/session.ts
@@ -31,6 +31,40 @@ const PKG_VERSION =
  */
 const PROXY_INITIALIZE_TIMEOUT_MS = 1_000;
 
+const LIST_CHANGED = 'notifications/tools/list_changed';
+
+/**
+ * Owes the client exactly one `tools/list_changed` per `load_tools` call that
+ * un-hid a profile-suppressed tool (TRA-796).
+ *
+ * The suppression lives on the wire, so nothing below the session knows the
+ * surface changed and `load_tools` answers `already_loaded` without notifying.
+ * But the same call can *also* load a preset-deferred tool, and that path does
+ * notify — one request, two notifications, and a compliant host re-reads the
+ * whole surface twice. So the backend's notification cancels the debt, and only
+ * a call that produced none pays it, after its response.
+ */
+export class ListChangedDebt {
+  private owedFor: string | number | null = null;
+
+  /** Record that this request changed the advertised surface. */
+  owe(id: string | number | undefined): void {
+    if (id !== undefined) this.owedFor = id;
+  }
+
+  /** For each outbound frame: true when our own notification must follow it. */
+  settle(frame: { id?: string | number; method?: string }): boolean {
+    if (this.owedFor === null) return false;
+    if (frame.method === LIST_CHANGED) {
+      this.owedFor = null;
+      return false;
+    }
+    if (frame.id !== this.owedFor) return false;
+    this.owedFor = null;
+    return true;
+  }
+}
+
 function isInitializeRequest(msg: JSONRPCMessage): boolean {
   const m = msg as Record<string, unknown>;
   return m.method === 'initialize' && m.id !== undefined && m.id !== null;
@@ -102,6 +136,8 @@ export class StdioSession {
    * sees the handshake and every frame going back to the client.
    */
   private readonly clientProfile: ClientProfileGate;
+  /** One `tools/list_changed` per profile reinstatement, never two (TRA-796). */
+  private readonly listChanged = new ListChangedDebt();
   /** Id of the in-flight `initialize` request the watchdog below is timing. */
   private initializeId: string | number | null = null;
   private initializeTimer: ReturnType<typeof setTimeout> | null = null;
@@ -130,7 +166,7 @@ export class StdioSession {
             return;
           }
         }
-        return this.stdio.send(this.clientProfile.applyToClient(msg) as JSONRPCMessage);
+        return this.sendAndSettleListChanged(msg);
       },
       drainTimeoutMs: opts.drainTimeoutMs ?? 5_000,
     });
@@ -157,12 +193,10 @@ export class StdioSession {
       if (isInitializeRequest(msg as JSONRPCMessage)) this.cachedInitialize = msg as JSONRPCMessage;
       // Reinstating a profile-suppressed tool changes what tools/list would
       // answer, and nothing below this layer knows that — the tool was never
-      // deregistered, only hidden here. Tell the client to re-read (TRA-796).
+      // deregistered, only hidden here. Owe the client one re-read, and settle
+      // the debt when the call answers (TRA-796).
       if (this.clientProfile.observeFromClient(msg)) {
-        void this.stdio.send({
-          jsonrpc: '2.0',
-          method: 'notifications/tools/list_changed',
-        } as JSONRPCMessage);
+        this.listChanged.owe((msg as unknown as { id?: string | number }).id);
       }
       if (isInitializeRequest(msg as JSONRPCMessage)) {
         logger.info({ profile: this.clientProfile.name }, 'StdioSession: resolved client profile');
@@ -327,6 +361,13 @@ export class StdioSession {
   }
 
   // ── Internals ───────────────────────────────────────────────────────
+
+  /** Send one frame, then any `tools/list_changed` it left owed (TRA-796). */
+  private async sendAndSettleListChanged(msg: unknown): Promise<void> {
+    const owed = this.listChanged.settle(msg as { id?: string | number; method?: string });
+    await this.stdio.send(this.clientProfile.applyToClient(msg) as JSONRPCMessage);
+    if (owed) await this.stdio.send({ jsonrpc: '2.0', method: LIST_CHANGED } as JSONRPCMessage);
+  }
 
   /**
    * A reachable /health is not proof that the daemon's MCP handler can answer.

--- a/src/daemon/router/session.ts
+++ b/src/daemon/router/session.ts
@@ -155,7 +155,15 @@ export class StdioSession {
       // Cache the handshake so a later swapped-in proxy backend can re-establish
       // the daemon session (the client only sends `initialize` once).
       if (isInitializeRequest(msg as JSONRPCMessage)) this.cachedInitialize = msg as JSONRPCMessage;
-      this.clientProfile.observeFromClient(msg);
+      // Reinstating a profile-suppressed tool changes what tools/list would
+      // answer, and nothing below this layer knows that — the tool was never
+      // deregistered, only hidden here. Tell the client to re-read (TRA-796).
+      if (this.clientProfile.observeFromClient(msg)) {
+        void this.stdio.send({
+          jsonrpc: '2.0',
+          method: 'notifications/tools/list_changed',
+        } as JSONRPCMessage);
+      }
       if (isInitializeRequest(msg as JSONRPCMessage)) {
         logger.info({ profile: this.clientProfile.name }, 'StdioSession: resolved client profile');
         this.armInitializeWatchdog((msg as unknown as { id: string | number }).id);

--- a/src/server/__tests__/client-profile.test.ts
+++ b/src/server/__tests__/client-profile.test.ts
@@ -206,6 +206,16 @@ describe('instructions retargeting', () => {
     expect(instructions).toContain('load_tools');
   });
 
+  // TRA-796: the notice used to spell the escalation call out in full, and
+  // sessions ran it on sight — 18 of 22 `load_tools` calls over 371 mined
+  // sessions asked for `search_text` back, 12 of them never using it. Naming
+  // the path is discoverability; pasting the call is an instruction.
+  it('does not hand the session a ready-to-run load_tools call', () => {
+    const { instructions } = runSession('claude-code');
+    const notice = instructions.slice(instructions.indexOf('Client profile "claude-code"'));
+    expect(notice).not.toMatch(/load_tools\s*\(/);
+  });
+
   // The retarget is a substring swap against the exact lines buildInstructions
   // emitted. If the two drift apart the swap silently no-ops, so pin it here.
   it('keeps every generic host-tool line present in the built instructions', () => {

--- a/src/server/__tests__/client-profile.test.ts
+++ b/src/server/__tests__/client-profile.test.ts
@@ -20,6 +20,7 @@ import {
   getClientProfile,
   resolveClientProfile,
   retargetInstructions,
+  suppressionNotice,
 } from '../client-profile.js';
 import { HOST_TOOLS_GENERIC, buildInstructions, hostToolLines } from '../instructions.js';
 import { UNGATED_META_TOOLS } from '../tool-filter.js';
@@ -136,6 +137,28 @@ describe('resolved tool surface, per profile', () => {
     expect(list.result.tools.map((t) => t.name)).toContain('search_text');
   });
 
+  // TRA-796: reachable is not the same as re-advertised. The tool was never
+  // deregistered, so `load_tools` answers `already_loaded` and fires nothing —
+  // the notification a host needs to re-read `tools/list` can only come from
+  // this gate, and only when the escalation actually un-hid something.
+  it('reports that a reinstatement needs a tools/list_changed, once', () => {
+    process.env.TRACE_MCP_CLIENT_PROFILE = 'claude-code';
+    const gate = new ClientProfileGate(cfg());
+    const load = {
+      method: 'tools/call',
+      params: { name: 'load_tools', arguments: { tools: ['search_text'] } },
+    };
+    expect(gate.observeFromClient({ method: 'initialize', params: {} })).toBe(false);
+    expect(gate.observeFromClient(load)).toBe(true);
+    expect(gate.observeFromClient(load)).toBe(false);
+    expect(
+      gate.observeFromClient({
+        method: 'tools/call',
+        params: { name: 'search', arguments: {} },
+      }),
+    ).toBe(false);
+  });
+
   it('composes after the preset rather than replacing it', () => {
     process.env.TRACE_MCP_CLIENT_PROFILE = 'claude-code';
     // A surface the preset already narrowed to two tools stays narrowed; the
@@ -211,8 +234,9 @@ describe('instructions retargeting', () => {
   // sessions asked for `search_text` back, 12 of them never using it. Naming
   // the path is discoverability; pasting the call is an instruction.
   it('does not hand the session a ready-to-run load_tools call', () => {
-    const { instructions } = runSession('claude-code');
-    const notice = instructions.slice(instructions.indexOf('Client profile "claude-code"'));
+    const notice = suppressionNotice(getClientProfile('claude-code'), ['search_text']);
+    expect(notice).toContain('search_text');
+    expect(notice).toContain('load_tools');
     expect(notice).not.toMatch(/load_tools\s*\(/);
   });
 

--- a/src/server/client-profile.ts
+++ b/src/server/client-profile.ts
@@ -176,18 +176,27 @@ export function retargetInstructions(instructions: string, profile: ClientProfil
 }
 
 /**
- * One line telling the session what the profile took away and how to get it
- * back. Without it a suppressed tool is invisible: `load_tools` with no
- * arguments lists what the *preset* deferred, and a profile-suppressed tool is
- * inside the preset, so it shows up in neither list.
+ * One line telling the session what the profile took away. Without it a
+ * suppressed tool is invisible: `load_tools` with no arguments lists what the
+ * *preset* deferred, and a profile-suppressed tool is inside the preset, so it
+ * shows up in neither list.
+ *
+ * It states the names and stops there, deliberately (TRA-796). The first
+ * version spelled out `load_tools({ tools: ["search_text"] })`, and sessions
+ * ran that call on sight: over 2026-08-31..09-04, 18 of 22 `load_tools` calls
+ * across 371 mined sessions asked for exactly `search_text`, and 12 of those 18
+ * never called it afterwards. Each one fires `tools/list_changed`, so a
+ * compliant host re-reads the whole surface — thousands of tokens to reinstate
+ * a 442-token tool the host already covers. Naming the escalation path without
+ * pasting the call keeps it discoverable to a session that actually needs it.
  */
 export function suppressionNotice(profile: ClientProfile, hidden: readonly string[]): string {
   if (hidden.length === 0) return '';
   return (
     `Client profile "${profile.name}": ${hidden.length} tool(s) your host already covers ` +
-    `are hidden from tools/list — ${hidden.join(', ')}. ` +
-    `Call load_tools({ tools: ["${hidden[0]}"] }) to advertise them anyway, or set ` +
-    'tools.client_profile to "off" to disable this layer.'
+    `are hidden from tools/list — ${hidden.join(', ')}. Use your host's equivalent. ` +
+    'They remain reachable through load_tools, which re-sends the entire tool list, so ' +
+    'escalate only if the host tool is genuinely unavailable.'
   );
 }
 

--- a/src/server/client-profile.ts
+++ b/src/server/client-profile.ts
@@ -185,10 +185,9 @@ export function retargetInstructions(instructions: string, profile: ClientProfil
  * version spelled out `load_tools({ tools: ["search_text"] })`, and sessions
  * ran that call on sight: over 2026-08-31..09-04, 18 of 22 `load_tools` calls
  * across 371 mined sessions asked for exactly `search_text`, and 12 of those 18
- * never called it afterwards. Each one fires `tools/list_changed`, so a
- * compliant host re-reads the whole surface — thousands of tokens to reinstate
- * a 442-token tool the host already covers. Naming the escalation path without
- * pasting the call keeps it discoverable to a session that actually needs it.
+ * never called it afterwards. Naming the escalation path without pasting the
+ * call keeps it discoverable to a session that actually needs it, and stops the
+ * ones that do not from spending a round trip plus a surface refresh on it.
  */
 export function suppressionNotice(profile: ClientProfile, hidden: readonly string[]): string {
   if (hidden.length === 0) return '';
@@ -236,24 +235,35 @@ export class ClientProfileGate {
     return this.lastHidden;
   }
 
-  /** Inbound: learn who the client is, and honour explicit escalation. */
-  observeFromClient(msg: unknown): void {
+  /**
+   * Inbound: learn who the client is, and honour explicit escalation.
+   *
+   * Returns true when this frame un-hid a tool that was still being suppressed,
+   * which the caller owes the client one `notifications/tools/list_changed`
+   * for. A profile-suppressed tool is registered on the server — the gate only
+   * hides it on the wire — so `load_tools` answers `already_loaded` and fires
+   * nothing itself. Without a notification from here a compliant host never
+   * re-reads `tools/list`, and the tool the session just asked for by name
+   * stays invisible to it (TRA-796).
+   */
+  observeFromClient(msg: unknown): boolean {
     const m = msg as Frame;
     if (m.method === 'initialize') {
       const info = (m.params as Frame | undefined)?.clientInfo as Frame | undefined;
       const clientName = typeof info?.name === 'string' ? info.name : undefined;
       this.profile = resolveClientProfile(clientName, this.config);
-      return;
+      return false;
     }
-    if (m.method !== 'tools/call') return;
+    if (m.method !== 'tools/call') return false;
     const params = m.params as Frame | undefined;
-    if (params?.name !== 'load_tools') return;
+    if (params?.name !== 'load_tools') return false;
+    const before = this.suppressed().length;
     const args = params.arguments as { preset?: string; tools?: string[] } | undefined;
     for (const t of args?.tools ?? []) this.reinstated.add(t);
-    if (!args?.preset) return;
-    const resolved = resolvePreset(args.preset);
+    const resolved = args?.preset ? resolvePreset(args.preset) : null;
     if (resolved === 'all') for (const t of this.profile?.suppress ?? []) this.reinstated.add(t);
     else if (resolved) for (const t of resolved) this.reinstated.add(t);
+    return this.suppressed().length < before;
   }
 
   /** Outbound: retarget the instructions and thin the advertised surface. */


### PR DESCRIPTION
## What

Two things, found in that order.

**1. The client-profile suppression notice was an instruction.** It ends the
`initialize` instructions on every claude-code/codex/cursor/vscode session, and
it used to read:

> Call `load_tools({ tools: ["search_text"] })` to advertise them anyway…

Sessions ran that call on sight. The notice stays — a suppressed tool sits
inside the preset, so `load_tools` with no arguments does not list it and
without the notice it is invisible — but the paste-ready call is gone.

**2. Reviewing (1) turned up that the escalation path did not work.** A
profile-suppressed tool is registered on the server and only hidden on the
wire, so `load_tools({ tools: ["search_text"] })` answers `already_loaded` and
fires no `tools/list_changed`. A compliant host therefore never re-reads
`tools/list`, and the tool the session just asked for by name stays invisible
to it. The gate is the only layer that knows the suppression exists, so it now
reports when an escalation un-hid something and the stdio session emits one
`notifications/tools/list_changed` for it. It sits at the session boundary, so
this covers both the local and the proxy backend.

## Measured

Mined session analytics on the owner's machine (`~/.trace/analytics.db`,
`trace analytics sync`, 2026-09-04), window 2026-08-31 → 2026-09-04,
371 sessions with tool calls:

| | |
|---|---:|
| `load_tools` calls in window | 22 |
| …asking for `search_text` | **18 (82%)** |
| …of those, never calling `search_text` afterwards | **12** |
| `search_text` calls actually made | 6 |

Each of those 18 cost a round trip and an empty `already_loaded` response —
and, per (2), delivered nothing. `search_text`'s own schema is 442 tokens
against 7,857 for the whole `minimal` surface (gpt-tokenizer/o200k over the
reconstructed `tools/list`).

Sanity check on the suppression itself (same DB, 2026-08-20 → 08-30 vs
08-31 → 09-04, i.e. before/after TRA-513 shipped): `search_text` went 1,028 →
22 calls while `search` went 214 → 684 and `batch` 82 → 229. Text search per
session (`search_text` + `Grep` + Bash grep/rg over source paths) fell 6.05 →
1.97. Demand moved to symbol search rather than to shell greps, so TRA-513's
suppression stays — only its notice and its escalation path change here.

## Guards

- The notice carries no callable `load_tools(` form — asserted against
  `suppressionNotice()` directly, so a renamed prefix cannot make it vacuous.
- A first escalation reports that it needs a `tools/list_changed`; a repeat and
  an ordinary `tools/call` do not.
