### PR TITLE
fix(server): scope instructions to the session's advertised tool surface

### DIFF
--- a/src/server/instructions.ts
+++ b/src/server/instructions.ts
@@ -43,10 +43,41 @@ export function hostToolLines(h: HostToolNames): string[] {
     `THE RULE (${h.rubric}):`,
     `- Full-file ${h.read} for discovery: not the move. Take \`get_outline\`, then pull the one symbol with \`get_symbol\`. Read the file directly only when you already have the outline and the span you want is a few lines — or the file is not code (.md/.json/.yaml/config), or you are about to edit it.`,
     `- ${h.grep} or ${h.glob} over source: not the move. \`search\` and \`find_usages\` resolve symbol kinds, imports, and call sites; a text scan cannot rank its hits and misses re-exports, aliases, and dynamic dispatch.`,
-    `- After every ${h.edit} → \`register_edit\` { file_path } (reindexes one file; far lighter than \`reindex\`). If the reply carries \`_duplication_warnings\`, review them before continuing.`,
+    `- After every ${h.edit} → \`register_edit\` { file_path } (reindexes just that file). If the reply carries \`_duplication_warnings\`, review them before continuing.`,
     `Use trace-mcp tools instead of ${h.read}/${h.grep}/${h.glob} for source code.`,
     `Use ${h.read}/${h.grep} only for non-code files (.md, .json, .yaml) or before ${h.edit}.`,
   ];
+}
+
+/**
+ * Is this tool on the surface this session actually advertises (TRA-929)?
+ *
+ * The block used to be preset-blind: it routed every session to the `full`
+ * catalog, so a default (`minimal`) install was told by name to call 26 tools
+ * missing from its own `tools/list`. The likely agent response to an unknown
+ * tool is the host's own `read`/`content-match` — the exact behaviour this
+ * block exists to prevent — and we paid for the lines that caused it on every
+ * connect. The predicate is `createToolFilter`'s, passed in by server.ts; the
+ * default keeps every line, for callers with no surface to declare (docs
+ * generation, the token-budget baseline).
+ */
+export type ToolOnSurface = (name: string) => boolean;
+
+/** A routing line and the tools it names — the line ships only if they all do. */
+interface RoutingLine {
+  tools: string[];
+  text: string;
+}
+
+/** Keep the lines whose tools are all on the surface. */
+function live(lines: RoutingLine[], onSurface: ToolOnSurface): string[] {
+  return lines.filter((l) => l.tools.every(onSurface)).map((l) => l.text);
+}
+
+/** A heading plus its lines, dropped whole when nothing under it survives. */
+function section(heading: string, lines: RoutingLine[], onSurface: ToolOnSurface): string[] {
+  const kept = live(lines, onSurface);
+  return kept.length ? [heading, ...kept, ''] : [];
 }
 
 /** Builds the MCP server instructions string based on verbosity level. */
@@ -54,6 +85,7 @@ export function buildInstructions(
   detectedFrameworks: string,
   verbosity: 'full' | 'minimal' | 'none',
   agentBehavior: 'strict' | 'minimal' | 'off' = 'off',
+  onSurface: ToolOnSurface = () => true,
 ): string {
   const behaviorBlock = buildBehaviorBlock(agentBehavior);
   const host = hostToolLines(HOST_TOOLS_GENERIC);
@@ -61,64 +93,199 @@ export function buildInstructions(
   if (verbosity === 'none') return behaviorBlock;
 
   if (verbosity === 'minimal') {
+    const keyTools = [
+      'search',
+      'get_outline',
+      'get_symbol',
+      'get_task_context',
+      'get_change_impact',
+      'find_usages',
+      'batch',
+    ].filter(onSurface);
     const core = [
       `trace-mcp: framework-aware code intelligence. Detected: ${detectedFrameworks}.`,
       host[4],
-      'Key tools: search, get_outline, get_symbol, get_task_context, get_change_impact, find_usages, batch.',
-      'Use batch for 2+ independent queries. Use get_task_context to start tasks.',
+      ...(keyTools.length ? [`Key tools: ${keyTools.join(', ')}.`] : []),
+      ...(onSurface('batch') ? ['Use batch for 2+ independent queries.'] : []),
+      ...(onSurface('get_task_context') ? ['Use get_task_context to start tasks.'] : []),
       host[5],
     ].join(' ');
     return behaviorBlock ? `${core}\n\n${behaviorBlock}` : core;
   }
 
+  const rule = live(
+    [
+      { tools: ['get_outline', 'get_symbol'], text: host[1] },
+      { tools: ['search', 'find_usages'], text: host[2] },
+    ],
+    onSurface,
+  );
+
+  const rationalizations = live(
+    [
+      {
+        tools: [],
+        text: '- "I already know the path, so one read is cheaper than a lookup." — knowing the path does not shrink the file. The lookup returns the symbol; the read returns everything around it.',
+      },
+      {
+        tools: [],
+        text: '- "The read tool\'s description says to use it when I know the file." — it was written for hosts without a symbol index. This project has one.',
+      },
+      {
+        tools: ['batch'],
+        text: '- "Three of these calls versus one built-in call." — what costs is tokens returned into context, not calls issued. `batch` sends up to 10 as one request.',
+      },
+      {
+        tools: ['get_symbol'],
+        text: '- "This is a quick check, not exploration." — a quick check on a 500-line file still costs 500 lines; `get_symbol` costs the symbol.',
+      },
+      {
+        tools: ['get_outline'],
+        text: '- "I read this file already, re-reading is free." — it is not; call `get_outline` for a structure reminder instead.',
+      },
+    ],
+    onSurface,
+  );
+
+  const routing = [
+    ...section(
+      'Navigation & search:',
+      [
+        {
+          tools: ['search'],
+          text: '- Find a function/class/method → `search` (add `fusion=true` for best ranking; `implements`/`extends` filter by interface)',
+        },
+        { tools: ['get_outline'], text: '- Understand a file before editing → `get_outline`' },
+        {
+          tools: ['get_symbol', 'get_context_bundle'],
+          text: "- Read one symbol's source → `get_symbol`; symbol + its imports → `get_context_bundle`",
+        },
+        {
+          tools: ['get_feature_context', 'get_task_context'],
+          text: '- Quick keyword context → `get_feature_context`; starting a task → `get_task_context`',
+        },
+      ],
+      onSurface,
+    ),
+    ...section(
+      'Relationships & impact:',
+      [
+        { tools: ['get_change_impact'], text: '- What breaks if I change X → `get_change_impact`' },
+        { tools: ['get_call_graph'], text: '- Who calls this / what it calls → `get_call_graph`' },
+        { tools: ['find_usages'], text: '- All usages of a symbol → `find_usages`' },
+        { tools: ['get_tests_for'], text: '- Tests for a symbol/file → `get_tests_for`' },
+      ],
+      onSurface,
+    ),
+    ...section(
+      'Architecture & meta-analysis:',
+      [
+        {
+          tools: ['get_implementations'],
+          text: '- Implementations of an interface → `get_implementations`',
+        },
+        {
+          tools: ['self_audit', 'get_untested_symbols'],
+          text: '- Health, dead exports, hotspots → `self_audit`; untested symbols → `get_untested_symbols`',
+        },
+        {
+          tools: ['get_dead_code'],
+          text: '- Dead code → `get_dead_code` (`mode: "exports_only"` for exports)',
+        },
+        {
+          tools: ['get_import_graph', 'get_module_graph', 'get_circular_imports', 'get_coupling'],
+          text: '- Imports → `get_import_graph` (`get_module_graph` on NestJS); cycles → `get_circular_imports`; coupling → `get_coupling`',
+        },
+      ],
+      onSurface,
+    ),
+    // Framework tools are registered only when their framework is detected, so
+    // the lines are worth their tokens only on a project that has one.
+    ...(detectedFrameworks === 'none'
+      ? []
+      : section(
+          'Framework-specific:',
+          [
+            { tools: ['get_request_flow'], text: '- HTTP route→controller → `get_request_flow`' },
+            {
+              tools: ['get_model_context', 'get_schema'],
+              text: '- DB models and schema → `get_model_context`, `get_schema`',
+            },
+            {
+              tools: ['get_component_tree'],
+              text: '- React/Vue/Angular components → `get_component_tree`',
+            },
+            {
+              tools: ['get_state_stores', 'get_event_graph'],
+              text: '- Stores and events → `get_state_stores`, `get_event_graph`',
+            },
+          ],
+          onSurface,
+        )),
+    ...section(
+      'Token optimization:',
+      [
+        {
+          tools: ['batch'],
+          text: '- 2+ independent queries → `batch` ({ calls: [{ tool, args }, ...] }), up to 10 per request',
+        },
+        {
+          tools: ['get_task_context'],
+          text: '- `get_task_context` replaces spawning a subagent to explore — same context, one call, inside a token budget',
+        },
+        {
+          tools: ['get_optimization_report', 'get_session_stats', 'get_real_savings'],
+          text: '- Check waste → `get_optimization_report`; track savings → `get_session_stats`, `get_real_savings`',
+        },
+      ],
+      onSurface,
+    ),
+    ...section(
+      'Editing:',
+      [
+        { tools: ['register_edit'], text: host[3] },
+        {
+          tools: ['check_duplication'],
+          text: '- Before writing a new function/class → `check_duplication` { name, kind }',
+        },
+        {
+          tools: [
+            'apply_rename',
+            'apply_move',
+            'change_signature',
+            'remove_dead_code',
+            'plan_refactoring',
+          ],
+          text: '- Rename → `apply_rename`; move a symbol or file → `apply_move`; change params → `change_signature`; delete → `remove_dead_code`. All dry-run by default: review, then re-call with `dry_run: false` (`confirm_large: true` past 20 files). Preview any of them with `plan_refactoring`.',
+        },
+        {
+          tools: ['apply_codemod'],
+          text: '- Same mechanical change 2+ times → `apply_codemod` { pattern, replacement, file_pattern }, not a run of edits.',
+        },
+      ],
+      onSurface,
+    ),
+  ];
+
   return [
     `trace-mcp is a framework-aware code intelligence server for this project. Detected frameworks: ${detectedFrameworks}.`,
     '',
-    host[0],
-    host[1],
-    host[2],
-    '',
-    'If you catch yourself thinking one of these, that is the signal to switch:',
-    '- "I already know the path, so one read is cheaper than a lookup." — knowing the path does not shrink the file. The lookup returns the symbol; the read returns everything around it.',
-    '- "The read tool\'s description says to use it when I know the file." — it was written for hosts without a symbol index. This project has one.',
-    '- "Three of these calls versus one built-in call." — what costs is tokens returned into context, not calls issued. `batch` sends up to 10 as one request.',
-    '- "This is a quick check, not exploration." — a quick check on a 500-line file still costs 500 lines; `get_symbol` costs the symbol.',
-    '- "I read this file already, re-reading is free." — it is not; call `get_outline` for a structure reminder instead.',
-    '',
+    ...(rule.length ? [host[0], ...rule, ''] : []),
+    ...(rationalizations.length
+      ? [
+          'If you catch yourself thinking one of these, that is the signal to switch:',
+          ...rationalizations,
+          '',
+        ]
+      : []),
     'WHEN TO USE trace-mcp tools (tool descriptions carry the details):',
     '',
-    'Navigation & search:',
-    '- Find a function/class/method → `search` (add `fusion=true` for best ranking; `implements`/`extends` filter by interface)',
-    '- Understand a file before editing → `get_outline`',
-    "- Read one symbol's source → `get_symbol`; symbol + its imports → `get_context_bundle`",
-    '- Quick keyword context → `get_feature_context`; starting a task → `get_task_context`',
-    '',
-    'Relationships & impact:',
-    '- What breaks if I change X → `get_change_impact`',
-    '- Who calls this / what it calls → `get_call_graph`',
-    '- All usages of a symbol → `find_usages`',
-    '- Tests for a symbol/file → `get_tests_for`',
-    '',
-    'Architecture & meta-analysis:',
-    '- Implementations of an interface → `get_implementations`',
-    '- Health, dead exports, hotspots → `self_audit`; untested symbols → `get_untested_symbols`',
-    '- Dead code → `get_dead_code` (`mode: "exports_only"` for exports)',
-    '- Imports → `get_import_graph` (`get_module_graph` on NestJS); cycles → `get_circular_imports`; coupling → `get_coupling`',
-    '',
-    'Framework-specific: `get_request_flow` (HTTP route→controller), `get_model_context` and `get_schema` (DB), `get_component_tree` (React/Vue/Angular), `get_state_stores`, `get_event_graph`.',
-    '',
-    'Token optimization:',
-    '- 2+ independent queries → `batch` ({ calls: [{ tool, args }, ...] }), up to 10 per request',
-    '- `get_task_context` replaces spawning a subagent to explore — same context, one call, inside a token budget',
-    '- Check waste → `get_optimization_report`; track savings → `get_session_stats`, `get_real_savings`',
-    '',
-    'Editing:',
-    host[3],
-    '- Before writing a new function/class → `check_duplication` { name, kind }',
-    '- Rename → `apply_rename`; move a symbol or file → `apply_move`; change params → `change_signature`; delete → `remove_dead_code`. All dry-run by default: review, then re-call with `dry_run: false` (`confirm_large: true` past 20 files). Preview any of them with `plan_refactoring`. `extract_function` is disabled.',
-    '- Same mechanical change 2+ times → `apply_codemod` { pattern, replacement, file_pattern }, not a run of edits.',
-    '',
-    'Start with `get_project_map` (summary_only=true) to orient yourself.',
+    ...routing,
+    // Said once, instead of naming every deferred tool as if it were live.
+    'Anything not listed above is deferred, not missing: `load_tools` registers a tool for direct calls, `batch` dispatches one by name without registering it.',
+    ...(onSurface('get_project_map')
+      ? ['Start with `get_project_map` (summary_only=true) to orient yourself.']
+      : []),
     ...(behaviorBlock ? ['', behaviorBlock] : []),
   ].join('\n');
 }

--- a/src/server/instructions.ts
+++ b/src/server/instructions.ts
@@ -80,6 +80,32 @@ function section(heading: string, lines: RoutingLine[], onSurface: ToolOnSurface
   return kept.length ? [heading, ...kept, ''] : [];
 }
 
+/**
+ * The refactoring bullet, naming only the operations this session can perform.
+ *
+ * Its clauses share one tail (the dry-run protocol), so it is assembled rather
+ * than gated whole: `standard` carries `remove_dead_code` and none of the
+ * others, and an all-or-nothing line would hide the one tool it does have.
+ */
+function refactorLine(onSurface: ToolOnSurface): RoutingLine[] {
+  const ops: string[] = [];
+  if (onSurface('apply_rename')) ops.push('rename → `apply_rename`');
+  if (onSurface('apply_move')) ops.push('move a symbol or file → `apply_move`');
+  if (onSurface('change_signature')) ops.push('change params → `change_signature`');
+  if (onSurface('remove_dead_code')) ops.push('delete → `remove_dead_code`');
+  if (ops.length === 0) return [];
+  const preview = onSurface('plan_refactoring')
+    ? ' Preview any of them with `plan_refactoring`.'
+    : '';
+  const list = ops.join('; ');
+  return [
+    {
+      tools: [],
+      text: `- ${list[0].toUpperCase()}${list.slice(1)}. All dry-run by default: review, then re-call with \`dry_run: false\` (\`confirm_large: true\` past 20 files).${preview}`,
+    },
+  ];
+}
+
 /** Builds the MCP server instructions string based on verbosity level. */
 export function buildInstructions(
   detectedFrameworks: string,
@@ -156,14 +182,13 @@ export function buildInstructions(
           text: '- Find a function/class/method → `search` (add `fusion=true` for best ranking; `implements`/`extends` filter by interface)',
         },
         { tools: ['get_outline'], text: '- Understand a file before editing → `get_outline`' },
+        { tools: ['get_symbol'], text: "- Read one symbol's source → `get_symbol`" },
         {
-          tools: ['get_symbol', 'get_context_bundle'],
-          text: "- Read one symbol's source → `get_symbol`; symbol + its imports → `get_context_bundle`",
+          tools: ['get_context_bundle'],
+          text: '- A symbol plus its imports → `get_context_bundle`',
         },
-        {
-          tools: ['get_feature_context', 'get_task_context'],
-          text: '- Quick keyword context → `get_feature_context`; starting a task → `get_task_context`',
-        },
+        { tools: ['get_feature_context'], text: '- Quick keyword context → `get_feature_context`' },
+        { tools: ['get_task_context'], text: '- Starting a task → `get_task_context`' },
       ],
       onSurface,
     ),
@@ -184,18 +209,15 @@ export function buildInstructions(
           tools: ['get_implementations'],
           text: '- Implementations of an interface → `get_implementations`',
         },
-        {
-          tools: ['self_audit', 'get_untested_symbols'],
-          text: '- Health, dead exports, hotspots → `self_audit`; untested symbols → `get_untested_symbols`',
-        },
+        { tools: ['self_audit'], text: '- Health, dead exports, hotspots → `self_audit`' },
+        { tools: ['get_untested_symbols'], text: '- Untested symbols → `get_untested_symbols`' },
         {
           tools: ['get_dead_code'],
           text: '- Dead code → `get_dead_code` (`mode: "exports_only"` for exports)',
         },
-        {
-          tools: ['get_import_graph', 'get_module_graph', 'get_circular_imports', 'get_coupling'],
-          text: '- Imports → `get_import_graph` (`get_module_graph` on NestJS); cycles → `get_circular_imports`; coupling → `get_coupling`',
-        },
+        { tools: ['get_import_graph'], text: '- Imports → `get_import_graph`' },
+        { tools: ['get_circular_imports'], text: '- Import cycles → `get_circular_imports`' },
+        { tools: ['get_coupling'], text: '- Coupling → `get_coupling`' },
       ],
       onSurface,
     ),
@@ -207,18 +229,15 @@ export function buildInstructions(
           'Framework-specific:',
           [
             { tools: ['get_request_flow'], text: '- HTTP route→controller → `get_request_flow`' },
-            {
-              tools: ['get_model_context', 'get_schema'],
-              text: '- DB models and schema → `get_model_context`, `get_schema`',
-            },
+            { tools: ['get_model_context'], text: '- DB models → `get_model_context`' },
+            { tools: ['get_schema'], text: '- DB schema → `get_schema`' },
             {
               tools: ['get_component_tree'],
               text: '- React/Vue/Angular components → `get_component_tree`',
             },
-            {
-              tools: ['get_state_stores', 'get_event_graph'],
-              text: '- Stores and events → `get_state_stores`, `get_event_graph`',
-            },
+            { tools: ['get_state_stores'], text: '- State stores → `get_state_stores`' },
+            { tools: ['get_event_graph'], text: '- Events → `get_event_graph`' },
+            { tools: ['get_module_graph'], text: '- NestJS modules → `get_module_graph`' },
           ],
           onSurface,
         )),
@@ -248,16 +267,7 @@ export function buildInstructions(
           tools: ['check_duplication'],
           text: '- Before writing a new function/class → `check_duplication` { name, kind }',
         },
-        {
-          tools: [
-            'apply_rename',
-            'apply_move',
-            'change_signature',
-            'remove_dead_code',
-            'plan_refactoring',
-          ],
-          text: '- Rename → `apply_rename`; move a symbol or file → `apply_move`; change params → `change_signature`; delete → `remove_dead_code`. All dry-run by default: review, then re-call with `dry_run: false` (`confirm_large: true` past 20 files). Preview any of them with `plan_refactoring`.',
-        },
+        ...refactorLine(onSurface),
         {
           tools: ['apply_codemod'],
           text: '- Same mechanical change 2+ times → `apply_codemod` { pattern, replacement, file_pattern }, not a run of edits.',

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -63,7 +63,7 @@ import { createExploredTracker } from './explored-tracker.js';
 import { startHeartbeat } from './heartbeat.js';
 import { buildInstructions } from './instructions.js';
 import { installRetiredToolHints } from './retired-tools.js';
-import { resolveSessionPreset } from './tool-filter.js';
+import { createToolFilter, resolveSessionPreset } from './tool-filter.js';
 import { installToolGate } from './tool-gate.js';
 import type { MetaContext, ProjectRelay, ServerContext, ToolHandlerMap } from './types.js';
 
@@ -286,12 +286,28 @@ export function createServer(
   const has = (...names: string[]) => names.some((n) => frameworkNames.has(n));
   const detectedFrameworks = [...frameworkNames].join(', ') || 'none';
 
+  // Resolved before the instructions, because they are written against it
+  // (TRA-929): the block names only tools this session actually advertises.
+  // Single source of truth for the default, shared with the daemon proxy's
+  // per-session filter — the two used to spell it out separately. Unknown
+  // names fall back to the default surface and warn (TRA-648) — never to
+  // `full`, which silently made the cheap-by-request session the expensive one.
+  const { name: presetName, tools: activePreset } = resolveSessionPreset(config);
+
   // Create server with instructions
   const instructionsVerbosity = config.tools?.instructions_verbosity ?? 'full';
   const agentBehavior = config.tools?.agent_behavior ?? 'off';
+  const onSurface = createToolFilter(config, activePreset);
   const server = new McpServer(
     { name: 'trace', version: PKG_VERSION },
-    { instructions: buildInstructions(detectedFrameworks, instructionsVerbosity, agentBehavior) },
+    {
+      instructions: buildInstructions(
+        detectedFrameworks,
+        instructionsVerbosity,
+        agentBehavior,
+        onSurface,
+      ),
+    },
   );
 
   // Session tracking
@@ -528,19 +544,13 @@ export function createServer(
     }
   }
 
-  // Install tool gate (preset filtering, description overrides, savings/journal wrapping)
-  // Single source of truth for the default, shared with the daemon proxy's
-  // per-session filter — the two used to spell it out separately.
-  // Unknown names fall back to the default surface and warn (TRA-648) — never
-  // to `full`, which silently made the cheap-by-request session the expensive one.
-  const { name: presetName, tools: activePreset } = resolveSessionPreset(config);
-
   // Status sentinel — guard hook uses this to detect a live, healthy trace-mcp.
   // Records tool-call counters + last successful call timestamp so the v0.8+
   // hook can distinguish "process up but MCP channel stalled" from a healthy
   // server, and the desktop app can render the project status badge.
   const heartbeat = startHeartbeat(projectRoot, deps?.transport ?? 'stdio');
 
+  // Install tool gate (preset filtering, description overrides, savings/journal wrapping)
   const { _originalTool, registeredToolNames, ungatedToolNames, toolHandlers, deferredTools } =
     installToolGate(
       server,

--- a/tests/server/instructions-surface-drift.test.ts
+++ b/tests/server/instructions-surface-drift.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { buildInstructions } from '../../src/server/instructions.js';
+import { UNGATED_META_TOOLS } from '../../src/server/tool-filter.js';
+import { TOOL_PRESETS, resolvePreset } from '../../src/tools/project/presets.js';
+import { allToolNames } from '../docs/tool-surface.js';
+
+/**
+ * TRA-929: the instructions block used to be preset-blind — it routed every
+ * session to the `full` catalog, so a default (`minimal`) install was told by
+ * name to call 26 tools missing from its own `tools/list`.
+ *
+ * This is the guard that keeps it fixed as presets and tool names move: for
+ * every preset, every trace-mcp tool the emitted block names must be on that
+ * session's surface. A new preset, or a tool leaving one, fails here rather
+ * than shipping a block that promises it.
+ */
+
+const REGISTERED = new Set(allToolNames());
+
+/** Backticked identifiers that are params, values, or host vocabulary — not tools. */
+const NON_TOOLS = new Set([
+  'read',
+  'content-match',
+  'glob',
+  'fusion',
+  'implements',
+  'extends',
+  'exports_only',
+  'dry_run',
+  'confirm_large',
+  'file_path',
+  'true',
+  'false',
+  '_duplication_warnings',
+]);
+
+/** Every trace-mcp tool name the block mentions, backticked or not. */
+function toolsNamedIn(text: string): string[] {
+  const words = new Set([...text.matchAll(/[a-z][a-z0-9_]{2,}/g)].map((m) => m[0]));
+  return [...words].filter((w) => !NON_TOOLS.has(w) && REGISTERED.has(w));
+}
+
+describe('instructions match the session surface', () => {
+  for (const preset of Object.keys(TOOL_PRESETS)) {
+    const resolved = resolvePreset(preset);
+    if (!resolved) throw new Error(`unresolvable preset in TOOL_PRESETS: ${preset}`);
+    // Mirrors createToolFilter with no include/exclude configured.
+    const onSurface = (name: string): boolean =>
+      resolved === 'all' || resolved.has(name) || UNGATED_META_TOOLS.has(name);
+
+    for (const verbosity of ['full', 'minimal'] as const) {
+      it(`names no tool outside the "${preset}" preset (verbosity=${verbosity})`, () => {
+        // 'none' for frameworks: framework-gated tools are registered only when
+        // their framework is detected, which no preset can tell us.
+        const out = buildInstructions('none', verbosity, 'off', onSurface);
+        const offSurface = toolsNamedIn(out).filter((n) => !onSurface(n));
+        expect(
+          offSurface,
+          `instructions route "${preset}" to tools it does not advertise: ${offSurface.join(', ')}`,
+        ).toEqual([]);
+      });
+    }
+  }
+
+  it('still routes the default preset to the tools it does have', () => {
+    const minimal = resolvePreset('minimal') as Set<string>;
+    const out = buildInstructions('none', 'full', 'off', (n) => minimal.has(n));
+    for (const tool of ['search', 'get_outline', 'get_symbol', 'find_usages', 'register_edit']) {
+      expect(out).toContain(tool);
+    }
+  });
+
+  it('tells a session with a deferred half how to reach it', () => {
+    const minimal = resolvePreset('minimal') as Set<string>;
+    const out = buildInstructions('none', 'full', 'off', (n) => minimal.has(n));
+    expect(out).toContain('load_tools');
+    expect(out).toContain('batch');
+  });
+
+  it('costs the default surface less than routing it to the full catalog', () => {
+    const minimal = resolvePreset('minimal') as Set<string>;
+    const preset = buildInstructions('none', 'full', 'off', (n) => minimal.has(n));
+    const catalog = buildInstructions('none', 'full', 'off');
+    expect(preset.length).toBeLessThan(catalog.length);
+  });
+});

--- a/tests/server/instructions-surface-drift.test.ts
+++ b/tests/server/instructions-surface-drift.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { buildInstructions } from '../../src/server/instructions.js';
 import { UNGATED_META_TOOLS } from '../../src/server/tool-filter.js';
 import { TOOL_PRESETS, resolvePreset } from '../../src/tools/project/presets.js';
-import { allToolNames } from '../docs/tool-surface.js';
+import { allToolNames, frameworkGatedToolNames } from '../docs/tool-surface.js';
 
 /**
  * TRA-929: the instructions block used to be preset-blind — it routed every
@@ -61,6 +61,18 @@ describe('instructions match the session surface', () => {
       });
     }
   }
+
+  // `full` passes every name, so the preset predicate cannot catch this one:
+  // framework tools are registered only on a project that has the framework.
+  it('names no framework-gated tool on a project with no framework detected', () => {
+    const gated = frameworkGatedToolNames();
+    const out = buildInstructions('none', 'full', 'off', () => true);
+    const leaked = [...gated].filter((n) => out.includes(n));
+    expect(
+      leaked,
+      `instructions name framework-only tools on a bare repo: ${leaked.join(', ')}`,
+    ).toEqual([]);
+  });
 
   it('still routes the default preset to the tools it does have', () => {
     const minimal = resolvePreset('minimal') as Set<string>;


### PR DESCRIPTION
Closes TRA-929.

## The bug

`buildInstructions(detectedFrameworks, verbosity, agentBehavior)` took no preset argument, so the instructions block every client pays for on connect routed the agent to the `full` catalog regardless of what the session actually advertises. On the shipped default (`minimal`), 26 named tools are absent from `tools/list` — entire sections ("Architecture & meta-analysis", "Framework-specific", "Editing") were unreachable by direct call, and `extract_function` was named and described as disabled in the same line.

It costs twice: the agent is told to call things it cannot call — and the most likely fallback on an unknown tool is the host's own read/grep, the exact behaviour the block exists to prevent — and we buy the misleading lines on every connect.

## The change

- `buildInstructions` takes an `onSurface: (name) => boolean` predicate; `server.ts` passes `createToolFilter(config, activePreset)`. The preset is now resolved before the `McpServer` is constructed instead of 240 lines later.
- Routing lines carry the tools they name; a line ships only when all of them are registered, and a section heading is dropped when nothing under it survives. Same for the `minimal` verbosity one-liner and the "THE RULE" / rationalization bullets.
- The deferred half is named once — `load_tools` registers, `batch` dispatches by name without registering — instead of naming each deferred tool as if it were live.
- `extract_function` line dropped.
- Framework-specific tools are gated on `detectedFrameworks !== 'none'` as well; the one-liner became four gateable bullets.
- `register_edit`'s line no longer name-drops `reindex` (not on the default preset).

## Test evidence

New `tests/server/instructions-surface-drift.test.ts`: for every preset in `TOOL_PRESETS`, at both emitting verbosities, every trace-mcp tool name appearing in the emitted block must be on that session's surface. Mutation-checked — reverting one line's gate fails 7 of its cases.

`pnpm test`: 10185 passed, 24 skipped, 915 files. `pnpm typecheck` and `biome ci` clean.

## Token delta on the default surface

gpt-tokenizer, `verbosity=full`, `agent_behavior=off`:

| preset | before | after |
|---|---|---|
| `minimal` (default) | 930 | **675** (−27%) |
| `standard` | 930 | 771 |
| `router` | 930 | 248 |
| `full` | 930 | 930 |

With frameworks detected, `full` grows by 28 tokens — the framework one-liner became four bullets so each can be gated. That is the only surface that gets more expensive, and it is not the default.

Out of scope, per the issue: what `minimal` contains.
