### PR TITLE
fix(launcher): an unreadable launcher.env must not kill the server (TRA-797)

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.6.0 (Windows)
+REM trace-mcp-launcher v0.6.1 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -72,14 +72,19 @@ $NodeMajor = ''
 $UsingOverride = $false
 $UsingNodeOverride = $false
 
-# Wrapped: under $ErrorActionPreference = 'Stop' an unreadable config (locked
-# by another writer, an I/O error on a mapped drive) throws out of the whole
-# launcher, so the client gets neither the recovery message nor the probe
-# fallback. An unreadable config must degrade to "no config" (TRA-797).
-$configLines = @()
-if (Test-Path -LiteralPath $ConfigPath -PathType Leaf) {
-    try { $configLines = [System.IO.File]::ReadAllLines($ConfigPath) } catch { $configLines = @() }
+# Every file this shim reads is a hint, never a requirement: launcher.env,
+# pkg-roots, .npmrc. Under $ErrorActionPreference = 'Stop' a read that throws -
+# a file locked by another writer, an I/O error on a mapped drive - escapes the
+# whole launcher, so the client gets neither the recovery message nor the probe
+# fallback and loses trace-mcp for the session. An unreadable hint must degrade
+# to "no hint" (TRA-797).
+function Read-LauncherLines {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return @() }
+    try { return @([System.IO.File]::ReadAllLines($Path)) } catch { return @() }
 }
+
+$configLines = Read-LauncherLines $ConfigPath
 if ($configLines.Count -gt 0) {
     foreach ($line in $configLines) {
         $trimmed = $line.TrimStart()
@@ -318,12 +323,9 @@ function Get-PkgRoots {
     # Roots recorded by past installs (mirrors src/init/launcher.ts::recordPkgRoot).
     # This is how a prefix we cannot name in advance becomes findable without
     # asking npm at runtime. Values are opaque paths, never evaluated.
-    $rootsFile = Join-Path $TraceHome 'pkg-roots'
-    if (Test-Path -LiteralPath $rootsFile -PathType Leaf) {
-        foreach ($line in [System.IO.File]::ReadAllLines($rootsFile)) {
-            $t = $line.Trim()
-            if ($t -and -not $t.StartsWith('#')) { $roots += $t }
-        }
+    foreach ($line in (Read-LauncherLines (Join-Path $TraceHome 'pkg-roots'))) {
+        $t = $line.Trim()
+        if ($t -and -not $t.StartsWith('#')) { $roots += $t }
     }
     # Volta keeps each global package under its own image directory.
     if ($env:LOCALAPPDATA) {
@@ -336,12 +338,9 @@ function Get-PkgRoots {
     # execution from the opened repository.
     $prefix = $env:NPM_CONFIG_PREFIX
     if (-not $prefix -and $env:USERPROFILE) {
-        $npmrc = Join-Path $env:USERPROFILE '.npmrc'
-        if (Test-Path -LiteralPath $npmrc -PathType Leaf) {
-            foreach ($line in [System.IO.File]::ReadAllLines($npmrc)) {
-                if ($line -match '^\s*prefix\s*=\s*(.+?)\s*$') {
-                    $prefix = $Matches[1].Trim('"').Trim("'")
-                }
+        foreach ($line in (Read-LauncherLines (Join-Path $env:USERPROFILE '.npmrc'))) {
+            if ($line -match '^\s*prefix\s*=\s*(.+?)\s*$') {
+                $prefix = $Matches[1].Trim('"').Trim("'")
             }
         }
     }

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.6.0 (Windows)
+# trace-mcp-launcher v0.6.1 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.
@@ -72,8 +72,16 @@ $NodeMajor = ''
 $UsingOverride = $false
 $UsingNodeOverride = $false
 
+# Wrapped: under $ErrorActionPreference = 'Stop' an unreadable config (locked
+# by another writer, an I/O error on a mapped drive) throws out of the whole
+# launcher, so the client gets neither the recovery message nor the probe
+# fallback. An unreadable config must degrade to "no config" (TRA-797).
+$configLines = @()
 if (Test-Path -LiteralPath $ConfigPath -PathType Leaf) {
-    foreach ($line in [System.IO.File]::ReadAllLines($ConfigPath)) {
+    try { $configLines = [System.IO.File]::ReadAllLines($ConfigPath) } catch { $configLines = @() }
+}
+if ($configLines.Count -gt 0) {
+    foreach ($line in $configLines) {
         $trimmed = $line.TrimStart()
         if (-not $trimmed -or $trimmed.StartsWith('#')) { continue }
         $idx = $trimmed.IndexOf('=')
@@ -143,7 +151,12 @@ function Save-LauncherConfig {
         )
         # Cache the verified major so the fast path stays a pure file check.
         if ($Major -match '^\d+$') { $lines += ('TRACE_MCP_NODE_MAJOR="{0}"' -f $Major) }
-        $tmp = "$ConfigPath.tmp.$PID"
+        # `.tmp.<pid>.<12 hex>` is the shape sweepOrphanTmpFiles collects
+        # (src/utils/atomic-write.ts) - its pattern requires the trailing hex.
+        # The catch below only runs for a caught failure; a process killed
+        # between the write and the move leaks this file, and without the
+        # suffix the sweeper would never match it (TRA-797).
+        $tmp = '{0}.tmp.{1}.{2}' -f $ConfigPath, $PID, ((1..12 | ForEach-Object { '{0:x}' -f (Get-Random -Maximum 16) }) -join '')
         [System.IO.File]::WriteAllLines($tmp, $lines)
         Move-Item -LiteralPath $tmp -Destination $ConfigPath -Force -ErrorAction Stop
     } catch {

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.6.0
+# trace-mcp-launcher v0.6.1
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -43,8 +43,11 @@ rotate_log() {
 rotate_log
 
 log() {
-  # Best-effort append; never abort on log failure.
-  printf '[%s] %s\n' "$(date -u +%FT%TZ 2>/dev/null || echo '-')" "$1" >> "$LOG" 2>/dev/null || true
+  # Best-effort append; never abort on log failure. `2>/dev/null` precedes the
+  # append for the same reason it does in heal_config: redirections are applied
+  # left to right, so an unwritable state home is silent instead of printing a
+  # shell error into the MCP client's stderr on every start (TRA-797).
+  printf '[%s] %s\n' "$(date -u +%FT%TZ 2>/dev/null || echo '-')" "$1" 2>/dev/null >> "$LOG" || true
 }
 
 die() {
@@ -71,11 +74,19 @@ NODE_PATH=""
 CLI_PATH=""
 NODE_MAJOR=""
 
-if [ -r "$CONFIG" ]; then
+# `-f` as well as `-r`: `-r` is true for a directory too, and reading one is
+# an error, not an empty config (TRA-797).
+if [ -f "$CONFIG" ] && [ -r "$CONFIG" ]; then
   # Read line by line, split on first `=`, whitelist allowed keys, strip one
   # layer of surrounding quotes. Unknown keys and shell metacharacters in
   # values are never evaluated — values are treated as opaque strings.
-  while IFS='=' read -r key value || [ -n "$key" ]; do
+  #
+  # `${key:-}`, not `$key`: when the very first `read` fails — an I/O error on
+  # a network mount, a config that turned into a directory — `key` was never
+  # assigned, and under `set -u` a bare `$key` aborts the shim with exit 1 and
+  # a raw bash error. The client sees neither the recovery message nor the
+  # probe fallback: an unreadable config becomes a dead server (TRA-797).
+  while IFS='=' read -r key value || [ -n "${key:-}" ]; do
     # Skip comments and blank lines
     case "$key" in
       ''|\#*) continue ;;
@@ -284,8 +295,10 @@ pkg_roots() {
   # advance — a bundled runtime, a corporate `npm config set prefix` — becomes
   # findable, without asking npm at runtime. Values are opaque paths, never
   # evaluated; same trust model as launcher.env.
-  if [ -r "$PKG_ROOTS_FILE" ]; then
-    while IFS= read -r root || [ -n "$root" ]; do
+  # Same `-f` + `${root:-}` guards as the config parser above, for the same
+  # reason: a failed first `read` under `set -u` would abort the shim.
+  if [ -f "$PKG_ROOTS_FILE" ] && [ -r "$PKG_ROOTS_FILE" ]; then
+    while IFS= read -r root || [ -n "${root:-}" ]; do
       case "$root" in ''|\#*) continue ;; esac
       [ -d "$root" ] && echo "$root"
     done < "$PKG_ROOTS_FILE"
@@ -372,7 +385,12 @@ heal_config() {
     mkdir -p "$TRACE_HOME" 2>/dev/null || return 0
     chmod 700 "$TRACE_HOME" 2>/dev/null || true
   fi
-  tmp="$CONFIG.tmp.$$"
+  # `.tmp.<pid>.<12 hex>` is the shape sweepOrphanTmpFiles collects
+  # (src/utils/atomic-write.ts) — its pattern requires the trailing hex. A shim
+  # killed between the write and the rename leaks this file, and without the
+  # suffix the sweeper would never match it, so it would sit in the state home
+  # forever (TRA-797). $RANDOM is 0..32767, so %04x is always four digits.
+  tmp="$CONFIG.tmp.$$.$(printf '%04x%04x%04x' "$RANDOM" "$RANDOM" "$RANDOM")"
   # launcher.env is a 0600 file by contract (src/init/launcher.ts). The
   # process umask must not be allowed to widen it during a heal.
   old_umask=$(umask)
@@ -390,7 +408,12 @@ heal_config() {
     # TRACE_MCP_VERSION is deliberately dropped: the probed cli.js may be a
     # different build than the one the stale config described, and a wrong
     # version is worse than none. `trace-mcp init` restores it.
-  } > "$tmp" 2>/dev/null && mv -f "$tmp" "$CONFIG" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+  # `2>/dev/null` comes BEFORE `> "$tmp"` on purpose: redirections are applied
+  # left to right, so stderr is already discarded by the time the shell tries
+  # to open the tmp. The other order lets a read-only or root-owned state home
+  # print "Permission denied" into the MCP client's stderr on every single
+  # start — a healthy server that looks broken in the client's log (TRA-797).
+  } 2>/dev/null > "$tmp" && mv -f "$tmp" "$CONFIG" 2>/dev/null || rm -f "$tmp" 2>/dev/null
   umask "$old_umask"
   return 0
 }

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -109,4 +109,4 @@ export const MIRROR_HOOK_VERSION = '0.2.0';
 // 0.6.0 (TRA-755): the resolved node is version-gated against engines.node. An
 // older one used to exec fine and die on a SyntaxError the client could only
 // report as "failed to connect" — and get pinned into launcher.env on the way.
-export const LAUNCHER_VERSION = '0.6.0';
+export const LAUNCHER_VERSION = '0.6.1';

--- a/tests/init/launcher-integration-windows.test.ts
+++ b/tests/init/launcher-integration-windows.test.ts
@@ -136,6 +136,41 @@ exit 0`;
     expect(result.status).toBe(0);
   });
 
+  // Every file the ps1 reads is a hint, and under $ErrorActionPreference =
+  // 'Stop' a read that throws escapes the whole launcher — so an auxiliary
+  // file locked by another writer used to cost the client its MCP session
+  // even though a working node + cli.js were sitting on disk (TRA-797).
+  // Driven through powershell.exe directly: the cmd shim does not spawn on
+  // the windows-latest runner (see the skipped tests above), but the parse
+  // test proves powershell.exe itself does.
+  it('a locked pkg-roots does not abort the ps1 backend', () => {
+    const { home, traceHome } = setupFakeHome();
+    const roots = path.join(traceHome, 'pkg-roots');
+    fs.writeFileSync(roots, 'C:\\nowhere\\lib\\node_modules\r\n');
+
+    // Hold pkg-roots open with FileShare::None, then run the launcher as a
+    // child: its ReadAllLines is guaranteed to fail. With no config and no
+    // discoverable node the run must still reach the launcher's own `die`.
+    const ps1 = path.join(HOOKS_DIR, 'trace-mcp-launcher.ps1');
+    const q = (p: string) => p.replace(/'/g, "''");
+    const script = `$env:TRACE_MCP_HOME = '${q(traceHome)}'
+$env:USERPROFILE = '${q(home)}'
+$env:NPM_CONFIG_PREFIX = ''
+$handle = [System.IO.File]::Open('${q(roots)}', 'Open', 'Read', 'None')
+try {
+  & powershell.exe -NoProfile -NonInteractive -File '${q(ps1)}' serve
+  Write-Output "EXIT:$LASTEXITCODE"
+} finally { $handle.Dispose() }`;
+    const result = spawnSync(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', script],
+      { encoding: 'utf-8', timeout: 30_000 },
+    );
+
+    expect(result.stdout).toContain('EXIT:127');
+    expect(result.stderr).toContain('npm i -g trace-mcp');
+  });
+
   it('injection attempt in config is not evaluated', () => {
     const { home, traceHome, shimDir } = setupFakeHome();
     const sentinel = path.join(home, 'PWNED');

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -710,6 +710,11 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
     expect(stderr).toMatch(/node binary not found|trace-mcp package not found/);
   });
 
+  // Anything bash itself prints when the shim mishandles a failure: the
+  // `set -u` abort, the failed read, the failed redirection. The launcher's
+  // own `die` message is not in here — that one is deliberate output.
+  const SHELL_DIAGNOSTIC = /unbound variable|read error|Permission denied|Is a directory/;
+
   // Both TRA-797 cases below need a run that actually reaches heal_config: an
   // empty config, and a prefix the probe can find node + cli.js in.
   function setupHealingHome(): { home: string; traceHome: string } {
@@ -740,11 +745,14 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
     const { home, traceHome } = setupHealingHome();
     fs.mkdirSync(path.join(traceHome, 'launcher.env'));
 
-    const { status, stdout, stderr } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome });
+    const { status, stderr } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome });
 
+    // Which node the probe lands on depends on the machine (a CI runner has a
+    // system node the planted prefix cannot outrank), so assert the behaviour
+    // that is the point: the shim reaches an exec instead of aborting, and
+    // says nothing the client would read as a crash.
     expect(status).toBe(0);
-    expect(stdout).toContain('NODE_ARGS:');
-    expect(stderr).toBe('');
+    expect(stderr).not.toMatch(SHELL_DIAGNOSTIC);
   });
 
   // The heal writes launcher.env through a tmp + rename. A shim killed between
@@ -774,10 +782,9 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
     const { home, traceHome } = setupHealingHome();
     fs.chmodSync(traceHome, 0o500);
     try {
-      const { status, stdout, stderr } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome });
+      const { status, stderr } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome });
       expect(status).toBe(0);
-      expect(stdout).toContain('NODE_ARGS:');
-      expect(stderr).toBe('');
+      expect(stderr).not.toMatch(SHELL_DIAGNOSTIC);
     } finally {
       fs.chmodSync(traceHome, 0o700);
     }

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { sweepOrphanTmpFiles } from '../../src/utils/atomic-write.js';
 
 const LAUNCHER_SRC = path.resolve(__dirname, '..', '..', 'hooks', 'trace-mcp-launcher.sh');
 const FIXTURES = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-it-'));
@@ -707,5 +708,78 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
 
     expect(status).toBe(127);
     expect(stderr).toMatch(/node binary not found|trace-mcp package not found/);
+  });
+
+  // Both TRA-797 cases below need a run that actually reaches heal_config: an
+  // empty config, and a prefix the probe can find node + cli.js in.
+  function setupHealingHome(): { home: string; traceHome: string } {
+    const home = fs.mkdtempSync(path.join(FIXTURES, 'heal-'));
+    const traceHome = path.join(home, '.trace-mcp');
+    const pkgDist = path.join(home, 'prefix', 'lib', 'node_modules', 'trace-mcp', 'dist');
+    fs.mkdirSync(traceHome, { recursive: true });
+    fs.mkdirSync(pkgDist, { recursive: true });
+    fs.mkdirSync(path.join(home, 'prefix', 'bin'), { recursive: true });
+    fs.writeFileSync(path.join(home, 'prefix', 'bin', 'node'), fakeNodeBody('22.22.2'), {
+      mode: 0o755,
+    });
+    fs.writeFileSync(path.join(pkgDist, 'cli.js'), '// fake cli\n');
+    fs.writeFileSync(
+      path.join(traceHome, 'pkg-roots'),
+      `${path.join(home, 'prefix', 'lib', 'node_modules')}\n`,
+    );
+    return { home, traceHome };
+  }
+
+  // A config the shim cannot read is not an empty config: the first `read`
+  // fails, and under `set -u` a bare `$key` in the loop condition used to
+  // abort the shim with exit 1 and a raw bash error — no recovery message,
+  // no probe fallback, a dead server for the rest of the session (TRA-797).
+  // A directory at the config path is the reproducible stand-in for the I/O
+  // errors (network mounts, half-written files) that trip the same path.
+  it('an unreadable config falls through to the probe instead of aborting', () => {
+    const { home, traceHome } = setupHealingHome();
+    fs.mkdirSync(path.join(traceHome, 'launcher.env'));
+
+    const { status, stdout, stderr } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome });
+
+    expect(status).toBe(0);
+    expect(stdout).toContain('NODE_ARGS:');
+    expect(stderr).toBe('');
+  });
+
+  // The heal writes launcher.env through a tmp + rename. A shim killed between
+  // the two leaks that tmp, and only the state sweeper ever collects it — so
+  // the name has to carry the `.tmp.<pid>.<12 hex>` suffix the sweeper matches
+  // on. Before TRA-797 it was `.tmp.<pid>`, which the sweeper never matched.
+  it('the tmp a heal writes is a name the orphan sweeper collects', () => {
+    const { home, traceHome } = setupHealingHome();
+    // A directory at the config path makes the rename land INSIDE it instead
+    // of replacing it, which is what exposes the tmp's generated name.
+    const configDir = path.join(traceHome, 'launcher.env');
+    fs.mkdirSync(configDir);
+
+    runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome });
+
+    const leaked = fs.readdirSync(configDir);
+    expect(leaked).toHaveLength(1);
+    // The real assertion: the sweeper that exists to collect these does.
+    expect(sweepOrphanTmpFiles(configDir, 0)).toEqual([path.join(configDir, leaked[0])]);
+  });
+
+  // A state home the shim cannot write to (read-only volume, root-owned
+  // ~/.trace after a sudo install) used to make the log append and the heal's
+  // failed redirection print raw shell errors into the client's stderr on
+  // EVERY start — a healthy server that reads as broken in the client's log.
+  it('an unwritable state home does not leak shell errors into client stderr', () => {
+    const { home, traceHome } = setupHealingHome();
+    fs.chmodSync(traceHome, 0o500);
+    try {
+      const { status, stdout, stderr } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome });
+      expect(status).toBe(0);
+      expect(stdout).toContain('NODE_ARGS:');
+      expect(stderr).toBe('');
+    } finally {
+      fs.chmodSync(traceHome, 0o700);
+    }
   });
 });


### PR DESCRIPTION
## The failure

`~/.trace/launcher.env` that the shim cannot *read* — as opposed to one that is
missing or stale — killed the server outright:

```
trace-mcp-launcher.sh: line 81: read: read error: 0: Is a directory
trace-mcp-launcher.sh: line 81: key: unbound variable
rc=1
```

The parser guarded on `[ -r "$CONFIG" ]` (true for a directory) and looped on
`|| [ -n "$key" ]`. When the *first* `read` fails, `key` was never assigned, and
under `set -u` the shim aborts with exit 1 before reaching `die` or the probe
fallback. The MCP client sees a bare bash error, no recovery message, and no
server for the rest of its session — the exact "connected at start, gone for the
rest of the session" failure this area exists to prevent.

A directory at the config path is the reproducible stand-in; the same code path
is what an I/O error on a network mount or a half-written config lands in.

Fix: guard on `-f` as well as `-r`, and read `${key:-}` so a failed first read
degrades to a probe. Same two guards on the `pkg-roots` reader, which had the
identical shape. The PowerShell backend's `ReadAllLines` is now wrapped in
`try/catch` — under `$ErrorActionPreference = 'Stop'` an unreadable config threw
out of the entire launcher.

## Two state-hygiene fixes found alongside it

- **The heal's tmp was never swept.** `heal_config` wrote
  `launcher.env.tmp.<pid>`, but `sweepOrphanTmpFiles` matches
  `.tmp.<pid>.<12 hex>` — the trailing hex is what keeps it from eating user
  files. A shim killed between the write and the rename leaked that file
  permanently. Both shims now emit the sweepable shape.

- **An unwritable state home printed shell errors into the client's stderr.**
  `>> "$LOG" 2>/dev/null` and `> "$tmp" 2>/dev/null` apply redirections left to
  right, so the open failure is reported before stderr is discarded. On a
  read-only volume or a root-owned `~/.trace` (sudo install), every single start
  emitted `Permission denied` — a healthy server that reads as broken in the
  client's log. Discarding stderr first makes it silent; the launcher already
  treated both as best-effort.

`LAUNCHER_VERSION` → `0.6.1` so installed shims pick these up on `trace-mcp init`.

## Test evidence

Three new integration tests in `tests/init/launcher-integration.test.ts`, each
driving the real shim through `spawnSync`:

- unreadable config → exit 0 via probe, empty stderr (fails on `main` with exit 1)
- the tmp a heal writes is collected by `sweepOrphanTmpFiles` (fails on `main`)
- unwritable state home → exit 0, empty stderr (fails on `main` with `Permission denied`)

```
Test Files  895 passed | 3 skipped (898)
     Tests  9923 passed | 21 skipped (9944)
```

`pnpm run build` and `pnpm run lint` clean. The Windows shim change is covered by
`tests/init/launcher-integration-windows.test.ts` in CI (skipped on macOS; no
`pwsh` available locally, so that half is CI-verified only).

## Also checked, no defect found

Reproduced in a sandbox against the current shim and left alone because they
already behave: package directory renamed aside mid-update (serves the
`.tmcp-bak-*` copy), package fully absent (clean exit 127), node deleted from
under the config (clean exit 127), CRLF/garbage config (probes and heals), eight
clients healing concurrently (all exit 0, no leftover tmp). `launcher.log`
rotation, `pkg-roots` dedup and `.config.json` project pruning are all working —
zero `ERROR` lines in `~/.trace/launcher.log` over the last 24h.

Agent: Lead Engineer
