### PR TITLE
fix(launcher): refuse to heal launcher.env when the path is not a regular file

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.6.1 (Windows)
+REM trace-mcp-launcher v0.6.2 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.6.1 (Windows)
+# trace-mcp-launcher v0.6.2 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.
@@ -141,6 +141,13 @@ function Save-LauncherConfig {
     # Never pin the config to a swap-window backup: that directory is about to
     # be deleted, so the "fast path" it buys would be a dangling one.
     if ($Cli -match 'trace-mcp\.tmcp-bak-' -or $Cli -match '[\\/]\.trace-mcp-') { return }
+    # A directory at the config path cannot be replaced by a move: Move-Item
+    # drops the tmp INSIDE it instead, so the heal never lands and every later
+    # start leaves another orphan there that nothing collects (TRA-829).
+    if (Test-Path -LiteralPath $ConfigPath -PathType Container) {
+        Write-LauncherLog ("ERROR: {0} is not a regular file - cannot persist the probed pair; remove it and run: trace-mcp init" -f $ConfigPath)
+        return
+    }
     try {
         if (-not (Test-Path -LiteralPath $TraceHome -PathType Container)) {
             New-Item -ItemType Directory -Path $TraceHome -Force -ErrorAction Stop | Out-Null

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.6.1
+# trace-mcp-launcher v0.6.2
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -381,6 +381,17 @@ heal_config() {
   case "$cli" in
     *trace-mcp.tmcp-bak-*|*/.trace-mcp-*) return 0 ;;
   esac
+  # A config path that is not a regular file — a directory left by a botched
+  # restore or a stray `mkdir`, a socket, a device node — cannot be replaced by
+  # `mv`: POSIX `mv` moves the tmp INSIDE a directory rather than over it. The
+  # heal never lands, so every later start deposits another orphan there, and
+  # nothing collects them: sweepOrphanTmpFilesUnderHome only reads the state
+  # dirs it knows by name, and this one is not among them (TRA-829). Refuse,
+  # and log it as an error — the shim cannot fix this, a human has to.
+  if [ -e "$CONFIG" ] && [ ! -f "$CONFIG" ]; then
+    log "ERROR: $CONFIG is not a regular file — cannot persist the probed pair; remove it and run: trace-mcp init"
+    return 0
+  fi
   if [ ! -d "$TRACE_HOME" ]; then
     mkdir -p "$TRACE_HOME" 2>/dev/null || return 0
     chmod 700 "$TRACE_HOME" 2>/dev/null || true

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -109,4 +109,4 @@ export const MIRROR_HOOK_VERSION = '0.2.0';
 // 0.6.0 (TRA-755): the resolved node is version-gated against engines.node. An
 // older one used to exec fine and die on a SyntaxError the client could only
 // report as "failed to connect" — and get pinned into launcher.env on the way.
-export const LAUNCHER_VERSION = '0.6.1';
+export const LAUNCHER_VERSION = '0.6.2';

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -755,23 +755,41 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
     expect(stderr).not.toMatch(SHELL_DIAGNOSTIC);
   });
 
-  // The heal writes launcher.env through a tmp + rename. A shim killed between
-  // the two leaks that tmp, and only the state sweeper ever collects it — so
-  // the name has to carry the `.tmp.<pid>.<12 hex>` suffix the sweeper matches
-  // on. Before TRA-797 it was `.tmp.<pid>`, which the sweeper never matched.
-  it('the tmp a heal writes is a name the orphan sweeper collects', () => {
+  // The heal writes launcher.env through a tmp + rename, and `mv` onto a
+  // DIRECTORY moves the tmp inside it rather than over it. So a directory at
+  // the config path used to make every single start deposit another orphan
+  // there — unbounded, and collected by nothing: the state sweeper only reads
+  // the directories it knows by name, and `launcher.env/` is not one of them
+  // (TRA-829). The heal has to refuse instead, loudly enough to be found by
+  // the one diagnostic a user is told to run: grep ERROR launcher.log.
+  it('refuses to heal onto a config path that is not a regular file', () => {
     const { home, traceHome } = setupHealingHome();
-    // A directory at the config path makes the rename land INSIDE it instead
-    // of replacing it, which is what exposes the tmp's generated name.
     const configDir = path.join(traceHome, 'launcher.env');
     fs.mkdirSync(configDir);
 
-    runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome });
+    for (let i = 0; i < 3; i++) runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome });
 
-    const leaked = fs.readdirSync(configDir);
-    expect(leaked).toHaveLength(1);
-    // The real assertion: the sweeper that exists to collect these does.
-    expect(sweepOrphanTmpFiles(configDir, 0)).toEqual([path.join(configDir, leaked[0])]);
+    expect(fs.readdirSync(configDir)).toEqual([]);
+    expect(sweepOrphanTmpFiles(configDir, 0)).toEqual([]);
+    const log = fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8');
+    expect(log).toContain(`ERROR: ${configDir} is not a regular file`);
+  });
+
+  // A shim killed between the heal's write and its rename still leaks its tmp
+  // into the state home, where only sweepOrphanTmpFiles collects it — so the
+  // name has to carry the `.tmp.<pid>.<12 hex>` suffix that sweeper matches on.
+  // Before TRA-797 it was `.tmp.<pid>`, which never matched. The window is too
+  // narrow to hit from a test, so the name is asserted where it is built.
+  it('builds its heal tmp with a name the orphan sweeper collects', () => {
+    expect(fs.readFileSync(LAUNCHER_SRC, 'utf-8')).toContain(
+      `tmp="$CONFIG.tmp.$$.$(printf '%04x%04x%04x'`,
+    );
+    // The same shape, resolved — this is what the sweeper is handed on disk.
+    const dir = fs.mkdtempSync(path.join(FIXTURES, 'tmpname-'));
+    const sample = path.join(dir, `launcher.env.tmp.${process.pid}.0123456789ab`);
+    fs.writeFileSync(sample, '');
+    // Negative age: cutoff in the future, so a file written a moment ago counts.
+    expect(sweepOrphanTmpFiles(dir, -1000)).toEqual([sample]);
   });
 
   // A state home the shim cannot write to (read-only volume, root-owned


### PR DESCRIPTION
## What

`mv` onto a **directory** moves the source *inside* it instead of over it (same for PowerShell's `Move-Item`). So when `~/.trace/launcher.env` is a directory rather than a file, the launcher's `heal_config` never landed — and each MCP client start dropped another `launcher.env.tmp.<pid>.<hex>` **inside** `launcher.env/`.

Nothing collects those: `sweepOrphanTmpFilesUnderHome` only reads the state directories it knows by name (`SWEPT_STATE_DIRS`), and `launcher.env/` is not among them. The leak is unbounded, and the config never heals, so every start pays the full probe forever — silently.

TRA-797 hardened the *read* side against exactly this state (`[ -f "$CONFIG" ]`) and used the rename-into-directory behaviour only as a test vehicle. The write side was left inconsistent; this closes it.

## Reproduction

```
mkdir -p ~/.trace/launcher.env      # sandboxed HOME in the actual run
<start the shim 3x>
$ ls -A ~/.trace/launcher.env | wc -l
3                                    # before
0                                    # after
```

## Change

- `hooks/trace-mcp-launcher.sh`, `hooks/trace-mcp-launcher.ps1`: refuse the heal when the config path exists and is not a regular file, and log it as `ERROR`. The shim cannot repair this state — `grep ERROR launcher.log` is the diagnostic users are pointed at, so it belongs there rather than being swallowed.
- Launcher version `0.6.1 → 0.6.2` (all three artifacts + `LAUNCHER_VERSION`) so installed shims pick the fix up on the next `trace-mcp init`.

## Tests

`tests/init/launcher-integration.test.ts`:
- The old *"the tmp a heal writes is a name the orphan sweeper collects"* test asserted the leak as if it were a feature. Replaced with **"refuses to heal onto a config path that is not a regular file"** — three starts, zero files left in `launcher.env/`, ERROR line present.
- The TRA-797 tmp-naming contract it also carried is preserved by a separate test: the shim builds `.tmp.<pid>.<12 hex>`, and a file of that shape is collected by `sweepOrphanTmpFiles`.

Nothing changes on the connection fast path — no behaviour difference when `launcher.env` is a normal file or absent.

Local: `pnpm test` → 9941 passed, 22 skipped. Build + `tsc --noEmit` clean.

Also verified this run (no regressions found, no fix needed): update-window with the package renamed aside (npm-style `.trace-mcp-*` and our `trace-mcp.tmcp-bak-*`), package removed entirely, configured node deleted, garbage/binary `launcher.env`, and a read-only state home. `~/.trace/launcher.log` carries **0** ERROR lines over the last 24h and `claude mcp list` reports trace-mcp connected.

Closes TRA-829 (partially — connection-reliability autopilot).

Agent: Lead Engineer
