### PR TITLE
docs: /vs/ deep links in README + TRA-905 index-coverage decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ trace-mcp combines **code graph navigation**, **cross-session memory**, and **re
 
 > Full side-by-side tables with GitHub stars, languages, and per-capability coverage: [trace-mcp vs. other code intelligence MCP servers](https://trace-mcp.com/comparisons.html).
 
+> Head-to-head: [vs Repomix](https://trace-mcp.com/vs/repomix.html) · [vs Serena](https://trace-mcp.com/vs/serena.html) · [vs codegraph](https://trace-mcp.com/vs/codegraph.html) · [vs codebase-memory-mcp](https://trace-mcp.com/vs/codebase-memory-mcp.html) · [vs Claude Code context mode](https://trace-mcp.com/vs/context-mode.html) · [Repomix vs codegraph](https://trace-mcp.com/vs/repomix-vs-codegraph.html).
+
 ---
 
 ## Token reduction — what we measured

--- a/ops/distribution.md
+++ b/ops/distribution.md
@@ -112,6 +112,17 @@ the site, the way the arrivals reading says whether it does anything for the rep
 **What the listings emit, read from their served HTML on 2026-09-04.** Nobody had
 checked; the answer is that the ones we can read pass nothing.
 
+**Decision 2026-09-05 (TRA-905): do not chase deep-URL links through these
+surfaces.** The question was whether the `/vs/` cluster and
+`/pr-context-benchmark.html` should be pushed into the listings instead of only
+the homepage. There is nothing to win: the surfaces we can read emit either no
+`trace-mcp.com` link at all or `rel="ugc nofollow"` on every one, and GitHub
+adds `nofollow` to external links in the awesome-list READMEs too — so no
+dofollow deep link exists in this channel set to go and get. The free lever
+instead is our own README, which glama scrapes live for all 31 of its anchors;
+it gained a head-to-head line linking the six `/vs/` pages the same day.
+Rationale and the 2026-09-26 re-read in [`ops/index-coverage.md`](index-coverage.md).
+
 | Surface | Links `trace-mcp.com`? | `rel` | Read how |
 |---|---|---|---|
 | glama.ai | Yes — **31 anchors**, deep pages included (`/comparisons.html`, `/configuration.html#cli`, `/supported-frameworks.html`) | `ugc nofollow` on every one | Fetched the page, parsed the anchors |

--- a/ops/index-coverage.md
+++ b/ops/index-coverage.md
@@ -71,6 +71,58 @@ TechArticle schema (TRA-419, 09-03).
 13 indexed, 11 not. The 11 are the newest pages and the whole `/vs/` cluster —
 the two groups carrying every non-branded keyword the site targets.
 
+## Reading 2026-09-05 (TRA-905), and what was decided about external links
+
+The SEO agent re-read Search Console on 2026-09-05: 14 of the now-25 sitemap
+URLs took zero impressions in 28 days, and `/vs/codegraph.html` came back
+`URL is unknown to Google`.
+
+**That is not a regression.** The 09-04 table above already recorded
+`/vs/codegraph.html` as unknown, so the two readings agree; nothing got worse
+between them. TRA-626 recorded the cluster as *discoverable by sitemap*, which
+was never a claim about the index. Do not re-report this as a discovery bug on
+the strength of one day's re-read.
+
+**Zero impressions is also not the same set as not indexed.** `/quality-gates.html`
+and `/telemetry.html` are in Google's index and still took no impressions in the
+window — that is the 0.0% non-branded demand recorded below, not a coverage
+problem. Keep the two measures separate when quoting either.
+
+### Decision: no deep-URL submissions to the directory channels (2026-09-05)
+
+TRA-905 asked whether to push deep URLs — the `/vs/` cluster and
+`/pr-context-benchmark.html` — through the surfaces in `ops/distribution.md`
+instead of only the homepage. **Declined, and the reason should stop this being
+re-opened:** every one of those surfaces either emits no link to `trace-mcp.com`
+at all (mcpservers.org, skillsllm.com — both rewrite our doc links to
+`github.com`) or emits `rel="ugc nofollow"` on all of them (glama.ai, 31
+anchors), and GitHub applies `nofollow` to external links in every awesome-list
+README we are in. There is no dofollow deep link available in that channel set
+to go and get, so a submission run cannot move the lever this ledger names.
+`ops/arrivals.md` (private repo) independently shows four consecutive 14-day
+windows in which no listing surface sent a single visitor.
+
+### What was done instead, and when to read it back
+
+The one deep-link surface that costs nothing per run is our own README: glama
+scrapes it live and already renders 31 anchors from it, and its deep links
+(`/comparisons.html`, `/configuration.html`, `/supported-frameworks.html`) are
+all indexed while the `/vs/` cluster, which had no external anchor anywhere, is
+not. That is correlation on three pages, not a finding — so it is being run as
+one cheap test rather than asserted: 2026-09-05 the README gained a
+head-to-head line linking all six `/vs/` pages (`/pr-context-benchmark.html`
+was already linked from it twice).
+
+**Re-read on or after 2026-09-26** (the ~3 weeks TRA-905 asked for): inspect the
+six `/vs/` URLs plus `/pr-context-benchmark.html`, `/tools-index.html` and
+`/reduce-claude-code-token-usage.html`, and record the rows here. If the `/vs/`
+pages moved off `unknown` and the other three did not, the nofollow README
+anchors did something and the same trick is worth extending. If nothing moved,
+close the external-link lever for the site: the remaining named inputs are page
+quality, update frequency and perceived inventory, none of which has been
+measured here, and the honest next step is to measure one rather than submit
+anywhere else.
+
 ## What has been ruled out, and what has not
 
 Every one of the 11 was verified serving-clean on 2026-09-04:


### PR DESCRIPTION
Closes the decision half of TRA-905.

**Decision: no deep-URL submissions to the directory channels.** The ask was whether to push `/vs/*` and `/pr-context-benchmark.html` through the surfaces in `ops/distribution.md` instead of only the homepage. There is nothing to win there — per the 2026-09-04 reading in that ledger, every surface we can read emits either no `trace-mcp.com` link at all (mcpservers.org, skillsllm.com rewrite our doc links to github.com) or `rel="ugc nofollow"` on all of them (glama.ai, 31 anchors), and GitHub adds `nofollow` in the awesome-list READMEs too. `ops/arrivals.md` (private repo) independently shows four consecutive 14-day windows with no listing surface sending a visitor.

**What is done instead:** the README gains a head-to-head line linking all six `/vs/` pages. glama scrapes the README live, so this is the one deep-link surface that costs nothing per run — and its existing deep links (`/comparisons.html`, `/configuration.html`, `/supported-frameworks.html`) are all indexed while the `/vs/` cluster, which had no external anchor anywhere, is not. Correlation on three pages, so it is recorded as a test with a re-read date, not asserted as a finding.

**Correction recorded:** `/vs/codegraph.html` being unknown to Google is not a regression — the 09-04 table in `ops/index-coverage.md` already had it unknown. And "zero impressions" is not the same set as "not indexed": `/quality-gates.html` and `/telemetry.html` are indexed and took none.

Re-read date **2026-09-26** written into `ops/index-coverage.md`.

Tests: `npx vitest run tests/docs/` — 18 files, 222 passed.