### PR TITLE
fix(daemon): share TopologyStore/DecisionStore/StateEngine across the whole daemon, not per project

### DIFF
--- a/packages/app/src/main/daemon-plist.ts
+++ b/packages/app/src/main/daemon-plist.ts
@@ -20,11 +20,13 @@ import path from 'node:path';
  * `src/daemon/lifecycle.ts`. `tests/scripts/postinstall-plist-version.test.ts`
  * keeps them in sync.
  */
-export const PLIST_VERSION = 4;
+export const PLIST_VERSION = 5;
 export const PLIST_LABEL = 'com.trace-mcp.server';
 export const PLIST_MARKER = `trace-mcp plist v${PLIST_VERSION}`;
 /** Seconds launchd waits after SIGTERM before SIGKILL (TRA-421). */
 const PLIST_EXIT_TIMEOUT_SEC = 30;
+/** Open-file ceiling for the daemon process (TRA-938). Mirrors PLIST_MAX_FILES in src/daemon/lifecycle.ts. */
+const PLIST_MAX_FILES = 4096;
 export const DEFAULT_DAEMON_PORT = 3741;
 
 export function generatePlist(shimPath: string, home: string, port = DEFAULT_DAEMON_PORT): string {
@@ -58,6 +60,16 @@ export function generatePlist(shimPath: string, home: string, port = DEFAULT_DAE
   <integer>5</integer>
   <key>ExitTimeOut</key>
   <integer>${PLIST_EXIT_TIMEOUT_SEC}</integer>
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>${PLIST_MAX_FILES}</integer>
+  </dict>
+  <key>HardResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>${PLIST_MAX_FILES}</integer>
+  </dict>
   <key>StandardOutPath</key>
   <string>${path.join(home, 'daemon.log')}</string>
   <key>StandardErrorPath</key>

--- a/scripts/postinstall-control-plane.mjs
+++ b/scripts/postinstall-control-plane.mjs
@@ -41,9 +41,14 @@ import { logDaemonStopAttribution } from './daemon-attribution.mjs';
 // shim everywhere so node-version swaps don't pin the daemon to a stale binary.
 // v4: adds ExitTimeOut — launchd's 5s default SIGKILLed the daemon mid-cleanup
 // (TRA-421), losing both the shutdown log line and the graceful DB close.
-const PLIST_VERSION = 4;
+// v5 (TRA-938): adds SoftResourceLimits/NumberOfFiles — launchd's 256-fd
+// default left no headroom for a daemon with several registered projects,
+// so accept() started failing with EMFILE.
+const PLIST_VERSION = 5;
 /** Seconds launchd waits after SIGTERM before SIGKILL. Mirrors PLIST_EXIT_TIMEOUT_SEC. */
 const PLIST_EXIT_TIMEOUT_SEC = 30;
+/** Open-file ceiling for the daemon process. Mirrors PLIST_MAX_FILES in src/daemon/lifecycle.ts. */
+const PLIST_MAX_FILES = 4096;
 const PLIST_LABEL = 'com.trace-mcp.server';
 const PLIST_MARKER = `trace-mcp plist v${PLIST_VERSION}`;
 const DEFAULT_DAEMON_PORT = 3741;
@@ -339,6 +344,16 @@ function generatePlist(binaryPath, port) {
   <integer>5</integer>
   <key>ExitTimeOut</key>
   <integer>${PLIST_EXIT_TIMEOUT_SEC}</integer>
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>${PLIST_MAX_FILES}</integer>
+  </dict>
+  <key>HardResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>${PLIST_MAX_FILES}</integer>
+  </dict>
   <key>StandardOutPath</key>
   <string>${DAEMON_LOG_PATH}</string>
   <key>StandardErrorPath</key>

--- a/src/daemon/__tests__/resource-pool.test.ts
+++ b/src/daemon/__tests__/resource-pool.test.ts
@@ -1,0 +1,106 @@
+/**
+ * TRA-938 regression guard: TopologyStore/DecisionStore/StateEngine each back
+ * a single fixed file under TRACE_MCP_HOME, the same file no matter which
+ * project asks for it. Before this fix, ProjectResourcePool still kept one
+ * SQLite connection per project root onto those files, so registering N
+ * projects opened N redundant fds per shared file instead of 1 — the daemon
+ * exhausted launchd's 256-fd soft limit and accept() started failing with
+ * EMFILE. Object identity across different project roots is the deterministic
+ * stand-in for "one connection, not N" — no real fd counting needed.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { TraceMcpConfig } from '../../config.js';
+import type { ProjectResourcePool as ProjectResourcePoolType } from '../resource-pool.js';
+
+let tmpHome: string;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'trace-mcp-resource-pool-'));
+  vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+async function freshPool(): Promise<ProjectResourcePoolType> {
+  const { ProjectResourcePool } = await import('../resource-pool.js');
+  return new ProjectResourcePool();
+}
+
+const topologyEnabledConfig = { topology: { enabled: true } } as TraceMcpConfig;
+
+describe('ProjectResourcePool — daemon-wide shared resources', () => {
+  it('acquire() returns the same store instances for different project roots', async () => {
+    const pool = await freshPool();
+    const depsA = pool.acquire('/project-a', topologyEnabledConfig);
+    const depsB = pool.acquire('/project-b', topologyEnabledConfig);
+
+    expect(depsB.topoStore).toBe(depsA.topoStore);
+    expect(depsB.decisionStore).toBe(depsA.decisionStore);
+    expect(depsB.stateEngine).toBe(depsA.stateEngine);
+
+    pool.disposeAll();
+  });
+
+  it('getSharedDeps() (addProject-style access) returns the same instances acquire() does, without bumping refcount', async () => {
+    const pool = await freshPool();
+    const acquired = pool.acquire('/project-a', topologyEnabledConfig);
+    const viaGetShared = pool.getSharedDeps(topologyEnabledConfig);
+
+    expect(viaGetShared.decisionStore).toBe(acquired.decisionStore);
+    expect(viaGetShared.stateEngine).toBe(acquired.stateEngine);
+    // getSharedDeps() must not count as a session — only acquire()/release() do.
+    expect(pool.getRefCount('/project-a')).toBe(1);
+
+    pool.disposeAll();
+  });
+
+  it('getRefCount() stays per-project even though the resources are shared', async () => {
+    const pool = await freshPool();
+    pool.acquire('/project-a', topologyEnabledConfig);
+    pool.acquire('/project-a', topologyEnabledConfig);
+    pool.acquire('/project-b', topologyEnabledConfig);
+
+    expect(pool.getRefCount('/project-a')).toBe(2);
+    expect(pool.getRefCount('/project-b')).toBe(1);
+    expect(pool.getRefCount('/project-c')).toBe(0);
+
+    pool.disposeAll();
+  });
+
+  it('release() and disposeProject() never close the shared resources — a later acquire() still returns live handles', async () => {
+    const pool = await freshPool();
+    const depsA = pool.acquire('/project-a', topologyEnabledConfig);
+    pool.release('/project-a');
+    pool.disposeProject('/project-a');
+    expect(pool.getRefCount('/project-a')).toBe(0);
+
+    // Still the same, still-open instances — not recreated, not closed.
+    const depsB = pool.acquire('/project-b', topologyEnabledConfig);
+    expect(depsB.decisionStore).toBe(depsA.decisionStore);
+    expect(() => depsB.decisionStore!.getStats()).not.toThrow();
+
+    pool.disposeAll();
+  });
+
+  it('disposeAll() closes the shared resources; a later acquire() opens fresh ones', async () => {
+    const pool = await freshPool();
+    const before = pool.acquire('/project-a', topologyEnabledConfig);
+    pool.disposeAll();
+
+    // The old handle is closed — using it now throws.
+    expect(() => before.decisionStore!.getStats()).toThrow();
+
+    const after = pool.acquire('/project-a', topologyEnabledConfig);
+    expect(after.decisionStore).not.toBe(before.decisionStore);
+
+    pool.disposeAll();
+  });
+});

--- a/src/daemon/__tests__/resource-pool.test.ts
+++ b/src/daemon/__tests__/resource-pool.test.ts
@@ -35,6 +35,7 @@ async function freshPool(): Promise<ProjectResourcePoolType> {
 }
 
 const topologyEnabledConfig = { topology: { enabled: true } } as TraceMcpConfig;
+const topologyDisabledConfig = { topology: { enabled: false } } as TraceMcpConfig;
 
 describe('ProjectResourcePool — daemon-wide shared resources', () => {
   it('acquire() returns the same store instances for different project roots', async () => {
@@ -54,6 +55,7 @@ describe('ProjectResourcePool — daemon-wide shared resources', () => {
     const acquired = pool.acquire('/project-a', topologyEnabledConfig);
     const viaGetShared = pool.getSharedDeps(topologyEnabledConfig);
 
+    expect(viaGetShared.topoStore).toBe(acquired.topoStore);
     expect(viaGetShared.decisionStore).toBe(acquired.decisionStore);
     expect(viaGetShared.stateEngine).toBe(acquired.stateEngine);
     // getSharedDeps() must not count as a session — only acquire()/release() do.
@@ -86,6 +88,29 @@ describe('ProjectResourcePool — daemon-wide shared resources', () => {
     const depsB = pool.acquire('/project-b', topologyEnabledConfig);
     expect(depsB.decisionStore).toBe(depsA.decisionStore);
     expect(() => depsB.decisionStore!.getStats()).not.toThrow();
+
+    pool.disposeAll();
+  });
+
+  it('a topology-disabled project loading first does not permanently disable topology for later projects', async () => {
+    const pool = await freshPool();
+
+    // A topology-disabled project acquires first — nothing to backfill from,
+    // so topoStore stays null for this call.
+    const depsDisabled = pool.acquire('/project-disabled', topologyDisabledConfig);
+    expect(depsDisabled.topoStore).toBeNull();
+
+    // A topology-enabled project acquires next. Before the TRA-938 review fix,
+    // ensureShared() short-circuited on the already-created `shared` object and
+    // returned the cached `topoStore: null` forever, regardless of this
+    // project's own config — silently deregistering topology tools daemon-wide.
+    const depsEnabled = pool.acquire('/project-enabled', topologyEnabledConfig);
+    expect(depsEnabled.topoStore).not.toBeNull();
+
+    // The backfilled instance is the one every subsequent caller gets too —
+    // including a later re-check from the disabled project.
+    const depsDisabledAgain = pool.acquire('/project-disabled', topologyDisabledConfig);
+    expect(depsDisabledAgain.topoStore).toBe(depsEnabled.topoStore);
 
     pool.disposeAll();
   });

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -37,7 +37,13 @@ const PLIST_LABEL = 'com.trace-mcp.server';
 // v4: ExitTimeOut — launchd's default 5s is shorter than a graceful shutdown
 // that closes every project DB, so launchd SIGKILLed the daemon mid-cleanup
 // (LastExitStatus=9) and the buffered "Daemon shutting down" line died with it.
-const PLIST_VERSION = 4;
+// v5 (TRA-938): SoftResourceLimits/NumberOfFiles — launchd's default 256-fd
+// soft limit left no headroom once a handful of projects were loaded, so
+// accept() started failing with EMFILE (surfaced to users as "the daemon was
+// installed but never answered"). The daemon-wide store sharing fix
+// (ProjectResourcePool) removes the per-project multiplier; this raises the
+// ceiling as defense in depth, not the fix itself.
+const PLIST_VERSION = 5;
 /**
  * Seconds launchd waits after SIGTERM before escalating to SIGKILL. Graceful
  * shutdown closes DBs, tears down watchers and flushes indexes for every
@@ -48,6 +54,14 @@ const PLIST_VERSION = 4;
  * tests/scripts/postinstall-control-plane.test.ts.
  */
 const PLIST_EXIT_TIMEOUT_SEC = 30;
+/**
+ * Open-file ceiling for the daemon process (both soft and hard). launchd's
+ * own default is 256 — comfortably below what a daemon holding a handful of
+ * registered projects needs (each project's index DB is 3 fds, plus sockets,
+ * logs, and the daemon-wide shared stores). Well under macOS's per-process
+ * kern.maxfilesperproc ceiling (10240 by default), so no root/sudo required.
+ */
+const PLIST_MAX_FILES = 4096;
 const PLIST_MARKER = `trace-mcp plist v${PLIST_VERSION}`;
 const isMac = process.platform === 'darwin';
 const isWin = process.platform === 'win32';
@@ -186,6 +200,16 @@ function generatePlist(binaryPath: string, port: number): string {
   <integer>5</integer>
   <key>ExitTimeOut</key>
   <integer>${PLIST_EXIT_TIMEOUT_SEC}</integer>
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>${PLIST_MAX_FILES}</integer>
+  </dict>
+  <key>HardResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>${PLIST_MAX_FILES}</integer>
+  </dict>
   <key>StandardOutPath</key>
   <string>${DAEMON_LOG_PATH}</string>
   <key>StandardErrorPath</key>

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -413,7 +413,17 @@ export class ProjectManager {
       ? new BackgroundLspEnricher({ store, config, rootPath: projectRoot })
       : null;
 
-    const serverHandle = createServer(store, registry, config, projectRoot, progress);
+    // TRA-938: route through the shared pool so this server's TopologyStore/
+    // DecisionStore/StateEngine are the daemon-wide singletons, not private
+    // per-project SQLite connections onto the same three files.
+    const serverHandle = createServer(
+      store,
+      registry,
+      config,
+      projectRoot,
+      progress,
+      this.resourcePool?.getSharedDeps(config),
+    );
 
     const managed: ManagedProject = {
       root: projectRoot,
@@ -939,12 +949,13 @@ export class ProjectManager {
     } catch (err) {
       logger.warn({ error: err, projectRoot: root }, 'sharedPool.dropProject failed (non-fatal)');
     }
-    // Force-dispose the per-project entry in the resource pool (TopologyStore
-    // + DecisionStore SQLite handles). stopProject runs unconditionally — we
-    // don't wait for refCount to drain because by this point the project is
-    // gone from `projects` and no new sessions can be acquired for this root.
-    // Any in-flight session.onclose handler will see a stale entry but its
-    // release() call is a no-op (entry already deleted).
+    // Forget this project's own refcount bookkeeping in the resource pool.
+    // TRA-938: the pool's TopologyStore/DecisionStore/StateEngine are
+    // daemon-wide singletons now, not owned per-project, so this no longer
+    // closes any SQLite handle — it only drops the counter used by
+    // unloadIdleProjects/sweepEphemeralProjects. Any in-flight
+    // session.onclose handler will see a stale entry but its release() call
+    // is a no-op (entry already deleted).
     try {
       this.resourcePool?.disposeProject(root);
     } catch (err) {

--- a/src/daemon/resource-pool.ts
+++ b/src/daemon/resource-pool.ts
@@ -1,10 +1,23 @@
 /**
- * ProjectResourcePool — manages shared project-level resources for the daemon.
+ * ProjectResourcePool — owns the daemon-wide shared resources every managed
+ * project's MCP server draws on: TopologyStore, DecisionStore, StateEngine.
  *
- * Resources like TopologyStore and DecisionStore are expensive (SQLite connections)
- * and should be shared across all MCP sessions for the same project instead of
- * being created per-session. This pool uses reference counting to track active
- * sessions and closes resources when no sessions remain.
+ * TRA-938: these three each back a single fixed file under TRACE_MCP_HOME
+ * (topology.db / decisions.db / state.db) — the SAME file regardless of
+ * which project asks for it. Earlier this pool still kept a separate
+ * TopologyStore/DecisionStore per project root, so N loaded projects meant N
+ * redundant SQLite connections (3 fds apiece) onto those three files. At
+ * daemon scale that exhausted launchd's default 256 open-file soft limit,
+ * which surfaced as accept() returning EMFILE and clients seeing "the daemon
+ * was installed but never answered" — no crash, no log line naming the real
+ * cause. Since the underlying file is process-global, so is this pool: one
+ * TopologyStore/DecisionStore/StateEngine instance for the daemon's entire
+ * lifetime, created lazily on first use and closed once, in disposeAll(), at
+ * daemon shutdown.
+ *
+ * getRefCount() stays per-project — it backs the idle-unload / ephemeral-
+ * sweep "is any client session still using this project" signal, which is
+ * unrelated to how the shared files are opened.
  */
 
 import * as path from 'node:path';
@@ -14,149 +27,131 @@ import {
   ensureGlobalDirs,
   TRACE_MCP_HOME,
   TOPOLOGY_DB_PATH,
+  STATE_DB_PATH,
 } from '../global.js';
 import { logger } from '../logger.js';
 import { createAuditLogger } from '../memory/decision-audit-log.js';
 import { DecisionStore } from '../memory/decision-store.js';
 import type { ServerDeps } from '../server/server.js';
+import { StateEngine } from '../state/state-engine.js';
 import { TopologyStore } from '../topology/topology-db.js';
 
-interface PoolEntry {
+interface SharedResources {
   topoStore: TopologyStore | null;
   decisionStore: DecisionStore;
-  refCount: number;
+  stateEngine: StateEngine;
 }
 
 export class ProjectResourcePool {
-  private pools = new Map<string, PoolEntry>();
+  /** Per-project session refcount — see getRefCount(). Unrelated to `shared`. */
+  private entries = new Map<string, { refCount: number }>();
+
+  /** The daemon-wide singleton. Null until the first acquire()/getSharedDeps(). */
+  private shared: SharedResources | null = null;
 
   /**
-   * Grace period before idle (refCount === 0) project resources are closed.
-   * Lets a fast reconnect reuse the live SQLite handles instead of paying the
-   * reopen cost, while still releasing handles for projects that go quiet.
+   * Create the shared resources on first call; a no-op afterwards. The first
+   * caller's config wins for whether topology tracking and the decision
+   * audit log are enabled — these are effectively daemon-wide files, so a
+   * per-project override only matters for which project happens to open them
+   * first.
    */
-  private readonly idleGraceMs = 60_000;
-
-  /** Pending idle-close timers, keyed by projectRoot. */
-  private idleTimers = new Map<string, ReturnType<typeof setTimeout>>();
-
-  /** Cancel and forget any pending idle-close timer for a project. */
-  private clearIdleTimer(projectRoot: string): void {
-    const timer = this.idleTimers.get(projectRoot);
-    if (timer) {
-      clearTimeout(timer);
-      this.idleTimers.delete(projectRoot);
-    }
+  private ensureShared(config: TraceMcpConfig): SharedResources {
+    if (this.shared) return this.shared;
+    ensureGlobalDirs();
+    const topoStore = config.topology?.enabled ? new TopologyStore(TOPOLOGY_DB_PATH) : null;
+    // Opt-in JSONL audit log alongside SQLite. Best-effort writes inside
+    // the store — a misconfigured directory must not break decision
+    // mutations. Defaults the directory to ~/.trace-mcp/decisions/.
+    const auditCfg = config.memory?.audit_log;
+    const auditLogger = auditCfg?.enabled
+      ? createAuditLogger({
+          dir: auditCfg.dir ?? path.join(TRACE_MCP_HOME, 'decisions'),
+          retentionDays: auditCfg.retentionDays,
+        })
+      : null;
+    const decisionStore = new DecisionStore(DECISIONS_DB_PATH, {
+      auditLogger,
+      memoHistoryLimit: config.memory?.memo?.historyLimit,
+    });
+    const stateEngine = new StateEngine(STATE_DB_PATH);
+    this.shared = { topoStore, decisionStore, stateEngine };
+    logger.debug({ auditLog: !!auditLogger }, 'Resource pool: opened daemon-wide shared resources');
+    return this.shared;
   }
 
   /**
-   * Acquire shared resources for a project. Increments refCount.
-   * Creates resources on first acquisition.
+   * Return the shared TopologyStore/DecisionStore/StateEngine, creating them
+   * on first call. Does NOT touch per-project refcounts — for callers that
+   * aren't a client session (e.g. ProjectManager.addProject's own server,
+   * which nothing ever connects a transport to) and must not affect the
+   * idle-unload/ephemeral-sweep "is this project busy" signal read via
+   * getRefCount().
    */
-  acquire(projectRoot: string, config: TraceMcpConfig): ServerDeps {
-    // A reconnect arrived before the idle grace period fired — keep the live
-    // handles by cancelling the pending close.
-    this.clearIdleTimer(projectRoot);
-    let entry = this.pools.get(projectRoot);
-    if (!entry) {
-      ensureGlobalDirs();
-      const topoStore = config.topology?.enabled ? new TopologyStore(TOPOLOGY_DB_PATH) : null;
-      // Opt-in JSONL audit log alongside SQLite. Best-effort writes inside
-      // the store — a misconfigured directory must not break decision
-      // mutations. Defaults the directory to ~/.trace-mcp/decisions/.
-      const auditCfg = config.memory?.audit_log;
-      const auditLogger = auditCfg?.enabled
-        ? createAuditLogger({
-            dir: auditCfg.dir ?? path.join(TRACE_MCP_HOME, 'decisions'),
-            retentionDays: auditCfg.retentionDays,
-          })
-        : null;
-      const decisionStore = new DecisionStore(DECISIONS_DB_PATH, {
-        auditLogger,
-        memoHistoryLimit: config.memory?.memo?.historyLimit,
-      });
-      entry = { topoStore, decisionStore, refCount: 0 };
-      this.pools.set(projectRoot, entry);
-      logger.debug(
-        { projectRoot, auditLog: !!auditLogger },
-        'Resource pool: created shared resources',
-      );
-    }
-    entry.refCount++;
-    logger.debug({ projectRoot, refCount: entry.refCount }, 'Resource pool: acquired');
+  getSharedDeps(config: TraceMcpConfig): ServerDeps {
+    const shared = this.ensureShared(config);
     return {
-      topoStore: entry.topoStore,
-      decisionStore: entry.decisionStore,
+      topoStore: shared.topoStore,
+      decisionStore: shared.decisionStore,
+      stateEngine: shared.stateEngine,
     };
   }
 
   /**
-   * Release a reference. When refCount drops to 0, resources are scheduled to
-   * be closed after an idle grace period (idleGraceMs) rather than held open
-   * forever. A reconnect within the grace window cancels the close via
-   * acquire(). The fire-time guard re-checks refCount so a session that
-   * arrived after the timer was armed keeps the handles alive.
+   * Acquire shared resources for a project session. Increments that
+   * project's refcount (read back via getRefCount()).
    */
+  acquire(projectRoot: string, config: TraceMcpConfig): ServerDeps {
+    const deps = this.getSharedDeps(config);
+    const entry = this.entries.get(projectRoot) ?? { refCount: 0 };
+    entry.refCount++;
+    this.entries.set(projectRoot, entry);
+    logger.debug({ projectRoot, refCount: entry.refCount }, 'Resource pool: acquired');
+    return deps;
+  }
+
+  /** Release a project session's reference. The shared resources stay open
+   *  regardless — other projects, or a future reload of this one, still need
+   *  them; they only close in disposeAll(). */
   release(projectRoot: string): void {
-    const entry = this.pools.get(projectRoot);
+    const entry = this.entries.get(projectRoot);
     if (!entry) return;
     entry.refCount = Math.max(0, entry.refCount - 1);
     logger.debug({ projectRoot, refCount: entry.refCount }, 'Resource pool: released');
-    if (entry.refCount === 0) {
-      // Replace any earlier pending timer (defensive — acquire normally
-      // clears it) so we never leak overlapping timers for one project.
-      this.clearIdleTimer(projectRoot);
-      const timer = setTimeout(() => {
-        this.idleTimers.delete(projectRoot);
-        // Only close if still idle — a reconnect may have re-acquired since
-        // the timer was armed.
-        if ((this.pools.get(projectRoot)?.refCount ?? 0) === 0) {
-          this.disposeProject(projectRoot);
-        }
-      }, this.idleGraceMs);
-      // Do not keep the daemon process alive solely for this cleanup timer.
-      timer.unref?.();
-      this.idleTimers.set(projectRoot, timer);
-    }
   }
 
-  /** Close resources for a specific project and remove from pool. Idempotent. */
+  /** Forget a stopped project's own refcount bookkeeping. Idempotent. Does
+   *  not close the shared resources — see class doc. */
   disposeProject(projectRoot: string): void {
-    // Always clear any pending idle timer first — even if the project is
-    // already gone — so a stale timer can never fire on a disposed project.
-    this.clearIdleTimer(projectRoot);
-    const entry = this.pools.get(projectRoot);
-    if (!entry) return;
-    try {
-      entry.topoStore?.close();
-    } catch {
-      /* best-effort */
-    }
-    try {
-      entry.decisionStore.close();
-    } catch {
-      /* best-effort */
-    }
-    this.pools.delete(projectRoot);
-    logger.debug({ projectRoot }, 'Resource pool: disposed project resources');
+    this.entries.delete(projectRoot);
   }
 
-  /** Close all resources across all projects. */
+  /** Close the daemon-wide shared resources. Call once, at daemon shutdown. */
   disposeAll(): void {
-    // Snapshot keys: disposeProject mutates this.pools while iterating.
-    for (const root of [...this.pools.keys()]) {
-      this.disposeProject(root);
+    this.entries.clear();
+    if (!this.shared) return;
+    try {
+      this.shared.topoStore?.close();
+    } catch {
+      /* best-effort */
     }
-    // Defensive sweep — clear any idle timers for projects that were never in
-    // the pool map (none expected, but keeps the timer map from leaking).
-    for (const timer of this.idleTimers.values()) {
-      clearTimeout(timer);
+    try {
+      this.shared.decisionStore.close();
+    } catch {
+      /* best-effort */
     }
-    this.idleTimers.clear();
+    try {
+      this.shared.stateEngine.close();
+    } catch {
+      /* best-effort */
+    }
+    this.shared = null;
+    logger.debug('Resource pool: closed daemon-wide shared resources');
   }
 
-  /** Get current session count for a project. */
+  /** Current session count for a project — used to gate idle-unload /
+   *  ephemeral-sweep eviction, not the shared resources' lifecycle. */
   getRefCount(projectRoot: string): number {
-    return this.pools.get(projectRoot)?.refCount ?? 0;
+    return this.entries.get(projectRoot)?.refCount ?? 0;
   }
 }

--- a/src/daemon/resource-pool.ts
+++ b/src/daemon/resource-pool.ts
@@ -50,14 +50,26 @@ export class ProjectResourcePool {
   private shared: SharedResources | null = null;
 
   /**
-   * Create the shared resources on first call; a no-op afterwards. The first
-   * caller's config wins for whether topology tracking and the decision
-   * audit log are enabled — these are effectively daemon-wide files, so a
-   * per-project override only matters for which project happens to open them
-   * first.
+   * Create the shared resources on first call; backfills `topoStore` on
+   * later calls if it's still null and this caller's config enables
+   * topology. Without that backfill, a topology-disabled project loading
+   * first would permanently pin `topoStore` to null for the daemon's whole
+   * lifetime — silently deregistering topology tools (get_topology,
+   * get_change_impact, list_subprojects, ...) for every OTHER project too,
+   * with nothing in the log to say why (TRA-938 review). decisionStore/
+   * stateEngine have no such per-project opt-out, so the first caller's
+   * config is authoritative for those (audit log dir/retention, memo
+   * history limit) — these are effectively daemon-wide files regardless of
+   * which project opens them first.
    */
   private ensureShared(config: TraceMcpConfig): SharedResources {
-    if (this.shared) return this.shared;
+    if (this.shared) {
+      if (!this.shared.topoStore && config.topology?.enabled) {
+        ensureGlobalDirs();
+        this.shared.topoStore = new TopologyStore(TOPOLOGY_DB_PATH);
+      }
+      return this.shared;
+    }
     ensureGlobalDirs();
     const topoStore = config.topology?.enabled ? new TopologyStore(TOPOLOGY_DB_PATH) : null;
     // Opt-in JSONL audit log alongside SQLite. Best-effort writes inside


### PR DESCRIPTION
## Summary

Fixes TRA-938: the daemon exhausted launchd's 256-fd soft limit once a handful of projects were registered, and `accept()` started failing with `EMFILE` — surfacing to users as "the daemon was installed but never answered" with no trace in `daemon.log`.

Root cause (per TRA-938's investigation): `TopologyStore`/`DecisionStore`/`StateEngine` each back a single fixed file under `TRACE_MCP_HOME` (`topology.db`/`decisions.db`/`state.db`) — the same file regardless of which project asks for it. But:
- `ProjectResourcePool` kept a separate instance **per project root** instead of one for the whole daemon.
- `ProjectManager.addProject()` bypassed the pool entirely (its own always-created — but never transport-connected — server opened three more private handles per project).

So N loaded projects meant up to `3 × (N+1)` redundant SQLite connections onto three files that only need 3 total.

## Changes

- `src/daemon/resource-pool.ts`: `ProjectResourcePool` now owns one daemon-wide singleton for the three stores, created lazily on first use and closed once at daemon shutdown (`disposeAll()`). Added `stateEngine` to the pool (previously only topo/decision were shared). `getRefCount()` stays per-project — it backs the idle-unload / ephemeral-sweep "is this project busy" signal, which is unrelated to how the shared files are opened. Added `getSharedDeps()` for non-session callers (see next point) that must not affect that per-project signal.
- `src/daemon/project-manager.ts`: `addProject()` now draws its server's deps from the shared pool via `getSharedDeps()` instead of leaving them `undefined` (which made `createServer()` open its own handles).
- Defense in depth: bumped the LaunchAgent plist's `SoftResourceLimits`/`HardResourceLimits` `NumberOfFiles` (256 → 4096) in all three plist generators (`src/daemon/lifecycle.ts`, `scripts/postinstall-control-plane.mjs`, `packages/app/src/main/daemon-plist.ts`), version-synced per the existing `PLIST_VERSION` convention (bumped 4 → 5, tested by `tests/scripts/postinstall-control-plane.test.ts` and `packages/app/.../daemon-install.test.ts`).
- New regression test `src/daemon/__tests__/resource-pool.test.ts`: asserts `acquire()` for different project roots returns the *same* store instances (object identity is the deterministic proxy for "one connection, not N" — no real fd counting needed), that `getRefCount()` stays per-project, and that `release()`/`disposeProject()` never close the shared handles while `disposeAll()` does.

## Not included (flagged as follow-up, not guessed at)

TRA-938 also asked for (3) logging EMFILE loudly on accept and (4) capping client reconnect retries. I looked at (3): Node's `net.Server` handles accept-time `EMFILE`/`ENFILE` internally via a self-throttle/retry (not an `'error'` event), which is exactly why nothing showed up in `daemon.log` — the existing `httpServer.on('error', ...)` handler in `cli.ts` won't catch it. A real fix needs a periodic fd-headroom monitor, not an event hook, which is new-subsystem work I didn't want to ship unverified in the same PR as the fd fix itself. Filing this as a precise starting point for a follow-up rather than guessing at Node internals I can't validate under load here.

## Test plan
- [x] `pnpm run build` (tsup + DTS) — clean
- [x] `pnpm run lint` (`tsc --noEmit`) — clean
- [x] `pnpm exec biome check` on all changed root-repo files — clean
- [x] `pnpm run test` — full suite: **918 files / 10208 tests passed, 0 failed** (3 files / 22 tests skipped, pre-existing)
- [x] `packages/app`: `vitest run src/main/__tests__/daemon-install.test.ts` — 24/24 passed (plist version + content sync)
- [x] New `src/daemon/__tests__/resource-pool.test.ts` — 5/5 passed