### PR TITLE
docs(init): route agents to the SKILL.state tools (TRA-884)

### DIFF
--- a/src/init/ide-rules.ts
+++ b/src/init/ide-rules.ts
@@ -35,6 +35,7 @@ const TOOL_ROUTING_POLICY = `IMPORTANT: For ANY code exploration task, ALWAYS us
 | DB model relationships | \`get_model_context\` (framework-gated) | reading model + migration files |
 | Component tree | \`get_component_tree\` (framework-gated) | reading component files |
 | Circular dependencies | \`get_circular_imports\` | manual tracing |
+| Task spanning many turns | \`trace_state_init\` once, then \`trace_state_patch\` / \`trace_state_add_dead_end\` per step, \`trace_state_get\` to re-read (deferred — \`load_tools({preset:"state"})\`) | re-reading the whole transcript every turn |
 
 Start sessions with \`get_project_map\` (summary_only=true) to get project overview.
 Use built-in file reading ONLY for non-code files (.md, .json, .yaml, config) or before editing.`;

--- a/src/init/md-block.ts
+++ b/src/init/md-block.ts
@@ -61,6 +61,7 @@ IMPORTANT: For ANY code exploration task, ALWAYS use trace tools first. NEVER us
 | DB model relationships | \`get_model_context\` (framework-gated) | reading model + migrations |
 | Component tree | \`get_component_tree\` (framework-gated) | reading component files |
 | Circular dependencies | \`get_circular_imports\` | manual tracing |
+| Task spanning many turns | \`trace_state_init\` once, then \`trace_state_patch\` / \`trace_state_add_dead_end\` per step, \`trace_state_get\` to re-read (deferred — \`load_tools({preset:"state"})\`) | re-reading the whole transcript every turn |
 
 Use Read/Grep/Glob ONLY for non-code files (.md, .json, .yaml, config) or before Edit.
 Start sessions with \`get_project_map\` (summary_only=true).

--- a/tests/init/state-routing.test.ts
+++ b/tests/init/state-routing.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { installCursorRules } from '../../src/init/ide-rules.js';
+import { TRACE_ROUTING_BLOCK } from '../../src/init/md-block.js';
+
+/**
+ * The state tools (TRA-596) are deferred behind `load_tools`, so the generated
+ * routing files are the only thing that tells an agent they exist. Two
+ * generators write those files and they drift independently — this pins the
+ * SKILL.state row into both.
+ */
+describe('SKILL.state routing', () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const mustRoute = (text: string) => {
+    expect(text).toContain('trace_state_init');
+    expect(text).toContain('trace_state_patch');
+    expect(text).toContain('trace_state_get');
+    // Deferred outside `full`/`state`, so the escalation call has to be named
+    // alongside the tools or the row points at something unreachable.
+    expect(text).toContain('load_tools({preset:"state"})');
+  };
+
+  it('names the state tools in the CLAUDE.md / AGENTS.md block', () => {
+    mustRoute(TRACE_ROUTING_BLOCK);
+  });
+
+  it('names the state tools in the Cursor/Windsurf rules', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-state-routing-'));
+    tmpDirs.push(dir);
+
+    const result = installCursorRules(dir, {});
+    expect(result.action).toBe('created');
+    mustRoute(fs.readFileSync(result.target, 'utf-8'));
+  });
+});


### PR DESCRIPTION
## What

Adds one row to the tool-routing block that `trace init` writes into `CLAUDE.md` / `AGENTS.md` (`src/init/md-block.ts`) and into `.cursor/rules/trace.mdc` / `.windsurfrules` (`src/init/ide-rules.ts`), naming the SKILL.state tools and the `load_tools({preset:"state"})` call that pulls them in.

## Why

TRA-596 shipped the state engine and TRA-600 measured it on real traces: median **67.25% billed-token saving** across 30 sessions (`docs/_data/state_replay_bench.json`). But:

- the `trace_state_*` tools are members of the `state` and `full` presets only (`src/tools/project/presets.ts:124`), and the shipped default is `minimal` (`src/server/tool-filter.ts:57`);
- `docs/SKILL_STATE.md` documents that correctly and `load_tools` makes them one call away, so they are **reachable**;
- but the generated routing files — the only mechanism that gets an agent to call trace tools at all, and the only one that reaches non-Claude-Code clients — did not mention them anywhere.

Reachable and undiscoverable at the same time. This is the smallest change that closes it: no preset membership changes, no new tools advertised by default, ~60 tokens added to a file the agent reads once per session.

## Test evidence

New `tests/init/state-routing.test.ts` pins the row into **both** generators (they drift independently) and asserts the escalation call is named alongside the tools, so the row can never point at something the session cannot reach.

```
pnpm test --run tests/init src/init
  Test Files  18 passed | 1 skipped (19)
  Tests  275 passed | 5 skipped (280)

pnpm run build   ✅
pnpm run lint    ✅ (tsc --noEmit)
```

## Contract / budget

No MCP tool signature, schema or DB change. No change to the advertised tool surface for any preset — token cost is the added markdown row only.

Refs TRA-884, TRA-596.
