### PR TITLE
perf(indexer): stop probing every manifest name with its own syscall

### DIFF
--- a/src/indexer/project-context.ts
+++ b/src/indexer/project-context.ts
@@ -203,17 +203,34 @@ export function buildProjectContext(rootPath: string): ProjectContext {
     }
   };
 
+  // One readdir per scanned directory, instead of an lstat+open per candidate
+  // filename. ~60 manifest/config names are probed per directory and a monorepo
+  // scan visits hundreds of directories, so the misses — not the hits — were the
+  // cost: 245 ms of blocking syscalls per pipeline run on this repo (TRA-922).
+  const dirEntries = new Map<string, Set<string>>();
+  const plainFilesIn = (dir: string): Set<string> => {
+    let names = dirEntries.get(dir);
+    if (names) return names;
+    names = new Set<string>();
+    try {
+      for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+        // Symlinks stay excluded, same as the previous per-file lstat check.
+        if (e.isFile()) names.add(e.name);
+      }
+    } catch {
+      /* unreadable dir → no candidates */
+    }
+    dirEntries.set(dir, names);
+    return names;
+  };
+
   const readFile = (dir: string, file: string): string | undefined => {
     try {
+      if (!plainFilesIn(dir).has(file)) return undefined;
       const fullPath = path.resolve(dir, file);
       const relToRoot = path.relative(rootPath, fullPath);
       const check = validatePath(relToRoot, rootPath);
       if (check.isErr()) return undefined;
-      try {
-        if (fs.lstatSync(fullPath).isSymbolicLink()) return undefined;
-      } catch {
-        return undefined;
-      }
       return fs.readFileSync(fullPath, 'utf-8');
     } catch {
       return undefined;
@@ -705,22 +722,13 @@ export function buildProjectContext(rootPath: string): ProjectContext {
     }
 
     // ========== Config files scan ==========
+    const present = plainFilesIn(dir);
     for (const name of CONFIG_FILE_NAMES) {
-      try {
-        const fullPath = path.resolve(dir, name);
-        const relToRoot = path.relative(rootPath, fullPath);
-        const check = validatePath(relToRoot, rootPath);
-        if (check.isErr()) continue;
-        try {
-          if (fs.lstatSync(fullPath).isSymbolicLink()) continue;
-        } catch {
-          continue;
-        }
-        fs.accessSync(fullPath);
-        configFiles.push(getRelPath(name));
-      } catch {
-        /* not found */
-      }
+      if (!present.has(name)) continue;
+      const fullPath = path.resolve(dir, name);
+      const relToRoot = path.relative(rootPath, fullPath);
+      if (validatePath(relToRoot, rootPath).isErr()) continue;
+      configFiles.push(getRelPath(name));
     }
   }
 

--- a/tests/indexer/project-context.test.ts
+++ b/tests/indexer/project-context.test.ts
@@ -3,7 +3,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildProjectContext } from '../../src/indexer/project-context.js';
 import { createTmpDir, removeTmpDir, writeFixtureFile } from '../test-utils.js';
 
@@ -459,6 +459,55 @@ golang 1.22.0
   });
 
   // ========== Config files scan ==========
+
+  // ========== Syscall budget (TRA-922) ==========
+
+  describe('syscall budget', () => {
+    it('probes each scanned directory once instead of once per candidate name', () => {
+      // ~60 manifest/config names are probed per directory. Doing that with a
+      // per-name lstat/access made a single-file reindex block the daemon's
+      // event loop for 219 ms on this repo, so every session gave up on the
+      // daemon and indexed on its own (TRA-922). One readdir per directory is
+      // the budget; the ceiling below is generous but bounded by DIRECTORIES,
+      // not by the length of CONFIG_FILE_NAMES.
+      writeFixtureFile(tmpDir, 'package.json', '{}');
+      for (const sub of ['apps', 'apps/web', 'apps/api', 'libs', 'libs/ui']) {
+        fs.mkdirSync(path.join(tmpDir, sub), { recursive: true });
+        writeFixtureFile(tmpDir, `${sub}/package.json`, '{}');
+      }
+      // root + 2 level-1 + 3 level-2 = 6 scanned directories.
+      const scannedDirs = 6;
+
+      const lstat = vi.spyOn(fs, 'lstatSync');
+      const access = vi.spyOn(fs, 'accessSync');
+      const readdir = vi.spyOn(fs, 'readdirSync');
+      try {
+        buildProjectContext(tmpDir);
+        expect(readdir.mock.calls.length).toBeLessThanOrEqual(scannedDirs * 2);
+        expect(lstat.mock.calls.length).toBeLessThanOrEqual(scannedDirs * 2);
+        expect(access).not.toHaveBeenCalled();
+      } finally {
+        lstat.mockRestore();
+        access.mockRestore();
+        readdir.mockRestore();
+      }
+    });
+
+    it('still ignores symlinked manifests and config files', () => {
+      writeFixtureFile(
+        tmpDir,
+        'real-package.json',
+        JSON.stringify({ dependencies: { vue: '^3' } }),
+      );
+      fs.symlinkSync(path.join(tmpDir, 'real-package.json'), path.join(tmpDir, 'package.json'));
+      writeFixtureFile(tmpDir, 'real-tsconfig.json', '{}');
+      fs.symlinkSync(path.join(tmpDir, 'real-tsconfig.json'), path.join(tmpDir, 'tsconfig.json'));
+
+      const ctx = buildProjectContext(tmpDir);
+      expect(ctx.packageJson).toBeUndefined();
+      expect(ctx.configFiles).not.toContain('tsconfig.json');
+    });
+  });
 
   describe('configFiles', () => {
     it('detects known config files', () => {


### PR DESCRIPTION
## Problem

TRA-922: the daemon's main thread blocks long enough that the TCP accept queue on 3741 never drains, so stdio sessions cannot reach it and each falls back to indexing on its own.

One measured source of that block, on the daemon's main thread, on *every* pipeline run and *every* `get_project_map` / `plan_turn` call:

`buildProjectContext()` scans the root plus every directory 1–2 levels deep, and in each one probes ~60 manifest/config filenames — `package.json`, `composer.json`, … plus all 43 `CONFIG_FILE_NAMES` — with a per-name `lstatSync` (and an extra `accessSync` for config names). The misses, not the hits, are the cost. Nothing caches the result across runs, and `registerFrameworkEdgeTypes()` repeats the whole thing per workspace (44 of them on this repo).

## Fix

One `readdirSync` per scanned directory; a name that isn't in that directory's entry set is never touched. Symlinks stay excluded — `dirent.isFile()` is false for a symlink, which is exactly what the removed `lstatSync().isSymbolicLink()` check tested.

## Numbers

Measured on this repo, M-series Mac, warm fs cache, 1164 indexed files, median of 3 runs after a full index:

| | before | after |
|---|---|---|
| `buildProjectContext(root)` | 219 ms | **3.0 ms** |
| scoped reindex of one file, wall | 357 ms | **137 ms** |
| scoped reindex, **max event-loop block** | 163 ms | **42 ms** |

Method: `IndexingPipeline.indexFiles(['src/indexer/pipeline.ts'])` against a warm index, with a 5 ms `setInterval` probe recording the largest gap between ticks. The first run after a cold start blocked 631 ms before, 48 ms after.

Correctness: the full `ProjectContext` JSON is byte-identical before/after for the repo root, `packages/app`, `tests/fixtures/laravel-11` and `tests/fixtures/nuxt3` (919 lines of output, `diff` clean).

## Regression guard

`tests/indexer/project-context.test.ts` → `syscall budget`: builds a 6-directory monorepo fixture and asserts the `readdirSync`/`lstatSync` count stays bounded by the number of **directories**, not by the length of `CONFIG_FILE_NAMES`, and that `accessSync` is never called. Verified to fail on the previous implementation (`lstatSync` called 300+ times) and pass on this one. A second test keeps the symlinked-manifest exclusion honest.

## Not in this PR

- The `metadata LIKE '%"callSites"%'` full scans that show at the top of the daemon `sample(1)` stack — TRA-924.
- Re-resolving the whole graph on a one-file change — TRA-923.
- The fail-fast half of TRA-922 already shipped as TRA-704: `StdioSession` arms a 1 s watchdog on the client's `initialize`, and a daemon that misses it gets a `logger.warn` and a deliberate local-mode fallback with the frame replayed in-process (`src/daemon/router/session.ts:376-412`). `getDaemonHealth` already aborts at 500 ms.

Local: `pnpm test` 10188 passed / 24 skipped, `tsc --noEmit` clean, `tsup` build clean, `biome ci` clean.
