### PR TITLE
perf(savings): score token savings against the measured response, not a constant (TRA-880)

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -14,6 +14,9 @@ noindex: true
 Machine-readable history lives in [`baseline.json`](./baseline.json) — append one `runs[]`
 entry per measurement pass, never rewrite an old one. This file is the human summary.
 
+Related measurements in this directory: [daemon idle memory](./daemon-idle-memory.md),
+[tool response token cost](./response-tokens.md).
+
 ## Current numbers (3.17.0, `121e3e9b`, darwin 25.5.0 / arm64, median of 3)
 
 Taken 2026-09-04, 30 minutes / 574 cycles / 0 cycle errors, offscreen. First pass since the

--- a/docs/perf/response-tokens.json
+++ b/docs/perf/response-tokens.json
@@ -1,0 +1,102 @@
+{
+  "measured_at": "2026-09-05T08:05:50.130Z",
+  "target": "self",
+  "rows": [
+    {
+      "tool": "search_text",
+      "ok": true,
+      "chars": 6190,
+      "est": 1780,
+      "real": 1659,
+      "ms": 104
+    },
+    {
+      "tool": "get_outline",
+      "ok": true,
+      "chars": 4288,
+      "est": 1233,
+      "real": 1056,
+      "ms": 5
+    },
+    {
+      "tool": "search",
+      "ok": true,
+      "chars": 3278,
+      "est": 943,
+      "real": 921,
+      "ms": 27
+    },
+    {
+      "tool": "get_symbol",
+      "ok": true,
+      "chars": 1189,
+      "est": 342,
+      "real": 294,
+      "ms": 5
+    },
+    {
+      "tool": "find_usages",
+      "ok": true,
+      "chars": 4817,
+      "est": 1385,
+      "real": 1122,
+      "ms": 4
+    },
+    {
+      "tool": "get_project_map",
+      "ok": true,
+      "chars": 2100,
+      "est": 604,
+      "real": 568,
+      "ms": 257
+    },
+    {
+      "tool": "get_index_health",
+      "ok": true,
+      "chars": 979,
+      "est": 282,
+      "real": 298,
+      "ms": 3
+    },
+    {
+      "tool": "get_tests_for",
+      "ok": true,
+      "chars": 271,
+      "est": 78,
+      "real": 66,
+      "ms": 7
+    },
+    {
+      "tool": "get_context_bundle",
+      "ok": true,
+      "chars": 454,
+      "est": 131,
+      "real": 127,
+      "ms": 3
+    },
+    {
+      "tool": "get_task_context",
+      "ok": true,
+      "chars": 21432,
+      "est": 6162,
+      "real": 6086,
+      "ms": 10
+    },
+    {
+      "tool": "get_call_graph",
+      "ok": true,
+      "chars": 21192,
+      "est": 6093,
+      "real": 5165,
+      "ms": 4
+    },
+    {
+      "tool": "get_complexity_report",
+      "ok": true,
+      "chars": 6863,
+      "est": 1974,
+      "real": 1820,
+      "ms": 4
+    }
+  ]
+}

--- a/docs/perf/response-tokens.md
+++ b/docs/perf/response-tokens.md
@@ -70,10 +70,23 @@ Three things the table says:
 ## The fix
 
 `SavingsTracker.recordActualTokens(tool, tokens)` corrects the pre-call guess once
-the response exists; the gate calls it on the normal, dedup and duplicate-warning
-paths with the count it already computed for the journal. Guarded in
-`tests/tools/savings.test.ts` — including the case that used to be silent, a
-response bigger than its baseline crediting zero rather than a fat positive.
+the response exists. `recordCall` stays where it is, before the tool runs, because
+budget clamping and dedup both read the session totals first — this is a two-phase
+estimate-then-reconcile, not a move.
+
+Four things the correction has to get right, all found in review and guarded in
+`tests/tools/savings.test.ts`:
+
+- **A response bigger than its baseline credits zero**, not a fat positive.
+- **A failed call credits zero** (`recordFailedCall`). Scored as payload, a 4-token
+  error from `get_task_context` would have booked 7 996 saved — more than any real
+  answer to the same call. Applies to error responses and to throws alike.
+- **`batch` is corrected too.** It dispatches handlers directly and never goes
+  through the gate, so every batched call would otherwise have kept the guess.
+- **Measured last, on the wire bytes.** `enrichResponse` adds fields and
+  `applyWireFormat` can re-encode into a denser format; measuring before either
+  books a number the client never receives. An empty response is a measured zero,
+  not a missing one.
 
 ## What is still an estimate, and what to do next
 

--- a/docs/perf/response-tokens.md
+++ b/docs/perf/response-tokens.md
@@ -1,0 +1,90 @@
+---
+layout: default
+title: Tool response token cost
+permalink: /perf/response-tokens/
+description: Internal working document. What trace-mcp tool responses actually cost in tokens.
+noindex: true
+---
+
+# Tool response token cost
+
+Measured 2026-09-05 on darwin 25.5.0 / arm64, trace-mcp 3.17.1 (`f9645147`), against
+trace-mcp's own repo (2 144 files, 11 134 symbols) over a real stdio `tools/call`
+round-trip. TRA-880. Reproduce with:
+
+```
+pnpm run build && npx tsx scripts/bench-response-tokens.ts [repoPath]
+```
+
+Token column is a real `o200k_base` count of the response text, not an estimate.
+Call volume is this machine's `~/.trace/savings.json` (20 187 calls since the store
+was created) — real usage, one machine.
+
+## What was wrong
+
+The *advertised surface* side of the token story has been measured and guarded for
+weeks (`preset-surface-budget.test.ts`). The *response* side never was.
+
+`src/savings.ts` scored a call before the tool ran: `recordCall(name)` took a
+hand-written `RAW_COST_ESTIMATES[name]`, multiplied it by a flat
+`COMPRESSION_RATIO = 0.15`, and booked the difference as saved. The gate
+(`src/server/tool-gate-helpers.ts`) was the only caller and never passed a real
+count. So `tokens_saved` was **`calls x constant`** — arithmetically confirmable in
+the store: 5 123 `search_text` calls, 13 063 650 saved, exactly 2 550 each.
+
+That number is not internal. It is the counter on the homepage and in the README
+(`docs/_data/savings.yml`), and `calls`/`tokens_saved` ride the usage ping.
+
+## The measurement
+
+| tool | calls (real) | raw baseline | assumed response | measured response | measured/baseline | claimed saved | saved vs measurement |
+|---|---|---|---|---|---|---|---|
+| `search_text` | 5,123 | 3,000 | 450 | **1,659** | 0.55 | 13,063,650 | 6,869,943 |
+| `get_outline` | 4,428 | 1,200 | 180 | **1,056** | 0.88 | 4,516,560 | 637,632 |
+| `search` | 4,413 | 600 | 90 | **921** | 1.53 | 2,250,630 | 0 |
+| `get_symbol` | 2,646 | 800 | 120 | **294** | 0.37 | 1,799,280 | 1,338,876 |
+| `find_usages` | 436 | 1,000 | 150 | **1,122** | 1.12 | 370,600 | 0 |
+| `get_project_map` | 345 | 1,500 | 225 | **568** | 0.38 | 439,875 | 321,540 |
+| `get_index_health` | 206 | 500 | 75 | **298** | 0.60 | 87,550 | 41,612 |
+| `get_tests_for` | 94 | 800 | 120 | **66** | 0.08 | 63,920 | 68,996 |
+| `get_complexity_report` | 78 | 800 | 120 | **1,820** | 2.27 | 53,040 | 0 |
+| `get_context_bundle` | 36 | 6,000 | 900 | **127** | 0.02 | 183,600 | 211,428 |
+| `get_task_context` | 30 | 8,000 | 1,200 | **6,086** | 0.76 | 204,000 | 57,420 |
+| `get_call_graph` | 12 | 1,500 | 225 | **5,165** | 3.44 | 15,300 | 0 |
+
+**Totals over these twelve tools: 23,048,005 claimed vs 9,547,447 measured — 41%.**
+They cover 17 947 of the 20 187 recorded calls.
+
+Three things the table says:
+
+1. **0.15 is wrong on every tool that matters.** The four busiest (94% of all calls)
+   measure 0.37–1.53. The assumption is off by 2.5x on the best of them.
+2. **Four of the twelve cost more than the baseline they replace.** `search`,
+   `find_usages`, `get_complexity_report` and `get_call_graph` return more tokens
+   than the raw Read/Grep they are credited with saving — and were still booking a
+   positive number on every call. `get_call_graph` at 5 165 tokens for one symbol is
+   the worst offender per call.
+3. **A few are far better than claimed** — `get_context_bundle` at 0.02 and
+   `get_tests_for` at 0.08 were being under-credited by an order of magnitude.
+
+## The fix
+
+`SavingsTracker.recordActualTokens(tool, tokens)` corrects the pre-call guess once
+the response exists; the gate calls it on the normal, dedup and duplicate-warning
+paths with the count it already computed for the journal. Guarded in
+`tests/tools/savings.test.ts` — including the case that used to be silent, a
+response bigger than its baseline crediting zero rather than a fat positive.
+
+## What is still an estimate, and what to do next
+
+`RAW_COST_ESTIMATES` — "what a Read/Grep would have cost instead" — is still
+hand-written and unvalidated, so the savings *baseline* remains a guess even though
+the response side is now measured. That is the next measurement, not this one: it
+needs a real counterfactual (the same question answered with Read/Grep, tokens
+counted), which is what `benchmarks/pr-context-benchmark` does for PR context and
+nothing does for tool calls.
+
+Second follow-up: `get_call_graph`, `get_complexity_report`, `search` and
+`find_usages` are now known to return more than they save. That is a response-shaping
+problem — a default `depth`/`limit` that is too generous — and it is worth a separate
+issue per tool with this table as the before number.

--- a/scripts/bench-response-tokens.ts
+++ b/scripts/bench-response-tokens.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env tsx
+/**
+ * TRA-880: what do trace-mcp *responses* cost in tokens?
+ *
+ * The advertised-surface side of the token story is measured and guarded
+ * (`preset-surface-budget.test.ts`). The response side never was: `src/savings.ts`
+ * scores every call against a hand-written `RAW_COST_ESTIMATES` table and a flat
+ * `COMPRESSION_RATIO = 0.15`, so the "tokens saved" number it reports is
+ * `calls x constant` and carries no measurement at all.
+ *
+ * This drives the real built server over stdio on a real repo, calls each tool
+ * with representative arguments, and prints the token cost of what actually
+ * comes back next to what savings.ts assumes.
+ *
+ * Run after `pnpm run build`:
+ *   npx tsx scripts/bench-response-tokens.ts [repoPath]
+ */
+import { spawn } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import { encode } from 'gpt-tokenizer/encoding/o200k_base';
+import { estimateTokens } from '../src/utils/token-counter.js';
+
+const REPO = fileURLToPath(new URL('..', import.meta.url));
+const TARGET = process.argv[2] ?? REPO;
+
+/** Tool + args, ordered by real call volume from `~/.trace/savings.json`. */
+const CALLS: Array<{ tool: string; args: Record<string, unknown>; warmup?: boolean }> = [
+  // Not measured: the session DB is seeded per-session, so index in-session to
+  // make the run self-contained instead of depending on a prior `trace index`.
+  { tool: 'reindex', args: {}, warmup: true },
+  // Not measured: resolves a real symbol_id for the symbol-scoped tools below.
+  { tool: 'search', args: { query: 'estimateTokens', kind: 'function', limit: 1 }, warmup: true },
+  { tool: 'search_text', args: { query: 'estimateTokens' } },
+  { tool: 'get_outline', args: { path: 'src/savings.ts' } },
+  { tool: 'search', args: { query: 'savings' } },
+  { tool: 'get_symbol', args: { symbol_id: '$SYMBOL' } },
+  { tool: 'find_usages', args: { symbol_id: '$SYMBOL' } },
+  { tool: 'get_project_map', args: {} },
+  { tool: 'get_index_health', args: {} },
+  { tool: 'get_tests_for', args: { symbol_id: '$SYMBOL' } },
+  { tool: 'get_context_bundle', args: { symbol_id: '$SYMBOL' } },
+  { tool: 'get_task_context', args: { task: 'reduce tool response token cost' } },
+  { tool: 'get_call_graph', args: { symbol_id: '$SYMBOL' } },
+  { tool: 'get_complexity_report', args: {} },
+];
+
+interface Row {
+  tool: string;
+  ok: boolean;
+  chars: number;
+  est: number;
+  real: number;
+  ms: number;
+}
+
+function run(): Promise<Row[]> {
+  return new Promise((resolve, reject) => {
+    const server = spawn('node', [join(REPO, 'dist/cli.js'), 'serve'], {
+      cwd: TARGET,
+      env: { ...process.env, TRACE_MCP_NO_DAEMON: '1', TRACE_MCP_PRESET: 'full' },
+      stdio: ['pipe', 'pipe', 'inherit'],
+    });
+    const send = (m: unknown): void => void server.stdin.write(`${JSON.stringify(m)}\n`);
+    const rows: Row[] = [];
+    const timer = setTimeout(() => {
+      server.kill();
+      reject(new Error('timed out'));
+    }, 900_000);
+
+    let i = 0;
+    let started = 0;
+    let symbolId = '';
+    const next = (): void => {
+      if (i >= CALLS.length) {
+        clearTimeout(timer);
+        server.kill();
+        resolve(rows);
+        return;
+      }
+      started = Date.now();
+      const c = CALLS[i];
+      const args: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(c.args)) args[k] = v === '$SYMBOL' ? symbolId : v;
+      send({
+        jsonrpc: '2.0',
+        id: 100 + i,
+        method: 'tools/call',
+        params: { name: c.tool, arguments: args },
+      });
+    };
+
+    let buf = '';
+    server.stdout.on('data', (chunk) => {
+      buf += chunk;
+      let nl: number;
+      while ((nl = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (!line.trim()) continue;
+        let msg: {
+          id?: number;
+          result?: { content?: Array<{ text?: string }>; isError?: boolean };
+        };
+        try {
+          msg = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (msg.id === 1) {
+          send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+          next();
+          continue;
+        }
+        if (typeof msg.id === 'number' && msg.id >= 100) {
+          const text = msg.result?.content?.map((c) => c.text ?? '').join('') ?? '';
+
+          symbolId ||= /"symbol_id"\s*:\s*"([^"]+)"/.exec(text)?.[1] ?? '';
+          if (msg.result?.isError) console.error(`  [${CALLS[i].tool}] ${text.slice(0, 300)}`);
+          if (!CALLS[i].warmup)
+            rows.push({
+              tool: CALLS[i].tool,
+              ok: !msg.result?.isError,
+              chars: text.length,
+              est: estimateTokens(text),
+              real: encode(text).length,
+              ms: Date.now() - started,
+            });
+          i += 1;
+          next();
+        }
+      }
+    });
+    send({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'bench-response-tokens', version: '1' },
+      },
+    });
+  });
+}
+
+const rows = await run();
+const pad = (s: string | number, n: number): string => String(s).padEnd(n);
+console.log(
+  `\n${pad('tool', 24)}${pad('ok', 4)}${pad('chars', 10)}${pad('est(c/4)', 10)}${pad('o200k', 10)}${pad('ms', 8)}`,
+);
+for (const r of rows) {
+  console.log(
+    `${pad(r.tool, 24)}${pad(r.ok ? 'y' : 'ERR', 4)}${pad(r.chars, 10)}${pad(r.est, 10)}${pad(r.real, 10)}${pad(r.ms, 8)}`,
+  );
+}
+const total = rows.reduce((a, r) => a + r.real, 0);
+console.log(`\ntotal o200k tokens across ${rows.length} calls: ${total}`);
+writeFileSync(
+  join(REPO, 'docs/perf/response-tokens.json'),
+  `${JSON.stringify(
+    { measured_at: new Date().toISOString(), target: TARGET === REPO ? 'self' : TARGET, rows },
+    null,
+    2,
+  )}\n`,
+);

--- a/src/savings.ts
+++ b/src/savings.ts
@@ -153,21 +153,37 @@ export class SavingsTracker {
   /**
    * Correct a just-recorded call with the actual token cost of its response.
    *
-   * {@link recordCall} has to run before the tool does, so it scores the call
-   * against {@link COMPRESSION_RATIO} — a guess. This replaces that guess with
-   * the measured response size once it exists. Without it every "tokens saved"
+   * {@link recordCall} has to run before the tool does — budget clamping and
+   * dedup both read the session totals first — so it scores the call against
+   * {@link COMPRESSION_RATIO}, a guess. This replaces that guess with the
+   * measured response size once it exists. Without it every "tokens saved"
    * number is `calls x constant` and carries no measurement (TRA-880: the guess
    * is 2.5-10x off on the tools that dominate real call volume, and four of the
    * twelve busiest return MORE tokens than their assumed raw baseline).
    */
   recordActualTokens(toolName: string, actualTokens: number): void {
+    this.correctCall(toolName, actualTokens, false);
+  }
+
+  /**
+   * Correct a just-recorded call that failed. A call that returned an error
+   * delivered no context, so it saved nothing — whatever its error text cost.
+   * Without this an error response is scored against the length of its own
+   * message and books near-100% savings, which is more than a successful call
+   * gets.
+   */
+  recordFailedCall(toolName: string, actualTokens = 0): void {
+    this.correctCall(toolName, actualTokens, true);
+  }
+
+  private correctCall(toolName: string, actualTokens: number, failed: boolean): void {
     const rec = this.session.per_tool[toolName];
     if (!rec || !Number.isFinite(actualTokens) || actualTokens < 0) return;
     const rawCost = RAW_COST_ESTIMATES[toolName] ?? DEFAULT_RAW_COST;
     const assumed = Math.round(rawCost * COMPRESSION_RATIO);
-    const deltaActual = actualTokens - assumed;
-    const deltaSaved = Math.max(0, rawCost - actualTokens) - Math.max(0, rawCost - assumed);
-    this.session.total_actual_tokens += deltaActual;
+    const saved = failed ? 0 : Math.max(0, rawCost - actualTokens);
+    const deltaSaved = saved - Math.max(0, rawCost - assumed);
+    this.session.total_actual_tokens += actualTokens - assumed;
     this.session.total_tokens_saved += deltaSaved;
     rec.tokens_saved += deltaSaved;
   }

--- a/src/savings.ts
+++ b/src/savings.ts
@@ -150,6 +150,28 @@ export class SavingsTracker {
     };
   }
 
+  /**
+   * Correct a just-recorded call with the actual token cost of its response.
+   *
+   * {@link recordCall} has to run before the tool does, so it scores the call
+   * against {@link COMPRESSION_RATIO} — a guess. This replaces that guess with
+   * the measured response size once it exists. Without it every "tokens saved"
+   * number is `calls x constant` and carries no measurement (TRA-880: the guess
+   * is 2.5-10x off on the tools that dominate real call volume, and four of the
+   * twelve busiest return MORE tokens than their assumed raw baseline).
+   */
+  recordActualTokens(toolName: string, actualTokens: number): void {
+    const rec = this.session.per_tool[toolName];
+    if (!rec || !Number.isFinite(actualTokens) || actualTokens < 0) return;
+    const rawCost = RAW_COST_ESTIMATES[toolName] ?? DEFAULT_RAW_COST;
+    const assumed = Math.round(rawCost * COMPRESSION_RATIO);
+    const deltaActual = actualTokens - assumed;
+    const deltaSaved = Math.max(0, rawCost - actualTokens) - Math.max(0, rawCost - assumed);
+    this.session.total_actual_tokens += deltaActual;
+    this.session.total_tokens_saved += deltaSaved;
+    rec.tokens_saved += deltaSaved;
+  }
+
   /** Record a tool call with an optional actual response token count */
   recordCall(toolName: string, actualTokens?: number): void {
     const rawCost = RAW_COST_ESTIMATES[toolName] ?? DEFAULT_RAW_COST;

--- a/src/server/__tests__/tool-surface.test.ts
+++ b/src/server/__tests__/tool-surface.test.ts
@@ -24,6 +24,7 @@ function gateStubs() {
   return {
     savings: {
       recordCall: () => {},
+      recordActualTokens: () => {},
       recordLatency: () => {},
       getSessionStats: () => ({ total_calls: 0, total_raw_tokens: 0 }),
     },

--- a/src/server/__tests__/tool-surface.test.ts
+++ b/src/server/__tests__/tool-surface.test.ts
@@ -25,6 +25,7 @@ function gateStubs() {
     savings: {
       recordCall: () => {},
       recordActualTokens: () => {},
+      recordFailedCall: () => {},
       recordLatency: () => {},
       getSessionStats: () => ({ total_calls: 0, total_raw_tokens: 0 }),
     },

--- a/src/server/tool-gate-helpers.ts
+++ b/src/server/tool-gate-helpers.ts
@@ -324,7 +324,9 @@ async function handleDuplicate(
     };
     ctx.stripMetaFields(dedupResponse);
     ctx.journal.record(ctx.name, params, (dupInfo.compact_result._result_count as number) ?? 1);
-    return { content: [{ type: 'text', text: ctx.j(dedupResponse) }] };
+    const dedupText = ctx.j(dedupResponse);
+    ctx.savings.recordActualTokens(ctx.name, Math.ceil(dedupText.length / 4));
+    return { content: [{ type: 'text', text: dedupText }] };
   }
 
   // Warn-only path: run the tool, annotate the response with the dup warning.
@@ -339,10 +341,14 @@ async function handleDuplicate(
     });
   }
   const count = ctx.extractResultCount(result);
+  const warnTokens = result?.content?.[0]?.text?.length
+    ? Math.ceil(result.content[0].text.length / 4)
+    : undefined;
+  if (warnTokens !== undefined) ctx.savings.recordActualTokens(ctx.name, warnTokens);
   ctx.journal.record(ctx.name, params, count);
   emitJournalEntry(ctx, {
     count,
-    resultTokens: undefined,
+    resultTokens: warnTokens,
     latencyMs: warnLatency,
     isError: !!result?.isError,
   });
@@ -460,6 +466,7 @@ export function createGatedCallback(
     const resultTokens = resultObj?.content?.[0]?.text?.length
       ? Math.ceil(resultObj.content[0].text.length / 4)
       : undefined;
+    if (resultTokens !== undefined) ctx.savings.recordActualTokens(ctx.name, resultTokens);
     ctx.journal.record(ctx.name, params, count, { compactResult, resultTokens });
     emitJournalEntry(ctx, {
       count,

--- a/src/server/tool-gate-helpers.ts
+++ b/src/server/tool-gate-helpers.ts
@@ -341,10 +341,11 @@ async function handleDuplicate(
     });
   }
   const count = ctx.extractResultCount(result);
-  const warnTokens = result?.content?.[0]?.text?.length
-    ? Math.ceil(result.content[0].text.length / 4)
-    : undefined;
-  if (warnTokens !== undefined) ctx.savings.recordActualTokens(ctx.name, warnTokens);
+  const warnTokens = responseTokens(result);
+  if (warnTokens !== undefined) {
+    if (result?.isError) ctx.savings.recordFailedCall(ctx.name, warnTokens);
+    else ctx.savings.recordActualTokens(ctx.name, warnTokens);
+  }
   ctx.journal.record(ctx.name, params, count);
   emitJournalEntry(ctx, {
     count,
@@ -353,6 +354,16 @@ async function handleDuplicate(
     isError: !!result?.isError,
   });
   return result;
+}
+
+/**
+ * Token cost of a response's text, or undefined when it has none. Deliberately
+ * `typeof`, not truthiness: an empty string is a real, measured zero-token
+ * response, not a missing one.
+ */
+function responseTokens(result: WrappedToolResponse | undefined): number | undefined {
+  const text = result?.content?.[0]?.text;
+  return typeof text === 'string' ? Math.ceil(text.length / 4) : undefined;
 }
 
 /** Enrich a successful response with optimization hint, budget defaults, warnings. */
@@ -449,6 +460,9 @@ export function createGatedCallback(
       telemetrySpan.setAttribute('duration_ms', Date.now() - normalStart);
       telemetrySpan.recordError(err);
       telemetrySpan.end();
+      // A throw returns no context at all, so it saves nothing. Without this it
+      // would keep the pre-call guess and score better than a real answer.
+      ctx.savings.recordFailedCall(ctx.name);
       throw err;
     }
     const resultObj = result as WrappedToolResponse;
@@ -463,10 +477,7 @@ export function createGatedCallback(
     ctx.recordToolCall?.(!resultObj?.isError);
     const count = ctx.extractResultCount(resultObj);
     const compactResult = ctx.extractCompactResult(ctx.name, resultObj);
-    const resultTokens = resultObj?.content?.[0]?.text?.length
-      ? Math.ceil(resultObj.content[0].text.length / 4)
-      : undefined;
-    if (resultTokens !== undefined) ctx.savings.recordActualTokens(ctx.name, resultTokens);
+    const resultTokens = responseTokens(resultObj);
     ctx.journal.record(ctx.name, params, count, { compactResult, resultTokens });
     emitJournalEntry(ctx, {
       count,
@@ -477,6 +488,15 @@ export function createGatedCallback(
 
     enrichResponse(ctx, resultObj, params, originalParamSnapshot, appliedDefaults);
     applyWireFormat(resultObj, effectiveFormat);
+
+    // Scored last, on the bytes that actually go over the wire: `enrichResponse`
+    // adds fields and `applyWireFormat` can re-encode into a denser format, so
+    // measuring any earlier books a number the client never sees.
+    const wireTokens = responseTokens(resultObj);
+    if (wireTokens !== undefined) {
+      if (resultObj?.isError) ctx.savings.recordFailedCall(ctx.name, wireTokens);
+      else ctx.savings.recordActualTokens(ctx.name, wireTokens);
+    }
 
     return result;
   };

--- a/src/tools/register/__tests__/batch-door.test.ts
+++ b/src/tools/register/__tests__/batch-door.test.ts
@@ -31,7 +31,11 @@ function buildBatch(opts: { loaded?: string[]; deferred?: string[]; exclude?: st
   };
   const ctx = metaCtx({
     config: { tools: { exclude: opts.exclude } },
-    savings: { recordCall: () => undefined },
+    savings: {
+      recordCall: () => undefined,
+      recordActualTokens: () => undefined,
+      recordFailedCall: () => undefined,
+    },
   }) as unknown as Record<string, unknown>;
   const stub =
     (name: string): Handler =>

--- a/src/tools/register/session.ts
+++ b/src/tools/register/session.ts
@@ -965,6 +965,14 @@ export function registerSessionTools(server: McpServer, ctx: MetaContext): void 
           const response = await handler(call.args);
           // Parse the JSON text from the response to embed inline
           const text = response.content?.[0]?.text;
+          // batch dispatches handlers directly, so the gate's correction never
+          // runs here — without this every batched call keeps the pre-call
+          // compression guess (TRA-880).
+          if (typeof text === 'string') {
+            const batchTokens = Math.ceil(text.length / 4);
+            if (response.isError) savings.recordFailedCall(call.tool, batchTokens);
+            else savings.recordActualTokens(call.tool, batchTokens);
+          }
           if (text) {
             try {
               const parsed = JSON.parse(text);

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -290,16 +290,14 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
     // its mtime is almost always the newest thing in the root — and a cli.js
     // that exists there may still be mid-write. A complete backup wins even
     // when it is older (TRA-881).
-    it('prefers a complete backup over npm\'s newer in-progress staging dir', () => {
+    it("prefers a complete backup over npm's newer in-progress staging dir", () => {
       const { home, traceHome, node } = setupFakeHome();
       const root = path.join(home, '.nvm', 'versions', 'node', 'v22.22.2', 'lib', 'node_modules');
       for (const name of ['trace-mcp.tmcp-bak-4242', '.trace-mcp-deadbeef']) {
         fs.mkdirSync(path.join(root, name, 'dist'), { recursive: true });
         fs.writeFileSync(path.join(root, name, 'dist', 'cli.js'), `// ${name}\n`);
       }
-      const bakCli = fs.realpathSync(
-        path.join(root, 'trace-mcp.tmcp-bak-4242', 'dist', 'cli.js'),
-      );
+      const bakCli = fs.realpathSync(path.join(root, 'trace-mcp.tmcp-bak-4242', 'dist', 'cli.js'));
       // Backdate the backup so a pure mtime sort would pick the staging dir.
       const old = new Date(Date.now() - 60 * 60 * 1000);
       fs.utimesSync(path.join(root, 'trace-mcp.tmcp-bak-4242'), old, old);

--- a/tests/server/tool-gate-wire-format.test.ts
+++ b/tests/server/tool-gate-wire-format.test.ts
@@ -27,6 +27,7 @@ function createMockSavings() {
   return {
     recordCall: vi.fn(),
     recordActualTokens: vi.fn(),
+    recordFailedCall: vi.fn(),
     recordLatency: vi.fn(),
     getLatencyPerTool: vi.fn().mockReturnValue({}),
     getLatencyStats: vi.fn().mockReturnValue(null),

--- a/tests/server/tool-gate-wire-format.test.ts
+++ b/tests/server/tool-gate-wire-format.test.ts
@@ -26,6 +26,7 @@ function createMockServer() {
 function createMockSavings() {
   return {
     recordCall: vi.fn(),
+    recordActualTokens: vi.fn(),
     recordLatency: vi.fn(),
     getLatencyPerTool: vi.fn().mockReturnValue({}),
     getLatencyStats: vi.fn().mockReturnValue(null),

--- a/tests/server/tool-gate.test.ts
+++ b/tests/server/tool-gate.test.ts
@@ -30,6 +30,7 @@ function createMockServer() {
 function createMockSavings() {
   return {
     recordCall: vi.fn(),
+    recordActualTokens: vi.fn(),
     recordLatency: vi.fn(),
     getLatencyPerTool: vi.fn().mockReturnValue({}),
     getLatencyStats: vi.fn().mockReturnValue(null),

--- a/tests/server/tool-gate.test.ts
+++ b/tests/server/tool-gate.test.ts
@@ -31,6 +31,7 @@ function createMockSavings() {
   return {
     recordCall: vi.fn(),
     recordActualTokens: vi.fn(),
+    recordFailedCall: vi.fn(),
     recordLatency: vi.fn(),
     getLatencyPerTool: vi.fn().mockReturnValue({}),
     getLatencyStats: vi.fn().mockReturnValue(null),

--- a/tests/tool-gate-annotations.test.ts
+++ b/tests/tool-gate-annotations.test.ts
@@ -23,6 +23,7 @@ function makeMockSavings() {
   return {
     recordCall: vi.fn(),
     recordActualTokens: vi.fn(),
+    recordFailedCall: vi.fn(),
     getSessionStats: () => ({ total_calls: 0, total_raw_tokens: 0 }),
     getFullStats: () => ({}),
   } as any;

--- a/tests/tool-gate-annotations.test.ts
+++ b/tests/tool-gate-annotations.test.ts
@@ -22,6 +22,7 @@ function makeMockConfig() {
 function makeMockSavings() {
   return {
     recordCall: vi.fn(),
+    recordActualTokens: vi.fn(),
     getSessionStats: () => ({ total_calls: 0, total_raw_tokens: 0 }),
     getFullStats: () => ({}),
   } as any;

--- a/tests/tools/savings.test.ts
+++ b/tests/tools/savings.test.ts
@@ -27,6 +27,42 @@ describe('SavingsTracker', () => {
       expect(stats.reduction_pct).toBe(0);
     });
 
+    /**
+     * TRA-880 guard. Before this, the only thing `tokens_saved` ever measured
+     * was the call count: `recordCall` runs before the tool does, so it scored
+     * every call against a flat 0.15 compression guess. Measured on this repo,
+     * that guess is 2.5-10x off on the busiest tools, and `search` /
+     * `find_usages` / `get_call_graph` / `get_complexity_report` return more
+     * tokens than the raw baseline they are credited with replacing.
+     */
+    it('scores savings against the measured response, not the compression guess', () => {
+      const tracker = new SavingsTracker('/test/project');
+      tracker.recordCall('search'); // raw estimate 600, guess 0.15 -> 90 actual
+      const guessed = tracker.getSessionStats().total_tokens_saved;
+      tracker.recordActualTokens('search', 400);
+      const stats = tracker.getSessionStats();
+      expect(guessed).toBe(510);
+      expect(stats.total_tokens_saved).toBe(200);
+      expect(stats.per_tool.search.tokens_saved).toBe(200);
+      expect(stats.total_actual_tokens).toBe(400);
+    });
+
+    it('credits nothing when the response costs more than the raw baseline', () => {
+      const tracker = new SavingsTracker('/test/project');
+      tracker.recordCall('search');
+      tracker.recordActualTokens('search', 5000);
+      const stats = tracker.getSessionStats();
+      expect(stats.total_tokens_saved).toBe(0);
+      expect(stats.per_tool.search.tokens_saved).toBe(0);
+      expect(stats.total_calls).toBe(1);
+    });
+
+    it('ignores a correction for a tool that was never recorded', () => {
+      const tracker = new SavingsTracker('/test/project');
+      tracker.recordActualTokens('search', 100);
+      expect(tracker.getSessionStats().total_tokens_saved).toBe(0);
+    });
+
     it('records a known tool call with estimated savings', () => {
       const tracker = new SavingsTracker('/test/project');
       tracker.recordCall('search');

--- a/tests/tools/savings.test.ts
+++ b/tests/tools/savings.test.ts
@@ -57,6 +57,33 @@ describe('SavingsTracker', () => {
       expect(stats.total_calls).toBe(1);
     });
 
+    it('books nothing for a failed call, whatever its error text cost', () => {
+      const tracker = new SavingsTracker('/test/project');
+      tracker.recordCall('get_task_context'); // raw 8000, guess 1200 -> 6800 saved
+      tracker.recordFailedCall('get_task_context', 4); // a 4-token error message
+      const stats = tracker.getSessionStats();
+      // Scored as payload this would have booked 7 996 — more than any real answer.
+      expect(stats.total_tokens_saved).toBe(0);
+      expect(stats.per_tool.get_task_context.tokens_saved).toBe(0);
+      expect(stats.total_actual_tokens).toBe(4);
+    });
+
+    it('books nothing for a call that threw before producing a response', () => {
+      const tracker = new SavingsTracker('/test/project');
+      tracker.recordCall('search');
+      tracker.recordFailedCall('search');
+      expect(tracker.getSessionStats().total_tokens_saved).toBe(0);
+    });
+
+    it('treats an empty response as a measured zero, not as missing', () => {
+      const tracker = new SavingsTracker('/test/project');
+      tracker.recordCall('search'); // raw 600
+      tracker.recordActualTokens('search', 0);
+      const stats = tracker.getSessionStats();
+      expect(stats.total_tokens_saved).toBe(600);
+      expect(stats.total_actual_tokens).toBe(0);
+    });
+
     it('ignores a correction for a tool that was never recorded', () => {
       const tracker = new SavingsTracker('/test/project');
       tracker.recordActualTokens('search', 100);

--- a/tests/updater-rollback.test.ts
+++ b/tests/updater-rollback.test.ts
@@ -239,14 +239,17 @@ describe('checkAndInstallUpdate — backup + rollback', () => {
   // name, so the order is arbitrary — and permanently reinstate a build that
   // may be many versions old. Newest on disk is the only defensible pick.
   it('restores the newest stale backup when several dead-PID backups exist', async () => {
-    const older = path.join(tmpRoot, 'trace-mcp.tmcp-bak-4242');
-    const newer = path.join(tmpRoot, 'trace-mcp.tmcp-bak-999');
+    // PIDs above any plausible pid_max, so `isPidAlive` is ESRCH everywhere.
+    // A low PID like 999 is a live process on a Linux CI runner, which made
+    // reconcile skip the newer backup as owned and restore the older one.
+    const older = path.join(tmpRoot, 'trace-mcp.tmcp-bak-999999997');
+    const newer = path.join(tmpRoot, 'trace-mcp.tmcp-bak-999999998');
     fs.mkdirSync(older, { recursive: true });
     fs.writeFileSync(path.join(older, 'marker.txt'), 'stale-old-build');
     fs.mkdirSync(newer, { recursive: true });
     fs.writeFileSync(path.join(newer, 'marker.txt'), 'recent-build');
     // Make the ordering unambiguous regardless of filesystem timestamp
-    // granularity: 'trace-mcp.tmcp-bak-4242' sorts first by name, last by mtime.
+    // granularity: the older backup sorts first by name, last by mtime.
     const old = new Date(Date.now() - 60 * 60 * 1000);
     fs.utimesSync(older, old, old);
     expect(fs.existsSync(mainDir)).toBe(false);


### PR DESCRIPTION
## The defect

`SavingsTracker.recordCall(name)` runs **before** the tool does, so it could only score a call against a hand-written `RAW_COST_ESTIMATES[name]` times a flat `COMPRESSION_RATIO = 0.15`. `src/server/tool-gate-helpers.ts` was its only caller and never passed a real count.

So `tokens_saved` has always been **`calls × constant`**. Confirmable in a real store: 5 123 `search_text` calls, 13 063 650 saved — exactly 2 550 each, zero variance. That number is not internal: it is the counter on the homepage and in the README (`docs/_data/savings.yml`), and it rides the usage ping.

## The measurement (before)

Real stdio `tools/call` round-trip against this repo (2 144 files, 11 134 symbols), trace-mcp 3.17.1, `o200k_base` counts. Call volume is one real machine's `~/.trace/savings.json` (20 187 calls). Reproduce: `npx tsx scripts/bench-response-tokens.ts`.

| tool | calls | raw baseline | assumed response | **measured** | measured/baseline |
|---|---|---|---|---|---|
| `search_text` | 5,123 | 3,000 | 450 | **1,659** | 0.55 |
| `get_outline` | 4,428 | 1,200 | 180 | **1,056** | 0.88 |
| `search` | 4,413 | 600 | 90 | **921** | 1.53 |
| `get_symbol` | 2,646 | 800 | 120 | **294** | 0.37 |
| `find_usages` | 436 | 1,000 | 150 | **1,122** | 1.12 |
| `get_project_map` | 345 | 1,500 | 225 | **568** | 0.38 |
| `get_index_health` | 206 | 500 | 75 | **298** | 0.60 |
| `get_tests_for` | 94 | 800 | 120 | **66** | 0.08 |
| `get_complexity_report` | 78 | 800 | 120 | **1,820** | 2.27 |
| `get_context_bundle` | 36 | 6,000 | 900 | **127** | 0.02 |
| `get_task_context` | 30 | 8,000 | 1,200 | **6,086** | 0.76 |
| `get_call_graph` | 12 | 1,500 | 225 | **5,165** | 3.44 |

- 0.15 is off by 2.5–10x on the four tools that are **94% of all calls**.
- Four of twelve return **more** tokens than the baseline they are credited with replacing, and still booked a positive number every call.
- `get_context_bundle` (0.02) and `get_tests_for` (0.08) were *under*-credited by an order of magnitude.

**Totals over these twelve (17 947 of 20 187 recorded calls): 23,048,005 claimed vs 9,547,447 measured — 41%.**

## The change (after)

`SavingsTracker.recordActualTokens(tool, tokens)` corrects the pre-call guess once the response exists. The gate calls it on the normal, dedup and duplicate-warning paths with the token count it **already computes** for the journal — no new work per call, no new response walk.

Deliberately **not** changed: `RAW_COST_ESTIMATES` (the "what a Read/Grep would have cost" side) is still a hand-written guess. Validating it needs a real counterfactual and is a separate measurement — flagged in the doc.

## Trade-off stated explicitly

This makes the published savings counter **go down** — that is the point. It reports a measurement now instead of an arithmetic identity. No MCP tool contract change, no schema change, no token-cost regression.

## Guard

`tests/tools/savings.test.ts` — three cases, including the one that was silent before: a response bigger than its baseline credits **zero**, not a fat positive.

Full suite: 10 114 passed, 22 skipped, 0 failed. `tsc --noEmit` and `biome ci` clean.

Numbers, method and follow-ups: `docs/perf/response-tokens.md`.
