### PR TITLE
docs: guard the visible home page copy carries trace-mcp (TRA-907)

### DIFF
--- a/ops/rename-to-trace.md
+++ b/ops/rename-to-trace.md
@@ -169,6 +169,28 @@ the claim above.
 
 *Measured by the SEO Agent autopilot, TRA-876 → TRA-879.*
 
+### Second window, wider: 90 days says the same thing (added 2026-09-05, TRA-907)
+
+An independent GSC read on the same property over 2026-06-05 → 2026-09-02 —
+three months, not one — lands on the same ratio: 101 clicks, of which 98 (97%)
+came from `trace-mcp`, `trace mcp`, `trayce mcp` or `mcp trace`. Non-brand
+clicks in a full quarter: two, both `"codegraphcontext"` → `/comparisons.html`.
+The one-month and three-month windows agreeing rules out the reading that the
+77–83% brand share was an artefact of the late-August impression spike.
+
+It also sharpens what a redirect can and cannot buy, which is the part worth
+remembering on cutover day: a 301 preserves link equity for a URL, it does not
+make anyone type a new name into Google. The asset here is query demand for a
+string, and nothing on our side controls that. Under the boundary above the
+question does not arise — the domain, the package and the on-page copy all keep
+the string, and `tests/docs/searchable-name.test.ts` now also asserts the
+*visible* home page copy carries it, not only the metadata. Should a domain
+move ever be reopened, the new host must be verified in Search Console and the
+Change of Address tool used **before** the cutover; it does not work
+retroactively.
+
+*Measured by the SEO Agent autopilot, TRA-907.*
+
 ## If someone reopens this
 
 The two facts that close it are checkable in under a minute and should be

--- a/tests/docs/searchable-name.test.ts
+++ b/tests/docs/searchable-name.test.ts
@@ -38,6 +38,15 @@ describe('the searchable name stays trace-mcp', () => {
     expect(index).toMatch(/property="og:title" content="[^"]*trace-mcp[^"]*"/);
   });
 
+  it('the visible home page copy carries it, not only the metadata', () => {
+    const index = read('docs/index.html');
+    const body = index.slice(index.indexOf('<body'));
+    // Tags stripped: a rename sweep that leaves the string only in <meta> would
+    // keep the SERP snippet matching while the page a visitor reads no longer does.
+    const visible = body.replace(/<script[\s\S]*?<\/script>/g, '').replace(/<[^>]+>/g, ' ');
+    expect(visible).toMatch(/\btrace-mcp\b/);
+  });
+
   it('the JSON-LD entity anchor names it', () => {
     const layout = read('docs/_layouts/default.html');
     const names = [


### PR DESCRIPTION
TRA-907 measured Search Console over a 90-day window (2026-06-05 → 2026-09-02) and found the same thing TRA-879 found on a 30-day one: **98 of 101 clicks (97%) come from the literal string `trace-mcp` or a misspelling of it**, two non-brand clicks in a full quarter. Two windows of different length agreeing rules out the reading that the earlier 77–83% brand share was an artefact of the late-August impression spike.

Its four asks (keep the domain, keep the npm name, keep the string on the homepage, use Change of Address if the domain ever moves) are all already settled by `ops/rename-to-trace.md` — the boundary keeps every searchable surface on `trace-mcp`. One of them was not actually guarded, though: `tests/docs/searchable-name.test.ts` asserts the `<title>`, `og:title`, JSON-LD names, package/registry identity and the `trace-mcp` bin, but nothing about the copy a visitor reads. A sweep that renamed the visible page and left the metadata alone would pass CI while the page stops matching the query it ranks for.

Changes:
- one assertion in `tests/docs/searchable-name.test.ts`: with tags and scripts stripped, the home page body still contains `trace-mcp`.
- a short section in `ops/rename-to-trace.md` recording the 90-day window, and the redirect point worth remembering — a 301 preserves link equity for a URL, it does not make anyone type a new name into Google; if a domain move is ever reopened, Change of Address must be used before the cutover, it is not retroactive.

Test evidence: `pnpm vitest run tests/docs/searchable-name.test.ts` → 5 passed. Negative check: substituting `trace-mcp` → `trace` in the body makes the new assertion fail.
