### PR TITLE
fix(daemon): never index or watch a dangerous project root (TRA-893)

### DIFF
--- a/src/daemon/router/local-backend.ts
+++ b/src/daemon/router/local-backend.ts
@@ -13,6 +13,7 @@ import {
 } from '../../ai/index.js';
 import { SummarizationPipeline } from '../../ai/summarization-pipeline.js';
 import type { TraceMcpConfig } from '../../config.js';
+import { isDangerousProjectRoot } from '../../dangerous-root.js';
 import { initializeDatabase } from '../../db/schema.js';
 import { Store } from '../../db/store.js';
 import { DECISIONS_DB_PATH, ensureGlobalDirs, TOPOLOGY_DB_PATH } from '../../global.js';
@@ -248,7 +249,21 @@ export class LocalBackend implements Backend {
     // DB already holds the daemon's index, so skip the entire indexing stack —
     // no indexAll (which spawns the ExtractPool worker threads), no AI passes.
     // Full indexing only runs in the genuine daemonless case (nothing seeded).
-    const readOnly = seeded;
+    // Never index or watch an obviously-wrong root. MCP clients that spawn us
+    // with cwd=/ (Claude Desktop does) otherwise pull the ENTIRE filesystem
+    // through indexAll + @parcel/watcher: 1.5 GB RSS and a permanent ~70% CPU
+    // burn per session, forever, on a project that does not exist (TRA-893).
+    // Reads still work — this only takes the write side offline.
+    const dangerReason = isDangerousProjectRoot(projectRoot);
+    if (dangerReason) {
+      logger.error(
+        { projectRoot, reason: dangerReason },
+        'LocalBackend: refusing to index — not a project directory. ' +
+          'Start trace-mcp with its working directory set to your project.',
+      );
+    }
+
+    const readOnly = seeded || dangerReason !== null;
     this.readOnly = readOnly;
 
     // Kick off initial indexing in the background — do not block start.

--- a/tests/daemon/local-backend-dangerous-root.test.ts
+++ b/tests/daemon/local-backend-dangerous-root.test.ts
@@ -1,0 +1,195 @@
+import os from 'node:os';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Dangerous-root guard for LocalBackend.start() (TRA-893).
+ *
+ * MCP clients that spawn `trace-mcp serve` with cwd=/ (Claude Desktop does)
+ * used to make the local backend index and watch the whole filesystem —
+ * ~1.5 GB RSS and permanent ~70% CPU per session. start() must bring up the
+ * read side and leave indexAll() + the file watcher untouched.
+ *
+ * Heavy collaborators are stubbed so the test runs in <1s.
+ */
+
+vi.mock('../../src/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+// In-memory fake DB handle — just needs .close() and to be passed around.
+const makeFakeDb = () => ({
+  close: vi.fn(),
+  exec: vi.fn(),
+  prepare: vi.fn(() => ({ run: vi.fn(), get: vi.fn(), all: vi.fn(() => []) })),
+  pragma: vi.fn(),
+  inTransaction: false,
+});
+
+const initializeDatabaseMock = vi.fn(() => makeFakeDb());
+vi.mock('../../src/db/schema.js', () => ({
+  initializeDatabase: initializeDatabaseMock,
+}));
+
+vi.mock('../../src/db/store.js', () => ({
+  Store: class FakeStore {
+    db: unknown;
+    constructor(db: unknown) {
+      this.db = db;
+    }
+  },
+}));
+
+vi.mock('../../src/global.js', () => ({
+  ensureGlobalDirs: vi.fn(),
+  TRACE_MCP_HOME: '/tmp/never-exists-trace-mcp-home',
+  TOPOLOGY_DB_PATH: '/tmp/never-exists-topology.db',
+  DECISIONS_DB_PATH: '/tmp/never-exists-decisions.db',
+}));
+
+vi.mock('../../src/progress.js', () => ({
+  ProgressState: class FakeProgressState {},
+  writeServerPid: vi.fn(),
+  clearServerPid: vi.fn(),
+}));
+
+vi.mock('../../src/plugin-api/registry.js', () => ({
+  PluginRegistry: { createWithDefaults: vi.fn(() => ({})) },
+}));
+
+vi.mock('../../src/indexer/extract-pool.js', () => ({
+  ExtractPool: class FakeExtractPool {
+    async terminate(): Promise<void> {}
+  },
+}));
+
+const indexAllMock = vi.fn(async () => undefined);
+vi.mock('../../src/indexer/pipeline.js', () => ({
+  IndexingPipeline: class FakeIndexingPipeline {
+    indexAll = indexAllMock;
+    async indexFiles(): Promise<void> {}
+    deleteFiles(): void {}
+    async dispose(): Promise<void> {}
+  },
+}));
+
+const watcherStartMock = vi.fn(async () => undefined);
+const watcherStopMock = vi.fn(async () => undefined);
+vi.mock('../../src/indexer/watcher.js', () => ({
+  FileWatcher: class FakeFileWatcher {
+    start = watcherStartMock;
+    stop = watcherStopMock;
+  },
+}));
+
+vi.mock('../../src/pipeline/index.js', () => ({
+  SqliteTaskCache: class FakeSqliteTaskCache {},
+}));
+
+vi.mock('../../src/ai/index.js', () => ({
+  createAIProvider: vi.fn(() => ({
+    embedding: vi.fn(),
+    fastInference: vi.fn(),
+  })),
+  BlobVectorStore: class FakeBlobVectorStore {},
+  CachedInferenceService: class FakeCachedInferenceService {},
+  EmbeddingPipeline: class FakeEmbeddingPipeline {},
+  InferenceCache: class FakeInferenceCache {
+    evictExpired(): void {}
+  },
+}));
+
+vi.mock('../../src/ai/summarization-pipeline.js', () => ({
+  SummarizationPipeline: class FakeSummarizationPipeline {},
+}));
+
+vi.mock('../../src/memory/decision-store.js', () => ({
+  DecisionStore: class FakeDecisionStore {},
+}));
+
+vi.mock('../../src/topology/topology-db.js', () => ({
+  TopologyStore: class FakeTopologyStore {},
+}));
+
+const serverDispose = vi.fn();
+vi.mock('../../src/server/server.js', () => ({
+  createServer: vi.fn(() => ({
+    server: {
+      connect: vi.fn(async () => undefined),
+    },
+    dispose: serverDispose,
+  })),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/inMemory.js', () => ({
+  InMemoryTransport: {
+    createLinkedPair: vi.fn(() => {
+      const client = {
+        onmessage: undefined as unknown,
+        onerror: undefined as unknown,
+        start: vi.fn(async () => undefined),
+        close: vi.fn(async () => undefined),
+        send: vi.fn(async () => undefined),
+      };
+      const server = {
+        onmessage: undefined as unknown,
+        onerror: undefined as unknown,
+        start: vi.fn(async () => undefined),
+        close: vi.fn(async () => undefined),
+        send: vi.fn(async () => undefined),
+      };
+      return [client, server];
+    }),
+  },
+}));
+
+// Import LocalBackend AFTER vi.mock calls.
+const { LocalBackend } = await import('../../src/daemon/router/local-backend.js');
+import type { TraceMcpConfig } from '../../src/config.js';
+
+function makeBackend(projectRoot: string) {
+  const config = {
+    ai: { enabled: false },
+    topology: { enabled: false },
+    indexer: { workers: 1 },
+  } as unknown as TraceMcpConfig;
+  return new LocalBackend({
+    projectRoot,
+    indexRoot: projectRoot,
+    config,
+    sharedDbPath: '/nonexistent/trace-mcp-danger.db',
+  });
+}
+
+describe('LocalBackend dangerous-root guard', () => {
+  beforeEach(() => {
+    watcherStartMock.mockClear();
+    indexAllMock.mockClear();
+  });
+
+  it.each(['/', os.homedir(), '/Users', '/etc'])('does not index or watch %s', async (root) => {
+    const backend = makeBackend(root);
+    await backend.start();
+
+    expect(indexAllMock).not.toHaveBeenCalled();
+    expect(watcherStartMock).not.toHaveBeenCalled();
+
+    await backend.stop();
+  });
+
+  it('still indexes and watches a real project root', async () => {
+    const backend = makeBackend('/nonexistent/trace-mcp-test-project');
+    await backend.start();
+
+    expect(indexAllMock).toHaveBeenCalled();
+    expect(watcherStartMock).toHaveBeenCalled();
+
+    await backend.stop();
+  });
+});


### PR DESCRIPTION
## What

`LocalBackend.doStart()` now refuses to index or watch an obviously-wrong project root.

## Why

Two `trace-mcp serve` processes on a user machine were pinned at **1.6 GB RSS and ~70% CPU each for 7+ hours** (277 min CPU time apiece). They were indexing and watching the whole filesystem.

Claude Desktop spawns MCP servers with **cwd = `/`**. `src/cli.ts:413` takes `process.cwd()` as the project root unchecked, and `LocalBackend` runs `indexAll()` + `FileWatcher.start()` on it.

Evidence:

- 4596/4596 `reindex-file` telemetry events logged `"project":"/"`; watched paths included Comet cookies, Telegram `network-stats`, `postgresql@18.log`.
- Session DB named `-8a5edab28263-session-*.db` — `8a5edab28263` = `sha256("/")`.
- `sample(1)`: main thread entirely in `uv_fs_scandir` → `__getdirentries64`; workers in V8 `Scavenge` / `ConcurrentMarking`.
- `indexing started: 0 items` → `completed: 0 items in 165s`, on loop. Log file reached 78 MB.

`isDangerousProjectRoot()` already existed and already rejected `/`, `$HOME` and system dirs — its own doc comment describes this exact failure. It was wired into `project-setup`, the daemon router, `project-manager` and the subproject store, but never into the stdio `serve` path that every desktop MCP client uses.

## How

A dangerous root now takes the same branch as the existing read-only fallback: no `indexAll()`, no `FileWatcher`, no AI passes, one `logger.error` telling the user to start trace-mcp from a project directory. Reads keep working, so a misconfigured client degrades instead of breaking.

No MCP tool signature or DB schema change. Token budget unaffected.

## Tests

`tests/daemon/local-backend-dangerous-root.test.ts` — `/`, `$HOME`, `/Users`, `/etc` must not call `indexAll()` or `watcher.start()`; a real project root still must. Verified failing (4/5) with the fix reverted, passing with it.

Full suite: `911 files passed, 10116 tests passed`. `pnpm typecheck` and `biome ci` clean.

Closes TRA-893.
