### PR TITLE
test(indexer): stop the crash-loop dedup case from depending on any timer (TRA-885)

### DIFF
--- a/src/indexer/__tests__/extract-pool-crash-loop.test.ts
+++ b/src/indexer/__tests__/extract-pool-crash-loop.test.ts
@@ -172,11 +172,11 @@ describe('ExtractPool — crash-loop guard', () => {
     // only the dedup path, not the disable path.
     for (let i = 0; i < 4; i++) {
       internals.onError(0, new Error('MODULE_NOT_FOUND: extract-worker.js'));
-      // Advance by this crash's own backoff (200ms doubling, 3s in total)
-      // rather than runAllTimers(): since TRA-811 the pool also arms a
-      // 5-minute keepAlive idle-teardown timer, and running it would push the
-      // fake clock past the 5s dedup window this case is about.
-      vi.advanceTimersByTime(200 * 2 ** i);
+      // Deliberately advance no timers here. onError() does its counting and
+      // dedup synchronously, so this case needs neither the respawn backoff
+      // nor the keepAlive idle teardown to fire — and running either one
+      // (TRA-811 armed a 5-minute idle timer; TRA-885 caught the fallout)
+      // pushes the fake clock past the 5s dedup window this case is about.
     }
 
     // First crash logs a full error with err+stack; subsequent identical


### PR DESCRIPTION
TRA-885 reported `src/indexer/__tests__/extract-pool-crash-loop.test.ts:184` failing deterministically on master and blocking the CI gate.

**It is already fixed on master** by #912 (merged 2026-09-05 00:03 PT, before the issue was filed). Verified on `origin/master` @ 32aaadc6: the file passes, and the full suite is green — **910 files / 10110 tests passed, 5 files / 24 tests skipped**, 36.6s.

What is left is the fragility that produced it. #912 fixed the dedup case by advancing each crash's own backoff (`200 * 2 ** i`), which re-couples the test to the pool's backoff constants: raise the base to 2s and the four crashes again span more than the 5s dedup window, and the same failure returns looking exactly like a product regression.

`onError()` counts failures and dedups synchronously — the case needs neither the respawn backoff nor the keepAlive idle teardown to fire. So advance no timers at all. Comment records why, naming both TRA-811 and TRA-885.

No product change. `pnpm lint` (tsc --noEmit) clean; file passes 7/7.
