### PR TITLE
fix(tools): report dropped fs events in get_index_health (TRA-813)

### DIFF
--- a/src/indexer/__tests__/watcher-events-dropped.test.ts
+++ b/src/indexer/__tests__/watcher-events-dropped.test.ts
@@ -4,7 +4,7 @@
  * return — every change in the lost window stayed invisible to the index
  * forever. It must now run the reconcile pass instead.
  */
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as parcelWatcher from '@parcel/watcher';
 
 type Callback = (err: Error | null, events: parcelWatcher.Event[]) => void | Promise<void>;
@@ -18,7 +18,7 @@ vi.mock('@parcel/watcher', () => ({
   },
 }));
 
-const { FileWatcher } = await import('../watcher.js');
+const { FileWatcher, getDroppedEventStats, resetDroppedEventStats } = await import('../watcher.js');
 
 async function startWatcher(onRescan?: () => Promise<void>) {
   const watcher = new FileWatcher();
@@ -94,5 +94,44 @@ describe('FileWatcher — dropped fs events', () => {
     release();
     await stopping;
     expect(stopped).toBe(true);
+  });
+});
+
+/**
+ * TRA-813 asked for a counter on top of the repair: without one a later run
+ * cannot tell "the OS never dropped anything" from "it dropped events and the
+ * repair was silently skipped". `get_index_health` reads this tally.
+ */
+describe('FileWatcher — dropped-event tally', () => {
+  beforeEach(() => resetDroppedEventStats());
+
+  it('counts every drop report and every reconcile pass it starts', async () => {
+    const onRescan = vi.fn(async () => {});
+    const watcher = await startWatcher(onRescan);
+    const dropped = new Error('Events were dropped by the FSEvents client.');
+
+    await capturedCallback!(dropped, []);
+    await capturedCallback!(dropped, []);
+
+    expect(getDroppedEventStats()).toEqual({ drops: 2, reconciles: 2 });
+    await watcher.stop();
+  });
+
+  it('counts the drop even when no reconcile callback is wired', async () => {
+    const watcher = await startWatcher(undefined);
+
+    await capturedCallback!(new Error('Events were dropped by the FSEvents client.'), []);
+
+    expect(getDroppedEventStats()).toEqual({ drops: 1, reconciles: 0 });
+    await watcher.stop();
+  });
+
+  it('leaves the tally alone for unrelated watcher errors', async () => {
+    const watcher = await startWatcher(vi.fn(async () => {}));
+
+    await capturedCallback!(new Error('EMFILE: too many open files'), []);
+
+    expect(getDroppedEventStats()).toEqual({ drops: 0, reconciles: 0 });
+    await watcher.stop();
   });
 });

--- a/src/indexer/watcher.ts
+++ b/src/indexer/watcher.ts
@@ -36,6 +36,25 @@ function isEventsDroppedError(err: unknown): boolean {
   return typeof msg === 'string' && msg.toLowerCase().includes('events were dropped');
 }
 
+/**
+ * Process-wide tally of drop reports and the reconcile passes they triggered.
+ * Reported by `get_index_health` so a session can tell "the OS never dropped
+ * anything" from "it dropped events and the repair did/didn't run" — a
+ * distinction that otherwise only exists in the daemon log, which the agent
+ * asking the question cannot read (TRA-813).
+ */
+const droppedEventStats = { drops: 0, reconciles: 0 };
+
+export function getDroppedEventStats(): { drops: number; reconciles: number } {
+  return { ...droppedEventStats };
+}
+
+/** Test-only reset — the tally is module state shared by every watcher. */
+export function resetDroppedEventStats(): void {
+  droppedEventStats.drops = 0;
+  droppedEventStats.reconciles = 0;
+}
+
 function isMacSystemPolicyError(e: unknown): boolean {
   if (process.platform !== 'darwin') return false;
   const err = e as NodeJS.ErrnoException & { message?: string };
@@ -243,6 +262,7 @@ export class FileWatcher {
       async (err, events) => {
         if (err) {
           if (isEventsDroppedError(err)) {
+            droppedEventStats.drops++;
             // Don't just log: the events are gone, so nothing else will ever
             // reindex what changed in the lost window (TRA-852).
             logger.warn(
@@ -330,6 +350,7 @@ export class FileWatcher {
       this.rescanPending = true;
       return;
     }
+    droppedEventStats.reconciles++;
     this.activeRescan = onRescan()
       .catch((e) => {
         logger.error({ error: e, rootPath }, 'Index reconcile after dropped events failed');

--- a/src/tools/project/project.ts
+++ b/src/tools/project/project.ts
@@ -1,6 +1,7 @@
 import { readEmbeddingBreakerState } from '../../ai/embedding-pipeline.js';
 import type { TraceMcpConfig } from '../../config.js';
 import type { IndexStats, Store } from '../../db/store.js';
+import { getDroppedEventStats } from '../../indexer/watcher.js';
 import type { PluginRegistry } from '../../plugin-api/registry.js';
 import type { DetectedVersion, ProjectContext } from '../../plugin-api/types.js';
 import type { ProgressSnapshot } from '../../progress.js';
@@ -65,6 +66,19 @@ export function getIndexHealth(store: Store, config: TraceMcpConfig): IndexHealt
       `Low edge density: ${stats.totalEdges} edges for ${stats.totalSymbols} symbols ` +
         `(${Math.round((stats.totalEdges / stats.totalSymbols) * 100)}% ratio). ` +
         `Some call graph queries may return incomplete results.`,
+    );
+  }
+
+  // The OS dropped fs events at least once this process: everything changed
+  // inside those windows was invisible to the watcher until the reconcile pass
+  // caught up (TRA-852). Report it — an agent asking about index freshness
+  // cannot read the daemon log, which is where this otherwise only exists.
+  const { drops, reconciles } = getDroppedEventStats();
+  if (drops > 0) {
+    warnings.push(
+      `The OS dropped file-system events ${drops} time(s) since this process started; ` +
+        `${reconciles} index reconcile pass(es) ran in response. ` +
+        `Results served between a drop and its reconcile may have been stale.`,
     );
   }
 

--- a/src/tools/project/project.ts
+++ b/src/tools/project/project.ts
@@ -77,7 +77,8 @@ export function getIndexHealth(store: Store, config: TraceMcpConfig): IndexHealt
   if (drops > 0) {
     warnings.push(
       `The OS dropped file-system events ${drops} time(s) since this process started; ` +
-        `${reconciles} index reconcile pass(es) ran in response. ` +
+        `${reconciles} index reconcile pass(es) were started in response ` +
+        `(started, not necessarily finished — a pass that failed is logged, not subtracted). ` +
         `Results served between a drop and its reconcile may have been stale.`,
     );
   }


### PR DESCRIPTION
Follow-up to #892 (and #871). Closes TRA-813.

## What changed since this PR was opened

This PR originally carried the whole TRA-813 fix. While it sat, #892 landed the
same repair from a parallel run under TRA-852 — a dropped-event report now runs
`pipeline.indexAll()` instead of log-and-return, with burst collapsing and a
`stop()` that awaits the in-flight pass. That implementation is good and this
branch has been reset onto it rather than competing with it.

What #892 did **not** carry is the second half of TRA-813's ask: the counter.

> Add a counter so the next run can tell whether the repair fires and how often;
> today we cannot distinguish "never happens" from "happens and is silently ignored".

So this PR is now just that delta.

## Change

- `src/indexer/watcher.ts` tallies drop reports (`drops`) and the reconcile
  passes they start (`reconciles`), exposed via `getDroppedEventStats()`.
  A drop is counted even when no `onRescan` is wired — that case is precisely
  the "silently ignored" state the issue wants visible.
- `get_index_health` reports the tally as a warning when `drops > 0`.

The point of putting it there rather than only in the log: the agent asking
whether the index is fresh is exactly the one that cannot read the daemon log,
which is where this signal otherwise only exists.

## Test evidence

Three cases appended to the existing `src/indexer/__tests__/watcher-events-dropped.test.ts`
(7 tests total, all green): drops and reconciles both counted; a drop still counted
with no callback wired; unrelated errors (`EMFILE`) leaving the tally alone.

Full suite: `Test Files 902 passed | 4 skipped · Tests 10026 passed | 23 skipped`,
with one unrelated flake — `src/daemon/__tests__/project-relay.test.ts > returns null
for a root that was never registered` timed out at 10s under full-suite load and passes
in 7s in isolation. It does not touch the watcher or `get_index_health`.
`pnpm run lint` and `pnpm run biome:ci` clean.

Agent: Lead Engineer
