### PR TITLE
fix(indexer): index the metadata-existence checks in edge resolvers

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,7 +2,7 @@ import Database from 'better-sqlite3';
 import { restrictDbPerms } from '../shared/db-perms.js';
 import { logger } from '../logger.js';
 
-const SCHEMA_VERSION = 31;
+const SCHEMA_VERSION = 32;
 
 /**
  * Canonical column list for the `symbols_fts` virtual table.
@@ -259,6 +259,19 @@ CREATE INDEX IF NOT EXISTS idx_symbols_parent ON symbols(parent_id);
 CREATE INDEX IF NOT EXISTS idx_symbols_exported
   ON symbols(json_extract(metadata, '$.exported'))
   WHERE json_extract(metadata, '$.exported') IS NOT NULL;
+-- v32: the edge resolvers (typescript-calls, python-calls, typescript-types,
+-- python-types, python-heritage) used to gate their source SELECT with a
+-- leading-wildcard metadata LIKE '%"callSites"%' (etc.), which SQLite can't
+-- serve from an index -- it ran the pattern matcher over every symbol's
+-- metadata blob. These partial indexes on the same json_extract expression
+-- the resolvers now filter on turns that full scan into an index seek.
+-- Mirrored in MIGRATIONS[32].
+CREATE INDEX IF NOT EXISTS idx_symbols_call_sites ON symbols(file_id)
+  WHERE json_extract(metadata, '$.callSites') IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_symbols_type_refs ON symbols(file_id)
+  WHERE json_extract(metadata, '$.typeRefs') IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_symbols_bases ON symbols(file_id)
+  WHERE json_extract(metadata, '$.bases') IS NOT NULL;
 -- idx_files_workspace and idx_edges_cross_ws created in migration v9
 
 -- ============================================================
@@ -1759,6 +1772,20 @@ const MIGRATIONS: Record<number, (db: Database.Database) => void> = {
     // Backfill is a no-op on existing DBs (no scip_resolved rows exist yet),
     // but kept for symmetry with the per-tier backfill in migration 25.
     db.exec(`UPDATE edges SET confidence = 1.00 WHERE resolution_tier = 'scip_resolved'`);
+  },
+  32: (db) => {
+    // Partial indexes for the metadata-existence checks in the edge
+    // resolvers (typescript-calls, python-calls, typescript-types,
+    // python-types, python-heritage). Mirrored in the top-of-file DDL block
+    // for fresh-DB parity (byte-identical definitions).
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_symbols_call_sites ON symbols(file_id)
+        WHERE json_extract(metadata, '$.callSites') IS NOT NULL;
+      CREATE INDEX IF NOT EXISTS idx_symbols_type_refs ON symbols(file_id)
+        WHERE json_extract(metadata, '$.typeRefs') IS NOT NULL;
+      CREATE INDEX IF NOT EXISTS idx_symbols_bases ON symbols(file_id)
+        WHERE json_extract(metadata, '$.bases') IS NOT NULL;
+    `);
   },
 };
 

--- a/src/indexer/edge-resolvers/python-calls.ts
+++ b/src/indexer/edge-resolvers/python-calls.ts
@@ -62,7 +62,7 @@ export function resolvePythonCallEdges(state: PipelineState, scope?: ChangeScope
       LEFT JOIN symbols p ON s.parent_id = p.id
       WHERE f.language = 'python'
         AND s.metadata IS NOT NULL
-        AND s.metadata LIKE '%"callSites"%'
+        AND json_extract(s.metadata, '$.callSites') IS NOT NULL
         AND s.file_id IN (${ph})
     `)
       .all(...scopedIds) as SymbolRow[];
@@ -76,7 +76,7 @@ export function resolvePythonCallEdges(state: PipelineState, scope?: ChangeScope
       LEFT JOIN symbols p ON s.parent_id = p.id
       WHERE f.language = 'python'
         AND s.metadata IS NOT NULL
-        AND s.metadata LIKE '%"callSites"%'
+        AND json_extract(s.metadata, '$.callSites') IS NOT NULL
     `)
       .all() as SymbolRow[];
   }

--- a/src/indexer/edge-resolvers/python-heritage.ts
+++ b/src/indexer/edge-resolvers/python-heritage.ts
@@ -28,14 +28,14 @@ export function resolvePythonHeritageEdges(state: PipelineState, scope?: ChangeS
     query = `SELECT s.id, s.name, s.metadata FROM symbols s
              JOIN files f ON s.file_id = f.id
              WHERE f.language = 'python' AND s.kind = 'class'
-             AND s.metadata IS NOT NULL AND s.metadata LIKE '%"bases"%'
+             AND s.metadata IS NOT NULL AND json_extract(s.metadata, '$.bases') IS NOT NULL
              AND f.id IN (${ph})`;
     params.push(...changedFileIds);
   } else {
     query = `SELECT s.id, s.name, s.metadata FROM symbols s
              JOIN files f ON s.file_id = f.id
              WHERE f.language = 'python' AND s.kind = 'class'
-             AND s.metadata IS NOT NULL AND s.metadata LIKE '%"bases"%'`;
+             AND s.metadata IS NOT NULL AND json_extract(s.metadata, '$.bases') IS NOT NULL`;
   }
 
   const classesWithBases = store.db.prepare(query).all(...params) as Array<{

--- a/src/indexer/edge-resolvers/python-types.ts
+++ b/src/indexer/edge-resolvers/python-types.ts
@@ -66,7 +66,7 @@ export function resolvePythonTypeEdges(state: PipelineState, scope?: ChangeScope
         JOIN files f ON s.file_id = f.id
        WHERE f.language = 'python'
          AND s.metadata IS NOT NULL
-         AND s.metadata LIKE '%"typeRefs"%'
+         AND json_extract(s.metadata, '$.typeRefs') IS NOT NULL
          AND s.file_id IN (${ph})
     `)
       .all(...scopedIds) as SourceRow[];
@@ -78,7 +78,7 @@ export function resolvePythonTypeEdges(state: PipelineState, scope?: ChangeScope
         JOIN files f ON s.file_id = f.id
        WHERE f.language = 'python'
          AND s.metadata IS NOT NULL
-         AND s.metadata LIKE '%"typeRefs"%'
+         AND json_extract(s.metadata, '$.typeRefs') IS NOT NULL
     `)
       .all() as SourceRow[];
   }

--- a/src/indexer/edge-resolvers/typescript-calls.ts
+++ b/src/indexer/edge-resolvers/typescript-calls.ts
@@ -83,7 +83,7 @@ export function resolveTypeScriptCallEdges(state: PipelineState, scope?: ChangeS
         LEFT JOIN symbols p ON s.parent_id = p.id
        WHERE f.language IN ${TS_JS_LANGS}
          AND s.metadata IS NOT NULL
-         AND s.metadata LIKE '%"callSites"%'
+         AND json_extract(s.metadata, '$.callSites') IS NOT NULL
          AND s.file_id IN (${ph})
     `)
       .all(...scopedIds) as SymbolRow[];
@@ -97,7 +97,7 @@ export function resolveTypeScriptCallEdges(state: PipelineState, scope?: ChangeS
         LEFT JOIN symbols p ON s.parent_id = p.id
        WHERE f.language IN ${TS_JS_LANGS}
          AND s.metadata IS NOT NULL
-         AND s.metadata LIKE '%"callSites"%'
+         AND json_extract(s.metadata, '$.callSites') IS NOT NULL
     `)
       .all() as SymbolRow[];
   }

--- a/src/indexer/edge-resolvers/typescript-types.ts
+++ b/src/indexer/edge-resolvers/typescript-types.ts
@@ -63,7 +63,7 @@ export function resolveTypeScriptTypeEdges(state: PipelineState, scope?: ChangeS
         JOIN files f ON s.file_id = f.id
        WHERE f.language IN ${TS_JS_LANGS}
          AND s.metadata IS NOT NULL
-         AND s.metadata LIKE '%"typeRefs"%'
+         AND json_extract(s.metadata, '$.typeRefs') IS NOT NULL
          AND s.file_id IN (${ph})
     `)
       .all(...scopedIds) as SymbolRow[];
@@ -75,7 +75,7 @@ export function resolveTypeScriptTypeEdges(state: PipelineState, scope?: ChangeS
         JOIN files f ON s.file_id = f.id
        WHERE f.language IN ${TS_JS_LANGS}
          AND s.metadata IS NOT NULL
-         AND s.metadata LIKE '%"typeRefs"%'
+         AND json_extract(s.metadata, '$.typeRefs') IS NOT NULL
     `)
       .all() as SymbolRow[];
   }

--- a/tests/db/metadata-existence-index.test.ts
+++ b/tests/db/metadata-existence-index.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression guard for TRA-924: the edge resolvers (typescript-calls,
+ * python-calls, typescript-types, python-types, python-heritage) used to
+ * gate their source SELECT with a leading-wildcard
+ * `metadata LIKE '%"callSites"%'` (etc.), which SQLite can't serve from an
+ * index -- it ran the LIKE pattern matcher over every symbol row's metadata
+ * blob (89% of daemon profile samples). This runs BEFORE the pipeline's
+ * post-pass `ANALYZE` (src/indexer/pipeline.ts), so sqlite_stat1 is empty or
+ * stale exactly when these queries fire -- these checks deliberately don't
+ * run ANALYZE either, to match that condition.
+ *
+ * The fix replaced those predicates with `json_extract(metadata, '$.x') IS
+ * NOT NULL` and added matching partial indexes (idx_symbols_call_sites,
+ * idx_symbols_type_refs, idx_symbols_bases). Assert the resolvers' actual
+ * query shapes now avoid a bare full-table scan of `symbols`, so a future
+ * edit can't silently reintroduce the LIKE scan.
+ */
+
+import type Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { initializeDatabase } from '../../src/db/schema.js';
+
+describe('metadata-existence partial indexes (TRA-924)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = initializeDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('fresh DB ships idx_symbols_call_sites, idx_symbols_type_refs, idx_symbols_bases', () => {
+    const idxRows = db.prepare("SELECT name FROM sqlite_master WHERE type = 'index'").all() as {
+      name: string;
+    }[];
+    const names = new Set(idxRows.map((r) => r.name));
+
+    expect(names.has('idx_symbols_call_sites')).toBe(true);
+    expect(names.has('idx_symbols_type_refs')).toBe(true);
+    expect(names.has('idx_symbols_bases')).toBe(true);
+  });
+
+  function planLines(sql: string, params: unknown[] = []): string[] {
+    const plan = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(...params) as Array<{
+      detail: string;
+    }>;
+    return plan.map((p) => p.detail);
+  }
+
+  // A bare "SCAN s" line (no "USING INDEX ..." suffix) means SQLite is
+  // walking every row of the symbols table -- the exact shape the LIKE scan
+  // produced. Any indexed access (SEARCH, or SCAN ... USING INDEX) avoids it.
+  function hasBareTableScan(lines: string[]): boolean {
+    return lines.some((l) => /^SCAN s$/.test(l));
+  }
+
+  it('resolveTypeScriptCallEdges / resolvePythonCallEdges predicate avoids a bare symbols scan', () => {
+    const lines = planLines(`
+      SELECT s.id FROM symbols s
+        JOIN files f ON s.file_id = f.id
+       WHERE f.language IN ('typescript','javascript','tsx','jsx','vue')
+         AND s.metadata IS NOT NULL
+         AND json_extract(s.metadata, '$.callSites') IS NOT NULL
+    `);
+    expect(lines.join(' | ')).toContain('idx_symbols_call_sites');
+    expect(hasBareTableScan(lines)).toBe(false);
+  });
+
+  it('scoped call-site query (file_id IN) seeks idx_symbols_call_sites', () => {
+    const lines = planLines(
+      `
+      SELECT s.id FROM symbols s
+        JOIN files f ON s.file_id = f.id
+       WHERE f.language = 'python'
+         AND s.metadata IS NOT NULL
+         AND json_extract(s.metadata, '$.callSites') IS NOT NULL
+         AND s.file_id IN (?, ?, ?)
+    `,
+      [1, 2, 3],
+    );
+    expect(lines.join(' | ')).toContain('idx_symbols_call_sites');
+    expect(hasBareTableScan(lines)).toBe(false);
+  });
+
+  it('resolveTypeScriptTypeEdges / resolvePythonTypeEdges predicate avoids a bare symbols scan', () => {
+    const lines = planLines(`
+      SELECT s.id FROM symbols s
+        JOIN files f ON s.file_id = f.id
+       WHERE f.language = 'python'
+         AND s.metadata IS NOT NULL
+         AND json_extract(s.metadata, '$.typeRefs') IS NOT NULL
+    `);
+    expect(lines.join(' | ')).toContain('idx_symbols_type_refs');
+    expect(hasBareTableScan(lines)).toBe(false);
+  });
+
+  it('scoped python-heritage query (file_id IN) seeks idx_symbols_bases', () => {
+    // The unscoped heritage query also filters `s.kind = 'class'`, which the
+    // pre-existing idx_symbols_kind already made index-driven even under the
+    // old LIKE predicate -- so idx_symbols_bases's contribution shows up in
+    // the scoped (incremental-reindex) branch, where it out-competes
+    // idx_symbols_kind for the combined file_id + metadata-presence filter.
+    const lines = planLines(
+      `
+      SELECT s.id, s.name, s.metadata FROM symbols s
+             JOIN files f ON s.file_id = f.id
+             WHERE f.language = 'python' AND s.kind = 'class'
+             AND s.metadata IS NOT NULL AND json_extract(s.metadata, '$.bases') IS NOT NULL
+             AND f.id IN (?, ?, ?)
+    `,
+      [1, 2, 3],
+    );
+    expect(lines.join(' | ')).toContain('idx_symbols_bases');
+    expect(hasBareTableScan(lines)).toBe(false);
+  });
+});

--- a/tests/db/schema-migration.test.ts
+++ b/tests/db/schema-migration.test.ts
@@ -38,12 +38,12 @@ describe('schema-migration (fresh DB at v1.36.0)', () => {
     db = initializeDatabase(':memory:');
   });
 
-  it('SCHEMA_VERSION row is 31 in schema_meta', () => {
+  it('SCHEMA_VERSION row is 32 in schema_meta', () => {
     const row = db.prepare("SELECT value FROM schema_meta WHERE key = 'schema_version'").get() as
       | { value: string }
       | undefined;
     expect(row).toBeDefined();
-    expect(Number(row!.value)).toBe(31);
+    expect(Number(row!.value)).toBe(32);
   });
 
   it('ranking_pins table exists with the expected columns and PK', () => {


### PR DESCRIPTION
## Summary

- `typescript-calls.ts`, `python-calls.ts`, `typescript-types.ts`, `python-types.ts`, and `python-heritage.ts` each gated their resolver's source SELECT with a leading-wildcard `metadata LIKE '%"callSites"%'` (etc.) on the `symbols.metadata` JSON blob — unindexable in SQLite, so it ran the pattern matcher over every symbol row's metadata (89% of one daemon profile `sample(1)` run, reproduced in a second run).
- Replaced each predicate with `json_extract(s.metadata, '$.x') IS NOT NULL` and added matching partial indexes — `idx_symbols_call_sites`, `idx_symbols_type_refs`, `idx_symbols_bases` — mirroring the existing `idx_symbols_exported` expression-index pattern already in the schema.
- Bumped `SCHEMA_VERSION` 31 → 32 with a matching `MIGRATIONS[32]` entry (mirrored into the fresh-DB DDL block for parity), and updated the version-pinned assertion in `tests/db/schema-migration.test.ts`.

Closes TRA-924.

### Note on scope
`src/tools/quality/antipatterns.ts` has three more occurrences of the exact same `metadata LIKE '%"callSites"%'` pattern that TRA-924 didn't list — out of scope here since the issue named these 5 files specifically, flagging for a possible follow-up.

## Test plan
- Added `tests/db/metadata-existence-index.test.ts`: asserts the 3 new partial indexes exist on a fresh DB, and uses `EXPLAIN QUERY PLAN` against the resolvers' actual query shapes (unscoped + scoped `file_id IN (...)` variants) to assert they no longer produce a bare full-table scan of `symbols`. Verified empirically at ~30k-row scale that the old LIKE queries did `SCAN s` (bare table scan) for the calls/types predicates and the new queries seek the partial index instead.
- `pnpm run build` — passes.
- `pnpm run lint` (`tsc --noEmit`) — passes.
- `pnpm test` — full suite: 918 files / 10193 tests passed, 22 pre-existing skips, 0 failures.