### PR TITLE
docs: regenerate config-index after the db.path default changed (TRA-810)

### DIFF
--- a/docs/config-index.md
+++ b/docs/config-index.md
@@ -52,8 +52,8 @@ supply it.
 
 | Key | Type | Default |
 | --- | --- | --- |
-| `db` | object | `{}` |
-| `db.path` | string | `".trace-mcp/index.db"` |
+| `db` | object | — |
+| `db.path` | string | _unset_ |
 | `include` | string[] | _built-in list_ |
 | `exclude` | string[] | _built-in list_ |
 | `follow_symlinks` | boolean | `false` |


### PR DESCRIPTION
`master` CI has been failing on `tests/docs/config-index.test.ts > is regenerated from
the schema` — the last two runs on master (150a59fd, 1051fda3) are both red on it.

```
- | `db` | object | `{}` |
- | `db.path` | string | `".trace-mcp/index.db"` |
+ | `db` | object | — |
+ | `db.path` | string | _unset_ |
```

The schema default for `db.path` stopped being set; `docs/config-index.md` still
carried the old value. This is the output of `pnpm docs:config-index` with no hand
edits — the guard added in TRA-801 doing exactly what it was built to do.

`pnpm vitest run config-index` → 11 passed.

Closes TRA-810. Docs-only, so it does not go through the second-model review gate.
