### PR TITLE
feat(tools): per-call compute ceiling for heavy graph traversals

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -935,6 +935,25 @@ With `enabled: "auto"` the provider is registered at boot; discovery returns an 
 |---|---|
 | `TRACE_MCP_LOG_LEVEL` | Log level (debug, info, warn, error) |
 | `HERMES_HOME` | Override for Hermes Agent storage root (default `~/.hermes`). Read by `discover_hermes_sessions` and the Hermes session provider. |
+| `TRACE_MCP_COMPUTE_TIMEOUT_MS` | Wall-clock ceiling for one heavy graph traversal (default `15000`). |
+| `TRACE_MCP_COMPUTE_RSS_MB` | Resident-memory ceiling checked during a traversal (default `3000`). |
+| `TRACE_MCP_COMPUTE_MAX_ITERATIONS` | Iteration ceiling for one traversal (default `2000000`). |
+| `TRACE_MCP_NO_COMPUTE_GUARD` | Set to `1` to disable all compute ceilings (debugging). |
+
+### Compute ceilings
+
+`get_call_graph`, `get_change_impact`, `get_dependency_diagram`,
+`get_circular_imports`, `find_usages` and `get_pagerank` tick a per-call guard
+inside their traversal loops. When a ceiling is hit the tool returns the
+**partial** result with a `_budget_exceeded` field naming the ceiling, the
+limit, and the elapsed time — never a tool-call error — and the daemon log
+gets one `Compute budget exceeded` line with the tool name.
+
+The defaults come from `scripts/bench-compute-guard.ts`: a deliberately heavy
+`get_call_graph` (37,449 symbols, depth 5) consumes 79,577 ticks in ~85 ms, so
+every ceiling sits one to two orders of magnitude above anything a real query
+reaches. Measured tick overhead on that same query is within run-to-run noise
+(−2.7% … +2.1% across five runs).
 
 ---
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2494,6 +2494,25 @@ With `enabled: "auto"` the provider is registered at boot; discovery returns an 
 |---|---|
 | `TRACE_MCP_LOG_LEVEL` | Log level (debug, info, warn, error) |
 | `HERMES_HOME` | Override for Hermes Agent storage root (default `~/.hermes`). Read by `discover_hermes_sessions` and the Hermes session provider. |
+| `TRACE_MCP_COMPUTE_TIMEOUT_MS` | Wall-clock ceiling for one heavy graph traversal (default `15000`). |
+| `TRACE_MCP_COMPUTE_RSS_MB` | Resident-memory ceiling checked during a traversal (default `3000`). |
+| `TRACE_MCP_COMPUTE_MAX_ITERATIONS` | Iteration ceiling for one traversal (default `2000000`). |
+| `TRACE_MCP_NO_COMPUTE_GUARD` | Set to `1` to disable all compute ceilings (debugging). |
+
+### Compute ceilings
+
+`get_call_graph`, `get_change_impact`, `get_dependency_diagram`,
+`get_circular_imports`, `find_usages` and `get_pagerank` tick a per-call guard
+inside their traversal loops. When a ceiling is hit the tool returns the
+**partial** result with a `_budget_exceeded` field naming the ceiling, the
+limit, and the elapsed time — never a tool-call error — and the daemon log
+gets one `Compute budget exceeded` line with the tool name.
+
+The defaults come from `scripts/bench-compute-guard.ts`: a deliberately heavy
+`get_call_graph` (37,449 symbols, depth 5) consumes 79,577 ticks in ~85 ms, so
+every ceiling sits one to two orders of magnitude above anything a real query
+reaches. Measured tick overhead on that same query is within run-to-run noise
+(−2.7% … +2.1% across five runs).
 
 ---
 

--- a/scripts/bench-compute-guard.ts
+++ b/scripts/bench-compute-guard.ts
@@ -1,0 +1,92 @@
+/**
+ * Tick overhead of the per-call compute guard (TRA-841).
+ *
+ * The guard only earns its place if an ordinary call does not notice it. This
+ * runs the same `get_call_graph` traversal twice on a synthetic graph — once
+ * with the guard live, once with `TRACE_MCP_NO_COMPUTE_GUARD=1` — and prints
+ * the delta. Numbers quoted anywhere about guard overhead come from here.
+ *
+ *   pnpm exec tsx scripts/bench-compute-guard.ts
+ */
+import { createTestStore } from '../tests/test-utils.js';
+import { getCallGraph } from '../src/tools/framework/call-graph.js';
+import { forTool } from '../src/compute-guard.js';
+
+const FANOUT = 8;
+const LEVELS = 5;
+const DEPTH = 5;
+const RUNS = 40;
+
+function buildGraph() {
+  const store = createTestStore();
+  store.ensureEdgeType('calls', 'code', 'Function calls');
+  const fileId = store.insertFile('src/bench.ts', 'typescript', null, null);
+
+  const nodeIds: number[] = [];
+  let count = 0;
+  for (let level = 0; level <= LEVELS; level++) count += FANOUT ** level;
+  for (let i = 0; i < count; i++) {
+    const symbolDbId = store.insertSymbol(fileId, {
+      symbolId: `src/bench.ts::fn${i}#function`,
+      name: `fn${i}`,
+      kind: 'function',
+      byteStart: 0,
+      byteEnd: 10,
+      lineStart: i + 1,
+      lineEnd: i + 1,
+    });
+    nodeIds.push(store.getNodeId('symbol', symbolDbId)!);
+  }
+  // Balanced FANOUT-ary tree of `calls` edges.
+  for (let i = 0; i * FANOUT + FANOUT < nodeIds.length; i++) {
+    for (let k = 1; k <= FANOUT; k++) {
+      store.insertEdge(nodeIds[i], nodeIds[i * FANOUT + k], 'calls');
+    }
+  }
+  return { store, nodes: nodeIds.length };
+}
+
+function once(store: ReturnType<typeof buildGraph>['store'], guarded: boolean): number {
+  if (guarded) delete process.env.TRACE_MCP_NO_COMPUTE_GUARD;
+  else process.env.TRACE_MCP_NO_COMPUTE_GUARD = '1';
+  const guard = forTool('get_call_graph');
+  const started = process.hrtime.bigint();
+  getCallGraph(store, { symbolId: 'src/bench.ts::fn0#function' }, DEPTH, guard);
+  const ms = Number(process.hrtime.bigint() - started) / 1e6;
+  if (guarded) lastTicks = guard.consumed;
+  return ms;
+}
+
+let lastTicks = 0;
+
+function median(xs: number[]): number {
+  const sorted = [...xs].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+const { store, nodes } = buildGraph();
+process.stdout.write(`graph: ${nodes} symbols, fanout ${FANOUT}, depth ${DEPTH}, ${RUNS} runs\n`);
+
+// Warm up so JIT and SQLite statement caches are not part of the measurement.
+for (let i = 0; i < 10; i++) once(store, true);
+
+// Alternate the two variants run-by-run: measuring them in separate blocks
+// makes the first block eat every cold-cache cost and produced swings larger
+// than the effect being measured.
+const on: number[] = [];
+const off: number[] = [];
+for (let i = 0; i < RUNS; i++) {
+  on.push(once(store, true));
+  off.push(once(store, false));
+}
+const ticks = lastTicks;
+
+const withGuard = median(on);
+const withoutGuard = median(off);
+const overhead = ((withGuard - withoutGuard) / withoutGuard) * 100;
+process.stdout.write(
+  `ticks/call:    ${ticks}\n` +
+    `with guard:    ${withGuard.toFixed(3)} ms/call (median)\n` +
+    `without guard: ${withoutGuard.toFixed(3)} ms/call (median)\n` +
+    `overhead:      ${overhead.toFixed(2)}%\n`,
+);

--- a/src/compute-guard.ts
+++ b/src/compute-guard.ts
@@ -1,0 +1,198 @@
+/**
+ * Per-call compute ceiling for heavy graph tools (TRA-841).
+ *
+ * Why this exists: `src/server/budget-defaults.ts` caps *expansive parameters*
+ * so the answer stays small, and `computeAdaptiveBudget` sizes context
+ * payloads. Both shape the answer. Neither bounds the work done to produce it.
+ * A traversal that materializes a tree out of a dense graph runs to completion
+ * or to the OS limit, whichever comes first — and an OS-level kill (macOS
+ * Jetsam / OOM killer) runs no JS, so `src/daemon/vitals-log.ts` can only
+ * record that the daemon died, never which call killed it (TRA-809, TRA-811).
+ *
+ * The guard is ticked inside the hot loop. It holds three ceilings — wall
+ * clock, resident memory, iteration count — and once any is hit, `tick()`
+ * returns false forever. Callers stop and return the *partial* result plus
+ * `_budget_exceeded`; an abort is never a tool-call error, because a truncated
+ * call graph with an explicit reason is a usable answer and a thrown error
+ * costs the agent the whole turn.
+ *
+ * Cost discipline: the iteration ceiling is an integer compare on every tick.
+ * The clock and RSS ceilings are only sampled every `SAMPLE_INTERVAL` ticks —
+ * `Date.now()` and `process.memoryUsage.rss()` are syscalls and calling them
+ * per node would be the slowest thing in the traversal.
+ */
+import { logger } from './logger.js';
+import { readRssMb } from './daemon/vitals-log.js';
+
+export type BudgetExceededReason = 'timeout' | 'rss' | 'iterations';
+
+export interface BudgetExceeded {
+  /** Which ceiling was hit */
+  reason: BudgetExceededReason;
+  /** The ceiling's value: ms for timeout, MB for rss, count for iterations */
+  limit: number;
+  /** Wall clock consumed when the guard tripped */
+  elapsed_ms: number;
+  /** Ticks consumed when the guard tripped */
+  iterations: number;
+  /** Resident memory at the trip, when RSS was the reason */
+  rss_mb?: number;
+  /** Tool that owns the guard */
+  tool: string;
+  /** Fixed hint so the agent knows the payload is partial, not empty */
+  note: string;
+}
+
+export interface ComputeCeilings {
+  timeout_ms: number;
+  rss_mb: number;
+  iterations: number;
+}
+
+/**
+ * Defaults, chosen from measurement, not taste. `scripts/bench-compute-guard.ts`
+ * runs a deliberately heavy `get_call_graph` — a 37,449-symbol graph walked to
+ * depth 5 — and it consumes 79,577 ticks in ~85 ms. The iteration ceiling sits
+ * ~25x above that and the timeout ~175x, so nothing anyone runs today comes
+ * close. The RSS ceiling sits above the ~950 MB idle resident figure reported
+ * in TRA-811, so it fires on a runaway call rather than on a normal one.
+ */
+export const DEFAULT_CEILINGS: ComputeCeilings = {
+  timeout_ms: 15_000,
+  rss_mb: 3_000,
+  iterations: 2_000_000,
+};
+
+/** How often the clock and RSS ceilings are actually sampled. */
+const SAMPLE_INTERVAL = 4096;
+
+function envNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/** Read the ceilings from env on every call — cheap, and keeps tests hermetic. */
+export function resolveCeilings(): ComputeCeilings {
+  return {
+    timeout_ms: envNumber('TRACE_MCP_COMPUTE_TIMEOUT_MS', DEFAULT_CEILINGS.timeout_ms),
+    rss_mb: envNumber('TRACE_MCP_COMPUTE_RSS_MB', DEFAULT_CEILINGS.rss_mb),
+    iterations: envNumber('TRACE_MCP_COMPUTE_MAX_ITERATIONS', DEFAULT_CEILINGS.iterations),
+  };
+}
+
+/** `TRACE_MCP_NO_COMPUTE_GUARD=1` disables every guard (debugging escape hatch). */
+export function guardsDisabled(): boolean {
+  const raw = process.env.TRACE_MCP_NO_COMPUTE_GUARD;
+  return raw === '1' || raw === 'true';
+}
+
+export class BudgetGuard {
+  private readonly startedAt: number;
+  private ticks = 0;
+  private nextSample = SAMPLE_INTERVAL;
+  private tripped: BudgetExceeded | undefined;
+
+  constructor(
+    readonly tool: string,
+    private readonly ceilings: ComputeCeilings,
+    private readonly deps: { now: () => number; rssMb: () => number } = {
+      now: Date.now,
+      rssMb: readRssMb,
+    },
+  ) {
+    this.startedAt = deps.now();
+  }
+
+  /** Consume one unit of work. Returns false once any ceiling has been hit. */
+  tick(): boolean {
+    if (this.tripped) return false;
+    this.ticks++;
+
+    if (this.ticks > this.ceilings.iterations) {
+      return this.trip('iterations', this.ceilings.iterations);
+    }
+    if (this.ticks < this.nextSample) return true;
+    this.nextSample = this.ticks + SAMPLE_INTERVAL;
+    return this.check();
+  }
+
+  /**
+   * Force the sampled ceilings to be evaluated now, ignoring the sample
+   * interval. Use at coarse boundaries (one depth level, one batch fetch)
+   * where a single step is expensive enough to deserve its own check.
+   */
+  check(): boolean {
+    if (this.tripped) return false;
+
+    const elapsed = this.deps.now() - this.startedAt;
+    if (elapsed > this.ceilings.timeout_ms) {
+      return this.trip('timeout', this.ceilings.timeout_ms);
+    }
+
+    const rss = this.deps.rssMb();
+    if (rss > this.ceilings.rss_mb) {
+      return this.trip('rss', this.ceilings.rss_mb, rss);
+    }
+    return true;
+  }
+
+  /** True once a ceiling has been hit. */
+  get aborted(): boolean {
+    return this.tripped !== undefined;
+  }
+
+  /** Ticks consumed so far — used by the overhead benchmark and by tests. */
+  get consumed(): number {
+    return this.ticks;
+  }
+
+  /**
+   * Spread into a tool's result: `{ ...payload, ...guard.marker() }`. Empty
+   * object when nothing tripped, so the field never appears on normal calls.
+   */
+  marker(): { _budget_exceeded?: BudgetExceeded } {
+    return this.tripped ? { _budget_exceeded: this.tripped } : {};
+  }
+
+  private trip(reason: BudgetExceededReason, limit: number, rssMb?: number): false {
+    this.tripped = {
+      reason,
+      limit,
+      elapsed_ms: this.deps.now() - this.startedAt,
+      iterations: this.ticks,
+      ...(rssMb === undefined ? {} : { rss_mb: rssMb }),
+      tool: this.tool,
+      note: 'Result is partial: the traversal was stopped at a compute ceiling. Narrow the query (lower depth / tighter scope) or raise the ceiling via the TRACE_MCP_COMPUTE_* env vars.',
+    };
+    // This is the line that pays back TRA-809: when a heavy tool is the thing
+    // driving the daemon toward the OOM killer, the log now says so *before*
+    // the process disappears rather than after it is gone.
+    logger.warn(this.tripped, 'Compute budget exceeded');
+    return false;
+  }
+}
+
+/** A guard that never trips — used when guards are disabled. */
+class NullGuard extends BudgetGuard {
+  constructor(tool: string) {
+    super(tool, {
+      timeout_ms: Number.MAX_SAFE_INTEGER,
+      rss_mb: Number.MAX_SAFE_INTEGER,
+      iterations: Number.MAX_SAFE_INTEGER,
+    });
+  }
+  override tick(): boolean {
+    return true;
+  }
+  override check(): boolean {
+    return true;
+  }
+}
+
+/** Build a guard for one tool call. */
+export function forTool(tool: string): BudgetGuard {
+  if (guardsDisabled()) return new NullGuard(tool);
+  return new BudgetGuard(tool, resolveCeilings());
+}

--- a/src/daemon/vitals-log.ts
+++ b/src/daemon/vitals-log.ts
@@ -31,6 +31,15 @@ export interface ProjectCounts {
 
 const toMb = (bytes: number): number => Math.round(bytes / 1024 / 1024);
 
+/**
+ * Resident set size in MB. The single measurement path for RSS — `buildVitals`
+ * below and the per-call compute guard (`src/compute-guard.ts`, TRA-841) both
+ * read memory through here so the log line and the ceiling can never disagree.
+ */
+export function readRssMb(): number {
+  return toMb(process.memoryUsage.rss());
+}
+
 /** Snapshot process memory + project counts. Pure apart from two cheap syscalls. */
 export function buildVitals(counts: ProjectCounts): DaemonVitals {
   const mem = process.memoryUsage();

--- a/src/tools/analysis/graph-analysis.ts
+++ b/src/tools/analysis/graph-analysis.ts
@@ -537,9 +537,11 @@ export function getPageRank(
     outDegree[i] = graph.forward.get(nodes[i])?.size ?? 0;
   }
 
-  for (let iter = 0; iter < maxIterations; iter++) {
-    // One full sweep over N nodes per iteration — check the clock/RSS
-    // ceilings once per sweep rather than per node.
+  // A sweep is O(V+E). The guard is ticked inside the edge distribution so a
+  // single enormous sweep cannot outrun the ceilings, and an abort leaves the
+  // loop via `sweeps` WITHOUT swapping the half-filled `newScores` buffer in —
+  // the caller then gets the last fully converged vector, never a partial one.
+  sweeps: for (let iter = 0; iter < maxIterations; iter++) {
     if (!guard.check()) break;
     // Dangling mass: nodes with no outlinks redistribute uniformly
     let danglingMass = 0;
@@ -552,6 +554,7 @@ export function getPageRank(
 
     // Distribute scores along edges
     for (let i = 0; i < N; i++) {
+      if (!guard.tick()) break sweeps;
       const neighbors = graph.forward.get(nodes[i]);
       if (!neighbors || neighbors.size === 0) continue;
       const share = (damping * scores[i]) / neighbors.size;
@@ -569,6 +572,9 @@ export function getPageRank(
     [scores, newScores] = [newScores, scores];
     if (diff < tolerance) break;
   }
+  // A long final sweep can cross the wall clock after the last in-loop sample;
+  // one closing check makes sure that run is still reported as truncated.
+  guard.check();
 
   // Build results. E10 — apply user-supplied pin weights as a final
   // multiplicative pass. Precedence rules:

--- a/src/tools/analysis/graph-analysis.ts
+++ b/src/tools/analysis/graph-analysis.ts
@@ -7,6 +7,7 @@
  * - Hotspots placeholder (git integration for Phase 2)
  */
 
+import { type BudgetGuard, forTool } from '../../compute-guard.js';
 import type { Store } from '../../db/store.js';
 import { getFilePinWeightExplicit, getSymbolPinWeightsByFile } from '../../scoring/pins.js';
 
@@ -329,6 +330,7 @@ export interface GetDependencyCyclesOptions {
 export function getDependencyCycles(
   store: Store,
   options: GetDependencyCyclesOptions = {},
+  guard: BudgetGuard = forTool('get_circular_imports'),
 ): DependencyCycle[] {
   const { includeTests = false } = options;
   // Use the import-only view of the graph. `projected:true` edges are
@@ -384,8 +386,9 @@ export function getDependencyCycles(
   const finishOrder: number[] = [];
 
   for (const node of nodes) {
+    if (guard.aborted) break;
     if (!visited.has(node)) {
-      dfsForward(node, forward, visited, finishOrder);
+      dfsForward(node, forward, visited, finishOrder, guard);
     }
   }
 
@@ -394,10 +397,11 @@ export function getDependencyCycles(
   const sccs: number[][] = [];
 
   for (let i = finishOrder.length - 1; i >= 0; i--) {
+    if (guard.aborted) break;
     const node = finishOrder[i];
     if (!visited2.has(node)) {
       const component: number[] = [];
-      dfsReverse(node, reverse, visited2, component);
+      dfsReverse(node, reverse, visited2, component, guard);
       if (component.length > 1) {
         sccs.push(component);
       }
@@ -416,10 +420,12 @@ function dfsForward(
   adj: Map<number, Set<number>>,
   visited: Set<number>,
   finishOrder: number[],
+  guard: BudgetGuard,
 ): void {
   const stack: Array<{ node: number; phase: 'enter' | 'exit' }> = [{ node: start, phase: 'enter' }];
 
   while (stack.length > 0) {
+    if (!guard.tick()) return;
     const { node, phase } = stack.pop()!;
     if (phase === 'exit') {
       finishOrder.push(node);
@@ -445,9 +451,11 @@ function dfsReverse(
   adj: Map<number, Set<number>>,
   visited: Set<number>,
   component: number[],
+  guard: BudgetGuard,
 ): void {
   const stack = [start];
   while (stack.length > 0) {
+    if (!guard.tick()) return;
     const node = stack.pop()!;
     if (visited.has(node)) continue;
     visited.add(node);
@@ -500,6 +508,7 @@ export function getPageRank(
      */
     includeExternals?: boolean;
   } = {},
+  guard: BudgetGuard = forTool('get_pagerank'),
 ): PageRankResult[] {
   const {
     damping = 0.85,
@@ -529,6 +538,9 @@ export function getPageRank(
   }
 
   for (let iter = 0; iter < maxIterations; iter++) {
+    // One full sweep over N nodes per iteration — check the clock/RSS
+    // ceilings once per sweep rather than per node.
+    if (!guard.check()) break;
     // Dangling mass: nodes with no outlinks redistribute uniformly
     let danglingMass = 0;
     for (let i = 0; i < N; i++) {

--- a/src/tools/analysis/impact.ts
+++ b/src/tools/analysis/impact.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { type BudgetExceeded, type BudgetGuard, forTool } from '../../compute-guard.js';
 import type { Store, SymbolRow } from '../../db/store.js';
 import { err, notFound, ok, type TraceMcpResult } from '../../errors.js';
 import { safeGitEnv } from '../../utils/git-env.js';
@@ -134,6 +135,8 @@ export interface ChangeImpactResult {
   pennant?: PennantImpactResult;
   /** When symbol_ids are provided, only those symbols are analyzed (diff-aware mode) */
   scopedToSymbols?: string[];
+  /** Present only when a compute ceiling stopped the traversal (TRA-841) */
+  _budget_exceeded?: BudgetExceeded;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -420,6 +423,7 @@ export function getChangeImpact(
   depth = 3,
   maxDependents = 200,
   cwd?: string,
+  guard: BudgetGuard = forTool('get_change_impact'),
 ): TraceMcpResult<ChangeImpactResult> {
   let startNodeIds: number[] = [];
   let targetPath: string;
@@ -556,6 +560,7 @@ export function getChangeImpact(
     rawDeps,
     testedFileIds,
     testedSymNames,
+    guard,
   );
 
   const truncated = rawDeps.length >= maxDependents;
@@ -775,6 +780,7 @@ export function getChangeImpact(
   if (truncated || dependentsTruncated) result.truncated = true;
   if (pennant) result.pennant = pennant;
   if (scopedToSymbols) result.scopedToSymbols = scopedToSymbols;
+  Object.assign(result, guard.marker());
 
   return ok(result);
 }
@@ -851,11 +857,15 @@ function traverseIncoming(
   rawDeps: RawDependent[],
   testedFileIds: Set<number>,
   testedSymNames: Map<number, Set<string>>,
+  guard: BudgetGuard,
 ): void {
   let frontier = startNodeIds;
 
   for (let depth = 1; depth <= maxDepth; depth++) {
     if (frontier.length === 0 || rawDeps.length >= maxDependents) break;
+    // A batch edge fetch over a wide frontier is the expensive step here, so
+    // check the clock/RSS ceilings before paying for it.
+    if (!guard.check()) break;
 
     const allEdges = store.getEdgesForNodesBatch(frontier);
 
@@ -865,6 +875,7 @@ function traverseIncoming(
     const edgeBySource = new Map<number, { type: string; tier: EdgeResolution }>();
 
     for (const edge of allEdges) {
+      if (!guard.tick()) break;
       if (rawDeps.length + sourceNodeIds.length >= maxDependents) break;
       if (!frontierSet.has(edge.target_node_id)) continue;
       if (edge.source_node_id === edge.target_node_id) continue;

--- a/src/tools/analysis/visualize.ts
+++ b/src/tools/analysis/visualize.ts
@@ -406,16 +406,20 @@ function buildFileGraph(
   let frontier = new Set(allSeedNodeIds);
   const allCollectedEdges: typeof filteredEdges = [...filteredEdges];
 
-  const guard = opts.guard ?? forTool('get_dependency_diagram');
+  // Opt-in: only a caller that can surface `_budget_exceeded` passes a guard.
+  // `visualizeGraph()` and the CLI share this builder and have nowhere to
+  // report an abort, so they run unguarded rather than truncating silently
+  // under another tool's name.
+  const guard = opts.guard;
   for (let d = 0; d < depth && frontier.size > 0; d++) {
-    if (!guard.check()) break;
+    if (guard && !guard.check()) break;
     const nextFrontier = new Set<number>();
     const batchEdges = d === 0 ? filteredEdges : store.getEdgesForNodesBatch([...frontier]);
 
     if (d > 0) allCollectedEdges.push(...batchEdges);
 
     for (const edge of batchEdges) {
-      if (!guard.tick()) break;
+      if (guard && !guard.tick()) break;
       const otherNode =
         edge.pivot_node_id === edge.source_node_id ? edge.target_node_id : edge.source_node_id;
 
@@ -559,16 +563,20 @@ function buildSymbolGraph(
   // Collect ALL edges we encounter during traversal
   const collectedEdges: typeof filteredEdges = [...filteredEdges];
 
-  const guard = opts.guard ?? forTool('get_dependency_diagram');
+  // Opt-in: only a caller that can surface `_budget_exceeded` passes a guard.
+  // `visualizeGraph()` and the CLI share this builder and have nowhere to
+  // report an abort, so they run unguarded rather than truncating silently
+  // under another tool's name.
+  const guard = opts.guard;
   for (let d = 0; d < depth && frontier.size > 0; d++) {
-    if (!guard.check()) break;
+    if (guard && !guard.check()) break;
     const nextFrontier = new Set<number>();
     const batchEdges = d === 0 ? filteredEdges : store.getEdgesForNodesBatch([...frontier]);
 
     if (d > 0) collectedEdges.push(...batchEdges);
 
     for (const edge of batchEdges) {
-      if (!guard.tick()) break;
+      if (guard && !guard.tick()) break;
       const otherNode =
         edge.pivot_node_id === edge.source_node_id ? edge.target_node_id : edge.source_node_id;
 

--- a/src/tools/analysis/visualize.ts
+++ b/src/tools/analysis/visualize.ts
@@ -10,6 +10,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type Database from 'better-sqlite3';
 import picomatch from 'picomatch';
+import { type BudgetExceeded, type BudgetGuard, forTool } from '../../compute-guard.js';
 import { initializeDatabase } from '../../db/schema.js';
 import { type FileRow, Store } from '../../db/store.js';
 import { err, ok, type TraceMcpResult, validationError } from '../../errors.js';
@@ -36,6 +37,7 @@ export interface VisualizeGraphOptions {
   projectRoot?: string; // current project root — used to scope subprojects to connected repos only
   highlightDepth?: number; // BFS depth for click-highlight (default: 1)
   includeBottlenecks?: boolean; // annotate edges/nodes with bottleneck scores, bridges, and articulation points (file granularity only)
+  guard?: BudgetGuard; // per-call compute ceiling ticked inside the frontier expansions (TRA-841)
 }
 
 interface VizNode {
@@ -78,6 +80,7 @@ interface MermaidDiagramOptions {
   depth?: number;
   maxNodes?: number;
   format?: 'mermaid' | 'dot';
+  guard?: BudgetGuard;
 }
 
 interface MermaidDiagramResult {
@@ -85,6 +88,8 @@ interface MermaidDiagramResult {
   format: string;
   nodes: number;
   edges: number;
+  /** Present only when a compute ceiling stopped the expansion (TRA-841) */
+  _budget_exceeded?: BudgetExceeded;
 }
 
 // ── Community Detection (simple label propagation) ─────────────────────
@@ -401,13 +406,16 @@ function buildFileGraph(
   let frontier = new Set(allSeedNodeIds);
   const allCollectedEdges: typeof filteredEdges = [...filteredEdges];
 
+  const guard = opts.guard ?? forTool('get_dependency_diagram');
   for (let d = 0; d < depth && frontier.size > 0; d++) {
+    if (!guard.check()) break;
     const nextFrontier = new Set<number>();
     const batchEdges = d === 0 ? filteredEdges : store.getEdgesForNodesBatch([...frontier]);
 
     if (d > 0) allCollectedEdges.push(...batchEdges);
 
     for (const edge of batchEdges) {
+      if (!guard.tick()) break;
       const otherNode =
         edge.pivot_node_id === edge.source_node_id ? edge.target_node_id : edge.source_node_id;
 
@@ -551,13 +559,16 @@ function buildSymbolGraph(
   // Collect ALL edges we encounter during traversal
   const collectedEdges: typeof filteredEdges = [...filteredEdges];
 
+  const guard = opts.guard ?? forTool('get_dependency_diagram');
   for (let d = 0; d < depth && frontier.size > 0; d++) {
+    if (!guard.check()) break;
     const nextFrontier = new Set<number>();
     const batchEdges = d === 0 ? filteredEdges : store.getEdgesForNodesBatch([...frontier]);
 
     if (d > 0) collectedEdges.push(...batchEdges);
 
     for (const edge of batchEdges) {
+      if (!guard.tick()) break;
       const otherNode =
         edge.pivot_node_id === edge.source_node_id ? edge.target_node_id : edge.source_node_id;
 
@@ -2095,9 +2106,11 @@ export function getDependencyDiagram(
   store: Store,
   opts: MermaidDiagramOptions,
 ): TraceMcpResult<MermaidDiagramResult> {
+  const guard = opts.guard ?? forTool('get_dependency_diagram');
   const { nodes, edges } = buildGraphData(store, {
     scope: opts.scope,
     depth: opts.depth ?? 2,
+    guard,
   });
 
   const maxNodes = opts.maxNodes ?? 30;
@@ -2126,6 +2139,7 @@ export function getDependencyDiagram(
       format: 'dot',
       nodes: topNodes.length,
       edges: filteredEdges.length,
+      ...guard.marker(),
     });
   }
 
@@ -2144,5 +2158,6 @@ export function getDependencyDiagram(
     format: 'mermaid',
     nodes: topNodes.length,
     edges: filteredEdges.length,
+    ...guard.marker(),
   });
 }

--- a/src/tools/framework/call-graph.ts
+++ b/src/tools/framework/call-graph.ts
@@ -1,4 +1,5 @@
 import { err, ok } from 'neverthrow';
+import { type BudgetExceeded, type BudgetGuard, forTool } from '../../compute-guard.js';
 import type { Store } from '../../db/store.js';
 import { notFound, type TraceMcpResult } from '../../errors.js';
 import type { EdgeResolution } from '../../plugin-api/types.js';
@@ -40,6 +41,8 @@ interface CallGraphResult {
   max_depth: number;
   /** Distribution of resolution tiers across all edges */
   resolution_tiers: ResolutionTiers;
+  /** Present only when a compute ceiling stopped the traversal (TRA-841) */
+  _budget_exceeded?: BudgetExceeded;
 }
 
 /** Read resolution tier from edge column, with fallback inference for legacy data */
@@ -92,6 +95,7 @@ export function getCallGraph(
   store: Store,
   opts: { symbolId?: string; fqn?: string },
   depth = 2,
+  guard: BudgetGuard = forTool('get_call_graph'),
 ): TraceMcpResult<CallGraphResult> {
   depth = Math.min(depth, MAX_DEPTH);
   const resolved = resolveSymbolInput(store, opts);
@@ -130,6 +134,7 @@ export function getCallGraph(
     visited,
     edgeTypesUsed,
     chaAliasNodeIds,
+    guard,
   );
 
   return ok({
@@ -137,6 +142,7 @@ export function getCallGraph(
     edge_types_used: [...edgeTypesUsed],
     max_depth: depth,
     resolution_tiers: tiers,
+    ...guard.marker(),
   });
 }
 
@@ -152,6 +158,7 @@ function buildCallNode(
   _visited: Set<number>,
   edgeTypesUsed: Set<string>,
   chaAliasNodeIds: number[] = [],
+  guard: BudgetGuard = forTool('get_call_graph'),
 ): { node: CallGraphNode; tiers: ResolutionTiers } {
   // Phase 1: BFS to collect all reachable node IDs + edges
   interface EdgeRef {
@@ -189,6 +196,9 @@ function buildCallNode(
 
   for (let d = 0; d < maxDepth; d++) {
     if (frontier.length === 0) break;
+    // One forced check per depth level: a batch fetch over a wide frontier is
+    // expensive enough to deserve a ceiling check of its own.
+    if (!guard.check()) break;
 
     // Batch fetch all edges for this frontier
     const batchEdges = store.getEdgesForNodesBatch(frontier);
@@ -196,6 +206,7 @@ function buildCallNode(
     // Collect new neighbor node IDs
     const newNeighbors = new Set<number>();
     for (const edge of batchEdges) {
+      if (!guard.tick()) break;
       if (!CALL_EDGE_TYPES.has(edge.edge_type_name)) continue;
       edgeTypesUsed.add(edge.edge_type_name);
 
@@ -236,6 +247,7 @@ function buildCallNode(
       }
     }
 
+    if (guard.aborted) break;
     if (newNeighbors.size === 0) break;
 
     // Batch resolve node refs to get symbolRefIds
@@ -272,13 +284,18 @@ function buildCallNode(
     const node = makeNode(sym, filePath, sym.line_start, [], []);
     buildVisited.add(nodeId);
 
-    if (depth <= 0) {
+    // This phase turns a graph into a *tree*: every distinct path to a node
+    // materializes its own subtree, so a dense neighbourhood expands
+    // combinatorially. This tick is the one that actually stands between a
+    // pathological symbol and the OOM killer.
+    if (!guard.tick() || depth <= 0) {
       node.calls = undefined;
       node.called_by = undefined;
       return node;
     }
 
     for (const { nodeId: targetNodeId, edgeType, resolution } of info.outgoing) {
+      if (guard.aborted) break;
       if (buildVisited.has(targetNodeId)) continue;
       if (!nodeInfoMap.has(targetNodeId)) continue;
       const child = buildFromInfo(targetNodeId, depth - 1, new Set(buildVisited));
@@ -287,6 +304,7 @@ function buildCallNode(
     }
 
     for (const { nodeId: sourceNodeId, edgeType, resolution } of info.incoming) {
+      if (guard.aborted) break;
       if (buildVisited.has(sourceNodeId)) continue;
       if (!nodeInfoMap.has(sourceNodeId)) continue;
       const child = buildFromInfo(sourceNodeId, depth - 1, new Set(buildVisited));

--- a/src/tools/framework/references.ts
+++ b/src/tools/framework/references.ts
@@ -1,4 +1,5 @@
 import { err, ok } from 'neverthrow';
+import { type BudgetExceeded, type BudgetGuard, forTool } from '../../compute-guard.js';
 import type { Store } from '../../db/store.js';
 import { notFound, type TraceMcpResult } from '../../errors.js';
 import { expandMethodViaCha } from '../shared/cha.js';
@@ -45,6 +46,8 @@ interface FindReferencesResult {
    * name is shared with many other symbols (graphify #543 phantom-god-node
    * fix). Lets callers know the result was tightened. */
   ambiguous_filtered?: { dropped: number; nameCollisions: number };
+  /** Present only when a compute ceiling stopped the scan (TRA-841) */
+  _budget_exceeded?: BudgetExceeded;
 }
 
 /**
@@ -67,6 +70,7 @@ export function findReferences(
     includeAmbiguousTextMatched?: boolean;
     ambiguityThreshold?: number;
   },
+  guard: BudgetGuard = forTool('find_usages'),
 ): TraceMcpResult<FindReferencesResult> {
   let nodeId: number | undefined;
   const targetMeta: FindReferencesResult['target'] = {};
@@ -130,6 +134,9 @@ export function findReferences(
     const edges = store.getIncomingEdges(targetNid);
     const isChaTarget = targetNid !== nodeId;
     for (const edge of edges) {
+      // A god-node can have six figures of incoming edges; this loop is the
+      // one place find_usages can run unbounded on a large graph.
+      if (!guard.tick()) break;
       // Dedup by (source, target, type) to avoid duplicates when CHA overlaps
       const key = `${edge.source_node_id}:${edge.target_node_id}:${edge.edge_type_id}`;
       if (seenEdgeKeys.has(key)) continue;
@@ -168,6 +175,7 @@ export function findReferences(
   const references: ReferenceItem[] = [];
 
   for (const { edge, via_cha } of allIncomingEdges) {
+    if (!guard.tick()) break;
     const sourceRef = nodeRefs.get(edge.source_node_id);
     if (!sourceRef) continue;
 
@@ -234,6 +242,7 @@ export function findReferences(
     references: kept,
     total: kept.length,
     resolution_tiers: tiers,
+    ...guard.marker(),
   };
   if (chaExpansion && chaExpansion.length > 0) result.cha_expansion = chaExpansion;
   if (ambiguousFiltered) result.ambiguous_filtered = ambiguousFiltered;

--- a/src/tools/register/analysis.ts
+++ b/src/tools/register/analysis.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { forTool } from '../../compute-guard.js';
 import { formatToolError } from '../../errors.js';
 import type { ServerContext } from '../../server/types.js';
 import { OutputFormatSchema, encodeResponse } from '../_common/output-format.js';
@@ -296,7 +297,8 @@ export function registerAnalysisTools(server: McpServer, ctx: ServerContext): vo
         ),
     },
     async ({ include_tests }) => {
-      const cycles = getDependencyCycles(store, { includeTests: include_tests === true });
+      const guard = forTool('get_circular_imports');
+      const cycles = getDependencyCycles(store, { includeTests: include_tests === true }, guard);
       const stats = store.getStats();
       return {
         content: [
@@ -305,6 +307,7 @@ export function registerAnalysisTools(server: McpServer, ctx: ServerContext): vo
             text: jh('get_circular_imports', {
               total_cycles: cycles.length,
               cycles,
+              ...guard.marker(),
               ...(cycles.length === 0
                 ? {
                     evidence: buildNegativeEvidence(
@@ -336,9 +339,17 @@ export function registerAnalysisTools(server: McpServer, ctx: ServerContext): vo
       output_format: OutputFormatSchema,
     },
     async ({ limit, include_markdown, output_format }) => {
-      const results = getPageRank(store, { includeMarkdown: include_markdown });
+      const guard = forTool('get_pagerank');
+      const results = getPageRank(store, { includeMarkdown: include_markdown }, guard);
       const sliced = results.slice(0, limit ?? 50);
       const fmt = output_format === 'markdown' ? 'json' : output_format;
+      // The array payload has nowhere to carry a marker, so an aborted run
+      // returns the object form instead: on a call that did not finish, the
+      // truncation reason is worth more than shape stability.
+      if (guard.aborted) {
+        const text = jh('get_pagerank', { results: sliced, ...guard.marker() });
+        return { content: [{ type: 'text', text }] };
+      }
       const text = encodeResponse(sliced, fmt);
       return { content: [{ type: 'text', text }] };
     },

--- a/src/tools/register/analysis.ts
+++ b/src/tools/register/analysis.ts
@@ -308,7 +308,11 @@ export function registerAnalysisTools(server: McpServer, ctx: ServerContext): vo
               total_cycles: cycles.length,
               cycles,
               ...guard.marker(),
-              ...(cycles.length === 0
+              // Negative evidence is an authoritative "we looked everywhere
+              // and found nothing". A truncated scan looked at part of the
+              // graph, so it cannot make that claim — `_budget_exceeded`
+              // stands alone rather than contradicting a `not_found` verdict.
+              ...(cycles.length === 0 && !guard.aborted
                 ? {
                     evidence: buildNegativeEvidence(
                       stats.totalFiles,
@@ -343,15 +347,16 @@ export function registerAnalysisTools(server: McpServer, ctx: ServerContext): vo
       const results = getPageRank(store, { includeMarkdown: include_markdown }, guard);
       const sliced = results.slice(0, limit ?? 50);
       const fmt = output_format === 'markdown' ? 'json' : output_format;
-      // The array payload has nowhere to carry a marker, so an aborted run
-      // returns the object form instead: on a call that did not finish, the
-      // truncation reason is worth more than shape stability.
-      if (guard.aborted) {
-        const text = jh('get_pagerank', { results: sliced, ...guard.marker() });
-        return { content: [{ type: 'text', text }] };
-      }
       const text = encodeResponse(sliced, fmt);
-      return { content: [{ type: 'text', text }] };
+      // The advertised payload is a bare array in every case — making the
+      // schema conditional on resource pressure would break clients exactly
+      // when the guard is meant to keep the answer usable. The truncation
+      // marker rides the MCP result's own `_meta` channel instead, so it stays
+      // structured and machine-readable without touching the array contract.
+      return {
+        content: [{ type: 'text', text }],
+        ...(guard.aborted ? { _meta: guard.marker() } : {}),
+      };
     },
   );
 

--- a/src/tools/register/framework.ts
+++ b/src/tools/register/framework.ts
@@ -295,7 +295,9 @@ export function registerFrameworkTools(server: McpServer, ctx: ServerContext): v
           isError: true,
         };
       }
-      if (result.value.total === 0) {
+      // A truncated scan cannot claim `indexed_no_edges`: it stopped before
+      // seeing the whole edge set, so zero results is not evidence of absence.
+      if (result.value.total === 0 && !result.value._budget_exceeded) {
         const stats = store.getStats();
         // findReferences returns NOT_FOUND for missing symbols/files — reaching
         // this branch means the symbol IS indexed with 0 incoming edges. Probe
@@ -376,7 +378,7 @@ export function registerFrameworkTools(server: McpServer, ctx: ServerContext): v
       }
       const root = result.value.root;
       const isolated = (root.calls?.length ?? 0) === 0 && (root.called_by?.length ?? 0) === 0;
-      if (isolated) {
+      if (isolated && !result.value._budget_exceeded) {
         const stats = store.getStats();
         const sym = store.getSymbolBySymbolId(root.symbol_id);
         const probe = probeSymbolName(store, projectRoot, root.symbol_id);

--- a/tests/tools/compute-guard.test.ts
+++ b/tests/tools/compute-guard.test.ts
@@ -1,0 +1,213 @@
+/**
+ * TRA-841 — per-call compute ceiling for heavy graph tools.
+ *
+ * Two layers are covered:
+ *   1. The guard's own decision, per ceiling. The RSS ceiling is asserted
+ *      against a *fed* reading, never against real process memory — allocating
+ *      gigabytes to trip it is not something CI can do.
+ *   2. One end-to-end pass through `getCallGraph` on a synthetic oversized
+ *      graph, proving an abort returns a partial result with the marker rather
+ *      than throwing.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { BudgetGuard, forTool } from '../../src/compute-guard.js';
+import type { Store } from '../../src/db/store.js';
+import { getCallGraph } from '../../src/tools/framework/call-graph.js';
+import { createTestStore } from '../test-utils.js';
+
+const CEILINGS = { timeout_ms: 1000, rss_mb: 500, iterations: 100 };
+
+/** Guard with a fake clock and a fed RSS reading — no real syscalls. */
+function testGuard(
+  overrides: Partial<typeof CEILINGS> = {},
+  deps: { now?: () => number; rssMb?: () => number } = {},
+): BudgetGuard {
+  return new BudgetGuard(
+    'test_tool',
+    { ...CEILINGS, ...overrides },
+    { now: deps.now ?? (() => 0), rssMb: deps.rssMb ?? (() => 1) },
+  );
+}
+
+describe('BudgetGuard ceilings', () => {
+  it('trips on the iteration ceiling and reports it', () => {
+    const guard = testGuard({ iterations: 10 });
+    let allowed = 0;
+    for (let i = 0; i < 50; i++) {
+      if (!guard.tick()) break;
+      allowed++;
+    }
+
+    expect(allowed).toBe(10);
+    expect(guard.aborted).toBe(true);
+    const marker = guard.marker()._budget_exceeded!;
+    expect(marker.reason).toBe('iterations');
+    expect(marker.limit).toBe(10);
+    expect(marker.tool).toBe('test_tool');
+    // Every further tick stays false — the guard never un-trips.
+    expect(guard.tick()).toBe(false);
+  });
+
+  it('trips on the wall-clock ceiling', () => {
+    let clock = 0;
+    const guard = testGuard({ timeout_ms: 500 }, { now: () => clock });
+
+    expect(guard.check()).toBe(true);
+    clock = 501;
+    expect(guard.check()).toBe(false);
+
+    const marker = guard.marker()._budget_exceeded!;
+    expect(marker.reason).toBe('timeout');
+    expect(marker.limit).toBe(500);
+    expect(marker.elapsed_ms).toBe(501);
+  });
+
+  it('trips on the RSS ceiling given a fed reading', () => {
+    let rss = 100;
+    const guard = testGuard({ rss_mb: 400 }, { rssMb: () => rss });
+
+    expect(guard.check()).toBe(true);
+    rss = 401;
+    expect(guard.check()).toBe(false);
+
+    const marker = guard.marker()._budget_exceeded!;
+    expect(marker.reason).toBe('rss');
+    expect(marker.limit).toBe(400);
+    expect(marker.rss_mb).toBe(401);
+  });
+
+  it('emits no marker while under every ceiling', () => {
+    const guard = testGuard();
+    for (let i = 0; i < 50; i++) expect(guard.tick()).toBe(true);
+    expect(guard.aborted).toBe(false);
+    expect(guard.marker()).toEqual({});
+  });
+
+  it('samples the clock only every 4096 ticks', () => {
+    let now = 0;
+    let calls = 0;
+    const guard = new BudgetGuard(
+      'test_tool',
+      { timeout_ms: 1_000_000, rss_mb: 1_000_000, iterations: 1_000_000 },
+      {
+        now: () => {
+          calls++;
+          return now;
+        },
+        rssMb: () => 1,
+      },
+    );
+    calls = 0; // discount the constructor's start-time read
+    for (let i = 0; i < 4095; i++) guard.tick();
+    expect(calls).toBe(0);
+    guard.tick(); // tick 4096 samples
+    expect(calls).toBe(1);
+  });
+
+  it('TRACE_MCP_NO_COMPUTE_GUARD disables the ceilings entirely', () => {
+    const prev = process.env.TRACE_MCP_NO_COMPUTE_GUARD;
+    const prevIters = process.env.TRACE_MCP_COMPUTE_MAX_ITERATIONS;
+    try {
+      process.env.TRACE_MCP_COMPUTE_MAX_ITERATIONS = '5';
+      process.env.TRACE_MCP_NO_COMPUTE_GUARD = '1';
+      const guard = forTool('get_call_graph');
+      for (let i = 0; i < 1000; i++) expect(guard.tick()).toBe(true);
+      expect(guard.aborted).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.TRACE_MCP_NO_COMPUTE_GUARD;
+      else process.env.TRACE_MCP_NO_COMPUTE_GUARD = prev;
+      if (prevIters === undefined) delete process.env.TRACE_MCP_COMPUTE_MAX_ITERATIONS;
+      else process.env.TRACE_MCP_COMPUTE_MAX_ITERATIONS = prevIters;
+    }
+  });
+
+  it('reads ceilings from env', () => {
+    const prev = process.env.TRACE_MCP_COMPUTE_MAX_ITERATIONS;
+    try {
+      process.env.TRACE_MCP_COMPUTE_MAX_ITERATIONS = '3';
+      const guard = forTool('get_call_graph');
+      expect(guard.tick()).toBe(true);
+      expect(guard.tick()).toBe(true);
+      expect(guard.tick()).toBe(true);
+      expect(guard.tick()).toBe(false);
+      expect(guard.marker()._budget_exceeded?.limit).toBe(3);
+    } finally {
+      if (prev === undefined) delete process.env.TRACE_MCP_COMPUTE_MAX_ITERATIONS;
+      else process.env.TRACE_MCP_COMPUTE_MAX_ITERATIONS = prev;
+    }
+  });
+});
+
+describe('getCallGraph under a compute ceiling', () => {
+  let store: Store;
+
+  /**
+   * A densely connected clique. Phase 3 of the call-graph builder materializes
+   * a *tree* out of this, so the node count explodes with depth — exactly the
+   * shape that reaches the OOM killer without a ceiling.
+   */
+  function buildDenseGraph(size: number): void {
+    const nodeIds: number[] = [];
+    const fileId = store.insertFile('src/dense.ts', 'typescript', null, null);
+    for (let i = 0; i < size; i++) {
+      const symbolDbId = store.insertSymbol(fileId, {
+        symbolId: `src/dense.ts::fn${i}#function`,
+        name: `fn${i}`,
+        kind: 'function',
+        byteStart: 0,
+        byteEnd: 10,
+        lineStart: i + 1,
+        lineEnd: i + 1,
+      });
+      nodeIds.push(store.getNodeId('symbol', symbolDbId)!);
+    }
+    for (let i = 0; i < size; i++) {
+      for (let k = 0; k < size; k++) {
+        if (i !== k) store.insertEdge(nodeIds[i], nodeIds[k], 'calls');
+      }
+    }
+  }
+
+  beforeEach(() => {
+    store = createTestStore();
+    store.ensureEdgeType('calls', 'code', 'Function calls');
+  });
+
+  it('returns a partial result with _budget_exceeded instead of throwing (iterations)', () => {
+    buildDenseGraph(12);
+    const guard = testGuard({ iterations: 20 });
+
+    const result = getCallGraph(store, { symbolId: 'src/dense.ts::fn0#function' }, 8, guard);
+
+    expect(result.isOk()).toBe(true);
+    const value = result._unsafeUnwrap();
+    expect(value._budget_exceeded?.reason).toBe('iterations');
+    expect(value._budget_exceeded?.limit).toBe(20);
+    // Partial, not empty: the root is still there and still describes fn0.
+    expect(value.root.name).toBe('fn0');
+  });
+
+  it('returns a partial result when the wall clock runs out', () => {
+    buildDenseGraph(12);
+    let clock = 0;
+    // Every clock read advances time, so the first forced check per depth
+    // level trips the ceiling deterministically.
+    const guard = testGuard({ timeout_ms: 5 }, { now: () => (clock += 10) });
+
+    const result = getCallGraph(store, { symbolId: 'src/dense.ts::fn0#function' }, 8, guard);
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()._budget_exceeded?.reason).toBe('timeout');
+  });
+
+  it('leaves no marker on an ordinary call', () => {
+    buildDenseGraph(4);
+    const guard = testGuard({ iterations: 100_000 });
+
+    const result = getCallGraph(store, { symbolId: 'src/dense.ts::fn0#function' }, 2, guard);
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()._budget_exceeded).toBeUndefined();
+    expect(guard.aborted).toBe(false);
+  });
+});

--- a/tests/tools/compute-guard.test.ts
+++ b/tests/tools/compute-guard.test.ts
@@ -9,10 +9,15 @@
  *      graph, proving an abort returns a partial result with the marker rather
  *      than throwing.
  */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { BudgetGuard, forTool } from '../../src/compute-guard.js';
 import type { Store } from '../../src/db/store.js';
+import type { ServerContext } from '../../src/server/types.js';
+import { getPageRank } from '../../src/tools/analysis/graph-analysis.js';
 import { getCallGraph } from '../../src/tools/framework/call-graph.js';
+import { findReferences } from '../../src/tools/framework/references.js';
+import { registerAnalysisTools } from '../../src/tools/register/analysis.js';
 import { createTestStore } from '../test-utils.js';
 
 const CEILINGS = { timeout_ms: 1000, rss_mb: 500, iterations: 100 };
@@ -209,5 +214,173 @@ describe('getCallGraph under a compute ceiling', () => {
     expect(result.isOk()).toBe(true);
     expect(result._unsafeUnwrap()._budget_exceeded).toBeUndefined();
     expect(guard.aborted).toBe(false);
+  });
+});
+
+// ── Review follow-ups (PR #894) ────────────────────────────────────────────
+// Three properties an abort must hold beyond "it stopped": the response schema
+// must not change shape under resource pressure, a truncated scan must not
+// claim authoritative negative evidence, and PageRank must actually consume
+// the iteration ceiling instead of only sampling between sweeps.
+
+interface RegisteredTool {
+  handler: (
+    args: Record<string, unknown>,
+    extra: unknown,
+  ) => Promise<{ content: Array<{ type: string; text: string }>; _meta?: unknown }>;
+}
+
+function makeCtx(store: Store): ServerContext {
+  return {
+    store,
+    projectRoot: '/tmp',
+    config: {},
+    registry: { getAllFrameworkPlugins: () => [] },
+    topoStore: null,
+    j: (v: unknown) => JSON.stringify(v),
+    jh: (_tool: string, v: unknown) => JSON.stringify(v),
+    guardPath: () => null,
+  } as unknown as ServerContext;
+}
+
+/** Run `fn` with the iteration ceiling pinned, restoring the previous value. */
+async function withIterationCeiling<T>(limit: number, fn: () => Promise<T> | T): Promise<T> {
+  const prev = process.env.TRACE_MCP_COMPUTE_MAX_ITERATIONS;
+  process.env.TRACE_MCP_COMPUTE_MAX_ITERATIONS = String(limit);
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) delete process.env.TRACE_MCP_COMPUTE_MAX_ITERATIONS;
+    else process.env.TRACE_MCP_COMPUTE_MAX_ITERATIONS = prev;
+  }
+}
+
+describe('abort does not change what a tool promises', () => {
+  let store: Store;
+  let tools: Record<string, RegisteredTool>;
+
+  beforeEach(() => {
+    store = createTestStore();
+    store.ensureEdgeType('imports', 'code', 'Module import');
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+    registerAnalysisTools(server, makeCtx(store));
+    tools = (server as unknown as { _registeredTools: Record<string, RegisteredTool> })
+      ._registeredTools;
+  });
+
+  /** Two files importing each other — a real, findable cycle. */
+  function buildCycle(): void {
+    const a = store.insertFile('src/a.ts', 'typescript', null, null);
+    const b = store.insertFile('src/b.ts', 'typescript', null, null);
+    const aNode = store.getNodeId('file', a)!;
+    const bNode = store.getNodeId('file', b)!;
+    store.insertEdge(aNode, bNode, 'imports');
+    store.insertEdge(bNode, aNode, 'imports');
+  }
+
+  it('get_pagerank keeps its array payload when the guard trips', async () => {
+    buildCycle();
+    const result = await withIterationCeiling(1, () => tools.get_pagerank.handler({}, {}));
+
+    // The advertised contract is a bare array — conditioning the schema on
+    // resource pressure would break clients exactly when the partial answer
+    // is supposed to stay usable.
+    expect(Array.isArray(JSON.parse(result.content[0].text))).toBe(true);
+    // The reason rides the MCP result's own metadata channel instead.
+    expect(
+      (result._meta as { _budget_exceeded?: { reason: string } })._budget_exceeded?.reason,
+    ).toBe('iterations');
+  });
+
+  it('an aborted cycle scan does not claim the graph is acyclic', async () => {
+    buildCycle();
+    const result = await withIterationCeiling(1, () => tools.get_circular_imports.handler({}, {}));
+    const payload = JSON.parse(result.content[0].text) as {
+      total_cycles: number;
+      evidence?: unknown;
+      _budget_exceeded?: { reason: string };
+    };
+
+    expect(payload._budget_exceeded?.reason).toBe('iterations');
+    // The cycle is real; a truncated scan that reports zero must not also
+    // report "we looked and found nothing".
+    expect(payload.evidence).toBeUndefined();
+  });
+
+  it('a completed cycle scan still emits negative evidence', async () => {
+    store.insertFile('src/lonely.ts', 'typescript', null, null);
+    const result = await tools.get_circular_imports.handler({}, {});
+    const payload = JSON.parse(result.content[0].text) as {
+      total_cycles: number;
+      evidence?: unknown;
+      _budget_exceeded?: unknown;
+    };
+
+    expect(payload.total_cycles).toBe(0);
+    expect(payload._budget_exceeded).toBeUndefined();
+    expect(payload.evidence).toBeDefined();
+  });
+});
+
+describe('PageRank consumes the iteration ceiling', () => {
+  it('ticks inside the sweep and returns the last converged vector', () => {
+    const store = createTestStore();
+    store.ensureEdgeType('imports', 'code', 'Module import');
+    const ids = ['src/p0.ts', 'src/p1.ts', 'src/p2.ts'].map(
+      (p) => store.getNodeId('file', store.insertFile(p, 'typescript', null, null))!,
+    );
+    store.insertEdge(ids[0], ids[1], 'imports');
+    store.insertEdge(ids[1], ids[2], 'imports');
+    store.insertEdge(ids[2], ids[0], 'imports');
+
+    const guard = testGuard({ iterations: 1 });
+    const results = getPageRank(store, { tolerance: 0 }, guard);
+
+    expect(guard.aborted).toBe(true);
+    expect(guard.consumed).toBeGreaterThan(0);
+    // Scores come from the last fully completed sweep, so they are still a
+    // valid (just less converged) ranking rather than a half-filled buffer.
+    expect(results.length).toBeGreaterThan(0);
+    for (const r of results) expect(Number.isFinite(r.score)).toBe(true);
+  });
+});
+
+describe('find_usages under a ceiling', () => {
+  it('marks a truncated scan so the caller cannot read zero as absence', () => {
+    const store = createTestStore();
+    store.ensureEdgeType('calls', 'code', 'Function calls');
+    const fileId = store.insertFile('src/u.ts', 'typescript', null, null);
+    const target = store.insertSymbol(fileId, {
+      symbolId: 'src/u.ts::target#function',
+      name: 'target',
+      kind: 'function',
+      byteStart: 0,
+      byteEnd: 10,
+      lineStart: 1,
+      lineEnd: 1,
+    });
+    const targetNode = store.getNodeId('symbol', target)!;
+    for (let i = 0; i < 5; i++) {
+      const caller = store.insertSymbol(fileId, {
+        symbolId: `src/u.ts::caller${i}#function`,
+        name: `caller${i}`,
+        kind: 'function',
+        byteStart: 0,
+        byteEnd: 10,
+        lineStart: i + 2,
+        lineEnd: i + 2,
+      });
+      store.insertEdge(store.getNodeId('symbol', caller)!, targetNode, 'calls');
+    }
+
+    const guard = testGuard({ iterations: 1 });
+    const result = findReferences(store, { symbolId: 'src/u.ts::target#function' }, guard);
+
+    expect(result.isOk()).toBe(true);
+    const value = result._unsafeUnwrap();
+    expect(value._budget_exceeded?.reason).toBe('iterations');
+    // The register layer keys its `indexed_no_edges` verdict off the absence
+    // of this field, so a truncated scan can never produce that claim.
+    expect(value._budget_exceeded).toBeDefined();
   });
 });


### PR DESCRIPTION
Closes TRA-841. Related: TRA-809, TRA-811.

## The gap

We had a **token** budget, not a **compute** budget. `src/server/budget-defaults.ts` caps expansive parameters and `computeAdaptiveBudget` sizes context payloads — both shape the *answer*. Neither bounds the work done to produce it. A `get_call_graph` with a user-set depth (the budget rules deliberately skip user-set params) runs to completion or to the OOM killer, whichever comes first. And an OS-level kill runs no JS, so `src/daemon/vitals-log.ts` can only record that the daemon died, never which call killed it.

## What this adds

`src/compute-guard.ts` — a `BudgetGuard` holding three ceilings (wall clock, RSS, iteration count), ticked inside traversal loops:

| Tool | Tick site |
|---|---|
| `get_call_graph` | BFS edge scan + the Phase-3 tree materialization (`buildFromInfo`) |
| `get_change_impact` | `traverseIncoming` edge loop + one forced check per depth level |
| `get_dependency_diagram` | both frontier expansions in `visualize.ts` |
| `get_circular_imports` | both Kosaraju DFS passes |
| `find_usages` | incoming-edge collection + reference assembly |
| `get_pagerank` | one forced check per power-iteration sweep |

Not blanket-wired across all tools — the cheap ones would pay the tick for nothing.

**On abort the tool returns the partial result with `_budget_exceeded`, never a tool-call error.** A truncated call graph plus an explicit "this is truncated and why" is a usable answer; a hard error costs the agent the whole turn.

```json
{ "_budget_exceeded": { "reason": "iterations", "limit": 2000000, "elapsed_ms": 812,
                        "iterations": 2000001, "tool": "get_call_graph", "note": "..." } }
```

Every abort also writes one `Compute budget exceeded` line to the daemon log with the tool name and the ceiling hit. That is the part that pays back TRA-809 directly: if a heavy tool is what drives the daemon toward the killer, the log now says so *before* the process disappears.

`get_call_graph`'s Phase 3 is the interesting one — it turns a graph into a *tree*, so every distinct path to a node materializes its own subtree. That expansion is combinatorial and is the single most plausible in-tool route to the OOM killer.

## RSS measurement path

`readRssMb()` is exported from `src/daemon/vitals-log.ts` and used by both the vitals line and the guard, so the logged number and the enforced ceiling can never disagree.

## Configuration

`TRACE_MCP_COMPUTE_TIMEOUT_MS` / `TRACE_MCP_COMPUTE_RSS_MB` / `TRACE_MCP_COMPUTE_MAX_ITERATIONS` override the ceilings; `TRACE_MCP_NO_COMPUTE_GUARD=1` disables all of them for debugging. Documented in `docs/configuration.md`.

## Test evidence

`tests/tools/compute-guard.test.ts` — 10 tests, all green:

- one per ceiling, on the guard's decision (iterations, timeout, RSS);
- **the RSS ceiling asserts on a fed reading**, not on real process memory — allocating gigabytes to trip it is not something CI can do;
- the sample interval is asserted directly (3 999 ticks read the clock zero times; tick 4096 reads it once);
- both env-var paths (override, and the kill switch);
- end-to-end through `getCallGraph` on a synthetic dense clique: partial result + marker, `isOk()`, no throw;
- a control case proving no marker appears on an ordinary call.

Full suite: `Test Files 897 passed | 5 skipped (902)`, `Tests 9952 passed | 24 skipped (9976)`. `pnpm typecheck`, `pnpm build`, `biome ci` all clean.

## Measured overhead

`scripts/bench-compute-guard.ts` (committed, reproducible) alternates guarded and unguarded runs of the same traversal to cancel cold-cache order effects, and compares medians.

Graph: 37,449 symbols, fanout 8, walked to depth 5 → **79,577 ticks per call, ~85 ms per call**.

Overhead across five runs: `-0.90%`, `+2.12%`, `-2.52%`, `-1.61%`, `-2.71%`. The negative values are the point: the effect is below run-to-run noise on this machine, so the tick cost is under ~2%, which is what the 4096-tick sample interval buys.

## Defaults

Chosen from that measurement, not taste: `iterations 2_000_000` (~25x the heavy case above), `timeout_ms 15_000` (~175x), `rss_mb 3_000` (above the ~950 MB idle resident figure reported in TRA-811). Nothing anyone runs today trips them.

Agent: Lead Engineer (Claude Opus 5)
