### PR TITLE
docs: guard the searchable name after the trace rename (TRA-879)

### DIFF
--- a/ops/rename-to-trace.md
+++ b/ops/rename-to-trace.md
@@ -115,6 +115,60 @@ This decision needs no browser login, no purchase, no paid listing edit, no
 domain and no registry re-identification. The batched ask for Nikolai that
 TRA-644 anticipated is **empty** — that is the result, not an omission.
 
+## First-party confirmation: the string is the traffic (added 2026-09-05, TRA-879)
+
+The table above decided the domain, the package and the on-page titles on the
+argument that we have no index coverage to spend. GSC now says something
+stronger — those surfaces are not merely cheap to keep, they are the entire
+funnel.
+
+Search Analytics, `sc-domain:trace-mcp.com`, 2026-08-06 → 2026-09-04:
+
+| Query | Impressions | Clicks | Avg position |
+|---|---|---|---|
+| `trace-mcp` | 89 | 24 | 1.5 |
+| `trace mcp` | 38 | 17 | 1.4 |
+| `trayce mcp` | 10 | 1 | 3.1 |
+| `"codegraphcontext"` | 2 | 2 | 1.5 |
+| `traceix mcp` | 61 | 0 | 6.0 |
+| `mcp tracing` | 54 | 0 | 13.7 |
+| everything else (10 queries) | ~21 | 0 | — |
+
+53 clicks total. 41 (77%) from the two exact strings `trace-mcp` / `trace mcp`,
+44 (83%) from some spelling of the name. **Zero** from any query describing what
+the product does — nothing containing "code graph", "context", "token" or
+"MCP server for…" earned a click.
+
+The two largest impression sources are both name collisions we already lose:
+`traceix mcp` (61 impressions, position 6.0) is a different product with the
+same prefix, and `mcp tracing` (54 impressions, position 13.7) is the
+observability category. 115 impressions, no clicks — and that is what the
+late-August impression spike was made of (10–20/day → 48 on 08-29 → 93 on
+09-02, clicks flat at 2–3, CTR ~15% → 2.2%). More impressions here is not
+growth.
+
+So `-mcp` is doing load-bearing work in the SERP: it is the token that
+disambiguates us from `traceix` and from tracing/observability, *and we are
+losing both collisions while still carrying it*. Dropping it from anything
+searchable removes the disambiguator from the only string that converts.
+
+Nothing in the disposition table changes — this is the confirmation, not a
+revision. What changes is that the three surfaces are now guarded in CI rather
+than by this document alone: `tests/docs/searchable-name.test.ts` fails if
+`site.title`, `site.url`, the home page `<title>`/`og:title`, the JSON-LD
+Organization/WebSite `name`, the npm `name`/`mcpName`/`homepage`, the
+`server.json` identity or the `trace-mcp` bin loses the string. A rename sweep
+that reaches them now breaks the build instead of the funnel.
+
+**PLAUSIBLE, not confirmed:** that a rename would cost clicks — a name cannot
+be A/B tested. Confirmed is that 100% of current clicks depend on the current
+string and that a semantically adjacent name already collides badly in this
+same SERP. No independent search-volume figure for `trace` vs `trace-mcp`
+(DataForSEO was unreachable on that runtime); GSC is first-party and enough for
+the claim above.
+
+*Measured by the SEO Agent autopilot, TRA-876 → TRA-879.*
+
 ## If someone reopens this
 
 The two facts that close it are checkable in under a minute and should be

--- a/tests/docs/searchable-name.test.ts
+++ b/tests/docs/searchable-name.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The literal string `trace-mcp` is the only thing the site ranks for.
+ *
+ * GSC Search Analytics for `sc-domain:trace-mcp.com`, 2026-08-06 → 2026-09-04:
+ * 53 clicks total, 41 of them (77%) on the exact queries `trace-mcp` and
+ * `trace mcp` at average position 1.5. Zero clicks came from any descriptive
+ * query. Meanwhile `traceix mcp` (61 impressions) and `mcp tracing` (54)
+ * returned no clicks at all — the `-mcp` suffix is what keeps us apart from
+ * a same-prefix product and from the observability category.
+ *
+ * `ops/rename-to-trace.md` therefore decided: the domain, the npm package,
+ * the registry identity and the on-page titles keep `trace-mcp`; only the CLI
+ * verb and the MCP server key become `trace`. This test is that boundary's
+ * guard — a rename sweep that reaches these strings would remove 100% of the
+ * site's organic entry points silently, with no test failing. (TRA-879)
+ */
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const read = (p: string) => readFileSync(join(REPO_ROOT, p), 'utf-8');
+
+describe('the searchable name stays trace-mcp', () => {
+  it('site title, url and description carry it', () => {
+    const config = read('docs/_config.yml');
+    expect(config).toMatch(/^title: trace-mcp$/m);
+    expect(config).toMatch(/^url: https:\/\/trace-mcp\.com$/m);
+    // jekyll-seo-tag renders `<title>{page.title} | {site.title}</title>`, so
+    // site.title above is what puts the string on every page but the home page.
+    expect(config).toMatch(/^description:.*\btrace-mcp\b/m);
+  });
+
+  it('the home page title and og:title carry it', () => {
+    const index = read('docs/index.html');
+    expect(index).toMatch(/<title>[^<]*trace-mcp[^<]*<\/title>/);
+    expect(index).toMatch(/property="og:title" content="[^"]*trace-mcp[^"]*"/);
+  });
+
+  it('the JSON-LD entity anchor names it', () => {
+    const layout = read('docs/_layouts/default.html');
+    const names = [
+      ...layout.matchAll(/"@type": "(Organization|WebSite)",\s*"@id":[^}]*?"name": "([^"]+)"/g),
+    ];
+    expect(names.map((m) => m[2])).toEqual(['trace-mcp', 'trace-mcp']);
+  });
+
+  it('the package and registry identity stay trace-mcp', () => {
+    const pkg = JSON.parse(read('package.json'));
+    expect(pkg.name).toBe('trace-mcp');
+    // `trace` is taken on npm and the registry name is what directories key on.
+    expect(pkg.mcpName).toBe('io.github.nikolai-vysotskyi/trace-mcp');
+    expect(pkg.homepage).toBe('https://trace-mcp.com');
+    expect(JSON.parse(read('server.json')).name).toBe('io.github.nikolai-vysotskyi/trace-mcp');
+    // The unambiguous bin name stays installed forever (/usr/bin/trace collision).
+    expect(Object.keys(pkg.bin)).toContain('trace-mcp');
+  });
+});


### PR DESCRIPTION
## What

GSC Search Analytics for `sc-domain:trace-mcp.com`, 2026-08-06 → 2026-09-04: **53 clicks, 41 (77%) from the exact queries `trace-mcp` / `trace mcp`** at average position 1.5, and **zero** from any query describing what the product does. The two largest impression sources are name collisions we already lose *while still carrying `-mcp`*: `traceix mcp` (61 impressions, position 6.0, 0 clicks) and `mcp tracing` (54 impressions, position 13.7, 0 clicks).

That confirms — first-party, for the first time — the boundary `ops/rename-to-trace.md` already decided: `trace` is the command, `trace-mcp` is the project, and nothing searchable changes.

- `ops/rename-to-trace.md` — new "First-party confirmation" section with the query table and what it does/doesn't claim. No disposition changes; this is evidence, not a revision.
- `tests/docs/searchable-name.test.ts` — CI guard on the strings the decision depends on: `site.title`/`site.url`/`site.description`, the home page `<title>` and `og:title`, the JSON-LD Organization/WebSite `name`, `package.json` `name`/`mcpName`/`homepage`, `server.json` identity, and the `trace-mcp` bin entry. Previously nothing failed if a rename sweep removed them.

## Test evidence

- `pnpm vitest run tests/docs` → 18 files, 230 passed, 4 skipped.
- Mutation-checked the guard: setting `title: trace` in `_config.yml` and `"name": "trace"` in the layout's JSON-LD fails 2 of the 4 assertions; reverted.
- `pnpm lint` / `pnpm typecheck` / `pnpm format:check` clean.

Closes TRA-879.