### PR TITLE
fix(launcher): stop a throwaway TRACE_MCP_HOME from breaking the real MCP launcher path

### DIFF
--- a/src/init/launcher.ts
+++ b/src/init/launcher.ts
@@ -359,6 +359,10 @@ function installLegacyBinCompat(): void {
       return;
     }
     // Anything we did not write is the user's own wrapper — leave it alone.
+    // A dangling symlink has no content to sniff, so it cannot be checked for
+    // ownership and is always repaired. That is the intended trade: a broken
+    // link at this exact path spawns nothing for anyone, so there is no working
+    // setup left to protect.
     if (exists && !isOwnedShim(legacyPath)) return;
     ensureDir(legacyDir);
     writeLegacyCompat(legacyPath, current);

--- a/src/init/launcher.ts
+++ b/src/init/launcher.ts
@@ -336,8 +336,20 @@ function installLegacyBinCompat(): void {
   // When the legacy home *is* the launcher home, the real shim already lives at
   // this path; delegating it would point it at itself.
   if (path.resolve(legacyPath) === path.resolve(current)) return;
+  // The legacy path lives in the real home no matter where the launcher home
+  // points, so a run aimed at some other home would reach out and repoint it at
+  // a directory the real machine does not use. When that home is a throwaway one
+  // — our own test suite's mkdtemp, a sandboxed install probe — the symlink
+  // dangles the moment it is cleaned up, and every MCP client registered at the
+  // legacy path gets ENOENT with nothing in launcher.log to explain it: the shim
+  // never runs, so it never logs (TRA-910). A custom TRACE_MCP_HOME means "use
+  // this home"; writing into a different one is never what it asked for.
+  if (path.resolve(getLauncherDir()) !== path.resolve(os.homedir(), '.trace')) return;
   try {
-    if (isSymlink(legacyPath)) return; // already delegating to the current shim
+    // existsSync follows the link: a symlink pointing at a target that is gone
+    // is the one state that actually breaks clients, so it must not be mistaken
+    // for a healthy delegation and skipped (TRA-910).
+    if (isSymlink(legacyPath) && fs.existsSync(legacyPath)) return; // already delegating
     const exists = fs.existsSync(legacyPath);
     if (
       !exists &&

--- a/tests/init/launcher-legacy-compat.test.ts
+++ b/tests/init/launcher-legacy-compat.test.ts
@@ -144,6 +144,39 @@ describe.skipIf(process.platform === 'win32')('legacy bin compat', () => {
     expect(fs.readdirSync(path.dirname(legacyPath))).toEqual(['trace-mcp']);
   });
 
+  // TRA-910. A run pointed at a throwaway TRACE_MCP_HOME (the test suite's own
+  // mkdtemp home, a sandboxed install probe) must not reach out of that home and
+  // repoint the real `~/.trace-mcp/bin/trace-mcp` at it. When the temp dir is
+  // cleaned up the symlink dangles, and every MCP client registered at that path
+  // gets ENOENT with nothing in launcher.log — the shim never runs to log it.
+  it('does not touch the real legacy path when TRACE_MCP_HOME is a throwaway dir', () => {
+    writeLegacy(STALE_SHIM);
+    const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-launcher-'));
+    process.env.TRACE_MCP_HOME = scratch;
+    try {
+      installLauncher({ force: true });
+
+      expect(fs.lstatSync(legacyPath).isSymbolicLink()).toBe(false);
+      expect(fs.readFileSync(legacyPath, 'utf-8')).toBe(STALE_SHIM);
+    } finally {
+      delete process.env.TRACE_MCP_HOME;
+      fs.rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  // TRA-910. `isSymlink` alone treated a dangling link as "already delegating",
+  // so the one state that actually breaks clients was the one state no later
+  // `trace init` would ever repair.
+  it('repairs a legacy symlink whose target no longer exists', () => {
+    const gone = path.join(home, 'evicted', 'bin', 'trace');
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    fs.symlinkSync(gone, legacyPath);
+
+    installLauncher({ force: true });
+
+    expect(fs.realpathSync(legacyPath)).toBe(fs.realpathSync(getLauncherPath()));
+  });
+
   it('does not link the legacy path to itself when it is the launcher home', () => {
     process.env.TRACE_MCP_HOME = path.join(home, '.trace-mcp');
     try {


### PR DESCRIPTION
## The failure

`trace-mcp` was **disconnected on the developer machine** and would have stayed that way:

```
trace-mcp: /Users/nikolai/.trace-mcp/bin/trace-mcp serve
  - ✘ Failed to connect — ENOENT: no such file or directory, posix_spawn '/Users/nikolai/.trace-mcp/bin/trace-mcp'
```

```
~/.trace/bin/trace-mcp -> /tmp/multica-task-1715038714/trace-mcp-launcher-elIfRY/bin/trace   (dangling)
```

`launcher.log` showed **zero errors over 24h** the whole time. That is not reassurance, it is the shape of this bug: the spawn fails before any of our code runs, so the shim never gets to log anything. A launcher-health check that reads only the log cannot see this failure class at all.

## Root cause

`installLegacyBinCompat()` mixes two different notions of "home":

- the legacy path comes from `os.homedir()` → always the **real** `~/.trace-mcp/bin/trace-mcp`
- its symlink target comes from `getLauncherDir()` → honours **`TRACE_MCP_HOME`**

So any process pointed at a different home reaches *out* of that home and repoints the real, client-registered launcher path at it. When that home is a throwaway directory, the symlink dangles the moment it is cleaned up.

**Our own test suite is such a process.** `mkTmpHome()` in `tests/init/launcher.test.ts` sets `TRACE_MCP_HOME` to an `mkdtemp` dir without stubbing `os.homedir()`. The observed dangling target is literally `mkdtemp(os.tmpdir(), 'trace-mcp-launcher-') + '/bin/trace'`. Running `pnpm test` severed the MCP connection of the machine it ran on.

Worse, it was unrecoverable: `if (isSymlink(legacyPath)) return;` treated the dangling link as "already delegating", so the single state that actually breaks clients was the single state no later `trace init` or `trace upgrade` would ever repair.

## The fix

- Skip the legacy repair unless the launcher home *is* the real `~/.trace`. A custom `TRACE_MCP_HOME` means "use this home" — never "write into a different one".
- Treat a dangling symlink as needing repair (`existsSync` follows the link), restoring self-healing in the state that matters.

14 lines of source, most of it comment.

## Test evidence

Both new tests fail on `main` and pass here.

- Full suite: **10140 passed**, 0 failed, and `~/.trace/bin/trace-mcp` **survives the run intact** — the same run that broke it before.
- `pnpm lint` (tsc --noEmit) and `pnpm build` clean.
- Live client after repair: `trace-mcp: ✔ Connected`.

The one pre-existing failure I hit in `tests/scripts/postinstall-app.test.ts` reproduces on a clean stashed tree under the same env and is unrelated to this change.

Refs TRA-910
