### PR TITLE
perf(app): time the synchronous half of every UI action, and record the 3.17.0 baseline (TRA-835)

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -14,39 +14,35 @@ noindex: true
 Machine-readable history lives in [`baseline.json`](./baseline.json) — append one `runs[]`
 entry per measurement pass, never rewrite an old one. This file is the human summary.
 
-## Current numbers (3.11.0, `e8a0dd7c`, darwin 25.5.0 / arm64, median of 3)
+## Current numbers (3.17.0, `121e3e9b`, darwin 25.5.0 / arm64, median of 3)
 
-Two passes on 2026-09-02, by the same autopilot, reconciled into one series: the
-2026-09-01 entry that first filled the workload metrics, and this one, which repeats them
-on the merged harness and adds the two rows marked new. Where they overlap they agree —
-`ui_p95_ms` 668 / 690, `heap_growth_mb_per_hour` 1.39 / 0.19, `rss_after_index_settle_mb`
-383 / 316 — which is the first independent confirmation these numbers have had.
-
-The `artifact_mb` rows are from a separate artifact-only pack (3.11.0, `64b14a12`). Sizes
-are deterministic, so they do not need a median.
+Taken 2026-09-04, 30 minutes / 574 cycles / 0 cycle errors, offscreen. First pass since the
+3.11.0 series and six app-visible releases later. **No regression on any metric** against the
+median of the last five runs; four improved. The `artifact_mb` rows come from
+`pnpm -C packages/app run pack` on this same commit; sizes are deterministic and need no median.
 
 | Metric | Value | Ceiling | Status |
 |---|---|---|---|
-| `renderer_first_content_ms` | 97 | — | **the startup metric of record** (new, new series) |
+| `renderer_first_content_ms` | 93 | — | **the startup metric of record** — 97 last time |
 | `renderer_fcp_ms` | null | — | structurally unavailable offscreen — see below |
-| `cold_start_ms` | 393 | 3000 | ok, load-sensitive |
-| `window_interactive_ms` | 129 | — | load-sensitive, do not trend it |
-| `ui_p95_ms` | 690 | — | search p95 690, open p95 144, switch p95 130 |
-| `renderer_cpu_idle_pct.overview` | 2.9 | — | new |
-| `renderer_cpu_idle_pct.graph` | **29.3** | — | **new — the Graph tab never idles**, TRA-683 |
-| `heap_idle_mb` (5 min idle) | 15.4 | — | ok — see note below, not comparable to 9.5 |
-| `heap_after_workload_mb` | 7.8 | — | ok |
-| `heap_growth_mb_per_hour` | +0.19 | 50 | ok — no leak over 521 cycles |
-| `tree_rss_idle_mb` (app + daemon) | 920 | — | ok vs 955 |
-| `tree_rss_peak_mb` (app + daemon) | 1250 | 2000 | ok |
-| `tree_cpu_peak_pct` (combined, sums cores) | 180 | — | ok |
-| `rss_after_index_settle_mb` (daemon only) | 316 | 500 | ok settled — **but ~700 MB while serving, see below** |
+| `cold_start_ms` | 415 | 3000 | ok, load-sensitive |
+| `window_interactive_ms` | 141 | — | load-sensitive, do not trend it |
+| `ui_p95_ms` | 667 | — | **old detector — see the correction below**; search p95 667, open 73, switch 189 |
+| `renderer_cpu_idle_pct.overview` | 0.1 | — | was 2.9 |
+| `renderer_cpu_idle_pct.graph` | **6.8** | — | **was 29.3 — TRA-683 landed and this is its field number** |
+| `heap_idle_mb` (5 min idle) | 9.5 | — | ok — was 15.4 |
+| `heap_after_workload_mb` | 7.7 | — | ok |
+| `heap_growth_mb_per_hour` | +1.56 | 50 | ok — flat 9.3–9.8 MB across 574 cycles |
+| `tree_rss_idle_mb` (app + daemon) | 878 | — | ok vs 920 |
+| `tree_rss_peak_mb` (app + daemon) | 1512 | 2000 | ok |
+| `tree_cpu_peak_pct` (combined, sums cores) | 133 | — | ok vs 180 |
+| `rss_after_index_settle_mb` (daemon only) | 196 | 500 | ok — was 316 |
 | `main_cpu_idle_pct` | 0.1 | 2 | ok |
-| `renderer_eager_kb` | 2131 | — | **the size metric of record** |
-| `renderer_bundle_kb` | 2301 | — | +1.4% vs 2270 — noise |
-| `artifact_mb.mac_app_unpacked` | 346.2 | x1.5 growth | re-anchored 2026-09-02, was 478.2 |
-| `artifact_mb.mac_server_payload` | 77 | **100 MB, absolute** | ok |
-| `artifact_mb.mac_asar` | 6 | x1.5 growth | ok |
+| `renderer_eager_kb` | 2084 | — | **the size metric of record** — -0.9% |
+| `renderer_bundle_kb` | 2346 | — | +3.3%, all of it in lazy chunks |
+| `artifact_mb.mac_app_unpacked` | 350 | x1.5 growth | +1.1% vs the 346.2 re-anchor |
+| `artifact_mb.mac_server_payload` | 80 | **100 MB, absolute** | ok, watch it |
+| `artifact_mb.mac_asar` | 7 | x1.5 growth | ok |
 
 **Open finding — the daemon costs ~700 MB to serve one small project.** With a fresh data
 dir, a private port and exactly one registered project (this repo at the pinned fixture
@@ -71,17 +67,21 @@ sets itself when React commits the first content under `#root`
 the pipeline. **It starts a new series: 97 ms here is not comparable to the 136 ms
 `renderer_fcp_ms` of the 2026-09-01 entry, which ran with a visible window.**
 
-### The Graph tab burns 29.3% of a core with nobody touching it
+### The Graph tab used to burn 29.3% of a core with nobody touching it — now 6.8%
 
 `renderer_cpu_idle_pct` is renderer CPU over a 60 s window with **no input**, per view,
 taken from `cputime` deltas — `ps -o %cpu` is a decaying lifetime average and cannot answer
-"busy right now". Overview reads 2.9% of a core, Graph 29.3%; measured three times across
-two harness versions on 2026-09-02 (27.0 / 27.7 / 29.3).
+"busy right now".
 
-This is the `.cosmos-gpu-label` finding priced. The settle detector had to stop counting
-that layer because it mutates every animation frame forever (~730 mutations/second with no
-input); that established the tab never goes quiet, and this metric says what the quiet
-costs. Tracked as TRA-683, not fixed here.
+| | 2026-09-02 (3.11.0) | 2026-09-04 (3.17.0) |
+|---|---|---|
+| Overview | 2.9% of a core | 0.1% |
+| Graph | 29.3% (27.0 / 27.7 / 29.3 across three passes) | **6.8%** (6.5 / 6.8 / 6.8) |
+
+The fix is `0c79f0e2`, "let the Graph tab go quiet when nobody is watching" (TRA-683),
+merged between the two runs. This is the metric that found the cost and the metric that
+confirms it went away — the tab is now roughly a fifth of what it was, and Overview is
+effectively free. What is left is not zero, so keep sampling it.
 
 ### `heap_idle_mb` moved 9.5 to 15.4 and it is not a leak
 
@@ -244,10 +244,20 @@ How each number is derived:
   `switch_view` into Graph times the surrounding DOM, not the graph's own render. "The
   graph has actually loaded" is enforced separately, by the `matchCount() > 0` gate before
   the cycle loop starts.
-- The **search median reads near zero and that is not a bug**: the graph typeahead filters
-  nodes the renderer already holds, so the list updates within a few milliseconds of the
-  keystroke. `ui_p95_ms` takes the worst per-action p95 precisely so a cheap action cannot
-  hide an expensive one.
+- **The completion detector arms its observer before the action fires** (TRA-835). It used
+  to fire the action first and attach the `MutationObserver` afterwards. React commits a
+  discrete event — a click, an `input` — synchronously inside `dispatchEvent`, so by the time
+  the observer attached, the render the action caused was already on the page and there was
+  nothing left to see: the action scored 0 ms. In a controlled 2-minute run on 2026-09-04
+  that was **42.5% of 360 searches**, and two of the ten fixture queries (`search`, `graph`)
+  measured 0 ms on all 36 of their occurrences while the same queries measured 300–800 ms on
+  other cycles. Arming first takes the zero rate to **0.0%** and moved search p95 from 592 to
+  758 ms on matched runs. Earlier revisions of this file read that near-zero median as the
+  typeahead being fast; it was the harness starting its clock after the work.
+  **`ui_p95_ms` and the per-action p95s therefore start a new series with the run after
+  2026-09-04** and will read higher for that reason alone.
+  Guard: `packages/app/src/renderer/__tests__/perf-driver.test.ts` evaluates the injected
+  driver text against jsdom and fails on the old ordering.
 - **`heap_after_workload_mb`** — the post-GC heap after the first complete cycle.
 - **`heap_growth_mb_per_hour`** — least-squares slope of the post-GC heap series over the
   whole run. Over 50 is an issue on its own, whatever the delta to the previous run.
@@ -262,6 +272,14 @@ Compare against the median of the last 5 runs: >+10% is a warning to note, >+25%
 (or two consecutive warnings) is a regression worth an issue.
 
 ## Changes worth remembering
+
+**2026-09-04 — the harness was not timing the synchronous half of every action (TRA-835).**
+See the detector bullet above: observer armed after the action, 42.5% of searches recorded
+as exactly 0 ms, `ui_p95_ms` roughly 20% low. Found by noticing that the 30-minute run
+reported a search *median* of 0 against 64 in the previous entry while p95 barely moved —
+a median that collapses while the tail does not is a measurement fault, not a speed-up.
+Fixed by arming the observer first; the primitive moved into `scripts/perf-lib.mjs` as
+`MEASURE_SRC` so a jsdom test can run the same text the renderer runs.
 
 **2026-09-02 — four secondary tabs were sitting in the startup chunk (TRA-593).**
 `Activity`, `Insights`, `MemoryExplorer` and `Notebook` were static imports in `App.tsx`, so

--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -2094,6 +2094,988 @@
         ]
       },
       "notes": "Reconciliation run: this entry supersedes nothing, it adds to the 2026-09-01 entry measured by the same autopilot on a harness that had not yet landed. The two pieces of work were done in parallel and are merged here rather than one being thrown away (PR #744 closed into this one). Numbers line up with that entry where they overlap \u2014 ui_p95_ms 690 vs 668, heap_growth 0.19 vs 1.39 MB/h, rss_after_index_settle 316 vs 383 MB \u2014 which is the first time two independent passes have agreed on the workload metrics at all. 30 min, 521 cycles, 3 recovered cycle errors, 0 open retries. Two additions this run. (1) The app is launched with TRACE_MCP_AGENT_RUN=1 so the window is never mapped: a 55-minute pass runs on the machine somebody is working on and must not steal their screen. The cost is that renderer_fcp_ms is structurally null \u2014 Chromium only emits a paint entry for a frame the compositor presented \u2014 so it is replaced by renderer_first_content_ms, a mark the renderer sets itself when React commits the first content under #root (97 ms here). New series: not comparable to the 136 ms renderer_fcp_ms of the 2026-09-01 entry, which ran with a visible window. (2) New metric renderer_cpu_idle_pct \u2014 renderer CPU over a 60 s window with no input, per view, from cputime deltas rather than ps %cpu, which is a decaying lifetime average. Overview 2.9% of a core, Graph 29.3%. Measured three times across two harness versions today: 27.0, 27.7, 29.3. The Graph tab never idles; filed as TRA-683. The .cosmos-gpu-label layer the 2026-09-01 run had to exclude from the settle detector is the same root cause seen from the other side \u2014 that run proved the DOM never goes quiet, this one prices it. heap_idle_mb 15.4 against 9.5 in earlier runs is not a leak: earlier runs idled against no daemon at all, this one against a served fixture. artifact_mb not sampled (no pack); no dependency changed."
+    },
+    {
+      "date": "2026-09-04T21:31:08.380Z",
+      "app_version": "3.17.0",
+      "commit": "121e3e9b",
+      "env": {
+        "os": "darwin 25.5.0",
+        "arch": "arm64",
+        "node": "22.22.3"
+      },
+      "samples": 3,
+      "metrics": {
+        "cold_start_ms": 415,
+        "window_interactive_ms": 141,
+        "renderer_first_content_ms": 93,
+        "renderer_fcp_ms": null,
+        "ui_p95_ms": 667,
+        "renderer_cpu_idle_pct": {
+          "overview": 0.1,
+          "graph": 6.8
+        },
+        "heap_idle_mb": 9.5,
+        "heap_after_workload_mb": 7.65,
+        "heap_growth_mb_per_hour": 1.56,
+        "tree_rss_peak_mb": 1512,
+        "tree_rss_idle_mb": 878,
+        "tree_cpu_peak_pct": 132.8,
+        "rss_after_index_settle_mb": 196,
+        "main_cpu_idle_pct": 0.1,
+        "renderer_bundle_kb": 2346,
+        "renderer_eager_kb": 2084,
+        "artifact_mb": {
+          "mac_app_unpacked": 350,
+          "mac_asar": 7,
+          "mac_server_payload": 80
+        }
+      },
+      "raw_samples": [
+        {
+          "cold_start_ms": 3119,
+          "window_interactive_ms": 174,
+          "renderer_first_content_ms": 98,
+          "renderer_fcp_ms": 156
+        },
+        {
+          "cold_start_ms": 372,
+          "window_interactive_ms": 119,
+          "renderer_first_content_ms": 88,
+          "renderer_fcp_ms": null
+        },
+        {
+          "cold_start_ms": 415,
+          "window_interactive_ms": 141,
+          "renderer_first_content_ms": 93,
+          "renderer_fcp_ms": null,
+          "heap_idle_mb": 9.5,
+          "main_cpu_idle_pct": 0.1
+        }
+      ],
+      "workload": {
+        "fixture": {
+          "commit": "fc47c10f44eb539cbb01b0bb2e4ff633c59b7151",
+          "revision": 2,
+          "files": 1817,
+          "symbols": 9705
+        },
+        "minutes": 30,
+        "index_s": 7.9,
+        "settle_minutes": 10,
+        "cycles": 574,
+        "cycle_errors": 0,
+        "open_warmup_ms": 68,
+        "open_retries": 0,
+        "open_project_ms": [40, 42, 73, 39, 42, 39, 41, 40, 43, 64, 55],
+        "actions": {
+          "open_project": {
+            "n": 11,
+            "median_ms": 42,
+            "p95_ms": 73
+          },
+          "search": {
+            "n": 5740,
+            "median_ms": 0,
+            "p95_ms": 667
+          },
+          "switch_view": {
+            "n": 1723,
+            "median_ms": 9,
+            "p95_ms": 189
+          }
+        },
+        "heap_series": [
+          {
+            "t_min": 0.05,
+            "heap_mb": 7.65
+          },
+          {
+            "t_min": 0.64,
+            "heap_mb": 8.96
+          },
+          {
+            "t_min": 1.22,
+            "heap_mb": 9.13
+          },
+          {
+            "t_min": 1.78,
+            "heap_mb": 9.21
+          },
+          {
+            "t_min": 2.35,
+            "heap_mb": 9.23
+          },
+          {
+            "t_min": 2.9,
+            "heap_mb": 9.29
+          },
+          {
+            "t_min": 3.5,
+            "heap_mb": 9.4
+          },
+          {
+            "t_min": 3.98,
+            "heap_mb": 9.32
+          },
+          {
+            "t_min": 4.6,
+            "heap_mb": 9.36
+          },
+          {
+            "t_min": 4.96,
+            "heap_mb": 9.34
+          },
+          {
+            "t_min": 5.35,
+            "heap_mb": 9.38
+          },
+          {
+            "t_min": 5.7,
+            "heap_mb": 9.34
+          },
+          {
+            "t_min": 6.11,
+            "heap_mb": 9.37
+          },
+          {
+            "t_min": 6.48,
+            "heap_mb": 9.37
+          },
+          {
+            "t_min": 6.84,
+            "heap_mb": 9.5
+          },
+          {
+            "t_min": 7.22,
+            "heap_mb": 9.41
+          },
+          {
+            "t_min": 7.56,
+            "heap_mb": 9.42
+          },
+          {
+            "t_min": 7.9,
+            "heap_mb": 9.6
+          },
+          {
+            "t_min": 8.4,
+            "heap_mb": 9.58
+          },
+          {
+            "t_min": 9,
+            "heap_mb": 9.59
+          },
+          {
+            "t_min": 9.55,
+            "heap_mb": 9.61
+          },
+          {
+            "t_min": 10.1,
+            "heap_mb": 9.65
+          },
+          {
+            "t_min": 10.52,
+            "heap_mb": 9.64
+          },
+          {
+            "t_min": 11.1,
+            "heap_mb": 9.63
+          },
+          {
+            "t_min": 11.67,
+            "heap_mb": 9.64
+          },
+          {
+            "t_min": 12.28,
+            "heap_mb": 9.76
+          },
+          {
+            "t_min": 12.87,
+            "heap_mb": 12.14
+          },
+          {
+            "t_min": 13.44,
+            "heap_mb": 9.64
+          },
+          {
+            "t_min": 14,
+            "heap_mb": 9.65
+          },
+          {
+            "t_min": 14.53,
+            "heap_mb": 9.69
+          },
+          {
+            "t_min": 15.07,
+            "heap_mb": 9.66
+          },
+          {
+            "t_min": 15.55,
+            "heap_mb": 9.69
+          },
+          {
+            "t_min": 15.94,
+            "heap_mb": 12.14
+          },
+          {
+            "t_min": 16.31,
+            "heap_mb": 9.69
+          },
+          {
+            "t_min": 16.84,
+            "heap_mb": 9.68
+          },
+          {
+            "t_min": 17.35,
+            "heap_mb": 9.67
+          },
+          {
+            "t_min": 17.93,
+            "heap_mb": 9.67
+          },
+          {
+            "t_min": 18.53,
+            "heap_mb": 9.68
+          },
+          {
+            "t_min": 19.11,
+            "heap_mb": 9.67
+          },
+          {
+            "t_min": 19.68,
+            "heap_mb": 9.67
+          },
+          {
+            "t_min": 20.28,
+            "heap_mb": 9.68
+          },
+          {
+            "t_min": 20.91,
+            "heap_mb": 9.69
+          },
+          {
+            "t_min": 21.51,
+            "heap_mb": 9.7
+          },
+          {
+            "t_min": 22.04,
+            "heap_mb": 12.17
+          },
+          {
+            "t_min": 22.65,
+            "heap_mb": 9.69
+          },
+          {
+            "t_min": 23.25,
+            "heap_mb": 12.15
+          },
+          {
+            "t_min": 23.74,
+            "heap_mb": 9.73
+          },
+          {
+            "t_min": 24.1,
+            "heap_mb": 9.74
+          },
+          {
+            "t_min": 24.52,
+            "heap_mb": 12.17
+          },
+          {
+            "t_min": 25.13,
+            "heap_mb": 9.73
+          },
+          {
+            "t_min": 25.64,
+            "heap_mb": 9.72
+          },
+          {
+            "t_min": 26.25,
+            "heap_mb": 9.74
+          },
+          {
+            "t_min": 26.88,
+            "heap_mb": 9.71
+          },
+          {
+            "t_min": 27.49,
+            "heap_mb": 9.71
+          },
+          {
+            "t_min": 28.05,
+            "heap_mb": 9.72
+          },
+          {
+            "t_min": 28.69,
+            "heap_mb": 9.73
+          },
+          {
+            "t_min": 29.31,
+            "heap_mb": 11.06
+          },
+          {
+            "t_min": 29.88,
+            "heap_mb": 9.83
+          },
+          {
+            "t_min": 30.05,
+            "heap_mb": 9.75
+          }
+        ],
+        "tree_series": [
+          {
+            "t": 1788554869443,
+            "app_rss_mb": 483,
+            "app_cpu_pct": 13.2,
+            "app_procs": 4,
+            "daemon_rss_mb": 554,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1037,
+            "cpu_pct": 13.2
+          },
+          {
+            "t": 1788554914269,
+            "app_rss_mb": 475,
+            "app_cpu_pct": 0.1,
+            "app_procs": 4,
+            "daemon_rss_mb": 403,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 878,
+            "cpu_pct": 0.1
+          },
+          {
+            "t": 1788554959222,
+            "app_rss_mb": 608,
+            "app_cpu_pct": 47.9,
+            "app_procs": 4,
+            "daemon_rss_mb": 518,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1126,
+            "cpu_pct": 47.9
+          },
+          {
+            "t": 1788555004252,
+            "app_rss_mb": 615,
+            "app_cpu_pct": 54.6,
+            "app_procs": 4,
+            "daemon_rss_mb": 528,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1143,
+            "cpu_pct": 54.6
+          },
+          {
+            "t": 1788555049262,
+            "app_rss_mb": 620,
+            "app_cpu_pct": 54.7,
+            "app_procs": 4,
+            "daemon_rss_mb": 599,
+            "daemon_cpu_pct": 19.5,
+            "daemon_procs": 1,
+            "rss_mb": 1220,
+            "cpu_pct": 74.2
+          },
+          {
+            "t": 1788555094282,
+            "app_rss_mb": 621,
+            "app_cpu_pct": 50.5,
+            "app_procs": 4,
+            "daemon_rss_mb": 600,
+            "daemon_cpu_pct": 0.1,
+            "daemon_procs": 1,
+            "rss_mb": 1221,
+            "cpu_pct": 50.6
+          },
+          {
+            "t": 1788555139328,
+            "app_rss_mb": 621,
+            "app_cpu_pct": 60.9,
+            "app_procs": 4,
+            "daemon_rss_mb": 601,
+            "daemon_cpu_pct": 5,
+            "daemon_procs": 1,
+            "rss_mb": 1222,
+            "cpu_pct": 65.9
+          },
+          {
+            "t": 1788555184319,
+            "app_rss_mb": 624,
+            "app_cpu_pct": 61.9,
+            "app_procs": 4,
+            "daemon_rss_mb": 851,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1475,
+            "cpu_pct": 61.9
+          },
+          {
+            "t": 1788555229528,
+            "app_rss_mb": 620,
+            "app_cpu_pct": 32.5,
+            "app_procs": 4,
+            "daemon_rss_mb": 881,
+            "daemon_cpu_pct": 27.5,
+            "daemon_procs": 1,
+            "rss_mb": 1500,
+            "cpu_pct": 60
+          },
+          {
+            "t": 1788555274562,
+            "app_rss_mb": 632,
+            "app_cpu_pct": 25.2,
+            "app_procs": 4,
+            "daemon_rss_mb": 857,
+            "daemon_cpu_pct": 22.4,
+            "daemon_procs": 1,
+            "rss_mb": 1489,
+            "cpu_pct": 47.6
+          },
+          {
+            "t": 1788555319651,
+            "app_rss_mb": 624,
+            "app_cpu_pct": 62.1,
+            "app_procs": 4,
+            "daemon_rss_mb": 865,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1489,
+            "cpu_pct": 62.1
+          },
+          {
+            "t": 1788555364688,
+            "app_rss_mb": 624,
+            "app_cpu_pct": 27.6,
+            "app_procs": 4,
+            "daemon_rss_mb": 871,
+            "daemon_cpu_pct": 23.3,
+            "daemon_procs": 1,
+            "rss_mb": 1495,
+            "cpu_pct": 50.9
+          },
+          {
+            "t": 1788555409420,
+            "app_rss_mb": 638,
+            "app_cpu_pct": 39.2,
+            "app_procs": 4,
+            "daemon_rss_mb": 855,
+            "daemon_cpu_pct": 20.8,
+            "daemon_procs": 1,
+            "rss_mb": 1493,
+            "cpu_pct": 60
+          },
+          {
+            "t": 1788555454387,
+            "app_rss_mb": 627,
+            "app_cpu_pct": 56.4,
+            "app_procs": 4,
+            "daemon_rss_mb": 856,
+            "daemon_cpu_pct": 6.1,
+            "daemon_procs": 1,
+            "rss_mb": 1483,
+            "cpu_pct": 62.5
+          },
+          {
+            "t": 1788555499411,
+            "app_rss_mb": 630,
+            "app_cpu_pct": 57.1,
+            "app_procs": 4,
+            "daemon_rss_mb": 865,
+            "daemon_cpu_pct": 1.7,
+            "daemon_procs": 1,
+            "rss_mb": 1495,
+            "cpu_pct": 58.8
+          },
+          {
+            "t": 1788555544613,
+            "app_rss_mb": 631,
+            "app_cpu_pct": 62.2,
+            "app_procs": 4,
+            "daemon_rss_mb": 875,
+            "daemon_cpu_pct": 0.7,
+            "daemon_procs": 1,
+            "rss_mb": 1506,
+            "cpu_pct": 62.9
+          },
+          {
+            "t": 1788555589431,
+            "app_rss_mb": 611,
+            "app_cpu_pct": 51.9,
+            "app_procs": 4,
+            "daemon_rss_mb": 828,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1439,
+            "cpu_pct": 51.9
+          },
+          {
+            "t": 1788555634454,
+            "app_rss_mb": 616,
+            "app_cpu_pct": 58.5,
+            "app_procs": 4,
+            "daemon_rss_mb": 834,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1450,
+            "cpu_pct": 58.5
+          },
+          {
+            "t": 1788555679484,
+            "app_rss_mb": 614,
+            "app_cpu_pct": 60.2,
+            "app_procs": 4,
+            "daemon_rss_mb": 835,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1450,
+            "cpu_pct": 60.2
+          },
+          {
+            "t": 1788555724482,
+            "app_rss_mb": 613,
+            "app_cpu_pct": 62.9,
+            "app_procs": 4,
+            "daemon_rss_mb": 830,
+            "daemon_cpu_pct": 20.9,
+            "daemon_procs": 1,
+            "rss_mb": 1443,
+            "cpu_pct": 83.8
+          },
+          {
+            "t": 1788555769509,
+            "app_rss_mb": 614,
+            "app_cpu_pct": 69.3,
+            "app_procs": 4,
+            "daemon_rss_mb": 828,
+            "daemon_cpu_pct": 4.5,
+            "daemon_procs": 1,
+            "rss_mb": 1442,
+            "cpu_pct": 73.8
+          },
+          {
+            "t": 1788555814550,
+            "app_rss_mb": 574,
+            "app_cpu_pct": 74.7,
+            "app_procs": 4,
+            "daemon_rss_mb": 786,
+            "daemon_cpu_pct": 0.5,
+            "daemon_procs": 1,
+            "rss_mb": 1360,
+            "cpu_pct": 75.2
+          },
+          {
+            "t": 1788555860010,
+            "app_rss_mb": 572,
+            "app_cpu_pct": 67.9,
+            "app_procs": 4,
+            "daemon_rss_mb": 787,
+            "daemon_cpu_pct": 2.6,
+            "daemon_procs": 1,
+            "rss_mb": 1359,
+            "cpu_pct": 70.5
+          },
+          {
+            "t": 1788555904571,
+            "app_rss_mb": 574,
+            "app_cpu_pct": 61.7,
+            "app_procs": 4,
+            "daemon_rss_mb": 794,
+            "daemon_cpu_pct": 0.1,
+            "daemon_procs": 1,
+            "rss_mb": 1368,
+            "cpu_pct": 61.8
+          },
+          {
+            "t": 1788555949961,
+            "app_rss_mb": 553,
+            "app_cpu_pct": 60.2,
+            "app_procs": 4,
+            "daemon_rss_mb": 777,
+            "daemon_cpu_pct": 0.7,
+            "daemon_procs": 1,
+            "rss_mb": 1330,
+            "cpu_pct": 60.9
+          },
+          {
+            "t": 1788555996241,
+            "app_rss_mb": 559,
+            "app_cpu_pct": 57.6,
+            "app_procs": 4,
+            "daemon_rss_mb": 772,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1330,
+            "cpu_pct": 57.6
+          },
+          {
+            "t": 1788556039579,
+            "app_rss_mb": 567,
+            "app_cpu_pct": 61.8,
+            "app_procs": 4,
+            "daemon_rss_mb": 773,
+            "daemon_cpu_pct": 27.3,
+            "daemon_procs": 1,
+            "rss_mb": 1339,
+            "cpu_pct": 89.1
+          },
+          {
+            "t": 1788556084615,
+            "app_rss_mb": 567,
+            "app_cpu_pct": 58.1,
+            "app_procs": 4,
+            "daemon_rss_mb": 773,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1341,
+            "cpu_pct": 58.1
+          },
+          {
+            "t": 1788556129608,
+            "app_rss_mb": 570,
+            "app_cpu_pct": 57.2,
+            "app_procs": 4,
+            "daemon_rss_mb": 773,
+            "daemon_cpu_pct": 0.3,
+            "daemon_procs": 1,
+            "rss_mb": 1342,
+            "cpu_pct": 57.5
+          },
+          {
+            "t": 1788556174648,
+            "app_rss_mb": 580,
+            "app_cpu_pct": 60.3,
+            "app_procs": 4,
+            "daemon_rss_mb": 773,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1353,
+            "cpu_pct": 60.3
+          },
+          {
+            "t": 1788556219743,
+            "app_rss_mb": 566,
+            "app_cpu_pct": 74.4,
+            "app_procs": 4,
+            "daemon_rss_mb": 785,
+            "daemon_cpu_pct": 4.4,
+            "daemon_procs": 1,
+            "rss_mb": 1351,
+            "cpu_pct": 78.8
+          },
+          {
+            "t": 1788556264655,
+            "app_rss_mb": 568,
+            "app_cpu_pct": 30.2,
+            "app_procs": 4,
+            "daemon_rss_mb": 798,
+            "daemon_cpu_pct": 14.9,
+            "daemon_procs": 1,
+            "rss_mb": 1365,
+            "cpu_pct": 45.1
+          },
+          {
+            "t": 1788556309701,
+            "app_rss_mb": 572,
+            "app_cpu_pct": 64.7,
+            "app_procs": 4,
+            "daemon_rss_mb": 770,
+            "daemon_cpu_pct": 23.5,
+            "daemon_procs": 1,
+            "rss_mb": 1342,
+            "cpu_pct": 88.2
+          },
+          {
+            "t": 1788556355361,
+            "app_rss_mb": 572,
+            "app_cpu_pct": 27.5,
+            "app_procs": 4,
+            "daemon_rss_mb": 776,
+            "daemon_cpu_pct": 31.9,
+            "daemon_procs": 1,
+            "rss_mb": 1349,
+            "cpu_pct": 59.4
+          },
+          {
+            "t": 1788556399932,
+            "app_rss_mb": 558,
+            "app_cpu_pct": 31.5,
+            "app_procs": 4,
+            "daemon_rss_mb": 782,
+            "daemon_cpu_pct": 38.3,
+            "daemon_procs": 1,
+            "rss_mb": 1340,
+            "cpu_pct": 69.8
+          },
+          {
+            "t": 1788556444856,
+            "app_rss_mb": 576,
+            "app_cpu_pct": 73.8,
+            "app_procs": 4,
+            "daemon_rss_mb": 795,
+            "daemon_cpu_pct": 3.9,
+            "daemon_procs": 1,
+            "rss_mb": 1371,
+            "cpu_pct": 77.7
+          },
+          {
+            "t": 1788556489759,
+            "app_rss_mb": 537,
+            "app_cpu_pct": 63.4,
+            "app_procs": 4,
+            "daemon_rss_mb": 780,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1317,
+            "cpu_pct": 63.4
+          },
+          {
+            "t": 1788556534745,
+            "app_rss_mb": 543,
+            "app_cpu_pct": 63,
+            "app_procs": 4,
+            "daemon_rss_mb": 772,
+            "daemon_cpu_pct": 23.5,
+            "daemon_procs": 1,
+            "rss_mb": 1315,
+            "cpu_pct": 86.5
+          },
+          {
+            "t": 1788556579757,
+            "app_rss_mb": 547,
+            "app_cpu_pct": 47.4,
+            "app_procs": 4,
+            "daemon_rss_mb": 777,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1324,
+            "cpu_pct": 47.4
+          },
+          {
+            "t": 1788556624771,
+            "app_rss_mb": 551,
+            "app_cpu_pct": 44.9,
+            "app_procs": 4,
+            "daemon_rss_mb": 792,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1343,
+            "cpu_pct": 44.9
+          },
+          {
+            "t": 1788556669797,
+            "app_rss_mb": 561,
+            "app_cpu_pct": 55.8,
+            "app_procs": 4,
+            "daemon_rss_mb": 780,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 1341,
+            "cpu_pct": 55.8
+          },
+          {
+            "t": 1788556714850,
+            "app_rss_mb": 551,
+            "app_cpu_pct": 58.5,
+            "app_procs": 4,
+            "daemon_rss_mb": 779,
+            "daemon_cpu_pct": 56.3,
+            "daemon_procs": 1,
+            "rss_mb": 1329,
+            "cpu_pct": 114.8
+          },
+          {
+            "t": 1788556759863,
+            "app_rss_mb": 535,
+            "app_cpu_pct": 0,
+            "app_procs": 4,
+            "daemon_rss_mb": 304,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 839,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788556804831,
+            "app_rss_mb": 597,
+            "app_cpu_pct": 47.6,
+            "app_procs": 4,
+            "daemon_rss_mb": 390,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 986,
+            "cpu_pct": 47.6
+          },
+          {
+            "t": 1788556849902,
+            "app_rss_mb": 572,
+            "app_cpu_pct": 3.5,
+            "app_procs": 4,
+            "daemon_rss_mb": 304,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 876,
+            "cpu_pct": 3.5
+          },
+          {
+            "t": 1788556894974,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 304,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 304,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788556940429,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 304,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 304,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788556985795,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 196,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 196,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788557031245,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 196,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 196,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788557077445,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 196,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 196,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788557123305,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 196,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 196,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788557168672,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 196,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 196,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788557214108,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 196,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 196,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788557259656,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 196,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 196,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788557305136,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 196,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 196,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788557350614,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 196,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 196,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788557396572,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 196,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 196,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788557442834,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 196,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 196,
+            "cpu_pct": 0
+          },
+          {
+            "t": 1788557462939,
+            "app_rss_mb": 0,
+            "app_cpu_pct": 0,
+            "app_procs": 1,
+            "daemon_rss_mb": 196,
+            "daemon_cpu_pct": 0,
+            "daemon_procs": 1,
+            "rss_mb": 196,
+            "cpu_pct": 0
+          }
+        ]
+      },
+      "notes": "Manual run (TRA-835), first pass since the Multica claude-runtime fix and the first at 3.17.0 \u2014 six app-visible releases after the 3.11.0 series. 30 min, 574 cycles, 0 cycle errors, 0 open retries, offscreen (TRACE_MCP_AGENT_RUN=1) so renderer_fcp_ms stays structurally null. No regression against the median of the last five runs on any metric; four improved. renderer_cpu_idle_pct.graph 29.3 -> 6.8% of a core (-77%): TRA-683 (0c79f0e2, 'let the Graph tab go quiet when nobody is watching') landed after the previous entry and this is its field number \u2014 the finding filed on 2026-09-02 is closed by measurement, not by inspection. rss_after_index_settle_mb 316 -> 196 and tree_rss_idle_mb 920 -> 878, both below their ceilings. heap_idle_mb back to 9.5 from 15.4. heap_growth_mb_per_hour 1.56 against a median of 0.79 is +98% on a metric whose ceiling is 50 and which has only two prior samples: noise, not a leak \u2014 the 574-cycle series is flat between 9.3 and 9.8 MB. renderer_bundle_kb 2346 (+3.3%) with renderer_eager_kb 2084 (-0.9%): the growth is all in lazy chunks, which is what the eager metric exists to separate. artifact_mb re-measured on this commit: 350 MB unpacked (+1.1% vs the 346.2 re-anchor), server payload 80 MB against its 100 MB absolute ceiling. KNOWN-BAD METRIC, read ui_p95_ms with care: this run was measured with the completion detector that armed its MutationObserver after firing the action, so any DOM work React committed synchronously inside the event was invisible. 42.5% of 360 search actions in a controlled 2-minute repeat measured exactly 0 ms, and two of the ten fixture queries measured 0 ms on all 36 of their occurrences. Fixed in this same change; on matched 2-minute runs the zero rate goes 42.5% -> 0.0% and search p95 592 -> 758. This entry keeps the old detector's numbers so it stays comparable with the 3.11.0 series; ui_p95_ms and the per-action p95s start a NEW SERIES from the next run and will read higher for that reason alone."
     }
   ]
 }

--- a/packages/app/scripts/perf-lib.mjs
+++ b/packages/app/scripts/perf-lib.mjs
@@ -153,3 +153,73 @@ export function pidOnPort(port) {
     return null;
   }
 }
+
+/**
+ * The completion detector the CDP driver runs inside the renderer (TRA-835).
+ *
+ * It lives here, as source text, for one reason: it is the only part of
+ * `scripts/perf-measure.mjs` whose correctness is not obvious by reading it, and
+ * the harness itself takes 55 minutes so nothing in CI ever runs it. Exported as
+ * a string because it is injected into the page, not imported by it —
+ * `__tests__/perf-driver.test.ts` evaluates this same text against jsdom.
+ */
+export const MEASURE_SRC = String.raw`
+  const QUIET_MS = 120;
+  const SETTLE_CAP_MS = 5000;
+  // An action is done when the DOM stops changing, not when React returns:
+  // switching to the Graph tab paints an empty canvas in a few ms and then
+  // spends real time loading the graph. Measuring only the first paint would
+  // report single-digit milliseconds for every action and catch no regression.
+  //
+  // Except for one layer. The GPU graph repaints its HTML label overlay every
+  // animation frame — measured at ~730 mutations/second, unbroken, with no input
+  // at all — so a whole-document observer never sees 120 ms of quiet and every
+  // action in the Graph tab burns the cap instead of being timed. That is how
+  // ui_p95_ms first read as exactly 5000 ms (TRA-617). An animation that never
+  // stops cannot be a completion signal, so its mutations are not one.
+  const IGNORED = '.cosmos-gpu-label';
+  const ignorable = (rec) => {
+    const el = rec.target.nodeType === 1 ? rec.target : rec.target.parentElement;
+    return !!(el && el.closest && el.closest(IGNORED));
+  };
+  // The observer is armed BEFORE the action fires, not after. React dispatches
+  // discrete events (a click, an input) synchronously: by the time an
+  // 'act(); settled(t)' sequence gets to attach an observer, the whole render
+  // that the action caused has already been committed and there is nothing left
+  // to see. That is why 42.5% of searches measured exactly 0 ms on 2026-09-04
+  // while the same query measured 500 ms on the next cycle — the metric was
+  // timing only the part of the update React happened to defer.
+  const measure = (act) =>
+    new Promise((resolve, reject) => {
+      let last = null;
+      const obs = new MutationObserver((recs) => {
+        if (recs.every(ignorable)) return;
+        last = performance.now();
+      });
+      obs.observe(document.documentElement, {
+        subtree: true, childList: true, characterData: true, attributes: true,
+      });
+      let start;
+      try {
+        start = performance.now();
+        act();
+      } catch (e) {
+        obs.disconnect();
+        return reject(e);
+      }
+      // Nothing can have observed yet — MutationObserver callbacks are
+      // microtasks and this is still the same synchronous block — so the
+      // quiet window starts at the action, and a synchronous commit lands on
+      // 'last' before the first tick 16 ms from now.
+      last = start;
+      const tick = () => {
+        const now = performance.now();
+        if (now - last >= QUIET_MS || now - start >= SETTLE_CAP_MS) {
+          obs.disconnect();
+          return resolve(Math.min(last - start, SETTLE_CAP_MS));
+        }
+        setTimeout(tick, 16);
+      };
+      setTimeout(tick, 16);
+    });
+`;

--- a/packages/app/scripts/perf-measure.mjs
+++ b/packages/app/scripts/perf-measure.mjs
@@ -28,6 +28,7 @@ import { fileURLToPath } from 'node:url';
 import {
   cpuOverWindow,
   fitGrowth,
+  MEASURE_SRC,
   median,
   p95,
   pidOnPort,
@@ -402,44 +403,7 @@ function artifactMb() {
  */
 const DRIVER = `
 window.__perf = (() => {
-  const QUIET_MS = 120;
-  const SETTLE_CAP_MS = 5000;
-  // An action is done when the DOM stops changing, not when React returns:
-  // switching to the Graph tab paints an empty canvas in a few ms and then
-  // spends real time loading the graph. Measuring only the first paint would
-  // report single-digit milliseconds for every action and catch no regression.
-  //
-  // Except for one layer. The GPU graph repaints its HTML label overlay every
-  // animation frame — measured at ~730 mutations/second, unbroken, with no input
-  // at all — so a whole-document observer never sees 120 ms of quiet and every
-  // action in the Graph tab burns the cap instead of being timed. That is how
-  // ui_p95_ms first read as exactly 5000 ms (TRA-617). An animation that never
-  // stops cannot be a completion signal, so its mutations are not one.
-  const IGNORED = '.cosmos-gpu-label';
-  const ignorable = (rec) => {
-    const el = rec.target.nodeType === 1 ? rec.target : rec.target.parentElement;
-    return !!(el && el.closest && el.closest(IGNORED));
-  };
-  const settled = (start) =>
-    new Promise((resolve) => {
-      let last = start;
-      const obs = new MutationObserver((recs) => {
-        if (recs.every(ignorable)) return;
-        last = performance.now();
-      });
-      obs.observe(document.documentElement, {
-        subtree: true, childList: true, characterData: true, attributes: true,
-      });
-      const tick = () => {
-        const now = performance.now();
-        if (now - last >= QUIET_MS || now - start >= SETTLE_CAP_MS) {
-          obs.disconnect();
-          return resolve(Math.min(last - start, SETTLE_CAP_MS));
-        }
-        setTimeout(tick, 16);
-      };
-      setTimeout(tick, 16);
-    });
+${MEASURE_SRC}
   const mainText = () => (document.querySelector('main') || {}).innerText || '';
   const overviewReady = () =>
     mainText().indexOf('Files indexed') !== -1 && mainText().indexOf('Symbols') !== -1;
@@ -473,16 +437,12 @@ window.__perf = (() => {
     async switchView(label) {
       const btn = sidebarButton(label);
       if (!btn) throw new Error('perf: no sidebar tab "' + label + '"');
-      const t = performance.now();
-      btn.click();
-      return settled(t);
+      return measure(() => btn.click());
     },
     async search(q) {
       const el = searchInput();
       if (!el) throw new Error('perf: no graph search input');
-      const t = performance.now();
-      setReactValue(el, q);
-      return settled(t);
+      return measure(() => setReactValue(el, q));
     },
   };
 })();

--- a/packages/app/src/renderer/__tests__/perf-driver.test.ts
+++ b/packages/app/src/renderer/__tests__/perf-driver.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+
+// @ts-expect-error — plain .mjs helper shared by the perf scripts, no types.
+import { MEASURE_SRC } from '../../../scripts/perf-lib.mjs';
+
+/**
+ * The completion detector behind `ui_p95_ms` (TRA-835).
+ *
+ * It measured 0 ms for 42.5% of the search actions in the 2026-09-04 run,
+ * because it armed its MutationObserver *after* firing the action and React
+ * commits discrete events synchronously — the whole render was already on the
+ * page before anything was watching. p95 came out ~20% low. The harness runs
+ * for 55 minutes on a developer machine and never in CI, so this is the only
+ * thing standing between that ordering and a silently wrong baseline.
+ */
+function loadMeasure(): (act: () => void) => Promise<number> {
+  // The driver is injected as text, so it is exercised as text.
+  const factory = new Function(`${MEASURE_SRC}\n return measure;`);
+  return factory();
+}
+
+describe('perf driver: measure()', () => {
+  it('times a synchronous DOM commit instead of reporting zero', async () => {
+    const ms = await loadMeasure()(() => {
+      // Exactly what React does for a discrete event: mutate before returning.
+      document.body.appendChild(document.createElement('div'));
+    });
+    expect(ms).toBeGreaterThan(0);
+  });
+
+  it('keeps timing while the DOM is still changing', async () => {
+    const measure = loadMeasure();
+    const ms = await measure(() => {
+      let n = 0;
+      const id = setInterval(() => {
+        document.body.appendChild(document.createElement('span'));
+        if (++n === 4) clearInterval(id);
+      }, 40);
+    });
+    // Four mutations 40 ms apart, then 120 ms of quiet before it resolves.
+    expect(ms).toBeGreaterThanOrEqual(120);
+    expect(ms).toBeLessThan(5000);
+  });
+
+  it('does not treat the never-quiet graph label layer as progress', async () => {
+    const layer = document.createElement('div');
+    layer.className = 'cosmos-gpu-label';
+    document.body.appendChild(layer);
+    const ms = await loadMeasure()(() => {
+      const id = setInterval(() => layer.appendChild(document.createElement('i')), 16);
+      setTimeout(() => clearInterval(id), 1000);
+    });
+    // The ignored layer alone must not hold the measurement open to the 5 s cap.
+    expect(ms).toBeLessThan(1000);
+  });
+});

--- a/packages/app/src/renderer/__tests__/perf-driver.test.ts
+++ b/packages/app/src/renderer/__tests__/perf-driver.test.ts
@@ -47,10 +47,11 @@ describe('perf driver: measure()', () => {
     const layer = document.createElement('div');
     layer.className = 'cosmos-gpu-label';
     document.body.appendChild(layer);
+    let id: ReturnType<typeof setInterval> | undefined;
     const ms = await loadMeasure()(() => {
-      const id = setInterval(() => layer.appendChild(document.createElement('i')), 16);
-      setTimeout(() => clearInterval(id), 1000);
+      id = setInterval(() => layer.appendChild(document.createElement('i')), 16);
     });
+    clearInterval(id);
     // The ignored layer alone must not hold the measurement open to the 5 s cap.
     expect(ms).toBeLessThan(1000);
   });


### PR DESCRIPTION
## What this is

The 3.17.0 desktop baseline pass (TRA-835) — and the harness bug it found.

## The bug: the completion detector started its clock after the work

`__perf.search()` / `__perf.switchView()` fired the action and *then* attached the
`MutationObserver`. React commits a discrete event (a click, an `input`) synchronously
inside `dispatchEvent`, so by the time the observer attached, the render the action caused
was already on the page. Nothing left to observe → 120 ms of quiet → the action scored
**0 ms**.

Measured, not inferred — two matched 2-minute runs on the same build and fixture:

| | before | after |
|---|---|---|
| search actions measuring exactly 0 ms | **153 / 360 (42.5%)** | **0 / 360 (0.0%)** |
| queries measuring 0 ms on *every* occurrence | `search` 36/36, `graph` 36/36 | none |
| search p95 | 592 ms | 758 ms |
| search median | 53 ms | 53 ms |

The median not moving is the tell: the zeros were short actions that now land as small
non-zero values, while the tail — the part `ui_p95_ms` is made of — was being clipped.
`ui_p95_ms` has been reading roughly 20% low.

How it surfaced: the 30-minute run reported a search **median of 0** against 64 in the
previous entry while p95 barely moved. A median that collapses while the tail does not is a
measurement fault, not a speed-up. `docs/perf/README.md` previously read that near-zero
median as "the typeahead is fast, and that is not a bug" — that claim is corrected here.

## The guard

`packages/app/src/renderer/__tests__/perf-driver.test.ts` evaluates the injected driver text
against jsdom and asserts a synchronous commit measures > 0. **Verified to fail on the old
ordering** and pass on the new one. The primitive moved into `scripts/perf-lib.mjs` as
`MEASURE_SRC` (source text, because it is injected into the page rather than imported by it)
purely so the test can run the same characters the renderer runs. The harness takes 55
minutes and never runs in CI; this is the only thing standing between that ordering and a
silently wrong baseline.

## The baseline pass (3.17.0, `121e3e9b`, 30 min, 574 cycles, 0 cycle errors, offscreen)

No regression on any metric against the median of the last five runs. Four improved:

| Metric | Was (3.11.0) | Now | |
|---|---|---|---|
| `renderer_cpu_idle_pct.graph` | 29.3% of a core | **6.8%** | TRA-683 landed; this is its field number |
| `renderer_cpu_idle_pct.overview` | 2.9% | 0.1% | |
| `rss_after_index_settle_mb` | 316 | 196 | ceiling 500 |
| `heap_idle_mb` | 15.4 | 9.5 | |
| `renderer_first_content_ms` | 97 | 93 | the startup metric of record |
| `tree_rss_peak_mb` | 1250 | 1512 | ceiling 2000 |
| `renderer_eager_kb` | 2131 | 2084 | the size metric of record |
| `artifact_mb.mac_server_payload` | 77 | 80 | absolute ceiling 100 — watch it |

`heap_growth_mb_per_hour` 1.56 vs a median of 0.79 is +98% on a metric whose ceiling is 50
and which has two prior samples: noise, not a leak — the 574-cycle series is flat between
9.3 and 9.8 MB.

**`ui_p95_ms` starts a new series after this entry.** The recorded 667 is the old detector's
number, kept so the entry stays comparable with the 3.11.0 series; the next run will read
higher for that reason alone, and the entry's `notes` say so.

## Trade-offs

None against token cost or the MCP tool contract — nothing here ships to users. The only cost
is that `ui_p95_ms` and the per-action p95s become incomparable across 2026-09-04, which is
the price of them having been wrong.

## Verification

`pnpm -C packages/app run test` (66 files / 662 tests), `typecheck`, `build`, `pack`,
`biome check .` — all clean locally. The refactored harness was re-run end-to-end (1 min
workload, 0 cycle errors) before recording anything.
