### PR TITLE
fix(indexer): resolve C/C++ imports, the next language after Rust (TRA-832)

### DIFF
--- a/docs/language-matrix.md
+++ b/docs/language-matrix.md
@@ -48,7 +48,7 @@ is the two-pass pipeline in [architecture](architecture.md#indexing-pipeline).
 
 - **indexed with the default config:** 78 (the rest need an `include` entry — see below)
 - **tree-sitter parser:** 29 · **regex parser:** 46 · **custom parser:** 6
-- **import edges:** 13
+- **import edges:** 15
 - **call edges (`get_call_graph`, call-aware `find_usages`):** 3
 - **type / inheritance edges:** 2
 - **covered by a plugin test:** 68
@@ -104,12 +104,12 @@ second thing, so it is much shorter than the language list — see
 | autohotkey | .ahk .ah2 | regex | yes | — | — | — | yes |
 | bash | .sh .bash .zsh | tree-sitter | yes | — | — | — | yes |
 | blade | .blade.php | regex | yes | — | — | — | yes |
-| c | .c .h | tree-sitter | yes | — | — | — | yes |
+| c | .c .h | tree-sitter | yes | yes | — | — | yes |
 | clojure | .clj .cljs .cljc .edn | regex | yes | — | — | — | — |
 | cmake | .cmake CMakeLists.txt | regex | yes | — | — | — | yes |
 | cobol | .cob .cbl .cpy .cobol | regex (multi-pass) | yes | — | — | — | yes |
 | common-lisp | .lisp .lsp .cl .asd | regex (multi-pass) | yes | — | — | — | yes |
-| cpp | .cpp .cxx .cc .hpp | tree-sitter | yes | — | — | — | yes |
+| cpp | .cpp .cxx .cc .hpp | tree-sitter | yes | yes | — | — | yes |
 | csharp | .cs | tree-sitter | yes | — | — | — | yes |
 | css | .css .scss .sass .less | tree-sitter | yes | yes | — | — | yes |
 | cuda | .cu .cuh | regex | yes | — | — | — | — |
@@ -121,7 +121,7 @@ second thing, so it is much shorter than the language list — see
 | elixir | .ex .exs | tree-sitter | yes | — | — | — | yes |
 | elm | .elm | tree-sitter | yes | — | — | — | — |
 | erlang | .erl .hrl | regex | yes | — | — | — | yes |
-| form | .frm .prc .h | regex | yes | — | — | — | — |
+| form | .frm .prc | regex | yes | — | — | — | — |
 | fortran | .f .f90 .f95 .f03 | regex | yes | — | — | — | yes |
 | fsharp | .fs .fsi .fsx | regex (multi-pass) | yes | — | — | — | — |
 | gdscript | .gd | regex | yes | — | — | — | yes |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4350,7 +4350,7 @@ is the two-pass pipeline in [architecture](architecture.md#indexing-pipeline).
 
 - **indexed with the default config:** 78 (the rest need an `include` entry — see below)
 - **tree-sitter parser:** 29 · **regex parser:** 46 · **custom parser:** 6
-- **import edges:** 13
+- **import edges:** 15
 - **call edges (`get_call_graph`, call-aware `find_usages`):** 3
 - **type / inheritance edges:** 2
 - **covered by a plugin test:** 68
@@ -4406,12 +4406,12 @@ second thing, so it is much shorter than the language list — see
 | autohotkey | .ahk .ah2 | regex | yes | — | — | — | yes |
 | bash | .sh .bash .zsh | tree-sitter | yes | — | — | — | yes |
 | blade | .blade.php | regex | yes | — | — | — | yes |
-| c | .c .h | tree-sitter | yes | — | — | — | yes |
+| c | .c .h | tree-sitter | yes | yes | — | — | yes |
 | clojure | .clj .cljs .cljc .edn | regex | yes | — | — | — | — |
 | cmake | .cmake CMakeLists.txt | regex | yes | — | — | — | yes |
 | cobol | .cob .cbl .cpy .cobol | regex (multi-pass) | yes | — | — | — | yes |
 | common-lisp | .lisp .lsp .cl .asd | regex (multi-pass) | yes | — | — | — | yes |
-| cpp | .cpp .cxx .cc .hpp | tree-sitter | yes | — | — | — | yes |
+| cpp | .cpp .cxx .cc .hpp | tree-sitter | yes | yes | — | — | yes |
 | csharp | .cs | tree-sitter | yes | — | — | — | yes |
 | css | .css .scss .sass .less | tree-sitter | yes | yes | — | — | yes |
 | cuda | .cu .cuh | regex | yes | — | — | — | — |
@@ -4423,7 +4423,7 @@ second thing, so it is much shorter than the language list — see
 | elixir | .ex .exs | tree-sitter | yes | — | — | — | yes |
 | elm | .elm | tree-sitter | yes | — | — | — | — |
 | erlang | .erl .hrl | regex | yes | — | — | — | yes |
-| form | .frm .prc .h | regex | yes | — | — | — | — |
+| form | .frm .prc | regex | yes | — | — | — | — |
 | fortran | .f .f90 .f95 .f03 | regex | yes | — | — | — | yes |
 | fsharp | .fs .fsi .fsx | regex (multi-pass) | yes | — | — | — | — |
 | gdscript | .gd | regex | yes | — | — | — | yes |

--- a/src/indexer/edge-resolver.ts
+++ b/src/indexer/edge-resolver.ts
@@ -12,6 +12,7 @@ import {
   purgeForbiddenCrossWorkspaceEdges as _purgeCrossWs,
   resolveFileProjectionEdges as _resolveFileProjection,
 } from './edge-resolvers/file-projection.js';
+import { resolveCImportEdges as _resolveCImports } from './edge-resolvers/c-imports.js';
 import { resolveTypeScriptHeritageEdges as _resolveHeritage } from './edge-resolvers/heritage.js';
 import { resolveIacImportEdges as _resolveIacImports } from './edge-resolvers/iac-imports.js';
 import { resolveGoImportEdges as _resolveGoImports } from './edge-resolvers/go-imports.js';
@@ -152,6 +153,11 @@ export class EdgeResolver {
   /** Pass 2e5: Rust import edges (module path → module file). */
   resolveRustImportEdges(scope?: ChangeScope): void {
     timed('rust-imports', () => _resolveRustImports(this.state, scope));
+  }
+
+  /** Pass 2e6: C/C++ import edges (`#include` path → header/source file). */
+  resolveCImportEdges(scope?: ChangeScope): void {
+    timed('c-imports', () => _resolveCImports(this.state, scope));
   }
 
   /** Pass 2e2: PHP import edges (PSR-4 use statements). */

--- a/src/indexer/edge-resolvers/c-imports.ts
+++ b/src/indexer/edge-resolvers/c-imports.ts
@@ -42,13 +42,22 @@ function addTo(map: Map<string, number[]>, key: string, id: number): void {
   else map.set(key, [id]);
 }
 
-/** Collapse `.` and `..` segments in a posix-style relative path. */
+/**
+ * Collapse `.` and `..` segments in a posix-style relative path. A `..` that
+ * pops past an empty prefix is kept rather than dropped — otherwise
+ * `src/../../config.h` would collapse to `config.h` and could wrongly match a
+ * same-named file at the repo root, when the include actually escapes the repo.
+ */
 function normalizePath(p: string): string {
   const out: string[] = [];
   for (const part of p.split('/')) {
     if (part === '' || part === '.') continue;
-    if (part === '..') out.pop();
-    else out.push(part);
+    if (part === '..') {
+      if (out.length > 0 && out[out.length - 1] !== '..') out.pop();
+      else out.push('..');
+    } else {
+      out.push(part);
+    }
   }
   return out.join('/');
 }
@@ -110,6 +119,11 @@ export function resolveCImportEdges(state: PipelineState, _scope?: ChangeScope):
     return candidates?.length === 1 ? candidates[0] : undefined;
   };
 
+  // MSVC accepts `#include "sub\header.h"`; `byPath`/`bySuffix` keys are
+  // forward-slash only (see the file-path normalization above), so a
+  // backslash specifier must be normalized before either lookup.
+  const normalizeSpecifier = (s: string): string => s.split('\\').join('/');
+
   let created = 0;
   let external = 0;
   let ambiguous = 0;
@@ -126,19 +140,26 @@ export function resolveCImportEdges(state: PipelineState, _scope?: ChangeScope):
 
       const seen = new Set<string>();
       for (const { from } of imports) {
-        if (!from || seen.has(from)) continue;
-        seen.add(from);
+        if (!from) continue;
+        const specifier = normalizeSpecifier(from);
+        if (seen.has(specifier)) continue;
+        seen.add(specifier);
 
-        const targetId = resolve(from, fromDir);
+        const targetId = resolve(specifier, fromDir);
         if (targetId == null) {
-          const candidates = bySuffix.get(from);
+          const candidates = bySuffix.get(specifier);
           if (candidates && candidates.length > 1) ambiguous++;
           else external++;
           continue;
         }
         const targetNodeId = nodeIds.get(targetId);
         if (targetNodeId == null || targetNodeId === sourceNodeId) continue;
-        insertStmt.run(sourceNodeId, targetNodeId, importsEdgeType.id, JSON.stringify({ from }));
+        insertStmt.run(
+          sourceNodeId,
+          targetNodeId,
+          importsEdgeType.id,
+          JSON.stringify({ from: specifier }),
+        );
         created++;
       }
     }

--- a/src/indexer/edge-resolvers/c-imports.ts
+++ b/src/indexer/edge-resolvers/c-imports.ts
@@ -1,0 +1,150 @@
+/**
+ * Pass 2e6: Resolve C/C++ `#include` specifiers to file→file graph edges (TRA-832).
+ *
+ * `#include "foo/bar.h"` and `#include <foo/bar.h>` both name a path, not a
+ * package: the C/C++ plugins already extract every include into
+ * `metadata.module` (`extractImportEdges` in `plugins/language/{c,cpp}/helpers.ts`),
+ * but no pipeline pass consumed it — the same gap TRA-449 closed for Go,
+ * TRA-483 for Java and TRA-565 for Rust. Indexing redis produced zero import
+ * edges across 191 C files.
+ *
+ * C and C++ share one resolver because they share one target set: a `.cpp`
+ * file routinely includes a `.h` the C plugin owns, and vice versa in mixed
+ * codebases — splitting them would silently miss every cross-language edge.
+ *
+ * Resolution tries the quoted-include rule a C compiler actually uses first
+ * — relative to the including file's own directory — then falls back to
+ * matching the specifier as a path suffix against every indexed C/C++ file,
+ * which is what makes `<mylib/foo.h>` resolve when the repo's own include
+ * root isn't known. A suffix with more than one candidate is ambiguous (a
+ * bare `"util.h"` matching a dozen subsystems) and is left unresolved rather
+ * than guessing; a system or third-party header simply fails to match either
+ * way, so no edge is invented for it.
+ */
+import { logger } from '../../logger.js';
+import type { ChangeScope } from '../../plugin-api/types.js';
+import type { PipelineState } from '../pipeline-state.js';
+
+const C_FAMILY_LANGUAGES = new Set(['c', 'cpp']);
+
+/** Every trailing `/`-aligned suffix of a path, longest first. */
+function suffixes(p: string): string[] {
+  const out = [p];
+  for (let i = p.indexOf('/'); i >= 0; i = p.indexOf('/', i + 1)) {
+    out.push(p.slice(i + 1));
+  }
+  return out;
+}
+
+function addTo(map: Map<string, number[]>, key: string, id: number): void {
+  const list = map.get(key);
+  if (list) list.push(id);
+  else map.set(key, [id]);
+}
+
+/** Collapse `.` and `..` segments in a posix-style relative path. */
+function normalizePath(p: string): string {
+  const out: string[] = [];
+  for (const part of p.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') out.pop();
+    else out.push(part);
+  }
+  return out.join('/');
+}
+
+export function resolveCImportEdges(state: PipelineState, _scope?: ChangeScope): void {
+  // WHY: driven by `state.pendingImports`, already scoped to re-extracted files.
+  void _scope;
+  const { store } = state;
+  if (state.pendingImports.size === 0) return;
+
+  const pendingFileIds = Array.from(state.pendingImports.keys());
+  const fileMap = store.getFilesByIds(pendingFileIds);
+  const hasCFamily = pendingFileIds.some((id) =>
+    C_FAMILY_LANGUAGES.has(fileMap.get(id)?.language ?? ''),
+  );
+  if (!hasCFamily) return;
+
+  // Exact normalized path → file id, for the compiler's own quoted-include
+  // resolution rule. Suffix → candidate file ids, for everything else.
+  const byPath = new Map<string, number>();
+  const bySuffix = new Map<string, number[]>();
+  const allIds: number[] = [];
+  for (const f of store.getAllFiles()) {
+    if (!C_FAMILY_LANGUAGES.has(f.language ?? '')) continue;
+    const p = f.path.split('\\').join('/');
+    allIds.push(f.id);
+    byPath.set(p, f.id);
+    for (const s of suffixes(p)) addTo(bySuffix, s, f.id);
+  }
+  if (allIds.length === 0) return;
+
+  const importsEdgeType = store.db
+    .prepare('SELECT id FROM edge_types WHERE name = ?')
+    .get('imports') as { id: number } | undefined;
+  if (!importsEdgeType) return;
+
+  const nodeIds = new Map<number, number>();
+  const lookupIds = allIds.concat(pendingFileIds);
+  const CHUNK = 500;
+  for (let i = 0; i < lookupIds.length; i += CHUNK) {
+    for (const [k, v] of store.getNodeIdsBatch('file', lookupIds.slice(i, i + CHUNK))) {
+      nodeIds.set(k, v);
+    }
+  }
+
+  const insertStmt = store.db.prepare(
+    `INSERT INTO edges (source_node_id, target_node_id, edge_type_id, resolved, metadata, is_cross_ws)
+     VALUES (?, ?, ?, 1, ?, 0)
+     ON CONFLICT(source_node_id, target_node_id, edge_type_id)
+     DO UPDATE SET metadata = excluded.metadata`,
+  );
+
+  const resolve = (specifier: string, fromDir: string): number | undefined => {
+    const relative = normalizePath(fromDir ? `${fromDir}/${specifier}` : specifier);
+    const exact = byPath.get(relative);
+    if (exact != null) return exact;
+
+    const candidates = bySuffix.get(specifier);
+    return candidates?.length === 1 ? candidates[0] : undefined;
+  };
+
+  let created = 0;
+  let external = 0;
+  let ambiguous = 0;
+
+  store.db.transaction(() => {
+    for (const [fileId, imports] of state.pendingImports) {
+      const file = fileMap.get(fileId);
+      if (!file || !C_FAMILY_LANGUAGES.has(file.language ?? '')) continue;
+      const sourceNodeId = nodeIds.get(fileId);
+      if (sourceNodeId == null) continue;
+
+      const fromPath = file.path.split('\\').join('/');
+      const fromDir = fromPath.includes('/') ? fromPath.slice(0, fromPath.lastIndexOf('/')) : '';
+
+      const seen = new Set<string>();
+      for (const { from } of imports) {
+        if (!from || seen.has(from)) continue;
+        seen.add(from);
+
+        const targetId = resolve(from, fromDir);
+        if (targetId == null) {
+          const candidates = bySuffix.get(from);
+          if (candidates && candidates.length > 1) ambiguous++;
+          else external++;
+          continue;
+        }
+        const targetNodeId = nodeIds.get(targetId);
+        if (targetNodeId == null || targetNodeId === sourceNodeId) continue;
+        insertStmt.run(sourceNodeId, targetNodeId, importsEdgeType.id, JSON.stringify({ from }));
+        created++;
+      }
+    }
+  })();
+
+  if (created > 0 || external > 0 || ambiguous > 0) {
+    logger.info({ edges: created, external, ambiguous }, 'C/C++ import edges resolved');
+  }
+}

--- a/src/indexer/edge-resolvers/import-capable-languages.ts
+++ b/src/indexer/edge-resolvers/import-capable-languages.ts
@@ -44,6 +44,8 @@ export const IMPORT_EDGE_LANGUAGES: ReadonlySet<string> = new Set([
   'go', // resolveGoImportEdges
   'java', // resolveJavaImportEdges
   'rust', // resolveRustImportEdges
+  'c', // resolveCImportEdges
+  'cpp', // resolveCImportEdges
   'yaml', // resolveIacImportEdges — kustomize / docker-compose refs
   'hcl', // resolveIacImportEdges — local terraform module sources
   'markdown', // resolveMarkdownWikilinkEdges

--- a/src/indexer/pipeline.ts
+++ b/src/indexer/pipeline.ts
@@ -899,6 +899,7 @@ export class IndexingPipeline {
       () => edgeResolver.resolveGoImportEdges(scope),
       () => edgeResolver.resolveJavaImportEdges(scope),
       () => edgeResolver.resolveRustImportEdges(scope),
+      () => edgeResolver.resolveCImportEdges(scope),
       () => edgeResolver.resolvePhpCallEdges(scope),
       () => edgeResolver.resolveTypeScriptCallEdges(scope),
       () => edgeResolver.resolveTypeScriptTypeEdges(scope),

--- a/src/indexer/plugins/language/c/helpers.ts
+++ b/src/indexer/plugins/language/c/helpers.ts
@@ -101,24 +101,40 @@ export function containsFunctionDeclarator(node: TSNode): boolean {
   return false;
 }
 
-/** Extract #include import edges from the root node. */
+// Header-guard and feature-test blocks put nearly every real #include inside
+// one of these — tree-sitter-c flattens the guarded body onto the wrapper's
+// own namedChildren rather than nesting it under a separate field, so a scan
+// of only `root.namedChildren` misses almost everything behind a guard.
+const PREPROC_CONDITIONAL_TYPES = new Set([
+  'preproc_ifdef',
+  'preproc_if',
+  'preproc_elif',
+  'preproc_else',
+]);
+
+/** Extract #include import edges, descending into #ifdef/#if/#elif/#else blocks. */
 export function extractImportEdges(root: TSNode): RawEdge[] {
   const edges: RawEdge[] = [];
-  for (const child of root.namedChildren) {
-    if (child.type === 'preproc_include') {
-      const pathNode = child.childForFieldName('path');
-      if (pathNode) {
-        const raw = pathNode.text;
-        const isSystem = raw.startsWith('<');
-        // Strip quotes / angle brackets
-        const module = raw.replace(/^["<]|[">]$/g, '');
-        edges.push({
-          edgeType: 'imports',
-          metadata: { module, system: isSystem },
-        });
+  const visit = (node: TSNode): void => {
+    for (const child of node.namedChildren) {
+      if (child.type === 'preproc_include') {
+        const pathNode = child.childForFieldName('path');
+        if (pathNode) {
+          const raw = pathNode.text;
+          const isSystem = raw.startsWith('<');
+          // Strip quotes / angle brackets
+          const module = raw.replace(/^["<]|[">]$/g, '');
+          edges.push({
+            edgeType: 'imports',
+            metadata: { module, system: isSystem },
+          });
+        }
+      } else if (PREPROC_CONDITIONAL_TYPES.has(child.type)) {
+        visit(child);
       }
     }
-  }
+  };
+  visit(root);
   return edges;
 }
 

--- a/src/indexer/plugins/language/c/helpers.ts
+++ b/src/indexer/plugins/language/c/helpers.ts
@@ -109,6 +109,7 @@ const PREPROC_CONDITIONAL_TYPES = new Set([
   'preproc_ifdef',
   'preproc_if',
   'preproc_elif',
+  'preproc_elifdef', // C23 #elifdef / #elifndef
   'preproc_else',
 ]);
 

--- a/src/indexer/plugins/language/cpp/helpers.ts
+++ b/src/indexer/plugins/language/cpp/helpers.ts
@@ -103,32 +103,49 @@ export function extractTemplateParams(node: TSNode): string | undefined {
 /**
  * Extract #include directives and using-namespace directives as import edges.
  */
+// Header-guard and feature-test blocks put nearly every real #include inside
+// one of these — tree-sitter-cpp flattens the guarded body onto the wrapper's
+// own namedChildren rather than nesting it under a separate field, so a scan
+// of only `root.namedChildren` misses almost everything behind a guard.
+const PREPROC_CONDITIONAL_TYPES = new Set([
+  'preproc_ifdef',
+  'preproc_if',
+  'preproc_elif',
+  'preproc_else',
+]);
+
+/** Extract #include / using-namespace import edges, descending into #ifdef/#if/#elif/#else blocks. */
 export function extractImportEdges(root: TSNode): RawEdge[] {
   const edges: RawEdge[] = [];
-  for (const child of root.namedChildren) {
-    if (child.type === 'preproc_include') {
-      const pathNode = child.childForFieldName('path');
-      if (pathNode) {
-        const raw = pathNode.text;
-        const importPath = raw.replace(/^["<]|[">]$/g, '');
-        const isSystem = raw.startsWith('<');
-        edges.push({
-          edgeType: 'imports',
-          metadata: { module: importPath, ...(isSystem ? { system: true } : {}) },
-        });
-      }
-    } else if (child.type === 'using_declaration') {
-      // using namespace std; is a using_declaration in tree-sitter-cpp
-      const text = child.text.trim();
-      const nsMatch = text.match(/^using\s+namespace\s+([\w:]+)\s*;?$/);
-      if (nsMatch) {
-        edges.push({
-          edgeType: 'imports',
-          metadata: { module: nsMatch[1], usingNamespace: true },
-        });
+  const visit = (node: TSNode): void => {
+    for (const child of node.namedChildren) {
+      if (child.type === 'preproc_include') {
+        const pathNode = child.childForFieldName('path');
+        if (pathNode) {
+          const raw = pathNode.text;
+          const importPath = raw.replace(/^["<]|[">]$/g, '');
+          const isSystem = raw.startsWith('<');
+          edges.push({
+            edgeType: 'imports',
+            metadata: { module: importPath, ...(isSystem ? { system: true } : {}) },
+          });
+        }
+      } else if (child.type === 'using_declaration') {
+        // using namespace std; is a using_declaration in tree-sitter-cpp
+        const text = child.text.trim();
+        const nsMatch = text.match(/^using\s+namespace\s+([\w:]+)\s*;?$/);
+        if (nsMatch) {
+          edges.push({
+            edgeType: 'imports',
+            metadata: { module: nsMatch[1], usingNamespace: true },
+          });
+        }
+      } else if (PREPROC_CONDITIONAL_TYPES.has(child.type)) {
+        visit(child);
       }
     }
-  }
+  };
+  visit(root);
   return edges;
 }
 

--- a/src/indexer/plugins/language/cpp/helpers.ts
+++ b/src/indexer/plugins/language/cpp/helpers.ts
@@ -111,6 +111,7 @@ const PREPROC_CONDITIONAL_TYPES = new Set([
   'preproc_ifdef',
   'preproc_if',
   'preproc_elif',
+  'preproc_elifdef', // C++23 #elifdef / #elifndef
   'preproc_else',
 ]);
 

--- a/src/indexer/plugins/language/form/index.ts
+++ b/src/indexer/plugins/language/form/index.ts
@@ -11,7 +11,11 @@ import { createRegexLanguagePlugin } from '../regex-base.js';
 const _plugin = createRegexLanguagePlugin({
   name: 'form',
   language: 'form',
-  extensions: ['.frm', '.prc', '.h'],
+  // WHY no `.h`: FORM's own include headers use it too, but `.h` is
+  // overwhelmingly a C/C++ header in the wild, and this plugin's priority (4)
+  // beat the C plugin's (5) for the shared extension — every C header in
+  // every repo was silently indexed as FORM instead of C (TRA-832).
+  extensions: ['.frm', '.prc'],
   priority: 4,
   symbolPatterns: [
     // Symbols name1,...,nameN;

--- a/tests/integration/c-import-resolution-e2e.test.ts
+++ b/tests/integration/c-import-resolution-e2e.test.ts
@@ -7,8 +7,10 @@
  * (confirmed on redis: 191 files, 0 edges). These tests pin the shapes an
  * include comes in — same-directory quoted, `../` relative, an angle-bracket
  * path resolved by suffix, a cross-language C header included from a `.cpp`
- * file — plus the rules that a system header resolves to nothing and an
- * ambiguous bare filename is left unresolved rather than guessed.
+ * file, one nested inside a header guard, backslash-separated (MSVC) — plus
+ * the rules that a system header resolves to nothing, an ambiguous bare
+ * filename is left unresolved rather than guessed, and a `..` that escapes
+ * the repo root does not collapse onto an unrelated same-named file.
  */
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { TraceMcpConfig } from '../../src/config.js';
@@ -27,8 +29,11 @@ int main(void) { return 0; }
 `,
   'src/app.h': `#ifndef APP_H
 #define APP_H
+#include "types.h"
 void app_init(void);
 #endif
+`,
+  'src/types.h': `typedef int app_int_t;
 `,
   'src/utils/helper.c': `#include "../app.h"
 
@@ -49,6 +54,20 @@ void wrap() {}
   'src/moduleC/user2.c': `#include "common.h"
 
 void use(void) {}
+`,
+  // A file literally named outside.h at the fixture root — deliberately
+  // placed so a `..`-past-root normalization bug would wrongly match it.
+  'outside.h': `/* not the file src/deep/escape.c means to include */
+`,
+  'src/deep/escape.c': `#include "../../../outside.h"
+
+void escape(void) {}
+`,
+  'src/sub/win.h': `#define WIN 1
+`,
+  'src/winstyle.c': `#include "sub\\win.h"
+
+void winstyle(void) {}
 `,
 };
 
@@ -119,5 +138,23 @@ describe('C/C++ import resolution E2E', () => {
     // directory has neither, so the suffix match is ambiguous and no edge
     // is created for either candidate.
     expect(importTargets(store, 'src/moduleC/user2.c').size).toBe(0);
+  });
+
+  it('resolves an include nested inside a header guard', () => {
+    // app.h's own #include "types.h" sits inside #ifndef APP_H — only
+    // reachable if extraction recurses into the guard.
+    expect(importTargets(store, 'src/app.h')).toContain('src/types.h');
+  });
+
+  it('does not let a `..` past repo root collapse onto an unrelated same-named file', () => {
+    // `../../../outside.h` from src/deep/ has one `..` more than the path is
+    // deep, so it escapes the repo. A buggy normalizer that drops the extra
+    // `..` instead of keeping it would collapse this to `outside.h` and
+    // wrongly match the unrelated file at the fixture root.
+    expect(importTargets(store, 'src/deep/escape.c').size).toBe(0);
+  });
+
+  it('resolves a backslash-separated include (MSVC style)', () => {
+    expect(importTargets(store, 'src/winstyle.c')).toContain('src/sub/win.h');
   });
 });

--- a/tests/integration/c-import-resolution-e2e.test.ts
+++ b/tests/integration/c-import-resolution-e2e.test.ts
@@ -1,0 +1,123 @@
+/**
+ * C/C++ cross-file `#include` resolution E2E (TRA-832).
+ *
+ * Same gap TRA-449 closed for Go, TRA-483 for Java and TRA-565 for Rust: the
+ * C and C++ plugins extracted every `#include` into `metadata.module`, but no
+ * pipeline pass consumed it, so a C repo indexed with zero import edges
+ * (confirmed on redis: 191 files, 0 edges). These tests pin the shapes an
+ * include comes in — same-directory quoted, `../` relative, an angle-bracket
+ * path resolved by suffix, a cross-language C header included from a `.cpp`
+ * file — plus the rules that a system header resolves to nothing and an
+ * ambiguous bare filename is left unresolved rather than guessed.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { TraceMcpConfig } from '../../src/config.js';
+import type { Store } from '../../src/db/store.js';
+import { IndexingPipeline } from '../../src/indexer/pipeline.js';
+import { CLanguagePlugin } from '../../src/indexer/plugins/language/c/index.js';
+import { CppLanguagePlugin } from '../../src/indexer/plugins/language/cpp/index.js';
+import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import { createTestStore, createTmpFixture, removeTmpDir } from '../test-utils.js';
+
+const FILES: Record<string, string> = {
+  'src/main.c': `#include "app.h"
+#include <stdio.h>
+
+int main(void) { return 0; }
+`,
+  'src/app.h': `#ifndef APP_H
+#define APP_H
+void app_init(void);
+#endif
+`,
+  'src/utils/helper.c': `#include "../app.h"
+
+void helper(void) {}
+`,
+  'include/api/api.hpp': `#pragma once
+namespace api { void call(); }
+`,
+  'src/wrapper.cpp': `#include "app.h"
+#include <api/api.hpp>
+
+void wrap() {}
+`,
+  'src/moduleA/common.h': `#define A 1
+`,
+  'src/moduleB/common.h': `#define B 2
+`,
+  'src/moduleC/user2.c': `#include "common.h"
+
+void use(void) {}
+`,
+};
+
+function importTargets(store: Store, sourcePath: string): Set<string> {
+  const file = store.getFile(sourcePath);
+  if (!file) return new Set();
+  const nodeId = store.getNodeId('file', file.id);
+  if (nodeId == null) return new Set();
+  const targets = new Set<string>();
+  for (const edge of store.getOutgoingEdges(nodeId)) {
+    if (edge.edge_type_name !== 'imports') continue;
+    const ref = store.getNodeRef(edge.target_node_id);
+    if (ref?.nodeType === 'file') targets.add(store.getFileById(ref.refId)?.path ?? '');
+  }
+  return targets;
+}
+
+describe('C/C++ import resolution E2E', () => {
+  let store: Store;
+  let fixtureDir: string;
+
+  beforeAll(async () => {
+    fixtureDir = createTmpFixture(FILES, 'trace-mcp-c-imports-');
+    store = createTestStore();
+    const registry = new PluginRegistry();
+    registry.registerLanguagePlugin(new CLanguagePlugin());
+    registry.registerLanguagePlugin(new CppLanguagePlugin());
+
+    const config: TraceMcpConfig = {
+      root: fixtureDir,
+      include: ['**/*.c', '**/*.h', '**/*.cpp', '**/*.hpp'],
+      exclude: ['node_modules/**'],
+      plugins: [],
+    } as TraceMcpConfig;
+
+    await new IndexingPipeline(store, registry, config, fixtureDir).indexAll();
+  });
+
+  afterAll(() => {
+    removeTmpDir(fixtureDir);
+  });
+
+  it('resolves a same-directory quoted include', () => {
+    expect(importTargets(store, 'src/main.c')).toContain('src/app.h');
+  });
+
+  it('resolves a `../` relative include', () => {
+    expect(importTargets(store, 'src/utils/helper.c')).toContain('src/app.h');
+  });
+
+  it('resolves a cross-language include — a .cpp file pulling in a C header', () => {
+    expect(importTargets(store, 'src/wrapper.cpp')).toContain('src/app.h');
+  });
+
+  it('resolves an angle-bracket include by path suffix when it is not relative to the source file', () => {
+    // `#include <api/api.hpp>` in src/wrapper.cpp — the file lives at
+    // include/api/api.hpp, unreachable by relative-path resolution alone.
+    expect(importTargets(store, 'src/wrapper.cpp')).toContain('include/api/api.hpp');
+  });
+
+  it('skips a system header rather than inventing a target', () => {
+    // main.c also includes <stdio.h>, which is not part of the repo.
+    expect(importTargets(store, 'src/main.c')).toEqual(new Set(['src/app.h']));
+  });
+
+  it('leaves an ambiguous bare-filename include unresolved', () => {
+    // Two files named common.h exist (moduleA, moduleB); user2.c's own
+    // directory has neither, so the suffix match is ambiguous and no edge
+    // is created for either candidate.
+    expect(importTargets(store, 'src/moduleC/user2.c').size).toBe(0);
+  });
+});

--- a/tests/languages/c.test.ts
+++ b/tests/languages/c.test.ts
@@ -82,6 +82,30 @@ int main() { return 0; }
     expect(imports.length).toBeGreaterThanOrEqual(2);
   });
 
+  it('extracts #include edges behind header guards and #if/#elifdef/#else chains', async () => {
+    // Nearly every real C header wraps its includes in a guard; TRA-832 found
+    // that a scan of only root.namedChildren missed all of them.
+    const result = await extract(`
+#ifndef APP_H
+#define APP_H
+
+#include "always.h"
+
+#if defined(WINDOWS)
+#include "win.h"
+#elifdef POSIX
+#include "posix.h"
+#else
+#include "fallback.h"
+#endif
+
+#endif
+    `);
+    const imports = result.edges!.filter((e) => e.edgeType === 'imports');
+    const modules = imports.map((e) => (e.metadata as { module: string }).module);
+    expect(modules).toEqual(expect.arrayContaining(['always.h', 'win.h', 'posix.h', 'fallback.h']));
+  });
+
   it('extracts #define macros', async () => {
     const result = await extract(`
 #define MAX_SIZE 1024

--- a/tests/languages/cpp.test.ts
+++ b/tests/languages/cpp.test.ts
@@ -89,6 +89,32 @@ int main() { return 0; }
     expect(imports.length).toBeGreaterThanOrEqual(2);
   });
 
+  it('extracts #include edges behind header guards and #if/#elifdef/#else chains', async () => {
+    // Nearly every real C++ header wraps its includes in a guard; TRA-832
+    // found that a scan of only root.namedChildren missed all of them.
+    const result = await extract(`
+#ifndef APP_HPP
+#define APP_HPP
+
+#include "always.hpp"
+
+#if defined(WINDOWS)
+#include "win.hpp"
+#elifdef POSIX
+#include "posix.hpp"
+#else
+#include "fallback.hpp"
+#endif
+
+#endif
+    `);
+    const imports = result.edges!.filter((e) => e.edgeType === 'imports');
+    const modules = imports.map((e) => (e.metadata as { module: string }).module);
+    expect(modules).toEqual(
+      expect.arrayContaining(['always.hpp', 'win.hpp', 'posix.hpp', 'fallback.hpp']),
+    );
+  });
+
   it('extracts structs', async () => {
     const result = await extract(`
 struct Point {

--- a/tests/plugin-api/registry.test.ts
+++ b/tests/plugin-api/registry.test.ts
@@ -55,6 +55,14 @@ describe('plugin registry', () => {
     expect(registry.getLanguagePluginForFile('readme.md')).toBeUndefined();
   });
 
+  it('routes .h to the C plugin, not FORM (TRA-832 regression)', () => {
+    // Both plugins used to declare `.h`; FORM's lower priority number won the
+    // shared extension, so every C/C++ header in every repo was silently
+    // indexed as the FORM symbolic-computation language instead of C.
+    const registry = PluginRegistry.createWithDefaults();
+    expect(registry.getLanguagePluginForFile('src/server.h')?.manifest.name).toBe('c-language');
+  });
+
   it('topological sorts framework plugins by dependencies', () => {
     const registry = new PluginRegistry();
     registry.registerFrameworkPlugin(


### PR DESCRIPTION
## Summary

- `resolveCImportEdges` turns `#include` specifiers (already extracted into `metadata.module` by the C/C++ plugins but never consumed) into file→file `imports` edges — the same gap TRA-449 closed for Go, TRA-483 for Java, TRA-565 for Rust. C and C++ share one resolver because they share one target set: a `.cpp` file routinely includes a `.h` the C plugin owns.
- Resolution order: exact relative-to-source-directory match first (what a compiler does for a quoted include), then a path-suffix fallback across all indexed C/C++ files (handles `<mylib/foo.h>`-style includes without knowing the repo's own `-I` root). An ambiguous suffix match (2+ candidates) is left unresolved rather than guessed; system/third-party headers simply fail to match.
- Verifying on real repos (not fixtures) surfaced two more bugs blocking the resolver from doing anything on real code:
  - `extractImportEdges` only scanned `root.namedChildren`, so every `#include` behind a header guard (`#ifndef X_H` / `#define X_H` ... `#endif` — nearly universal) was invisible. Fixed by recursing into `preproc_ifdef`/`preproc_if`/`preproc_elif`/`preproc_else`.
  - The FORM language plugin (a physics symbolic-computation language) also claimed the bare `.h` extension, at a *higher* priority than the C plugin — so **every** C/C++ header in **every** repo was silently indexed as FORM instead of C (87/87 `.h` files in redis). Removed `.h` from FORM's extensions (kept `.frm`/`.prc`) and added a registry regression test pinning `.h` → `c-language`.
- `docs/language-matrix.md` regenerated: Imports 13 → 15.

## Verification

- Cloned real repos and indexed them with the full default plugin registry:
  - redis: 191 → 278 C/C++ files correctly classified (headers were being stolen by FORM), 0 → 587 first-party import edges, 816 system/stdlib includes correctly left unresolved, 0 ambiguous.
  - fmt: 0 → 155 first-party import edges (410 external), spot-checked targets resolve to the right file (`fmt/base.h`, `fmt/format-inl.h`, `fmt/os.h`, etc.).
- New `tests/integration/c-import-resolution-e2e.test.ts` (6 tests) pins: same-directory quoted include, `../` relative include, cross-language `.cpp` → C header, angle-bracket suffix fallback, system header skipped, ambiguous bare-filename skipped.
- New regression test in `tests/plugin-api/registry.test.ts` pins `.h` routing to `c-language`.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `pnpm exec biome check` on all changed files
- [x] `pnpm run test` — 897 files / 9949 tests passed, 24 skipped (full suite, no regressions)
- [x] Verified on real repos (redis, fmt) — see above

Agent: Implementation Engineer