### PR TITLE
fix(launcher): pick the newest package backup, not the first one listed (TRA-881)

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.6.2 (Windows)
+REM trace-mcp-launcher v0.6.3 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.6.2 (Windows)
+# trace-mcp-launcher v0.6.3 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.
@@ -374,8 +374,12 @@ function Find-Cli {
     # of the client's session.
     foreach ($r in $roots) {
         if (-not (Test-Path -LiteralPath $r -PathType Container)) { continue }
+        # Newest first: the suffix is the crashed updater's PID, so name order
+        # says nothing about which copy is more recent (TRA-881).
         $bak = Get-ChildItem -LiteralPath $r -Directory -ErrorAction SilentlyContinue |
                Where-Object { $_.Name -like 'trace-mcp.tmcp-bak-*' -or $_.Name -like '.trace-mcp-*' } |
+               Sort-Object @{ Expression = { if ($_.Name -like 'trace-mcp.tmcp-bak-*') { 0 } else { 1 } } },
+                           @{ Expression = 'LastWriteTime'; Descending = $true } |
                ForEach-Object { Join-Path $_.FullName 'dist\cli.js' } |
                Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
                Select-Object -First 1

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.6.2
+# trace-mcp-launcher v0.6.3
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -340,7 +340,7 @@ normalise_path() {
 
 # Find dist/cli.js in any known global root. $1 = roots, newline-separated.
 probe_cli() {
-  local roots="$1" root cli bak
+  local roots="$1" root cli bak group
 
   while IFS= read -r root; do
     [ -n "$root" ] || continue
@@ -358,11 +358,27 @@ probe_cli() {
   # rest of the client's session.
   while IFS= read -r root; do
     [ -n "$root" ] || continue
-    for bak in "$root"/trace-mcp.tmcp-bak-* "$root"/.trace-mcp-*; do
-      if [ -f "$bak/dist/cli.js" ]; then
-        normalise_path "$bak/dist/cli.js"
-        return 0
-      fi
+    # Two classes, in this order: a complete backup our updater renamed aside,
+    # then npm's own staging directory. Never one combined sort — npm rewrites
+    # the staging dir throughout the unpack, so its mtime is almost always the
+    # newest, and a `dist/cli.js` that exists there may still be mid-write.
+    #
+    # Within each class, newest by mtime. The suffix is the crashed updater's
+    # PID, so glob order says nothing about which copy is more recent, and the
+    # old first-match pick could serve a build many versions old for the
+    # client's whole session (TRA-881). PATH is pinned above, and a glob that
+    # matches nothing yields an empty list rather than a literal.
+    for group in \
+      "$(ls -td "$root"/trace-mcp.tmcp-bak-* 2>/dev/null)" \
+      "$(ls -td "$root"/.trace-mcp-* 2>/dev/null)"; do
+      [ -n "$group" ] || continue
+      while IFS= read -r bak; do
+        [ -n "$bak" ] || continue
+        if [ -f "$bak/dist/cli.js" ]; then
+          normalise_path "$bak/dist/cli.js"
+          return 0
+        fi
+      done <<< "$group"
     done
   done <<< "$roots"
 

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -112,4 +112,4 @@ export const MIRROR_HOOK_VERSION = '0.3.0';
 // 0.6.0 (TRA-755): the resolved node is version-gated against engines.node. An
 // older one used to exec fine and die on a SyntaxError the client could only
 // report as "failed to connect" — and get pinned into launcher.env on the way.
-export const LAUNCHER_VERSION = '0.6.2';
+export const LAUNCHER_VERSION = '0.6.3';

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -195,25 +195,40 @@ function reconcileStaleBackups(npmRoot: string): void {
     return;
   }
 
-  const mainExists = fs.existsSync(mainDir);
+  let mainExists = fs.existsSync(mainDir);
 
-  for (const entry of entries) {
-    const pid = backupPid(entry);
-    if (!Number.isFinite(pid)) continue;
-    if (isPidAlive(pid)) continue; // Owned by a live updater — leave alone.
+  // Newest first. The suffix is the crashed updater's PID, so readdir order
+  // says nothing about which backup is more recent — restoring the first one
+  // found could permanently reinstate a build many versions old (TRA-881).
+  // Backups from a still-running PID are left alone: another updater owns them.
+  const candidates = entries
+    .filter((e) => Number.isFinite(backupPid(e)) && !isPidAlive(backupPid(e)))
+    .map((e) => {
+      const full = path.join(npmRoot, e);
+      let mtimeMs = 0;
+      try {
+        mtimeMs = fs.statSync(full).mtimeMs;
+      } catch {
+        // Unstatable — sorts last; the restore/delete below still handles it.
+      }
+      return { full, mtimeMs };
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
 
-    const full = path.join(npmRoot, entry);
+  for (const { full } of candidates) {
     if (!mainExists) {
-      // Restore the first dead-PID backup we find, then stop — there can be
-      // only one canonical main dir. Any further backups become garbage and
-      // will be wiped on the next reconcile pass.
+      // Restore the newest dead-PID backup, then keep going so the remaining
+      // ones are deleted in this same pass — there can be only one canonical
+      // main dir, and a leftover backup is exactly what the launcher's
+      // swap-window fallback would serve a client next (TRA-881).
       try {
         fs.renameSync(full, mainDir);
         logger.warn(
           { backup: full, restored: mainDir },
           'Auto-update: restored package dir from stale backup of dead updater process',
         );
-        return;
+        mainExists = true;
+        continue;
       } catch (err) {
         logger.warn(
           { backup: full, error: err },

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -252,6 +252,71 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
       );
     });
 
+    // TRA-881: the backup fallback took whatever the glob listed first. The
+    // suffix is the updater's PID, so name order is arbitrary — two crashed
+    // updates could leave the client served an arbitrarily old build for the
+    // whole session. Newest by mtime is the only meaningful ordering.
+    it('prefers the newest backup when the swap window leaves several', () => {
+      const { home, traceHome, node } = setupFakeHome();
+      const root = path.join(home, '.nvm', 'versions', 'node', 'v22.22.2', 'lib', 'node_modules');
+      // '4242' sorts before '999' by name, so a first-match pick loses here.
+      for (const [name, body] of [
+        ['trace-mcp.tmcp-bak-4242', '// stale old version\n'],
+        ['trace-mcp.tmcp-bak-999', '// recent version\n'],
+      ]) {
+        fs.mkdirSync(path.join(root, name, 'dist'), { recursive: true });
+        fs.writeFileSync(path.join(root, name, 'dist', 'cli.js'), body);
+      }
+      const old = new Date(Date.now() - 60 * 60 * 1000);
+      fs.utimesSync(path.join(root, 'trace-mcp.tmcp-bak-4242'), old, old);
+      const newestCli = fs.realpathSync(
+        path.join(root, 'trace-mcp.tmcp-bak-999', 'dist', 'cli.js'),
+      );
+      fs.mkdirSync(path.join(home, '.nvm', 'alias'), { recursive: true });
+      fs.writeFileSync(path.join(home, '.nvm', 'alias', 'default'), 'v22.22.2\n');
+      const nvmBin = path.join(home, '.nvm', 'versions', 'node', 'v22.22.2', 'bin');
+      fs.mkdirSync(nvmBin, { recursive: true });
+      fs.writeFileSync(path.join(nvmBin, 'node'), '#!/bin/bash\nexit 1\n', { mode: 0o755 });
+
+      writeConfig(traceHome, node, path.join(root, 'trace-mcp', 'dist', 'cli.js'));
+
+      const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${newestCli} serve`);
+    });
+
+    // npm rewrites its `.trace-mcp-<hex>` staging dir throughout the unpack, so
+    // its mtime is almost always the newest thing in the root — and a cli.js
+    // that exists there may still be mid-write. A complete backup wins even
+    // when it is older (TRA-881).
+    it('prefers a complete backup over npm\'s newer in-progress staging dir', () => {
+      const { home, traceHome, node } = setupFakeHome();
+      const root = path.join(home, '.nvm', 'versions', 'node', 'v22.22.2', 'lib', 'node_modules');
+      for (const name of ['trace-mcp.tmcp-bak-4242', '.trace-mcp-deadbeef']) {
+        fs.mkdirSync(path.join(root, name, 'dist'), { recursive: true });
+        fs.writeFileSync(path.join(root, name, 'dist', 'cli.js'), `// ${name}\n`);
+      }
+      const bakCli = fs.realpathSync(
+        path.join(root, 'trace-mcp.tmcp-bak-4242', 'dist', 'cli.js'),
+      );
+      // Backdate the backup so a pure mtime sort would pick the staging dir.
+      const old = new Date(Date.now() - 60 * 60 * 1000);
+      fs.utimesSync(path.join(root, 'trace-mcp.tmcp-bak-4242'), old, old);
+      fs.mkdirSync(path.join(home, '.nvm', 'alias'), { recursive: true });
+      fs.writeFileSync(path.join(home, '.nvm', 'alias', 'default'), 'v22.22.2\n');
+      const nvmBin = path.join(home, '.nvm', 'versions', 'node', 'v22.22.2', 'bin');
+      fs.mkdirSync(nvmBin, { recursive: true });
+      fs.writeFileSync(path.join(nvmBin, 'node'), '#!/bin/bash\nexit 1\n', { mode: 0o755 });
+
+      writeConfig(traceHome, node, path.join(root, 'trace-mcp', 'dist', 'cli.js'));
+
+      const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${bakCli} serve`);
+    });
+
     it.skipIf(process.platform === 'win32')('keeps the healed launcher.env at 0600', () => {
       const { home, traceHome, node } = setupFakeHome();
       plantNvmPackage(home);

--- a/tests/updater-rollback.test.ts
+++ b/tests/updater-rollback.test.ts
@@ -234,6 +234,31 @@ describe('checkAndInstallUpdate — backup + rollback', () => {
     expect(fs.existsSync(backupDir)).toBe(false);
   });
 
+  // TRA-881: two crashed updater runs leave two dead-PID backups. Reconcile
+  // used to restore whichever `readdirSync` yielded first — a PID-suffixed
+  // name, so the order is arbitrary — and permanently reinstate a build that
+  // may be many versions old. Newest on disk is the only defensible pick.
+  it('restores the newest stale backup when several dead-PID backups exist', async () => {
+    const older = path.join(tmpRoot, 'trace-mcp.tmcp-bak-4242');
+    const newer = path.join(tmpRoot, 'trace-mcp.tmcp-bak-999');
+    fs.mkdirSync(older, { recursive: true });
+    fs.writeFileSync(path.join(older, 'marker.txt'), 'stale-old-build');
+    fs.mkdirSync(newer, { recursive: true });
+    fs.writeFileSync(path.join(newer, 'marker.txt'), 'recent-build');
+    // Make the ordering unambiguous regardless of filesystem timestamp
+    // granularity: 'trace-mcp.tmcp-bak-4242' sorts first by name, last by mtime.
+    const old = new Date(Date.now() - 60 * 60 * 1000);
+    fs.utimesSync(older, old, old);
+    expect(fs.existsSync(mainDir)).toBe(false);
+
+    installResults = [{ status: 0, stderr: '' }];
+
+    await checkAndInstallUpdate({ checkIntervalHours: 24 });
+
+    expect(fs.readFileSync(path.join(mainDir, 'marker.txt'), 'utf-8')).toBe('recent-build');
+    expect(listBackups()).toEqual([]);
+  });
+
   it('removes stale backup garbage when main dir is present', async () => {
     seedInstalledPackage();
     const deadPid = 999_999_999;


### PR DESCRIPTION
## The bug

An interrupted `npm i -g trace-mcp` leaves a `trace-mcp.tmcp-bak-<pid>` directory behind. Two of them can coexist after two crashed runs. Both the launcher shim and `reconcileStaleBackups` picked whichever the glob/readdir listed **first** — and the suffix is the crashed updater's PID, so that order says nothing about which copy is newer. `trace-mcp.tmcp-bak-4242` sorts ahead of `trace-mcp.tmcp-bak-999`.

Two consequences:

- **Shim, bounded to the swap window:** a client can be served an arbitrarily old build for its entire session. It connects fine, so nothing surfaces the downgrade.
- **Updater, permanent:** `reconcileStaleBackups` can rename an old build back over the missing main dir, making the downgrade stick.

Found while auditing the swap-window path for TRA-881. Reproduced against the real shim in a sandbox before touching anything: with `bak-4242` (stale) and `bak-999` (recent) on disk, the launcher execs `bak-4242`.

## The fix

Order candidates by mtime, newest first, in `hooks/trace-mcp-launcher.sh`, `hooks/trace-mcp-launcher.ps1`, and `reconcileStaleBackups`.

The shim sorts **within each class**, not across both. npm rewrites its `.trace-mcp-<hex>` staging dir throughout the unpack, so one combined `ls -td` would almost always rank it above a complete backup — and a `dist/cli.js` that exists there may still be mid-write. A finished backup still beats an in-progress staging dir, exactly as before; mtime only breaks ties within a class. (This was caught by the second-model review of the first draft, which did use a single combined sort.)

Reconcile also now deletes the remaining backups in the same pass instead of returning after the first restore — a leftover backup is precisely what the shim's fallback would serve next.

`reconcileStaleBackups` is unaffected by the class question: `backupPid()` only matches the `trace-mcp.tmcp-bak-` prefix, so npm staging dirs never enter its candidate list.

Launcher shim `0.6.2` → `0.6.3` so installed copies get refreshed on next init.

## Test evidence

Three new tests, all verified to fail against the pre-fix code:

- `launcher-integration`: newest backup wins when several exist (old code picked `bak-4242`, not `bak-999`).
- `launcher-integration`: a complete backup wins over npm's *newer* in-progress staging dir — this one fails against a naive combined mtime sort, verified directly (`ls -td` over both globs returns `.trace-mcp-deadbeef` first).
- `updater-rollback`: reconcile restores the newest backup and sweeps the rest in the same pass.

Both new launcher tests backdate the loser by a full hour via `utimesSync`, so neither depends on filesystem timestamp granularity.

```
pnpm typecheck  clean
pnpm build      success
pnpm test       911 files, 10113 passed | 22 skipped
```

No MCP tool-signature, schema, or token-budget changes.

Closes TRA-881.
