### PR TITLE
fix(watcher): reconcile the index when the OS drops fs events

### DIFF
--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -715,7 +715,15 @@ export class ProjectManager {
         async (deleted) => {
           pipeline.deleteFiles(deleted);
         },
-        { descendantExcludeGlobs: descendantExcludeGlobs(projectRoot) },
+        {
+          descendantExcludeGlobs: descendantExcludeGlobs(projectRoot),
+          // Dropped fs events (bulk checkout, install, wake from sleep) leave
+          // the index silently stale. indexAll() re-walks the root and is
+          // hash-gated, so unchanged files cost a stat+hash, not a reparse.
+          onRescan: async () => {
+            await pipeline.indexAll();
+          },
+        },
       );
     }
 

--- a/src/daemon/router/local-backend.ts
+++ b/src/daemon/router/local-backend.ts
@@ -419,6 +419,14 @@ export class LocalBackend implements Backend {
           if (this.stopping) return;
           this.pipeline!.deleteFiles(deleted);
         },
+        {
+          // Dropped fs events leave the index silently stale — re-walk the
+          // root. indexAll() is hash-gated, so unchanged files aren't reparsed.
+          onRescan: async () => {
+            if (this.stopping) return;
+            await this.pipeline!.indexAll();
+          },
+        },
       );
 
     // Create McpServer and wire it to our in-memory pair.

--- a/src/indexer/__tests__/watcher-events-dropped.test.ts
+++ b/src/indexer/__tests__/watcher-events-dropped.test.ts
@@ -1,0 +1,75 @@
+/**
+ * TRA-852: when the OS drops fs events ("Events were dropped by the FSEvents
+ * client. File system must be re-scanned."), the watcher used to log and
+ * return — every change in the lost window stayed invisible to the index
+ * forever. It must now run the reconcile pass instead.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import type * as parcelWatcher from '@parcel/watcher';
+
+type Callback = (err: Error | null, events: parcelWatcher.Event[]) => void | Promise<void>;
+
+let capturedCallback: Callback | null = null;
+
+vi.mock('@parcel/watcher', () => ({
+  subscribe: async (_root: string, cb: Callback) => {
+    capturedCallback = cb;
+    return { unsubscribe: async () => {} };
+  },
+}));
+
+const { FileWatcher } = await import('../watcher.js');
+
+async function startWatcher(onRescan?: () => Promise<void>) {
+  const watcher = new FileWatcher();
+  await watcher.start(process.cwd(), {} as never, async () => {}, 10, undefined, { onRescan });
+  return watcher;
+}
+
+describe('FileWatcher — dropped fs events', () => {
+  it('runs the reconcile pass when events were dropped', async () => {
+    const onRescan = vi.fn(async () => {});
+    const watcher = await startWatcher(onRescan);
+
+    await capturedCallback!(
+      new Error('Events were dropped by the FSEvents client. File system must be re-scanned.'),
+      [],
+    );
+
+    expect(onRescan).toHaveBeenCalledTimes(1);
+    await watcher.stop();
+  });
+
+  it('does not reconcile on unrelated watcher errors', async () => {
+    const onRescan = vi.fn(async () => {});
+    const watcher = await startWatcher(onRescan);
+
+    await capturedCallback!(new Error('some other watcher failure'), []);
+
+    expect(onRescan).not.toHaveBeenCalled();
+    await watcher.stop();
+  });
+
+  it('collapses a burst of drops into one in-flight pass plus one follow-up', async () => {
+    let release: () => void = () => {};
+    const onRescan = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const watcher = await startWatcher(onRescan);
+    const dropped = new Error('Events were dropped by the FSEvents client.');
+
+    await capturedCallback!(dropped, []);
+    await capturedCallback!(dropped, []);
+    await capturedCallback!(dropped, []);
+    expect(onRescan).toHaveBeenCalledTimes(1);
+
+    const first = release;
+    first();
+    await vi.waitFor(() => expect(onRescan).toHaveBeenCalledTimes(2));
+    release();
+    await watcher.stop();
+  });
+});

--- a/src/indexer/__tests__/watcher-events-dropped.test.ts
+++ b/src/indexer/__tests__/watcher-events-dropped.test.ts
@@ -72,4 +72,27 @@ describe('FileWatcher — dropped fs events', () => {
     release();
     await watcher.stop();
   });
+
+  it('stop() waits for an in-flight reconcile — callers dispose the pipeline right after', async () => {
+    let release: () => void = () => {};
+    const onRescan = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const watcher = await startWatcher(onRescan);
+    await capturedCallback!(new Error('Events were dropped by the FSEvents client.'), []);
+
+    let stopped = false;
+    const stopping = watcher.stop().then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+
+    release();
+    await stopping;
+    expect(stopped).toBe(true);
+  });
 });

--- a/src/indexer/watcher.ts
+++ b/src/indexer/watcher.ts
@@ -23,6 +23,19 @@ const MAC_LOAD_RETRY_DELAYS_MS = [300, 900, 2000];
 
 let cachedWatcher: ParcelWatcherModule | null = null;
 
+/**
+ * The OS event queue overflowed and events were discarded before reaching us
+ * (macOS FSEvents: "Events were dropped by the FSEvents client. File system
+ * must be re-scanned."; the inotify/Windows backends word it the same way).
+ * Happens on bulk changes — branch checkout, `pnpm install`, wake from sleep.
+ * Every change in the lost window is invisible to the watcher forever, so the
+ * index silently diverges from disk unless we re-walk the root.
+ */
+function isEventsDroppedError(err: unknown): boolean {
+  const msg = (err as { message?: string })?.message;
+  return typeof msg === 'string' && msg.toLowerCase().includes('events were dropped');
+}
+
 function isMacSystemPolicyError(e: unknown): boolean {
   if (process.platform !== 'darwin') return false;
   const err = e as NodeJS.ErrnoException & { message?: string };
@@ -82,6 +95,14 @@ interface StartOpts {
    * descendants.
    */
   descendantExcludeGlobs?: string[];
+  /**
+   * Repair pass for dropped fs events (see `isEventsDroppedError`). Must
+   * re-walk the project root and reconcile against the index — i.e.
+   * `pipeline.indexAll()`, which is hash-gated (unchanged files are skipped,
+   * not re-parsed) and drops rows for files that vanished. Optional: a caller
+   * that doesn't own a pipeline just keeps the old log-and-ignore behaviour.
+   */
+  onRescan?: () => Promise<void>;
 }
 
 export class FileWatcher {
@@ -96,7 +117,14 @@ export class FileWatcher {
     onChanges: (paths: string[]) => Promise<void>;
     debounceMs: number;
     onDeletes?: (paths: string[]) => Promise<void>;
+    onRescan?: () => Promise<void>;
   } | null = null;
+  /** Guards against a rescan stampede: FSEvents drops arrive in bursts, and a
+   *  reconcile pass walks the whole root. At most one runs at a time; drops
+   *  seen while one is in flight collapse into a single follow-up pass (the
+   *  in-flight walk may have already passed the files they touched). */
+  private rescanInFlight = false;
+  private rescanPending = false;
   /**
    * Serializes start()/stop()/restartWithExcludes() on this instance. Without
    * this, two overlapping calls (e.g. ProjectManager.restartManagedAncestorWatchers
@@ -140,7 +168,14 @@ export class FileWatcher {
     onDeletes: ((paths: string[]) => Promise<void>) | undefined,
     opts: StartOpts | undefined,
   ): Promise<void> {
-    this.lastStartArgs = { rootPath, config, onChanges, debounceMs, onDeletes };
+    this.lastStartArgs = {
+      rootPath,
+      config,
+      onChanges,
+      debounceMs,
+      onDeletes,
+      onRescan: opts?.onRescan,
+    };
     // Re-entry guard: if start() is invoked again while a prior subscription is
     // live, the old AsyncSubscription (native fs-event handle + the registered
     // callback closure capturing onChanges/pipeline/traceignore) would leak.
@@ -178,6 +213,16 @@ export class FileWatcher {
       rootPath,
       async (err, events) => {
         if (err) {
+          if (isEventsDroppedError(err)) {
+            // Don't just log: the events are gone, so nothing else will ever
+            // reindex what changed in the lost window (TRA-852).
+            logger.warn(
+              { rootPath, error: String(err) },
+              'File system events were dropped — reconciling index with disk',
+            );
+            this.runRescan(opts?.onRescan, rootPath);
+            return;
+          }
           logger.error({ error: err }, 'Watcher error');
           return;
         }
@@ -246,6 +291,26 @@ export class FileWatcher {
     logger.info({ rootPath }, 'File watcher started');
   }
 
+  private runRescan(onRescan: (() => Promise<void>) | undefined, rootPath: string): void {
+    if (!onRescan) return;
+    if (this.rescanInFlight) {
+      this.rescanPending = true;
+      return;
+    }
+    this.rescanInFlight = true;
+    void onRescan()
+      .catch((e) => {
+        logger.error({ error: e, rootPath }, 'Index reconcile after dropped events failed');
+      })
+      .finally(() => {
+        this.rescanInFlight = false;
+        if (this.rescanPending) {
+          this.rescanPending = false;
+          this.runRescan(onRescan, rootPath);
+        }
+      });
+  }
+
   /**
    * Re-subscribe with a fresh `descendantExcludeGlobs` list, reusing every
    * other argument from the most recent `start()` call. Used by
@@ -260,9 +325,10 @@ export class FileWatcher {
       logger.debug('restartWithExcludes called before start() — ignoring');
       return;
     }
-    const { rootPath, config, onChanges, debounceMs, onDeletes } = this.lastStartArgs;
+    const { rootPath, config, onChanges, debounceMs, onDeletes, onRescan } = this.lastStartArgs;
     await this.start(rootPath, config, onChanges, debounceMs, onDeletes, {
       descendantExcludeGlobs,
+      onRescan,
     });
   }
 
@@ -296,5 +362,9 @@ export class FileWatcher {
       this.debounceTimer = null;
     }
     this.pendingPaths.clear();
+    // Don't let a queued follow-up reconcile fire after stop() — it would run
+    // against torn-down state (closed DB). An already in-flight one can't be
+    // cancelled; callers guard it with their own stopping flag.
+    this.rescanPending = false;
   }
 }

--- a/src/indexer/watcher.ts
+++ b/src/indexer/watcher.ts
@@ -119,11 +119,12 @@ export class FileWatcher {
     onDeletes?: (paths: string[]) => Promise<void>;
     onRescan?: () => Promise<void>;
   } | null = null;
-  /** Guards against a rescan stampede: FSEvents drops arrive in bursts, and a
-   *  reconcile pass walks the whole root. At most one runs at a time; drops
-   *  seen while one is in flight collapse into a single follow-up pass (the
-   *  in-flight walk may have already passed the files they touched). */
-  private rescanInFlight = false;
+  /** The reconcile pass currently running, or null. Guards against a rescan
+   *  stampede (FSEvents drops arrive in bursts and each pass walks the whole
+   *  root): at most one runs at a time, and drops seen while one is in flight
+   *  collapse into a single follow-up pass. Also what `stop()` awaits — the
+   *  pass holds a pipeline the caller disposes right after stop() returns. */
+  private activeRescan: Promise<void> | null = null;
   private rescanPending = false;
   /**
    * Serializes start()/stop()/restartWithExcludes() on this instance. Without
@@ -293,17 +294,16 @@ export class FileWatcher {
 
   private runRescan(onRescan: (() => Promise<void>) | undefined, rootPath: string): void {
     if (!onRescan) return;
-    if (this.rescanInFlight) {
+    if (this.activeRescan) {
       this.rescanPending = true;
       return;
     }
-    this.rescanInFlight = true;
-    void onRescan()
+    this.activeRescan = onRescan()
       .catch((e) => {
         logger.error({ error: e, rootPath }, 'Index reconcile after dropped events failed');
       })
       .finally(() => {
-        this.rescanInFlight = false;
+        this.activeRescan = null;
         if (this.rescanPending) {
           this.rescanPending = false;
           this.runRescan(onRescan, rootPath);
@@ -362,9 +362,11 @@ export class FileWatcher {
       this.debounceTimer = null;
     }
     this.pendingPaths.clear();
-    // Don't let a queued follow-up reconcile fire after stop() — it would run
-    // against torn-down state (closed DB). An already in-flight one can't be
-    // cancelled; callers guard it with their own stopping flag.
+    // A reconcile pass holds the caller's pipeline, and callers dispose it as
+    // soon as stop() returns. Drop any queued follow-up (cleared first, so the
+    // in-flight pass's `finally` doesn't start one) and wait out the active
+    // pass rather than letting it resume against a closed DB.
     this.rescanPending = false;
+    if (this.activeRescan) await this.activeRescan;
   }
 }


### PR DESCRIPTION
## Problem

`~/.trace/daemon.log` on Nikolai's machine shows 31 occurrences in 31 hours of:

```
Watcher error: Events were dropped by the FSEvents client. File system must be re-scanned.
```

The handler in `src/indexer/watcher.ts` logged and returned. The message states exactly what is needed — a re-scan — and we did nothing with it. Every change that happened in the dropped window stays invisible to the watcher forever, so the index silently diverges from disk: an agent gets stale symbols and signatures with no signal that the answer is stale. FSEvents overflows precisely when many files change at once (branch checkout, `pnpm install`, unpacking, wake from sleep).

## Change

- `isEventsDroppedError()` distinguishes the overflow error from other watcher errors (matched case-insensitively on "events were dropped", which is how the FSEvents/inotify/Windows backends all word it).
- New optional `StartOpts.onRescan`. On a drop the watcher runs it instead of returning; other errors keep the old `logger.error` path.
- Both daemon call sites (`project-manager.ts`, `router/local-backend.ts`) wire it to `pipeline.indexAll()` — a re-walk that is hash-gated (unchanged files cost a stat+hash, not a reparse) and whose `reconcileScope()` also drops rows for files that vanished during the lost window. Not a forced full reindex, so a `pnpm install` burst doesn't re-parse the project.
- Bursts are collapsed: at most one reconcile in flight, drops seen during it become one follow-up pass. `stop()` clears a queued follow-up so it can't fire against a closed DB.

## Tests

`src/indexer/__tests__/watcher-events-dropped.test.ts` — mocks `@parcel/watcher`, delivers the error to the captured callback and asserts: reconcile runs on the drop error, does not run on an unrelated watcher error, and a burst of three drops yields one in-flight pass plus one follow-up.

Full suite: 9944 passed, 1 unrelated flake (`tests/ai/onnx.test.ts` import timeout under full-suite load; passes standalone). `pnpm run typecheck` clean.

Closes TRA-852.

Agent: Lead Engineer
