### PR TITLE
fix(daemon): stop the file watcher before awaiting the initial index on shutdown

### DIFF
--- a/src/daemon/__tests__/project-manager-shutdown-order.test.ts
+++ b/src/daemon/__tests__/project-manager-shutdown-order.test.ts
@@ -1,0 +1,108 @@
+/**
+ * TRA-834: shutdown must unsubscribe the file watcher before it waits on the
+ * initial index.
+ *
+ * Field evidence (daemon.log, 2026-09-03..04): every "File change handler
+ * failed / The database connection is not open" landed AFTER "Daemon shutting
+ * down" for the same pid — one project logged five of them spread over 27
+ * seconds. Cause: `stopProject` awaited `initialIndexPromise` first, and the
+ * still-subscribed watcher kept scheduling indexing runs against stores that
+ * were being closed.
+ *
+ * Mocks IndexingPipeline + FileWatcher + createServer like
+ * project-manager-ephemeral-sweep.test.ts, so only the teardown ordering is
+ * under test.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/** Ordered log of teardown-relevant events, shared with the mocks below. */
+const events: string[] = [];
+/** Resolves the fake initial index — held open until the test releases it. */
+let releaseIndex: () => void = () => {};
+
+vi.mock('../../indexer/pipeline.js', () => {
+  class FakeIndexingPipeline {
+    async indexAll() {
+      events.push('index-start');
+      await new Promise<void>((resolve) => {
+        releaseIndex = () => {
+          events.push('index-done');
+          resolve();
+        };
+      });
+      return { totalFiles: 0, indexed: 0, skipped: 0, errors: 0, durationMs: 0 };
+    }
+    async indexFiles() {
+      return { totalFiles: 0, indexed: 0, skipped: 0, errors: 0, durationMs: 0 };
+    }
+    deleteFiles() {}
+    async dispose() {}
+  }
+  return { IndexingPipeline: FakeIndexingPipeline };
+});
+
+vi.mock('../../indexer/watcher.js', () => {
+  class FakeWatcher {
+    async start() {}
+    async restartWithExcludes() {}
+    async stop() {
+      events.push('watcher-stop');
+    }
+  }
+  return { FileWatcher: FakeWatcher };
+});
+
+vi.mock('../../server/server.js', async (orig) => {
+  const real = (await orig()) as Record<string, unknown>;
+  return {
+    ...real,
+    createServer: () => ({
+      server: { close: async () => undefined },
+      dispose: () => undefined,
+    }),
+  };
+});
+
+let tmpHome: string;
+
+beforeEach(() => {
+  events.length = 0;
+  releaseIndex = () => {};
+  tmpHome = mkdtempSync(join(tmpdir(), 'trace-mcp-shutdown-order-'));
+  vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe('ProjectManager.shutdown teardown order (TRA-834)', () => {
+  it('stops the watcher before waiting for the in-flight initial index', async () => {
+    const { ProjectManager } = await import('../project-manager.js');
+
+    const root = join(tmpHome, 'proj');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'a.ts'), 'export const a = 1;\n');
+
+    const pm = new ProjectManager();
+    await pm.addProject(root);
+
+    const shutdown = pm.shutdown();
+    // Give shutdown a few turns to reach its first await, then release the
+    // index. With the old ordering, `watcher-stop` could only appear after
+    // `index-done`.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    releaseIndex();
+    await shutdown;
+
+    expect(events).toContain('watcher-stop');
+    expect(events).toContain('index-done');
+    expect(events.indexOf('watcher-stop')).toBeLessThan(events.indexOf('index-done'));
+  }, 30_000);
+});

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -883,6 +883,20 @@ export class ProjectManager {
     // one project logging five of them over 27 seconds. Stopping the source of
     // new work first is what makes the teardown below finite.
     await managed.watcher.stop();
+    // A drained handler ends by re-arming debouncedSummarize/debouncedEmbed and
+    // scheduling LSP enrichment (see the onChanges tail in addProject), and
+    // `trailingDebounce` mints a fresh AbortController when it is scheduled
+    // after a cancel — so the cancels above no longer cover those timers. Cancel
+    // once more now that no handler is left to arm another one.
+    managed.cancelDebouncedAI?.();
+    try {
+      managed.lspEnricher?.cancel();
+    } catch (err) {
+      logger.warn(
+        { error: err, projectRoot: root },
+        'lspEnricher.cancel() failed during stopProject (non-fatal)',
+      );
+    }
     // Wait for the background initial-index chain (indexAll → summarize/embed →
     // subproject auto-sync) to finish so its topology.db handle is closed
     // before we tear down this project — see initialIndexPromise's doc comment.

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -858,7 +858,17 @@ export class ProjectManager {
   private async stopProject(root: string): Promise<void> {
     const managed = this.projects.get(root);
     if (!managed) return;
-    // Abort in-flight AI fetches FIRST so any pending summarization /
+    // Unsubscribe the file watcher BEFORE anything we await below (TRA-834).
+    // `await managed.initialIndexPromise` can run for tens of seconds on a cold
+    // project, and a still-subscribed watcher keeps firing debounced
+    // `onChanges` handlers throughout it — each one starting a fresh indexing
+    // run against a Store that a sibling stopProject() is closing. Field logs
+    // showed 12 "The database connection is not open" failures, every one of
+    // them after "Daemon shutting down", one project logging five of them over
+    // 27 seconds. Stopping the source of new work first is what makes the
+    // teardown below finite.
+    await managed.watcher.stop();
+    // Abort in-flight AI fetches next so any pending summarization /
     // embedding fetch tears its socket down before we start disposing the
     // store. Without this, a long-running summarize batch can return after
     // the DB has already closed and write into stale references.
@@ -886,7 +896,6 @@ export class ProjectManager {
         'initialIndexPromise rejected during stopProject (non-fatal)',
       );
     }
-    await managed.watcher.stop();
     clearServerPid(managed.db);
     managed.serverHandle.dispose();
     await managed.server.close();

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -858,25 +858,13 @@ export class ProjectManager {
   private async stopProject(root: string): Promise<void> {
     const managed = this.projects.get(root);
     if (!managed) return;
-    // Unsubscribe the file watcher BEFORE anything we await below (TRA-834).
-    // `await managed.initialIndexPromise` can run for tens of seconds on a cold
-    // project, and a still-subscribed watcher keeps firing debounced
-    // `onChanges` handlers throughout it — each one starting a fresh indexing
-    // run against a Store that a sibling stopProject() is closing. Field logs
-    // showed 12 "The database connection is not open" failures, every one of
-    // them after "Daemon shutting down", one project logging five of them over
-    // 27 seconds. Stopping the source of new work first is what makes the
-    // teardown below finite.
-    await managed.watcher.stop();
-    // Abort in-flight AI fetches next so any pending summarization /
-    // embedding fetch tears its socket down before we start disposing the
-    // store. Without this, a long-running summarize batch can return after
-    // the DB has already closed and write into stale references.
+    // Signal every background producer synchronously, before the first await:
+    // abort in-flight AI fetches so a long-running summarize batch cannot
+    // return after the DB has closed and write into stale references, and
+    // cancel the LSP enricher so its run aborts via its AbortSignal. These are
+    // non-blocking, so nothing below can starve them.
     managed.aiAbortController?.abort();
     managed.cancelDebouncedAI?.();
-    // Cancel background LSP enricher BEFORE closing the store so any
-    // in-flight enrichment run aborts via its AbortSignal and won't try to
-    // write into a disposed Store.
     try {
       managed.lspEnricher?.cancel();
     } catch (err) {
@@ -885,6 +873,16 @@ export class ProjectManager {
         'lspEnricher.cancel() failed during stopProject (non-fatal)',
       );
     }
+    // Then unsubscribe the file watcher and drain its in-flight handler BEFORE
+    // the waits below (TRA-834). `await managed.initialIndexPromise` can run
+    // for tens of seconds on a cold project, and a still-subscribed watcher
+    // keeps firing debounced `onChanges` handlers throughout it — each one
+    // starting a fresh indexing run against a Store that a sibling
+    // stopProject() is closing. Field logs showed 12 "The database connection
+    // is not open" failures, every one of them after "Daemon shutting down",
+    // one project logging five of them over 27 seconds. Stopping the source of
+    // new work first is what makes the teardown below finite.
+    await managed.watcher.stop();
     // Wait for the background initial-index chain (indexAll → summarize/embed →
     // subproject auto-sync) to finish so its topology.db handle is closed
     // before we tear down this project — see initialIndexPromise's doc comment.

--- a/src/indexer/watcher.ts
+++ b/src/indexer/watcher.ts
@@ -139,13 +139,18 @@ export class FileWatcher {
    */
   private opQueue: Promise<void> = Promise.resolve();
   /**
-   * The handler run currently executing, if any. Unsubscribing stops future
-   * events and clearing the debounce timer stops a scheduled run, but neither
-   * touches a run whose timer has already fired — that one is mid-`onChanges`,
-   * indexing into a Store the caller is about to close (TRA-834). `stop()`
-   * awaits this so "the watcher is stopped" means no handler is still running.
+   * Handler runs currently executing. Unsubscribing stops future events and
+   * clearing the debounce timer stops a scheduled run, but neither touches a
+   * run whose timer has already fired — that one is mid-`onChanges`, indexing
+   * into a Store the caller is about to close (TRA-834). `stop()` awaits these
+   * so "the watcher is stopped" means no handler is still running.
+   *
+   * A set, not a single reference: nothing serializes handlers, so a second
+   * burst can fire while the first is still indexing. With one slot the second
+   * run overwrites the first and, if it finishes quickly, clears the slot —
+   * `stop()` would then return while the first is still writing.
    */
-  private activeHandler: Promise<void> | null = null;
+  private readonly activeHandlers = new Set<Promise<void>>();
 
   constructor(
     private readonly _setTimeout: typeof setTimeout = setTimeout,
@@ -279,9 +284,9 @@ export class FileWatcher {
             }
           })();
           const tracked: Promise<void> = run.finally(() => {
-            if (this.activeHandler === tracked) this.activeHandler = null;
+            this.activeHandlers.delete(tracked);
           });
-          this.activeHandler = tracked;
+          this.activeHandlers.add(tracked);
         }, debounceMs);
       },
       {
@@ -382,10 +387,10 @@ export class FileWatcher {
     // pass rather than letting it resume against a closed DB.
     this.rescanPending = false;
     if (this.activeRescan) await this.activeRescan;
-    // Same for a handler whose debounce timer had already fired before we got
+    // Same for every handler whose debounce timer had already fired before we got
     // here. Without this the caller closes the DB out from under a running
-    // indexing pass (TRA-834). `run` swallows its own errors, so this can only
-    // wait, never throw.
-    await this.activeHandler;
+    // indexing pass (TRA-834). Each run swallows its own errors, so this can
+    // only wait, never throw.
+    await Promise.all(this.activeHandlers);
   }
 }

--- a/src/indexer/watcher.ts
+++ b/src/indexer/watcher.ts
@@ -138,6 +138,14 @@ export class FileWatcher {
    * settled state left by the previous call.
    */
   private opQueue: Promise<void> = Promise.resolve();
+  /**
+   * The handler run currently executing, if any. Unsubscribing stops future
+   * events and clearing the debounce timer stops a scheduled run, but neither
+   * touches a run whose timer has already fired — that one is mid-`onChanges`,
+   * indexing into a Store the caller is about to close (TRA-834). `stop()`
+   * awaits this so "the watcher is stopped" means no handler is still running.
+   */
+  private activeHandler: Promise<void> | null = null;
 
   constructor(
     private readonly _setTimeout: typeof setTimeout = setTimeout,
@@ -258,16 +266,22 @@ export class FileWatcher {
         for (const p of changed) this.pendingPaths.add(p);
 
         if (this.debounceTimer) this._clearTimeout(this.debounceTimer);
-        this.debounceTimer = this._setTimeout(async () => {
+        this.debounceTimer = this._setTimeout(() => {
           const paths = Array.from(this.pendingPaths);
           this.pendingPaths.clear();
           this.debounceTimer = null;
           logger.debug({ count: paths.length }, 'File changes detected');
-          try {
-            await onChanges(paths);
-          } catch (e) {
-            logger.error({ error: e }, 'File change handler failed');
-          }
+          const run = (async () => {
+            try {
+              await onChanges(paths);
+            } catch (e) {
+              logger.error({ error: e }, 'File change handler failed');
+            }
+          })();
+          const tracked: Promise<void> = run.finally(() => {
+            if (this.activeHandler === tracked) this.activeHandler = null;
+          });
+          this.activeHandler = tracked;
         }, debounceMs);
       },
       {
@@ -368,5 +382,10 @@ export class FileWatcher {
     // pass rather than letting it resume against a closed DB.
     this.rescanPending = false;
     if (this.activeRescan) await this.activeRescan;
+    // Same for a handler whose debounce timer had already fired before we got
+    // here. Without this the caller closes the DB out from under a running
+    // indexing pass (TRA-834). `run` swallows its own errors, so this can only
+    // wait, never throw.
+    await this.activeHandler;
   }
 }

--- a/tests/daemon/project-manager-abort.test.ts
+++ b/tests/daemon/project-manager-abort.test.ts
@@ -185,3 +185,46 @@ describe('ProjectManager.stopProject — AbortSignal teardown', () => {
     expect(signalB.aborted).toBe(true);
   });
 });
+
+/**
+ * TRA-834, Reviewer B finding 2: draining the watcher closed one hole and
+ * opened another. A drained onChanges handler ends by re-arming
+ * debouncedSummarize/debouncedEmbed and scheduling LSP enrichment, and
+ * `trailingDebounce` mints a fresh AbortController when it is scheduled after a
+ * cancel — so the cancel that ran *before* the drain no longer covers those
+ * timers. They would fire ~1s later, against a closed DB.
+ */
+describe('ProjectManager.stopProject — cancels background AI again after the watcher drain', () => {
+  it('cancels debounced AI and the LSP enricher after watcher.stop() resolves', async () => {
+    const pm = new ProjectManager();
+    const callOrder: string[] = [];
+    const fake = makeFakeManaged('/tmp/proj-rearm', callOrder);
+    // A watcher whose stop() drains a handler that re-arms the AI debounces,
+    // exactly as the real onChanges tail does.
+    fake.watcher.stop = vi.fn(async () => {
+      callOrder.push('watcher.stop');
+      callOrder.push('handler-rearms-ai');
+    });
+    // biome-ignore lint/suspicious/noExplicitAny: fake ManagedProject shape
+    (fake as any).lspEnricher = {
+      cancel: vi.fn(() => {
+        callOrder.push('lsp.cancel');
+      }),
+    };
+    injectProject(pm, fake);
+
+    await pm.removeProject('/tmp/proj-rearm');
+
+    // Two cancels: one before the drain (nothing in flight escapes it) and one
+    // after (whatever the drained handler armed).
+    expect(fake.cancelDebouncedAI).toHaveBeenCalledTimes(2);
+    const rearm = callOrder.indexOf('handler-rearms-ai');
+    const lastCancel = callOrder.lastIndexOf('cancelDebouncedAI');
+    const closeIdx = callOrder.indexOf('pipeline.dispose');
+    expect(rearm).toBeGreaterThanOrEqual(0);
+    expect(lastCancel).toBeGreaterThan(rearm);
+    expect(lastCancel).toBeLessThan(closeIdx);
+    // biome-ignore lint/suspicious/noExplicitAny: fake ManagedProject shape
+    expect((fake as any).lspEnricher.cancel).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/indexer/watcher-lifecycle.test.ts
+++ b/tests/indexer/watcher-lifecycle.test.ts
@@ -298,3 +298,63 @@ describe('FileWatcher.stop drains an in-flight change handler (TRA-834)', () => 
     expect(handlerDone).toBe(true);
   });
 });
+
+/**
+ * TRA-834, Reviewer B finding 1: nothing serializes change handlers, so a
+ * second burst can fire while the first is still indexing. With a single
+ * `activeHandler` slot the second run overwrote the first and, finishing
+ * quickly, cleared the slot — `stop()` then returned while the first was still
+ * writing into a Store the caller was about to close.
+ */
+describe('FileWatcher.stop drains ALL in-flight handlers (TRA-834)', () => {
+  it('waits for a slow first handler even after a fast second one finishes', async () => {
+    let deliver: ((events: Array<{ type: string; path: string }>) => Promise<void>) | undefined;
+    vi.mocked(parcelWatcher.subscribe).mockImplementation(async (_dir, cb) => {
+      deliver = (events) =>
+        (cb as (err: Error | null, events: unknown[]) => Promise<void>)(null, events);
+      return { unsubscribe: vi.fn().mockResolvedValue(undefined) };
+    });
+
+    const immediate = ((fn: () => void) => {
+      fn();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof setTimeout;
+    const watcher = new FileWatcher(immediate, (() => {}) as unknown as typeof clearTimeout);
+
+    let releaseSlow: () => void = () => {};
+    let slowDone = false;
+    let call = 0;
+    const onChanges = vi.fn(async () => {
+      call += 1;
+      // First burst blocks; every later burst returns immediately, which is
+      // what used to clear the single tracking slot.
+      if (call === 1) {
+        await new Promise<void>((resolve) => {
+          releaseSlow = () => {
+            slowDone = true;
+            resolve();
+          };
+        });
+      }
+    });
+
+    await watcher.start('/project', mockConfig, onChanges);
+    await deliver?.([{ type: 'update', path: '/project/src/a.ts' }]);
+    await deliver?.([{ type: 'update', path: '/project/src/b.ts' }]);
+    expect(onChanges).toHaveBeenCalledTimes(2);
+
+    let stopped = false;
+    const stopping = watcher.stop().then(() => {
+      stopped = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(slowDone).toBe(false);
+    expect(stopped).toBe(false);
+
+    releaseSlow();
+    await stopping;
+    expect(stopped).toBe(true);
+    expect(slowDone).toBe(true);
+  });
+});

--- a/tests/indexer/watcher-lifecycle.test.ts
+++ b/tests/indexer/watcher-lifecycle.test.ts
@@ -241,3 +241,60 @@ describe('ProjectManager watcher lifecycle', () => {
     expect((pm as any).projects.size).toBe(0);
   });
 });
+
+/**
+ * TRA-834, review finding 1: unsubscribing and clearing the debounce timer says
+ * nothing about a handler whose timer has ALREADY fired. That run is
+ * mid-`onChanges`, indexing into the very Store `stopProject()` closes a few
+ * lines later — the residual half of the "database connection is not open"
+ * race. `stop()` must not resolve until it has settled.
+ */
+describe('FileWatcher.stop drains an in-flight change handler (TRA-834)', () => {
+  it('does not resolve while onChanges is still running', async () => {
+    let deliver: ((events: Array<{ type: string; path: string }>) => Promise<void>) | undefined;
+    vi.mocked(parcelWatcher.subscribe).mockImplementation(async (_dir, cb) => {
+      deliver = (events) =>
+        (cb as (err: Error | null, events: unknown[]) => Promise<void>)(null, events);
+      return { unsubscribe: vi.fn().mockResolvedValue(undefined) };
+    });
+
+    // Fire the debounce synchronously so the handler is genuinely in flight by
+    // the time stop() is called.
+    const immediate = ((fn: () => void) => {
+      fn();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof setTimeout;
+    const watcher = new FileWatcher(immediate, (() => {}) as unknown as typeof clearTimeout);
+
+    let releaseHandler: () => void = () => {};
+    let handlerDone = false;
+    const onChanges = vi.fn(
+      async () =>
+        await new Promise<void>((resolve) => {
+          releaseHandler = () => {
+            handlerDone = true;
+            resolve();
+          };
+        }),
+    );
+
+    await watcher.start('/project', mockConfig, onChanges);
+    await deliver?.([{ type: 'update', path: '/project/src/a.ts' }]);
+    expect(onChanges).toHaveBeenCalledOnce();
+
+    let stopped = false;
+    const stopping = watcher.stop().then(() => {
+      stopped = true;
+    });
+
+    // Several turns of the microtask queue: stop() must still be pending.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(handlerDone).toBe(false);
+    expect(stopped).toBe(false);
+
+    releaseHandler();
+    await stopping;
+    expect(stopped).toBe(true);
+    expect(handlerDone).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

`ProjectManager.stopProject()` unsubscribed the file watcher only *after*
`await managed.initialIndexPromise`. On a cold project that wait runs for tens
of seconds, and the still-subscribed watcher keeps firing debounced
`onChanges` handlers throughout it — each one starting a fresh indexing run
against a `Store` that a sibling `stopProject()` is closing.

The watcher stop now happens first, before anything the teardown awaits.

## Evidence (field, not hypothesis)

From `~/.trace/daemon.log` + `daemon.log.1` (2026-09-03 17:40 → 2026-09-05 00:40,
34 daemon lifetimes):

- 12 × `File change handler failed` / `TypeError: The database connection is not open`
  — **every one of them after** the `Daemon shutting down` line of the same pid.
- pid 90876 logged five of them at +4.5 s, +8.7 s, +13.8 s, +21.6 s, +26.8 s after
  shutdown began — separate debounce timers, i.e. the watcher was still
  subscribed 27 s into teardown.

## Test

`src/daemon/__tests__/project-manager-shutdown-order.test.ts` holds the fake
`indexAll` open and asserts `watcher-stop` is recorded before `index-done`.
Verified it fails on the pre-fix ordering (`expected 2 to be less than 1`).

Full suite: 9941 passed / 22 skipped. `tsc --noEmit` clean.

Found while working TRA-834 (Daemon & Runtime Reliability manual run).

Agent: Lead Engineer