### PR TITLE
fix(state): bound the global state.db instead of growing it forever (TRA-830)

### DIFF
--- a/docs/SKILL_STATE.md
+++ b/docs/SKILL_STATE.md
@@ -96,6 +96,20 @@ which are short — is not justified by anything measured.
 
 ---
 
+## Storage and retention
+
+State lives in `state.db` under `TRACE_MCP_HOME`, shared by every project and
+every task the install has ever run. Two limits keep it bounded:
+
+- Patch history is capped at the newest **200 revisions per task**. The current
+  state and all checkpoints are unaffected; only the older audit rows are dropped.
+- Task states in a terminal status (`completed`, `failed`) that have not been
+  updated for **30 days** are deleted on server start, along with their revisions
+  and checkpoints. `in_progress`, `paused` and `blocked` states are never swept,
+  however old they are.
+
+---
+
 ## MCP Resource: `trace://state/{task_id}`
 
 Clients subscribing to MCP resources receive live updates whenever `trace_state_patch` or `trace_state_rollback` mutates a task state.

--- a/src/state/__tests__/state-engine.test.ts
+++ b/src/state/__tests__/state-engine.test.ts
@@ -159,3 +159,57 @@ describe('StateEngine SQLite Storage and Lifecycle', () => {
     expect(engine.listStates().length).toBe(1);
   });
 });
+
+describe('StateEngine retention', () => {
+  it('caps revision history per task', () => {
+    const db = new Database(':memory:');
+    const engine = new StateEngine(db);
+    engine.initState('TRA-1', 'long running task');
+
+    for (let i = 0; i < 250; i++) {
+      engine.patchState('TRA-1', { next_action: `step ${i}` });
+    }
+
+    const { count, max } = db
+      .prepare(
+        'SELECT COUNT(*) AS count, MAX(version) AS max FROM agent_state_revisions WHERE task_id = ?',
+      )
+      .get('TRA-1') as { count: number; max: number };
+
+    expect(max).toBe(251);
+    expect(count).toBe(200);
+    // Current state is untouched by the trim
+    expect(engine.getState('TRA-1')?.state.next_action).toBe('step 249');
+  });
+
+  it('drops finished states untouched past the retention window, keeps the rest', () => {
+    const db = new Database(':memory:');
+    const engine = new StateEngine(db);
+    engine.initState('OLD-DONE', 'finished long ago');
+    engine.initState('OLD-PAUSED', 'parked long ago');
+    engine.initState('NEW-DONE', 'finished today');
+    engine.patchState('OLD-DONE', { status: 'completed' });
+    engine.patchState('OLD-PAUSED', { status: 'paused' });
+    engine.patchState('NEW-DONE', { status: 'completed' });
+    engine.createCheckpoint('OLD-DONE', 'before-refactor');
+
+    const ancient = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare("UPDATE agent_states SET updated_at = ? WHERE task_id LIKE 'OLD-%'").run(ancient);
+
+    // Reopening the same db runs the retention sweep
+    const reopened = new StateEngine(db);
+
+    expect(reopened.getState('OLD-DONE')).toBeNull();
+    expect(reopened.getState('OLD-PAUSED')).not.toBeNull();
+    expect(reopened.getState('NEW-DONE')).not.toBeNull();
+
+    const orphans = db
+      .prepare(
+        `SELECT
+           (SELECT COUNT(*) FROM agent_state_revisions WHERE task_id = 'OLD-DONE') AS revisions,
+           (SELECT COUNT(*) FROM agent_state_checkpoints WHERE task_id = 'OLD-DONE') AS checkpoints`,
+      )
+      .get() as { revisions: number; checkpoints: number };
+    expect(orphans).toEqual({ revisions: 0, checkpoints: 0 });
+  });
+});

--- a/src/state/__tests__/state-engine.test.ts
+++ b/src/state/__tests__/state-engine.test.ts
@@ -182,6 +182,27 @@ describe('StateEngine retention', () => {
     expect(engine.getState('TRA-1')?.state.next_action).toBe('step 249');
   });
 
+  it('caps revision history under repeated re-initialization of the same task', () => {
+    const db = new Database(':memory:');
+    const engine = new StateEngine(db);
+
+    for (let i = 0; i < 250; i++) {
+      engine.initState('TRA-2', `retried goal ${i}`);
+    }
+    engine.initState('TRA-3', 'other task');
+
+    const counts = db
+      .prepare(
+        `SELECT
+           (SELECT COUNT(*) FROM agent_state_revisions WHERE task_id = 'TRA-2') AS retried,
+           (SELECT COUNT(*) FROM agent_state_revisions WHERE task_id = 'TRA-3') AS other`,
+      )
+      .get() as { retried: number; other: number };
+
+    expect(counts).toEqual({ retried: 200, other: 1 });
+    expect(engine.getState('TRA-2')?.state.goal).toBe('retried goal 249');
+  });
+
   it('drops finished states untouched past the retention window, keeps the rest', () => {
     const db = new Database(':memory:');
     const engine = new StateEngine(db);

--- a/src/state/state-engine.ts
+++ b/src/state/state-engine.ts
@@ -59,6 +59,14 @@ CREATE INDEX IF NOT EXISTS idx_state_checkpoints_task
     ON agent_state_checkpoints(task_id);
 `;
 
+/**
+ * Retention limits for the global state.db. Nothing else ever deletes from it:
+ * `state.db` lives in TRACE_MCP_HOME and is shared by every project and every
+ * task an install has ever run, so without these it only ever grows.
+ */
+const REVISION_HISTORY_LIMIT = 200;
+const FINISHED_STATE_RETENTION_DAYS = 30;
+
 export type StateChangeListener = (event: {
   taskId: string;
   version: number;
@@ -81,6 +89,55 @@ export class StateEngine {
     }
 
     this.db.exec(STATE_ENGINE_DDL);
+    this.pruneFinishedStates();
+  }
+
+  /**
+   * Drop finished task states (and their revisions/checkpoints) that nobody has
+   * touched for FINISHED_STATE_RETENTION_DAYS. Only terminal statuses are
+   * eligible, so a paused or blocked task survives however long it takes.
+   */
+  private pruneFinishedStates(): void {
+    const cutoff = new Date(
+      Date.now() - FINISHED_STATE_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+    try {
+      this.db.transaction(() => {
+        const stale = this.db
+          .prepare(
+            `SELECT task_id FROM agent_states
+             WHERE status IN ('completed', 'failed') AND updated_at < ?`,
+          )
+          .all(cutoff) as Array<{ task_id: string }>;
+
+        for (const { task_id } of stale) {
+          this.db.prepare('DELETE FROM agent_state_checkpoints WHERE task_id = ?').run(task_id);
+          this.db.prepare('DELETE FROM agent_state_revisions WHERE task_id = ?').run(task_id);
+          this.db.prepare('DELETE FROM agent_states WHERE task_id = ?').run(task_id);
+        }
+      })();
+    } catch (err) {
+      // ponytail: retention is best-effort — a locked db must not break startup.
+      logger.warn({ err }, 'StateEngine retention sweep failed');
+    }
+  }
+
+  /**
+   * Keep only the newest REVISION_HISTORY_LIMIT patch rows for a task.
+   * ponytail: called after each revision insert; if the write rate ever makes
+   * that delete hot, move it behind a modulo counter.
+   */
+  private trimRevisions(taskId: string): void {
+    this.db
+      .prepare(
+        `DELETE FROM agent_state_revisions
+         WHERE task_id = ?
+           AND version <= (
+             SELECT MAX(version) FROM agent_state_revisions WHERE task_id = ?
+           ) - ?`,
+      )
+      .run(taskId, taskId, REVISION_HISTORY_LIMIT);
   }
 
   /**
@@ -274,6 +331,8 @@ export class StateEngine {
       `,
         )
         .run(taskId, nextVersion, patchJson, now);
+
+      this.trimRevisions(taskId);
     });
 
     patchTx();
@@ -382,6 +441,8 @@ export class StateEngine {
           JSON.stringify({ rollback_to_checkpoint: row?.label, checkpoint_id: row?.id }),
           now,
         );
+
+      this.trimRevisions(taskId);
     });
 
     rollbackTx();

--- a/src/state/state-engine.ts
+++ b/src/state/state-engine.ts
@@ -125,17 +125,22 @@ export class StateEngine {
 
   /**
    * Keep only the newest REVISION_HISTORY_LIMIT patch rows for a task.
-   * ponytail: called after each revision insert; if the write rate ever makes
-   * that delete hot, move it behind a modulo counter.
+   * "Newest" is insertion order, not version: re-initializing a task writes
+   * another revision numbered 1, so version arithmetic would let those rows
+   * accumulate without bound. Must be called from every transaction that
+   * inserts a revision.
    */
   private trimRevisions(taskId: string): void {
     this.db
       .prepare(
         `DELETE FROM agent_state_revisions
          WHERE task_id = ?
-           AND version <= (
-             SELECT MAX(version) FROM agent_state_revisions WHERE task_id = ?
-           ) - ?`,
+           AND id NOT IN (
+             SELECT id FROM agent_state_revisions
+             WHERE task_id = ?
+             ORDER BY id DESC
+             LIMIT ?
+           )`,
       )
       .run(taskId, taskId, REVISION_HISTORY_LIMIT);
   }
@@ -243,6 +248,8 @@ export class StateEngine {
       `,
         )
         .run(taskId, JSON.stringify({ init: true, state: validatedState }), now);
+
+      this.trimRevisions(taskId);
     });
 
     initTx();


### PR DESCRIPTION
`state.db` lives in `TRACE_MCP_HOME` and is shared by every project and every task an install has ever run. Nothing ever deleted from it:

- `agent_state_revisions` gains a row on every `trace_state_patch` and every rollback, and is never `SELECT`ed by any code path — a write-only log that only grows.
- `StateEngine.deleteState()` exists but is reachable from no MCP tool (`search_text` finds it only in its own definition and two tests), so finished tasks stay on disk forever.

This adds two limits inside `StateEngine`, nothing else:

1. **Revision cap** — the newest 200 patch rows per task are kept, older ones dropped on each insert. Current state and checkpoints are untouched.
2. **Retention sweep** — task states in a terminal status (`completed`, `failed`) not updated for 30 days are deleted on server start together with their revisions and checkpoints. `in_progress` / `paused` / `blocked` are never swept, however old. The sweep is wrapped in try/catch so a locked db cannot break startup.

No MCP tool signature changes, no table or column changes — only rows the engine already owned. `docs/SKILL_STATE.md` gains a "Storage and retention" section stating both limits.

**Tests:** two new cases in `src/state/__tests__/state-engine.test.ts` — 250 patches leave exactly 200 revisions with `MAX(version)` intact and current state correct; an aged `completed` task and its revisions/checkpoints are swept while an equally aged `paused` task and a fresh `completed` task survive. Full suite: 9942 passed / 22 skipped, `tsc --noEmit` clean, build clean.

Closes TRA-830 (driver mandate item 3: SKILL.state must not inflate SQLite).
