### PR TITLE
fix(ai): stop retrying a dead embedding endpoint forever, and stop logging a total failure as "completed" (TRA-812)

### DIFF
--- a/docs/config-index.md
+++ b/docs/config-index.md
@@ -52,8 +52,8 @@ supply it.
 
 | Key | Type | Default |
 | --- | --- | --- |
-| `db` | object | `{}` |
-| `db.path` | string | `".trace-mcp/index.db"` |
+| `db` | object | — |
+| `db.path` | string | _unset_ |
 | `include` | string[] | _built-in list_ |
 | `exclude` | string[] | _built-in list_ |
 | `follow_symlinks` | boolean | `false` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -384,6 +384,19 @@ Voyage specializes in retrieval-grade embeddings. `voyage-code-3` is tuned for s
 | `ai.concurrency` | `1` | Max parallel requests to AI provider (1–32) |
 | `ai.reranker_model` | — | Model for search result reranking (ollama/openai only) |
 
+> **When the embedding endpoint is unreachable:** background embedding trips a
+> circuit breaker after 2 consecutive failed batches and then pauses for 10
+> minutes. The pause is stored in the project DB, so it survives a daemon
+> restart instead of re-attempting the whole backlog on every start. While it is
+> open, `get_index_health` reports `embedding: { queued, pausedUntil, lastError }`
+> and adds a warning — semantic and hybrid search results are incomplete until
+> the provider is reachable. `embed_repo` ignores the pause and retries
+> immediately.
+
+> **`ai.enabled` takes effect per project start.** A project already open in the
+> daemon keeps the config it was started with, so flipping `ai.enabled` off stops
+> embedding for that project only after it restarts.
+
 > **ONNX provider details:** Uses `@huggingface/transformers` (installed as optional dependency). The default model `Xenova/all-MiniLM-L6-v2` is Apache 2.0 licensed, produces 384-dimensional L2-normalized mean-pooled vectors, and weighs ~23 MB. The model is cached locally after first download. You can use any ONNX-compatible model from HuggingFace by setting `embedding_model`.
 
 > **Ollama parallelism:** When setting `concurrency` > 1, you must also configure Ollama to handle parallel requests. The desktop app UI does not expose this setting — use one of these methods:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -456,7 +456,7 @@ which excludes the framework-specific rows.
 | `get_health_trends` | Time-series health metrics for a file or module: bug score, complexity, coupling, churn over time. | always |
 | `get_implementations` | Find all classes that implement or extend a given interface or base class. | always |
 | `get_import_graph` | Show file-level dependency graph: what a file imports and what imports it (requires reindex for ESM edge resolution). | always |
-| `get_index_health` | Get index status, statistics, health information, and pipeline progress (indexing, summarization, embedding). | always |
+| `get_index_health` | Get index status, statistics, health, and pipeline progress (indexing, summarization, embedding). | always |
 | `get_livewire_context` | Get full context for a Livewire component: properties, actions, events, view, child components. | framework |
 | `get_middleware_chain` | Trace middleware chain for a route URL (Express/NestJS/FastAPI/Flask). | framework |
 | `get_minimal_context` | Single-call orientation context (~150 tokens). | always |
@@ -1943,6 +1943,19 @@ Voyage specializes in retrieval-grade embeddings. `voyage-code-3` is tuned for s
 | `ai.concurrency` | `1` | Max parallel requests to AI provider (1–32) |
 | `ai.reranker_model` | — | Model for search result reranking (ollama/openai only) |
 
+> **When the embedding endpoint is unreachable:** background embedding trips a
+> circuit breaker after 2 consecutive failed batches and then pauses for 10
+> minutes. The pause is stored in the project DB, so it survives a daemon
+> restart instead of re-attempting the whole backlog on every start. While it is
+> open, `get_index_health` reports `embedding: { queued, pausedUntil, lastError }`
+> and adds a warning — semantic and hybrid search results are incomplete until
+> the provider is reachable. `embed_repo` ignores the pause and retries
+> immediately.
+
+> **`ai.enabled` takes effect per project start.** A project already open in the
+> daemon keeps the config it was started with, so flipping `ai.enabled` off stops
+> embedding for that project only after it restarts.
+
 > **ONNX provider details:** Uses `@huggingface/transformers` (installed as optional dependency). The default model `Xenova/all-MiniLM-L6-v2` is Apache 2.0 licensed, produces 384-dimensional L2-normalized mean-pooled vectors, and weighs ~23 MB. The model is cached locally after first download. You can use any ONNX-compatible model from HuggingFace by setting `embedding_model`.
 
 > **Ollama parallelism:** When setting `concurrency` > 1, you must also configure Ollama to handle parallel requests. The desktop app UI does not expose this setting — use one of these methods:
@@ -2596,8 +2609,8 @@ supply it.
 
 | Key | Type | Default |
 | --- | --- | --- |
-| `db` | object | `{}` |
-| `db.path` | string | `".trace-mcp/index.db"` |
+| `db` | object | — |
+| `db.path` | string | _unset_ |
 | `include` | string[] | _built-in list_ |
 | `exclude` | string[] | _built-in list_ |
 | `follow_symlinks` | boolean | `false` |

--- a/docs/tools-index.md
+++ b/docs/tools-index.md
@@ -146,7 +146,7 @@ which excludes the framework-specific rows.
 | `get_health_trends` | Time-series health metrics for a file or module: bug score, complexity, coupling, churn over time. | always |
 | `get_implementations` | Find all classes that implement or extend a given interface or base class. | always |
 | `get_import_graph` | Show file-level dependency graph: what a file imports and what imports it (requires reindex for ESM edge resolution). | always |
-| `get_index_health` | Get index status, statistics, health information, and pipeline progress (indexing, summarization, embedding). | always |
+| `get_index_health` | Get index status, statistics, health, and pipeline progress (indexing, summarization, embedding). | always |
 | `get_livewire_context` | Get full context for a Livewire component: properties, actions, events, view, child components. | framework |
 | `get_middleware_chain` | Trace middleware chain for a route URL (Express/NestJS/FastAPI/Flask). | framework |
 | `get_minimal_context` | Single-call orientation context (~150 tokens). | always |

--- a/src/ai/__tests__/embedding-breaker-persistence.test.ts
+++ b/src/ai/__tests__/embedding-breaker-persistence.test.ts
@@ -1,0 +1,163 @@
+import Database from 'better-sqlite3';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EmbeddingPipeline, readEmbeddingBreakerState } from '../embedding-pipeline.js';
+import type { EmbeddingService } from '../interfaces.js';
+import { BlobVectorStore } from '../vector-store.js';
+
+/**
+ * TRA-812: with the embedding endpoint down (`lmstudio` configured, LM Studio
+ * not running) the daemon re-announced the same 3 445-symbol backlog 36 times
+ * in 40 hours and logged each total failure as `embedding completed: 0 items`.
+ * Two causes: the circuit breaker lived only in process memory, and a run where
+ * every batch failed still reported phase 'completed'.
+ */
+
+const {
+  warn: warnSpy,
+  error: errorSpy,
+  info: infoSpy,
+} = vi.hoisted(() => ({
+  warn: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock('../../logger.js', () => ({
+  logger: { warn: warnSpy, error: errorSpy, info: infoSpy, debug: vi.fn() },
+}));
+
+/** Minimal DB with the tables the pipeline and the breaker state touch. */
+function seedDb(symbolCount: number): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = OFF');
+  db.exec(`
+    CREATE TABLE symbols (
+      id INTEGER PRIMARY KEY,
+      name TEXT, fqn TEXT, kind TEXT, signature TEXT, summary TEXT
+    );
+    CREATE TABLE server_state (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+  `);
+  const ins = db.prepare('INSERT INTO symbols (id, name, kind) VALUES (?, ?, ?)');
+  for (let i = 1; i <= symbolCount; i++) ins.run(i, `sym${i}`, 'function');
+  return db;
+}
+
+function fakeStore(db: Database.Database) {
+  return {
+    db,
+    countUnembeddedSymbols(): number {
+      const row = db
+        .prepare(
+          'SELECT COUNT(*) AS c FROM symbols s LEFT JOIN symbol_embeddings se ON se.symbol_id = s.id WHERE se.symbol_id IS NULL',
+        )
+        .get() as { c: number };
+      return row.c;
+    },
+  } as unknown as import('../../db/store.js').Store;
+}
+
+/** Reproduces the field condition: every embedBatch call throws `fetch failed`. */
+function unreachableService(): EmbeddingService & { calls: number } {
+  const svc = {
+    calls: 0,
+    async embed() {
+      throw new TypeError('fetch failed');
+    },
+    async embedBatch(): Promise<number[][]> {
+      svc.calls++;
+      throw new TypeError('fetch failed');
+    },
+    dimensions: () => 768,
+    modelName: () => 'nomic-embed-text-v1.5',
+    providerName: () => 'openai',
+  };
+  return svc;
+}
+
+function workingService(dim = 4): EmbeddingService {
+  return {
+    async embed() {
+      return Array.from({ length: dim }, () => 0.1);
+    },
+    async embedBatch(texts: string[]) {
+      return texts.map(() => Array.from({ length: dim }, () => 0.1));
+    },
+    dimensions: () => dim,
+    modelName: () => 'nomic-embed-text-v1.5',
+    providerName: () => 'openai',
+  };
+}
+
+describe('embedding circuit breaker survives a daemon restart', () => {
+  beforeEach(() => {
+    warnSpy.mockClear();
+    errorSpy.mockClear();
+    infoSpy.mockClear();
+  });
+
+  it('persists the cooldown and skips the whole backlog in the next process', async () => {
+    const db = seedDb(10);
+    const store = fakeStore(db);
+
+    // A run bails out at its first failed batch, so one run == one failure.
+    // Each `new EmbeddingPipeline` here stands for a fresh daemon process
+    // against the same project DB.
+    const first = new EmbeddingPipeline(store, unreachableService(), new BlobVectorStore(db));
+    expect(await first.indexUnembedded(5)).toBe(0);
+    expect(first.getLastRunDiagnostics().breakerTripped).toBe(false);
+    // The failure count carries over — otherwise a restart loop resets it every
+    // few minutes and the threshold is never reached.
+    expect(readEmbeddingBreakerState(db)!.consecutiveFailures).toBe(1);
+
+    const second = new EmbeddingPipeline(store, unreachableService(), new BlobVectorStore(db));
+    expect(await second.indexUnembedded(5)).toBe(0);
+    expect(second.getLastRunDiagnostics().breakerTripped).toBe(true);
+
+    const persisted = readEmbeddingBreakerState(db);
+    expect(persisted!.disabledUntilMs).toBeGreaterThan(Date.now());
+    expect(persisted!.lastError).toMatch(/fetch failed/);
+
+    const svc = unreachableService();
+    const third = new EmbeddingPipeline(store, svc, new BlobVectorStore(db));
+    expect(await third.indexUnembedded(5)).toBe(0);
+    // The point of the fix: not one further call against the dead endpoint.
+    expect(svc.calls).toBe(0);
+    // …and it says so instead of going quiet.
+    expect(infoSpy.mock.calls.some(([, msg]) => /Embedding paused/.test(String(msg)))).toBe(true);
+  });
+
+  it('reports a run where every batch failed as an error, not "completed: 0 items"', async () => {
+    const db = seedDb(4);
+    const phases: string[] = [];
+    const progress = {
+      update(_name: string, partial: { phase?: string }) {
+        if (partial.phase) phases.push(partial.phase);
+      },
+    } as unknown as import('../../progress.js').ProgressState;
+
+    const pipeline = new EmbeddingPipeline(
+      fakeStore(db),
+      unreachableService(),
+      new BlobVectorStore(db),
+      progress,
+    );
+    expect(await pipeline.indexUnembedded(2)).toBe(0);
+    expect(phases).toContain('error');
+    expect(phases).not.toContain('completed');
+  });
+
+  it('clears the persisted breaker once a batch succeeds again', async () => {
+    const db = seedDb(3);
+    const store = fakeStore(db);
+
+    const failing = new EmbeddingPipeline(store, unreachableService(), new BlobVectorStore(db));
+    await failing.indexUnembedded(3);
+    expect(readEmbeddingBreakerState(db)).not.toBeNull();
+
+    // Explicit user action (embed_repo) must not be a no-op during the cooldown.
+    const recovered = new EmbeddingPipeline(store, workingService(), new BlobVectorStore(db));
+    recovered.resetCircuitBreaker();
+    expect(await recovered.indexUnembedded(3)).toBe(3);
+    expect(readEmbeddingBreakerState(db)).toBeNull();
+  });
+});

--- a/src/ai/embedding-pipeline.ts
+++ b/src/ai/embedding-pipeline.ts
@@ -2,6 +2,7 @@
  * Lazy background embedding indexer.
  * Finds symbols without embeddings and indexes them in batches.
  */
+import type Database from 'better-sqlite3';
 import type { Store } from '../db/store.js';
 import { logger } from '../logger.js';
 import type { ProgressState } from '../progress.js';
@@ -14,6 +15,48 @@ const DEFAULT_BATCH_SIZE = 50;
 const FAILURE_THRESHOLD = 2;
 /** How long to skip embedding work after the breaker trips. */
 const COOLDOWN_MS = 10 * 60 * 1000;
+/** `server_state` row holding the breaker state so it survives daemon restarts. */
+const BREAKER_STATE_KEY = 'embedding_breaker';
+
+/**
+ * Circuit-breaker state as persisted in `server_state`. In-memory only, the
+ * breaker resets on every process start — which under a restart loop (TRA-809)
+ * turns an unreachable embedding endpoint into a permanent retry storm against
+ * it (TRA-812). Persisting it makes the cooldown mean what it says.
+ */
+export interface EmbeddingBreakerState {
+  /** Epoch ms until which embedding work is skipped. */
+  disabledUntilMs: number;
+  /** Consecutive failed batches at the time of writing. */
+  consecutiveFailures: number;
+  /** Epoch ms of the most recent batch failure. */
+  lastFailureAt: number;
+  /** Message from the most recent batch failure. */
+  lastError?: string;
+}
+
+/**
+ * Read the persisted breaker state, or null when there is none (clean history,
+ * pre-migration DB without `server_state`, or an unparseable row).
+ */
+export function readEmbeddingBreakerState(db: Database.Database): EmbeddingBreakerState | null {
+  try {
+    const row = db.prepare('SELECT value FROM server_state WHERE key = ?').get(BREAKER_STATE_KEY) as
+      | { value: string }
+      | undefined;
+    if (!row) return null;
+    const parsed = JSON.parse(row.value) as Partial<EmbeddingBreakerState>;
+    if (typeof parsed?.disabledUntilMs !== 'number') return null;
+    return {
+      disabledUntilMs: parsed.disabledUntilMs,
+      consecutiveFailures: parsed.consecutiveFailures ?? 0,
+      lastFailureAt: parsed.lastFailureAt ?? 0,
+      lastError: parsed.lastError,
+    };
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Failure diagnostics for a single {@link EmbeddingPipeline} run, so callers
@@ -66,6 +109,21 @@ export class EmbeddingPipeline {
   };
   /** Per-run latch: set once a non-dimension-mismatch failure is seen. */
   private sawNonMismatchFailure = false;
+  /** Once-per-process latch for the "breaker still open" skip log. */
+  private skipNotified = false;
+
+  /**
+   * Forget any open cooldown so the next run actually calls the provider.
+   * For explicit user-driven runs (embed_repo) — a persisted breaker must not
+   * make "embed now" a silent no-op for the rest of the cooldown window.
+   */
+  resetCircuitBreaker(): void {
+    this.consecutiveFailures = 0;
+    this.disabledUntilMs = 0;
+    this.breakerNotified = false;
+    this.skipNotified = false;
+    this.clearBreakerState();
+  }
 
   /** Snapshot of why the last run embedded fewer symbols than expected. */
   getLastRunDiagnostics(): EmbeddingRunDiagnostics {
@@ -80,6 +138,49 @@ export class EmbeddingPipeline {
     options?: EmbeddingPipelineOptions,
   ) {
     this.autoRebuild = options?.autoRebuildOnProviderMismatch ?? true;
+    // Resume an open cooldown from a previous process. Without this the breaker
+    // is worthless in the daemon: every restart re-attempts the whole backlog.
+    const persisted = readEmbeddingBreakerState(store.db);
+    if (persisted && persisted.disabledUntilMs > Date.now()) {
+      this.disabledUntilMs = persisted.disabledUntilMs;
+      this.consecutiveFailures = persisted.consecutiveFailures;
+      // Already announced by the process that tripped it — don't re-log the trip.
+      this.breakerNotified = true;
+    } else if (persisted && Date.now() - persisted.lastFailureAt < COOLDOWN_MS) {
+      // A run stops at its first failed batch, so a single run can only ever
+      // add one to the counter. Starting from zero every process meant that
+      // under a restart loop the counter never reached FAILURE_THRESHOLD and
+      // the breaker never tripped at all — 36 full-backlog retries in 40 hours.
+      this.consecutiveFailures = persisted.consecutiveFailures;
+    }
+  }
+
+  /** Persist the breaker so the cooldown outlives this process. Best-effort. */
+  private persistBreakerState(): void {
+    try {
+      this.store.db.prepare('INSERT OR REPLACE INTO server_state (key, value) VALUES (?, ?)').run(
+        BREAKER_STATE_KEY,
+        JSON.stringify({
+          disabledUntilMs: this.disabledUntilMs,
+          consecutiveFailures: this.consecutiveFailures,
+          lastFailureAt: Date.now(),
+          lastError: this.diagnostics.lastError,
+        } satisfies EmbeddingBreakerState),
+      );
+    } catch (e) {
+      // Pre-migration DB without server_state, or a read-only store. The
+      // in-memory breaker still works for this process.
+      logger.debug({ error: e }, 'Failed to persist embedding breaker state');
+    }
+  }
+
+  /** Drop the persisted breaker after a successful batch. Best-effort. */
+  private clearBreakerState(): void {
+    try {
+      this.store.db.prepare('DELETE FROM server_state WHERE key = ?').run(BREAKER_STATE_KEY);
+    } catch {
+      /* see persistBreakerState */
+    }
   }
 
   /**
@@ -165,7 +266,22 @@ export class EmbeddingPipeline {
    */
   async indexUnembedded(batchSize = DEFAULT_BATCH_SIZE, signal?: AbortSignal): Promise<number> {
     if (this.inFlight) return 0;
-    if (this.disabledUntilMs > Date.now()) return 0;
+    if (this.disabledUntilMs > Date.now()) {
+      // Say it once per process. Silence here is what let a 3 445-symbol
+      // backlog sit undrained for two days with nothing in the log but
+      // "embedding completed: 0 items" (TRA-812).
+      if (!this.skipNotified) {
+        this.skipNotified = true;
+        logger.info(
+          {
+            queued: this.store.countUnembeddedSymbols(),
+            retryAfter: new Date(this.disabledUntilMs).toISOString(),
+          },
+          'Embedding paused — service failed recently, backlog is not being drained',
+        );
+      }
+      return 0;
+    }
     if (signal?.aborted) return 0;
 
     this.inFlight = true;
@@ -207,11 +323,23 @@ export class EmbeddingPipeline {
           if (this.disabledUntilMs > Date.now()) break;
         } while (batch > 0);
 
-        this.progress?.update('embedding', {
-          phase: 'completed',
-          processed: totalIndexed,
-          completedAt: Date.now(),
-        });
+        // A run that embedded nothing *because every batch failed* is not a
+        // completion. Reporting it as one made a two-day outage read as
+        // "embedding completed: 0 items in 2s" at info level (TRA-812).
+        if (totalIndexed === 0 && this.diagnostics.failedBatches > 0) {
+          this.progress?.update('embedding', {
+            phase: 'error',
+            processed: 0,
+            completedAt: Date.now(),
+            error: this.diagnostics.lastError ?? 'all embedding batches failed',
+          });
+        } else {
+          this.progress?.update('embedding', {
+            phase: 'completed',
+            processed: totalIndexed,
+            completedAt: Date.now(),
+          });
+        }
       } catch (e) {
         this.progress?.update('embedding', {
           phase: 'error',
@@ -269,6 +397,9 @@ export class EmbeddingPipeline {
         }
         this.consecutiveFailures = 0;
         this.breakerNotified = false;
+        this.disabledUntilMs = 0;
+        this.skipNotified = false;
+        this.clearBreakerState();
       }
     } catch (e) {
       logger.error({ error: e }, 'Embedding batch failed');
@@ -301,6 +432,9 @@ export class EmbeddingPipeline {
         // doesn't get probed the moment the previous window ends.
         this.disabledUntilMs = Date.now() + COOLDOWN_MS;
       }
+      // Record the failure (and any cooldown) for the next process and for
+      // get_index_health to surface.
+      this.persistBreakerState();
     }
 
     logger.debug({ indexed, total: unembedded.length }, 'Indexed unembedded symbols');
@@ -323,6 +457,7 @@ export class EmbeddingPipeline {
       );
     }
     this.consistent = true;
+    this.resetCircuitBreaker();
     return this.indexUnembedded(DEFAULT_BATCH_SIZE);
   }
 }

--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -503,6 +503,7 @@ export function createAIProvider(config: TraceMcpConfig): AIProvider {
           inferenceModel: pick(config.ai.inference_model, defaults.inferenceModel),
           fastModel: pick(config.ai.fast_model, defaults.fastModel),
           extraBody,
+          providerLabel: provider,
         }),
         provider,
         url,

--- a/src/ai/openai.ts
+++ b/src/ai/openai.ts
@@ -23,6 +23,15 @@ interface OpenAIConfig {
    * TRACE_MCP_OPENAI_EXTRA_BODY (env). Core fields always win over this.
    */
   extraBody?: Record<string, unknown>;
+  /**
+   * Configured provider name for log lines ('lmstudio', 'groq', …). This class
+   * serves every OpenAI-compatible endpoint, so hard-coding "OpenAI" in the
+   * retry/error text pointed diagnosis at an API-key problem when the real
+   * cause was a local LM Studio process that wasn't running (TRA-812).
+   * Display only — `providerName()` deliberately stays 'openai' because it is
+   * stamped into the vector store and changing it would drop existing indexes.
+   */
+  providerLabel?: string;
 }
 
 /**
@@ -62,12 +71,18 @@ export function resolveOpenAIExtraBody(
 }
 
 class OpenAIEmbeddingService implements EmbeddingService {
+  /** e.g. "lmstudio embeddings @ http://localhost:1234/v1" — used in logs only. */
+  private readonly label: string;
+
   constructor(
     private baseUrl: string,
     private apiKey: string,
     private model: string,
     private dims: number,
-  ) {}
+    providerLabel = 'openai',
+  ) {
+    this.label = `${providerLabel} embeddings @ ${baseUrl}`;
+  }
 
   async embed(
     text: string,
@@ -103,9 +118,7 @@ class OpenAIEmbeddingService implements EmbeddingService {
         if (!resp.ok) {
           const body = await resp.text().catch(() => '');
           const safeBody = body.length > 200 ? `${body.slice(0, 200)}…` : body;
-          throw new Error(
-            `OpenAI embeddings failed: ${resp.status} ${resp.statusText} — ${safeBody}`,
-          );
+          throw new Error(`${this.label} failed: ${resp.status} ${resp.statusText} — ${safeBody}`);
         }
 
         const data = (await resp.json()) as { data: { index: number; embedding: number[] }[] };
@@ -115,7 +128,7 @@ class OpenAIEmbeddingService implements EmbeddingService {
         }
         return result;
       },
-      { label: 'OpenAI embeddings' },
+      { label: this.label },
     );
   }
 
@@ -127,19 +140,31 @@ class OpenAIEmbeddingService implements EmbeddingService {
     return this.model;
   }
 
+  /**
+   * Wire-format identity, not the configured provider name. Stamped into the
+   * vector store meta — returning 'lmstudio' here would look like a provider
+   * change and drop every existing index built via an OpenAI-compatible
+   * endpoint. Log lines use `this.label` instead.
+   */
   providerName(): string {
     return 'openai';
   }
 }
 
 class OpenAIInferenceService implements InferenceService {
+  /** e.g. "lmstudio chat @ http://localhost:1234/v1" — used in logs only. */
+  private readonly label: string;
+
   constructor(
     private baseUrl: string,
     private apiKey: string,
     private model: string,
     /** Merged config+env extra body fields; core request fields win over these. */
     private extraBody: Record<string, unknown> = {},
-  ) {}
+    providerLabel = 'openai',
+  ) {
+    this.label = `${providerLabel} chat @ ${baseUrl}`;
+  }
 
   async generate(
     prompt: string,
@@ -172,13 +197,13 @@ class OpenAIInferenceService implements InferenceService {
         if (!resp.ok) {
           const body = await resp.text().catch(() => '');
           const safeBody = body.length > 200 ? `${body.slice(0, 200)}…` : body;
-          throw new Error(`OpenAI chat failed: ${resp.status} ${resp.statusText} — ${safeBody}`);
+          throw new Error(`${this.label} failed: ${resp.status} ${resp.statusText} — ${safeBody}`);
         }
 
         const data = (await resp.json()) as { choices: { message: { content: string } }[] };
         return data.choices[0]?.message?.content ?? '';
       },
-      { label: 'OpenAI chat' },
+      { label: this.label },
     );
   }
 
@@ -211,7 +236,9 @@ class OpenAIInferenceService implements InferenceService {
     if (!resp.ok) {
       const body = await resp.text().catch(() => '');
       const safeBody = body.length > 200 ? `${body.slice(0, 200)}…` : body;
-      throw new Error(`OpenAI chat stream failed: ${resp.status} ${resp.statusText} — ${safeBody}`);
+      throw new Error(
+        `${this.label} stream failed: ${resp.status} ${resp.statusText} — ${safeBody}`,
+      );
     }
 
     yield* parseOpenAIStream(resp.body!);
@@ -248,6 +275,7 @@ export class OpenAIProvider implements AIProvider {
       this.config.apiKey,
       this.config.embeddingModel,
       this.config.embeddingDimensions,
+      this.config.providerLabel,
     );
   }
 
@@ -257,6 +285,7 @@ export class OpenAIProvider implements AIProvider {
       this.config.apiKey,
       this.config.inferenceModel,
       this.config.extraBody,
+      this.config.providerLabel,
     );
   }
 
@@ -266,6 +295,7 @@ export class OpenAIProvider implements AIProvider {
       this.config.apiKey,
       this.config.fastModel,
       this.config.extraBody,
+      this.config.providerLabel,
     );
   }
 }

--- a/src/ai/openai.ts
+++ b/src/ai/openai.ts
@@ -70,6 +70,21 @@ export function resolveOpenAIExtraBody(
   return { ...envExtra, ...(configExtra ?? {}) };
 }
 
+/**
+ * Origin + path of `baseUrl`, with any userinfo and query string dropped. The
+ * URL goes into log lines and thrown errors, and some OpenAI-compatible
+ * gateways carry a token in userinfo or `?key=` — those must not reach the log.
+ * Unparseable input degrades to the scheme+host prefix, never the raw string.
+ */
+export function redactBaseUrlForLogs(baseUrl: string): string {
+  try {
+    const u = new URL(baseUrl);
+    return `${u.protocol}//${u.host}${u.pathname}`.replace(/\/$/, '');
+  } catch {
+    return '<invalid base_url>';
+  }
+}
+
 class OpenAIEmbeddingService implements EmbeddingService {
   /** e.g. "lmstudio embeddings @ http://localhost:1234/v1" — used in logs only. */
   private readonly label: string;
@@ -81,7 +96,7 @@ class OpenAIEmbeddingService implements EmbeddingService {
     private dims: number,
     providerLabel = 'openai',
   ) {
-    this.label = `${providerLabel} embeddings @ ${baseUrl}`;
+    this.label = `${providerLabel} embeddings @ ${redactBaseUrlForLogs(baseUrl)}`;
   }
 
   async embed(
@@ -163,7 +178,7 @@ class OpenAIInferenceService implements InferenceService {
     private extraBody: Record<string, unknown> = {},
     providerLabel = 'openai',
   ) {
-    this.label = `${providerLabel} chat @ ${baseUrl}`;
+    this.label = `${providerLabel} chat @ ${redactBaseUrlForLogs(baseUrl)}`;
   }
 
   async generate(

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -111,13 +111,26 @@ export class ProgressState {
         current.completedAt > 0 && current.startedAt > 0
           ? Math.round((current.completedAt - current.startedAt) / 1000)
           : 0;
-      logger.info(
-        { pipeline: name, processed: current.processed, elapsed },
-        '%s completed: %d items in %ds',
-        name,
-        current.processed,
-        elapsed,
-      );
+      // "completed: 0 items" for a non-empty queue is byte-for-byte the shape of
+      // "there was nothing to do" — which is how a two-day embedding outage read
+      // as 44 successful runs at info level (TRA-812). snapshot() already
+      // downgrades this to 'skipped'; the log line has to say it too.
+      if (current.total > 0 && current.processed === 0) {
+        logger.warn(
+          { pipeline: name, total: current.total, elapsed },
+          '%s finished without processing any of %d queued items',
+          name,
+          current.total,
+        );
+      } else {
+        logger.info(
+          { pipeline: name, processed: current.processed, elapsed },
+          '%s completed: %d items in %ds',
+          name,
+          current.processed,
+          elapsed,
+        );
+      }
     } else if (partial.phase === 'error') {
       logger.error({ pipeline: name, error: current.error }, '%s failed: %s', name, current.error);
     } else if (partial.processed !== undefined && current.total > 0) {

--- a/src/tools/project/project.ts
+++ b/src/tools/project/project.ts
@@ -1,3 +1,4 @@
+import { readEmbeddingBreakerState } from '../../ai/embedding-pipeline.js';
 import type { TraceMcpConfig } from '../../config.js';
 import type { IndexStats, Store } from '../../db/store.js';
 import type { PluginRegistry } from '../../plugin-api/registry.js';
@@ -15,6 +16,22 @@ interface IndexHealthResult {
   };
   warnings: string[];
   progress?: ProgressSnapshot;
+  /**
+   * Embedding backlog state. Present only when embeddings are configured or a
+   * previous run failed — otherwise the extra COUNT isn't worth paying for.
+   * Without this, semantic search silently degrades with nothing to look at
+   * (TRA-812).
+   */
+  embedding?: {
+    /** Indexed symbols with no vector yet. */
+    queued: number;
+    /** Epoch ms until which background embedding is paused, if it is. */
+    pausedUntil?: number;
+    /** Epoch ms of the last failed batch. */
+    lastFailureAt?: number;
+    /** Message from the last failed batch. */
+    lastError?: string;
+  };
 }
 
 export function getIndexHealth(store: Store, config: TraceMcpConfig): IndexHealthResult {
@@ -55,9 +72,32 @@ export function getIndexHealth(store: Store, config: TraceMcpConfig): IndexHealt
     .prepare("SELECT value FROM schema_meta WHERE key = 'schema_version'")
     .get() as { value: string } | undefined;
 
+  const breaker = readEmbeddingBreakerState(store.db);
+  let embedding: IndexHealthResult['embedding'];
+  if (config.ai?.enabled || breaker) {
+    const queued = store.countUnembeddedSymbols();
+    const paused = breaker && breaker.disabledUntilMs > Date.now();
+    embedding = {
+      queued,
+      pausedUntil: paused ? breaker.disabledUntilMs : undefined,
+      lastFailureAt: breaker?.lastFailureAt || undefined,
+      lastError: breaker?.lastError,
+    };
+    if (paused && queued > 0) {
+      if (status === 'ok') status = 'degraded';
+      warnings.push(
+        `${queued} symbols are queued for embedding but background embedding is paused until ` +
+          `${new Date(breaker.disabledUntilMs).toISOString()} after repeated failures ` +
+          `(${breaker.lastError ?? 'unknown error'}). Semantic and hybrid search results are ` +
+          `incomplete until the embedding provider is reachable; call embed_repo to retry now.`,
+      );
+    }
+  }
+
   return {
     status,
     stats,
+    embedding,
     schemaVersion: versionRow ? Number(versionRow.value) : 0,
     config: {
       // The path this store was actually opened at, not a config default —

--- a/src/tools/register/core.ts
+++ b/src/tools/register/core.ts
@@ -42,7 +42,7 @@ export function registerCoreTools(server: McpServer, ctx: ServerContext): void {
 
   server.tool(
     'get_index_health',
-    'Get index status, statistics, health information, and pipeline progress (indexing, summarization, embedding). Read-only, no side effects. Use to verify the index is ready before running queries. Returns JSON: { totalFiles, totalSymbols, languages, frameworks, pipelineProgress }.',
+    'Get index status, statistics, health, and pipeline progress (indexing, summarization, embedding). Read-only, no side effects. Use to verify the index is ready before running queries. Returns JSON: { totalFiles, totalSymbols, languages, frameworks, pipelineProgress, embedding }.',
     {},
     async () => {
       const result = getIndexHealth(store, config);
@@ -210,6 +210,9 @@ export function registerCoreTools(server: McpServer, ctx: ServerContext): void {
         progress ?? undefined,
         { autoRebuildOnProviderMismatch: autoRebuild },
       );
+      // Explicit user request — never a silent no-op because the background
+      // breaker is still in its cooldown from an earlier failure (TRA-812).
+      pipeline.resetCircuitBreaker();
       try {
         const startedAt = Date.now();
         // R09 v2: emit embed_started before the work begins. The total is

--- a/tests/ai/openai.test.ts
+++ b/tests/ai/openai.test.ts
@@ -3,6 +3,7 @@ import { createAIProvider } from '../../src/ai/index.js';
 import {
   OpenAIProvider,
   parseOpenAIExtraBodyEnv,
+  redactBaseUrlForLogs,
   resolveOpenAIExtraBody,
 } from '../../src/ai/openai.js';
 import type { TraceMcpConfig } from '../../src/config.js';
@@ -127,6 +128,13 @@ describe('OpenAIProvider', () => {
       await expect(provider.embedding().embedBatch(['a'])).rejects.toThrow(
         `lmstudio embeddings @ ${baseConfig.baseUrl} failed: 500`,
       );
+    });
+
+    it('keeps userinfo and query credentials out of the logged base URL', () => {
+      expect(redactBaseUrlForLogs('https://user:s3cret@gw.example.com/v1?key=abc123')).toBe(
+        'https://gw.example.com/v1',
+      );
+      expect(redactBaseUrlForLogs('not a url')).toBe('<invalid base_url>');
     });
   });
 

--- a/tests/ai/openai.test.ts
+++ b/tests/ai/openai.test.ts
@@ -111,7 +111,21 @@ describe('OpenAIProvider', () => {
       );
       const provider = new OpenAIProvider(baseConfig);
       await expect(provider.embedding().embedBatch(['a'])).rejects.toThrow(
-        /OpenAI embeddings failed/,
+        /openai embeddings @ .+ failed: 429/,
+      );
+    });
+
+    // TRA-812: this class serves every OpenAI-compatible endpoint, so the
+    // message has to name the *configured* provider and its URL. "OpenAI
+    // embeddings: transient failure" while `lmstudio` was configured sent
+    // diagnosis after an API-key problem instead of a dead local process.
+    it('names the configured provider and base URL, not "OpenAI"', async () => {
+      (globalThis.fetch as any).mockResolvedValue(
+        new Response('nope', { status: 500, statusText: 'Internal Server Error' }),
+      );
+      const provider = new OpenAIProvider({ ...baseConfig, providerLabel: 'lmstudio' });
+      await expect(provider.embedding().embedBatch(['a'])).rejects.toThrow(
+        `lmstudio embeddings @ ${baseConfig.baseUrl} failed: 500`,
       );
     });
   });

--- a/tests/tools/behavioural/get-index-health.behavioural.test.ts
+++ b/tests/tools/behavioural/get-index-health.behavioural.test.ts
@@ -104,6 +104,63 @@ describe('getIndexHealth() — behavioural contract', () => {
     expect(result.warnings.some((w) => /edges/i.test(w))).toBe(true);
   });
 
+  it('omits the embedding block when AI is off and nothing has failed', () => {
+    ctx.store.insertFile('src/a.ts', 'typescript', 'h-a', 100);
+    expect(getIndexHealth(ctx.store, ctx.config).embedding).toBeUndefined();
+  });
+
+  // TRA-812: a paused embedding backlog degraded semantic search silently for
+  // two days. get_index_health is the surface that has to say so.
+  it('reports a paused embedding backlog as degraded, with the deadline and cause', () => {
+    const fid = ctx.store.insertFile('src/a.ts', 'typescript', 'h-a', 100);
+    ctx.store.insertSymbol(fid, {
+      symbolId: 'src/a.ts::unembedded#function',
+      name: 'unembedded',
+      kind: 'function',
+      fqn: 'unembedded',
+      byteStart: 0,
+      byteEnd: 30,
+      lineStart: 1,
+      lineEnd: 3,
+    });
+    const pausedUntil = Date.now() + 600_000;
+    ctx.store.db.prepare('INSERT OR REPLACE INTO server_state (key, value) VALUES (?, ?)').run(
+      'embedding_breaker',
+      JSON.stringify({
+        disabledUntilMs: pausedUntil,
+        consecutiveFailures: 2,
+        lastFailureAt: Date.now(),
+        lastError: 'fetch failed',
+      }),
+    );
+
+    const result = getIndexHealth(ctx.store, ctx.config);
+    expect(result.embedding?.queued).toBe(1);
+    expect(result.embedding?.pausedUntil).toBe(pausedUntil);
+    expect(result.embedding?.lastError).toBe('fetch failed');
+    expect(result.status).toBe('degraded');
+    expect(result.warnings.some((w) => /queued for embedding.*paused/s.test(w))).toBe(true);
+  });
+
+  it('an elapsed pause is not reported as paused', () => {
+    ctx.store.insertFile('src/a.ts', 'typescript', 'h-a', 100);
+    ctx.store.db.prepare('INSERT OR REPLACE INTO server_state (key, value) VALUES (?, ?)').run(
+      'embedding_breaker',
+      JSON.stringify({
+        disabledUntilMs: Date.now() - 1_000,
+        consecutiveFailures: 2,
+        lastFailureAt: Date.now() - 601_000,
+        lastError: 'fetch failed',
+      }),
+    );
+
+    const result = getIndexHealth(ctx.store, ctx.config);
+    expect(result.embedding?.pausedUntil).toBeUndefined();
+    // The last failure is still worth reporting — it explains a stale backlog.
+    expect(result.embedding?.lastError).toBe('fetch failed');
+    expect(result.status).toBe('ok');
+  });
+
   it('reflects include/exclude patterns from the supplied config', () => {
     const custom: TraceMcpConfig = {
       ...ctx.config,


### PR DESCRIPTION
Fixes TRA-812.

With `lmstudio` configured and LM Studio not running, the daemon re-announced the same embedding backlog 36 times in 40 hours and logged every total failure as a success. From `~/.trace/daemon.log` + `.1`, 2026-09-02 18:47 → 2026-09-04 10:37 UTC: 51 `embedding started`, 49 completions, 44 of them `processed: 0`, 47 `Embedding batch failed`, and `Embedding service unreachable` — the circuit-breaker trip message — **not once**.

Reproducible with no network trickery: configure `lmstudio`, don't start it, restart the daemon.

## Why the breaker never tripped

A run bails out at its first failed batch — `embedBatch` returns 0 and the `while (batch > 0)` loop ends — so one run can only ever add one to `consecutiveFailures`. That counter lived in process memory. Under the ~3-minute restart loop of TRA-809 it reset before it could reach `FAILURE_THRESHOLD = 2`, so the 10-minute cooldown that already existed in the code was unreachable in the field. The log confirms it: exactly one `Embedding batch failed` per `embedding started`, never a trip.

`consecutiveFailures` and `disabledUntilMs` now persist to the project DB (`server_state`, key `embedding_breaker`). Best-effort: a pre-migration DB or a read-only store just keeps the old in-memory behaviour. The counter carries over only while the last failure is recent, so an idle project doesn't accumulate a trip from last month.

`embed_repo` calls `resetCircuitBreaker()` before running — an explicit "embed now" must never be a silent no-op inside a background cooldown.

## A total failure logged as a success

A run where every batch failed reported `phase: 'completed'`, producing `embedding completed: 0 items in 2s` at info — byte-for-byte the shape of "there was nothing to embed". It now reports `phase: 'error'` carrying the last batch error.

`ProgressState.update` also downgrades any `completed` with `processed: 0` of `total > 0` to a warn line. `snapshot()` already called that case `skipped`; the log did not, and the log is what anyone actually reads. This covers the summarization pipeline too.

## Nothing told the user

`get_index_health` gains an `embedding` block — `queued`, `pausedUntil`, `lastFailureAt`, `lastError` — plus a warning and `status: degraded` while a non-empty backlog is paused. Computed only when AI is enabled or a failure is on record, so the extra COUNT isn't paid by every caller. Additive only; no tool-signature or on-disk schema change, no migration needed (`server_state` has existed since migration 18).

The tool description got *shorter* on net — the TRA-186 schema budget had 8 chars of headroom left, so `health information` → `health` paid for `, embedding`.

## The retry line named the wrong provider

`OpenAI embeddings: transient failure, retrying` fired while `lmstudio` was configured. That cost real diagnosis time: it points at a network or API-key problem when the cause is a local process that isn't running. `OpenAIProvider` takes a display-only `providerLabel`, so the line now reads `lmstudio embeddings @ http://localhost:1234/v1`.

`providerName()` deliberately still returns `openai` — it is stamped into the vector store, and changing it would read as a provider swap and drop every existing index built through an OpenAI-compatible endpoint.

Pre-merge review flagged that the URL now reaching the log is new exposure, since some gateways carry a token in userinfo or `?key=`. `redactBaseUrlForLogs` keeps scheme/host/path only.

## On the `ai.enabled` question in the issue

Checked, and the gate is **not** leaking — worth stating plainly since the issue asked not to assume either way. It's enforced at all three construction sites (`project-manager.ts:310`, `local-backend.ts:178`, `server.ts:606`), no project section in `~/.trace/.config.json` sets `ai`, and no project-local config does either. What happened is timing: the config file was written at 10:50:12Z, two minutes before the last embedding attempt at 10:52:33Z. `enabled` was true for the observed window.

One real caveat did fall out of it: a project already open in the daemon keeps the config it started with, so flipping `ai.enabled` off only takes effect on the next project start. That is now written down in `docs/configuration.md` rather than changed — config hot-reload is a much larger change than this issue warrants.

## Test evidence

`pnpm test`: **9948 passed, 22 skipped, 0 failed** (901 files). `tsc --noEmit` clean, `biome check` clean, `pnpm build` succeeds.

New — `src/ai/__tests__/embedding-breaker-persistence.test.ts`:
- the breaker trips across simulated restarts (each `new EmbeddingPipeline` against the same DB standing for a fresh process), and the third process makes **zero** calls against the dead endpoint
- an all-batches-failed run reports `error`, never `completed`
- a successful batch clears the persisted row

Extended — `tests/tools/behavioural/get-index-health.behavioural.test.ts` (3 cases for the new field) and `tests/ai/openai.test.ts` (provider label, URL redaction).

One unrelated thing folded in: `docs/config-index.md` carried generator drift from before this branch (a `db.path` default row). Verified pre-existing by stashing — the regeneration is included so CI is green rather than left red for the next PR to trip over.

Agent: Lead Engineer (Multica)
