### PR TITLE
fix(docs): regenerate the config index after db.path lost its default (TRA-810)

### DIFF
--- a/docs/config-index.md
+++ b/docs/config-index.md
@@ -52,8 +52,8 @@ supply it.
 
 | Key | Type | Default |
 | --- | --- | --- |
-| `db` | object | `{}` |
-| `db.path` | string | `".trace-mcp/index.db"` |
+| `db` | object | — |
+| `db.path` | string | _unset_ |
 | `include` | string[] | _built-in list_ |
 | `exclude` | string[] | _built-in list_ |
 | `follow_symlinks` | boolean | `false` |
@@ -314,7 +314,7 @@ supply it.
 | `hermes.home_override` | string | _unset_ |
 | `hermes.profile` | string | _unset_ |
 
-One default is worth reading with care: `db.path` is vestigial. Nothing derives
-the index location from it — `getDbPath()` in `src/global.ts` puts every index
-under `~/.trace/index/` — and its only reader is the `config.dbPath` field of
-`get_project_status`, which therefore reports a path the database is not at.
+One key is worth reading with care: `db.path` is vestigial. Nothing reads it.
+The index location is not configurable — `getDbPath()` in `src/global.ts` puts
+every project's database under `~/.trace/index/`. The key is still accepted so
+existing config files keep validating, and will be dropped in the next major.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2596,8 +2596,8 @@ supply it.
 
 | Key | Type | Default |
 | --- | --- | --- |
-| `db` | object | `{}` |
-| `db.path` | string | `".trace-mcp/index.db"` |
+| `db` | object | — |
+| `db.path` | string | _unset_ |
 | `include` | string[] | _built-in list_ |
 | `exclude` | string[] | _built-in list_ |
 | `follow_symlinks` | boolean | `false` |
@@ -2858,10 +2858,10 @@ supply it.
 | `hermes.home_override` | string | _unset_ |
 | `hermes.profile` | string | _unset_ |
 
-One default is worth reading with care: `db.path` is vestigial. Nothing derives
-the index location from it — `getDbPath()` in `src/global.ts` puts every index
-under `~/.trace/index/` — and its only reader is the `config.dbPath` field of
-`get_project_status`, which therefore reports a path the database is not at.
+One key is worth reading with care: `db.path` is vestigial. Nothing reads it.
+The index location is not configurable — `getDbPath()` in `src/global.ts` puts
+every project's database under `~/.trace/index/`. The key is still accepted so
+existing config files keep validating, and will be dropped in the next major.
 
 ---
 

--- a/scripts/config-index.ts
+++ b/scripts/config-index.ts
@@ -214,10 +214,10 @@ supply it.
 | --- | --- | --- |
 ${table}
 
-One default is worth reading with care: \`db.path\` is vestigial. Nothing derives
-the index location from it — \`getDbPath()\` in \`src/global.ts\` puts every index
-under \`~/.trace/index/\` — and its only reader is the \`config.dbPath\` field of
-\`get_project_status\`, which therefore reports a path the database is not at.
+One key is worth reading with care: \`db.path\` is vestigial. Nothing reads it.
+The index location is not configurable — \`getDbPath()\` in \`src/global.ts\` puts
+every project's database under \`~/.trace/index/\`. The key is still accepted so
+existing config files keep validating, and will be dropped in the next major.
 `;
 }
 


### PR DESCRIPTION
`tests/docs/config-index.test.ts > is regenerated from the schema` is red on a clean
`origin/master`. The generator is not the problem — it reads only
`z.toJSONSchema(TraceMcpConfigSchema)` and no env, cwd or ambient config. The
committed page is the stale side.

TRA-802 (#864) turned `db: z.object({ path: z.string().default('.trace-mcp/index.db') })`
into an accepted-and-ignored optional key. Its branch was cut before #863 landed
`docs/config-index.md`, so its CI never ran the guard that exists to catch exactly
this. Both PRs were green; master went red the moment they met.

- regenerate `docs/config-index.md` (`db` → `—`, `db.path` → `_unset_`)
- regenerate `docs/llms-full.txt`, which embeds the same table
- rewrite the page's closing note: it still pointed at the `get_index_health`
  reader TRA-802 deleted

## Test evidence

```
$ npx vitest run tests/docs/
 Test Files  16 passed (16)
      Tests  219 passed | 4 skipped (223)
```

`pnpm run lint` (tsc --noEmit) clean. Before the change, `tests/docs/` was
1 failed | 15 passed, and `npx tsx scripts/config-index.ts --check` reported the
page stale.

No repeat guard is added here: nothing in the tree can catch a semantic conflict
between two branches that are each green. The lever is the branch-protection
setting "Require branches to be up to date before merging", which is a repo
setting, not code.

Closes TRA-810.

Agent: Lead Engineer
