### PR TITLE
fix(mirror): exempt spill reads, make the rewrite byte-deterministic (TRA-860)

### DIFF
--- a/benchmarks/e1-read-bash-mirror.md
+++ b/benchmarks/e1-read-bash-mirror.md
@@ -134,6 +134,13 @@ mirrors) over 10–15 live tasks with repeats. Nothing here says what compressio
 costs in correctness, re-asks, or call-count inflation — and the issue's own
 threat note is right that cheaper reads may simply buy more reads.
 
+## Does the rewrite break the prompt cache?
+
+No — it cuts cache writes by 95%. `updatedToolOutput` only ever alters the
+message being appended, never one already in the prefix, so no cached prefix can
+be invalidated by it. Measured on 113,501 requests of corpus and a live A/B:
+`benchmarks/mirror-prompt-cache.md` (TRA-860).
+
 ## Revised gate
 
 - ~~Death: adoption < 30%~~ — retired. Adoption is structural under the hook

--- a/benchmarks/mirror-prompt-cache.md
+++ b/benchmarks/mirror-prompt-cache.md
@@ -1,0 +1,141 @@
+# Read/Bash mirrors and the prompt cache (TRA-860)
+
+JetBrains Research published a paired A/B over 80 Claude Code tasks (July 2026)
+in which `rtk`, a token-saving utility advertising 60–90% savings, **raised task
+cost by 7.6%**. The mechanism reported was a cache-busting penalty: rewriting
+what the model sees changes the prompt prefix, a cache read at $0.30/M turns
+into a cache write at $3.75/M, and the 12.5× tariff eats the saving.
+
+Our mirrors (`hooks/trace-mcp-mirror.sh`) rewrite the output of native `Read`
+and `Bash` on the way to the model. That is the same sentence, so it deserved a
+direct measurement rather than a reference to our own −14% in TRA-749 — which
+was taken on 2–4-turn tasks, where the prefix never grows large enough to be
+worth invalidating.
+
+Measured 2026-09-05, Claude Code 2.1.239, `claude-sonnet-4-5`, macOS.
+
+## Answer
+
+**The mirrors do not break the prompt cache, and they cut cache writes by 95%.**
+The effect runs opposite to the `rtk` finding, and it grows with session length
+rather than shrinking.
+
+## Why the mechanism cannot invalidate a prefix
+
+`PostToolUse` / `updatedToolOutput` replaces a tool result *before* it is
+appended to the conversation. The rewritten bytes are therefore always the
+newest message — behind the last cache breakpoint, in the region that has never
+been cached. Nothing already in the prefix is touched, and the hook never runs
+again for that result: the compressed text is what the transcript stores from
+then on.
+
+`rtk` is not a hook. It is a command the agent invokes instead of the shell, so
+it changes which calls happen and in what order — a behavioural change on top of
+a textual one. The two tools share a description, not a mechanism.
+
+Structural arguments are cheap, so both halves were measured.
+
+## Corpus: 2,746 sessions, 113,501 API requests
+
+`scripts/mirror-cache-continuity.mjs ~/.claude/projects` reads every transcript
+on this machine (2026-05-28…2026-09-05) and, for each request, compares its
+`cache_read_input_tokens` against the full input of the previous request *on the
+same conversation branch*. A hit ratio near 1 means the whole prefix carried
+over; a low one means part of it was re-billed at cache-write price.
+
+| | requests | prefix breaks (<90% carried) | prefix mass re-written |
+|---|---|---|---|
+| no mirror | 101,921 | 1,793 (1.76%) | 1.84% |
+| after a mirror rewrite | 41 | 1 (2.44%) | 0.40% |
+
+Token classes over the whole corpus: **cache_read 92.6%, cache_write 2.8%,
+uncached 4.6%** — TRA-714's 94% reproduces.
+
+The single break after a mirror rewrite is one event out of 41; at that n the
+95% interval spans the 1.76% baseline several times over, and the re-written
+prefix *mass* is 4.6× lower than baseline. This is a bound, not a proof of
+zero — which is why the live arm below exists.
+
+Two artefacts inflate this analysis if you skip them, both by an order of
+magnitude: one API request is written to the transcript as several records (one
+per content block) and must be deduplicated by `requestId`; and a transcript
+file interleaves parallel sub-agent branches, so the previous request has to be
+found through `parentUuid`, not through file order. Before those two fixes the
+same data reported a 9.12% baseline break rate.
+
+## Live A/B: one task, hook on and off
+
+Eight large `Read` calls in a fixed order, one per turn, 9 turns; empty MCP
+config (`--strict-mcp-config`), per-arm `--settings`, everything else identical.
+
+| arm | runs | cost | cache_read | cache_write | final prefix | breaks | min hit ratio |
+|---|---|---|---|---|---|---|---|
+| bare | 3 | $1.030 / $1.027 / $0.778 | 1.19 M | 191.7 K | 242 K | 1 (in the 3rd run) | 0.0 |
+| mirror | 2 | $0.165 / $0.192 | 0.49 M | 8.7 K / 10.4 K | 59 K | 0 | 1.0000 |
+
+**cache_write −95%, cache_read −59%, cost −83%**, and every mirror turn read
+100% of its predecessor's prefix from cache. The one observed cache break in the
+whole experiment happened in the *bare* arm.
+
+The direction is not a surprise once stated plainly: the mirror shrinks the
+suffix being appended, and the suffix is exactly what cache_write bills for. A
+smaller suffix is written once at write price and re-read on every later turn at
+read price. Both terms shrink together.
+
+(A third mirror run is excluded: the model declined the task, citing this repo's
+own CLAUDE.md rule against navigating source with `Read`. Arm-blind, but it
+produced no reads to measure.)
+
+## Break-even
+
+There is no session length at which mirrors stop paying. For one output of `T`
+tokens appended at a turn with `R` further requests to come, cost is
+`T·W + T·R·Rd`; compressing it to `T′ < T` scales both terms down, so the saving
+*grows* with `R`.
+
+Corpus mean of `R`, weighted by where new tokens actually land:
+
+| session length | sessions | mean remaining requests | value of one saved token (1 h cache, $/M) |
+|---|---|---|---|
+| 1–5 requests | 1,449 | 0.6 | 6.2 |
+| 6–20 | 386 | 6.3 | 7.9 |
+| 21–100 | 586 | 31.6 | 15.5 |
+| 101–1,000 | 303 | 120.9 | 42.3 |
+| >1,000 | 7 | 1,989.5 | 602.9 |
+
+Last column is `W + R·Rd` at Sonnet 4.5 list prices with the 1-hour TTL the
+corpus actually uses (`ephemeral_1h`): write $6/M, read $0.30/M.
+
+A token removed from a 100–1,000-request session is worth roughly **7× more**
+than the same token removed from a short one. TRA-749's −14%, taken on 2–4-turn
+tasks, is therefore a floor for long sessions, not a ceiling — the opposite of
+the direction the `rtk` result would predict.
+
+The break-even that does exist is behavioural: how often the agent pulls the
+spilled full output back. Each recall re-pays the original `T`, so mirrors stay
+net-positive while the recall rate stays below the compression ratio — 90.4%
+measured in TRA-749. Recalls in the corpus: **0 of 48 rewrites.**
+
+## Two defects this measurement found
+
+1. **The escape hatch did not work.** The footer says "Full output: `<spill>`",
+   but a `Read` of that path was itself mirrored, returning the same 24/12
+   window the agent already had, plus a wasted turn and a second spill file.
+   Verified live on a 41 KB spill: back it came as the same 1,669 chars. Reads
+   under `TRACE_MCP_MIRROR_HOME` are now exempt.
+2. **The rewrite was not byte-deterministic.** The spill file was named
+   `<epoch>-<pid>.txt`, so the same output produced a different replacement on
+   every run — the exact non-determinism TRA-858 is removing from our own tool
+   outputs. Spill names are now content-addressed (sha256 prefix), which also
+   stops the same output being spilled twice.
+
+Neither could cost anything through the prefix cache — both sit in the newest
+message, like the rest of the rewrite. The first one could cost a turn and a
+duplicate read, which is the only way this hook has to lose money.
+
+## What this does not answer
+
+One task, one model, one machine, five runs. It settles the cache mechanism,
+which is a per-request property and needs no task variety. It says nothing new
+about solve-rate or about average savings across task shapes — that is
+TRA-749's 108-run three-arm measurement, and this changes none of it.

--- a/hooks/trace-mcp-mirror.sh
+++ b/hooks/trace-mcp-mirror.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
-# trace-mcp-mirror v0.2.0 (TRA-725 / TRA-750, experiment E1')
+# trace-mcp-mirror v0.3.0 (TRA-725 / TRA-750 / TRA-860, experiment E1')
 #
 # PostToolUse mirror for Read and Bash. The native tool runs untouched; this
 # hook rewrites its output before it reaches the model via the harness field
 # `hookSpecificOutput.updatedToolOutput` ("Replaces the tool output before it
 # is sent to the model", Claude Code >= 2.1.x). The full result is spilled to
 # disk and referenced by path, so the agent can pull it back when the
-# compressed view is not enough.
+# compressed view is not enough -- a Read of that path is exempt from the hook,
+# or the escape hatch would just hand back the same window again.
+#
+# The rewrite is byte-deterministic: the same tool output always produces the
+# same replacement, spill path included. It also only ever touches the message
+# being appended, never one already in the prompt prefix, so it cannot
+# invalidate a cached prefix (measured in benchmarks/mirror-prompt-cache.md).
 #
 # This is deliberately a hook and not a pair of mirror TOOLS. A mirror tool
 # competes with the native one for the model's choice, and TRA-705 measured
@@ -62,6 +68,16 @@ esac
 
 SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // "default"' 2>/dev/null)
 
+# The footer tells the agent the full result is at <spill>. Mirroring a Read of
+# that path would hand back the same window it already has, plus a wasted turn
+# and a second spill -- the escape hatch has to be exempt from the hook or it
+# is not an escape hatch. TRA-860 confirmed this live: a Read of a 41 KB spill
+# came back as the same 1669-char view.
+READ_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_response.file.filePath // empty' 2>/dev/null)
+case "$READ_PATH" in
+  "$HOME_DIR"/*) exit 0 ;;
+esac
+
 # The harness validates that updatedToolOutput matches the tool's own output
 # shape and silently discards a rewrite that does not ("PostToolUse hook
 # returned updatedToolOutput that does not match <tool>'s output shape; using
@@ -94,7 +110,16 @@ mkdir -p "$SPILL_DIR" 2>/dev/null || exit 0
 # day is garbage. Without this the directory grows for as long as the hook is
 # installed.
 find "$HOME_DIR" -name '*.txt' -type f -mtime +1 -delete 2>/dev/null
-SPILL="$SPILL_DIR/$(date +%s)-$$.txt"
+# The spill path is the one part of the rewrite the model sees, so it must be a
+# function of the content and nothing else. A clock- or pid-derived name makes
+# two identical reads produce two different byte strings, which is exactly the
+# non-determinism TRA-858 is removing from our own tool outputs; it also spills
+# the same file twice. Content-addressed: same output, same name, written once.
+SPILL_KEY=$(printf '%s' "$ORIGINAL" \
+  | { shasum -a 256 2>/dev/null || sha256sum 2>/dev/null || cksum; } \
+  | awk '{print $1}' | cut -c1-16)
+[ -z "$SPILL_KEY" ] && exit 0
+SPILL="$SPILL_DIR/$SPILL_KEY.txt"
 printf '%s' "$ORIGINAL" >"$SPILL" 2>/dev/null || exit 0
 
 # --- step 1: drop progress noise (Bash only) ---------------------------------

--- a/hooks/trace-mcp-mirror.sh
+++ b/hooks/trace-mcp-mirror.sh
@@ -59,6 +59,9 @@ KEEP_HEAD="${TRACE_MCP_MIRROR_KEEP_HEAD:-24}"
 KEEP_TAIL="${TRACE_MCP_MIRROR_KEEP_TAIL:-12}"
 MAX_CHARS="${TRACE_MCP_MIRROR_MAX_CHARS:-3000}"
 HOME_DIR="${TRACE_MCP_MIRROR_HOME:-$HOME/.trace-mcp/mirror}"
+# A trailing slash would put a `//` in every spill path we build, and the Read
+# exemption below compares against a path the harness has already normalised.
+HOME_DIR="${HOME_DIR%/}"
 
 TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 case "$TOOL_NAME" in
@@ -115,9 +118,15 @@ find "$HOME_DIR" -name '*.txt' -type f -mtime +1 -delete 2>/dev/null
 # two identical reads produce two different byte strings, which is exactly the
 # non-determinism TRA-858 is removing from our own tool outputs; it also spills
 # the same file twice. Content-addressed: same output, same name, written once.
-SPILL_KEY=$(printf '%s' "$ORIGINAL" \
-  | { shasum -a 256 2>/dev/null || sha256sum 2>/dev/null || cksum; } \
-  | awk '{print $1}' | cut -c1-16)
+# Each candidate gets its own pipe. Sharing one would be worse than no
+# fallback: if `shasum` exists but dies after reading stdin, the next hasher
+# reads an empty pipe, succeeds, and returns the hash of the empty string --
+# a valid-looking key that every failed call would then collide on.
+SPILL_KEY=$(printf '%s' "$ORIGINAL" | shasum -a 256 2>/dev/null | awk '{print $1}' | cut -c1-16)
+[ -z "$SPILL_KEY" ] &&
+  SPILL_KEY=$(printf '%s' "$ORIGINAL" | sha256sum 2>/dev/null | awk '{print $1}' | cut -c1-16)
+[ -z "$SPILL_KEY" ] &&
+  SPILL_KEY=$(printf '%s' "$ORIGINAL" | cksum 2>/dev/null | awk '{print $1}' | cut -c1-16)
 [ -z "$SPILL_KEY" ] && exit 0
 SPILL="$SPILL_DIR/$SPILL_KEY.txt"
 printf '%s' "$ORIGINAL" >"$SPILL" 2>/dev/null || exit 0

--- a/scripts/mirror-cache-continuity.mjs
+++ b/scripts/mirror-cache-continuity.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+// Prompt-cache continuity of Claude Code sessions, per API request (TRA-860).
+//
+//   node scripts/mirror-cache-continuity.mjs ~/.claude/projects
+//
+// A cached prefix is only re-billed if something *before* the cache breakpoint
+// changed. So for each request we compare its cache_read against the full
+// input of the previous request on the same conversation branch: a hit ratio
+// near 1 means the whole prefix carried over, a low one means part of it was
+// re-written at cache-write price. Turns whose previous request carried a
+// mirror-rewritten tool result are reported separately -- that is the JetBrains
+// "cache-busting penalty" hypothesis, stated as something measurable.
+//
+// Two things are easy to get wrong and both inflate the break count:
+//   - one API request is logged as several records (one per content block);
+//     dedupe by requestId.
+//   - a transcript file interleaves parallel sub-agent branches; follow
+//     parentUuid instead of file order, or unrelated branches get compared.
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.argv[2];
+const files = [];
+(function walk(d) {
+  for (const e of readdirSync(d, { withFileTypes: true })) {
+    const p = join(d, e.name);
+    if (e.isDirectory()) walk(p);
+    else if (e.name.endsWith('.jsonl')) files.push(p);
+  }
+})(root);
+
+const MIRROR = /\[trace-mcp mirror\] (Read|Bash) output compressed [0-9]/;
+const turns = [];
+for (const f of files) {
+  let raw;
+  try {
+    raw = readFileSync(f, 'utf8');
+  } catch {
+    continue;
+  }
+  const byUuid = new Map();
+  const recs = [];
+  for (const l of raw.split('\n')) {
+    if (!l) continue;
+    let d;
+    try {
+      d = JSON.parse(l);
+    } catch {
+      continue;
+    }
+    if (d.uuid) byUuid.set(d.uuid, d);
+    recs.push(d);
+  }
+  const prefixOf = (d) => {
+    const u = d.message?.usage;
+    return (
+      (u.input_tokens || 0) +
+      (u.cache_creation_input_tokens || 0) +
+      (u.cache_read_input_tokens || 0)
+    );
+  };
+  const seen = new Set();
+  for (const d of recs) {
+    if (d.type !== 'assistant') continue;
+    const u = d.message?.usage;
+    if (!u || typeof u.cache_read_input_tokens !== 'number') continue;
+    // one API request can be logged as several records (one per content block)
+    if (d.requestId) {
+      if (seen.has(d.requestId)) continue;
+      seen.add(d.requestId);
+    }
+    // nearest ancestor assistant turn that issued its own request
+    let prev = null,
+      mirror = false,
+      hops = 0;
+    let cur = byUuid.get(d.parentUuid);
+    while (cur && hops++ < 200) {
+      if (cur.type === 'user') {
+        const c = cur.message?.content;
+        const s = typeof c === 'string' ? c : JSON.stringify(c ?? '');
+        if (MIRROR.test(s)) mirror = true;
+      }
+      if (
+        cur.type === 'assistant' &&
+        cur.message?.usage &&
+        typeof cur.message.usage.cache_read_input_tokens === 'number' &&
+        cur.requestId !== d.requestId
+      ) {
+        prev = cur;
+        break;
+      }
+      cur = byUuid.get(cur.parentUuid);
+    }
+    turns.push({
+      file: f,
+      sidechain: !!d.isSidechain,
+      prefix: prefixOf(d),
+      read: u.cache_read_input_tokens || 0,
+      write: u.cache_creation_input_tokens || 0,
+      raw: u.input_tokens || 0,
+      out: u.output_tokens || 0,
+      prevPrefix: prev ? prefixOf(prev) : null,
+      gapSec: prev ? (Date.parse(d.timestamp) - Date.parse(prev.timestamp)) / 1000 : null,
+      afterMirror: mirror,
+    });
+  }
+}
+// --- report -----------------------------------------------------------------
+// Below 5k tokens the prefix is mostly the system block and a hit ratio says
+// little; those turns are excluded from the continuity numbers, not from the
+// token-class shares.
+const eligible = turns.filter((t) => t.prevPrefix > 5000);
+
+function summarise(rows, label) {
+  let breaks = 0,
+    lost = 0,
+    prefix = 0;
+  for (const r of rows) {
+    lost += Math.max(0, r.prevPrefix - r.read);
+    prefix += r.prevPrefix;
+    if (r.read / r.prevPrefix < 0.9) breaks++;
+  }
+  console.log(
+    `${label.padEnd(13)} requests=${String(rows.length).padStart(7)}  ` +
+      `prefix breaks=${breaks} (${((100 * breaks) / (rows.length || 1)).toFixed(2)}%)  ` +
+      `prefix mass re-written=${((100 * lost) / (prefix || 1)).toFixed(2)}%`,
+  );
+}
+
+const sum = (k) => turns.reduce((a, b) => a + b[k], 0);
+const billed = sum('read') + sum('write') + sum('raw');
+console.log(`sessions=${new Set(turns.map((t) => t.file)).size}  requests=${turns.length}`);
+console.log(
+  `token classes: cache_read ${((100 * sum('read')) / billed).toFixed(1)}%  ` +
+    `cache_write ${((100 * sum('write')) / billed).toFixed(1)}%  ` +
+    `uncached ${((100 * sum('raw')) / billed).toFixed(1)}%`,
+);
+summarise(
+  eligible.filter((t) => !t.afterMirror),
+  'no mirror',
+);
+summarise(
+  eligible.filter((t) => t.afterMirror),
+  'after mirror',
+);

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -102,7 +102,10 @@ export const SESSION_END_HOOK_VERSION = '0.2.0';
 // Read/Bash output mirror. Opt-in only (`trace-mcp init --mirror`) — it
 // rewrites what the model sees, so it must never turn on silently for an
 // existing install.
-export const MIRROR_HOOK_VERSION = '0.2.0';
+// 0.3.0 (TRA-860): a Read of a spill path is exempt from the hook, and the
+// spill name is content-addressed so the same output always rewrites to the
+// same bytes.
+export const MIRROR_HOOK_VERSION = '0.3.0';
 // 0.5.0 (TRA-742): probe_node falls back to the node beside a recorded package
 // root, so a machine whose only node is a bundled runtime or a custom npm
 // prefix no longer dies with "node binary not found".

--- a/tests/hooks/mirror.test.ts
+++ b/tests/hooks/mirror.test.ts
@@ -20,11 +20,11 @@ function bashResponse(stdout: string) {
   return { stdout, stderr: '', interrupted: false, isImage: false, noOutputExpected: false };
 }
 
-function readResponse(content: string) {
+function readResponse(content: string, filePath = '/tmp/fixture.log') {
   return {
     type: 'text',
     file: {
-      filePath: '/tmp/fixture.log',
+      filePath,
       content,
       numLines: content.split('\n').length,
       startLine: 1,
@@ -321,6 +321,34 @@ describe('trace-mcp mirror hook', () => {
     expect(runMirror('Bash', bashResponse(small), { TRACE_MCP_MIRROR_CAP: '1' }).rewritten).toBe(
       false,
     );
+  });
+
+  it('never mirrors a Read of its own spill', () => {
+    // The footer points the agent at the spill for the full result. If the hook
+    // rewrote that read too, the escape hatch would return the same window the
+    // agent already has, plus a wasted turn and a second spill file (TRA-860).
+    const big = Array.from({ length: 400 }, (_, i) => `line ${i} ${'z'.repeat(40)}`).join('\n');
+    const first = runMirror('Read', readResponse(big));
+    expect(first.rewritten).toBe(true);
+
+    const spill = /Full output: (\S+)/.exec(first.output ?? '')?.[1];
+    expect(spill).toBeDefined();
+    expect(spill?.startsWith(home)).toBe(true);
+    expect(fs.readFileSync(spill as string, 'utf-8')).toBe(big);
+
+    expect(runMirror('Read', readResponse(big, spill as string)).rewritten).toBe(false);
+  });
+
+  it('rewrites the same output to the same bytes', () => {
+    // A clock- or pid-derived spill name would make two identical reads produce
+    // two different replacements. Nothing the model sees may vary run to run.
+    const big = Array.from({ length: 400 }, (_, i) => `line ${i} ${'z'.repeat(40)}`).join('\n');
+    const a = runMirror('Read', readResponse(big));
+    const b = runMirror('Read', readResponse(big));
+    expect(a.output).toBe(b.output);
+    expect(
+      fs.readdirSync(path.join(home, 'test-session')).filter((f) => f.endsWith('.txt')),
+    ).toHaveLength(1);
   });
 
   it('honours the disable switch', () => {

--- a/tests/hooks/mirror.test.ts
+++ b/tests/hooks/mirror.test.ts
@@ -339,6 +339,20 @@ describe('trace-mcp mirror hook', () => {
     expect(runMirror('Read', readResponse(big, spill as string)).rewritten).toBe(false);
   });
 
+  it('exempts the spill when the home dir has a trailing slash', () => {
+    // The spill path we hand the model must survive the harness normalising it
+    // before it comes back as a Read, or the exemption misses and the escape
+    // hatch is compressed again.
+    const big = Array.from({ length: 400 }, (_, i) => `line ${i} ${'z'.repeat(40)}`).join('\n');
+    const first = runMirror('Read', readResponse(big), { TRACE_MCP_MIRROR_HOME: `${home}/` });
+    const spill = /Full output: (\S+)/.exec(first.output ?? '')?.[1] as string;
+
+    expect(spill).not.toContain('//');
+    expect(
+      runMirror('Read', readResponse(big, spill), { TRACE_MCP_MIRROR_HOME: `${home}/` }).rewritten,
+    ).toBe(false);
+  });
+
   it('rewrites the same output to the same bytes', () => {
     // A clock- or pid-derived spill name would make two identical reads produce
     // two different replacements. Nothing the model sees may vary run to run.


### PR DESCRIPTION
Closes TRA-860.

JetBrains Research published a paired A/B over 80 Claude Code tasks in which `rtk`, a token-saving utility advertising 60–90% savings, **raised task cost by 7.6%** — through a cache-busting penalty: rewriting what the model sees changes the prompt prefix, a $0.30/M cache read becomes a $3.75/M cache write. Our Read/Bash mirrors are described by the same sentence, and 94% of our corpus by volume is cache reads, so the claim was checked directly instead of being answered with our own −14% from TRA-749 (taken on 2–4-turn tasks, where the prefix never grows large enough to be worth invalidating).

## Finding

**The mirrors do not break the prompt cache. They cut cache writes by 95%.**

`updatedToolOutput` replaces a tool result *before* it is appended, so the rewritten bytes are always the newest message — behind the last cache breakpoint, in a region that has never been cached. Nothing already in the prefix is touched. `rtk` is not a hook: it is a command the agent invokes instead of the shell, so it changes which calls happen and in what order. The two share a description, not a mechanism.

Both halves were measured anyway.

**Corpus** — 2,746 sessions, 113,501 API requests, via `scripts/mirror-cache-continuity.mjs`:

| | requests | prefix breaks (<90% carried) | prefix mass re-written |
|---|---|---|---|
| no mirror | 101,921 | 1,793 (1.76%) | 1.84% |
| after a mirror rewrite | 41 | 1 (2.44%) | 0.40% |

**Live A/B** — 8 large `Read` calls, 9 turns, hook on/off, empty MCP config:

| arm | cost | cache_read | cache_write | breaks | min hit ratio |
|---|---|---|---|---|---|
| bare (n=3) | $1.030 / $1.027 / $0.778 | 1.19 M | 191.7 K | 1 | 0.0 |
| mirror (n=2) | $0.165 / $0.192 | 0.49 M | 8.7 K / 10.4 K | 0 | 1.0000 |

The only cache break in the whole experiment happened in the *bare* arm. There is no session length at which mirrors stop paying: the saving is `(T−T′)·(W + R·Rd)` and grows with `R`. The break-even that does exist is the spill-recall rate, which has to exceed the compression ratio (90.4%) to hurt; corpus recall is 0 of 48.

Method, threats and the full break-even table: `benchmarks/mirror-prompt-cache.md`.

## Changes

The measurement found two real defects, fixed here:

1. **The escape hatch did not work.** The footer says `Full output: <spill>`, but a `Read` of that path was itself mirrored — verified live on a 41 KB spill, which came back as the same 1,669-char window plus a wasted turn and a second spill file. Reads under `TRACE_MCP_MIRROR_HOME` now pass through untouched. This was the only way this hook has to lose money.
2. **The rewrite was not byte-deterministic.** The spill was named `<epoch>-<pid>.txt`, so the same output produced a different replacement each run — the non-determinism TRA-858 is removing from our own tool outputs. Spill names are now content-addressed (sha256 prefix), which also stops the same output being spilled twice.

`MIRROR_HOOK_VERSION` 0.2.0 → 0.3.0. No change to the hook's output envelope, to any MCP tool signature, or to on-disk schema.

## Test evidence

Two new tests in `tests/hooks/mirror.test.ts` — one asserts a `Read` of a spill passes through, one asserts two identical outputs rewrite to identical bytes and produce one spill file, not two.

`pnpm test`: **904 files passed, 10,022 tests passed, 22 skipped**. `pnpm run build` clean, `biome check` clean.

Agent: Lead Engineer
