### PR TITLE
docs(seo): retarget the telemetry page at the 'mcp tracing' query (TRA-897)

### DIFF
--- a/docs/_data/docs_nav.yml
+++ b/docs/_data/docs_nav.yml
@@ -41,7 +41,7 @@
   url: /analytics.html
 - title: TOON savings
   url: /toon-savings.html
-- title: Telemetry
+- title: MCP tracing
   url: /telemetry.html
 - title: Daemon memory
   url: /daemon-memory.html

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4672,15 +4672,18 @@ actually hold is the storage layer described in
 
 ---
 
-# Telemetry & Observability
+# MCP Tracing & Telemetry
 
 Source: https://trace-mcp.com/telemetry.html
 
 
-trace-mcp ships a pluggable observability bridge (P13) that emits
-OpenTelemetry-compatible spans for every AI provider call and every MCP tool
-invocation. The default sink is `noop` — opt-in only, and switched on with the
-`telemetry.*` keys described in [configuration](configuration.md). Turning it on
+Tracing an MCP server means seeing which tool the agent called, how long it
+took and what it threw. trace-mcp ships a pluggable observability bridge (P13)
+that emits OpenTelemetry-compatible spans for every AI provider call and every
+MCP tool invocation, so MCP tool traffic shows up in the same tracing backend
+as the rest of your stack. The default sink is `noop` — opt-in only, and
+switched on with the `telemetry.*` keys described in
+[configuration](configuration.md). Turning it on
 also unlocks the persistent `window` values of `analyze_perf`, which is
 otherwise limited to the current session ([analytics](analytics.md)).
 
@@ -4715,7 +4718,7 @@ JSON
 pnpm run build && node dist/cli.js eval run --dataset default
 ```
 
-## Where spans appear
+## Where the traces appear
 
 Open <http://localhost:16686>, pick `trace-mcp` from the **Service** dropdown,
 click **Find Traces**.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,10 +1,10 @@
 ---
-title: "Telemetry & Observability — OpenTelemetry spans for every MCP tool call"
-description: "trace-mcp's pluggable observability bridge emits OpenTelemetry-compatible spans for every AI provider call and every MCP tool call."
+title: "MCP Tracing — OpenTelemetry spans for every MCP tool call"
+description: "How to trace MCP tool calls: trace-mcp emits OpenTelemetry-compatible spans for every MCP tool invocation and AI provider call, exported to Jaeger, Honeycomb or Langfuse."
 updated: 2026-09-04
 ---
 
-# Telemetry & Observability
+# MCP Tracing & Telemetry
 
 <script type="application/ld+json">
 {
@@ -31,10 +31,13 @@ updated: 2026-09-04
   }
 }
 </script>
-trace-mcp ships a pluggable observability bridge (P13) that emits
-OpenTelemetry-compatible spans for every AI provider call and every MCP tool
-invocation. The default sink is `noop` — opt-in only, and switched on with the
-`telemetry.*` keys described in [configuration](configuration.md). Turning it on
+Tracing an MCP server means seeing which tool the agent called, how long it
+took and what it threw. trace-mcp ships a pluggable observability bridge (P13)
+that emits OpenTelemetry-compatible spans for every AI provider call and every
+MCP tool invocation, so MCP tool traffic shows up in the same tracing backend
+as the rest of your stack. The default sink is `noop` — opt-in only, and
+switched on with the `telemetry.*` keys described in
+[configuration](configuration.md). Turning it on
 also unlocks the persistent `window` values of `analyze_perf`, which is
 otherwise limited to the current session ([analytics](analytics.md)).
 
@@ -69,7 +72,7 @@ JSON
 pnpm run build && node dist/cli.js eval run --dataset default
 ```
 
-## Where spans appear
+## Where the traces appear
 
 Open <http://localhost:16686>, pick `trace-mcp` from the **Service** dropdown,
 click **Find Traces**.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,6 +1,6 @@
 ---
 title: "MCP Tracing — OpenTelemetry spans for every MCP tool call"
-description: "How to trace MCP tool calls: trace-mcp emits OpenTelemetry-compatible spans for every MCP tool invocation and AI provider call, exported to Jaeger, Honeycomb or Langfuse."
+description: "How to trace MCP tool calls: trace-mcp emits OpenTelemetry spans for every MCP tool invocation and AI provider call, exported to Jaeger or Langfuse."
 updated: 2026-09-04
 ---
 


### PR DESCRIPTION
## Why

`mcp tracing` is trace-mcp.com's largest non-brand impression source in Google Search Console — **82 impressions over 90 days (2026-06-05 → 2026-09-02), average position 12.7, zero clicks**. Over the same window the site took 101 clicks total, 98 of them from name-variant queries (`trace-mcp`, `trace mcp`, `trayce mcp`, `mcp trace`).

The query currently ranks the **homepage**, which contains the words "tracing" and "OpenTelemetry" zero times — it matches on the domain name alone, which is why the CTR is 0%.

The page that actually answers the query, `/telemetry.html` ("OpenTelemetry spans for every MCP tool call"), also never used the word "tracing" — 0 occurrences — and had zero impressions. GSC confirms it is `Submitted and indexed` (last crawl 2026-08-28), so it is eligible to rank; it just gave Google nothing to match.

## What changed

Markdown text only, no code:

- `docs/telemetry.md` — title, meta description, H1 and the lead paragraph now use the searcher's vocabulary ("tracing an MCP server", "tracing backend") without overstating: the page still describes exactly the opt-in OTel bridge it always did.
- `docs/_data/docs_nav.yml` — nav label `Telemetry` → `MCP tracing`, so the site's most-repeated internal anchor text to this page is the term it should rank for.

## Not done here

GSC reports the **sitemap as the only referring URL** for `/telemetry.html` — Google sees no internal link to it. The strongest remaining fix is a contextual link from the homepage, but `docs/index.html` is shared with Web Design Agent, so that is raised for coordination rather than taken unilaterally.

Review gate: markdown text edit — exempt per the workspace rule.
