### PR TITLE
ci(release): attach provenance bundles and an SPDX SBOM to releases (TRA-902)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ on:
 permissions:
   contents: read
 
-# Scorecard flags the four job-level `contents: write` grants below
-# (release-please, the macOS/Windows build jobs, and verify-release-assets).
-# They are accepted, not oversights: release-please has to push the release
-# branch and cut the tag, the build jobs upload signed installers as release
-# assets, and verify-release-assets has to be able to take an incomplete
-# release back out of `latest` (TRA-566). All are already scoped to the job,
-# never top-level (TRA-255).
+# Scorecard flags the five job-level `contents: write` grants below
+# (release-please, the macOS/Windows build jobs, verify-release-assets, and
+# sbom). They are accepted, not oversights: release-please has to push the
+# release branch and cut the tag, the build jobs upload signed installers as
+# release assets, verify-release-assets has to be able to take an incomplete
+# release back out of `latest` (TRA-566), and sbom uploads one more asset.
+# All are already scoped to the job, never top-level (TRA-255).
 
 jobs:
   release-please:
@@ -192,6 +192,12 @@ jobs:
         run: |
           set -euo pipefail
           FILE="trace-mcp-${TAG#v}.spdx.json"
+          # DEPRECATED, Sunset: 2026-11-13 (headers on the response itself;
+          # github.blog/changelog/2026-05-12-synchronous-sbom-api-deprecated).
+          # The successor is async — POST .../sbom/generate-report, then poll
+          # .../fetch-report/{uuid} — and returned 404 when probed on
+          # 2026-09-05, so it is not yet usable here. Migrate before the
+          # sunset or this step starts failing (TRA-908).
           gh api "repos/${{ github.repository }}/dependency-graph/sbom" --jq .sbom > "$FILE"
           # An empty package list means the dependency graph had not been
           # ingested for this commit yet — better to fail loudly than to ship

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,32 @@ jobs:
           echo "::error::$TAG verified but could not be returned to stable — users will not be offered it"
           exit 1
 
+  # An SPDX SBOM is the first artifact an enterprise evaluator asks for, and
+  # GitHub already builds one from the dependency graph — no scanner, no
+  # service, one API call (TRA-902). Deliberately not a gate on anything: a
+  # missing SBOM is a paperwork problem, not a broken release.
+  sbom:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true' || github.event.inputs.publish_tag != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ github.event.inputs.publish_tag != '' && github.event.inputs.publish_tag || needs.release-please.outputs.tag_name }}
+    steps:
+      - name: Generate and attach the SPDX SBOM
+        run: |
+          set -euo pipefail
+          FILE="trace-mcp-${TAG#v}.spdx.json"
+          gh api "repos/${{ github.repository }}/dependency-graph/sbom" --jq .sbom > "$FILE"
+          # An empty package list means the dependency graph had not been
+          # ingested for this commit yet — better to fail loudly than to ship
+          # an SBOM that claims we depend on nothing.
+          test "$(jq '.packages | length' "$FILE")" -gt 1
+          gh release upload "$TAG" "$FILE" --repo "${{ github.repository }}" --clobber
+
   # TRA-368: the asset gate above proves latest.yml is ON the release. It cannot
   # prove an install would act on it — a feed whose sha512 no longer matches the
   # installer beside it passes that check and still leaves every Windows install
@@ -462,11 +488,21 @@ jobs:
         run: node scripts/generate-shasums.mjs packages/app/release .zip .dmg
 
       - name: Generate SLSA build provenance attestation
+        id: attest
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
             packages/app/release/*.zip
             packages/app/release/*.dmg
+
+      # The attestation above lives in GitHub's attestation API, which needs
+      # network access to a service that must still be up, and which OpenSSF
+      # Scorecard does not look at (Signed-Releases counts release assets only).
+      # The same sigstore bundle attached to the release makes verification
+      # offline-capable — `gh attestation verify --bundle` — and is what a
+      # mirror or an air-gapped evaluator can actually check (TRA-902).
+      - name: Attach the provenance bundle to the release
+        run: cp "${{ steps.attest.outputs.bundle-path }}" "packages/app/release/trace-mcp-mac.intoto.jsonl"
 
       - name: Upload to release
         env:
@@ -477,6 +513,7 @@ jobs:
             packages/app/release/*.zip.sha256 \
             packages/app/release/*.dmg \
             packages/app/release/*.dmg.sha256 \
+            packages/app/release/trace-mcp-mac.intoto.jsonl \
             packages/app/release/latest-mac.yml \
             --clobber
 
@@ -554,11 +591,18 @@ jobs:
         run: node scripts/generate-shasums.mjs packages/app/release .exe .zip
 
       - name: Generate SLSA build provenance attestation
+        id: attest
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
             packages/app/release/*.exe
             packages/app/release/*-win*.zip
+
+      # See the matching step in build-app-mac for why the bundle is uploaded
+      # as well as registered with GitHub's attestation API (TRA-902).
+      - name: Attach the provenance bundle to the release
+        shell: bash
+        run: cp "${{ steps.attest.outputs.bundle-path }}" "packages/app/release/trace-mcp-win.intoto.jsonl"
 
       - name: Upload to release
         env:
@@ -575,5 +619,6 @@ jobs:
           gh release upload "${{ needs.release-please.outputs.tag_name }}" \
             "${FILES[@]}" \
             "${SUMS[@]}" \
+            packages/app/release/trace-mcp-win.intoto.jsonl \
             packages/app/release/latest.yml \
             --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -600,9 +600,10 @@ jobs:
 
       # See the matching step in build-app-mac for why the bundle is uploaded
       # as well as registered with GitHub's attestation API (TRA-902).
+      # pwsh, not bash: the action emits a Windows path with backslashes and
+      # Git Bash's handling of those is not worth relying on here.
       - name: Attach the provenance bundle to the release
-        shell: bash
-        run: cp "${{ steps.attest.outputs.bundle-path }}" "packages/app/release/trace-mcp-win.intoto.jsonl"
+        run: Copy-Item "${{ steps.attest.outputs.bundle-path }}" "packages/app/release/trace-mcp-win.intoto.jsonl"
 
       - name: Upload to release
         env:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -118,7 +118,7 @@ Files matching `.gitignore` patterns are **indexed for graph metadata** (symbols
 
 CodeQL and Semgrep run on every push/PR with `security-extended` + OWASP/nodejsscan rulesets, which surfaces a structural false-positive shape specific to this codebase: **`js/path-injection`**. Nearly every MCP tool takes a `file_path`-shaped argument, and the sanitizer (`validatePath()` / `guardPath()`, see above) runs in the tool-registration wrapper (`src/tools/register/*.ts`) one call away from the implementation function CodeQL flags — interprocedural taint tracking doesn't follow the sanitizer across that boundary. Per the precedent set in alerts #1068/#1069 ("local read-only search under the registered project root, same trust domain as the CLI/MCP user"), this bucket is dismissed in bulk as **won't fix** whenever the flagged path either passes through `validatePath()`/`guardPath()` before use, or is sourced from already-validated indexed data (e.g. `file_path` columns populated at index time). New `js/path-injection` alerts should be checked against this pattern and dismissed with the same justification rather than left to accumulate — but a path that reaches a sink *without* going through the wrapper is a real bug, not this exception.
 
-OpenSSF Scorecard contributes a second structural bucket: **`TokenPermissionsID` on `.github/workflows/release.yml`**. Scorecard flags any `contents: write`, but release-please *is* the release: it pushes release commits, creates tags, and publishes GitHub Releases, so the workflow cannot function without that scope. These alerts are dismissed as **won't fix** with the justification "release-please requires `contents: write` to create tags and releases; the permission is scoped to a job in a workflow gated on `master`", and re-dismissed the same way when a Scorecard run re-raises them. The exception is deliberately narrow — it covers `release.yml` only. A `contents: write` grant in any other workflow, or one at the top level rather than scoped to the job that needs it, is a real finding and gets fixed (as `ga4-snapshot.yml` was). Two adjacent Scorecard results are also expected and not gaps: `Signed-Releases: 0` reflects that release assets carry `actions/attest-build-provenance` attestations, which Scorecard does not look for (it only counts `.sig`/`.asc`/`.intoto.jsonl` uploaded as release assets), and the legacy branch-protection API reporting `allow_force_pushes: true` on `master` is overridden by the active `default` ruleset's `non_fast_forward` rule with an empty bypass list.
+OpenSSF Scorecard contributes a second structural bucket: **`TokenPermissionsID` on `.github/workflows/release.yml`**. Scorecard flags any `contents: write`, but release-please *is* the release: it pushes release commits, creates tags, and publishes GitHub Releases, so the workflow cannot function without that scope. These alerts are dismissed as **won't fix** with the justification "release-please requires `contents: write` to create tags and releases; the permission is scoped to a job in a workflow gated on `master`", and re-dismissed the same way when a Scorecard run re-raises them. The exception is deliberately narrow — it covers `release.yml` only. A `contents: write` grant in any other workflow, or one at the top level rather than scoped to the job that needs it, is a real finding and gets fixed (as `ga4-snapshot.yml` was). One adjacent Scorecard result is also expected and not a gap: the legacy branch-protection API reporting `allow_force_pushes: true` on `master` is overridden by the active `default` ruleset's `non_fast_forward` rule with an empty bypass list.
 
 The remaining volume buckets (`ajinabraham.njsscan.dos.regex_dos`, `js/insecure-temporary-file`, `js/file-system-race`) are **not** covered by this exception — they involve regex-shape and TOCTOU analysis that has to be judged per call site, not by a single architectural argument, and a lazy blanket dismissal here would hide a real bug class (this tool is designed to scan arbitrary — including untrusted/third-party — codebases, so a crafted file triggering catastrophic backtracking in one of the scanner's own detection regexes is a plausible local DoS). These are tracked for individual review rather than dismissed.
 
@@ -234,6 +234,29 @@ cosign verify-blob --bundle <bundle-url> <tarball>
 | Build environment | `ubuntu-latest`, Node 22 |
 
 A missing or invalid attestation means the package was **not** built by the official GitHub Actions pipeline and should be treated as suspect.
+
+---
+
+## Desktop App Provenance
+
+The desktop installers on GitHub Releases carry the same class of claim as the npm package. Each build job runs `actions/attest-build-provenance`, so every `.dmg`, `.exe`, and `.zip` on a release has a SLSA v1 provenance statement tied to this repository and to the workflow run that produced it:
+
+```bash
+gh attestation verify trace-mcp-3.17.1-arm64.dmg --repo nikolai-vysotskyi/trace-mcp
+```
+
+The same sigstore bundles are also attached to the release as `trace-mcp-mac.intoto.jsonl` and `trace-mcp-win.intoto.jsonl`, so verification works without reaching GitHub's attestation API:
+
+```bash
+gh attestation verify trace-mcp.Setup.3.17.1.exe --bundle trace-mcp-win.intoto.jsonl \
+  --repo nikolai-vysotskyi/trace-mcp
+```
+
+The `.sha256` file beside each artifact answers a different and much weaker question — whether the download arrived intact. It is published on the same page by the same token as the artifact, so it is not a tamper control; the attestation is.
+
+Each release also carries an SPDX SBOM (`trace-mcp-<version>.spdx.json`), generated from GitHub's dependency graph.
+
+macOS builds are additionally signed and notarized with an Apple Developer ID, which is what Gatekeeper checks. **Windows builds are not code-signed** — there is no Authenticode certificate — so SmartScreen will warn on first run, and `gh attestation verify` is the only way to establish that a Windows installer came from this pipeline.
 
 ---
 
@@ -372,5 +395,7 @@ If you discover a security vulnerability, please report it responsibly:
 | Auto-update Gatekeeper check | `spctl -a -t exec` on staged bundle | No |
 | Auto-update opt-out | Disabled when set | Yes (`TRACE_MCP_NO_AUTO_UPDATE=1`) |
 | npm provenance attestation | Sigstore/OIDC on every release | No |
+| Desktop build provenance | SLSA attestation + `.intoto.jsonl` bundle on every release | No |
+| Release SBOM | SPDX, from GitHub's dependency graph | No |
 | Apple signing secret scope | `apple-signing` environment, protected branches only | No |
 | GA4 telemetry credentials | Public by design, ship in `dist/`, write-only | Yes (`TRACE_MCP_TELEMETRY=off`) |

--- a/tests/ci/release-provenance.test.ts
+++ b/tests/ci/release-provenance.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import YAML from 'yaml';
+
+// TRA-902. The desktop artifacts have carried `actions/attest-build-provenance`
+// since #108, but the sigstore bundle stayed inside GitHub's attestation API:
+// verification needed that service to be reachable, OpenSSF Scorecard's
+// Signed-Releases check (which reads release assets and nothing else) scored 0,
+// and a mirror had no way to check anything at all.
+//
+// Uploading the bundle fixes all three, and it fails silently if it regresses —
+// the release still builds and ships, only unverifiable. So assert the shape:
+// a job that attests must also put its bundle on the release.
+const jobs: Record<string, any> = YAML.parse(
+  readFileSync(join(import.meta.dirname, '../../.github/workflows/release.yml'), 'utf8'),
+).jobs;
+
+const attestingJobs = Object.entries(jobs).filter(([, job]) =>
+  (job.steps ?? []).some((s: any) => String(s.uses ?? '').includes('attest-build-provenance')),
+);
+
+describe('release provenance', () => {
+  it('attests the desktop artifacts on both platforms', () => {
+    expect(attestingJobs.map(([name]) => name).sort()).toEqual(['build-app-mac', 'build-app-win']);
+  });
+
+  it.each(attestingJobs)('%s uploads its provenance bundle as a release asset', (_name, job) => {
+    const steps = JSON.stringify(job.steps);
+    expect(steps).toContain('outputs.bundle-path');
+    // Scorecard only counts an asset whose name ends in `.intoto.jsonl`.
+    expect(steps.match(/[\w.-]+\.intoto\.jsonl/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('attaches an SPDX SBOM to the release', () => {
+    const steps = JSON.stringify(jobs.sbom?.steps ?? []);
+    expect(steps).toContain('dependency-graph/sbom');
+    expect(steps).toContain('.spdx.json');
+  });
+});


### PR DESCRIPTION
Closes TRA-902 — with a correction to its premise.

## The premise was wrong; the gap underneath it is real

TRA-902 reports that GitHub release binaries ship without build provenance. They don't. `actions/attest-build-provenance` has run in both desktop build jobs since #108, and it works on the shipped binaries today:

```
$ gh attestation verify trace-mcp.Setup.3.17.1.exe --repo nikolai-vysotskyi/trace-mcp --format json
buildSignerURI:  …/trace-mcp/.github/workflows/release.yml@refs/heads/master
sourceRepositoryURI: https://github.com/nikolai-vysotskyi/trace-mcp
```

The `gh api …/attestations/sha256:…` → 404 in the issue was a wrong digest; querying the real artifact digests returns one attestation each for both the arm64 DMG and the Windows installer.

What is actually missing is that **nothing on the release itself carries the claim**. The sigstore bundle lived only in GitHub's attestation API, so:

- verification requires that service to be reachable — no offline or air-gapped path;
- a mirror of the release assets carries no provenance at all;
- OpenSSF Scorecard's `Signed-Releases` scores 0/10, because it reads release assets and nothing else (measured 2026-09-05, overall 7.7).

## What changed

- Both build jobs copy `steps.attest.outputs.bundle-path` to `trace-mcp-{mac,win}.intoto.jsonl` and upload it with the artifacts. `gh attestation verify --bundle` then works without the API, and Scorecard's check has something to count.
- New `sbom` job attaches `trace-mcp-<version>.spdx.json`, pulled from GitHub's dependency graph (`GET /repos/{owner}/{repo}/dependency-graph/sbom`). One API call, no scanner, no new service. It gates nothing — a missing SBOM is paperwork, a missing installer is a broken release, and only the second should stop a release.
- `SECURITY.md` gains a "Desktop App Provenance" section with the verify commands, says plainly why a `.sha256` beside the artifact is not a tamper control, and states that Windows builds are **not** Authenticode-signed. The stale note claiming `Signed-Releases: 0` is expected is removed.

Not done, deliberately: Windows code signing. There is no Authenticode certificate and buying one is a paid-infrastructure decision, not mine. Attestation is what a Windows user has until then, which is why the docs say so out loud.

## Test evidence

`tests/ci/release-provenance.test.ts` asserts the shape that regresses silently — a job that attests must also upload a `.intoto.jsonl`, and the SBOM job must exist. The failure mode without it is invisible: the release still builds and ships, only unverifiable.

```
✓ tests/ci/release-provenance.test.ts (4 tests)
✓ tests/ci/release-secret-scoping.test.ts (3 tests)
```

`pnpm run lint`, `pnpm run typecheck`, `pnpm run format:check` clean. The SBOM API call was run against this repo before wiring it up — 1293 packages, valid SPDX document.
