### PR TITLE
docs(ops): the same referrer finding, second occurrence in the same file

### DIFF
--- a/scripts/ga4-snapshot.mjs
+++ b/scripts/ga4-snapshot.mjs
@@ -123,7 +123,7 @@ const why = (e) =>
  * The top of the funnel: where visitors to the repo came from.
  *
  * GitHub's traffic API is the only acquisition source available to us — the
- * docs site has no analytics of its own, and Reddit (our largest referrer) is
+ * docs site has no analytics of its own, and the largest external referrer is
  * unreadable from a run at all (`ops/user-signal.md`, private repo). Its window is a rolling
  * 14 days and nothing older is retrievable, which is exactly why the numbers
  * are copied into the daily snapshot: the `adoption-data` branch becomes the


### PR DESCRIPTION
Follow-up to [#922](https://github.com/nikolai-vysotskyi/trace-mcp/pull/922). That PR fixed the largest-referrer sentence at `scripts/ga4-snapshot.mjs:519` and missed the one at `:126` — same sentence, same file, same class as findings 1-4 on TRA-889.

Worth naming why both my sweep and the review missed it: we grepped for the **file path that moved** (`ops/user-signal.md`, `"Arrivals" column`) rather than for the **finding itself**. Line 126 had already had its path reference updated, so it looked clean by that test while still carrying the claim.

Comment-only change; the string ships inside the generated snapshot header, so it is published output rather than an internal note.

```
biome ci .      clean
tsc --noEmit    clean
grep 'largest referrer'  → no hits outside CHANGELOG history
```