### PR TITLE
feat(analytics): watch the startup block for growth and notify with one number (TRA-865)

### DIFF
--- a/hooks/trace-mcp-session-start.cmd
+++ b/hooks/trace-mcp-session-start.cmd
@@ -43,6 +43,7 @@ powershell -NoProfile -Command ^
   "} elseif ($w.memory.sessions_mined -gt 0) { $lines += 'No recent decisions yet -- ' + $w.memory.sessions_mined + ' sessions already mined found none. Try `trace-mcp memory mine --force --min-confidence <lower>` to re-examine them.' } else { $lines += 'No recent decisions yet -- run trace-mcp memory mine.' };" ^
   "$lines += 'Memory: ' + $w.memory.sessions_mined + ' sessions mined, ' + $w.memory.sessions_indexed + ' indexed, ' + $w.memory.total_decisions + ' total decisions';" ^
   "$lines += 'Tip: call get_wake_up / query_decisions for richer context.';" ^
+  "if ($w.startupWatch) { $lines += $w.startupWatch.message };" ^
   "$ctx = $lines -join \"`n\";" ^
   "@{hookSpecificOutput=@{hookEventName='SessionStart';additionalContext=$ctx}} | ConvertTo-Json -Compress -Depth 5"
 

--- a/hooks/trace-mcp-session-start.sh
+++ b/hooks/trace-mcp-session-start.sh
@@ -90,7 +90,8 @@ CONTEXT=$(printf '%s' "$WAKE_JSON" | jq -r '
     "Memory: " + ((.memory.sessions_mined // 0) | tostring) + " sessions mined, "
       + ((.memory.sessions_indexed // 0) | tostring) + " indexed, "
       + ((.memory.total_decisions // 0) | tostring) + " total decisions",
-    "Tip: call get_wake_up / query_decisions for richer context."
+    "Tip: call get_wake_up / query_decisions for richer context.",
+    (if (.startupWatch != null) then .startupWatch.message else empty end)
   ] | join("\n")
 ' 2>/dev/null) || exit 0
 

--- a/src/analytics/startup-context.ts
+++ b/src/analytics/startup-context.ts
@@ -46,8 +46,8 @@ const USD_PER_MTOK_CACHE_READ = 0.3;
 const CHARS_PER_TOKEN = 4;
 /** cache_creation big enough mid-session to mean the prefix was rebuilt, not grown. */
 const PREFIX_REBUILD_MIN_TOKENS = 20_000;
-/** Files below this are handshakes and aborted runs, not sessions. */
-const MIN_SESSION_BYTES = 20_000;
+/** Files below this are handshakes and aborted runs, not sessions. Exported for startup-watch.ts, which scans the same logs for a single latest sample rather than the full window. */
+export const MIN_SESSION_BYTES = 20_000;
 /** A gap longer than the longest cache TTL explains a rebuild on its own. */
 const CACHE_TTL_SECONDS = 3600;
 
@@ -300,7 +300,8 @@ interface ApiCall {
   events: Set<string>;
 }
 
-interface FreshSession {
+/** Exported for startup-watch.ts (TRA-865), which needs a single session's startup size. */
+export interface FreshSession {
   projectPath: string;
   startupTokens: number;
   cacheCreate: number;
@@ -333,8 +334,11 @@ function timestampSeconds(ts: unknown): number {
  * parsed — a substring test first, `JSON.parse` second. On a 45-day corpus
  * that is the difference between parsing every line and parsing half of them,
  * and the report is one the user waits on.
+ *
+ * Exported for startup-watch.ts, which calls this on one file at a time
+ * rather than the whole corpus this module scans.
  */
-async function scanSessionFile(filePath: string, projectPath: string): Promise<FileScan> {
+export async function scanSessionFile(filePath: string, projectPath: string): Promise<FileScan> {
   const calls: ApiCall[] = [];
   const mcpToolCalls = new Map<string, number>();
   const skillInvocations = new Set<string>();

--- a/src/analytics/startup-watch.ts
+++ b/src/analytics/startup-watch.ts
@@ -1,0 +1,219 @@
+/**
+ * Startup-block growth watch (TRA-865 — the fourth leg of TRA-759: measure,
+ * suggest, apply, watch).
+ *
+ * `get_startup_context_audit` (startup-context.ts) is a report nobody opens
+ * twice in a row — which is exactly why a block that crept back up after
+ * being trimmed goes unnoticed for months. This module takes one cheap
+ * sample per session (the latest session's already-measured startup size,
+ * not a fresh corpus scan) and compares it against a small local history, so
+ * a session-start hook can print a one-line notice instead of the user
+ * having to remember to re-run the audit.
+ *
+ * Deliberately NOT what `analyzeStartupContext` does:
+ *  - Scoped to one project by default. The audit's log scan is machine-wide
+ *    on purpose (a 30-day median needs volume); this tracks one project's
+ *    trend, and mixing in a second project's differently-sized CLAUDE.md
+ *    would read as "grew" on nothing but a `cd`.
+ *  - No cost, no recommendations, no text compression — just one number.
+ *
+ * Nothing here is sent anywhere. The history file lives next to the rest of
+ * trace-mcp's local state (STARTUP_WATCH_PATH, under TRACE_MCP_HOME) and is
+ * read, compared, and rewritten — never uploaded.
+ */
+import fs from 'node:fs';
+import { STARTUP_WATCH_PATH } from '../shared/paths.js';
+import { atomicWriteJson } from '../utils/atomic-write.js';
+import { listAllSessions } from './log-parser.js';
+import { MIN_SESSION_BYTES, scanSessionFile } from './startup-context.js';
+
+/** Recent sessions are almost always fresh; this just bounds the pathological case. */
+const MAX_FILES_TO_SCAN = 20;
+
+/** Snapshots kept per project. At a few sessions/day this covers months. */
+const MAX_HISTORY_PER_PROJECT = 60;
+
+/**
+ * How far back a baseline may be. "Did it grow" compares the latest sample
+ * to the oldest snapshot still inside this window, not to the immediately
+ * preceding one — a CLAUDE.md that doubles over many small edits across a
+ * month should still trip this, even though no single session-to-session
+ * delta looks large.
+ */
+const LOOKBACK_DAYS = 14;
+
+/**
+ * Growth below this is noise, not signal: chars/4 token estimation, and
+ * session-to-session variance in what SessionStart hooks happen to print
+ * (e.g. how many recent decisions there are to list). The issue this module
+ * implements names the failure mode explicitly — a notice firing on +200
+ * tokens gets muted within a week. 2,000 tokens is roughly what one small
+ * MCP server's tool schemas cost, which is the smallest change worth a
+ * human's attention.
+ */
+const GROWTH_ABS_FLOOR_TOKENS = 2000;
+
+/** ...or a smaller absolute jump if it's still a big relative move for a small block. */
+const GROWTH_REL_FLOOR = 0.1;
+
+export interface StartupSample {
+  /** ISO timestamp of the sampled session (its log file's mtime). */
+  takenAt: string;
+  startupTokens: number;
+  projectPath: string;
+}
+
+export interface StartupWatchEntry {
+  takenAt: string;
+  startupTokens: number;
+}
+
+interface StartupWatchState {
+  version: 1;
+  /** Project root (or 'global' when unscoped) → history, oldest first. */
+  perProject: Record<string, StartupWatchEntry[]>;
+}
+
+export interface StartupWatchNotice {
+  deltaTokens: number;
+  previousTokens: number;
+  currentTokens: number;
+  sinceDays: number;
+  /** One number, one action — nothing else. Meant to be printed as-is. */
+  message: string;
+}
+
+export interface StartupWatchOptions {
+  projectRoot?: string;
+  /** Injectable for tests; same seam analyzeStartupContext uses. */
+  listSessions?: typeof listAllSessions;
+  statePath?: string;
+}
+
+/**
+ * The latest session with a measured startup block, scoped to `projectRoot`
+ * when given (falls back to machine-wide otherwise). Scans newest-first and
+ * stops at the first hit, so this costs one small file read in the common
+ * case — safe to call on every session start.
+ */
+export async function sampleLatestStartup(
+  opts: StartupWatchOptions = {},
+): Promise<StartupSample | null> {
+  const list = opts.listSessions ?? listAllSessions;
+  const files = list(opts.projectRoot)
+    .filter((f) => {
+      try {
+        return fs.statSync(f.filePath).size >= MIN_SESSION_BYTES;
+      } catch {
+        return false;
+      }
+    })
+    .sort((a, b) => b.mtime - a.mtime)
+    .slice(0, MAX_FILES_TO_SCAN);
+
+  for (const file of files) {
+    let scan: Awaited<ReturnType<typeof scanSessionFile>>;
+    try {
+      scan = await scanSessionFile(file.filePath, file.projectPath);
+    } catch {
+      continue;
+    }
+    if (scan.fresh) {
+      return {
+        takenAt: new Date(file.mtime).toISOString(),
+        startupTokens: scan.fresh.startupTokens,
+        projectPath: file.projectPath,
+      };
+    }
+  }
+  return null;
+}
+
+function loadState(statePath: string): StartupWatchState {
+  try {
+    const raw = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    if (raw?.version === 1 && raw.perProject && typeof raw.perProject === 'object') {
+      return raw as StartupWatchState;
+    }
+  } catch {
+    /* missing or corrupt — start fresh */
+  }
+  return { version: 1, perProject: {} };
+}
+
+function saveState(statePath: string, state: StartupWatchState): void {
+  atomicWriteJson(statePath, state);
+}
+
+/**
+ * Pure comparison — no I/O, so this is the part unit tests exercise directly
+ * without touching disk or session logs.
+ *
+ * Returns null when there is nothing to say: no baseline inside the lookback
+ * window (first-ever sample, or a gap wider than the window), or growth
+ * under threshold. Never fires on shrinkage.
+ */
+export function evaluateStartupGrowth(
+  history: StartupWatchEntry[],
+  sample: StartupSample,
+  nowMs: number = Date.parse(sample.takenAt),
+): StartupWatchNotice | null {
+  const cutoffMs = nowMs - LOOKBACK_DAYS * 86_400_000;
+  const baseline = history.find((e) => Date.parse(e.takenAt) >= cutoffMs);
+  if (!baseline) return null;
+
+  const delta = sample.startupTokens - baseline.startupTokens;
+  const threshold = Math.max(GROWTH_ABS_FLOOR_TOKENS, baseline.startupTokens * GROWTH_REL_FLOOR);
+  if (delta < threshold) return null;
+
+  const sinceDays = Math.max(
+    1,
+    Math.round((Date.parse(sample.takenAt) - Date.parse(baseline.takenAt)) / 86_400_000),
+  );
+  return {
+    deltaTokens: delta,
+    previousTokens: baseline.startupTokens,
+    currentTokens: sample.startupTokens,
+    sinceDays,
+    message: `trace-mcp: startup block grew by +${delta.toLocaleString()} tokens. Run get_startup_context_audit for details.`,
+  };
+}
+
+/**
+ * Sample, compare against history, record the sample, return a notice or
+ * null. Safe to call once per session start — recording is deduped by
+ * `takenAt` so re-invoking against the same underlying session never grows
+ * the history file.
+ *
+ * The notice itself is NOT deduped the same way: as long as the block that
+ * grew stays inside the `LOOKBACK_DAYS` window, every session start repeats
+ * the same notice. That is deliberate — "shown once" would need its own
+ * acknowledged-state to track, and a real regression should keep surfacing
+ * until either the user acts on it or it ages out of the window on its own
+ * (at which point it stops on its own, with nothing to clean up).
+ */
+export async function checkStartupWatch(
+  opts: StartupWatchOptions = {},
+): Promise<StartupWatchNotice | null> {
+  const sample = await sampleLatestStartup(opts);
+  if (!sample) return null;
+
+  const statePath = opts.statePath ?? STARTUP_WATCH_PATH;
+  const key = opts.projectRoot ?? 'global';
+  const state = loadState(statePath);
+  const history = state.perProject[key] ?? [];
+
+  const notice = evaluateStartupGrowth(history, sample);
+
+  const last = history[history.length - 1];
+  if (!last || last.takenAt !== sample.takenAt) {
+    history.push({ takenAt: sample.takenAt, startupTokens: sample.startupTokens });
+    if (history.length > MAX_HISTORY_PER_PROJECT) {
+      history.splice(0, history.length - MAX_HISTORY_PER_PROJECT);
+    }
+    state.perProject[key] = history;
+    saveState(statePath, state);
+  }
+
+  return notice;
+}

--- a/src/analytics/startup-watch.ts
+++ b/src/analytics/startup-watch.ts
@@ -22,6 +22,7 @@
  * read, compared, and rewritten — never uploaded.
  */
 import fs from 'node:fs';
+import path from 'node:path';
 import { STARTUP_WATCH_PATH } from '../shared/paths.js';
 import { atomicWriteJson } from '../utils/atomic-write.js';
 import { listAllSessions } from './log-parser.js';
@@ -53,7 +54,7 @@ const LOOKBACK_DAYS = 14;
  */
 const GROWTH_ABS_FLOOR_TOKENS = 2000;
 
-/** ...or a smaller absolute jump if it's still a big relative move for a small block. */
+/** ...or a larger threshold if 10% of the baseline exceeds 2,000 tokens. */
 const GROWTH_REL_FLOOR = 0.1;
 
 export interface StartupSample {
@@ -70,7 +71,7 @@ export interface StartupWatchEntry {
 
 interface StartupWatchState {
   version: 1;
-  /** Project root (or 'global' when unscoped) → history, oldest first. */
+  /** Resolved project root → history, oldest first. Unscoped callers key by the sampled session's own project rather than a shared bucket. */
   perProject: Record<string, StartupWatchEntry[]>;
 }
 
@@ -175,7 +176,7 @@ export function evaluateStartupGrowth(
     previousTokens: baseline.startupTokens,
     currentTokens: sample.startupTokens,
     sinceDays,
-    message: `trace-mcp: startup block grew by +${delta.toLocaleString()} tokens. Run get_startup_context_audit for details.`,
+    message: `trace-mcp: startup block grew by +${delta.toLocaleString('en-US')} tokens. Run get_startup_context_audit for details.`,
   };
 }
 
@@ -199,7 +200,13 @@ export async function checkStartupWatch(
   if (!sample) return null;
 
   const statePath = opts.statePath ?? STARTUP_WATCH_PATH;
-  const key = opts.projectRoot ?? 'global';
+  // Key by the sampled session's own project, not a shared 'global' bucket —
+  // an unscoped caller (no projectRoot) can pick up a different project's
+  // latest session between calls, and comparing across two projects would
+  // read as "grew" on nothing but a `cd` (see the module doc above).
+  // path.resolve normalizes trailing slashes / relative input so the same
+  // project always lands on the same key.
+  const key = path.resolve(opts.projectRoot ?? sample.projectPath);
   const state = loadState(statePath);
   const history = state.perProject[key] ?? [];
 

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -14,6 +14,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { Command } from 'commander';
 import { listAllSessions } from '../analytics/log-parser.js';
+import { checkStartupWatch } from '../analytics/startup-watch.js';
 import { DECISIONS_DB_PATH, ensureGlobalDirs } from '../global.js';
 import { mineSessions } from '../memory/conversation-miner.js';
 import {
@@ -308,16 +309,20 @@ memoryCommand
   .option('--project <path>', 'Project root (default: current directory)', process.cwd())
   .option('--max-decisions <n>', 'Max recent decisions to include (default: 10)', '10')
   .option('--json', 'Output as JSON (default: pretty text)')
-  .action((opts: { project: string; maxDecisions: string; json?: boolean }) => {
+  .action(async (opts: { project: string; maxDecisions: string; json?: boolean }) => {
     const store = openStore();
     try {
       const projectRoot = path.resolve(opts.project);
       const wakeUp = assembleWakeUp(store, projectRoot, {
         maxDecisions: parseInt(opts.maxDecisions, 10),
       });
+      // Independent of decision memory — reads session logs, not the decision
+      // store — so a failure here (e.g. no session logs yet) must never take
+      // the rest of wake-up down with it.
+      const startupWatch = await checkStartupWatch({ projectRoot }).catch(() => null);
 
       if (opts.json) {
-        console.log(JSON.stringify(wakeUp, null, 2));
+        console.log(JSON.stringify({ ...wakeUp, startupWatch }, null, 2));
         return;
       }
 
@@ -341,6 +346,10 @@ memoryCommand
         );
       }
       console.log(`Estimated tokens: ${wakeUp.estimated_tokens}`);
+      if (startupWatch) {
+        console.log();
+        console.log(startupWatch.message);
+      }
     } finally {
       store.close();
     }

--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -77,6 +77,9 @@ export const TELEMETRY_STATE_PATH = path.join(TRACE_MCP_HOME, 'telemetry-state.j
 /** Backup bundles for applied startup-context recommendations (TRA-769) — one dir per apply call, rollback source of truth. */
 export const STARTUP_BACKUPS_DIR = path.join(TRACE_MCP_HOME, 'startup-backups');
 
+/** Startup-block size history for growth watch (TRA-865) — one snapshot per session, per project. */
+export const STARTUP_WATCH_PATH = path.join(TRACE_MCP_HOME, 'startup-watch.json');
+
 // ── Foreign IDE / agent paths trace-mcp introspects ──────────────
 
 /**

--- a/tests/analytics/startup-watch.test.ts
+++ b/tests/analytics/startup-watch.test.ts
@@ -273,4 +273,28 @@ describe('checkStartupWatch (end-to-end)', () => {
     });
     expect(notice).toBeNull();
   });
+
+  it("keys an unscoped call by the sampled session's own project, not a shared bucket", async () => {
+    // No `projectRoot` passed — the caller relies on machine-wide scanning.
+    // Project A's baseline must not leak into project B's comparison just
+    // because both calls omitted projectRoot (review finding, TRA-865 PR).
+    const fileA = path.join(dir, 'a.jsonl');
+    writeSessionFile(fileA, 15_000, '2026-01-01T00:00:00Z');
+    await checkStartupWatch({
+      listSessions: () => [
+        { filePath: fileA, projectPath: '/project-a', client: 'claude-code' as const, mtime: 1 },
+      ],
+      statePath,
+    });
+
+    const fileB = path.join(dir, 'b.jsonl');
+    writeSessionFile(fileB, 60_000, '2026-01-01T00:00:00Z');
+    const notice = await checkStartupWatch({
+      listSessions: () => [
+        { filePath: fileB, projectPath: '/project-b', client: 'claude-code' as const, mtime: 1 },
+      ],
+      statePath,
+    });
+    expect(notice).toBeNull();
+  });
 });

--- a/tests/analytics/startup-watch.test.ts
+++ b/tests/analytics/startup-watch.test.ts
@@ -1,0 +1,276 @@
+/**
+ * TRA-865: the third leg of TRA-759 ("measure, suggest, apply, watch") — a
+ * snapshot of the startup block's size, compared against history, that
+ * stays silent unless growth crosses a threshold big enough to not be noise.
+ *
+ * What must hold, and what breaks if it does not:
+ *  - the very first sample on a machine never fires — there is nothing to
+ *    compare it to, and "grew from zero" is a lie, not a measurement;
+ *  - a session-to-session wobble under the threshold stays silent — the
+ *    issue this module implements names +200 tokens explicitly as the
+ *    failure mode ("gets muted within a week");
+ *  - real growth, whether one big jump or creep spread across many small
+ *    sessions inside the lookback window, produces exactly one number (the
+ *    delta) and exactly one action (run the audit) — never a shrinkage.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  checkStartupWatch,
+  evaluateStartupGrowth,
+  sampleLatestStartup,
+  type StartupWatchEntry,
+} from '../../src/analytics/startup-watch.js';
+
+const DAY_MS = 86_400_000;
+
+describe('evaluateStartupGrowth (pure)', () => {
+  it('stays silent with no baseline in the lookback window (first-ever sample)', () => {
+    const notice = evaluateStartupGrowth([], {
+      takenAt: new Date().toISOString(),
+      startupTokens: 20_000,
+      projectPath: '/p',
+    });
+    expect(notice).toBeNull();
+  });
+
+  it('stays silent when a baseline exists but is older than the lookback window', () => {
+    const now = Date.now();
+    const history: StartupWatchEntry[] = [
+      { takenAt: new Date(now - 30 * DAY_MS).toISOString(), startupTokens: 10_000 },
+    ];
+    const notice = evaluateStartupGrowth(history, {
+      takenAt: new Date(now).toISOString(),
+      startupTokens: 50_000,
+      projectPath: '/p',
+    });
+    expect(notice).toBeNull();
+  });
+
+  it('stays silent on growth under both the absolute and relative floor', () => {
+    const now = Date.now();
+    const history: StartupWatchEntry[] = [
+      { takenAt: new Date(now - 2 * DAY_MS).toISOString(), startupTokens: 20_000 },
+    ];
+    // +200 tokens is the exact number the issue calls out as noise.
+    const notice = evaluateStartupGrowth(history, {
+      takenAt: new Date(now).toISOString(),
+      startupTokens: 20_200,
+      projectPath: '/p',
+    });
+    expect(notice).toBeNull();
+  });
+
+  it('never fires on shrinkage', () => {
+    const now = Date.now();
+    const history: StartupWatchEntry[] = [
+      { takenAt: new Date(now - 2 * DAY_MS).toISOString(), startupTokens: 30_000 },
+    ];
+    const notice = evaluateStartupGrowth(history, {
+      takenAt: new Date(now).toISOString(),
+      startupTokens: 10_000,
+      projectPath: '/p',
+    });
+    expect(notice).toBeNull();
+  });
+
+  it('fires with exactly one number and one action once growth clears the floor', () => {
+    const now = Date.now();
+    const history: StartupWatchEntry[] = [
+      { takenAt: new Date(now - 12 * DAY_MS).toISOString(), startupTokens: 18_000 },
+    ];
+    const notice = evaluateStartupGrowth(history, {
+      takenAt: new Date(now).toISOString(),
+      startupTokens: 22_300,
+      projectPath: '/p',
+    });
+    expect(notice).not.toBeNull();
+    expect(notice?.deltaTokens).toBe(4300);
+    expect(notice?.previousTokens).toBe(18_000);
+    expect(notice?.currentTokens).toBe(22_300);
+    expect(notice?.sinceDays).toBe(12);
+    // Exactly one number in the message, and exactly one action.
+    const numbers = notice?.message.match(/[\d,]+/g) ?? [];
+    expect(numbers).toEqual(['4,300']);
+    expect(notice?.message).toContain('get_startup_context_audit');
+  });
+
+  it('catches slow creep against the oldest in-window baseline, not the last sample', () => {
+    // Three small steps, each under threshold on its own, but the total
+    // since the oldest in-window snapshot clears it.
+    const now = Date.now();
+    const history: StartupWatchEntry[] = [
+      { takenAt: new Date(now - 10 * DAY_MS).toISOString(), startupTokens: 20_000 },
+      { takenAt: new Date(now - 6 * DAY_MS).toISOString(), startupTokens: 20_500 },
+      { takenAt: new Date(now - 2 * DAY_MS).toISOString(), startupTokens: 21_000 },
+    ];
+    const notice = evaluateStartupGrowth(history, {
+      takenAt: new Date(now).toISOString(),
+      startupTokens: 22_500,
+      projectPath: '/p',
+    });
+    expect(notice?.deltaTokens).toBe(2500);
+    expect(notice?.previousTokens).toBe(20_000);
+  });
+});
+
+// --- Integration: sampleLatestStartup + checkStartupWatch against real
+// (fixture) session logs, the way the wake-up CLI actually calls this. ---
+
+function usage(over: Record<string, unknown> = {}) {
+  return {
+    input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+    output_tokens: 50,
+    ...over,
+  };
+}
+
+/** One minimal fresh session: a single first API call sized `startupTokens`. */
+function writeSessionFile(filePath: string, startupTokens: number, timestamp: string): void {
+  const lines: unknown[] = [
+    {
+      type: 'assistant',
+      timestamp,
+      message: {
+        id: 'm1',
+        model: 'claude-x',
+        usage: usage({ cache_creation_input_tokens: startupTokens }),
+        content: [],
+      },
+    },
+    // Padding past MIN_SESSION_BYTES (20_000) — lines the scanner skips.
+    ...Array.from({ length: 40 }, () => ({ type: 'noise', pad: 'x'.repeat(4000) })),
+  ];
+  fs.writeFileSync(filePath, lines.map((l) => JSON.stringify(l)).join('\n'));
+}
+
+let dir: string;
+let statePath: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-watch-'));
+  statePath = path.join(dir, 'startup-watch.json');
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('sampleLatestStartup', () => {
+  it('returns the most recent fresh session, not the largest or oldest', () => {
+    const older = path.join(dir, 'older.jsonl');
+    const newer = path.join(dir, 'newer.jsonl');
+    writeSessionFile(older, 15_000, '2026-01-01T00:00:00Z');
+    writeSessionFile(newer, 25_000, '2026-01-02T00:00:00Z');
+
+    const listSessions = () => [
+      { filePath: older, projectPath: '/p', client: 'claude-code' as const, mtime: 1000 },
+      { filePath: newer, projectPath: '/p', client: 'claude-code' as const, mtime: 2000 },
+    ];
+
+    return sampleLatestStartup({ listSessions }).then((sample) => {
+      expect(sample?.startupTokens).toBe(25_000);
+    });
+  });
+
+  it('returns null when no session has a measurable first call', () => {
+    return sampleLatestStartup({ listSessions: () => [] }).then((sample) => {
+      expect(sample).toBeNull();
+    });
+  });
+});
+
+describe('checkStartupWatch (end-to-end)', () => {
+  it('is silent on the first check and records a baseline', async () => {
+    const file = path.join(dir, 's1.jsonl');
+    writeSessionFile(file, 18_000, '2026-01-01T00:00:00Z');
+    const listSessions = () => [
+      { filePath: file, projectPath: '/p', client: 'claude-code' as const, mtime: 1 },
+    ];
+
+    const notice = await checkStartupWatch({ listSessions, statePath, projectRoot: '/p' });
+    expect(notice).toBeNull();
+    expect(fs.existsSync(statePath)).toBe(true);
+  });
+
+  it('stays silent on a second check with no real growth', async () => {
+    const file1 = path.join(dir, 's1.jsonl');
+    writeSessionFile(file1, 18_000, '2026-01-01T00:00:00Z');
+    await checkStartupWatch({
+      listSessions: () => [
+        { filePath: file1, projectPath: '/p', client: 'claude-code' as const, mtime: 1 },
+      ],
+      statePath,
+      projectRoot: '/p',
+    });
+
+    const file2 = path.join(dir, 's2.jsonl');
+    writeSessionFile(file2, 18_150, '2026-01-02T00:00:00Z');
+    const notice = await checkStartupWatch({
+      listSessions: () => [
+        { filePath: file1, projectPath: '/p', client: 'claude-code' as const, mtime: 1 },
+        { filePath: file2, projectPath: '/p', client: 'claude-code' as const, mtime: 2 },
+      ],
+      statePath,
+      projectRoot: '/p',
+    });
+    expect(notice).toBeNull();
+  });
+
+  it('reports the correct delta after a CLAUDE.md-sized growth', async () => {
+    const file1 = path.join(dir, 's1.jsonl');
+    writeSessionFile(file1, 18_000, '2026-01-01T00:00:00Z');
+    await checkStartupWatch({
+      listSessions: () => [
+        { filePath: file1, projectPath: '/p', client: 'claude-code' as const, mtime: 1 },
+      ],
+      statePath,
+      projectRoot: '/p',
+    });
+
+    // A file grown well past both the absolute and relative floor.
+    const file2 = path.join(dir, 's2.jsonl');
+    writeSessionFile(file2, 24_000, '2026-01-05T00:00:00Z');
+    const notice = await checkStartupWatch({
+      listSessions: () => [
+        { filePath: file1, projectPath: '/p', client: 'claude-code' as const, mtime: 1 },
+        { filePath: file2, projectPath: '/p', client: 'claude-code' as const, mtime: 2 },
+      ],
+      statePath,
+      projectRoot: '/p',
+    });
+    expect(notice?.deltaTokens).toBe(6000);
+    expect(notice?.message).toBe(
+      'trace-mcp: startup block grew by +6,000 tokens. Run get_startup_context_audit for details.',
+    );
+  });
+
+  it('keeps separate history per project so switching projects is not "growth"', async () => {
+    const fileA = path.join(dir, 'a.jsonl');
+    writeSessionFile(fileA, 15_000, '2026-01-01T00:00:00Z');
+    await checkStartupWatch({
+      listSessions: () => [
+        { filePath: fileA, projectPath: '/project-a', client: 'claude-code' as const, mtime: 1 },
+      ],
+      statePath,
+      projectRoot: '/project-a',
+    });
+
+    // A much bigger, unrelated project's first-ever sample — must not be
+    // compared against project A's baseline.
+    const fileB = path.join(dir, 'b.jsonl');
+    writeSessionFile(fileB, 60_000, '2026-01-01T00:00:00Z');
+    const notice = await checkStartupWatch({
+      listSessions: () => [
+        { filePath: fileB, projectPath: '/project-b', client: 'claude-code' as const, mtime: 1 },
+      ],
+      statePath,
+      projectRoot: '/project-b',
+    });
+    expect(notice).toBeNull();
+  });
+});

--- a/tests/hooks/lifecycle-hooks.test.ts
+++ b/tests/hooks/lifecycle-hooks.test.ts
@@ -201,6 +201,50 @@ describe.skipIf(process.platform === 'win32')('lifecycle hook scripts (POSIX)', 
       expect(status).toBe(0);
       expect(stdout.trim()).toBe('');
     });
+
+    it('appends the startup-watch notice when the CLI reports growth (TRA-865)', () => {
+      const wakeUpJson = JSON.stringify({
+        project: { name: 'demo', root: projectDir },
+        decisions: { total_active: 0, recent: [] },
+        memory: { total_decisions: 0, sessions_mined: 0, sessions_indexed: 0, by_type: {} },
+        estimated_tokens: 40,
+        startupWatch: {
+          deltaTokens: 4300,
+          previousTokens: 18000,
+          currentTokens: 22300,
+          sinceDays: 12,
+          message:
+            'trace-mcp: startup block grew by +4,300 tokens. Run get_startup_context_audit for details.',
+        },
+      });
+      makeStub(stubDir, wakeUpJson, 0);
+
+      const { stdout, status } = runHook(SESSION_START, '{}', { stubDir, cwd: projectDir });
+      expect(status).toBe(0);
+      const envelope = JSON.parse(stdout.trim());
+      expect(envelope.hookSpecificOutput.additionalContext).toContain(
+        'trace-mcp: startup block grew by +4,300 tokens. Run get_startup_context_audit for details.',
+      );
+    });
+
+    it('omits the startup-watch line when the CLI reports no growth', () => {
+      const wakeUpJson = JSON.stringify({
+        project: { name: 'demo', root: projectDir },
+        decisions: { total_active: 0, recent: [] },
+        memory: { total_decisions: 0, sessions_mined: 0, sessions_indexed: 0, by_type: {} },
+        estimated_tokens: 40,
+        startupWatch: null,
+      });
+      makeStub(stubDir, wakeUpJson, 0);
+
+      const { stdout, status } = runHook(SESSION_START, '{}', { stubDir, cwd: projectDir });
+      expect(status).toBe(0);
+      const envelope = JSON.parse(stdout.trim());
+      expect(envelope.hookSpecificOutput.additionalContext).not.toContain('startup block grew');
+      expect(envelope.hookSpecificOutput.additionalContext.trim().endsWith('richer context.')).toBe(
+        true,
+      );
+    });
   });
 
   describe('trace-mcp-user-prompt-submit.sh', () => {


### PR DESCRIPTION
## Summary

The fourth leg of TRA-759 ("measure, suggest, apply, watch"). `get_startup_context_audit` (TRA-759/#843) and `apply_startup_recommendations` (TRA-769/#869) are a report you have to remember to re-open — this closes the loop with a cheap per-session snapshot that notices when the block creeps back up and says so without anyone having to ask.

- **`src/analytics/startup-watch.ts`** — new module. `sampleLatestStartup` finds the most recent session with a measured startup block (reuses `scanSessionFile`, exported from `startup-context.ts` for this), scoped per-project by default (deliberately *not* machine-wide like the audit — mixing projects would read as "grew" on nothing but a `cd`). `evaluateStartupGrowth` is a pure comparison against a 14-day-lookback local history: silent on the first-ever sample, silent under a 2,000-token/10% growth floor (the issue names +200 tokens explicitly as the "muted within a week" failure mode), fires with exactly one number (the delta) and one action (`get_startup_context_audit`) once real growth clears it. History persists to `TRACE_MCP_HOME/startup-watch.json` — local only, no telemetry, no hosting.
- **`src/cli/memory.ts`** — `memory wake-up` now also runs the check (independently try/caught so a failure here can't take decision-memory wake-up down with it) and includes `startupWatch` in its JSON/text output.
- **`hooks/trace-mcp-session-start.sh` / `.cmd`** — the existing SessionStart hook (already the thing that injects `[trace-mcp wake-up]` context every session) appends the notice line when present. This answers the issue's open question of *where* the periodic check lives: piggybacked on session start, no daemon, no new process.

**Left deliberately alone:** `get_startup_context_audit`'s MCP tool response. Its description promises "Read-only, local," and `checkStartupWatch` writes a snapshot — wiring it in there would silently break that documented contract. The honest answer to "what does an MCP-only user without the hook see" is: nothing proactive right now, same as before this issue — building a new always-on notifying tool just for that felt like scope growth the issue didn't ask for.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `npx biome check` on all touched files — clean
- [x] New unit tests: `tests/analytics/startup-watch.test.ts` (pure `evaluateStartupGrowth` cases: silent-first-run, silent-under-threshold, never-fires-on-shrinkage, catches-slow-creep-against-oldest-in-window-baseline; integration `sampleLatestStartup`/`checkStartupWatch` against fixture session logs)
- [x] New hook tests in `tests/hooks/lifecycle-hooks.test.ts` (notice line appended / omitted correctly, existing tests unaffected)
- [x] Full suite: `pnpm test` → 908 test files, 10070 tests passed, 22 skipped (pre-existing), 0 failures
- [x] Manual e2e against the built CLI (`dist/cli.js memory wake-up`) with real fixture session logs under a sandboxed `HOME`/`TRACE_MCP_DATA_DIR`: first sample silent → unchanged block silent → session with startup grown from 18,000 to 24,300 tokens reports `"trace-mcp: startup block grew by +6,300 tokens. Run get_startup_context_audit for details."` — matches the issue's stated acceptance criteria verbatim