### PR TITLE
fix(watcher): stop() must wait for a handler that already started (TRA-808)

### DIFF
--- a/src/indexer/__tests__/watcher-stop-inflight.test.ts
+++ b/src/indexer/__tests__/watcher-stop-inflight.test.ts
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * TRA-808: `stop()` used to return while a debounce callback that had already
+ * fired was still awaiting `onChanges`. ProjectManager.stopProject() calls
+ * `watcher.stop()` and then `db.close()`, so that in-flight reindex kept
+ * running against a closed SQLite handle — 206 `The database connection is not
+ * open` errors in the field daemon log, every one of them a file change that
+ * silently never landed in the index.
+ */
+
+let capturedCallback: ((err: Error | null, events: unknown[]) => void) | undefined;
+
+vi.mock('@parcel/watcher', () => ({
+  subscribe: async (_root: string, cb: (err: Error | null, events: unknown[]) => void) => {
+    capturedCallback = cb;
+    return { unsubscribe: async () => {} };
+  },
+}));
+
+const { FileWatcher } = await import('../watcher.js');
+
+describe('FileWatcher.stop() with an in-flight change handler', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'watcher-inflight-'));
+    capturedCallback = undefined;
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('waits for a handler that already started before resolving', async () => {
+    const watcher = new FileWatcher();
+    let finished = false;
+    let started = false;
+
+    await watcher.start(
+      root,
+      {} as never,
+      async () => {
+        started = true;
+        await new Promise((r) => setTimeout(r, 50));
+        finished = true;
+      },
+      1,
+    );
+
+    capturedCallback?.(null, [{ type: 'update', path: path.join(root, 'a.ts') }]);
+    // Let the 1 ms debounce fire so onChanges is genuinely mid-flight.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(started).toBe(true);
+    expect(finished).toBe(false);
+
+    await watcher.stop();
+    expect(finished).toBe(true);
+  });
+
+  it('waits for an in-flight delete handler too', async () => {
+    const watcher = new FileWatcher();
+    let finished = false;
+
+    await watcher.start(root, {} as never, async () => {}, 1, async () => {
+      await new Promise((r) => setTimeout(r, 50));
+      finished = true;
+    });
+
+    capturedCallback?.(null, [{ type: 'delete', path: path.join(root, 'a.ts') }]);
+    await new Promise((r) => setTimeout(r, 5));
+
+    await watcher.stop();
+    expect(finished).toBe(true);
+  });
+});

--- a/src/indexer/__tests__/watcher-stop-inflight.test.ts
+++ b/src/indexer/__tests__/watcher-stop-inflight.test.ts
@@ -65,10 +65,16 @@ describe('FileWatcher.stop() with an in-flight change handler', () => {
     const watcher = new FileWatcher();
     let finished = false;
 
-    await watcher.start(root, {} as never, async () => {}, 1, async () => {
-      await new Promise((r) => setTimeout(r, 50));
-      finished = true;
-    });
+    await watcher.start(
+      root,
+      {} as never,
+      async () => {},
+      1,
+      async () => {
+        await new Promise((r) => setTimeout(r, 50));
+        finished = true;
+      },
+    );
 
     capturedCallback?.(null, [{ type: 'delete', path: path.join(root, 'a.ts') }]);
     await new Promise((r) => setTimeout(r, 5));

--- a/src/indexer/watcher.ts
+++ b/src/indexer/watcher.ts
@@ -141,8 +141,8 @@ export class FileWatcher {
   /**
    * Handler runs currently executing. Unsubscribing stops future events and
    * clearing the debounce timer stops a scheduled run, but neither touches a
-   * run whose timer has already fired — that one is mid-`onChanges`, indexing
-   * into a Store the caller is about to close (TRA-834). `stop()` awaits these
+   * run whose timer has already fired — that one is mid-`onChanges`/`onDeletes`,
+   * indexing into a Store the caller is about to close (TRA-834). `stop()` awaits these
    * so "the watcher is stopped" means no handler is still running.
    *
    * A set, not a single reference: nothing serializes handlers, so a second
@@ -151,6 +151,21 @@ export class FileWatcher {
    * `stop()` would then return while the first is still writing.
    */
   private readonly activeHandlers = new Set<Promise<void>>();
+
+  /**
+   * Register an already-started handler run so `stop()` waits it out. The
+   * tracked copy swallows errors so `stop()`'s `Promise.all` can only wait,
+   * never throw; the caller still sees the original rejection.
+   */
+  private track(run: Promise<void>): Promise<void> {
+    const tracked: Promise<void> = run
+      .catch(() => {})
+      .finally(() => {
+        this.activeHandlers.delete(tracked);
+      });
+    this.activeHandlers.add(tracked);
+    return run;
+  }
 
   constructor(
     private readonly _setTimeout: typeof setTimeout = setTimeout,
@@ -262,7 +277,7 @@ export class FileWatcher {
 
         if (deleted.length > 0 && onDeletes) {
           logger.debug({ count: deleted.length }, 'File deletions detected');
-          await onDeletes(deleted);
+          await this.track(onDeletes(deleted));
         }
 
         if (changed.length === 0) return;
@@ -276,17 +291,15 @@ export class FileWatcher {
           this.pendingPaths.clear();
           this.debounceTimer = null;
           logger.debug({ count: paths.length }, 'File changes detected');
-          const run = (async () => {
-            try {
-              await onChanges(paths);
-            } catch (e) {
-              logger.error({ error: e }, 'File change handler failed');
-            }
-          })();
-          const tracked: Promise<void> = run.finally(() => {
-            this.activeHandlers.delete(tracked);
-          });
-          this.activeHandlers.add(tracked);
+          void this.track(
+            (async () => {
+              try {
+                await onChanges(paths);
+              } catch (e) {
+                logger.error({ error: e }, 'File change handler failed');
+              }
+            })(),
+          );
         }, debounceMs);
       },
       {


### PR DESCRIPTION
`FileWatcher.stop()` cleared the debounce timer but returned while a handler
invocation that had already fired was still awaiting `onChanges`/`onDeletes`.
`ProjectManager.stopProject()` calls `watcher.stop()` and then `db.close()`, so
that reindex kept running against a closed SQLite handle: 206 error-level
"The database connection is not open" records in the field daemon log, each one
a file change that silently never landed in the index.

**Rebased 2026-09-05 — scope reduced.** While this PR sat, #881 (TRA-834) landed
the same fix for the `onChanges` path on master (`activeHandlers` + drain in
`stopLocked()`). The rebase resolution keeps master's mechanism verbatim; what
remains here is the half master does not cover:

- `onDeletes` is now tracked too. `unsubscribe()` does not await a parcel
  callback already in progress, so a delete handler mid-flight still outlived
  `stop()`.
- The tracking is factored into one `track()` helper used by both call sites,
  so both share the same invariant (the tracked copy swallows errors, so
  `stop()`'s `Promise.all` can only wait, never throw).

**Test evidence.** `src/indexer/__tests__/watcher-stop-inflight.test.ts` — two
cases, in-flight `onChanges` and in-flight `onDeletes`. Verified non-vacuous:
reverting the one-line `onDeletes` change fails the delete case and passes the
other. Full suite locally: 10025 passed / 24 skipped, `tsc --noEmit` and
`biome ci` clean.
