### PR TITLE
test(mirror): structural-unit selection gate — the measured ceiling closes the direction (TRA-861)

### DIFF
--- a/benchmarks/skeleton-gate/.gitignore
+++ b/benchmarks/skeleton-gate/.gitignore
@@ -1,0 +1,1 @@
+dataset.json

--- a/benchmarks/skeleton-gate/README.md
+++ b/benchmarks/skeleton-gate/README.md
@@ -1,0 +1,134 @@
+# TRA-861 — skeletonisation gate: structural units instead of lines
+
+TRA-758 measured a line-level relevance selector inside the Read/Bash mirror
+hook and failed the recall gate (55.6% evidence recall at a 50% cut, threshold
+0.85). Its own post-mortem named the failure mode: *line-level selection
+fragments code and destroys syntactic connectivity*. TRA-861 tests whether the
+unit of selection was the thing that failed, by re-running the same gate with
+exactly one variable changed — a **structural unit** (a symbol with its body)
+instead of a line, the way HCP (AAAI 2025) does it: focal code keeps its body,
+everything else keeps its signature.
+
+**Verdict: the gate fails again, and this time the ceiling is measured rather
+than inferred. The direction is closed.**
+
+## Corpus
+
+TRA-758's dataset was never committed (it is 10 MB of private source), so it is
+re-extracted here with the documented methodology — `extract.py`, same corpus
+(`~/.claude/projects`, 2 416 transcripts), same working band (2 000–64 000
+chars), same evidence labelling (a line counts when it reappears in the next 12
+assistant turns as a quote, inside an `Edit`'s `old_string`, or as a path /
+identifier carried into a later tool call), same strata.
+
+493 calls (243 Read, 250 Bash) against TRA-758's 497 (247/250). The baseline arm
+reproduces to within 2 pp of the published numbers (53.6% mean recall vs 55.8%),
+which is what makes the two runs comparable.
+
+Labels are heuristic, as they were in TRA-758. They were spot-checked here, not
+audited at the 50-example depth of the original — the conclusion below does not
+rest on label precision, because its decisive arm is an oracle.
+
+Recall is scored by substring containment, which is slightly optimistic where a
+file repeats a line: review re-scored the heuristic structural arm by exact line
+index and got 55.6% against the 60.6% below. The optimism runs in the
+structural arm's favour and it still misses 0.85, and the oracle scores 100.0%
+under both methods, so neither number that carries the verdict moves.
+
+## Results
+
+`TARGET_CUT=0.2 pnpm exec tsx benchmarks/skeleton-gate/eval.ts`
+
+| arm | n | mass cut | mean recall | median | recall<0.85 | ms/call |
+|---|---|---|---|---|---|---|
+| window 24/12 (shipped) | 493 | 67.8% | 53.6% | 50.0% | 65.1% | <0.01 |
+| window 24/12 + cap 3000 | 493 | 78.4% | 46.7% | 41.9% | 76.3% | <0.01 |
+| **structural units** | 493 | 53.2% | 62.3% | 72.1% | 55.0% | 0.9 |
+| structural units, Read subset | 180 | 51.2% | 60.6% | 73.5% | 54.4% | 0.9 |
+| window 24/12, same subset | 180 | 86.1% | 36.7% | 26.9% | 82.2% | <0.01 |
+| skeleton floor (signatures only) | 180 | 71.6% | 34.8% | 25.0% | 82.8% | <0.01 |
+| **window at the same budget** | 180 | 50.7% | **63.9%** | 84.6% | 50.6% | <0.01 |
+| ORACLE structural focus | 180 | **16.7%** | 100% | 100% | 0% | — |
+| ORACLE line focus | 180 | 92.0% | 100% | 100% | 0% | — |
+
+Gate condition: recall ≥0.85 at a ≥50% cut. Best structural result: **0.61 at
+51%**. Sweeping the budget does not reach it — 0.61 / 51% cut, 0.52 / 57%,
+0.48 / 62%, 0.41 / 68%.
+
+## What actually killed it
+
+**1. At equal mass, structure loses to a dumb window.** Trim a head/tail window
+to exactly the number of characters the structural arm spends and it scores
+63.9% against 60.6%. All of the structural arm's gain over the shipped 24/12
+comes from spending more mass, none from choosing better. The selection unit is
+not carrying the result.
+
+**2. The ceiling is 16.7%.** Give the structural selector a perfect ranker —
+keep every unit that contains any evidence, discard the rest — and it cuts
+**16.7%** of the mass at 100% recall. That is the physical ceiling of this unit
+of selection on this workload, independent of any ranker, any model, any
+budget. The gate asks for 50%. No amount of better focus scoring closes a gap
+that the granularity itself forbids.
+
+Decomposing classes into their methods — an oracle at the finest structural
+granularity that still keeps bodies whole — moves the ceiling to 22.2%. Still
+less than half of what the gate asks.
+
+The reason is in the spread: evidence touches 1.88 of 4.68 units per file, and
+those units hold 83% of the file's bytes. The agent reads a file and uses lines
+from its *largest* functions — keeping those whole means keeping the file.
+
+**3. HCP's own compression comes from the part we do not have.** HCP cuts 50K→8K
+because most of its context is *dependencies*, which it reduces to signatures.
+Inside a mirror hook there are no dependencies: the file the agent just read is
+by definition the focal file. Our skeleton floor — every body dropped, only
+signatures and top-level code kept, i.e. HCP's dependency representation — scores
+34.8% recall at 71.6% cut, worse than a same-mass window. HCP's result is real;
+it just does not transfer to a per-call output rewriter, because the ratio it
+exploits does not exist here.
+
+**4. The two oracles bracket the whole design space.** Perfect line selection
+cuts 92%; perfect structural selection cuts 16.7%. Both hit 100% recall. That
+gap is the price of syntactic coherence, and it is the entire argument in one
+number: you can have compression or coherence, and the workload does not leave
+room for both. TRA-758 bought compression and lost coherence. This bought
+coherence and lost compression.
+
+## Cost, measured separately
+
+The item TRA-758 was right to insist on. `footprint.ts`, 27 KB TypeScript file:
+grammar load + first parse 15.3 ms, warm parse p50 2.16 ms, RSS +49 MB for one
+grammar; Node boot ~20 ms on top, so ~40 ms per call in a per-call hook process.
+Against the encoder's +1 616 ms and +198 MB this is cheap. The direction died on
+headroom, not on cost — which is the useful half of the negative result.
+
+Prefix-cache impact was not measured here and is not this arm's to answer: any
+rewrite of tool output has the same exposure, and TRA-860 owns it.
+
+## Conclusion
+
+Two different units of selection have now failed the same gate, for two
+different and now-named reasons, with the second one bounded by an oracle rather
+than by a heuristic. "Compress tool output more cleverly than a deterministic
+window" is closed. The shipped deterministic selection (TRA-730 / TRA-750)
+stays.
+
+One observation belongs to whoever tunes that window, not here: on the Read
+subset the 24/12 window cuts 86% and drops to 36.7% recall, while a budget-based
+window at 50% cut holds 63.9%. The line window is over-compressing large source
+files. That is a parameter question for TRA-750, not a new mechanism.
+
+## Independent re-run
+
+Reviewer B re-extracted the corpus from scratch (7 921 candidates, 493 sampled)
+and reproduced every arm: baseline window 54.7%, oracle 16.0%, footprint +48.1 MB.
+The 2.2 pp gap between our baseline and TRA-758's published 55.8% is inside the
+sampling noise (SEM 1.78%, 95% CI [50.1%, 57.1%]).
+
+## Reproducing
+
+```sh
+python3 benchmarks/skeleton-gate/extract.py      # rebuilds dataset.json (gitignored: private source)
+pnpm exec tsx benchmarks/skeleton-gate/eval.ts   # TARGET_CUT env sweeps the budget
+pnpm exec tsx benchmarks/skeleton-gate/footprint.ts
+```

--- a/benchmarks/skeleton-gate/eval.ts
+++ b/benchmarks/skeleton-gate/eval.ts
@@ -1,0 +1,440 @@
+/**
+ * TRA-861 offline gate: structural-unit selection vs the line-level selectors
+ * TRA-758 measured.
+ *
+ * Same corpus, same evidence-recall metric, same 0.85 threshold. The single
+ * changed variable is the unit of selection: a symbol with its body, not a
+ * line. Run with `pnpm exec tsx benchmarks/skeleton-gate/eval.ts`.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getParser, LANG_GRAMMARS, type TSNode } from '../../src/parser/tree-sitter.js';
+
+type Call = {
+  tool: 'Read' | 'Bash';
+  input: Record<string, unknown>;
+  chars: number;
+  bucket: string;
+  query: string;
+  output: string;
+  evidence: number[];
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const KEEP_HEAD = 24;
+const KEEP_TAIL = 12;
+const CAP_CHARS = 3000;
+const TARGET_CUT = Number(process.env.TARGET_CUT ?? 0.5);
+
+// ---------------------------------------------------------------- selectors
+
+const READ_PREFIX = /^\s*\d+\t/;
+const stripPrefix = (l: string) => l.replace(READ_PREFIX, '');
+const norm = (s: string) => s.split(/\s+/).filter(Boolean).join(' ');
+
+/** hook steps 2+3: collapse repeats, then a head/tail line window. */
+function windowSelect(lines: string[]): string[] {
+  const collapsed: string[] = [];
+  let prev: string | null = null;
+  let run = 0;
+  for (const line of lines) {
+    if (prev !== null && line === prev) {
+      run++;
+      continue;
+    }
+    if (run > 0) {
+      collapsed.push(`  … previous line repeated ${run} more time(s)`);
+      run = 0;
+    }
+    collapsed.push(line);
+    prev = line;
+  }
+  if (run > 0) collapsed.push(`  … previous line repeated ${run} more time(s)`);
+
+  if (collapsed.length <= KEEP_HEAD + KEEP_TAIL) return collapsed;
+  return [
+    ...collapsed.slice(0, KEEP_HEAD),
+    `  … ${collapsed.length - KEEP_HEAD - KEEP_TAIL} line(s) elided by trace-mcp mirror …`,
+    ...collapsed.slice(-KEEP_TAIL),
+  ];
+}
+
+function charCap(text: string): string {
+  if (text.length <= CAP_CHARS) return text;
+  const head = Math.floor((CAP_CHARS * 2) / 3);
+  return `${text.slice(0, head)}\n  … ${text.length - CAP_CHARS} char(s) elided …\n${text.slice(-(CAP_CHARS - head))}`;
+}
+
+const EXT_LANG: Record<string, string> = {
+  ts: 'typescript',
+  mts: 'typescript',
+  cts: 'typescript',
+  tsx: 'tsx',
+  js: 'javascript',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  jsx: 'javascript',
+  py: 'python',
+  rb: 'ruby',
+  go: 'go',
+  rs: 'rust',
+  php: 'php',
+  java: 'java',
+  c: 'c',
+  h: 'c',
+  cc: 'cpp',
+  cpp: 'cpp',
+  hpp: 'cpp',
+  cs: 'csharp',
+  swift: 'swift',
+  kt: 'kotlin',
+  scala: 'scala',
+  lua: 'lua',
+  vue: 'vue',
+  sh: 'bash',
+  bash: 'bash',
+  ex: 'elixir',
+  exs: 'elixir',
+  dart: 'dart',
+  zig: 'zig',
+};
+
+function languageOf(path: string): string | null {
+  const ext = path.split('.').pop()?.toLowerCase() ?? '';
+  const lang = EXT_LANG[ext];
+  return lang && LANG_GRAMMARS[lang] ? lang : null;
+}
+
+const UNIT_RE =
+  /(function|method|class|struct|interface|enum|impl|trait|module|constructor|declaration|definition|arrow)/;
+
+type Unit = { start: number; end: number; header: number; text: string };
+
+/**
+ * Structural units of a parsed file: a node that owns a multi-line body.
+ * We keep the outermost such node per region -- a class is one unit, not one
+ * per method -- so a "keep" decision never lands mid-construct.
+ */
+function unitsOf(root: TSNode, minLines = 4): Unit[] {
+  const out: Unit[] = [];
+  const walk = (node: TSNode) => {
+    const span = node.endPosition.row - node.startPosition.row;
+    if (UNIT_RE.test(node.type) && span >= minLines) {
+      out.push({
+        start: node.startPosition.row,
+        end: node.endPosition.row,
+        header: node.childForFieldName?.('body')?.startPosition.row ?? node.startPosition.row,
+        text: node.text,
+      });
+      return; // outermost wins
+    }
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child) walk(child);
+    }
+  };
+  walk(root);
+  return out;
+}
+
+function tokens(s: string): Set<string> {
+  const out = new Set<string>();
+  for (const raw of s.match(/[A-Za-z_][A-Za-z0-9_]{2,}/g) ?? []) {
+    const t = raw.toLowerCase();
+    out.add(t);
+    for (const part of raw.split(/(?=[A-Z])|_/)) if (part.length > 2) out.add(part.toLowerCase());
+  }
+  return out;
+}
+
+/**
+ * HCP's rule, applied inside one file: what the question is about keeps its
+ * body, everything else keeps its signature. Scoring is lexical on purpose --
+ * TRA-758 proved the cost of a model here, and the claim under test is that
+ * the unit of selection carries the result, not the ranker.
+ */
+async function skeletonSelect(
+  call: Call,
+  targetCut = TARGET_CUT,
+  oracle = false,
+): Promise<string | null> {
+  const path = String(call.input.file_path ?? '');
+  const lang = languageOf(path);
+  if (!lang) return null;
+
+  const lines = call.output.split('\n');
+  const bodies = lines.map(stripPrefix);
+  const parser = await getParser(lang);
+  const tree = parser.parse(bodies.join('\n'));
+  const units = unitsOf(tree.rootNode).filter((u) => u.end < lines.length);
+  if (units.length === 0) return null;
+
+  const q = tokens(call.query);
+  const ev = new Set(call.evidence);
+  const scored = units
+    .map((u) => {
+      if (oracle) {
+        // Upper bound: perfect focus selection. Measures whether evidence is
+        // concentrated in a few units at all -- i.e. whether any ranker could win.
+        let n = 0;
+        for (let i = u.start; i <= u.end; i++) if (ev.has(i)) n++;
+        return { u, score: n > 0 ? 1 : 0 };
+      }
+      const sig = tokens(bodies.slice(u.start, Math.min(u.end, u.start + 3)).join(' '));
+      let hit = 0;
+      for (const t of sig) if (q.has(t)) hit++;
+      return { u, score: hit / Math.max(4, sig.size) };
+    })
+    .sort((a, b) => b.score - a.score);
+
+  const inUnit = new Uint8Array(lines.length);
+  for (const { u } of scored) for (let i = u.start; i <= u.end; i++) inUnit[i] = 1;
+
+  // Floor: everything outside a unit (imports, top-level consts, exports) plus
+  // one signature line per unit. Then spend what is left of the budget on
+  // whole bodies, highest-scoring first.
+  const keep = new Uint8Array(lines.length);
+  for (let i = 0; i < lines.length; i++) if (!inUnit[i]) keep[i] = 1;
+  for (const { u } of scored)
+    for (let i = u.start; i <= Math.min(u.header, u.end); i++) keep[i] = 1;
+
+  const budget = Math.floor(call.chars * (1 - targetCut));
+  const size = () => {
+    let n = 0;
+    for (let i = 0; i < lines.length; i++) if (keep[i]) n += lines[i].length + 1;
+    return n;
+  };
+  let used = size();
+  for (const { u, score } of scored) {
+    if (oracle && score === 0) continue;
+    let cost = 0;
+    for (let i = u.start; i <= u.end; i++) if (!keep[i]) cost += lines[i].length + 1;
+    if (!oracle && used + cost > budget) continue;
+    for (let i = u.start; i <= u.end; i++) keep[i] = 1;
+    used += cost;
+  }
+
+  const out: string[] = [];
+  let elided = 0;
+  for (let i = 0; i < lines.length; i++) {
+    if (keep[i]) {
+      if (elided > 0) {
+        out.push(`  … ${elided} line(s) of body elided by trace-mcp mirror …`);
+        elided = 0;
+      }
+      out.push(lines[i]);
+    } else elided++;
+  }
+  if (elided > 0) out.push(`  … ${elided} line(s) of body elided by trace-mcp mirror …`);
+  return out.join('\n');
+}
+
+/** A head/tail window trimmed to a given char budget -- the same mass the
+ * structural arm spends, so the two arms differ only in what they keep. */
+function windowToBudget(lines: string[], budget: number): string {
+  const head: string[] = [];
+  const tail: string[] = [];
+  let used = 0;
+  let i = 0;
+  let j = lines.length - 1;
+  while (i <= j && used < budget) {
+    if (head.length * 1 <= tail.length * 2) {
+      head.push(lines[i]);
+      used += lines[i].length + 1;
+      i++;
+    } else {
+      tail.unshift(lines[j]);
+      used += lines[j].length + 1;
+      j--;
+    }
+  }
+  return [...head, `  … ${j - i + 1} line(s) elided …`, ...tail].join('\n');
+}
+
+async function unitStats(call: Call): Promise<{ total: number; withEvidence: number } | null> {
+  const lang = languageOf(String(call.input.file_path ?? ''));
+  if (!lang) return null;
+  const lines = call.output.split('\n');
+  const parser = await getParser(lang);
+  const units = unitsOf(parser.parse(lines.map(stripPrefix).join('\n')).rootNode).filter(
+    (u) => u.end < lines.length,
+  );
+  const ev = new Set(call.evidence);
+  let withEvidence = 0;
+  for (const u of units) {
+    for (let i = u.start; i <= u.end; i++)
+      if (ev.has(i)) {
+        withEvidence++;
+        break;
+      }
+  }
+  return { total: units.length, withEvidence };
+}
+
+// ------------------------------------------------------------------ metrics
+
+function recall(call: Call, compressed: string): number {
+  const lines = call.output.split('\n');
+  const hay = norm(compressed);
+  let hit = 0;
+  for (const idx of call.evidence) {
+    const n = norm(stripPrefix(lines[idx]));
+    if (n.length > 0 && hay.includes(n)) hit++;
+  }
+  return call.evidence.length === 0 ? 1 : hit / call.evidence.length;
+}
+
+type Row = {
+  name: string;
+  cut: number;
+  recall: number;
+  median: number;
+  fail: number;
+  n: number;
+  ms: number;
+};
+
+function summarise(
+  name: string,
+  results: { orig: number; out: number; r: number }[],
+  ms: number,
+): Row {
+  const origMass = results.reduce((a, b) => a + b.orig, 0);
+  const outMass = results.reduce((a, b) => a + b.out, 0);
+  const recalls = results.map((r) => r.r).sort((a, b) => a - b);
+  return {
+    name,
+    n: results.length,
+    cut: (origMass - outMass) / origMass,
+    recall: recalls.reduce((a, b) => a + b, 0) / recalls.length,
+    median: recalls[Math.floor(recalls.length / 2)],
+    fail: recalls.filter((r) => r < 0.85).length / recalls.length,
+    ms,
+  };
+}
+
+async function main() {
+  const calls: Call[] = JSON.parse(readFileSync(join(HERE, 'dataset.json'), 'utf8'));
+  const rss0 = process.memoryUsage().rss;
+
+  const arms: Record<string, { orig: number; out: number; r: number }[]> = {
+    'window 24/12': [],
+    'window 24/12 + cap 3000': [],
+    'structural units (Read only)': [],
+    'structural units, Read subset': [],
+    'window 24/12, Read subset': [],
+    'skeleton floor: signatures only, Read subset': [],
+    'window at the same budget, Read subset': [],
+    'ORACLE structural focus, Read subset': [],
+    'ORACLE line focus, Read subset': [],
+  };
+  const timing: Record<string, number> = {};
+  const spread: number[] = [];
+  const unitCount: number[] = [];
+
+  for (const call of calls) {
+    const lines = call.output.split('\n');
+
+    let t = performance.now();
+    const win = windowSelect(lines).join('\n');
+    timing['window 24/12'] = (timing['window 24/12'] ?? 0) + (performance.now() - t);
+    arms['window 24/12'].push({ orig: call.chars, out: win.length, r: recall(call, win) });
+
+    const capped = charCap(win);
+    arms['window 24/12 + cap 3000'].push({
+      orig: call.chars,
+      out: capped.length,
+      r: recall(call, capped),
+    });
+
+    t = performance.now();
+    const skel = call.tool === 'Read' ? await skeletonSelect(call) : null;
+    timing.structural = (timing.structural ?? 0) + (performance.now() - t);
+    const chosen = skel ?? win;
+    arms['structural units (Read only)'].push({
+      orig: call.chars,
+      out: chosen.length,
+      r: recall(call, chosen),
+    });
+    if (skel !== null) {
+      arms['structural units, Read subset'].push({
+        orig: call.chars,
+        out: skel.length,
+        r: recall(call, skel),
+      });
+      arms['window 24/12, Read subset'].push({
+        orig: call.chars,
+        out: win.length,
+        r: recall(call, win),
+      });
+      const floor = (await skeletonSelect(call, 1)) ?? skel;
+      arms['skeleton floor: signatures only, Read subset'].push({
+        orig: call.chars,
+        out: floor.length,
+        r: recall(call, floor),
+      });
+      const stat = await unitStats(call);
+      if (stat) {
+        spread.push(stat.withEvidence);
+        unitCount.push(stat.total);
+      }
+      const oracleOut = (await skeletonSelect(call, TARGET_CUT, true)) ?? skel;
+      arms['ORACLE structural focus, Read subset'].push({
+        orig: call.chars,
+        out: oracleOut.length,
+        r: recall(call, oracleOut),
+      });
+      const evSet = new Set(call.evidence);
+      const lineOracle = lines.filter((_, i) => evSet.has(i)).join('\n');
+      arms['ORACLE line focus, Read subset'].push({
+        orig: call.chars,
+        out: lineOracle.length,
+        r: recall(call, lineOracle),
+      });
+      const iso = windowToBudget(lines, skel.length);
+      arms['window at the same budget, Read subset'].push({
+        orig: call.chars,
+        out: iso.length,
+        r: recall(call, iso),
+      });
+    }
+  }
+
+  console.log(
+    `evidence-bearing structural units: mean ${(spread.reduce((a, b) => a + b, 0) / Math.max(1, spread.length)).toFixed(2)} of ${(unitCount.reduce((a, b) => a + b, 0) / Math.max(1, unitCount.length)).toFixed(2)} units per file`,
+  );
+
+  const rows = Object.entries(arms)
+    .filter(([, v]) => v.length > 0)
+    .map(([k, v]) =>
+      summarise(
+        k,
+        v,
+        k.startsWith('structural')
+          ? timing.structural / calls.length
+          : timing['window 24/12'] / calls.length,
+      ),
+    );
+
+  const pct = (x: number) => `${(x * 100).toFixed(1)}%`;
+  console.log(
+    `\ncalls: ${calls.length} (Read ${calls.filter((c) => c.tool === 'Read').length}, Bash ${calls.filter((c) => c.tool === 'Bash').length})`,
+  );
+  console.log(
+    `evidence lines/call: median ${[...calls.map((c) => c.evidence.length)].sort((a, b) => a - b)[Math.floor(calls.length / 2)]}`,
+  );
+  console.log('\n| arm | n | mass cut | mean recall | median recall | recall<0.85 | ms/call |');
+  console.log('|---|---|---|---|---|---|---|');
+  for (const r of rows) {
+    console.log(
+      `| ${r.name} | ${r.n} | ${pct(r.cut)} | ${pct(r.recall)} | ${pct(r.median)} | ${pct(r.fail)} | ${r.ms.toFixed(2)} |`,
+    );
+  }
+  console.log(
+    `\nRSS delta over the run: ${((process.memoryUsage().rss - rss0) / 1e6).toFixed(1)} MB`,
+  );
+}
+
+main();

--- a/benchmarks/skeleton-gate/extract.py
+++ b/benchmarks/skeleton-gate/extract.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Rebuild the TRA-758 offline gate dataset from real Claude Code transcripts.
+
+TRA-758 measured a line-level selector against 497 real Read/Bash calls and
+failed the recall gate. Its dataset was never committed (10.6 MB of private
+source), so TRA-861 re-extracts it with the same documented methodology and
+re-runs the same metric with one variable changed: the unit of selection.
+
+Methodology (unchanged from TRA-758):
+  * corpus      : every session transcript under ~/.claude/projects
+  * working band: outputs of 2 000 .. 64 000 chars (below is not worth
+                  compressing, above the host persists it upstream)
+  * ground truth: a line counts as evidence when it reappears in the next 12
+                  assistant turns -- quoted in text, carried into an Edit's
+                  old_string, or transferred as a path/identifier into a
+                  later tool call.  >= 10 significant chars, so boilerplate
+                  ("}", "return") cannot be credited as evidence.
+
+Only past-facing fields are stored as the query (the last user message plus
+the assistant's own stated intent right before the call): a selector must not
+be able to see the future the labels are built from.
+
+Usage: python3 extract.py [--out dataset.json] [--limit N]
+"""
+
+import argparse
+import glob
+import json
+import os
+import random
+import re
+import sys
+
+MIN_CHARS = 2_000
+MAX_CHARS = 64_000
+FUTURE_TURNS = 12
+MIN_EVIDENCE_CHARS = 10
+MIN_EVIDENCE_LINES = 2
+
+BUCKETS = [(2_000, 4_000), (4_000, 8_000), (8_000, 16_000), (16_000, 32_000), (32_000, 64_000)]
+# The strata TRA-758 sampled, so the two runs are comparable call for call.
+BUCKET_QUOTA = {
+    (2_000, 4_000): (65, 75),
+    (4_000, 8_000): (65, 75),
+    (8_000, 16_000): (60, 60),
+    (16_000, 32_000): (40, 40),
+    (32_000, 64_000): (17, 0),
+}
+
+READ_PREFIX = re.compile(r"^\s*\d+\t")
+IDENT = re.compile(r"[A-Za-z0-9_./:\-]{6,}")
+
+
+def norm(line: str) -> str:
+    return " ".join(line.split())
+
+
+def significant(line: str) -> bool:
+    return len(re.sub(r"[^A-Za-z0-9_]", "", line)) >= MIN_EVIDENCE_CHARS
+
+
+def strip_read_prefix(line: str) -> str:
+    return READ_PREFIX.sub("", line, count=1) if READ_PREFIX.match(line) else line
+
+
+def load_records(path):
+    """Flatten a transcript into ordered records we can look forward from."""
+    records = []
+    try:
+        raw = open(path, encoding="utf-8", errors="replace").read().splitlines()
+    except OSError:
+        return records
+    for line in raw:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        kind = entry.get("type")
+        if kind not in ("assistant", "user"):
+            continue
+        content = (entry.get("message") or {}).get("content")
+        rec = {"role": kind, "texts": [], "tool_uses": [], "tool_results": {}}
+        if isinstance(content, str):
+            rec["texts"].append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type")
+                if btype == "text":
+                    rec["texts"].append(block.get("text") or "")
+                elif btype == "thinking":
+                    rec["texts"].append(block.get("thinking") or "")
+                elif btype == "tool_use":
+                    rec["tool_uses"].append(
+                        {"id": block.get("id"), "name": block.get("name"), "input": block.get("input") or {}}
+                    )
+                elif btype == "tool_result":
+                    body = block.get("content")
+                    if isinstance(body, str):
+                        rec["tool_results"][block.get("tool_use_id")] = body
+        records.append(rec)
+    return records
+
+
+def future_text(records, start, turns=FUTURE_TURNS):
+    """Everything the session said and did in the next `turns` assistant turns."""
+    chunks, seen = [], 0
+    for rec in records[start + 1 :]:
+        if rec["role"] == "assistant":
+            seen += 1
+            if seen > turns:
+                break
+        chunks.extend(rec["texts"])
+        for use in rec["tool_uses"]:
+            chunks.append(json.dumps(use["input"], ensure_ascii=False))
+    return "\n".join(chunks)
+
+
+def evidence_lines(lines, future, tool):
+    """Indices of lines the session demonstrably used afterwards."""
+    fut_norm = norm(future)
+    fut_idents = set(IDENT.findall(future)) if tool == "Bash" else None
+    hits = []
+    for i, line in enumerate(lines):
+        body = strip_read_prefix(line)
+        if not significant(body):
+            continue
+        n = norm(body)
+        if len(n) >= MIN_EVIDENCE_CHARS and n in fut_norm:
+            hits.append(i)
+            continue
+        if fut_idents:
+            # A shell result is used by lifting a path / test id / sha out of it.
+            if any(tok in fut_idents for tok in IDENT.findall(body)):
+                hits.append(i)
+    return hits
+
+
+def query_for(records, idx):
+    """What the hook could actually know at call time: last user ask + stated intent."""
+    intent = "\n".join(records[idx]["texts"])[-1_500:]
+    ask = ""
+    for rec in reversed(records[:idx]):
+        if rec["role"] == "user" and rec["texts"]:
+            joined = "\n".join(rec["texts"]).strip()
+            if joined and not joined.startswith("<"):
+                ask = joined[-2_000:]
+                break
+    return (ask + "\n" + intent).strip()
+
+
+def bucket_of(n):
+    for lo, hi in BUCKETS:
+        if lo <= n < hi:
+            return (lo, hi)
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default=os.path.join(os.path.dirname(__file__), "dataset.json"))
+    ap.add_argument("--projects", default=os.path.expanduser("~/.claude/projects"))
+    ap.add_argument("--seed", type=int, default=861)
+    args = ap.parse_args()
+
+    pool = []
+    transcripts = sorted(glob.glob(os.path.join(args.projects, "*", "*.jsonl")))
+    if not transcripts:
+        # A sandboxed $HOME points somewhere without transcripts, and an empty
+        # dataset otherwise looks like a real (and very wrong) result.
+        sys.exit(f"no transcripts under {args.projects} — pass --projects explicitly")
+    for n, path in enumerate(transcripts):
+        if n % 200 == 0:
+            print(f"  {n}/{len(transcripts)} transcripts, {len(pool)} candidates", file=sys.stderr)
+        records = load_records(path)
+        pending = {}
+        for idx, rec in enumerate(records):
+            for use in rec["tool_uses"]:
+                if use["name"] in ("Read", "Bash"):
+                    pending[use["id"]] = (idx, use)
+            for tid, body in rec["tool_results"].items():
+                if tid not in pending:
+                    continue
+                call_idx, use = pending.pop(tid)
+                if not (MIN_CHARS <= len(body) < MAX_CHARS):
+                    continue
+                if body.startswith("<persisted-output>"):
+                    continue
+                lines = body.split("\n")
+                ev = evidence_lines(lines, future_text(records, idx), use["name"])
+                if len(ev) < MIN_EVIDENCE_LINES:
+                    continue
+                pool.append(
+                    {
+                        "tool": use["name"],
+                        "input": use["input"],
+                        "chars": len(body),
+                        "bucket": f"{bucket_of(len(body))[0]}-{bucket_of(len(body))[1]}",
+                        "query": query_for(records, call_idx),
+                        "output": body,
+                        "evidence": ev,
+                    }
+                )
+
+    rng = random.Random(args.seed)
+    rng.shuffle(pool)
+    picked, counts = [], {}
+    for call in pool:
+        lo, hi = (int(x) for x in call["bucket"].split("-"))
+        quota = BUCKET_QUOTA[(lo, hi)][0 if call["tool"] == "Read" else 1]
+        key = (call["bucket"], call["tool"])
+        if counts.get(key, 0) >= quota:
+            continue
+        counts[key] = counts.get(key, 0) + 1
+        picked.append(call)
+
+    with open(args.out, "w", encoding="utf-8") as fh:
+        json.dump(picked, fh, ensure_ascii=False)
+    reads = sum(1 for c in picked if c["tool"] == "Read")
+    print(f"pool={len(pool)} picked={len(picked)} (Read {reads}, Bash {len(picked) - reads}) -> {args.out}")
+    for key in sorted(counts):
+        print(f"  {key[0]:>13} {key[1]:<5} {counts[key]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/skeleton-gate/footprint.ts
+++ b/benchmarks/skeleton-gate/footprint.ts
@@ -1,0 +1,28 @@
+/**
+ * The measurement everyone forgets (TRA-758): what the selector costs the
+ * client machine per tool call. The encoder cost +1.6 s and +198 MB; a
+ * structural selector runs no model, so this is the number that has to be
+ * near zero for the direction to have been worth trying at all.
+ */
+import { getParser } from '../../src/parser/tree-sitter.js';
+
+const sample = process.argv[2] ?? 'src/server/server.ts';
+const src = await import('node:fs').then((fs) => fs.readFileSync(sample, 'utf8'));
+const base = process.memoryUsage().rss;
+
+const t0 = performance.now();
+const parser = await getParser('typescript');
+parser.parse(src);
+const cold = performance.now() - t0;
+
+const runs: number[] = [];
+for (let i = 0; i < 50; i++) {
+  const t = performance.now();
+  parser.parse(src);
+  runs.push(performance.now() - t);
+}
+runs.sort((a, b) => a - b);
+console.log(`file: ${sample} (${(src.length / 1024).toFixed(1)} KB)`);
+console.log(`cold (grammar load + first parse): ${cold.toFixed(1)} ms`);
+console.log(`warm parse p50: ${runs[25].toFixed(2)} ms, p95: ${runs[47].toFixed(2)} ms`);
+console.log(`RSS delta: ${((process.memoryUsage().rss - base) / 1e6).toFixed(1)} MB`);


### PR DESCRIPTION
Re-runs the TRA-758 offline gate on the mirror hook with exactly one variable changed: the unit of selection is a structural unit (symbol + body, HCP-style) instead of a line.

**It fails the gate again — but this time the ceiling is measured, not inferred, so the direction closes properly.**

- Corpus re-extracted with TRA-758's documented methodology (its dataset was never committed — 10 MB of private source). 493 calls vs its 497; the baseline arm reproduces to within 2 pp, which is what makes the runs comparable.
- Best structural result: **0.61 recall at a 51% cut**. Gate asks for 0.85 at ≥50%. Sweeping the budget does not reach it.
- **At equal mass a plain head/tail window beats it** (63.9% vs 60.6%) — the structure was not carrying the result, the extra mass was.
- **Oracle: perfect structural focus cuts 16.7%** at 100% recall. That is the granularity's physical ceiling, independent of any ranker. Perfect *line* focus cuts 92%. The gap between the two oracles is the price of syntactic coherence, and the workload has no room for both.
- HCP's compression comes from reducing *dependencies* to signatures; a mirror hook has none — the file just read is by definition the focal file. Our skeleton floor (signatures only) scores 34.8% at 71.6% cut, worse than a same-mass window.
- Cost measured separately, as TRA-758 insisted: ~40 ms/call and +49 MB, against the encoder's +1 616 ms and +198 MB. The direction died on headroom, not on cost.

Ships the harness (`extract.py`, `eval.ts`, `footprint.ts`) and the report. The dataset stays gitignored.

No `src/` change; `pnpm test` green (10 018 passed), typecheck and biome clean.

Closes TRA-861.