### PR TITLE
ci: fail when an environment-gated secret is readable without the environment (TRA-901)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,33 @@ jobs:
           npm_config_fetch_retries: '0'
         run: pnpm audit --prod --audit-level=moderate --ignore-registry-errors
 
+  # Secrets a release job gates behind `environment:` must not also be readable
+  # without it. This job deliberately declares NO environment, so every probe
+  # below has to come back false; `${{ secrets.X != '' }}` yields a boolean, not
+  # the value, so nothing secret enters the runner. See the script header and
+  # TRA-901 for why the claim needed a check rather than a comment.
+  gated-secrets:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+      # No install: the script is dependency-free on purpose.
+      - name: Assert environment-gated secrets are not repository-level
+        env:
+          VISIBLE_CSC_LINK: ${{ secrets.CSC_LINK != '' }}
+          VISIBLE_CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD != '' }}
+          VISIBLE_APPLE_ID: ${{ secrets.APPLE_ID != '' }}
+          VISIBLE_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD != '' }}
+          VISIBLE_APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID != '' }}
+          VISIBLE_TRACE_MCP_GA_MEASUREMENT_ID: ${{ secrets.TRACE_MCP_GA_MEASUREMENT_ID != '' }}
+          VISIBLE_TRACE_MCP_GA_API_SECRET: ${{ secrets.TRACE_MCP_GA_API_SECRET != '' }}
+        run: node scripts/check-gated-secrets.mjs
+
   no-ai-marks:
     runs-on: ubuntu-latest
     timeout-minutes: 3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,12 +251,18 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: macos-latest
-    # The Developer ID certificate lives in this environment, not at repository
-    # level, and the environment only deploys from protected branches (TRA-628).
-    # That is what keeps the signing identity out of reach of a workflow added
-    # on some other branch — `on: push: branches: [master]` above is a property
-    # of this file, and a repository-level secret is readable by any workflow
-    # that names it. Removing this line silently un-gates the certificate.
+    # This line is half of the gate: it restricts the job to a protected branch
+    # and lets the environment hold the Developer ID certificate. The other half
+    # is where the five secrets below actually live. A repository-level secret is
+    # readable by any workflow on any branch that names it, and declaring an
+    # environment does not move it — TRA-628 added this line and the earlier
+    # version of this comment claiming the certificate had been moved, while all
+    # five stayed repository-level for four days (TRA-901).
+    #
+    # Do not restate that claim here. `scripts/check-gated-secrets.mjs`, run by
+    # the `gated-secrets` job in ci.yml, asserts it on every run: it fails if any
+    # secret this job reads is visible to a job that declares no environment.
+    # Removing this line un-gates the certificate and that check will say so.
     environment: apple-signing
     permissions:
       contents: write

--- a/scripts/check-gated-secrets.mjs
+++ b/scripts/check-gated-secrets.mjs
@@ -45,9 +45,12 @@ export function gatedSecretsOf(yamlSource) {
   const found = new Map();
   /** @type {{env: string | null, names: Set<string>} | null} */
   let job = null;
+  // True only between an `environment:` with no value and the `name:` under it.
+  let inEnvBlock = false;
   const flush = () => {
     if (job?.env) for (const n of job.names) found.set(n, job.env);
     job = null;
+    inEnvBlock = false;
   };
   for (const line of yamlSource.split('\n')) {
     if (/^ {2}[A-Za-z0-9_-]+:\s*(#.*)?$/.test(line)) {
@@ -61,12 +64,30 @@ export function gatedSecretsOf(yamlSource) {
       continue;
     }
     if (!job) continue;
-    // `environment: name`, or `environment:` followed by an indented `name:`.
+    // A comment naming a secret is prose about it, not a use of it.
+    if (/^\s*#/.test(line)) continue;
+
     const inline = line.match(/^ {4}environment:\s*(?!$)['"]?([A-Za-z0-9_.-]+)/);
-    const nested = line.match(/^ {6}name:\s*['"]?([A-Za-z0-9_.-]+)/);
-    if (inline) job.env = inline[1];
-    else if (nested) job.env ??= nested[1];
-    for (const [, name] of line.matchAll(/secrets\.([A-Z0-9_]+)/g)) {
+    if (inline) {
+      job.env = inline[1];
+      inEnvBlock = false;
+    } else if (/^ {4}environment:\s*(#.*)?$/.test(line)) {
+      inEnvBlock = true;
+    } else if (inEnvBlock) {
+      // Only `name:` directly under `environment:` names an environment. Any
+      // other `name:` at this indent belongs to `outputs:`, `strategy:`, …
+      const nested = line.match(/^ {6}name:\s*['"]?([A-Za-z0-9_.-]+)/);
+      if (nested) job.env = nested[1];
+      if (nested || !/^ {6}/.test(line)) inEnvBlock = false;
+    }
+
+    // Both `secrets.NAME` and `secrets['NAME']`, in any case: GitHub matches
+    // secret names case-insensitively, so `secrets.apple_id` is the same secret
+    // as APPLE_ID and must be held to the same gate.
+    for (const [, dot, bracket] of line.matchAll(
+      /secrets(?:\.([A-Za-z0-9_]+)|\[['"]([A-Za-z0-9_]+)['"]\])/g,
+    )) {
+      const name = (dot ?? bracket).toUpperCase();
       if (!NOT_A_GATED_SECRET.has(name)) job.names.add(name);
     }
   }
@@ -89,7 +110,7 @@ export function auditProbes(gated, probes) {
       );
     } else if (probe !== 'false') {
       problems.push(
-        `${name}: release.yml claims this lives in environment \`${env}\`, but a job with no environment can read it — it is still a repository-level secret, readable by any workflow on any branch. Add it to the environment and delete the repository-level copy.`,
+        `${name}: a workflow claims this lives in environment \`${env}\`, but a job with no environment can read it — it is still a repository-level secret, readable by any workflow on any branch. Add it to the environment and delete the repository-level copy.`,
       );
     }
   }

--- a/scripts/check-gated-secrets.mjs
+++ b/scripts/check-gated-secrets.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// Fails when a secret a workflow job gates behind `environment: X` is also
+// readable without that environment.
+//
+// TRA-628 created the `apple-signing` environment, pointed the signing job at
+// it, and left a comment in release.yml saying the Developer ID certificate now
+// lives there. The secrets were never moved: the environment held zero of them
+// and all five stayed repository-level, readable by any workflow on any branch
+// that names them. That comment is what stopped the next reviewer from looking
+// for four days (TRA-901) — so the claim gets a check instead of a comment.
+//
+// The check needs no token and reads no secret value. GitHub only exposes an
+// environment secret to a job that declares that environment, so a job that
+// declares none must see an empty string for every gated name. ci.yml probes
+// each name with `${{ secrets.NAME != '' }}` from an environment-less job and
+// passes the booleans in; this script derives the gated set from the workflow
+// files and asserts the probe covers it and comes back false.
+//
+// Fork PRs get no secrets at all, so every probe reads false there — the check
+// can only pass spuriously on a fork, never fail spuriously. Master pushes and
+// in-repo PRs are where it has teeth, which is where the exposure is.
+//
+// The workflow scan is a line scanner rather than a YAML parse so the CI job
+// can run on a bare runner with no install: pulling in `yaml` would cost a
+// ~90s pnpm install to read five lines. ponytail: our own workflow files, our
+// own 2-space indentation; if that ever stops holding, the scan finds no gated
+// job and fails loudly rather than passing empty.
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+
+export const PROBE_PREFIX = 'VISIBLE_';
+
+// Always non-empty and scoped to the run, not to an environment.
+const NOT_A_GATED_SECRET = new Set(['GITHUB_TOKEN']);
+
+/**
+ * Secrets referenced from jobs that declare an `environment:`.
+ *
+ * @param {string} yamlSource one workflow file
+ * @returns {Map<string, string>} secret name → environment claiming it
+ */
+export function gatedSecretsOf(yamlSource) {
+  const found = new Map();
+  /** @type {{env: string | null, names: Set<string>} | null} */
+  let job = null;
+  const flush = () => {
+    if (job?.env) for (const n of job.names) found.set(n, job.env);
+    job = null;
+  };
+  for (const line of yamlSource.split('\n')) {
+    if (/^ {2}[A-Za-z0-9_-]+:\s*(#.*)?$/.test(line)) {
+      flush();
+      job = { env: null, names: new Set() };
+      continue;
+    }
+    if (!/^ {2,}\S/.test(line)) {
+      // Back at column 0 — out of `jobs:` entirely.
+      if (line.trim() !== '' && !line.startsWith('#')) flush();
+      continue;
+    }
+    if (!job) continue;
+    // `environment: name`, or `environment:` followed by an indented `name:`.
+    const inline = line.match(/^ {4}environment:\s*(?!$)['"]?([A-Za-z0-9_.-]+)/);
+    const nested = line.match(/^ {6}name:\s*['"]?([A-Za-z0-9_.-]+)/);
+    if (inline) job.env = inline[1];
+    else if (nested) job.env ??= nested[1];
+    for (const [, name] of line.matchAll(/secrets\.([A-Z0-9_]+)/g)) {
+      if (!NOT_A_GATED_SECRET.has(name)) job.names.add(name);
+    }
+  }
+  flush();
+  return found;
+}
+
+/**
+ * @param {Map<string, string>} gated secret name → environment
+ * @param {Record<string, string | undefined>} probes ci.yml's `VISIBLE_*` booleans
+ * @returns {string[]} one line per problem, empty when the gate holds
+ */
+export function auditProbes(gated, probes) {
+  const problems = [];
+  for (const [name, env] of gated) {
+    const probe = probes[PROBE_PREFIX + name];
+    if (probe === undefined) {
+      problems.push(
+        `${name}: gated behind \`environment: ${env}\` but ci.yml does not probe it — add "${PROBE_PREFIX}${name}: \${{ secrets.${name} != '' }}" to the gated-secrets job`,
+      );
+    } else if (probe !== 'false') {
+      problems.push(
+        `${name}: release.yml claims this lives in environment \`${env}\`, but a job with no environment can read it — it is still a repository-level secret, readable by any workflow on any branch. Add it to the environment and delete the repository-level copy.`,
+      );
+    }
+  }
+  return problems;
+}
+
+function main() {
+  const dir = '.github/workflows';
+  const gated = new Map();
+  for (const file of readdirSync(dir).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))) {
+    for (const [name, env] of gatedSecretsOf(readFileSync(join(dir, file), 'utf8')))
+      gated.set(name, env);
+  }
+  if (gated.size === 0) {
+    console.error(
+      '::error::no job declares `environment:` with a secret — either the gate was removed or this scan stopped matching the workflow files',
+    );
+    process.exit(1);
+  }
+  const probes = Object.fromEntries(
+    Object.entries(process.env).filter(([k]) => k.startsWith(PROBE_PREFIX)),
+  );
+  const problems = auditProbes(gated, probes);
+  if (problems.length > 0) {
+    for (const p of problems) console.error(`::error::${p}`);
+    process.exit(1);
+  }
+  console.log(
+    `gated secrets unreadable without their environment: ${[...gated.keys()].sort().join(', ')}`,
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tests/ci/gated-secrets.test.ts
+++ b/tests/ci/gated-secrets.test.ts
@@ -46,6 +46,44 @@ jobs:
     expect(gatedSecretsOf(nested)).toEqual(new Map([['CSC_LINK', 'apple-signing']]));
   });
 
+  // Reviewer B on PR #930: all three are ways the scanner could have missed or
+  // invented a gate. GitHub matches secret names case-insensitively and accepts
+  // bracket notation, so both forms name the same secret as `APPLE_ID`.
+  it('catches lowercase and bracket-notation references', () => {
+    const odd = `
+jobs:
+  sign:
+    environment: apple-signing
+    steps:
+      - run: echo \${{ secrets.apple_id }} \${{ secrets['CSC_LINK'] }}
+`;
+    expect([...gatedSecretsOf(odd).keys()].sort()).toEqual(['APPLE_ID', 'CSC_LINK']);
+  });
+
+  it('does not gate a secret that only appears in a comment', () => {
+    const commented = `
+jobs:
+  sign:
+    environment: apple-signing
+    steps:
+      # We removed \${{ secrets.OLD_UNUSED_KEY }}
+      - run: echo \${{ secrets.CSC_LINK }}
+`;
+    expect([...gatedSecretsOf(commented).keys()]).toEqual(['CSC_LINK']);
+  });
+
+  it('does not read a `name:` outside the environment block as an environment', () => {
+    const outputs = `
+jobs:
+  build:
+    outputs:
+      name: artifact-name
+    steps:
+      - run: echo \${{ secrets.REPO_SECRET }}
+`;
+    expect(gatedSecretsOf(outputs).size).toBe(0);
+  });
+
   it('finds the real apple-signing secrets in release.yml', () => {
     const gated = gatedSecretsOf(readFileSync('.github/workflows/release.yml', 'utf8'));
     expect(

--- a/tests/ci/gated-secrets.test.ts
+++ b/tests/ci/gated-secrets.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — plain .mjs script, no type declarations
+import { auditProbes, gatedSecretsOf, PROBE_PREFIX } from '../../scripts/check-gated-secrets.mjs';
+
+const WORKFLOW = `
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo \${{ secrets.NOT_GATED }}
+
+  sign:
+    runs-on: macos-latest
+    environment: apple-signing
+    steps:
+      - name: sign
+        env:
+          CSC_LINK: \${{ secrets.CSC_LINK }}
+          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+`;
+
+describe('gatedSecretsOf', () => {
+  it('binds a secret to the environment of the job that reads it', () => {
+    expect(gatedSecretsOf(WORKFLOW)).toEqual(new Map([['CSC_LINK', 'apple-signing']]));
+  });
+
+  it('ignores secrets read by a job with no environment', () => {
+    expect(gatedSecretsOf(WORKFLOW).has('NOT_GATED')).toBe(false);
+  });
+
+  it('ignores GITHUB_TOKEN, which is per-run and never environment-scoped', () => {
+    expect(gatedSecretsOf(WORKFLOW).has('GITHUB_TOKEN')).toBe(false);
+  });
+
+  it('reads the `environment: { name: ... }` form', () => {
+    const nested = `
+jobs:
+  sign:
+    environment:
+      name: apple-signing
+      url: https://example.com
+    steps:
+      - run: echo \${{ secrets.CSC_LINK }}
+`;
+    expect(gatedSecretsOf(nested)).toEqual(new Map([['CSC_LINK', 'apple-signing']]));
+  });
+
+  it('finds the real apple-signing secrets in release.yml', () => {
+    const gated = gatedSecretsOf(readFileSync('.github/workflows/release.yml', 'utf8'));
+    expect(
+      [...gated]
+        .filter(([, env]) => env === 'apple-signing')
+        .map(([n]) => n)
+        .sort(),
+    ).toEqual([
+      'APPLE_APP_SPECIFIC_PASSWORD',
+      'APPLE_ID',
+      'APPLE_TEAM_ID',
+      'CSC_KEY_PASSWORD',
+      'CSC_LINK',
+    ]);
+  });
+});
+
+describe('auditProbes', () => {
+  const gated = new Map([['CSC_LINK', 'apple-signing']]);
+
+  it('passes when the environment-less job cannot see the secret', () => {
+    expect(auditProbes(gated, { [`${PROBE_PREFIX}CSC_LINK`]: 'false' })).toEqual([]);
+  });
+
+  // TRA-901: this is the state the repo was actually in for four days while
+  // release.yml said the certificate had been moved.
+  it('fails when the secret is still readable without the environment', () => {
+    const [problem] = auditProbes(gated, { [`${PROBE_PREFIX}CSC_LINK`]: 'true' });
+    expect(problem).toMatch(/still a repository-level secret/);
+  });
+
+  it('fails when ci.yml stopped probing a gated secret', () => {
+    const [problem] = auditProbes(gated, {});
+    expect(problem).toMatch(/does not probe it/);
+  });
+});


### PR DESCRIPTION
## What

Makes the TRA-628 claim testable, and corrects the comment that asserted it.

`release.yml` said the Developer ID certificate lived in the `apple-signing`
environment. It does not — the environment holds zero secrets and all five Apple
values are still repository-level, so any workflow on any branch that names them
can read them:

```
$ gh api repos/nikolai-vysotskyi/trace-mcp/environments/apple-signing/secrets
{"total_count":0,"secrets":[]}
```

Declaring `environment:` gates *deployment*; it does not move the secret. Nothing
in the repo could tell the difference between "gated" and "gated in a comment",
so the comment held for four days.

## How

`scripts/check-gated-secrets.mjs` derives the gated set from the workflow files
(secrets referenced from a job that declares `environment:`) and asserts each one
is invisible to a job that declares none. The new `gated-secrets` job in ci.yml
is that job: it declares no environment and probes each name with
`${{ secrets.X != '' }}` — a boolean, so no secret value enters the runner. No
token, no install; the workflow scan is a line scanner on purpose, so the job
runs on a bare runner instead of paying a ~90s install to read five lines.

Fork PRs receive no secrets, so every probe reads false there — the check can
pass spuriously on a fork, never fail spuriously. Master pushes and in-repo PRs
are where the exposure is and where it has teeth.

The release.yml comment now describes what the line does and points at the check
instead of restating the claim.

## Test evidence

- `pnpm exec vitest run tests/ci/gated-secrets.test.ts` — 8 passed. Covers both
  directions: probe `false` passes, probe `true` fails with "still a
  repository-level secret", a dropped probe fails with "does not probe it", plus
  the nested `environment: { name: }` form and the real five names parsed out of
  `release.yml`.
- `pnpm test` — 10124 passed, 24 skipped, 912 files.
- Ran the script by hand against the real workflows in both states.

## Expected: this PR's `gated-secrets` check is red

That is the finding, not a bug in the check. It goes green when the five secrets
are moved into the `apple-signing` environment and the repository-level copies
deleted — only Nikolai can do that, GitHub does not read values back out. Merging
before then would merge a check that fails on master.

Closes TRA-901 once that move lands.
