### PR TITLE
test(manifests): anchor the PR-benchmark exemption to the claim, not its neighbourhood (TRA-883)

### DIFF
--- a/ops/distribution.md
+++ b/ops/distribution.md
@@ -376,8 +376,6 @@ we do not own. `server.json`, `package.json` and `plugin.json` still said
 backwards for the surface it is on: the README is read by people who then read
 the rest of the README, while these three strings are rendered verbatim by
 every registry that ingests us and by npm, with no room to qualify anything.
-The tokenomics review (PR #53 above) made the same point from the outside —
-what convinced that maintainer was evidence we did not produce ourselves.
 
 All three now lead with the measured number. Two things worth keeping:
 

--- a/ops/distribution.md
+++ b/ops/distribution.md
@@ -39,7 +39,7 @@ Rules for keeping it honest:
 | Surface | Listed | What it shows | How to change it | Verified |
 |---|---|---|---|---|
 | [davila7/claude-code-templates](https://github.com/davila7/claude-code-templates) / [aitmpl.com](https://www.aitmpl.com/component/trace-mcp) | **Yes — and it is the largest surface we are on: 30,531★ / 3,459 forks, pushed daily** | `cli-tool/components/mcps/devtools/trace-mcp.json`, mirrored verbatim into `dashboard/public/component-content/mcps/devtools/trace-mcp.json` (same string, wrapped in a `content` field — both must be edited together). Ships `npx -y trace-mcp@latest` and a hand-typed description. **Already stale again**: it says "80 languages", `counts.yml` says 81 — six days after the refresh that was supposed to fix exactly this | **The entry is ours, not a third-party scrape.** Both commits are Nikolai's: [#553](https://github.com/davila7/claude-code-templates/commit/8b18c46f) 2026-04-29 added it, [#844](https://github.com/davila7/claude-code-templates/commit/bb0c681c) 2026-08-29 refreshed the counts. PRs are the route and two have been merged, so the door is open — but see the note below before spending a run on it. It hardcodes the npm name in `args`, so it belongs on the TRA-644 rename checklist; fold the 80→81 fix into that same PR rather than opening one for a digit | 2026-09-05 |
-| [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) | Yes — `io.github.nikolai-vysotskyi/trace-mcp` | Current: 3.15.0, published 2026-09-03, `status: active`, matching npm `latest` | Automatic: `.github/workflows/publish-mcp-registry.yml` republishes `server.json` on every release (GitHub OIDC, no secret). **This row is now more than one listing.** `modelcontextprotocol/servers` already redirects here, mcp.so and smithery ingest it, and as of 2026-09-02 goose retires its own 59-entry directory in favour of it too. The `description` field in `server.json` is therefore the copy those surfaces render, not just ours — see TRA-761 | 2026-09-04 |
+| [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) | Yes — `io.github.nikolai-vysotskyi/trace-mcp` | Current: 3.15.0, published 2026-09-03, `status: active`, matching npm `latest`. **The `description` it renders was rewritten 2026-09-05 (TRA-883)** and lands with the next release, not with the merge — see the one-liner section below | Automatic: `.github/workflows/publish-mcp-registry.yml` republishes `server.json` on every release (GitHub OIDC, no secret). **This row is now more than one listing.** `modelcontextprotocol/servers` already redirects here, mcp.so and smithery ingest it, and as of 2026-09-02 goose retires its own 59-entry directory in favour of it too. The `description` field in `server.json` is therefore the copy those surfaces render, not just ours — see TRA-761 | 2026-09-04 |
 | [glama.ai](https://glama.ai/mcp/servers/nikolai-vysotskyi/trace-mcp) | Yes | Correct — scrapes README/npm live | Nothing to do; fix the README and it follows. Renders 31 links to `trace-mcp.com` and rewrites every one to `rel="ugc nofollow"` — see TRA-792 below | 2026-09-04 |
 | [pulsemcp.com](https://www.pulsemcp.com/servers/nikolai-vysotskyi-trace) | Yes | **Stale: "44+ tools"** — their hand-written `server.json`, kept "until the maintainer publishes to the official registry" | Their submissions are **paused**; their own submit page says publishing to the official registry is the fix. Done 2026-08-29 — waiting on their next sync | 2026-08-29 |
 | [mcpservers.org](https://mcpservers.org/servers/nikolai-vysotskyi/trace-mcp) | Yes | Body correct; **header stale**: "53 framework integrations across 68 languages, 100+ tools" | Free form at `/submit` (no account, needs a contact email). Correction submitted 2026-08-29, review ≤12h — but it said "80 languages … up to 99% fewer tokens", and master has since moved to 81 languages and (TRA-904, 2026-09-05) to the PR-benchmark headline, so re-submit once it lands. Premium $39 — declined | 2026-08-29 |
@@ -366,6 +366,35 @@ do not hand-type the number into a submission form. It is generated into
 `docs/_data/pr_context_bench.json` by `scripts/bench-pr-context.ts` and guarded
 by `tests/docs/readme-claims.test.ts` — same discipline as
 `docs/_data/counts.yml`.
+
+**The one-liner every directory renders was still on our weakest number, six
+days after the strongest one landed** (TRA-883, 2026-09-05). README and the
+homepage moved to the PR-context benchmark on 2026-09-02 — 90.6% fewer input
+tokens to review a pull request, median over 60 merged PRs in six repositories
+we do not own. `server.json`, `package.json` and `plugin.json` still said
+"40–50% fewer tokens on average", our own aggregate over our own usage. That is
+backwards for the surface it is on: the README is read by people who then read
+the rest of the README, while these three strings are rendered verbatim by
+every registry that ingests us and by npm, with no room to qualify anything.
+The tokenomics review (PR #53 above) made the same point from the outside —
+what convinced that maintainer was evidence we did not produce ourselves.
+
+All three now lead with the measured number. Two things worth keeping:
+
+- **The honesty guard was blocking it.** `tests/plugin/manifest-sync.test.ts`
+  refused any `9x%` + tokens claim on the install surfaces (TRA-393, when they
+  advertised "up to 99% token reduction"). 90.6% is not that: it is a median,
+  not a peak, and it is measured off our own machines. The guard now admits a
+  `9x%` claim **only** when the number equals `median_savings_pct` in
+  `docs/_data/pr_context_bench.json` and the surrounding text names what was
+  measured; a bare "90.6% fewer tokens" still fails. Do not widen it further.
+- **The number is pinned to the data file**, so regenerating the benchmark
+  fails CI with the number to write, the same discipline `counts.yml` gets.
+  Never hand-type it into a submission form either.
+
+`server.json` is capped at 100 characters by the registry schema, so its version
+is compressed to "Framework-aware code graph: 81 languages, 87 frameworks, 90.6%
+less PR context (60-PR benchmark)" (96). The method lives at `websiteUrl`.
 
 **TRA-263's "165 tools" is stale.** `docs/_data/counts.yml` says 169 and the
 README already agreed. TRA-346's "141 schema-carrying tools" answers a different

--- a/ops/distribution.md
+++ b/ops/distribution.md
@@ -39,7 +39,7 @@ Rules for keeping it honest:
 | Surface | Listed | What it shows | How to change it | Verified |
 |---|---|---|---|---|
 | [davila7/claude-code-templates](https://github.com/davila7/claude-code-templates) / [aitmpl.com](https://www.aitmpl.com/component/trace-mcp) | **Yes — and it is the largest surface we are on: 30,531★ / 3,459 forks, pushed daily** | `cli-tool/components/mcps/devtools/trace-mcp.json`, mirrored verbatim into `dashboard/public/component-content/mcps/devtools/trace-mcp.json` (same string, wrapped in a `content` field — both must be edited together). Ships `npx -y trace-mcp@latest` and a hand-typed description. **Already stale again**: it says "80 languages", `counts.yml` says 81 — six days after the refresh that was supposed to fix exactly this | **The entry is ours, not a third-party scrape.** Both commits are Nikolai's: [#553](https://github.com/davila7/claude-code-templates/commit/8b18c46f) 2026-04-29 added it, [#844](https://github.com/davila7/claude-code-templates/commit/bb0c681c) 2026-08-29 refreshed the counts. PRs are the route and two have been merged, so the door is open — but see the note below before spending a run on it. It hardcodes the npm name in `args`, so it belongs on the TRA-644 rename checklist; fold the 80→81 fix into that same PR rather than opening one for a digit | 2026-09-05 |
-| [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) | Yes — `io.github.nikolai-vysotskyi/trace-mcp` | Current: 3.15.0, published 2026-09-03, `status: active`, matching npm `latest`. **The `description` it renders was rewritten 2026-09-05 (TRA-883)** and lands with the next release, not with the merge — see the one-liner section below | Automatic: `.github/workflows/publish-mcp-registry.yml` republishes `server.json` on every release (GitHub OIDC, no secret). **This row is now more than one listing.** `modelcontextprotocol/servers` already redirects here, mcp.so and smithery ingest it, and as of 2026-09-02 goose retires its own 59-entry directory in favour of it too. The `description` field in `server.json` is therefore the copy those surfaces render, not just ours — see TRA-761 | 2026-09-04 |
+| [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) | Yes — `io.github.nikolai-vysotskyi/trace-mcp` | Current: 3.15.0, published 2026-09-03, `status: active`, matching npm `latest`. **The `description` it renders was rewritten 2026-09-05 (TRA-904)** and lands with the next release, not with the merge — see the one-liner section below | Automatic: `.github/workflows/publish-mcp-registry.yml` republishes `server.json` on every release (GitHub OIDC, no secret). **This row is now more than one listing.** `modelcontextprotocol/servers` already redirects here, mcp.so and smithery ingest it, and as of 2026-09-02 goose retires its own 59-entry directory in favour of it too. The `description` field in `server.json` is therefore the copy those surfaces render, not just ours — see TRA-761 | 2026-09-04 |
 | [glama.ai](https://glama.ai/mcp/servers/nikolai-vysotskyi/trace-mcp) | Yes | Correct — scrapes README/npm live | Nothing to do; fix the README and it follows. Renders 31 links to `trace-mcp.com` and rewrites every one to `rel="ugc nofollow"` — see TRA-792 below | 2026-09-04 |
 | [pulsemcp.com](https://www.pulsemcp.com/servers/nikolai-vysotskyi-trace) | Yes | **Stale: "44+ tools"** — their hand-written `server.json`, kept "until the maintainer publishes to the official registry" | Their submissions are **paused**; their own submit page says publishing to the official registry is the fix. Done 2026-08-29 — waiting on their next sync | 2026-08-29 |
 | [mcpservers.org](https://mcpservers.org/servers/nikolai-vysotskyi/trace-mcp) | Yes | Body correct; **header stale**: "53 framework integrations across 68 languages, 100+ tools" | Free form at `/submit` (no account, needs a contact email). Correction submitted 2026-08-29, review ≤12h — but it said "80 languages … up to 99% fewer tokens", and master has since moved to 81 languages and (TRA-904, 2026-09-05) to the PR-benchmark headline, so re-submit once it lands. Premium $39 — declined | 2026-08-29 |
@@ -367,32 +367,36 @@ do not hand-type the number into a submission form. It is generated into
 by `tests/docs/readme-claims.test.ts` — same discipline as
 `docs/_data/counts.yml`.
 
-**The one-liner every directory renders was still on our weakest number, six
-days after the strongest one landed** (TRA-883, 2026-09-05). README and the
-homepage moved to the PR-context benchmark on 2026-09-02 — 90.6% fewer input
-tokens to review a pull request, median over 60 merged PRs in six repositories
-we do not own. `server.json`, `package.json` and `plugin.json` still said
-"40–50% fewer tokens on average", our own aggregate over our own usage. That is
-backwards for the surface it is on: the README is read by people who then read
-the rest of the README, while these three strings are rendered verbatim by
-every registry that ingests us and by npm, with no room to qualify anything.
+**The one-liner every directory renders is the widest surface we have, and it
+was the last to get the corrected number** (TRA-883 / TRA-904, 2026-09-05).
+`server.json`, `package.json` and `plugin.json` are rendered verbatim by every
+registry that ingests us and by npm, with no room to qualify anything, and they
+were still on "40–50% fewer tokens on average" — the figure TRA-880 showed was
+never a measurement — days after the storefront had moved. TRA-904 (#935)
+rewrote all three; TRA-883 reached the same conclusion independently the same
+day and its PR was rebased onto that copy rather than competing with it. Two
+runs finding the same thing on the same day is worth one note here: the install
+surfaces are nobody's home page, so they lag every wording change unless a guard
+makes them fail.
 
-All three now lead with the measured number. Two things worth keeping:
+What survives from TRA-883 is that guard, and the three ways of writing it that
+do not work. `tests/plugin/manifest-sync.test.ts` bans a `9x%` token claim on
+the install surfaces (TRA-393, when they advertised "up to 99% token
+reduction"), and the PR-context median has to be exempted from it. Every
+exemption keyed to the *text around* the claim was broken in review:
 
-- **The honesty guard was blocking it.** `tests/plugin/manifest-sync.test.ts`
-  refused any `9x%` + tokens claim on the install surfaces (TRA-393, when they
-  advertised "up to 99% token reduction"). 90.6% is not that: it is a median,
-  not a peak, and it is measured off our own machines. The guard now admits a
-  `9x%` claim **only** when the number equals `median_savings_pct` in
-  `docs/_data/pr_context_bench.json` and the surrounding text names what was
-  measured; a bare "90.6% fewer tokens" still fails. Do not widen it further.
-- **The number is pinned to the data file**, so regenerating the benchmark
-  fails CI with the number to write, the same discipline `counts.yml` gets.
-  Never hand-type it into a submission form either.
+- a neighbourhood of N characters crosses JSON fields and sentences, so an
+  unrelated "pull request" in the next field excused a bare number;
+- a per-sentence split still lets one claim shield another across a semicolon,
+  a comma or a conjunction, in either order;
+- plain span containment lets a whole peak claim hide inside the gap the
+  approved phrase itself allows.
 
-`server.json` is capped at 100 characters by the registry schema, so its version
-is compressed to "Framework-aware code graph: 81 languages, 87 frameworks, 90.6%
-less PR context (60-PR benchmark)" (96). The method lives at `websiteUrl`.
+What holds: list the approved phrasings, each of which **starts** at the
+measured percentage, and exempt a claim only when it sits inside one of those
+spans *and* the single percentage it carries is that anchor. "Contains 90.6%"
+is weaker still — a nested second copy satisfies it. **Qualify a match, never a
+region.** Eleven negative cases are pinned; do not widen it back.
 
 **TRA-263's "165 tools" is stale.** `docs/_data/counts.yml` says 169 and the
 README already agreed. TRA-346's "141 schema-carrying tools" answers a different

--- a/tests/plugin/manifest-sync.test.ts
+++ b/tests/plugin/manifest-sync.test.ts
@@ -151,38 +151,122 @@ describe('install-surface token claims stay honest', () => {
     'skills/README.md',
   ];
 
+  // Both orders — "99% fewer tokens" and "token usage by 99%" — and decimals.
+  // "token" alone is too narrow: "92%+ reduction on typical projects" never
+  // says the word, and that was the live defect on docs/tools-reference.md.
+  const pct = String.raw`9\d(?:\.\d+)?\s*%`;
+  const noun = 'tokens?|reduction|savings|fewer|less';
+  const claimPattern = new RegExp(`${pct}\\+?[^"]{0,40}?(?:${noun})|(?:${noun})[^"]{0,40}?${pct}`);
+
+  // TRA-904: one 9x% number IS defensible on an install surface — the PR review
+  // context benchmark, measured with a tokenizer on 60 merged PRs in repositories
+  // we do not own, generated into docs/_data/pr_context_bench.json. It is allowed
+  // only where the surface says which task it measures.
+  //
+  // TRA-883: that exemption has to be anchored to the claim, and three weaker
+  // versions were killed in review before this one — each is a negative test
+  // below. A neighbourhood of N characters crosses JSON fields and sentences; a
+  // per-sentence split still lets one claim shield another across a semicolon or
+  // a conjunction; plain span containment lets a peak claim hide inside the gap
+  // the approved phrase allows. What survives: list the approved phrasings, each
+  // of which STARTS at the measured percentage, and exempt a claim only when it
+  // sits inside one of those spans and the single percentage it carries is that
+  // anchor. "Contains 90.6%" is weaker still — a nested second copy satisfies it.
+  // Anything that qualifies a region rather than a match has this bug.
+  const measuredPct = String(PR_BENCH.median_savings_pct).replace('.', String.raw`\.`);
+  const approvedPhrasings = [
+    // package.json / plugin.json: the npm page has room for the whole sentence.
+    new RegExp(`${measuredPct}%\\s*(?:fewer|less)\\s*input tokens[^.]{0,60}?pull request`, 'gi'),
+    // server.json: the registry caps the description at 100 characters, so the
+    // claim names the task in the shortest form that still names it.
+    new RegExp(`${measuredPct}%\\s*(?:fewer|less)\\s*PR[ -](?:review tokens|context)`, 'gi'),
+  ];
+
+  function unqualifiedClaims(text: string): string[] {
+    const approved = approvedPhrasings.flatMap((pattern) =>
+      [...text.matchAll(pattern)].map((m) => ({ from: m.index, to: m.index + m[0].length })),
+    );
+    return [...text.matchAll(new RegExp(claimPattern.source, 'gi'))]
+      .filter((claim) => {
+        const percentages = [...claim[0].matchAll(new RegExp(pct, 'gi'))].map(
+          (m) => claim.index + m.index,
+        );
+        return !approved.some(
+          ({ from, to }) =>
+            claim.index >= from &&
+            claim.index + claim[0].length <= to &&
+            percentages.length === 1 &&
+            percentages[0] === from,
+        );
+      })
+      .map((claim) => claim[0]);
+  }
+
   for (const path of surfaces) {
     it(`${path} does not claim 9x% fewer tokens`, () => {
       const text = readFileSync(join(REPO_ROOT, ...path.split('/')), 'utf8');
-      // Both orders — "99% fewer tokens" and "token usage by 99%" — and decimals.
-      // "token" alone is too narrow: "92%+ reduction on typical projects" never
-      // says the word, and that was the live defect on docs/tools-reference.md.
-      const pct = String.raw`9\d(?:\.\d+)?\s*%`;
-      const noun = 'tokens?|reduction|savings|fewer|less';
-      const claim = text.match(
-        new RegExp(`${pct}\\+?[^"]{0,40}?(?:${noun})|(?:${noun})[^"]{0,40}?${pct}`, 'i'),
-      );
-      // TRA-904: one 9x% number IS defensible on an install surface — the PR
-      // review context benchmark, measured with a tokenizer on 60 merged PRs in
-      // repositories we do not own, generated into docs/_data/pr_context_bench.json.
-      // It is allowed only when the surface says which task it measures; the ban
-      // on selling benchmark_project's synthetic ceiling as a headline stands.
-      // Qualified *beside* the number, not anywhere in the file: docs/tools-reference.md
-      // says "PR impact report" 240 lines away, which would have excused a bare
-      // "90.6% fewer tokens" at the top of the page.
-      const at = claim ? text.indexOf(claim[0]) : -1;
-      const nearby = claim ? text.slice(Math.max(0, at - 60), at + claim[0].length + 60) : '';
-      const measuredPr =
-        claim?.[0].includes(`${PR_BENCH.median_savings_pct}%`) &&
-        /\bPR\b|pull request/i.test(nearby);
       expect(
-        measuredPr ? undefined : claim?.[0],
+        unqualifiedClaims(text)[0],
         `${path} advertises a peak token number as if it were the average. The measured ` +
           `aggregate is ${RESPONSE.reduction_pct}% (docs/_data/response_tokens.json); 99% is ` +
           '"less redundant processing" on structured calls, from a synthetic estimator.',
       ).toBeUndefined();
     });
   }
+
+  // The exemption's own regression tests: every bypass found in review on PR #914.
+  it.each([
+    ['bare claim', '{"description":"90.6% fewer tokens"}'],
+    [
+      'qualifier in a neighbouring JSON field',
+      '{"description":"90.6% fewer tokens","unrelated":"Pull request support is configured elsewhere"}',
+    ],
+    [
+      'qualifier in the next sentence',
+      '90.6% fewer tokens. Separately, this plugin can summarize a pull request.',
+    ],
+    ['peak claim beside a qualified one', 'Up to 99% fewer tokens. 90.6% fewer PR-review tokens.'],
+    [
+      'two claims across a semicolon',
+      'Up to 99% fewer tokens; separately, 90.6% fewer PR-review tokens.',
+    ],
+    [
+      'two claims across a conjunction',
+      'Up to 99% fewer tokens, while the benchmark reports 90.6% fewer PR-review tokens.',
+    ],
+    [
+      'peak claim after the qualified one',
+      '90.6% fewer PR-review tokens, but up to 99% fewer tokens everywhere else.',
+    ],
+    [
+      'peak claim swallowed by the approved span, semicolon',
+      '90.6% fewer input tokens; up to 99% fewer tokens per pull request',
+    ],
+    [
+      'peak claim swallowed by the approved span, dashes',
+      '90.6% fewer input tokens — 99% fewer tokens — to review a pull request',
+    ],
+    [
+      'peak claim swallowed by the approved span, apposition',
+      '90.6% fewer input tokens, including 99% savings, to review a pull request',
+    ],
+    [
+      'nested second copy of the measured number',
+      '90.6% fewer input tokens, 90.6% savings elsewhere, to review a pull request',
+    ],
+  ])('rejects a 9x%% claim that is not itself the measured wording (%s)', (_name, text) => {
+    expect(unqualifiedClaims(text).length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    ['server.json', 'Code intelligence for agents: 177 tools, 90.6% fewer PR-review tokens'],
+    [
+      'package.json',
+      'Framework-aware code intelligence MCP server — 90.6% fewer input tokens to review a pull request',
+    ],
+  ])('admits the measured median where the claim itself names the task (%s)', (_name, text) => {
+    expect(unqualifiedClaims(text)).toEqual([]);
+  });
 });
 
 describe('Codex CLI plugin manifests', () => {


### PR DESCRIPTION
## What this is now

This branch opened by rewriting `server.json` / `package.json` / `plugin.json` to the measured PR-context number. **TRA-904 (#935) landed that same rewrite on master the same day**, so the copy change is gone from this diff — the branch is rebased onto master's wording and no longer touches the three manifests.

What remains is the guard that keeps the exemption honest, hardened over four review rounds.

## The guard

`tests/plugin/manifest-sync.test.ts` bans a `9x%` token claim on the install surfaces (TRA-393, when they advertised "up to 99% token reduction"), and the PR-context median has to be exempted from it. Master's exemption keys on a 60-character neighbourhood and a non-global `match()`. Review confirmed three separate bypasses in that shape:

- a character neighbourhood crosses JSON fields and sentences — an unrelated `"pull request"` in the next field excuses a bare `90.6% fewer tokens`;
- a per-sentence split still lets one claim shield another across a `;`, a comma or a conjunction, in either order (`90.6% less PR context, but up to 99% fewer tokens everywhere else`);
- plain span containment lets a whole peak claim hide in the gap the approved phrase allows (`90.6% fewer input tokens; up to 99% fewer tokens per pull request`).

**What holds:** list the approved phrasings, each of which *starts* at the measured percentage; exempt a claim only when it sits inside one of those spans **and** the single percentage it carries is that anchor. Every other `9x%` in the text is judged on its own — including a nested second copy of `90.6%`, which a "contains the measured number" check would let through.

11 negative cases pinned, plus two positives on master's real `server.json` / `package.json` wording.

## Ledger

`ops/distribution.md` records that TRA-904 landed the copy, that two runs found the same thing the same day, and the rule the guard has to follow: qualify a match, never a region.

## Checks

- `vitest run tests/plugin/manifest-sync.test.ts` — 42 passed
- `vitest run tests/docs/savings-claims.test.ts tests/docs/readme-claims.test.ts` — 92 passed, 4 skipped
- `tsc --noEmit`, `biome check` — clean