### PR TITLE
test(tools): enforce cross-tool routing hints with a family drift gate (TRA-842)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,10 @@ For `search_text`, `grouping: "by_file"` is the default (lossless path-dedup in 
 
 Other tools are NOT TOON-enabled — they regressed in measurements (heterogeneous payloads with nested objects or arrays land in TOON's list mode, which costs more tokens than JSON). Don't pass `output_format: "toon"` to a tool not on this list; it will be rejected by schema validation. Drift guardrail: `src/tools/register/__tests__/toon-drift.test.ts` keeps the schema, description, and allowlist in sync.
 
+### Cross-tool routing hints
+
+Tools that overlap (`search` / `search_text` / `find_usages` / `get_feature_context`, the context family, the impact family) point at each other in their descriptions. That prose is the only routing mechanism reaching every MCP client — the PreToolUse guard hook is Claude Code only, `src/init/ide-rules.ts` covers Cursor/Windsurf. The families are declared in `src/tools/tool-families.ts`, enforced by `src/tools/register/__tests__/family-routing-drift.test.ts`, and protected from the `description_verbosity: minimal` collapse. Adding a tool to one of those families means adding a sibling pointer to its description — and trimming elsewhere to keep net description bytes flat.
+
 ## Plugin & LSP Architecture
 
 ### Plugin architecture

--- a/src/server/__tests__/tool-gate-verbosity.test.ts
+++ b/src/server/__tests__/tool-gate-verbosity.test.ts
@@ -64,4 +64,28 @@ describe('description_verbosity strips param prose from the emitted schema', () 
     applySchemaTransforms(args, cfg('minimal'));
     expect(args[1]).toBe('First sentence.');
   });
+
+  it('keeps the cross-tool routing sentence at minimal for a family member', () => {
+    // TRA-842: the description is the only routing mechanism that reaches every
+    // client, so the collapse must not drop the sibling pointer.
+    const args: unknown[] = [
+      'search',
+      'Search symbols by name. Padding sentence. For raw text use search_text. Returns JSON.',
+      {},
+      () => undefined,
+    ];
+    applySchemaTransforms(args, cfg('minimal'));
+    expect(args[1]).toBe('Search symbols by name. For raw text use search_text.');
+  });
+
+  it('drops trailing prose at minimal for a tool in no family', () => {
+    const args: unknown[] = [
+      'demo_tool',
+      'First sentence. For raw text use search_text.',
+      {},
+      () => undefined,
+    ];
+    applySchemaTransforms(args, cfg('minimal'));
+    expect(args[1]).toBe('First sentence.');
+  });
 });

--- a/src/server/tool-gate-helpers.ts
+++ b/src/server/tool-gate-helpers.ts
@@ -15,7 +15,7 @@ import { z } from 'zod';
 import type { TraceMcpConfig } from '../config.js';
 import type { SessionJournal } from '../session/journal.js';
 import type { SessionTracker } from '../session/tracker.js';
-import { allSiblings } from '../tools/tool-families.js';
+import { allSiblings, routesTo } from '../tools/tool-families.js';
 import type { JournalEntryCallbackData } from './journal-broadcast.js';
 import { getGlobalTelemetrySink } from '../telemetry/index.js';
 import { ALWAYS_LOAD_TOOLS } from '../tools/project/presets.js';
@@ -90,7 +90,7 @@ function applyVerbosity(name: string, description: string, verbosity: string): s
   const routing = description
     .slice(first.length)
     .split(/(?<=\.)\s+/)
-    .find((sentence) => siblings.some((s) => sentence.includes(s)));
+    .find((sentence) => siblings.some((s) => routesTo(sentence, s)));
   return routing ? `${first} ${routing.trim()}` : first;
 }
 

--- a/src/server/tool-gate-helpers.ts
+++ b/src/server/tool-gate-helpers.ts
@@ -15,6 +15,7 @@ import { z } from 'zod';
 import type { TraceMcpConfig } from '../config.js';
 import type { SessionJournal } from '../session/journal.js';
 import type { SessionTracker } from '../session/tracker.js';
+import { allSiblings } from '../tools/tool-families.js';
 import type { JournalEntryCallbackData } from './journal-broadcast.js';
 import { getGlobalTelemetrySink } from '../telemetry/index.js';
 import { ALWAYS_LOAD_TOOLS } from '../tools/project/presets.js';
@@ -70,12 +71,27 @@ export interface SchemaTransformConfig {
   sharedParamOverrides: Record<string, string>;
 }
 
-/** Collapse a tool description according to the configured verbosity level. */
-function applyVerbosity(description: string, verbosity: string): string {
+/**
+ * Collapse a tool description according to the configured verbosity level.
+ *
+ * `minimal` keeps the first sentence — plus, for members of a declared tool
+ * family, the sentence that names a sibling. That clause is the only routing
+ * mechanism that reaches every MCP client (TRA-842), so it is a protected
+ * region rather than trailing prose the collapse is free to drop.
+ */
+function applyVerbosity(name: string, description: string, verbosity: string): string {
   if (verbosity === 'full') return description;
   if (verbosity === 'none') return '';
   const match = description.match(/^[^.]*\./);
-  return match ? match[0] : description.split('\n')[0];
+  const first = match ? match[0] : description.split('\n')[0];
+
+  const siblings = allSiblings(name);
+  if (siblings.length === 0) return first;
+  const routing = description
+    .slice(first.length)
+    .split(/(?<=\.)\s+/)
+    .find((sentence) => siblings.some((s) => sentence.includes(s)));
+  return routing ? `${first} ${routing.trim()}` : first;
 }
 
 /** Rewrite the description argument (index 1) with any configured override. */
@@ -159,7 +175,7 @@ export function applySchemaTransforms(args: unknown[], cfg: SchemaTransformConfi
   applyDescriptionOverrides(args, cfg);
 
   if (cfg.descriptionVerbosity !== 'full' && typeof args[1] === 'string') {
-    args[1] = applyVerbosity(args[1] as string, cfg.descriptionVerbosity);
+    args[1] = applyVerbosity(args[0] as string, args[1] as string, cfg.descriptionVerbosity);
   }
 
   if (cfg.descriptionVerbosity === 'minimal' || cfg.descriptionVerbosity === 'none') {

--- a/src/tools/register/__tests__/family-routing-drift.test.ts
+++ b/src/tools/register/__tests__/family-routing-drift.test.ts
@@ -7,7 +7,7 @@
  * Modelled on toon-drift.test.ts.
  */
 import { describe, expect, it } from 'vitest';
-import { TOOL_FAMILIES, familySiblings } from '../../tool-families.js';
+import { TOOL_FAMILIES, familySiblings, routesTo } from '../../tool-families.js';
 import { captureAllTools } from './_capture-tools.js';
 
 describe('cross-tool routing hint drift guardrail', () => {
@@ -28,7 +28,7 @@ describe('cross-tool routing hint drift guardrail', () => {
         const description = byName.get(member);
         if (!description) continue;
         const siblings = members.filter((m) => m !== member);
-        if (!siblings.some((s) => description.includes(s))) {
+        if (!siblings.some((s) => routesTo(description, s))) {
           gaps.push(`  - ${member} (family "${family}") names none of: ${siblings.join(', ')}`);
         }
       }
@@ -38,6 +38,7 @@ describe('cross-tool routing hint drift guardrail', () => {
         `Routing hint drift — a tool description lost (or never had) its sibling pointer:\n${gaps.join('\n')}\n\n` +
           'Fix by adding a natural routing clause to the description, e.g.\n' +
           '  "For raw text/comment search use search_text; for references to a known symbol use find_usages."\n' +
+          'It must read "use / prefer / with <tool>" — see routesTo() for why a bare mention is not enough.\n' +
           'Keep it prose, not a mechanical list — and keep net description bytes flat by trimming elsewhere.\n' +
           'If the tool genuinely does not overlap, remove it from TOOL_FAMILIES in src/tools/tool-families.ts.',
       );

--- a/src/tools/register/__tests__/family-routing-drift.test.ts
+++ b/src/tools/register/__tests__/family-routing-drift.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Drift guardrail: every member of a declared tool family (src/tools/tool-families.ts)
+ * must name at least one sibling of THAT family in its description. Catches a new
+ * family member that points at nobody, and a description trimmed for token budget
+ * that lost its routing clause.
+ *
+ * Modelled on toon-drift.test.ts.
+ */
+import { describe, expect, it } from 'vitest';
+import { TOOL_FAMILIES, familySiblings } from '../../tool-families.js';
+import { captureAllTools } from './_capture-tools.js';
+
+describe('cross-tool routing hint drift guardrail', () => {
+  const tools = captureAllTools();
+  const byName = new Map(tools.map((t) => [t.name, t.description]));
+
+  it('every declared family member is a registered tool', () => {
+    const missing = Object.entries(TOOL_FAMILIES).flatMap(([family, members]) =>
+      members.filter((m) => !byName.has(m)).map((m) => `${family}: ${m}`),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('every family member names at least one sibling of that family', () => {
+    const gaps: string[] = [];
+    for (const [family, members] of Object.entries(TOOL_FAMILIES)) {
+      for (const member of members) {
+        const description = byName.get(member);
+        if (!description) continue;
+        const siblings = members.filter((m) => m !== member);
+        if (!siblings.some((s) => description.includes(s))) {
+          gaps.push(`  - ${member} (family "${family}") names none of: ${siblings.join(', ')}`);
+        }
+      }
+    }
+    if (gaps.length > 0) {
+      throw new Error(
+        `Routing hint drift — a tool description lost (or never had) its sibling pointer:\n${gaps.join('\n')}\n\n` +
+          'Fix by adding a natural routing clause to the description, e.g.\n' +
+          '  "For raw text/comment search use search_text; for references to a known symbol use find_usages."\n' +
+          'Keep it prose, not a mechanical list — and keep net description bytes flat by trimming elsewhere.\n' +
+          'If the tool genuinely does not overlap, remove it from TOOL_FAMILIES in src/tools/tool-families.ts.',
+      );
+    }
+  });
+
+  it('familySiblings() reports every family a multi-family tool belongs to', () => {
+    // find_usages sits in both the search and impact families; its description
+    // must satisfy each independently.
+    expect(familySiblings('find_usages')).toHaveLength(2);
+  });
+});

--- a/src/tools/register/framework.ts
+++ b/src/tools/register/framework.ts
@@ -265,7 +265,7 @@ export function registerFrameworkTools(server: McpServer, ctx: ServerContext): v
 
   server.tool(
     'find_usages',
-    'Find all places that reference a symbol or file (imports, calls, renders, dispatches). Use instead of Grep for symbol usages — understands semantic relationships, not just text matches. For bidirectional call graph use get_call_graph instead. By default, weakly-grounded `text_matched` edges into a target whose simple name collides with many other symbols are dropped (phantom god-node filter). Pass `include_ambiguous_text_matched: true` to keep them. Read-only. Returns JSON: { references: [{ file, line, kind, context }], total, ambiguous_filtered? }.',
+    'Find all places that reference a symbol or file (imports, calls, renders, dispatches). Use instead of Grep for symbol usages — semantic, not text matches. For raw text use search_text; for a bidirectional call graph use get_call_graph. By default, weakly-grounded `text_matched` edges into a target whose simple name collides with many other symbols are dropped (phantom god-node filter). Pass `include_ambiguous_text_matched: true` to keep them. Read-only. Returns JSON: { references: [{ file, line, kind, context }], total, ambiguous_filtered? }.',
     {
       symbol_id: optionalNonEmptyString(512).describe('Symbol ID to find references for'),
       fqn: optionalNonEmptyString(512).describe('Fully qualified name to find references for'),

--- a/src/tools/register/navigation/context-tools.ts
+++ b/src/tools/register/navigation/context-tools.ts
@@ -27,7 +27,7 @@ export function registerContextTools(server: McpServer, ctx: ServerContext): voi
 
   server.tool(
     'get_context_bundle',
-    "Get a symbol's source code + its import dependencies + optional callers, packed within a token budget. Supports batch queries with shared-import deduplication. Use instead of chaining get_symbol calls — deduplicates shared imports across symbols. For a single symbol without imports, get_symbol is lighter. Read-only. Returns JSON: { primary: [{ symbol_id, file, source }], imports: [{ file, source }], token_usage }.",
+    "Get a symbol's source code + its import dependencies + optional callers, packed within a token budget. Supports batch queries with shared-import deduplication. Use instead of chaining get_symbol calls. For a single symbol without imports, use get_symbol — lighter. Read-only. Returns JSON: { primary: [{ symbol_id, file, source }], imports: [{ file, source }], token_usage }.",
     {
       symbol_id: optionalNonEmptyString(512).describe('Single symbol ID'),
       symbol_ids: z

--- a/src/tools/register/navigation/lookup-tools.ts
+++ b/src/tools/register/navigation/lookup-tools.ts
@@ -266,7 +266,7 @@ export function registerLookupTools(server: McpServer, ctx: ServerContext): void
 
   server.tool(
     'get_change_impact',
-    'Full change impact report: risk score + mitigations, breaking change detection, enriched dependents (complexity, coverage, exports), module groups, affected tests, co-change hidden couplings. Supports diff-aware mode via symbol_ids to scope analysis to only changed symbols. Use before modifying code to understand blast radius. For quick risk assessment without full report, use assess_change_risk instead. Read-only. Returns JSON: { risk, dependents, affectedTests, breakingChanges, totalAffected }.',
+    'Full change impact report: risk score + mitigations, breaking change detection, enriched dependents (complexity, coverage, exports), module groups, affected tests, co-change hidden couplings. Pass symbol_ids to scope analysis to changed symbols only. Use before modifying code to understand blast radius. For a quick risk score alone use assess_change_risk; for who-calls-what use get_call_graph. Read-only. Returns JSON: { risk, dependents, affectedTests, breakingChanges, totalAffected }.',
     {
       file_path: optionalNonEmptyString(512).describe('Relative file path to analyze'),
       symbol_id: optionalNonEmptyString(512).describe('Symbol ID to analyze'),

--- a/src/tools/tool-families.ts
+++ b/src/tools/tool-families.ts
@@ -36,3 +36,22 @@ export function familySiblings(tool: string): string[][] {
 export function allSiblings(tool: string): string[] {
   return [...new Set(familySiblings(tool).flat())];
 }
+
+/**
+ * Does `text` route the reader to `sibling`, as opposed to merely containing
+ * its name?
+ *
+ * A bare substring test is not enough in either direction. `search_text`'s own
+ * first sentence — "Full-text search across all indexed files" — contains the
+ * word "search", which would let the drift gate pass a description that lost
+ * its routing clause. And `get_task_context` mentions `get_symbol` mid-sentence
+ * while narrating what it replaces ("replaces manual chaining of search →
+ * get_symbol → Read"), which is not the sentence a collapsed description should
+ * keep.
+ *
+ * So the convention is the imperative the existing hints already use: a routing
+ * clause reads "… use / prefer / with <tool>". Write new hints that way.
+ */
+export function routesTo(text: string, sibling: string): boolean {
+  return new RegExp(`\\b(?:use|prefer|with)\\s+${sibling}\\b`, 'i').test(text);
+}

--- a/src/tools/tool-families.ts
+++ b/src/tools/tool-families.ts
@@ -1,0 +1,38 @@
+/**
+ * Overlapping tool families — sets of tools an agent could plausibly reach for
+ * interchangeably. Every member's description must name at least one sibling of
+ * each family it belongs to, so the description text keeps steering the agent to
+ * the right tool.
+ *
+ * This matters because the description is the ONLY routing mechanism that
+ * reaches every client: the PreToolUse guard hook is Claude Code only,
+ * `src/init/ide-rules.ts` covers Cursor/Windsurf, and a large share of installs
+ * report a client we cannot identify at all.
+ *
+ * Enforced by `src/tools/register/__tests__/family-routing-drift.test.ts`.
+ * Also read by `src/server/tool-gate-helpers.ts`, which keeps the routing
+ * sentence when `tools.description_verbosity` collapses descriptions.
+ */
+export const TOOL_FAMILIES: Record<string, readonly string[]> = {
+  search: ['search', 'search_text', 'find_usages', 'get_feature_context'],
+  context: [
+    'get_task_context',
+    'get_feature_context',
+    'get_context_bundle',
+    'get_symbol',
+    'get_outline',
+  ],
+  impact: ['get_call_graph', 'get_change_impact', 'find_usages'],
+};
+
+/** Families `tool` belongs to, as sibling lists (the tool itself excluded). */
+export function familySiblings(tool: string): string[][] {
+  return Object.values(TOOL_FAMILIES)
+    .filter((members) => members.includes(tool))
+    .map((members) => members.filter((m) => m !== tool));
+}
+
+/** Flat set of every family sibling of `tool`, across all its families. */
+export function allSiblings(tool: string): string[] {
+  return [...new Set(familySiblings(tool).flat())];
+}


### PR DESCRIPTION
Closes TRA-842.

## Problem

Tool descriptions already carry good routing hints (`search` → "For raw text/comment search use `search_text`; for references to a known symbol use `find_usages`"). Nothing enforced them. They were written by hand, one tool at a time, and no test knew they existed — so a new family member could name nobody, and a verbosity trim could drop the clause as if it were padding. The description is the **only** routing mechanism that reaches every client: the PreToolUse guard hook is Claude Code only, `src/init/ide-rules.ts` covers Cursor/Windsurf.

## Change

1. **`src/tools/tool-families.ts`** — the overlapping families declared in one place: `search` (search, search_text, find_usages, get_feature_context), `context` (get_task_context, get_feature_context, get_context_bundle, get_symbol, get_outline), `impact` (get_call_graph, get_change_impact, find_usages).
2. **`src/tools/register/__tests__/family-routing-drift.test.ts`** — modelled on `toon-drift.test.ts`. Every member must name at least one sibling of *each* family it belongs to (`find_usages` is in two and must satisfy both).
3. **Two real gaps closed**, found by the new test on the existing surface:
   - `find_usages` named `get_call_graph` (impact family) but no search-family sibling → now points at `search_text` too.
   - `get_change_impact` named only `assess_change_risk`, which is in no declared family → now points at `get_call_graph`.
   Both edits pay for themselves by trimming wordier prose in the same descriptions, so net bytes went *down*.
4. **Protected region in the verbosity collapse** — `description_verbosity: minimal` kept only the first sentence, which is exactly where the routing clause lived. `applyVerbosity` now also keeps the sentence naming a sibling, for family members only. Tools in no family are unchanged.

## `tools/list` bytes, shipped default preset (`minimal`, 28 tools)

Measured with the same reconstruction `preset-surface-budget.test.ts` uses (`name` + `description` + `z.toJSONSchema`):

| | before | after | delta |
|---|---|---|---|
| description chars | 11,150 | 11,090 | **−60** |
| full payload chars | 34,257 | 34,197 | **−60** |
| `full` preset payload | 162,387 | 162,327 | −60 |

Constraint met: net description bytes did not grow. Both three-plus-member families are now complete without paying tokens for it.

## Test evidence

The gate fails when a sibling reference is deleted — demonstrated by removing the routing clause from `search`'s description:

```
Error: Routing hint drift — a tool description lost (or never had) its sibling pointer:
  - search (family "search") names none of: search_text, find_usages, get_feature_context
```

Restored, then full suite: `899 passed | 3 skipped (902)` files, `9949 passed | 22 skipped (9971)` tests. `pnpm run build`, `pnpm run lint` (tsc --noEmit) and `biome format` clean.

Agent: Lead Engineer

---

Follow-up to #880, which filed this issue but implements none of it — the duplicate-PR check flags the shared issue reference, not shared work.

## Review round (Reviewer B, needs-work → fixed)

Two confirmed findings, both in sibling detection, both fixed in `211b18d6`:

1. The drift gate passed when `search_text` lost its routing clause — its own first sentence ("Full-text search across all indexed files") contains the English word "search", satisfying a substring test against the sibling `search`.
2. `applyVerbosity` kept the wrong sentence for `get_task_context` and `get_context_bundle` — both mention a sibling mid-sentence before the actual pointer, and `.find()` stops at the first match.

Fixed with one shared predicate rather than two heuristics: `routesTo()` in `src/tools/tool-families.ts` requires the imperative the existing hints already use — `use` / `prefer` / `with <tool>`. `get_context_bundle`'s second pointer was reworded to match ("For a single symbol without imports, use get_symbol — lighter"), paid for by dropping a clause that repeated the dedup claim.

Verified: deleting `search_text`'s clause now fails the gate, and all ten family members emit the correct routing sentence at `description_verbosity: minimal`. Suite still 9,949 passed.
