### PR TITLE
fix(ci): only a claimed issue collides in check-duplicate-pr (TRA-856)

### DIFF
--- a/scripts/check-duplicate-pr.mjs
+++ b/scripts/check-duplicate-pr.mjs
@@ -29,19 +29,28 @@ export function issueKeys(text) {
 }
 
 /**
+ * One key in a closing list: `TRA-9`, `` `TRA-9` ``, `[TRA-9]`, `[TRA-9](url)`.
+ * Missing a wrapped key drops a real claim silently, which is the direction that
+ * costs a duplicated implementation.
+ */
+const CLAIMED_KEY = String.raw`[\`[]?TRA-\d+\b[\`\]]?(?:\([^)]*\))?`;
+
+/** List punctuation between keys. Repeats so `, and` reads as one separator. */
+const KEY_SEPARATOR = String.raw`(?:\s*(?:,|&|and)\s*)*`;
+
+const CLOSING_CLAIM = new RegExp(
+  String.raw`\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s*((?:${CLAIMED_KEY}${KEY_SEPARATOR})+)`,
+  'gi',
+);
+
+/**
  * Issue keys a PR *claims*: the ones in its title, plus the ones a closing
  * keyword names in the body. Everything else in the body is a reference.
  *
  * @param {{title?: string, body?: string}} pr
  */
 export function claimedKeys(pr) {
-  const closing = [
-    ...`${pr.body ?? ''}`.matchAll(
-      /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s*((?:TRA-\d+\b(?:\s*(?:,|and)\s*)?)+)/gi,
-    ),
-  ]
-    .map((m) => m[1])
-    .join(' ');
+  const closing = [...`${pr.body ?? ''}`.matchAll(CLOSING_CLAIM)].map((m) => m[1]).join(' ');
   return issueKeys(`${pr.title ?? ''}\n${closing}`);
 }
 

--- a/scripts/check-duplicate-pr.mjs
+++ b/scripts/check-duplicate-pr.mjs
@@ -10,6 +10,14 @@
 //
 // A PR that cites the other one in its body is a follow-up, not a duplicate
 // (#614 → #611, the healthy version), and passes.
+//
+// TRA-856: only a *claim* collides. A PR claims the issue named in its title or
+// in a `Closes/Fixes/Resolves TRA-NNN` line; any other TRA-NNN in the body is a
+// reference to a sibling issue for context, which is exactly what the PR
+// template asks for. Treating those as claims flagged four unrelated daemon
+// fixes against each other (#871/#874/#875, #882/#854) on 2026-09-04. Both real
+// incidents named the issue in the title *and* in a `Closes` line, so the guard
+// still catches them.
 
 import { execFileSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
@@ -18,6 +26,23 @@ import { fileURLToPath } from 'node:url';
 /** Distinct TRA issue keys mentioned in a blob of text, uppercased. */
 export function issueKeys(text) {
   return [...new Set((text ?? '').match(/\bTRA-\d+\b/gi)?.map((k) => k.toUpperCase()) ?? [])];
+}
+
+/**
+ * Issue keys a PR *claims*: the ones in its title, plus the ones a closing
+ * keyword names in the body. Everything else in the body is a reference.
+ *
+ * @param {{title?: string, body?: string}} pr
+ */
+export function claimedKeys(pr) {
+  const closing = [
+    ...`${pr.body ?? ''}`.matchAll(
+      /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s*((?:TRA-\d+\b(?:\s*(?:,|and)\s*)?)+)/gi,
+    ),
+  ]
+    .map((m) => m[1])
+    .join(' ');
+  return issueKeys(`${pr.title ?? ''}\n${closing}`);
 }
 
 /**
@@ -39,7 +64,7 @@ export function isReleasePr(pr) {
  */
 export function findDuplicatePrs(pr, openPrs) {
   if (isReleasePr(pr)) return [];
-  const keys = issueKeys(`${pr.title}\n${pr.body ?? ''}`);
+  const keys = claimedKeys(pr);
   if (keys.length === 0) return [];
   const cited = new Set(
     [...`${pr.body ?? ''}`.matchAll(/#(\d+)/g)].map((m) => Number.parseInt(m[1], 10)),
@@ -49,7 +74,7 @@ export function findDuplicatePrs(pr, openPrs) {
       other.number !== pr.number &&
       !cited.has(other.number) &&
       !isReleasePr(other) &&
-      issueKeys(`${other.title}\n${other.body ?? ''}`).some((k) => keys.includes(k)),
+      claimedKeys(other).some((k) => keys.includes(k)),
   );
 }
 

--- a/tests/ci/duplicate-pr.test.ts
+++ b/tests/ci/duplicate-pr.test.ts
@@ -125,10 +125,46 @@ describe('claimedKeys', () => {
     ]);
   });
 
+  // Review finding on #897: `, and` made the separator match `,`, leaving `and`
+  // in the way of the next key — so the last issue of an Oxford-comma list was
+  // dropped and a duplicate on it slipped through.
+  it('reads the last key of an Oxford-comma or ampersand list', () => {
+    expect(claimedKeys({ title: 'fix: x', body: 'Closes TRA-1, TRA-2, and TRA-3.' })).toEqual([
+      'TRA-1',
+      'TRA-2',
+      'TRA-3',
+    ]);
+    expect(claimedKeys({ title: 'fix: x', body: 'Closes TRA-1 & TRA-2' })).toEqual([
+      'TRA-1',
+      'TRA-2',
+    ]);
+  });
+
+  // Same finding, second half: a key wrapped in a markdown link or backticks
+  // bypassed the closing keyword entirely.
+  it('reads a key wrapped in a markdown link, brackets or backticks', () => {
+    const link = { title: 'docs: update pricing', body: 'Closes [TRA-448](https://x/448)' };
+    expect(claimedKeys(link)).toEqual(['TRA-448']);
+    expect(claimedKeys({ title: 'docs: x', body: 'Closes [TRA-448]' })).toEqual(['TRA-448']);
+    expect(claimedKeys({ title: 'docs: x', body: 'Closes `TRA-448`' })).toEqual(['TRA-448']);
+  });
+
   it('does not read a closing keyword separated from the key by prose', () => {
     expect(claimedKeys({ title: 'fix: x', body: 'Fixes the reporting half of TRA-9.' })).toEqual(
       [],
     );
+    expect(
+      claimedKeys({ title: 'fix: x', body: 'This closes the gap TRA-809 left behind.' }),
+    ).toEqual([]);
+  });
+
+  it('stops the claim list at prose that follows a key', () => {
+    expect(
+      claimedKeys({ title: 'fix: x', body: 'Closes TRA-1 and reduces the daemon footprint.' }),
+    ).toEqual(['TRA-1']);
+    expect(claimedKeys({ title: 'fix: x', body: 'Closes TRA-809 (found by Nikolai).' })).toEqual([
+      'TRA-809',
+    ]);
   });
 });
 

--- a/tests/ci/duplicate-pr.test.ts
+++ b/tests/ci/duplicate-pr.test.ts
@@ -111,11 +111,17 @@ describe('claimedKeys', () => {
     expect(claimedKeys(PR_882)).toEqual([]);
   });
 
+  // A real body from this repo's history: `Closes TRA-596, TRA-597, TRA-598,
+  // TRA-599, TRA-600`. Reading only the first key would hide four claims.
   it('reads a closing keyword that names several issues', () => {
     expect(claimedKeys({ title: 'fix: x', body: 'Closes TRA-1, TRA-2 and TRA-3.' })).toEqual([
       'TRA-1',
       'TRA-2',
       'TRA-3',
+    ]);
+    expect(claimedKeys({ title: 'fix: x', body: 'Closes: TRA-596, TRA-597' })).toEqual([
+      'TRA-596',
+      'TRA-597',
     ]);
   });
 
@@ -154,6 +160,11 @@ describe('findDuplicatePrs', () => {
 
   it('never flags a PR against the release PR either', () => {
     expect(findDuplicatePrs(PR_597, [PR_723])).toEqual([]);
+  });
+
+  it('still flags a PR whose rival claims the issue in its title alone', () => {
+    const titleOnly = { number: 900, title: 'fix(daemon): log exit context (TRA-809)', body: '' };
+    expect(findDuplicatePrs(titleOnly, [PR_871]).map((p) => p.number)).toEqual([871]);
   });
 
   it('passes the four PRs that only cite a sibling issue as context (TRA-856)', () => {

--- a/tests/ci/duplicate-pr.test.ts
+++ b/tests/ci/duplicate-pr.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 // @ts-expect-error — plain .mjs script, no type declarations
 import {
+  claimedKeys,
   findDuplicatePrs,
   formatReport,
   isReleasePr,
@@ -49,6 +50,35 @@ const PR_723 = {
   body: '## 3.12.0\n\n### Features\n\n* first-run setup flow (TRA-439)\n* price the default tool surface (TRA-448)\n* dead-daemon pane (TRA-469)',
 };
 
+// TRA-856: four real open PRs from 2026-09-04 that the guard flagged against
+// each other for citing a sibling issue as context. Bodies trimmed to the
+// sentences that carry the TRA keys.
+const PR_871 = {
+  number: 871,
+  title: 'Attribute daemon shutdowns: log exit context on SIGTERM (TRA-809)',
+  body: 'Fixes the diagnosability half of TRA-809: the daemon restarted 137 times in 40 h.',
+};
+const PR_874 = {
+  number: 874,
+  title: 'perf(daemon): release idle extract workers (TRA-811)',
+  body: 'The daemon on the measuring machine restarts every ~3 min (TRA-809) and never reaches the 5-minute window there.\n\nCloses TRA-811.',
+};
+const PR_875 = {
+  number: 875,
+  title: 'fix(indexer): re-scan when the watcher tells us it dropped events (TRA-813)',
+  body: 'Closes TRA-813.\n\nThere the daemon restarts every few minutes (TRA-809) and a start does a full pass.',
+};
+const PR_882 = {
+  number: 882,
+  title: 'docs(ops): user-signal run 2026-09-05 — code search as a channel',
+  body: 'Ledger update for the run of 2026-09-05 (TRA-837). Records TRA-845, TRA-846 and TRA-843, and the index-coverage work in TRA-791.',
+};
+const PR_854 = {
+  number: 854,
+  title: 'ops: index-coverage ledger — 11 of 24 pages unindexed (TRA-791)',
+  body: 'Records what Google actually has for trace-mcp.com, so a run stops re-deriving it by hand.',
+};
+
 describe('isReleasePr', () => {
   it('recognises the release-please title and nothing else', () => {
     expect(isReleasePr(PR_723)).toBe(true);
@@ -67,6 +97,32 @@ describe('issueKeys', () => {
 
   it('is empty for a PR that names no issue', () => {
     expect(issueKeys(PR_612.title)).toEqual([]);
+  });
+});
+
+describe('claimedKeys', () => {
+  it('claims the title key and the closing-keyword keys only', () => {
+    expect(claimedKeys(PR_874)).toEqual(['TRA-811']);
+    expect(claimedKeys(PR_875)).toEqual(['TRA-813']);
+    expect(claimedKeys(PR_871)).toEqual(['TRA-809']);
+  });
+
+  it('claims nothing when a body only references issues', () => {
+    expect(claimedKeys(PR_882)).toEqual([]);
+  });
+
+  it('reads a closing keyword that names several issues', () => {
+    expect(claimedKeys({ title: 'fix: x', body: 'Closes TRA-1, TRA-2 and TRA-3.' })).toEqual([
+      'TRA-1',
+      'TRA-2',
+      'TRA-3',
+    ]);
+  });
+
+  it('does not read a closing keyword separated from the key by prose', () => {
+    expect(claimedKeys({ title: 'fix: x', body: 'Fixes the reporting half of TRA-9.' })).toEqual(
+      [],
+    );
   });
 });
 
@@ -98,6 +154,13 @@ describe('findDuplicatePrs', () => {
 
   it('never flags a PR against the release PR either', () => {
     expect(findDuplicatePrs(PR_597, [PR_723])).toEqual([]);
+  });
+
+  it('passes the four PRs that only cite a sibling issue as context (TRA-856)', () => {
+    const open = [PR_871, PR_874, PR_875, PR_882, PR_854];
+    for (const pr of open) {
+      expect(findDuplicatePrs(pr, open)).toEqual([]);
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

`scripts/check-duplicate-pr.mjs` treated *any* `TRA-NNN` string anywhere in a PR title or body as a claim on that issue. A PR that merely names a sibling issue as context therefore collided with the PR that actually implements it, and the `check` job went red for a reason unrelated to the code.

Measured on the open board 2026-09-04: #874 (claims TRA-811) and #875 (claims TRA-813) were both flagged against #871 (claims TRA-809) and against each other, because their bodies explain the interaction with TRA-809 — "the daemon restarts constantly (TRA-809) and never reaches the 5-minute window there". #882 was flagged against #854 on TRA-791 the same way. None are duplicates.

The guard is right to exist (TRA-476: #598/#597 and #613/#611 were genuinely duplicated implementations). The defect was only in what counts as a claim.

## Change

New `claimedKeys(pr)`: a PR claims the issues named in its **title**, plus the ones a **`Closes`/`Fixes`/`Resolves` keyword** names in the body. Every other `TRA-NNN` in the body is a reference and does not collide. `findDuplicatePrs` compares claims on both sides.

Both TRA-476 incidents named the issue in the title *and* in a `Closes` line, so the guard keeps catching them — there is a regression test for the title-only half. The `Follow-up to #NNN` escape hatch and the release-please exclusion are untouched.

Two details the regex handles deliberately:

- A closing keyword may name several issues. `Closes TRA-596, TRA-597, TRA-598, TRA-599, TRA-600` is a real body from this repo's history; reading only the first key would hide four claims from the guard.
- Prose between the keyword and the key does not claim. #871's "Fixes the diagnosability half of TRA-809" is not read as a claim (its title is), which is the correct reading either way.

The loosening is narrow and intentional: a PR that names its issue only in prose, with no title key and no closing keyword, now claims nothing. Every real duplicate we have seen named it in the title.

## Reconciliation

Two runs worked TRA-856 concurrently — #896 opened three minutes before this one with the same `claimedKeys` design, which is precisely the failure mode this guard exists to catch, and it caught it. This PR is kept because its closing-keyword regex reads multi-issue `Closes` lines (see above) and an optional colon, where #896's takes only the first key. #896's title-only regression test is ported here; #896 is closed as the duplicate.

This body also names TRA-809 and TRA-811 in prose, so under the *old* logic on the base ref it collides with #894 (a daemon change citing the same issues). It also has to quote issue keys to explain the change at all (`Closes TRA-596, TRA-597, ...` above), which under the old logic collides with whatever open PR happens to name one of them — #859 at the time of writing. Citing #894, #896 and #859 here is the existing escape hatch; the merged logic makes all of these collisions impossible.

## Test evidence

- `pnpm exec vitest run tests/ci/duplicate-pr.test.ts` → 17 passed (8 pre-existing cases unchanged and green)
- Running the script against #871, #874, #875, #882 and #854 reports no duplicate for any of them
- `pnpm run lint` (tsc --noEmit) clean
- `pnpm test` → 9948 passed, 2 failed, both environmental and untouched by this diff: an ONNX provider test (pnpm skipped the `onnxruntime-node` build script on this runtime, so the native binding is absent) and `tests/perf/benchmark.test.ts` (timing threshold on a loaded machine)

Closes TRA-856.

Agent: Lead Engineer

