### PR TITLE
perf(app): stop freezing the whole app for the length of a daemon restart (TRA-806)

### DIFF
--- a/packages/app/src/main/__tests__/daemon-lifecycle-async.test.ts
+++ b/packages/app/src/main/__tests__/daemon-lifecycle-async.test.ts
@@ -1,0 +1,59 @@
+/* TRA-806: `daemon restart` takes 6-20 s to return on this machine, and until
+   this test existed the Electron main process ran it with execFileSync — so the
+   whole app froze for all of it. That is not a theoretical cost: the freeze
+   lands on the first launch after an app update, when the tray poll sees the
+   still-old daemon and restarts it, and the renderer's own clock measured 5.7 s
+   to first content on exactly the launch that printed "version mismatch".
+
+   The guard is behavioural rather than a grep for `execFileSync`: it runs a real
+   child that takes its time and asserts the event loop kept turning meanwhile. */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { restartDaemon, stopDaemon } from '../daemon-lifecycle';
+
+// Force the TRACE_MCP_BIN branch: with a launcher.env on the machine,
+// resolveCliInvocation would otherwise point at the real installed CLI.
+vi.mock('../daemon-install', () => ({
+  resolveCliInvocation: () => ({ file: '', prefixArgs: [] }),
+}));
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'daemon-lifecycle-'));
+const slowBin = path.join(dir, 'slow-cli');
+const previousBin = process.env.TRACE_MCP_BIN;
+
+beforeAll(() => {
+  fs.writeFileSync(slowBin, '#!/bin/sh\nsleep 0.4\n', { mode: 0o755 });
+  process.env.TRACE_MCP_BIN = slowBin;
+});
+
+afterAll(() => {
+  if (previousBin === undefined) delete process.env.TRACE_MCP_BIN;
+  else process.env.TRACE_MCP_BIN = previousBin;
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('daemon commands do not block the main process', () => {
+  it.skipIf(process.platform === 'win32')('lets timers run while the CLI works', async () => {
+    const ticks: number[] = [];
+    const timer = setInterval(() => ticks.push(Date.now()), 50);
+    const started = Date.now();
+    const result = await restartDaemon();
+    clearInterval(timer);
+
+    expect(result.ok).toBe(true);
+    expect(Date.now() - started).toBeGreaterThanOrEqual(350);
+    // execFileSync would have delivered zero of these.
+    expect(ticks.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it.skipIf(process.platform === 'win32')('runs one command at a time', async () => {
+    const order: string[] = [];
+    const first = restartDaemon().then(() => order.push('first'));
+    const second = stopDaemon().then(() => order.push('second'));
+    await Promise.all([first, second]);
+    expect(order).toEqual(['first', 'second']);
+  });
+});

--- a/packages/app/src/main/daemon-lifecycle.ts
+++ b/packages/app/src/main/daemon-lifecycle.ts
@@ -18,10 +18,11 @@
  *      nvm-installed binary won't be visible here.
  */
 
-import { execFileSync, execSync } from 'node:child_process';
+import { execFile, execSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { promisify } from 'node:util';
 import { type CliInvocation, resolveCliInvocation } from './daemon-install';
 import { getLauncherDir, getLauncherShimPath, SHIM_NAMES } from './trace-home';
 
@@ -85,10 +86,30 @@ function resolveTraceMcpBinary(): string {
   );
 }
 
-function runDaemonCommand(subcommand: 'start' | 'stop' | 'restart'): {
+const execFileAsync = promisify(execFile);
+
+/* One daemon command at a time. Until TRA-806 this file used execFileSync, which
+   serialized these calls by freezing the process; the async version must keep the
+   serialization without the freeze — the tray poll, the update flow and the
+   renderer's "Restart daemon" button can all fire within the same second, and two
+   `daemon restart` runs racing each other is how a stale PID file gets written. */
+let queue: Promise<unknown> = Promise.resolve();
+
+async function runDaemonCommand(
+  subcommand: 'start' | 'stop' | 'restart',
+): Promise<{ ok: boolean; error?: string }> {
+  const run = queue.then(
+    () => runDaemonCommandNow(subcommand),
+    () => runDaemonCommandNow(subcommand),
+  );
+  queue = run;
+  return run;
+}
+
+async function runDaemonCommandNow(subcommand: 'start' | 'stop' | 'restart'): Promise<{
   ok: boolean;
   error?: string;
-} {
+}> {
   // TRA-638: on Windows the shim is a `.cmd`, which execFileSync cannot launch
   // without a shell — `shell: isWin` below is the only reason this path worked
   // while the identical MCP-client spawns failed. Prefer the runtime + cli.js
@@ -102,10 +123,12 @@ function runDaemonCommand(subcommand: 'start' | 'stop' | 'restart'): {
   }
 
   try {
-    // execFileSync avoids shell-injection concerns around the resolved path.
-    // Windows paths may contain spaces; pass as single arg.
-    execFileSync(inv.file, [...inv.prefixArgs, 'daemon', subcommand], {
-      stdio: ['ignore', 'pipe', 'pipe'],
+    // execFile (not execFileSync, and not exec) avoids shell-injection concerns
+    // around the resolved path, and keeps the main process's event loop free:
+    // `daemon restart` takes 6-20 s to return, and a sync call spends all of it
+    // with every window, IPC reply and file:// asset load frozen behind it
+    // (TRA-806). Windows paths may contain spaces; pass as single arg.
+    await execFileAsync(inv.file, [...inv.prefixArgs, 'daemon', subcommand], {
       windowsHide: true,
       // Last resort only: a Windows machine with no launcher.env to point at
       // can still have a `.cmd` on PATH, and this argv is two literals.
@@ -115,10 +138,11 @@ function runDaemonCommand(subcommand: 'start' | 'stop' | 'restart'): {
     });
     return { ok: true };
   } catch (err) {
-    // execFileSync attaches stdout/stderr buffers to the thrown error in
-    // pipe mode. Surface stderr (which the CLI uses for error reporting)
-    // back to the renderer so the menu bar can show a real reason instead
-    // of "command failed with code 1".
+    // execFile attaches stdout/stderr to the rejected error. Surface stderr
+    // (which the CLI uses for error reporting) back to the renderer so the menu
+    // bar can show a real reason instead of "command failed with code 1".
+    // `code` is where the async form puts the exit status; `status` is the sync
+    // form's name for it and is kept so a mocked-sync error still reads right.
     const e = err as NodeJS.ErrnoException & {
       stderr?: Buffer | string;
       stdout?: Buffer | string;
@@ -127,20 +151,21 @@ function runDaemonCommand(subcommand: 'start' | 'stop' | 'restart'): {
     const stderr = e.stderr ? e.stderr.toString().trim() : '';
     const stdout = e.stdout ? e.stdout.toString().trim() : '';
     const detail = stderr || stdout || e.message;
-    const exitCode = typeof e.status === 'number' ? ` (exit ${e.status})` : '';
+    const status = typeof e.status === 'number' ? e.status : e.code;
+    const exitCode = typeof status === 'number' ? ` (exit ${status})` : '';
     return { ok: false, error: `daemon ${subcommand} failed${exitCode}: ${detail}` };
   }
 }
 
-export function ensureDaemon(): { ok: boolean; error?: string } {
+export function ensureDaemon(): Promise<{ ok: boolean; error?: string }> {
   return runDaemonCommand('start');
 }
 
-export function restartDaemon(): { ok: boolean; error?: string } {
+export function restartDaemon(): Promise<{ ok: boolean; error?: string }> {
   return runDaemonCommand('restart');
 }
 
-export function stopDaemon(): { ok: boolean; error?: string } {
+export function stopDaemon(): Promise<{ ok: boolean; error?: string }> {
   return runDaemonCommand('stop');
 }
 

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -1341,7 +1341,7 @@ ipcMain.handle('apply-daemon-update', async () => {
   const result = await dedupeInFlight(inFlightNpmUpdate, () => performNpmGlobalUpdate(npmBin));
   if (!result.ok) return daemonUpdateDegradeToCommand(result.error);
 
-  const restart = restartDaemon();
+  const restart = await restartDaemon();
   if (!restart.ok) {
     appendUpdateLog({ event: 'apply-daemon-update:restart-failed', error: restart.error });
     return {

--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -523,7 +523,7 @@ export async function checkHealth(): Promise<void> {
         );
         try {
           lastDaemonStartAttempt = Date.now();
-          const result = restartDaemon();
+          const result = await restartDaemon();
           if (!result.ok) {
             console.warn(
               `[trace-mcp] version-mismatch restart failed: ${result.error ?? 'unknown'}`,
@@ -612,7 +612,7 @@ export async function checkHealth(): Promise<void> {
         // 809 restarts fit into 22.8 hours.
         firstUnreachableAt = Date.now();
         restartsThisOutage++;
-        const result = useRestart ? restartDaemon() : ensureDaemon();
+        const result = await (useRestart ? restartDaemon() : ensureDaemon());
         if (!result.ok) {
           console.warn(`[trace-mcp] daemon ${action} failed: ${result.error ?? 'unknown'}`);
         }


### PR DESCRIPTION
## The defect

`trace-mcp daemon restart` takes **6-20 s** to return (measured 6.1 / 10.9 / 20.2 s on
this machine, three runs, throwaway data dir). The Electron main process ran it with
`execFileSync`, so it spent every one of those seconds with its event loop stopped: no
IPC replies, no window creation, no menu, and — during startup — no `file://` asset
loads for the renderer either, because those are served by the browser process.

The trigger is not exotic. The tray polls `/health` every 5 s and restarts the daemon on
a version mismatch, i.e. on every machine that has updated the app but not yet the CLI —
the first launch after an app update.

## Before / after

Main-process inspector pinged every 100 ms for 25 s while the tray's health poll ran one
daemon command. `TRACE_MCP_BIN` points at a shim that sleeps 6 s, so the machine's real
daemon is never touched and the only variable is who blocks.

| | max main-loop stall | pings > 1 s |
|---|---|---|
| before | 5923 / 5925 / 5987 ms | 1 per run |
| after | **7 / 9 / 19 ms** | 0 |

End-to-end, from a 20-launch probe on the unmodified app: the single launch that printed
`version mismatch — daemon=3.15.0 app=3.16.0, restarting daemon` reached first content in
**5702 ms** against a median of **110 ms** for the other 19, with `domContentLoaded` at
5679 ms — the renderer's own scripts queued behind a frozen main process. The same defect
killed a 55-minute baseline pass outright with `CDP Runtime.evaluate timed out after
30000 ms`.

## The change

- `runDaemonCommand` uses `execFile` (promisified) instead of `execFileSync`.
- Commands are chained so only one runs at a time. The sync version serialized them by
  freezing; two `daemon restart` runs racing each other is how a stale PID file gets
  written.
- `ensureDaemon` / `restartDaemon` / `stopDaemon` now return promises; the three
  main-process call sites (`tray.ts` x2, `index.ts`) await them. The renderer already
  went through `ipcMain.handle`, so its contract is unchanged.

## Guard

`daemon-lifecycle-async.test.ts` is behavioural, not a grep for `execFileSync`: it runs a
real child that sleeps 400 ms and asserts timers kept firing meanwhile. Verified against
the old code — it records **0** ticks there and fails.

Full app suite: 661 tests, 66 files, green. `tsc --noEmit` at the repo root: clean.

Closes TRA-806's first finding; the baseline entry for this run lands in a follow-up
commit on this branch.
