### PR TITLE
test(indexer): stop the crash-loop dedup case from running the idle timer

### DIFF
--- a/src/indexer/__tests__/extract-pool-crash-loop.test.ts
+++ b/src/indexer/__tests__/extract-pool-crash-loop.test.ts
@@ -172,7 +172,11 @@ describe('ExtractPool — crash-loop guard', () => {
     // only the dedup path, not the disable path.
     for (let i = 0; i < 4; i++) {
       internals.onError(0, new Error('MODULE_NOT_FOUND: extract-worker.js'));
-      vi.runAllTimers();
+      // Advance by this crash's own backoff (200ms doubling, 3s in total)
+      // rather than runAllTimers(): since TRA-811 the pool also arms a
+      // 5-minute keepAlive idle-teardown timer, and running it would push the
+      // fake clock past the 5s dedup window this case is about.
+      vi.advanceTimersByTime(200 * 2 ** i);
     }
 
     // First crash logs a full error with err+stack; subsequent identical


### PR DESCRIPTION
master is red: `src/indexer/__tests__/extract-pool-crash-loop.test.ts` > 'dedups identical errors' fails on 2972aeee and on every PR branched from it (reproduced locally on a clean `origin/master` checkout).

Cause is test-side, not product-side. TRA-811 (#874) gave `ExtractPool` a 5-minute keepAlive idle-teardown timer. The case drives four identical crashes with `vi.runAllTimers()` between them; that now runs the idle timer too and advances the fake clock five minutes, past the 5s `DEDUP_SUMMARY_INTERVAL_MS`, so every crash flushed a summary warn and `expect(warnSpy).not.toHaveBeenCalled()` failed.

Fix advances by each crash's own backoff (200ms doubling, 3s total — inside the dedup window) instead of draining every pending timer. No change to `extract-pool.ts`.

`pnpm vitest run src/indexer/__tests__/extract-pool-crash-loop.test.ts` → 7/7 (was 6/7).