### PR TITLE
fix(daemon): stop reporting requested shutdowns as exit=1 (TRA-849)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2980,10 +2980,7 @@ program
       // that await is the cost, instead of us guessing.
       const projectsStopStartedAt = Date.now();
       await projectManager.shutdown();
-      logger.info(
-        { elapsedMs: Date.now() - projectsStopStartedAt },
-        'Projects stopped',
-      );
+      logger.info({ elapsedMs: Date.now() - projectsStopStartedAt }, 'Projects stopped');
       // Drop our PID registration last: while it exists, clients treat the
       // daemon as alive-but-busy and refuse to restart it (TRA-421). Stop the
       // re-assert first — httpServer.close() below waits on live SSE sessions,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@
 import { hardenStdio } from './server/transport-hardening.js';
 import { installProcessSafetyNet } from './server/process-safety-net.js';
 import { startParentDeathWatch } from './server/parent-death-watch.js';
-import { armBoundedExit } from './server/bounded-shutdown.js';
+import { armBoundedExit, DAEMON_SHUTDOWN_DEADLINE_MS } from './server/bounded-shutdown.js';
 import {
   clearOwnDaemonPidFile,
   logPreviousExit,
@@ -517,7 +517,15 @@ program
       // — only SIGKILL worked. Arm a bounded hard-exit so a wedged session
       // cannot outlive its shutdown signal. Unref'd, so it never keeps the
       // process alive on its own.
-      armBoundedExit(reason);
+      // TRA-849: exit 0 — every reason that reaches here is a requested stop
+      // (signal, or the client closing stdin). Blowing the deadline means our
+      // cleanup ran long, not that the session crashed.
+      armBoundedExit(reason, {
+        exitCode: 0,
+        onTimeout: () => {
+          logger.warn({ reason }, 'Session shutdown exceeded its deadline — forcing exit');
+        },
+      });
       try {
         await session.shutdown(reason);
       } catch (err) {
@@ -2900,7 +2908,32 @@ program
       // close hangs or the event loop is starved, the daemon would never die on
       // a legitimate SIGTERM. Arm a bounded hard-exit so termination is
       // guaranteed within a bounded time. Unref'd — never keeps the process up.
-      armBoundedExit(reason ?? 'unknown');
+      // TRA-849: exit 0, not 1. Everything reaching `shutdown()` is a requested
+      // stop (SIGTERM/SIGINT/idle-exit); overrunning the deadline says our
+      // cleanup was slow, not that the daemon died. Exit 1 made launchd log a
+      // failed exit, `daemon status` report `last exit: 1`, and — because the
+      // forced exit skips `recordDaemonCleanStop()` below — the clean-stop
+      // telemetry count 56% of ordinary stops as unclean deaths. So record the
+      // clean stop and drop the PID file here too: both are what the graceful
+      // path would have done, and both are cheap and synchronous.
+      const shutdownStartedAt = Date.now();
+      armBoundedExit(reason ?? 'unknown', {
+        deadlineMs: DAEMON_SHUTDOWN_DEADLINE_MS,
+        exitCode: 0,
+        onTimeout: () => {
+          logger.warn(
+            {
+              reason: reason ?? 'unknown',
+              deadlineMs: DAEMON_SHUTDOWN_DEADLINE_MS,
+              elapsedMs: Date.now() - shutdownStartedAt,
+            },
+            'Graceful shutdown exceeded its deadline — forcing exit',
+          );
+          clearInterval(pidReassert);
+          clearOwnDaemonPidFile();
+          recordDaemonCleanStop();
+        },
+      });
       // Close SSE connections
       for (const res of sseConnections) {
         try {
@@ -2940,7 +2973,17 @@ program
       clearInterval(activityPoker);
       clearInterval(rateBucketCleanup);
       clearInterval(clientSweep);
+      // TRA-849: which phase eats the shutdown budget is not answerable from
+      // the log today — we only know the total sometimes exceeded 5s. Time the
+      // one phase that can block on real work (`stopProject` awaits each
+      // project's in-flight initial index) so the next field log says whether
+      // that await is the cost, instead of us guessing.
+      const projectsStopStartedAt = Date.now();
       await projectManager.shutdown();
+      logger.info(
+        { elapsedMs: Date.now() - projectsStopStartedAt },
+        'Projects stopped',
+      );
       // Drop our PID registration last: while it exists, clients treat the
       // daemon as alive-but-busy and refuse to restart it (TRA-421). Stop the
       // re-assert first — httpServer.close() below waits on live SSE sessions,
@@ -2950,7 +2993,10 @@ program
       clearOwnDaemonPidFile();
       // Reaching here at all is what makes this stop "clean" (TRA-671).
       recordDaemonCleanStop();
-      httpServer.close(() => process.exit(0));
+      httpServer.close(() => {
+        logger.info({ elapsedMs: Date.now() - shutdownStartedAt }, 'Daemon shutdown complete');
+        process.exit(0);
+      });
     };
     process.on('SIGINT', shutdown);
     process.on('SIGTERM', shutdown);

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -43,7 +43,9 @@ const PLIST_VERSION = 4;
  * shutdown closes DBs, tears down watchers and flushes indexes for every
  * registered project; on a machine with O(40) projects that does not fit in
  * launchd's 5s default. Must exceed the daemon's own bounded hard-exit
- * (src/server/bounded-shutdown.ts) so *we* decide when to give up, not launchd.
+ * (`DAEMON_SHUTDOWN_DEADLINE_MS`, src/server/bounded-shutdown.ts) so *we*
+ * decide when to give up, not launchd — asserted by
+ * tests/scripts/postinstall-control-plane.test.ts.
  */
 const PLIST_EXIT_TIMEOUT_SEC = 30;
 const PLIST_MARKER = `trace-mcp plist v${PLIST_VERSION}`;

--- a/src/server/__tests__/bounded-shutdown.test.ts
+++ b/src/server/__tests__/bounded-shutdown.test.ts
@@ -76,9 +76,7 @@ describe('armBoundedExit', () => {
     expect(exitFn).toHaveBeenCalledWith(0);
     // Order matters: the hook records the clean stop and drops the PID file,
     // which is pointless after the process is gone.
-    expect(onTimeout.mock.invocationCallOrder[0]).toBeLessThan(
-      exitFn.mock.invocationCallOrder[0],
-    );
+    expect(onTimeout.mock.invocationCallOrder[0]).toBeLessThan(exitFn.mock.invocationCallOrder[0]);
   });
 
   it('still exits when onTimeout throws', () => {

--- a/src/server/__tests__/bounded-shutdown.test.ts
+++ b/src/server/__tests__/bounded-shutdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { armBoundedExit } from '../bounded-shutdown.js';
+import { armBoundedExit, DAEMON_SHUTDOWN_DEADLINE_MS } from '../bounded-shutdown.js';
 
 // Issue #236 defect 2 (and #237 daemon path): SIGTERM'd sessions/daemons
 // survived because graceful shutdown could hang (a drain that never resolves,
@@ -51,5 +51,60 @@ describe('armBoundedExit', () => {
       },
     });
     expect(capturedMs).toBe(5_000);
+  });
+
+  // TRA-849: the forced exit reported code 1 on stops the user asked for. On a
+  // real machine 15 of 27 SIGTERM stops with a launchd post-mortem exited 1 —
+  // launchd logged a failed exit and `daemon status` said `last exit: 1` for a
+  // daemon that was simply told to stop.
+  it('exits with the caller-chosen code, and runs onTimeout before exiting', () => {
+    const exitFn = vi.fn();
+    const onTimeout = vi.fn();
+    const driver: { fire: () => void } = { fire: () => {} };
+    armBoundedExit('SIGTERM', {
+      exitFn,
+      exitCode: 0,
+      onTimeout,
+      setTimeoutFn: (handler) => {
+        driver.fire = handler;
+        return { unref: () => {} } as unknown as NodeJS.Timeout;
+      },
+    });
+
+    driver.fire();
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(exitFn).toHaveBeenCalledWith(0);
+    // Order matters: the hook records the clean stop and drops the PID file,
+    // which is pointless after the process is gone.
+    expect(onTimeout.mock.invocationCallOrder[0]).toBeLessThan(
+      exitFn.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('still exits when onTimeout throws', () => {
+    const exitFn = vi.fn();
+    const driver: { fire: () => void } = { fire: () => {} };
+    armBoundedExit('SIGTERM', {
+      exitFn,
+      exitCode: 0,
+      onTimeout: () => {
+        throw new Error('telemetry write failed');
+      },
+      setTimeoutFn: (handler) => {
+        driver.fire = handler;
+        return { unref: () => {} } as unknown as NodeJS.Timeout;
+      },
+    });
+
+    expect(() => driver.fire()).not.toThrow();
+    expect(exitFn).toHaveBeenCalledWith(0);
+  });
+
+  it('keeps the daemon deadline under launchd ExitTimeOut, and above the old 5s', () => {
+    // Below 30s (PLIST_EXIT_TIMEOUT_SEC) so we decide when to give up rather
+    // than taking a SIGKILL mid-cleanup; well above 5s, which cut off cleanup
+    // runs that legitimately took 5-27s.
+    expect(DAEMON_SHUTDOWN_DEADLINE_MS).toBeLessThan(30_000);
+    expect(DAEMON_SHUTDOWN_DEADLINE_MS).toBeGreaterThan(5_000);
   });
 });

--- a/src/server/bounded-shutdown.ts
+++ b/src/server/bounded-shutdown.ts
@@ -9,10 +9,29 @@
  *
  * The fix: when a shutdown signal arrives, start graceful shutdown AND arm a
  * short unref'd timer. If graceful shutdown hasn't called `process.exit()`
- * within the deadline, the timer forces `process.exit(1)`. The timer is
- * unref'd so it never keeps the process alive on its own — if graceful
- * shutdown finishes first and exits, the timer is moot.
+ * within the deadline, the timer forces an exit. The timer is unref'd so it
+ * never keeps the process alive on its own — if graceful shutdown finishes
+ * first and exits, the timer is moot.
+ *
+ * TRA-849: that forced exit used to be hard-coded to code 1. Overrunning the
+ * deadline of a *requested* stop is not a crash, but launchd, `daemon status`
+ * and the clean-stop telemetry all read it as one — 56% of ordinary SIGTERM
+ * stops on a real machine were recorded as failures. Callers now choose the
+ * code and get an `onTimeout` hook to log the overrun and settle their books
+ * before the process dies.
  */
+
+/**
+ * Deadline for the HTTP daemon's graceful shutdown.
+ *
+ * Must stay below `PLIST_EXIT_TIMEOUT_SEC` (30s) in `src/daemon/lifecycle.ts`,
+ * `scripts/postinstall-control-plane.mjs` and
+ * `packages/app/src/main/daemon-plist.ts` so *we* decide when to give up, not
+ * launchd's SIGKILL. The old 5s cut off cleanup that legitimately runs longer:
+ * `stopProject()` awaits each project's in-flight initial index, and on a
+ * machine with dozens of registered projects that regularly took 5-27s.
+ */
+export const DAEMON_SHUTDOWN_DEADLINE_MS = 20_000;
 
 export interface BoundedShutdownOptions {
   /** Hard-exit deadline in ms after graceful shutdown starts. Default 5_000. */
@@ -21,6 +40,17 @@ export interface BoundedShutdownOptions {
   exitFn?: (code: number) => void;
   /** Injectable for tests. Defaults to Node's `setTimeout`. */
   setTimeoutFn?: (handler: () => void, ms: number) => NodeJS.Timeout;
+  /**
+   * Exit code for the forced exit. Default 1 — kept for callers that really are
+   * reporting a failure. Pass 0 when the stop was requested and only its
+   * cleanup ran long (TRA-849).
+   */
+  exitCode?: number;
+  /**
+   * Called just before the forced exit — the last chance to log the overrun or
+   * record state. Runs synchronously; anything async is lost.
+   */
+  onTimeout?: () => void;
 }
 
 /**
@@ -38,12 +68,19 @@ export function armBoundedExit(
     deadlineMs = 5_000,
     exitFn = (code: number) => process.exit(code),
     setTimeoutFn = (handler, ms) => setTimeout(handler, ms),
+    exitCode = 1,
+    onTimeout,
   } = options;
 
   const timer = setTimeoutFn(() => {
     // Graceful shutdown didn't finish in time — force death so an orphaned or
     // wedged session cannot survive SIGTERM.
-    exitFn(1);
+    try {
+      onTimeout?.();
+    } catch {
+      /* bookkeeping must never keep a wedged process alive */
+    }
+    exitFn(exitCode);
   }, deadlineMs);
 
   // Never let the deadline timer itself hold the process open.

--- a/tests/scripts/postinstall-control-plane.test.ts
+++ b/tests/scripts/postinstall-control-plane.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DAEMON_SHUTDOWN_DEADLINE_MS } from '../../src/server/bounded-shutdown.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -274,9 +275,11 @@ describe('postinstall-control-plane', () => {
     const lifecycleTimeout = lifecycle.match(pattern)?.[1];
     expect(scriptTimeout).toBeDefined();
     expect(scriptTimeout).toBe(lifecycleTimeout);
-    // Must exceed the daemon's own 5s bounded hard-exit so we decide when to
-    // give up, not launchd.
-    expect(Number(scriptTimeout)).toBeGreaterThan(5);
+    // Must exceed the daemon's own bounded hard-exit so we decide when to give
+    // up, not launchd. Compared against the real constant (TRA-849): raising
+    // one of the two past the other silently reintroduces the SIGKILL that
+    // TRA-421 fixed.
+    expect(Number(scriptTimeout) * 1000).toBeGreaterThan(DAEMON_SHUTDOWN_DEADLINE_MS);
     for (const src of [script, lifecycle]) {
       expect(src).toContain('<key>ExitTimeOut</key>');
       expect(src).toContain('<integer>${PLIST_EXIT_TIMEOUT_SEC}</integer>');


### PR DESCRIPTION
Closes TRA-849.

## The bug

Over 31 hours on a real machine the daemon stopped 34 times. Of the 27 stops launchd left a post-mortem for, **15 exited with code 1** — although all 34 were ordinary graceful SIGTERMs. The split falls exactly on 5 seconds of shutdown time, which is `armBoundedExit()`'s hard-coded `process.exit(1)` at `deadlineMs = 5_000`.

That one hard-coded `1` misreports three things:

1. `recordDaemonCleanStop()` is the second-to-last line of `shutdown()`, so a forced exit never reaches it — **56% of normal stops were counted as unclean deaths** by the very telemetry meant to measure daemon reliability. Shipping the roadmap's reliability ping on top of that would publish a metric where most values are wrong.
2. launchd logs a failed exit and `daemon status` tells the user `last exit: 1` for a daemon that was simply asked to stop.
3. Exiting at the 5s mark tears through unfinished cleanup (DB/journal closes) — the source of the errors in #881.

## The change

- `armBoundedExit` gains `exitCode` (default `1`, so existing callers are unchanged) and an `onTimeout` hook that runs synchronously before the exit, guarded so a throwing hook can never keep a wedged process alive.
- Both shutdown paths pass `exitCode: 0`. Everything that reaches them is a *requested* stop (SIGTERM/SIGINT/idle-exit/stdin-end); overrunning the deadline means our cleanup was slow, not that the process died. The daemon's hook additionally logs the overrun, drops the PID file and records the clean stop — exactly what the graceful path would have done a few lines later.
- Daemon deadline raised from 5s to `DAEMON_SHUTDOWN_DEADLINE_MS` (20s), still comfortably under launchd's 30s `ExitTimeOut`. The plist test now asserts against that constant instead of a hard-coded `5`, so raising either side past the other can't silently reintroduce the mid-cleanup SIGKILL that TRA-421 fixed.

On "clean vs timeout": a deadline overrun is recorded as a clean stop deliberately. The metric answers "did the daemon die without running its handler" — we did run it. Splitting out a third `timeout` counter is a telemetry-schema change worth making only once someone needs the distinction.

## What is measured, not yet fixed

Why cleanup exceeds 5s at all is still open. The prime suspect is `await managed.initialIndexPromise` in `stopProject` — on SIGTERM we wait out a full index — but the log can't currently tell that from anything else, so shutdown now times `projectManager.shutdown()` and the whole shutdown. The next field log answers it with data instead of a guess. The three 23-27s cases in the issue also show the "guaranteed" exit isn't guaranteed: a `setTimeout` on the same starved event loop it exists to escape doesn't fire on time. Both stay on TRA-849's follow-up rather than being guessed at here.

## Test evidence

- `src/server/__tests__/bounded-shutdown.test.ts`: the caller-chosen exit code, `onTimeout` running *before* the exit (ordering asserted — recording a clean stop after the process is gone is pointless), the exit still happening when `onTimeout` throws, and the deadline staying inside `(5s, 30s)`.
- `tests/scripts/postinstall-control-plane.test.ts`: `ExitTimeOut` compared against `DAEMON_SHUTDOWN_DEADLINE_MS`.
- Full suite: 9947 passed, 22 skipped (901 files). `pnpm run build` and `pnpm run lint` clean.

Agent: Lead Engineer
