### PR TITLE
fix(test): unbreak master — formatting and a platform-dependent PID (TRA-881)

### DIFF
--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -290,16 +290,14 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
     // its mtime is almost always the newest thing in the root — and a cli.js
     // that exists there may still be mid-write. A complete backup wins even
     // when it is older (TRA-881).
-    it('prefers a complete backup over npm\'s newer in-progress staging dir', () => {
+    it("prefers a complete backup over npm's newer in-progress staging dir", () => {
       const { home, traceHome, node } = setupFakeHome();
       const root = path.join(home, '.nvm', 'versions', 'node', 'v22.22.2', 'lib', 'node_modules');
       for (const name of ['trace-mcp.tmcp-bak-4242', '.trace-mcp-deadbeef']) {
         fs.mkdirSync(path.join(root, name, 'dist'), { recursive: true });
         fs.writeFileSync(path.join(root, name, 'dist', 'cli.js'), `// ${name}\n`);
       }
-      const bakCli = fs.realpathSync(
-        path.join(root, 'trace-mcp.tmcp-bak-4242', 'dist', 'cli.js'),
-      );
+      const bakCli = fs.realpathSync(path.join(root, 'trace-mcp.tmcp-bak-4242', 'dist', 'cli.js'));
       // Backdate the backup so a pure mtime sort would pick the staging dir.
       const old = new Date(Date.now() - 60 * 60 * 1000);
       fs.utimesSync(path.join(root, 'trace-mcp.tmcp-bak-4242'), old, old);

--- a/tests/updater-rollback.test.ts
+++ b/tests/updater-rollback.test.ts
@@ -240,13 +240,19 @@ describe('checkAndInstallUpdate — backup + rollback', () => {
   // may be many versions old. Newest on disk is the only defensible pick.
   it('restores the newest stale backup when several dead-PID backups exist', async () => {
     const older = path.join(tmpRoot, 'trace-mcp.tmcp-bak-4242');
-    const newer = path.join(tmpRoot, 'trace-mcp.tmcp-bak-999');
+    // Both PIDs must be reliably dead on every platform, and a low one is not:
+    // on Linux PID 999 is typically a root-owned system process, so
+    // `process.kill(999, 0)` throws EPERM, which isPidAlive counts as alive.
+    // The backup was then skipped as "owned by another updater", leaving only
+    // the older one to restore — green on macOS, red on the CI runner.
+    const newer = path.join(tmpRoot, 'trace-mcp.tmcp-bak-999999998');
     fs.mkdirSync(older, { recursive: true });
     fs.writeFileSync(path.join(older, 'marker.txt'), 'stale-old-build');
     fs.mkdirSync(newer, { recursive: true });
     fs.writeFileSync(path.join(newer, 'marker.txt'), 'recent-build');
     // Make the ordering unambiguous regardless of filesystem timestamp
-    // granularity: 'trace-mcp.tmcp-bak-4242' sorts first by name, last by mtime.
+    // granularity: 'trace-mcp.tmcp-bak-4242' still sorts first by name and last
+    // by mtime, so this keeps proving that mtime order wins over readdir order.
     const old = new Date(Date.now() - 60 * 60 * 1000);
     fs.utimesSync(older, old, old);
     expect(fs.existsSync(mainDir)).toBe(false);


### PR DESCRIPTION
master has been red since #916. Two failures, both in that PR's tests, neither in its shipped logic — `reconcileStaleBackups` is correct as written.

### 1. biome (reproduces on a clean master checkout)

`tests/init/launcher-integration.test.ts` was committed unformatted. `biome format --write`, no behaviour change.

### 2. `tests/updater-rollback.test.ts` — green on macOS, red on Linux

The case *"restores the newest stale backup when several dead-PID backups exist"* names its newer backup `bak-999`, and the whole case depends on that PID being **dead** so the backup counts as a restore candidate.

On Linux PID 999 is typically a root-owned system process. `process.kill(999, 0)` then raises `EPERM`, and `isPidAlive` counts `EPERM` as alive on purpose — EPERM means the process exists, we just cannot signal it (`src/updater.ts:158-168`). The backup was skipped as "owned by another updater", only the older one was left, and the assertion got `'stale-old-build'`. macOS leaves 999 free, so the case passes locally.

Fixed by using `999999998`, the same guaranteed-dead range the neighbouring case already uses. `'trace-mcp.tmcp-bak-4242'` still sorts first by name and last by mtime, so the case still proves mtime order beats readdir order.

### Evidence

```
npx vitest run tests/updater-rollback.test.ts tests/init/   18 files, 279 passed
npx biome ci .                                              1783 files, no fixes applied
```

Found while CI on #917 failed on changes that touch only markdown.