### PR TITLE
docs(ops): tokenomics merged, third arrivals window, backend-slot door class

### DIFF
--- a/ops/distribution.md
+++ b/ops/distribution.md
@@ -35,7 +35,7 @@ Rules for keeping it honest:
 | [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) | **Yes** | None | Listed under `Developer Tools`, alphabetical, with the Glama badge and an accurate description | PR to README. Their CONTRIBUTING asks automated agents to append `🤖🤖🤖` to the PR title. Nothing to submit — only re-read the entry when the product's shape changes | 2026-09-01 |
 | [hashgraph-online/awesome-ai-plugins](https://github.com/hashgraph-online/awesome-ai-plugins) | **Yes** | None | Listed under `Community Plugins → Development & Workflow` | PR to README. PR #182 merged 2026-08-31 by `kantorcodes` without requiring third-party scanner action | 2026-09-01 |
 | [aaif-goose/goose](https://github.com/aaif-goose/goose) extension directory | **No — refused, and the directory itself is retired** | None | — | [Issue #11763](https://github.com/aaif-goose/goose/issues/11763) was **closed** 2026-09-02 by `alexhancock` (collaborator): "We aren't taking new submissions for the extensions directory." The reason is not about us — [discussion #10830](https://github.com/aaif-goose/goose/discussions/10830) retires goose's own registry in favour of the official MCP registry and the `server.json` format: "New contributions to the goose registry are halted. Please don't open PRs adding servers; we won't be merging them." The finished branch `nikolai-vysotskyi/goose:add-trace-mcp` was therefore **never opened as a PR** — the issues-first hold in the previous version of this row is what kept us from opening a PR into a closed door. **Do not re-submit and do not push back.** goose says the registry entry will appear in their doc pages automatically once their `server.json` support lands, and we are already in that registry (row above), so this door is covered without further work | 2026-09-04 |
-| [QuesmaOrg/awesome-ai-tokenomics](https://github.com/QuesmaOrg/awesome-ai-tokenomics) | **No — submitted** | None | — | [PR #53](https://github.com/QuesmaOrg/awesome-ai-tokenomics/pull/53), Optimize → Context Engineering, beside Serena and Repomix. An entry is three files: the README line, the same line in `research/optimize.md`, and a record in `research/manifest.json` carrying `verified_on` / `stale_after`. Their `scripts/lint_readme.sh` **fails the build on any em-dash in tracked markdown** and on a list of superlatives (`de facto`, `go-to`, `widely used`, `the leading`, …) — write entries accordingly. Self-submission is allowed but needs a disclosure, checkable primary sources, and an independent adoption signal that is not stars | 2026-09-01 |
+| [QuesmaOrg/awesome-ai-tokenomics](https://github.com/QuesmaOrg/awesome-ai-tokenomics) | **Yes** — merged 2026-09-04 | None | Line 112 of the README, Optimize → Context Engineering, plus the same line in `research/optimize.md` | [PR #53](https://github.com/QuesmaOrg/awesome-ai-tokenomics/pull/53) approved and merged by `bkotrys` (165★ list) after two rounds. **Two corrections came out of his review and both hold outside this listing.** (1) He read `src/analytics/benchmark.ts` and called the entry's "prints per-task token cost with and without the index" a measured claim the code does not support: both sides come from `estimateTokens()` over character counts and the trace-mcp side is a hardcoded fraction per scenario (0.05–0.45). The clause was dropped, not qualified. Do not describe that command as a measurement anywhere else either. (2) **Stop citing npm downloads.** ~40/day through July and most of August, then 1,300–2,000/day on Aug 27–30 — the same four days we published 31 releases. That is mirrors and CI. What convinced him instead was the issue tracker: 15 distinct external accounts filing behavioural reports. Entry format for reference: README line + `research/optimize.md` + a `research/manifest.json` record with `verified_on` / `stale_after`; their `scripts/lint_readme.sh` fails the build on any em-dash in tracked markdown and on a superlative list (`de facto`, `go-to`, `widely used`, `the leading`, …). Self-submission is allowed but needs a disclosure, checkable primary sources, and an independent adoption signal that is not stars | 2026-09-04 |
 | [hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) | **No** | None | — | **Gate met, door still human-only.** Their bar is ≥100 stars *or* 14 days of active development; we passed the star half on 2026-09-01 (102). But CONTRIBUTING is explicit: "ALL RECOMMENDATIONS MUST BE MADE USING THE WEB UI ISSUE FORM TEMPLATE, OR YOU RISK BEING RESTRICTED FROM INTERACTING WITH THIS REPOSITORY", "It is **not** possible to submit a resource recommendation using the `gh` CLI", and "recommendations must be created by human beings". Three of the form's required checkboxes are personal attestations. An agent must not fill this in; the ready-to-paste field values are in TRA-633 | 2026-09-01 |
 | [hashgraph-online/awesome-codex-plugins](https://github.com/hashgraph-online/awesome-codex-plugins) | **No — declined by us** | None | — | Same org that merged us into `awesome-ai-plugins`, and we do ship a Codex plugin, so this looks like the obvious next door. It is not. There the scanner action was *advisory* and we were merged without it; here CONTRIBUTING step 1 is "Set up scanner CI in your plugin repo (required) … This is not optional. We verify this during review" — `hashgraph-online/ai-plugin-scanner-action@v1` committed into our workflows, plus `pipx install plugin-scanner` run locally. Both are the thing we already refused. **Closed unless their gate changes** | 2026-09-01 |
 | [cursor.directory](https://cursor.directory) (`pontusab/directories`) | **No** | None | — | Repo holds no listing data ("All content is submitted through the website"); submission is `cursor.directory/plugins/new` behind GitHub or Google sign-in, so it is human-only like Smithery. Worth knowing anyway: they auto-detect components from a repo following the [Open Plugins](https://open-plugins.com) spec, and the MCP hook is a **`.mcp.json` at the repo root**. Ours lived only at `.claude-plugin/.mcp.json`. **2026-09-02 (TRA-634):** repo root now carries `plugin.json` + `mcp.json` per the Agent Plugins v1.0.0 spec, re-read at source that day (`agent-plugins.org/plugin-builders/specification`: manifest at `plugin.json`, MCP config at `mcp.json`, both at plugin root); `skills/*/SKILL.md` already matched. **Not verified that Cursor's scanner accepts it** — the only way to check is to feed it the repo through the logged-in form, and their own README still names a dotted `.mcp.json` and no `plugin.json`, so spec and scanner may disagree. We did not add a root `.mcp.json`: Claude Code reads that path as project-scoped MCP config, so it would change behaviour for anyone who clones the repo. Next step is Nikolai submitting, then reading back what the scanner detected | 2026-09-02 |
@@ -84,6 +84,16 @@ gh api repos/nikolai-vysotskyi/trace-mcp/traffic/views
 Google 37 uniques, reddit.com 31, trace-mcp.com 17, github.com 8,
 my.feishu.cn 1, l.threads.com 2, Bing 3, yandex.ru 1, DuckDuckGo 1,
 claude.ai 1.
+
+**Reading, 2026-09-04** — 796 views / 192 uniques over the trailing 14 days,
+104 stars: Google 36 uniques, reddit.com 33, trace-mcp.com 19, github.com 10,
+Bing 4, l.threads.com 2, my.feishu.cn 1, yandex.ru 1, DuckDuckGo 1,
+**chatgpt.com 1** (new, and the first referrer of its kind). Same shape as the
+two readings below, two days on and with a merged listing in between: still not
+one directory in the list. Three windows now agree, so a fourth reading is not
+what settles this question — treat the conclusion as established and spend the
+run elsewhere unless a surface we submit to is one an agent reads rather than a
+human clicks.
 
 **Not one of the twelve surfaces in the table appears.** No glama.ai, no
 pulsemcp.com, no mcpservers.org, no mcpmarket.com, no
@@ -413,11 +423,52 @@ Not blockers to route around — genuinely outside what an agent may do alone:
 **That sentence was true of MCP catalogues, and false of the wider list
 ecosystem** (2026-09-01). Two doors an agent can finish were found in one pass by
 searching README files for a competitor's repo path (`oraios/serena`) instead of
-for MCP directories: `aaif-goose/goose`'s extension directory (issue #11763 open,
-PR written and waiting on their Ready gate — TRA-631) and
-`QuesmaOrg/awesome-ai-tokenomics` (PR #53 open — TRA-632). Both are plain files
-in public repos with no account, payment or attestation anywhere. The exhausted
-list was the list of *MCP directories*, not the list of places our audience reads.
+for MCP directories: `aaif-goose/goose`'s extension directory and
+`QuesmaOrg/awesome-ai-tokenomics`. Both are plain files in public repos with no
+account, payment or attestation anywhere. The exhausted list was the list of
+*MCP directories*, not the list of places our audience reads.
+
+**Outcome of those two, 2026-09-04.** One in, one closed: the tokenomics PR
+merged (row above, TRA-632), goose closed its directory to all new submissions
+(row above, TRA-631). That is the realistic hit rate for the method, and the
+merged one took two review rounds in which the maintainer read our source and
+found a claim we could not support. Repeat the search — READMEs naming a
+competitor's repo path — rather than searching for directories; but read the
+Arrivals column first, because neither of these has sent a visitor yet.
+
+### A door class this ledger did not have: someone else's backend slot (2026-09-04)
+
+Same search method, different reading of the results. Several of the READMEs
+that name `oraios/serena` are not lists at all — they are tools that *install* a
+code-navigation MCP server on the user's behalf, which makes them distribution
+without a listing: the user never chooses us, the wrapper does.
+
+**[`headroomlabs-ai/headroom`](https://github.com/headroomlabs-ai/headroom)**
+(68.9k★, pushed daily) is the developed case and has **two** such slots:
+
+- `--code-memory` — a `click.Choice` in `headroom/cli/wrap.py`
+  (`_VALID_CODE_MEMORY`) whose only real member is `serena`, installed by
+  default when you run `headroom wrap` and registered at user scope in
+  `~/.claude.json`.
+- `--code-graph` — currently hard-wired to `DeusData/codebase-memory-mcp`.
+  [Issue #1009](https://github.com/headroomlabs-ai/headroom/issues/1009) asks
+  for that to become pluggable and names `codegraph` as the second candidate.
+  Open since 2026-06-15, labelled `Low`, **zero comments** until ours on
+  2026-09-04, which is where we made the case for the interface, added the
+  criterion their table was missing (tool-schema count, the one thing a
+  compression proxy cannot fix downstream) and offered to write the adapter.
+  Tracked in TRA-853.
+
+Why this class is worth more than a directory row: it ends in an install, not a
+link, so the Arrivals objection above does not apply to it. Cost is higher —
+it is code and a maintainer's review, not a README line — and the outcome is
+theirs to decide.
+
+Two more of the same shape, unexplored, for the next run: `Mibayy/token-savior`
+(1.1k★) publishes a compatibility matrix with a per-tool row telling users how
+to configure it *alongside* each navigator, so inclusion there is functional
+rather than promotional; and `gglucass/headroom-desktop` (535★) ships the same
+opt-in add-on table as headroom itself and is likely one door with it, not two.
 
 The paragraph below still holds for the MCP directories themselves:
 


### PR DESCRIPTION
Ledger-only change from the TRA-831 outreach run. No code.

- `QuesmaOrg/awesome-ai-tokenomics` PR #53 **merged** 2026-09-04. Row flipped to Yes, and both of the maintainer's corrections recorded because they apply outside that listing: `benchmark` is an estimator (do not call it a measurement anywhere), and npm download counts are mirrors/CI rather than users.
- Arrivals column: third 14-day window (796 views / 192 uniques, 104 stars). Still no directory referrer of any kind. Three windows agree, so the section now says to stop re-reading it.
- New subsection under *Next door to try*: wrappers that install a code-navigation MCP server on the user's behalf (`headroom`'s `--code-memory` / `--code-graph` slots). That door ends in an install rather than a link, which is the one class the Arrivals finding does not rule out. Tracked in TRA-853.
- `Next door to try` updated with the outcome of the two doors it opened: one merged, one closed.

Agent: Growth & Outreach Agent