### PR TITLE
fix(guard): move server↔hook sentinels out of $TMPDIR (TRA-869)

### DIFF
--- a/hooks/trace-mcp-guard-read.ps1
+++ b/hooks/trace-mcp-guard-read.ps1
@@ -118,9 +118,14 @@ if ($projectRoot) {
     }
     $relPath = $relPath -replace '\\', '/'
     $consultedHash = Sha256Hex $relPath
+    # Markers live under the state home; %TEMP% is the pre-TRA-869 location and
+    # is still checked because the server writes both while old hooks exist.
+    $traceStateHome = $env:TRACE_MCP_DATA_DIR
+    if (-not $traceStateHome) { $traceStateHome = Join-Path $env:USERPROFILE '.trace' }
+    $stateConsultedFile = Join-Path (Join-Path (Join-Path $traceStateHome 'status') ("trace-mcp-consulted-" + $projectHash)) $consultedHash
     $consultedDir = Join-Path $tmp ("trace-mcp-consulted-" + $projectHash)
     $consultedFile = Join-Path $consultedDir $consultedHash
-    if (Test-Path $consultedFile) {
+    if ((Test-Path $stateConsultedFile) -or (Test-Path $consultedFile)) {
         $newCount = $prevCount + 1
         Set-Content -LiteralPath $readState -Value ("{0}:{1}" -f $newCount, $curMtime) -NoNewline
         Write-Output 'ALLOW'

--- a/hooks/trace-mcp-guard.cmd
+++ b/hooks/trace-mcp-guard.cmd
@@ -140,6 +140,11 @@ set "REL_FOR_HASH=%FILE_PATH%"
 set "REL_FOR_HASH=!REL_FOR_HASH:%CD%\=!"
 set "REL_FOR_HASH=!REL_FOR_HASH:\=/!"
 for /f "usebackq delims=" %%h in (`powershell -NoProfile -Command "[System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes('!REL_FOR_HASH!'))).Replace('-','').ToLower()"`) do set "FILE_HASH=%%h"
+REM Markers live under the state home; %TEMP% is the pre-TRA-869 location and is
+REM still checked because the server writes both while old hooks exist.
+set "TRACE_STATE_HOME=%TRACE_MCP_DATA_DIR%"
+if "!TRACE_STATE_HOME!"=="" set "TRACE_STATE_HOME=%USERPROFILE%\.trace"
+if exist "!TRACE_STATE_HOME!\status\trace-mcp-consulted-!PROJ_HASH!\!FILE_HASH!" goto :allow
 if exist "%TEMP%\trace-mcp-consulted-!PROJ_HASH!\!FILE_HASH!" goto :allow
 
 set "DENY_DIR=%TEMP%\trace-mcp-guard-%SESSION_ID%"

--- a/hooks/trace-mcp-guard.sh
+++ b/hooks/trace-mcp-guard.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
-# trace-mcp-guard v0.15.1
+# trace-mcp-guard v0.16
 # REQUIRES: trace-mcp >= 1.32.7   (status JSON sentinel introduced in this version)
+#
+# v0.16 changes (TRA-869 — sentinels moved out of $TMPDIR):
+#   - The heartbeat, status, consultation-marker and bypass paths are read from
+#     <state home>/status/ first, $TMPDIR second. $TMPDIR is per-process: the
+#     server is spawned by the MCP client and this hook by the agent harness,
+#     and on macOS they routinely hold different values. Measured live: the
+#     server refreshed /var/folders/.../T/trace-mcp-alive-<hash> every 5s while
+#     the hook looked in /tmp/multica-task-<id>/, so every call reported
+#     "trace-mcp server not running" and degraded to the Read/Grep fallback,
+#     against a healthy connected session.
+#   - The $TMPDIR fallback keeps a server older than that fix discoverable.
 #
 # v0.15.1 changes (TRA-845 — Bash branch had no liveness fallback):
 #   - Read, Grep and Glob all degrade to allow-with-warning when trace-mcp is
@@ -370,11 +381,34 @@ elif command -v shasum >/dev/null 2>&1; then
 else
   PROJECT_HASH=""
 fi
-CONSULTED_DIR="${TMPDIR:-/tmp}/trace-mcp-consulted-${PROJECT_HASH}"
-HEARTBEAT_FILE="${TMPDIR:-/tmp}/trace-mcp-alive-${PROJECT_HASH}"
-STATUS_FILE="${TMPDIR:-/tmp}/trace-mcp-status-${PROJECT_HASH}.json"
-BYPASS_FILE="${TMPDIR:-/tmp}/trace-mcp-bypass-${PROJECT_HASH}"
-READS_DIR="${TMPDIR:-/tmp}/trace-mcp-reads-${SESSION_ID}"
+
+# The server↔hook sentinels live under the state home, NOT $TMPDIR (TRA-869).
+# $TMPDIR is per-process: the server is spawned by the MCP client, this hook by
+# the agent harness, and on macOS those routinely hold different values (a
+# per-user /var/folders/.../T vs. whatever a task runner exports). A sentinel
+# written to one is invisible in the other, so the hook reported "server not
+# running" against a live session and degraded to the Read/Grep fallback
+# trace-mcp exists to replace. $TMPDIR stays as the second choice so a server
+# installed before that fix is still found.
+TRACE_STATE_HOME="${TRACE_MCP_DATA_DIR:-$HOME/.trace}"
+case "$TRACE_STATE_HOME" in "~"/*) TRACE_STATE_HOME="$HOME/${TRACE_STATE_HOME#\~/}" ;; esac
+STATUS_HOME="$TRACE_STATE_HOME/status"
+TMP_HOME="${TMPDIR:-/tmp}"
+
+# First path that exists; the state-home one when neither does, so anything this
+# hook writes itself (the auto-degradation bypass) lands in the shared location.
+pick_path() {
+  if [[ -e "$1" ]]; then echo "$1"; else echo "$2"; fi
+}
+
+CONSULTED_DIR=$(pick_path "$STATUS_HOME/trace-mcp-consulted-${PROJECT_HASH}" "$TMP_HOME/trace-mcp-consulted-${PROJECT_HASH}")
+HEARTBEAT_FILE=$(pick_path "$STATUS_HOME/trace-mcp-alive-${PROJECT_HASH}" "$TMP_HOME/trace-mcp-alive-${PROJECT_HASH}")
+STATUS_FILE=$(pick_path "$STATUS_HOME/trace-mcp-status-${PROJECT_HASH}.json" "$TMP_HOME/trace-mcp-status-${PROJECT_HASH}.json")
+BYPASS_FILE=$(pick_path "$STATUS_HOME/trace-mcp-bypass-${PROJECT_HASH}" "$TMP_HOME/trace-mcp-bypass-${PROJECT_HASH}")
+mkdir -p "$STATUS_HOME" 2>/dev/null || true
+# Per-session read ledger: written and read by this hook family only, all
+# spawned by the same client, so $TMPDIR is the right home for it.
+READS_DIR="$TMP_HOME/trace-mcp-reads-${SESSION_ID}"
 DENY_AGGREGATE_FILE="$READS_DIR/.deny-aggregate"
 mkdir -p "$READS_DIR" 2>/dev/null || true
 

--- a/hooks/trace-mcp-guard.sh
+++ b/hooks/trace-mcp-guard.sh
@@ -391,21 +391,56 @@ fi
 # trace-mcp exists to replace. $TMPDIR stays as the second choice so a server
 # installed before that fix is still found.
 TRACE_STATE_HOME="${TRACE_MCP_DATA_DIR:-$HOME/.trace}"
-case "$TRACE_STATE_HOME" in "~"/*) TRACE_STATE_HOME="$HOME/${TRACE_STATE_HOME#\~/}" ;; esac
+case "$TRACE_STATE_HOME" in
+  "~") TRACE_STATE_HOME="$HOME" ;;
+  "~"/*) TRACE_STATE_HOME="$HOME/${TRACE_STATE_HOME#\~/}" ;;
+esac
 STATUS_HOME="$TRACE_STATE_HOME/status"
 TMP_HOME="${TMPDIR:-/tmp}"
 
-# First path that exists; the state-home one when neither does, so anything this
-# hook writes itself (the auto-degradation bypass) lands in the shared location.
-pick_path() {
-  if [[ -e "$1" ]]; then echo "$1"; else echo "$2"; fi
+# Whichever of the two was touched most recently, so a sentinel left behind by a
+# crashed new server cannot mask a live old one still refreshing the $TMPDIR
+# copy — the freshest file is by definition the one a running server owns. The
+# state-home path when neither exists, so anything this hook writes itself lands
+# in the shared location.
+newest_path() {
+  if [[ -e "$1" && -e "$2" ]]; then
+    if (( $(file_mtime "$2") > $(file_mtime "$1") )); then echo "$2"; else echo "$1"; fi
+  elif [[ -e "$2" ]]; then
+    echo "$2"
+  else
+    echo "$1"
+  fi
 }
 
-CONSULTED_DIR=$(pick_path "$STATUS_HOME/trace-mcp-consulted-${PROJECT_HASH}" "$TMP_HOME/trace-mcp-consulted-${PROJECT_HASH}")
-HEARTBEAT_FILE=$(pick_path "$STATUS_HOME/trace-mcp-alive-${PROJECT_HASH}" "$TMP_HOME/trace-mcp-alive-${PROJECT_HASH}")
-STATUS_FILE=$(pick_path "$STATUS_HOME/trace-mcp-status-${PROJECT_HASH}.json" "$TMP_HOME/trace-mcp-status-${PROJECT_HASH}.json")
-BYPASS_FILE=$(pick_path "$STATUS_HOME/trace-mcp-bypass-${PROJECT_HASH}" "$TMP_HOME/trace-mcp-bypass-${PROJECT_HASH}")
+# Consultation markers are NOT resolved to one directory: an older server writes
+# them to $TMPDIR while a state-home directory from an earlier run may still be
+# on disk, and binding to either one alone denies a Read the agent did consult.
+# Both are searched on every lookup.
+CONSULTED_DIR="$STATUS_HOME/trace-mcp-consulted-${PROJECT_HASH}"
+CONSULTED_DIR_TMP="$TMP_HOME/trace-mcp-consulted-${PROJECT_HASH}"
+HEARTBEAT_FILE=$(newest_path "$STATUS_HOME/trace-mcp-alive-${PROJECT_HASH}" "$TMP_HOME/trace-mcp-alive-${PROJECT_HASH}")
+STATUS_FILE=$(newest_path "$STATUS_HOME/trace-mcp-status-${PROJECT_HASH}.json" "$TMP_HOME/trace-mcp-status-${PROJECT_HASH}.json")
+BYPASS_FILE=$(newest_path "$STATUS_HOME/trace-mcp-bypass-${PROJECT_HASH}" "$TMP_HOME/trace-mcp-bypass-${PROJECT_HASH}")
+# Written, not read: this hook's own auto-degradation bypass always goes to the
+# shared location so every reader sees it, whatever their $TMPDIR.
+BYPASS_WRITE_FILE="$STATUS_HOME/trace-mcp-bypass-${PROJECT_HASH}"
+BYPASS_FILE_TMP="$TMP_HOME/trace-mcp-bypass-${PROJECT_HASH}"
 mkdir -p "$STATUS_HOME" 2>/dev/null || true
+
+# True when a consultation marker for $1 exists in either directory.
+consulted_marker_exists() {
+  [[ -f "$CONSULTED_DIR/$1" || -f "$CONSULTED_DIR_TMP/$1" ]]
+}
+
+# True when either consultation directory holds at least one marker.
+any_consultation_markers() {
+  local d
+  for d in "$CONSULTED_DIR" "$CONSULTED_DIR_TMP"; do
+    [[ -d "$d" ]] && [[ -n "$(ls -A "$d" 2>/dev/null)" ]] && return 0
+  done
+  return 1
+}
 # Per-session read ledger: written and read by this hook family only, all
 # spawned by the same client, so $TMPDIR is the right home for it.
 READS_DIR="$TMP_HOME/trace-mcp-reads-${SESSION_ID}"
@@ -517,7 +552,7 @@ elif [[ -f "$BYPASS_FILE" ]]; then
     HEARTBEAT_REASON="trace-mcp guard manually bypassed (${REMAINING}s remaining); re-enable: bash scripts/trace-mcp-enable-guard.sh"
   else
     # Expired bypass — clean up so it doesn't accumulate.
-    rm -f "$BYPASS_FILE" 2>/dev/null || true
+    rm -f "$BYPASS_WRITE_FILE" "$BYPASS_FILE_TMP" 2>/dev/null || true
   fi
 fi
 
@@ -609,7 +644,7 @@ maybe_auto_degrade() {
   fi
   # If consultation markers exist for this project, the agent is reaching
   # trace-mcp successfully — don't auto-degrade.
-  if [[ -d "$CONSULTED_DIR" ]] && [[ -n "$(ls -A "$CONSULTED_DIR" 2>/dev/null)" ]]; then
+  if any_consultation_markers; then
     return
   fi
 
@@ -631,11 +666,11 @@ maybe_auto_degrade() {
   if (( count >= AUTO_DEGRADE_DENY_THRESHOLD )); then
     # Trip auto-degradation: write bypass sentinel with mtime in the future.
     local expiry=$((NOW + AUTO_DEGRADE_DURATION_SEC))
-    echo "auto-degraded" > "$BYPASS_FILE" 2>/dev/null || true
+    echo "auto-degraded" > "$BYPASS_WRITE_FILE" 2>/dev/null || true
     if command -v gtouch >/dev/null 2>&1; then
-      gtouch -d "@$expiry" "$BYPASS_FILE" 2>/dev/null || true
+      gtouch -d "@$expiry" "$BYPASS_WRITE_FILE" 2>/dev/null || true
     else
-      touch -t "$(date -r "$expiry" +%Y%m%d%H%M.%S 2>/dev/null || date -d "@$expiry" +%Y%m%d%H%M.%S 2>/dev/null)" "$BYPASS_FILE" 2>/dev/null || true
+      touch -t "$(date -r "$expiry" +%Y%m%d%H%M.%S 2>/dev/null || date -d "@$expiry" +%Y%m%d%H%M.%S 2>/dev/null)" "$BYPASS_WRITE_FILE" 2>/dev/null || true
     fi
     HEARTBEAT_DEAD=1
     HEARTBEAT_REASON="auto-degraded — ${count} denies / 0 consultation markers in window. trace-mcp MCP channel appears unresponsive. Auto-bypass for $((AUTO_DEGRADE_DURATION_SEC / 60))min; will re-arm on next consultation marker"
@@ -645,7 +680,7 @@ maybe_auto_degrade() {
 
 # Reset deny aggregate as soon as ANY consultation marker exists — that proves
 # the MCP channel is alive in this session.
-if [[ -d "$CONSULTED_DIR" ]] && [[ -n "$(ls -A "$CONSULTED_DIR" 2>/dev/null)" ]]; then
+if any_consultation_markers; then
   rm -f "$DENY_AGGREGATE_FILE" 2>/dev/null || true
 fi
 
@@ -746,7 +781,7 @@ if [[ "$TOOL_NAME" == "Read" ]]; then
     REL_PATH_FOR_HASH="$REL_PATH"
     CONSULTED_HASH=$(file_sha256 "$REL_PATH_FOR_HASH")
     HAS_MARKER=0
-    if [[ -n "$PROJECT_HASH" && -f "$CONSULTED_DIR/$CONSULTED_HASH" ]]; then
+    if [[ -n "$PROJECT_HASH" ]] && consulted_marker_exists "$CONSULTED_HASH"; then
       HAS_MARKER=1
     fi
 

--- a/packages/app/src/main/guard-control.ts
+++ b/packages/app/src/main/guard-control.ts
@@ -102,10 +102,27 @@ function sentinelPaths(name: string): [string, string] {
   return [path.join(statusDir(), name), path.join(os.tmpdir(), name)];
 }
 
-/** Whichever of the two exists; the state-home one when neither does. */
+/**
+ * Whichever of the two was touched most recently; the state-home one when
+ * neither exists. Newest rather than primary-first: a sentinel left behind by a
+ * crashed current server would otherwise mask an older server still refreshing
+ * the $TMPDIR copy, showing a live session as dead.
+ */
 function resolveSentinel(name: string): string {
   const [primary, legacy] = sentinelPaths(name);
-  return fs.existsSync(primary) ? primary : fs.existsSync(legacy) ? legacy : primary;
+  const mtime = (p: string): number => {
+    try {
+      return fs.statSync(p).mtimeMs;
+    } catch {
+      return Number.NEGATIVE_INFINITY;
+    }
+  };
+  const primaryAt = mtime(primary);
+  const legacyAt = mtime(legacy);
+  if (primaryAt === Number.NEGATIVE_INFINITY && legacyAt === Number.NEGATIVE_INFINITY) {
+    return primary;
+  }
+  return legacyAt > primaryAt ? legacy : primary;
 }
 
 function statusPath(projectRoot: string): string {
@@ -736,7 +753,13 @@ export function setBypass(projectRoot: string, minutes: number): void {
     } catch {
       /* not present */
     }
-    fs.writeFileSync(file, 'manual', { flag: 'wx', mode: 0o600 });
-    fs.utimesSync(file, future, future);
+    try {
+      fs.writeFileSync(file, 'manual', { flag: 'wx', mode: 0o600 });
+      fs.utimesSync(file, future, future);
+    } catch {
+      // One unwritable location must not cost the other: if the state home is
+      // read-only the $TMPDIR copy still reaches a hook that reads it, and the
+      // reverse holds too.
+    }
   }
 }

--- a/packages/app/src/main/guard-control.ts
+++ b/packages/app/src/main/guard-control.ts
@@ -2,8 +2,9 @@
  * Guard control — read trace-mcp guard status / mode for a project,
  * and toggle the per-project mode file.
  *
- * Status reader: parses $TMPDIR/trace-mcp-status-{projectHash}.json written
- * by the trace-mcp server (see src/server/heartbeat.ts).
+ * Status reader: parses <state home>/status/trace-mcp-status-{projectHash}.json
+ * written by the trace-mcp server (see src/server/heartbeat.ts), falling back
+ * to the $TMPDIR copy a pre-TRA-869 server wrote.
  *
  * Mode toggle: writes <projectRoot>/.trace-mcp/guard-mode (one of
  * "strict" | "coach" | "off"). The hook reads this file before each call.
@@ -76,16 +77,47 @@ function projectHash(projectRoot: string): string {
     .slice(0, 12);
 }
 
+/**
+ * Shared sentinel directory, mirroring STATUS_DIR in the CLI's src/global.ts.
+ * Duplicated rather than imported because this package does not depend on the
+ * CLI sources; keep the two in step.
+ *
+ * Not $TMPDIR: the server writes these files from a process the MCP client
+ * spawned, this app runs from one launchd started, and on macOS those hold
+ * different per-process $TMPDIR values — so the app read an empty directory and
+ * showed a live server as not running (TRA-869).
+ */
+function statusDir(): string {
+  const override = process.env.TRACE_MCP_DATA_DIR;
+  const home = override
+    ? override.startsWith('~')
+      ? path.join(os.homedir(), override.slice(1))
+      : override
+    : path.join(os.homedir(), '.trace');
+  return path.join(path.resolve(home), 'status');
+}
+
+/** State-home path first, $TMPDIR second (a server older than TRA-869). */
+function sentinelPaths(name: string): [string, string] {
+  return [path.join(statusDir(), name), path.join(os.tmpdir(), name)];
+}
+
+/** Whichever of the two exists; the state-home one when neither does. */
+function resolveSentinel(name: string): string {
+  const [primary, legacy] = sentinelPaths(name);
+  return fs.existsSync(primary) ? primary : fs.existsSync(legacy) ? legacy : primary;
+}
+
 function statusPath(projectRoot: string): string {
-  return path.join(os.tmpdir(), `trace-mcp-status-${projectHash(projectRoot)}.json`);
+  return resolveSentinel(`trace-mcp-status-${projectHash(projectRoot)}.json`);
 }
 
 function legacyHeartbeatPath(projectRoot: string): string {
-  return path.join(os.tmpdir(), `trace-mcp-alive-${projectHash(projectRoot)}`);
+  return resolveSentinel(`trace-mcp-alive-${projectHash(projectRoot)}`);
 }
 
 function bypassPath(projectRoot: string): string {
-  return path.join(os.tmpdir(), `trace-mcp-bypass-${projectHash(projectRoot)}`);
+  return resolveSentinel(`trace-mcp-bypass-${projectHash(projectRoot)}`);
 }
 
 function modeFile(projectRoot: string): string {
@@ -673,27 +705,38 @@ export function checkCliVersion(): CliVersionCheck {
 
 /** Toggle bypass on/off (writes the same sentinel as scripts/trace-mcp-disable-guard.sh). */
 export function setBypass(projectRoot: string, minutes: number): void {
-  const file = bypassPath(projectRoot);
+  // Both copies: the state-home one every current reader prefers, and the
+  // $TMPDIR one a hook installed before TRA-869 still looks at.
+  const files = sentinelPaths(`trace-mcp-bypass-${projectHash(projectRoot)}`);
   if (minutes <= 0) {
+    for (const file of files) {
+      try {
+        fs.unlinkSync(file);
+      } catch {
+        /* not present */
+      }
+    }
+    return;
+  }
+  try {
+    fs.mkdirSync(statusDir(), { recursive: true, mode: 0o700 });
+  } catch {
+    /* best-effort */
+  }
+  const future = new Date(Date.now() + minutes * 60_000);
+  for (const file of files) {
+    // The bypass sentinel lives at a predictable path in a shared directory,
+    // so a stat-then-write here would follow a symlink another user planted at
+    // that path. Unlink whatever is there first (unlink acts on the link
+    // itself, never the target) then create exclusively so we only ever write
+    // to a file we just created, with permissions restricted to the current
+    // user.
     try {
       fs.unlinkSync(file);
     } catch {
       /* not present */
     }
-    return;
+    fs.writeFileSync(file, 'manual', { flag: 'wx', mode: 0o600 });
+    fs.utimesSync(file, future, future);
   }
-  // The bypass sentinel lives at a predictable path in the shared OS temp
-  // dir, so a stat-then-write here would follow a symlink another user
-  // planted at that path. Unlink whatever is there first (unlink acts on
-  // the link itself, never the target) then create exclusively so we only
-  // ever write to a file we just created, with permissions restricted to
-  // the current user.
-  try {
-    fs.unlinkSync(file);
-  } catch {
-    /* not present */
-  }
-  fs.writeFileSync(file, 'manual', { flag: 'wx', mode: 0o600 });
-  const future = new Date(Date.now() + minutes * 60_000);
-  fs.utimesSync(file, future, future);
 }

--- a/scripts/trace-mcp-disable-guard.sh
+++ b/scripts/trace-mcp-disable-guard.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Manually disable the trace-mcp PreToolUse guard for the current project.
 #
-# Writes a bypass sentinel to $TMPDIR/trace-mcp-bypass-{projectHash} whose
+# Writes a bypass sentinel to <state home>/status/trace-mcp-bypass-{projectHash} whose
 # mtime is set N minutes into the future. The guard hook treats the sentinel
 # as valid until its mtime is reached, then ignores it (TTL).
 #
@@ -35,23 +35,33 @@ else
   exit 1
 fi
 
-BYPASS_FILE="${TMPDIR:-/tmp}/trace-mcp-bypass-${PROJECT_HASH}"
+# Sentinels live under the state home, not $TMPDIR — the guard hook that reads
+# this file runs in a different process with a different $TMPDIR (TRA-869).
+# The $TMPDIR copy is kept for hooks installed before that fix.
+TRACE_STATE_HOME="${TRACE_MCP_DATA_DIR:-$HOME/.trace}"
+case "$TRACE_STATE_HOME" in "~"/*) TRACE_STATE_HOME="$HOME/${TRACE_STATE_HOME#\~/}" ;; esac
+STATUS_HOME="$TRACE_STATE_HOME/status"
+mkdir -p "$STATUS_HOME" 2>/dev/null || true
+BYPASS_FILE="$STATUS_HOME/trace-mcp-bypass-${PROJECT_HASH}"
+BYPASS_FILE_TMP="${TMPDIR:-/tmp}/trace-mcp-bypass-${PROJECT_HASH}"
 
 if [[ "$MINUTES" -eq 0 ]]; then
-  rm -f "$BYPASS_FILE"
+  rm -f "$BYPASS_FILE" "$BYPASS_FILE_TMP"
   echo "trace-mcp guard re-enabled for: $PROJECT_ROOT"
   exit 0
 fi
 
 # Write the sentinel with mtime = now + MINUTES*60 seconds.
-echo "trace-mcp-bypass" > "$BYPASS_FILE"
 EXPIRY=$(( $(date +%s) + MINUTES * 60 ))
-if touch -t "$(date -r "$EXPIRY" +%Y%m%d%H%M.%S 2>/dev/null || date -d "@$EXPIRY" +%Y%m%d%H%M.%S)" "$BYPASS_FILE" 2>/dev/null; then
-  :
-else
-  # Fallback: BSD `touch -d @epoch` (macOS supports it via -t with formatted date)
-  touch -d "@$EXPIRY" "$BYPASS_FILE" 2>/dev/null || true
-fi
+for f in "$BYPASS_FILE" "$BYPASS_FILE_TMP"; do
+  echo "trace-mcp-bypass" > "$f" 2>/dev/null || continue
+  if touch -t "$(date -r "$EXPIRY" +%Y%m%d%H%M.%S 2>/dev/null || date -d "@$EXPIRY" +%Y%m%d%H%M.%S)" "$f" 2>/dev/null; then
+    :
+  else
+    # Fallback: BSD `touch -d @epoch` (macOS supports it via -t with formatted date)
+    touch -d "@$EXPIRY" "$f" 2>/dev/null || true
+  fi
+done
 
 EXPIRY_HUMAN=$(date -r "$EXPIRY" 2>/dev/null || date -d "@$EXPIRY" 2>/dev/null || echo "+${MINUTES} min")
 echo "trace-mcp guard DISABLED for ${MINUTES} minute(s) — until $EXPIRY_HUMAN"

--- a/scripts/trace-mcp-disable-guard.sh
+++ b/scripts/trace-mcp-disable-guard.sh
@@ -39,7 +39,10 @@ fi
 # this file runs in a different process with a different $TMPDIR (TRA-869).
 # The $TMPDIR copy is kept for hooks installed before that fix.
 TRACE_STATE_HOME="${TRACE_MCP_DATA_DIR:-$HOME/.trace}"
-case "$TRACE_STATE_HOME" in "~"/*) TRACE_STATE_HOME="$HOME/${TRACE_STATE_HOME#\~/}" ;; esac
+case "$TRACE_STATE_HOME" in
+  "~") TRACE_STATE_HOME="$HOME" ;;
+  "~"/*) TRACE_STATE_HOME="$HOME/${TRACE_STATE_HOME#\~/}" ;;
+esac
 STATUS_HOME="$TRACE_STATE_HOME/status"
 mkdir -p "$STATUS_HOME" 2>/dev/null || true
 BYPASS_FILE="$STATUS_HOME/trace-mcp-bypass-${PROJECT_HASH}"

--- a/scripts/trace-mcp-enable-guard.sh
+++ b/scripts/trace-mcp-enable-guard.sh
@@ -43,8 +43,16 @@ else
   exit 1
 fi
 
-BYPASS_FILE="${TMPDIR:-/tmp}/trace-mcp-bypass-${PROJECT_HASH}"
-rm -f "$BYPASS_FILE"
+# Sentinels live under the state home, not $TMPDIR — the guard hook that reads
+# this file runs in a different process with a different $TMPDIR (TRA-869).
+# The $TMPDIR copy is kept for hooks installed before that fix.
+TRACE_STATE_HOME="${TRACE_MCP_DATA_DIR:-$HOME/.trace}"
+case "$TRACE_STATE_HOME" in "~"/*) TRACE_STATE_HOME="$HOME/${TRACE_STATE_HOME#\~/}" ;; esac
+STATUS_HOME="$TRACE_STATE_HOME/status"
+mkdir -p "$STATUS_HOME" 2>/dev/null || true
+BYPASS_FILE="$STATUS_HOME/trace-mcp-bypass-${PROJECT_HASH}"
+BYPASS_FILE_TMP="${TMPDIR:-/tmp}/trace-mcp-bypass-${PROJECT_HASH}"
+rm -f "$BYPASS_FILE" "$BYPASS_FILE_TMP"
 echo "trace-mcp guard re-enabled for: $PROJECT_ROOT"
 
 # ─── Persist TRACE_MCP_ENFORCE in the hook env block ───────────────

--- a/scripts/trace-mcp-enable-guard.sh
+++ b/scripts/trace-mcp-enable-guard.sh
@@ -47,7 +47,10 @@ fi
 # this file runs in a different process with a different $TMPDIR (TRA-869).
 # The $TMPDIR copy is kept for hooks installed before that fix.
 TRACE_STATE_HOME="${TRACE_MCP_DATA_DIR:-$HOME/.trace}"
-case "$TRACE_STATE_HOME" in "~"/*) TRACE_STATE_HOME="$HOME/${TRACE_STATE_HOME#\~/}" ;; esac
+case "$TRACE_STATE_HOME" in
+  "~") TRACE_STATE_HOME="$HOME" ;;
+  "~"/*) TRACE_STATE_HOME="$HOME/${TRACE_STATE_HOME#\~/}" ;;
+esac
 STATUS_HOME="$TRACE_STATE_HOME/status"
 mkdir -p "$STATUS_HOME" 2>/dev/null || true
 BYPASS_FILE="$STATUS_HOME/trace-mcp-bypass-${PROJECT_HASH}"

--- a/src/global.ts
+++ b/src/global.ts
@@ -157,6 +157,24 @@ export const STATE_DB_PATH = path.join(TRACE_MCP_HOME, 'state.db');
 /** Per-project + per-operation PID lock files (see src/utils/pid-lock.ts). */
 export const LOCKS_DIR = path.join(TRACE_MCP_HOME, 'locks');
 
+/**
+ * Cross-process sentinel directory: heartbeat/status files, consultation
+ * markers, the guard bypass file — everything the MCP server writes for the
+ * guard hook and the desktop app to read.
+ *
+ * Deliberately NOT `$TMPDIR` (TRA-869). TMPDIR is per-process, not per-machine:
+ * the writer (an MCP server the client spawned) and the readers (the guard hook
+ * the agent harness spawns, the desktop app launchd starts) routinely hold
+ * different values — macOS defaults to a per-user `/var/folders/.../T`, and any
+ * task runner sets its own. Measured on a live machine: the server was writing
+ * `/var/folders/.../T/trace-mcp-alive-d1c1b6f267c7` and refreshing it every 5s
+ * while the hook looked in `/tmp/multica-task-.../` and reported "trace-mcp
+ * server not running" on every single call — so the guard degraded to allowing
+ * the Read/Grep fallback this product exists to replace, against a healthy,
+ * connected session.
+ */
+export const STATUS_DIR = path.join(TRACE_MCP_HOME, 'status');
+
 /** Default port the daemon listens on. */
 export const DEFAULT_DAEMON_PORT = 3741;
 

--- a/src/server/consultation-markers.ts
+++ b/src/server/consultation-markers.ts
@@ -2,25 +2,30 @@
  * Consultation markers — bridge between trace-mcp server and guard hook.
  *
  * When a trace-mcp tool accesses a file (get_outline, get_symbol, etc.),
- * a marker is written to /tmp/trace-mcp-consulted-{projectHash}/{fileHash}.
+ * a marker is written to trace-mcp-consulted-{projectHash}/{fileHash}.
  * The PreToolUse guard hook checks these markers: if a file has been
  * "consulted" via trace-mcp, Read is allowed immediately without denial.
  *
- * Markers are ephemeral (tmpdir) and scoped per project.
+ * Markers are scoped per project and written to two directories: STATUS_DIR
+ * under the state home (primary — the only path the hook and the server agree
+ * on, see TRA-869) and `$TMPDIR` (for hooks installed before that fix).
+ *
+ * ponytail: drop the $TMPDIR half once no supported release reads it.
  */
 
 import crypto from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
-import { projectHash } from '../global.js';
+import { projectHash, STATUS_DIR } from '../global.js';
 import { ensureTmpDirSync, writeTmpFileSync } from '../utils/safe-fs.js';
 
 function fileHash(filePath: string): string {
   return crypto.createHash('sha256').update(filePath).digest('hex');
 }
 
-function markerDir(projectRoot: string): string {
-  return path.join(os.tmpdir(), `trace-mcp-consulted-${projectHash(path.resolve(projectRoot))}`);
+function markerDirs(projectRoot: string): string[] {
+  const name = `trace-mcp-consulted-${projectHash(path.resolve(projectRoot))}`;
+  return [path.join(STATUS_DIR, name), path.join(os.tmpdir(), name)];
 }
 
 // Per-process dedup: markers are existence-only (empty files) and the guard
@@ -32,20 +37,22 @@ const _writtenMarkers = new Set<string>();
 
 /** Write a consultation marker for a file. Non-blocking, best-effort. */
 function markConsulted(projectRoot: string, relPath: string): void {
-  try {
-    const dir = markerDir(projectRoot);
-    const markerPath = path.join(dir, fileHash(relPath));
-    if (_writtenMarkers.has(markerPath)) return; // already marked this process
-    if (!_ensuredDirs.has(dir)) {
-      if (!ensureTmpDirSync(dir)) return; // squatted or unwritable — skip markers
-      _ensuredDirs.add(dir);
+  const name = fileHash(relPath);
+  for (const dir of markerDirs(projectRoot)) {
+    try {
+      const markerPath = path.join(dir, name);
+      if (_writtenMarkers.has(markerPath)) continue; // already marked this process
+      if (!_ensuredDirs.has(dir)) {
+        if (!ensureTmpDirSync(dir)) continue; // squatted or unwritable — skip markers
+        _ensuredDirs.add(dir);
+      }
+      writeTmpFileSync(markerPath, '');
+      // ponytail: bound the dedup set — clearing only costs one repeat write.
+      if (_writtenMarkers.size >= 50_000) _writtenMarkers.clear();
+      _writtenMarkers.add(markerPath);
+    } catch {
+      /* best-effort — never block tool execution */
     }
-    writeTmpFileSync(markerPath, '');
-    // ponytail: bound the dedup set — clearing only costs one repeat write.
-    if (_writtenMarkers.size >= 50_000) _writtenMarkers.clear();
-    _writtenMarkers.add(markerPath);
-  } catch {
-    /* best-effort — never block tool execution */
   }
 }
 

--- a/src/server/heartbeat.ts
+++ b/src/server/heartbeat.ts
@@ -1,14 +1,18 @@
 /**
  * Status sentinel — bridge between trace-mcp server and guard hook.
  *
- * Two files are written:
- *   1. $TMPDIR/trace-mcp-status-{projectHash}.json — rich JSON status
- *      with PID, last heartbeat, tool-call counters, last successful call
- *      timestamp, etc. Used by the v0.8+ hook for stall detection and by
- *      the desktop app for the project status badge.
- *   2. $TMPDIR/trace-mcp-alive-{projectHash} — legacy mtime-only sentinel,
- *      kept for backward compatibility with hook v0.7.x. Removed once all
- *      installations are on v0.8+.
+ * Two files are written, each into two directories:
+ *   1. trace-mcp-status-{projectHash}.json — rich JSON status with PID, last
+ *      heartbeat, tool-call counters, last successful call timestamp, etc.
+ *      Used by the v0.8+ hook for stall detection and by the desktop app for
+ *      the project status badge.
+ *   2. trace-mcp-alive-{projectHash} — legacy mtime-only sentinel, kept for
+ *      backward compatibility with hook v0.7.x.
+ *
+ * The primary location is {@link STATUS_DIR} under the state home, which every
+ * process resolves identically. The `$TMPDIR` copies are written only so a hook
+ * installed before TRA-869 keeps working; see STATUS_DIR for why $TMPDIR alone
+ * silently broke the channel.
  *
  * The hook treats a missing/stale status as "MCP unavailable" and falls
  * back to allowing Read with a warning instead of hard-blocking. This
@@ -25,7 +29,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { projectHash } from '../global.js';
+import { projectHash, STATUS_DIR } from '../global.js';
 import { writeTmpFileSync } from '../utils/safe-fs.js';
 
 /** Flush cadence while at least one MCP session is active. */
@@ -77,12 +81,65 @@ export interface HeartbeatHandle {
   readonly legacyPath: string;
 }
 
+function statusName(projectRoot: string): string {
+  return `trace-mcp-status-${projectHash(path.resolve(projectRoot))}.json`;
+}
+
+function heartbeatName(projectRoot: string): string {
+  return `trace-mcp-alive-${projectHash(path.resolve(projectRoot))}`;
+}
+
 function statusPath(projectRoot: string): string {
-  return path.join(os.tmpdir(), `trace-mcp-status-${projectHash(path.resolve(projectRoot))}.json`);
+  return path.join(STATUS_DIR, statusName(projectRoot));
 }
 
 function legacyHeartbeatPath(projectRoot: string): string {
-  return path.join(os.tmpdir(), `trace-mcp-alive-${projectHash(path.resolve(projectRoot))}`);
+  return path.join(STATUS_DIR, heartbeatName(projectRoot));
+}
+
+/**
+ * `$TMPDIR` copies of the two sentinels, for hooks installed before TRA-869.
+ * ponytail: drop this pair — and the dual write below — once no supported
+ * release reads $TMPDIR.
+ */
+function tmpdirSentinelPaths(projectRoot: string): [string, string] {
+  return [
+    path.join(os.tmpdir(), statusName(projectRoot)),
+    path.join(os.tmpdir(), heartbeatName(projectRoot)),
+  ];
+}
+
+/** Age after which a sentinel left behind by a crashed server is collected. */
+const STALE_SENTINEL_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Drop sentinels from servers that died without running `stop()`.
+ *
+ * `stop()` unlinks its own files, but a killed process never gets there. In
+ * $TMPDIR that never mattered — the OS reaps it — whereas STATUS_DIR lives
+ * under the state home and is never cleaned by anyone else, so one file per
+ * crashed server would accumulate there forever. Best-effort: a sweep that
+ * cannot read the directory is not worth failing a server start over.
+ */
+function sweepStaleSentinels(): void {
+  const cutoff = Date.now() - STALE_SENTINEL_MAX_AGE_MS;
+  let names: string[];
+  try {
+    names = fs.readdirSync(STATUS_DIR);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    if (!name.startsWith('trace-mcp-status-') && !name.startsWith('trace-mcp-alive-')) continue;
+    const full = path.join(STATUS_DIR, name);
+    try {
+      const st = fs.lstatSync(full);
+      if (!st.isFile() || st.mtimeMs > cutoff) continue;
+      fs.unlinkSync(full);
+    } catch {
+      /* vanished under us, or not ours — skip */
+    }
+  }
 }
 
 /**
@@ -96,6 +153,13 @@ export function startHeartbeat(
 ): HeartbeatHandle {
   const file = statusPath(projectRoot);
   const legacy = legacyHeartbeatPath(projectRoot);
+  const [tmpFile, tmpLegacy] = tmpdirSentinelPaths(projectRoot);
+  try {
+    fs.mkdirSync(STATUS_DIR, { recursive: true, mode: 0o700 });
+  } catch {
+    /* best-effort — flush() below is already failure-tolerant */
+  }
+  sweepStaleSentinels();
   const startedAt = new Date().toISOString();
 
   const state: StatusState = {
@@ -119,12 +183,20 @@ export function startHeartbeat(
 
   const flush = () => {
     state.last_heartbeat_at = new Date().toISOString();
+    const payload = JSON.stringify(state);
+    const stamp = String(Date.now());
     try {
-      writeTmpFileSync(file, JSON.stringify(state));
+      writeTmpFileSync(file, payload);
       // Touch legacy sentinel for old hook installations.
-      writeTmpFileSync(legacy, String(Date.now()));
+      writeTmpFileSync(legacy, stamp);
     } catch {
       /* best-effort */
+    }
+    try {
+      writeTmpFileSync(tmpFile, payload);
+      writeTmpFileSync(tmpLegacy, stamp);
+    } catch {
+      /* best-effort — pre-TRA-869 readers only */
     }
   };
 
@@ -175,15 +247,12 @@ export function startHeartbeat(
     },
     stop() {
       clearInterval(timer);
-      try {
-        fs.unlinkSync(file);
-      } catch {
-        /* best-effort */
-      }
-      try {
-        fs.unlinkSync(legacy);
-      } catch {
-        /* best-effort */
+      for (const p of [file, legacy, tmpFile, tmpLegacy]) {
+        try {
+          fs.unlinkSync(p);
+        } catch {
+          /* best-effort */
+        }
       }
     },
   };

--- a/src/server/heartbeat.ts
+++ b/src/server/heartbeat.ts
@@ -113,13 +113,30 @@ function tmpdirSentinelPaths(projectRoot: string): [string, string] {
 const STALE_SENTINEL_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
+ * Everything STATUS_DIR holds, and nothing else: the sweep below deletes by
+ * this list, so an unrelated file a user dropped in there is never touched.
+ * `trace-mcp-consulted-` is a directory, the other three are files.
+ */
+const SWEPT_SENTINEL_PREFIXES = [
+  'trace-mcp-status-',
+  'trace-mcp-alive-',
+  'trace-mcp-bypass-',
+  'trace-mcp-consulted-',
+];
+
+/**
  * Drop sentinels from servers that died without running `stop()`.
  *
  * `stop()` unlinks its own files, but a killed process never gets there. In
  * $TMPDIR that never mattered — the OS reaps it — whereas STATUS_DIR lives
- * under the state home and is never cleaned by anyone else, so one file per
- * crashed server would accumulate there forever. Best-effort: a sweep that
- * cannot read the directory is not worth failing a server start over.
+ * under the state home and is never cleaned by anyone else, so every crashed
+ * server, every project ever opened and every expired bypass would accumulate
+ * there forever. Best-effort: a sweep that cannot read the directory is not
+ * worth failing a server start over.
+ *
+ * mtime, not age-since-creation: a live server rewrites its sentinel every 5s
+ * and a bypass carries a future mtime while it is in force, so neither can be
+ * collected while it still means something.
  */
 function sweepStaleSentinels(): void {
   const cutoff = Date.now() - STALE_SENTINEL_MAX_AGE_MS;
@@ -130,12 +147,13 @@ function sweepStaleSentinels(): void {
     return;
   }
   for (const name of names) {
-    if (!name.startsWith('trace-mcp-status-') && !name.startsWith('trace-mcp-alive-')) continue;
+    if (!SWEPT_SENTINEL_PREFIXES.some((p) => name.startsWith(p))) continue;
     const full = path.join(STATUS_DIR, name);
     try {
       const st = fs.lstatSync(full);
-      if (!st.isFile() || st.mtimeMs > cutoff) continue;
-      fs.unlinkSync(full);
+      if (st.isSymbolicLink() || st.mtimeMs > cutoff) continue;
+      if (st.isDirectory()) fs.rmSync(full, { recursive: true, force: true });
+      else if (st.isFile()) fs.unlinkSync(full);
     } catch {
       /* vanished under us, or not ours — skip */
     }

--- a/tests/hooks/guard.test.ts
+++ b/tests/hooks/guard.test.ts
@@ -333,6 +333,41 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-guard.sh v0.7', () => {
     expect(decision.allowed).toBe(false);
   });
 
+  // A crashed current server leaves its state-home sentinel behind. Preferring
+  // the state home unconditionally would then hide an older server that is
+  // still refreshing the $TMPDIR copy, and report a live session as stale.
+  it('prefers the fresher sentinel when a stale state-home one is left over', () => {
+    const stale = setHeartbeatAliveInStateHome(projectDir);
+    const past = new Date(Date.now() - 120_000);
+    fs.utimesSync(stale, past, past);
+    setHeartbeatAlive(projectDir); // live, in $TMPDIR, as an older server writes it
+    const file = path.join(projectDir, 'fresher-wins.ts');
+    fs.writeFileSync(file, 'export {};');
+    const decision = runGuard('Read', { file_path: file }, sessionId, projectDir);
+    expect(decision.context ?? '').not.toContain('stale');
+    expect(decision.allowed).toBe(false);
+  });
+
+  it('finds a consultation marker in $TMPDIR even when the state-home dir exists', () => {
+    // An older server marks in $TMPDIR while an empty state-home directory
+    // lingers from an earlier run — the marker must still count.
+    fs.mkdirSync(
+      path.join(
+        stateStatusDir as string,
+        `trace-mcp-consulted-${projectHash(fs.realpathSync(projectDir))}`,
+      ),
+      {
+        recursive: true,
+      },
+    );
+    const file = path.join(projectDir, 'legacy-marker.ts');
+    fs.writeFileSync(file, 'export {};');
+    runGuard('Read', { file_path: file }, sessionId, projectDir);
+    runGuard('Read', { file_path: file }, sessionId, projectDir); // BLOCKED #2
+    writeConsultationMarker(projectDir, 'legacy-marker.ts');
+    expect(runGuard('Read', { file_path: file }, sessionId, projectDir).allowed).toBe(true);
+  });
+
   it('allows Read with warning when heartbeat is stale', () => {
     setHeartbeatStale(projectDir);
     const file = path.join(projectDir, 'fallback2.ts');

--- a/tests/hooks/guard.test.ts
+++ b/tests/hooks/guard.test.ts
@@ -8,6 +8,15 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 const HOOK_SCRIPT = path.resolve('hooks/trace-mcp-guard.sh');
 const TMP_BASE = fs.realpathSync(os.tmpdir());
 
+/**
+ * Where a current server writes its sentinels: the state home, not $TMPDIR.
+ * Mirrors STATUS_DIR in src/global.ts — the two processes must agree on this
+ * path without agreeing on their environments (TRA-869).
+ */
+const stateStatusDir = process.env.TRACE_MCP_DATA_DIR
+  ? path.join(path.resolve(process.env.TRACE_MCP_DATA_DIR), 'status')
+  : null;
+
 interface HookDecision {
   allowed: boolean;
   reason?: string;
@@ -69,6 +78,19 @@ function runGuard(
     reason: hookOut.permissionDecisionReason,
     context: hookOut.additionalContext,
   };
+}
+
+/**
+ * Write the heartbeat sentinel where a current server writes it: the state
+ * home, not $TMPDIR. Returns the sentinel path.
+ */
+function setHeartbeatAliveInStateHome(cwd: string): string {
+  const dir = stateStatusDir;
+  if (!dir) throw new Error('test setup must isolate TRACE_MCP_DATA_DIR');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `trace-mcp-alive-${projectHash(fs.realpathSync(cwd))}`);
+  fs.writeFileSync(file, String(Date.now()));
+  return file;
 }
 
 /** Simulate a live trace-mcp server: write a fresh heartbeat sentinel for `cwd`. */
@@ -175,6 +197,12 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-guard.sh v0.7', () => {
   });
 
   afterEach(() => {
+    // State-home sentinels outlive the $TMPDIR ones — the state home is shared
+    // by every test in this file, so a leftover here would make the next test's
+    // "server is dead" setup silently see a live server.
+    if (stateStatusDir && fs.existsSync(stateStatusDir)) {
+      fs.rmSync(stateStatusDir, { recursive: true, force: true });
+    }
     const readsDir = path.join(TMP_BASE, `trace-mcp-reads-${sessionId}`);
     if (fs.existsSync(readsDir)) fs.rmSync(readsDir, { recursive: true, force: true });
     if (fs.existsSync(projectDir)) {
@@ -286,6 +314,23 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-guard.sh v0.7', () => {
     const decision = runGuard('Read', { file_path: file }, sessionId, projectDir);
     expect(decision.allowed).toBe(true);
     expect(decision.context).toContain('not running');
+  });
+
+  // TRA-869: the writer (server, spawned by the MCP client) and this reader
+  // (hook, spawned by the agent harness) do not share $TMPDIR. Observed live:
+  // the server refreshed /var/folders/.../T/trace-mcp-alive-<hash> every 5s
+  // while the hook looked in /tmp/multica-task-<id>/ and degraded every call.
+  it("finds the sentinel in the state home when $TMPDIR differs from the server's", () => {
+    fs.rmSync(heartbeatFile, { force: true });
+    setHeartbeatAliveInStateHome(projectDir);
+    const foreignTmp = fs.mkdtempSync(path.join(TMP_BASE, 'guard-foreign-tmp-'));
+    const file = path.join(projectDir, 'cross-tmpdir.ts');
+    fs.writeFileSync(file, 'export {};');
+    const decision = runGuard('Read', { file_path: file }, sessionId, projectDir, {
+      TMPDIR: foreignTmp,
+    });
+    expect(decision.context ?? '').not.toContain('not running');
+    expect(decision.allowed).toBe(false);
   });
 
   it('allows Read with warning when heartbeat is stale', () => {

--- a/tests/server/consultation-markers.test.ts
+++ b/tests/server/consultation-markers.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { projectHash } from '../../src/global.js';
+import { projectHash, STATUS_DIR } from '../../src/global.js';
 import {
   __resetConsultationMarkersForTests,
   markToolConsultation,
@@ -11,8 +11,17 @@ import {
 
 const TEST_ROOT = path.join(os.tmpdir(), `trace-mcp-test-consultation-${process.pid}`);
 
+function markerDirName(): string {
+  return `trace-mcp-consulted-${projectHash(path.resolve(TEST_ROOT))}`;
+}
+
 function getMarkerDir(): string {
-  return path.join(os.tmpdir(), `trace-mcp-consulted-${projectHash(path.resolve(TEST_ROOT))}`);
+  return path.join(os.tmpdir(), markerDirName());
+}
+
+/** Where a current server writes markers — see STATUS_DIR (TRA-869). */
+function getStateHomeMarkerDir(): string {
+  return path.join(STATUS_DIR, markerDirName());
 }
 
 function fileHash(filePath: string): string {
@@ -20,18 +29,29 @@ function fileHash(filePath: string): string {
 }
 
 afterEach(() => {
-  // Clean up marker files
-  const dir = getMarkerDir();
-  try {
-    fs.rmSync(dir, { recursive: true, force: true });
-  } catch {
-    /* may not exist */
+  // Clean up marker files — both locations the server writes.
+  for (const dir of [getMarkerDir(), getStateHomeMarkerDir()]) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* may not exist */
+    }
   }
   // Reset the per-process dedup caches so the next test re-creates the wiped dir.
   __resetConsultationMarkersForTests();
 });
 
 describe('markToolConsultation', () => {
+  // TRA-869: the guard hook reads these markers from a process that does not
+  // share the server's $TMPDIR, so a marker written only there is invisible and
+  // the guard denies a Read the agent already consulted trace-mcp about.
+  it('writes the marker under the state home as well as $TMPDIR', () => {
+    markToolConsultation(TEST_ROOT, 'get_outline', { path: 'src/cross-tmpdir.ts' });
+    const name = fileHash('src/cross-tmpdir.ts');
+    expect(fs.existsSync(path.join(getStateHomeMarkerDir(), name))).toBe(true);
+    expect(fs.existsSync(path.join(getMarkerDir(), name))).toBe(true);
+  });
+
   describe('file extraction from tool params', () => {
     it('marks file from get_outline path param', () => {
       markToolConsultation(TEST_ROOT, 'get_outline', { path: 'src/server.ts' });

--- a/tests/server/heartbeat.test.ts
+++ b/tests/server/heartbeat.test.ts
@@ -33,6 +33,41 @@ describe('status sentinel (heartbeat)', () => {
     }
   });
 
+  // TRA-869: the sentinel is a channel between two processes that do NOT share
+  // $TMPDIR — the server is spawned by the MCP client, the guard hook by the
+  // agent harness. Writing it only to os.tmpdir() made the hook report "server
+  // not running" against a live session and fall back to Read/Grep.
+  it('writes the sentinels under the state home, not only $TMPDIR', () => {
+    const stateHome = process.env.TRACE_MCP_DATA_DIR;
+    expect(stateHome, 'test setup must isolate the state home').toBeTruthy();
+    const handle = startHeartbeat(projectDir);
+    try {
+      const statusDir = path.join(path.resolve(stateHome as string), 'status');
+      expect(handle.path.startsWith(statusDir)).toBe(true);
+      expect(handle.legacyPath.startsWith(statusDir)).toBe(true);
+      expect(fs.existsSync(handle.path)).toBe(true);
+      expect(fs.existsSync(handle.legacyPath)).toBe(true);
+    } finally {
+      handle.stop();
+    }
+  });
+
+  it('still writes the $TMPDIR copies a pre-TRA-869 hook reads', () => {
+    const real = fs.realpathSync(projectDir);
+    const tmpStatus = path.join(TMP_BASE, `trace-mcp-status-${projectHash(real)}.json`);
+    const tmpLegacy = path.join(TMP_BASE, `trace-mcp-alive-${projectHash(real)}`);
+    const handle = startHeartbeat(projectDir);
+    try {
+      expect(fs.existsSync(tmpStatus)).toBe(true);
+      expect(fs.existsSync(tmpLegacy)).toBe(true);
+    } finally {
+      handle.stop();
+    }
+    // stop() clears both locations, so a stopped server never looks alive.
+    expect(fs.existsSync(tmpStatus)).toBe(false);
+    expect(fs.existsSync(tmpLegacy)).toBe(false);
+  });
+
   it('writes a JSON status file with required fields', () => {
     const handle = startHeartbeat(projectDir);
     try {


### PR DESCRIPTION
## The failure

The guard hook reported `trace-mcp server not running (no heartbeat sentinel)` on **every** tool call of a session whose MCP server was connected and healthy — so it degraded to allowing the Read/Grep fallback the product exists to replace, and the agent lost the routing that makes trace-mcp worth running.

Reproduced live, not hypothesised. At the same moment, on the same machine:

```
# what the server was writing, refreshed every 5s
/var/folders/dz/.../T/trace-mcp-status-d1c1b6f267c7.json
  {"schema":2,"pid":62977,"transport":"stdio","last_heartbeat_at":"2026-09-05T02:07:01.806Z",
   "mcp_sessions_active":1}

# where the hook looked
$TMPDIR=/tmp/multica-task-2899753741
/tmp/multica-task-2899753741/trace-mcp-alive-d1c1b6f267c7   → does not exist
```

`claude mcp list` said `trace-mcp: ✔ Connected` throughout.

## Root cause

Four cross-process channels were addressed through `os.tmpdir()` / `${TMPDIR:-/tmp}`:

| file | writer | reader |
|---|---|---|
| `trace-mcp-status-<hash>.json` | MCP server | guard hook, desktop app |
| `trace-mcp-alive-<hash>` | MCP server | guard hook, desktop app |
| `trace-mcp-consulted-<hash>/` | MCP server | guard hook |
| `trace-mcp-bypass-<hash>` | desktop app, `trace-mcp-disable-guard.sh` | guard hook |

`$TMPDIR` is per-process. The writer and the readers are never the same process — the server is spawned by the MCP client, the hook by the agent harness, the app by launchd — and on macOS the default is a per-user `/var/folders/.../T` path that any task runner, CI job or wrapper overrides. Whenever the two differ the channel is silently one-way-dead: no error, no log line, just a sentinel nobody finds.

## The fix

Sentinels move to `<state home>/status/` (`$TRACE_MCP_DATA_DIR` or `~/.trace`), which every process resolves identically without agreeing on its environment.

- `src/global.ts` — new `STATUS_DIR`.
- `src/server/heartbeat.ts`, `src/server/consultation-markers.ts` — write there, and keep writing the `$TMPDIR` copies so a hook installed before this change still works.
- `hooks/trace-mcp-guard.sh` (v0.16), `hooks/trace-mcp-guard.cmd` — read the state home first, `$TMPDIR` second, so a server older than this change is still found. Both skew directions work.
- `packages/app/src/main/guard-control.ts` — same fallback order; `setBypass` writes both copies.
- `scripts/trace-mcp-{disable,enable}-guard.sh` — same.
- `stop()` clears both locations, and `STATUS_DIR` gets a 7-day sweep for sentinels of servers killed before `stop()` — unlike `$TMPDIR`, nothing else ever cleans it.

The `$TMPDIR` half is marked `ponytail:` for removal once no supported release reads it.

No MCP tool signature, on-disk schema or token-budget change.

## Tests

Three regression tests, each failing before the fix:

- `tests/hooks/guard.test.ts` — the hook finds the sentinel in the state home while running with a `$TMPDIR` different from the writer's, and enforces instead of degrading. Verified red against the pre-fix hook (`expected false to be true` at the degradation assertion), green after.
- `tests/server/heartbeat.test.ts` — sentinels land under the state home; the `$TMPDIR` copies are still written and both are removed on `stop()`.
- `tests/server/consultation-markers.test.ts` — markers are written to both locations.

```
Test Files  907 passed | 5 skipped (912)
     Tests  10093 passed | 24 skipped (10117)
```

`tsc --noEmit` clean for the root package and `packages/app`; `pnpm run build` succeeds.

## Also checked, and not a bug

The launcher's swap-window fallback (`probe_cli` serving `dist/cli.js` out of a `trace-mcp.tmcp-bak-*` / `.trace-mcp-*` directory an update is about to `rm -rf`) looked like a mid-session kill: the bundle keeps 195 runtime deps, native `.node` bindings and `dist/extract-worker.js` in that directory. Tested it — cloned the installed package into a backup-shaped directory, drove a real stdio MCP session from it, deleted the directory underneath the running server, then called `get_project_map`, `load_tools`, `get_feature_context`, `search` and `get_index_health`, with the daemon both enabled and disabled. Every call succeeded and the process stayed up. The hypothesis does not reproduce; the fallback is safe as written.
