### PR TITLE
chore(security): deny-by-default token permissions in ga4-snapshot + scanner-config ledger (TRA-903)

### DIFF
--- a/.github/workflows/ga4-snapshot.yml
+++ b/.github/workflows/ga4-snapshot.yml
@@ -12,12 +12,15 @@ on:
     - cron: '17 6 * * *' # daily, after the UTC day the ping counts against has closed
   workflow_dispatch:
 
+# Deny everything at the top level so a future job added here starts with no
+# token scopes; the one job that needs `contents: write` grants it to itself.
+permissions: {}
+
 jobs:
   snapshot:
     runs-on: ubuntu-latest
-    # Scoped to the job rather than the top level: `contents: write` is only
-    # needed by the publish step below, and a top-level grant hands it to every
-    # future job added here (Scorecard TokenPermissions).
+    # Scoped to the job rather than the top level: only the publish step below
+    # needs it, and a top-level grant would hand it to every future job here.
     permissions:
       contents: write
     steps:

--- a/ops/security-posture.md
+++ b/ops/security-posture.md
@@ -1,0 +1,72 @@
+# Security posture ledger
+
+Scanner *configuration* state — what is on, what is deliberately off, and why.
+Not a vulnerability log (those go through `SECURITY.md`), and not a place for
+alert counts, which age out in days.
+
+It exists because scanner config is invisible from the code. TRA-899 spent a
+run re-deriving that `js/path-injection` should be excluded from CodeQL — six
+days after TRA-381 had already excluded it. The alerts it counted were all
+created before the fix landed. Read this file before proposing a scanner
+change; update it in the same change that touches a setting.
+
+## CodeQL
+
+Config: `.github/codeql/codeql-config.yml`. It carries its own reasoning inline
+including the conditions that should make each exclusion be reverted — read it
+there, don't restate it here.
+
+- **`js/path-injection` — excluded since 2026-08-30** (TRA-381, #665). Verified
+  2026-09-05: zero open alerts for this rule, and none created since
+  2026-08-29, the day before the exclusion landed. If a run counts recent
+  dismissals of this rule, check their `created_at` before concluding the
+  problem is live.
+- **Filesystem-taint family** (`js/insecure-temporary-file`,
+  `js/file-system-race`, `js/file-access-to-http`, `js/http-to-file-access`) —
+  excluded since TRA-518, same trust-boundary reasoning.
+
+## Workflow token permissions
+
+All twelve workflow files carry a top-level `permissions:` block as of
+2026-09-05 (TRA-903 gave `ga4-snapshot.yml` the last missing one, `{}`, with
+`contents: write` still scoped to the job). Scorecard's `TokenPermissions`
+alerts 1230/1231 were about that file.
+
+Check for a regression with:
+
+```sh
+for f in .github/workflows/*.yml; do grep -qE '^permissions:' "$f" || echo "$f"; done
+```
+
+## Secret scanning
+
+Read the live state with
+`gh api repos/nikolai-vysotskyi/trace-mcp --jq .security_and_analysis`.
+
+| Setting | State (2026-09-05) | Note |
+| --- | --- | --- |
+| `secret_scanning` | enabled | |
+| `secret_scanning_push_protection` | enabled | the one that actually blocks a paste |
+| `secret_scanning_non_provider_patterns` | **disabled** | wanted; see below |
+| `secret_scanning_validity_checks` | **disabled** | wanted; low noise |
+
+Non-provider patterns is what catches generic private keys and base64 key
+material — the shape of `CSC_LINK`, the Developer ID `.p12` this project
+handles (TRA-901). With it off, that class of paste passes push protection.
+
+**Blocked on a UI toggle, not on a decision.** `PATCH /repos/{owner}/{repo}`
+with `security_and_analysis` returns 200 for these two fields and silently
+leaves them `disabled` — confirmed 2026-09-05 with a `repo`-scoped token, twice
+(form encoding and JSON body). They are settable only from
+Settings → Advanced Security. Don't burn another run scripting around this.
+
+When non-provider patterns is turned on: watch one week. This repo is full of
+full-SHA action pins and hex fixtures, so false positives are plausible. If it
+is unusable, turn it back off **and record that here** rather than leaving the
+state ambiguous.
+
+## Known, accepted divergence
+
+Scorecard's `Code-Review` check reads 0/30 and structurally always will: merges
+here are gated by the workspace's mandatory second-model review, which leaves
+no recorded GitHub approval. Do not "fix" the score by weakening that gate.

--- a/tests/ci/workflow-token-permissions.test.ts
+++ b/tests/ci/workflow-token-permissions.test.ts
@@ -1,0 +1,26 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import YAML from 'yaml';
+
+// A workflow with no top-level `permissions:` runs on GitHub's default token,
+// which is broader than anything here asks for (Scorecard TokenPermissions).
+// `ga4-snapshot.yml` was the last one missing it (TRA-903) — and it was missing
+// it for a *good* reason that turned out to be a false choice: its
+// `contents: write` is scoped to the job on purpose, and a top-level `{}` keeps
+// that scoping while still denying the default. Both goals hold at once, so
+// there is no legitimate reason for a workflow here to omit the block.
+const WORKFLOWS = join(import.meta.dirname, '../../.github/workflows');
+
+describe('workflow token permissions', () => {
+  const files = readdirSync(WORKFLOWS).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
+
+  it('finds workflows to check', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it.each(files)('%s declares top-level permissions', (file) => {
+    const doc = YAML.parse(readFileSync(join(WORKFLOWS, file), 'utf8'));
+    expect(doc.permissions, `${file} has no top-level \`permissions:\``).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes the two agent-actionable items of TRA-903 and records the third, which needs a settings toggle.

## 1. `ga4-snapshot.yml` — top-level `permissions: {}`

The only one of the twelve workflows without a top-level block, and the source of open Scorecard `TokenPermissions` alerts 1230/1231. The omission was deliberate — `contents: write` is scoped to the job so a future job doesn't inherit it — but that reasoning presented a false choice: `permissions: {}` at the top level keeps the job scoping *and* denies the default token. Both goals hold at once.

Guarded by `tests/ci/workflow-token-permissions.test.ts` (one case per workflow file), so the next workflow added can't silently omit it. Verified the test fails when the line is removed.

## 2. `js/path-injection` — already fixed, nothing to do

TRA-903 asked for a structural fix so the repeating dismissals stop. It already landed: the rule has been excluded in `.github/codeql/codeql-config.yml` since 2026-08-30 (TRA-381, #665). Verified today — **zero open alerts** for the rule, and the most recent one was created 2026-08-29, the day before the exclusion. The 19 dismissals counted over the last five weeks all predate the fix.

## 3. Secret scanning — blocked on a UI toggle

`secret_scanning_non_provider_patterns` and `secret_scanning_validity_checks` are both still `disabled`. `PATCH /repos/{owner}/{repo}` returns 200 and silently leaves them off — tried twice, form encoding and JSON body, with a `repo`-scoped token. They're settable only from Settings → Advanced Security.

## `ops/security-posture.md`

New ledger for scanner *configuration* — what's on, what's deliberately off, why, and the conditions to revisit. It exists because item 2 above cost a full run to re-derive six days after it was fixed; a run that reads this file first won't repeat that. Also records the accepted Scorecard `Code-Review` 0/30 divergence so a future run doesn't "fix" the score by weakening the second-model review gate.

Full suite green (10 129 passed), `tsc --noEmit` clean.
