### PR TITLE
perf(app): measure and fix time to first useful paint, per screen

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -217,6 +217,77 @@ launches the built app against a throwaway `--user-data-dir`, drives it over CDP
 prints a ready-to-paste `runs[]` entry. `cold_start_ms` is process spawn → `#root` has
 painted real content; `window_interactive_ms` is the renderer's own share of that.
 
+## Per-screen time to first useful paint — TRA-934
+
+`cold_start_ms` above answers "when did the shell appear". It says nothing about when the
+user could read an answer, and those are different products: a screen that appears in
+40 ms with what we already know beats one that appears in 400 ms with complete data.
+
+Each screen declares its own useful paint in the renderer (`useUsefulPaint` in
+`packages/app/src/renderer/perf.ts`), and
+[`scripts/perf-screens.mjs`](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/packages/app/scripts/perf-screens.mjs)
+reads the marks over CDP. Numbers land in `docs/perf/screens.json`.
+
+```bash
+pnpm -C packages/app run build
+node packages/app/scripts/perf-screens.mjs --samples 3 \
+  --project /path/to/an/indexed/repo --json docs/perf/screens.json
+# the run that matters — daemon accepts and never answers:
+node packages/app/scripts/perf-screens.mjs --samples 3 --wedged \
+  --profile /tmp/warm-profile --project /path/to/an/indexed/repo
+```
+
+`--wedged` pauses every renderer request to `127.0.0.1:3741` and never resumes it. That is
+the daemon's observed failure shape (TRA-922) and the only one worth testing: a *refused*
+connection fails in microseconds and every screen already handles it. `--profile` reuses a
+user-data dir across samples, which is what tells a screen that keeps a snapshot apart from
+one that does not.
+
+**Measured 2026-09-05, M5 Max, nine live agent sessions, real registry daemon.** Under a
+daemon that accepts and never answers:
+
+| Screen | Before | After |
+|---|---|---|
+| Workspace | 8 064 ms (its own 8 s ceiling) | 67 ms — opens on the metrics snapshot |
+| Overview | never useful (> 30 s, unbounded) | 22 ms — opens on the stats snapshot |
+| Activity | never useful (> 30 s, unbounded) | 8 307 ms — bounded, states the failure |
+| Memory | 303 ms, but it was the *empty state*: "no decisions yet" over a fetch still in flight | 8 305 ms — honest, bounded |
+| Clients, Ask, Notebook, Insights | ~300 ms | ~300 ms — none of them read the daemon before first paint |
+
+The shell itself is not the problem and never was: `cold_shell_ms` is 20–80 ms on every
+screen. Everything above it is waiting for the daemon.
+
+Three things produced that change, in order of how much they mattered:
+
+1. **Every daemon read has a ceiling.** 50 of the renderer's 57 `fetch` calls had none.
+   A `fetch` with no signal against a socket that accepts and never answers neither
+   resolves nor rejects — the screen behind it stays on its skeleton for the life of the
+   window. `packages/app/src/renderer/daemon-fetch.ts` is now the only place that calls
+   `fetch` at the daemon, and `src/renderer/__tests__/daemon-fetch.test.ts` fails the build
+   if a fifty-eighth appears. The ceiling itself is unchanged at 8 s: this machine's daemon
+   has been measured answering `/health` in 5.8 s while indexing, so a tighter one would
+   abort reads that were going to succeed. It is the *existence* of a ceiling that was
+   missing, not its value.
+2. **Screens open on their last known numbers.** The Workspace already did this for
+   metrics (TRA-397); Overview now does it for the index summary, through the shared
+   `loadSnapshot`/`saveSnapshot` in `src/renderer/snapshot.ts`, and says
+   "The daemon is busy. These are the last indexed numbers." until the fresh read lands.
+3. **A screen that has not loaded does not claim to be empty.** All four Memory sub-views
+   started with `loading: false`, so the frame before their first fetch resolved read as
+   "nothing here".
+
+### The 7.8-second wait is the daemon's, not the app's
+
+Worth recording because it decides where the remaining work goes. On a cold profile, all
+five of the renderer's startup reads start at 52 ms and complete at 7 832 ms — *together*,
+to the millisecond. That is not five slow requests; it is one blocking event releasing all
+of them. `curl` against the same socket at the same moment took 7.799 s, while the same
+endpoint answers in 0.7 ms when the daemon is idle.
+
+So the app's own share of a cold launch is the 20–80 ms shell. Everything past that is
+TRA-921's accept queue. What the app can do about it — bound the wait, and have something
+on screen while it runs out — is what this change did.
+
 ## The fixed workload
 
 The three workload metrics are only comparable if the scenario is byte-identical

--- a/docs/perf/screens.json
+++ b/docs/perf/screens.json
@@ -1,0 +1,141 @@
+{
+  "schema": "trace-mcp app per-screen time-to-first-useful-paint, TRA-934",
+  "notes": [
+    "cold_ms  — Page.navigate -> the screen's own `useful:<id>` mark (src/renderer/perf.ts).",
+    "cold_shell_ms — `app-first-content`: React committed the shell. The gap to cold_ms is the wait for data.",
+    "warm_ms — sidebar click -> useful, in a window that is already up.",
+    "never_useful — samples where the screen produced no useful frame inside 30 s. Any non-zero value is the headline.",
+    "The `wedged-daemon` run holds every request to 127.0.0.1:3741 open and unanswered — the daemon's observed failure shape (TRA-922).",
+    "Produced by `node scripts/perf-screens.mjs` in packages/app; see docs/perf/README.md."
+  ],
+  "runs": [
+    {
+      "date": "2026-09-05T16:43:37.142Z",
+      "mode": "live-daemon",
+      "daemon": "http://127.0.0.1:3741",
+      "project": "/Users/nikolai/PhpstormProjects/trace-mcp",
+      "profile": "warm (reused)",
+      "samples": 3,
+      "deadline_ms": 30000,
+      "env": {
+        "os": "darwin 25.5.0",
+        "arch": "arm64",
+        "node": "v22.22.3"
+      },
+      "metrics": {
+        "workspace": {
+          "cold_ms": 67,
+          "cold_shell_ms": 72,
+          "warm_ms": null,
+          "never_useful": 0
+        },
+        "clients": {
+          "cold_ms": null,
+          "cold_shell_ms": null,
+          "warm_ms": 314,
+          "never_useful": 0
+        },
+        "overview": {
+          "cold_ms": 21,
+          "cold_shell_ms": 22,
+          "warm_ms": null,
+          "never_useful": 0
+        },
+        "ask": {
+          "cold_ms": null,
+          "cold_shell_ms": null,
+          "warm_ms": 303,
+          "never_useful": 0
+        },
+        "activity": {
+          "cold_ms": null,
+          "cold_shell_ms": null,
+          "warm_ms": 8306,
+          "never_useful": 0
+        },
+        "memory": {
+          "cold_ms": null,
+          "cold_shell_ms": null,
+          "warm_ms": 6485,
+          "never_useful": 0
+        },
+        "notebook": {
+          "cold_ms": null,
+          "cold_shell_ms": null,
+          "warm_ms": 302,
+          "never_useful": 0
+        },
+        "insights": {
+          "cold_ms": null,
+          "cold_shell_ms": null,
+          "warm_ms": 304,
+          "never_useful": 0
+        }
+      }
+    },
+    {
+      "date": "2026-09-05T16:42:36.406Z",
+      "mode": "wedged-daemon",
+      "daemon": "intercepted: accepts, never answers",
+      "project": "/Users/nikolai/PhpstormProjects/trace-mcp",
+      "profile": "warm (reused)",
+      "samples": 3,
+      "deadline_ms": 30000,
+      "env": {
+        "os": "darwin 25.5.0",
+        "arch": "arm64",
+        "node": "v22.22.3"
+      },
+      "metrics": {
+        "workspace": {
+          "cold_ms": 67,
+          "cold_shell_ms": 72,
+          "warm_ms": null,
+          "never_useful": 0
+        },
+        "clients": {
+          "cold_ms": null,
+          "cold_shell_ms": null,
+          "warm_ms": 326,
+          "never_useful": 0
+        },
+        "overview": {
+          "cold_ms": 22,
+          "cold_shell_ms": 24,
+          "warm_ms": null,
+          "never_useful": 0
+        },
+        "ask": {
+          "cold_ms": null,
+          "cold_shell_ms": null,
+          "warm_ms": 302,
+          "never_useful": 0
+        },
+        "activity": {
+          "cold_ms": null,
+          "cold_shell_ms": null,
+          "warm_ms": 8307,
+          "never_useful": 0
+        },
+        "memory": {
+          "cold_ms": null,
+          "cold_shell_ms": null,
+          "warm_ms": 8305,
+          "never_useful": 0
+        },
+        "notebook": {
+          "cold_ms": null,
+          "cold_shell_ms": null,
+          "warm_ms": 302,
+          "never_useful": 0
+        },
+        "insights": {
+          "cold_ms": null,
+          "cold_shell_ms": null,
+          "warm_ms": 304,
+          "never_useful": 0
+        }
+      }
+    }
+  ]
+}

--- a/packages/app/scripts/perf-screens.mjs
+++ b/packages/app/scripts/perf-screens.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+/**
+ * Time to first *useful* paint, per screen (TRA-934).
+ *
+ * `scripts/perf-measure.mjs` answers "when did the shell appear". This answers
+ * the question the user actually asks — "when could I read something" — for
+ * every screen the app has, and it answers it separately from "when was the
+ * data complete", because those are different products.
+ *
+ * The renderer marks its own screens (`src/renderer/perf.ts`); this script only
+ * navigates and reads `window.__traceUseful`. Two numbers per screen:
+ *
+ *   cold_ms  — fresh window, fresh profile: navigation → useful. This is the
+ *              number that includes bundle parse, React boot and the first
+ *              daemon read, and it is the one most evaluators will ever see.
+ *   warm_ms  — the same screen reached by clicking the sidebar in a window that
+ *              is already up. Pure data latency.
+ *
+ * Usage:
+ *   node scripts/perf-screens.mjs [--samples 3] [--project <root>]
+ *                                 [--daemon http://127.0.0.1:3741]
+ *                                 [--wedged] [--json out.json]
+ *
+ * `--wedged` is the important mode. It points the renderer at a socket that
+ * accepts connections and never answers — the daemon's observed failure shape
+ * (TRA-922) — and reports how long each screen stays unreadable. A screen whose
+ * `wedged_ms` is `null` never became useful at all: an unbounded wait, which is
+ * a hung screen with no way out.
+ *
+ * Requires `pnpm run build` first — it measures the production bundle.
+ */
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { connect } from './electron-cdp.mjs';
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const args = process.argv.slice(2);
+const flag = (name, fallback) => {
+  const i = args.indexOf(`--${name}`);
+  return i === -1 ? fallback : args[i + 1];
+};
+
+const SAMPLES = Number(flag('samples', 3));
+const OUT = flag('json', null);
+const WEDGED = args.includes('--wedged');
+const DAEMON = flag('daemon', 'http://127.0.0.1:3741');
+const PROJECT = flag('project', null);
+/* Reuse a profile across samples instead of a fresh one each time. This is the
+   cold/warm distinction that matters for this app: a warm profile has the
+   localStorage snapshots, so the screens that keep one can paint before the
+   daemon answers, and a screen whose warm number equals its cold number is a
+   screen that keeps nothing. */
+const PROFILE = flag('profile', null);
+/* Same reasoning as perf-measure.mjs: a fixed CDP port collides with whatever
+   chrome-devtools-mcp left running and the harness then measures a Chrome tab. */
+const PORT_RANGE = [9354, 9374];
+/** How long a screen gets to become useful before we call it hung. */
+const USEFUL_DEADLINE_MS = 30_000;
+
+/** Screens reachable in the menu window, in sidebar order. */
+const MENU_SCREENS = ['workspace', 'clients'];
+/** Screens reachable in a project window. `graph` is excluded: it needs a GPU
+    context the harness's unmapped window does not always get, and its own
+    settle time is a different measurement (renderer_cpu_idle_pct). */
+const PROJECT_SCREENS = ['overview', 'ask', 'activity', 'memory', 'notebook', 'insights'];
+
+// ── ports ───────────────────────────────────────────────────────────
+
+async function freePort([lo, hi]) {
+  for (let p = lo; p <= hi; p++) {
+    const ok = await new Promise((resolve) => {
+      const s = net.createServer();
+      s.once('error', () => resolve(false));
+      s.once('listening', () => s.close(() => resolve(true)));
+      s.listen(p, '127.0.0.1');
+    });
+    if (ok) return p;
+  }
+  throw new Error('no free CDP port');
+}
+
+/**
+ * Make the daemon look wedged to this window: pause every request to
+ * 127.0.0.1:3741 and never resume it. The TCP handshake succeeds, the response
+ * never arrives — the daemon's observed failure shape (TRA-922), and the only
+ * one that matters, since a *refused* connection fails in microseconds and
+ * every screen already handles that.
+ *
+ * There is deliberately no `Fetch.requestPaused` handler. A bounded fetch still
+ * aborts on its own AbortSignal; an unbounded one hangs forever. That is
+ * exactly the difference this mode is here to measure.
+ */
+async function wedgeDaemon(cdp) {
+  await cdp.send('Fetch.enable', { patterns: [{ urlPattern: 'http://127.0.0.1:3741/*' }] });
+}
+
+// ── app ─────────────────────────────────────────────────────────────
+
+async function rendererTarget(port, pid, deadline) {
+  for (;;) {
+    try {
+      const list = await (await fetch(`http://127.0.0.1:${port}/json/list`)).json();
+      const page = list.find((t) => t.type === 'page' && t.url.includes('index.html'));
+      if (page) return page;
+    } catch {
+      /* not up yet */
+    }
+    if (Date.now() > deadline) throw new Error(`no renderer target for pid ${pid}`);
+    await sleep(50);
+  }
+}
+
+async function launchApp(env) {
+  const userData = PROFILE ?? fs.mkdtempSync(path.join(os.tmpdir(), 'tracemcp-screens-'));
+  fs.mkdirSync(userData, { recursive: true });
+  const electron = path.join(
+    appDir, 'node_modules', 'electron', 'dist', 'Electron.app', 'Contents', 'MacOS', 'Electron',
+  );
+  const port = await freePort(PORT_RANGE);
+  const child = spawn(
+    electron,
+    [appDir, `--remote-debugging-port=${port}`, `--user-data-dir=${userData}`],
+    {
+      cwd: appDir,
+      // TRACE_MCP_AGENT_RUN keeps the window unmapped so a measurement run
+      // cannot drag the person at the keyboard off their Space.
+      env: { ...env, ELECTRON_RUN_AS_NODE: '', TRACE_MCP_AGENT_RUN: '1' },
+      stdio: 'ignore',
+    },
+  );
+  /* SIGTERM, not SIGKILL. Chromium flushes localStorage on the way out, and a
+     kill -9 drops whatever a screen wrote in its last second — which is exactly
+     the snapshot the *next* sample is supposed to open on. Measured: a
+     SIGKILLed sample left no `trace-mcp.overview.stats:*` key at all, so the
+     warm run was silently measuring a cold profile. */
+  const stop = async () => {
+    child.kill('SIGTERM');
+    await sleep(1200);
+    if (!child.killed) child.kill('SIGKILL');
+    if (!PROFILE) fs.rmSync(userData, { recursive: true, force: true });
+  };
+  try {
+    const target = await rendererTarget(port, child.pid, Date.now() + 60_000);
+    const cdp = await connect(target.webSocketDebuggerUrl);
+    await cdp.send('Runtime.enable');
+    await cdp.send('Page.enable');
+    return { child, cdp, stop, baseUrl: target.url.split('?')[0] };
+  } catch (e) {
+    await stop();
+    throw e;
+  }
+}
+
+async function evaluate(cdp, expr) {
+  const r = await cdp.send('Runtime.evaluate', {
+    expression: expr,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  return r.result?.value;
+}
+
+/** Wait until `screen` reports a useful paint; return its renderer timestamp. */
+async function waitUseful(cdp, screen, startedAt) {
+  const deadline = Date.now() + USEFUL_DEADLINE_MS;
+  for (;;) {
+    const at = await evaluate(cdp, `window.__traceUseful?.[${JSON.stringify(screen)}] ?? null`);
+    if (typeof at === 'number') return Math.round(at - startedAt);
+    if (Date.now() > deadline) return null; // never became useful
+    await sleep(25);
+  }
+}
+
+/** Navigate a window to `params` and measure the named screen from timeOrigin. */
+async function coldScreen(cdp, baseUrl, params, screen) {
+  const qs = new URLSearchParams(params).toString();
+  await cdp.send('Page.navigate', { url: `${baseUrl}?${qs}` });
+  const useful_ms = await waitUseful(cdp, screen, 0);
+  /* The shell's own share, so a slow screen can be attributed: bundle parse
+     and React boot (`app-first-content`) versus waiting on data. */
+  const shell_ms = await evaluate(
+    cdp,
+    `Math.round(performance.getEntriesByName('app-first-content')[0]?.startTime ?? -1)`,
+  );
+  return { cold_ms: useful_ms, cold_shell_ms: shell_ms >= 0 ? shell_ms : null };
+}
+
+/** Click a sidebar section in the current window and measure the delta. */
+async function warmScreen(cdp, screen) {
+  const clickedAt = await evaluate(
+    cdp,
+    `(() => {
+       const el = document.querySelector('[data-nav=${JSON.stringify(screen)}]');
+       if (!el) return null;
+       const t = performance.now();
+       el.click();
+       return t;
+     })()`,
+  );
+  if (clickedAt === null) return { warm_ms: null, note: 'no nav row' };
+  return { warm_ms: await waitUseful(cdp, screen, clickedAt) };
+}
+
+// ── one sample ──────────────────────────────────────────────────────
+
+async function runSample() {
+  const env = { ...process.env };
+  const { cdp, stop, baseUrl } = await launchApp(env);
+  const screens = {};
+  try {
+    if (WEDGED) await wedgeDaemon(cdp);
+
+    // Menu window, cold.
+    screens.workspace = await coldScreen(cdp, baseUrl, { view: 'menu', tab: 'workspace' }, 'workspace');
+    for (const s of MENU_SCREENS.slice(1)) {
+      screens[s] = await warmScreen(cdp, s);
+    }
+
+    if (PROJECT) {
+      // Project window, cold on Overview, then warm through the rest.
+      screens.overview = await coldScreen(cdp, baseUrl, { view: 'project', root: PROJECT }, 'overview');
+      for (const s of PROJECT_SCREENS.slice(1)) {
+        screens[s] = await warmScreen(cdp, s);
+      }
+    }
+    return screens;
+  } finally {
+    cdp.close();
+    await stop();
+  }
+}
+
+const median = (xs) => {
+  const v = xs.filter((x) => typeof x === 'number').sort((a, b) => a - b);
+  if (!v.length) return null;
+  const m = v.length >> 1;
+  return v.length % 2 ? v[m] : Math.round((v[m - 1] + v[m]) / 2);
+};
+
+async function main() {
+  if (!fs.existsSync(path.join(appDir, 'dist', 'renderer', 'index.html'))) {
+    throw new Error('run `pnpm run build` first — this measures the production bundle');
+  }
+
+  const samples = [];
+  for (let i = 0; i < SAMPLES; i++) samples.push(await runSample());
+
+  const names = [...new Set(samples.flatMap((s) => Object.keys(s)))];
+  const metrics = {};
+  for (const n of names) {
+    const cold = samples.map((s) => s[n]?.cold_ms);
+    const warm = samples.map((s) => s[n]?.warm_ms);
+    /* Samples in which this screen never produced a useful frame inside
+       USEFUL_DEADLINE_MS. Non-zero here is the headline, not the medians. */
+    const hung = samples.filter(
+      (s) => n in s && (s[n].cold_ms ?? s[n].warm_ms ?? null) === null,
+    ).length;
+    metrics[n] = {
+      cold_ms: median(cold),
+      cold_shell_ms: median(samples.map((s) => s[n]?.cold_shell_ms)),
+      warm_ms: median(warm),
+      never_useful: hung,
+    };
+  }
+
+  const report = {
+    date: new Date().toISOString(),
+    mode: WEDGED ? 'wedged-daemon' : 'live-daemon',
+    daemon: WEDGED ? 'intercepted: accepts, never answers' : DAEMON,
+    project: PROJECT,
+    profile: PROFILE ? 'warm (reused)' : 'cold (fresh per sample)',
+    samples: SAMPLES,
+    deadline_ms: USEFUL_DEADLINE_MS,
+    env: { os: `${os.platform()} ${os.release()}`, arch: os.arch(), node: process.version },
+    metrics,
+  };
+  const json = JSON.stringify(report, null, 2);
+  if (OUT) fs.writeFileSync(OUT, `${json}\n`);
+  console.log(json);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -126,6 +126,7 @@ const BASE = 'http://127.0.0.1:3741';
 // ── Recent projects (localStorage) ──────────────────────────
 // Helpers live in ./recent-projects.ts so the Workspace tab can import
 // `removeRecentProject` without pulling in App.tsx (import cycle).
+import { daemonFetch } from './daemon-fetch';
 import {
   addRecentProject,
   getRecentProjects,
@@ -319,7 +320,7 @@ function ProjectFileExplorer({
        sits in SYN_SENT and `fetch` neither resolves nor rejects — which is how
        the skeletons outlived the request (TRA-478). Without a deadline there is
        no terminal state to render. */
-    fetch(`${BASE}/api/projects/files?${params}`, {
+    daemonFetch(`${BASE}/api/projects/files?${params}`, {
       signal: AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS),
     })
       .then((r) => (r.ok ? r.json() : Promise.reject()))
@@ -1153,7 +1154,7 @@ function AppTabView({
     if (!quickOpen || !isProject || !root || quickFiles.length > 0) return;
     let cancelled = false;
     const params = new URLSearchParams({ project: root, sort: 'symbols', limit: '400' });
-    fetch(`${BASE}/api/projects/files?${params}`)
+    daemonFetch(`${BASE}/api/projects/files?${params}`)
       .then((r) => (r.ok ? r.json() : Promise.reject()))
       .then((data: { files?: { path: string }[] }) => {
         if (!cancelled) setQuickFiles((data.files ?? []).map((f) => f.path));
@@ -1273,6 +1274,7 @@ function AppTabView({
                   {(sectionList as { id: ProjectTab; label: string; icon: string }[]).map((s) => (
                     <SidebarRow
                       key={s.id}
+                      navId={s.id}
                       icon={s.icon}
                       label={s.label}
                       selected={projectTab === s.id}
@@ -1291,6 +1293,7 @@ function AppTabView({
                   {(sectionList as { id: GlobalTab; label: string; icon: string }[]).map((s) => (
                     <SidebarRow
                       key={s.id}
+                      navId={s.id}
                       icon={s.icon}
                       label={s.label}
                       selected={globalTab === s.id}

--- a/packages/app/src/renderer/__tests__/daemon-fetch.test.ts
+++ b/packages/app/src/renderer/__tests__/daemon-fetch.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Guard: no renderer read of the local daemon may be unbounded (TRA-934).
+ *
+ * Measured 2026-09-05 with the daemon's socket accepting and never answering:
+ * Overview and Activity never produced a useful frame inside 30 s, because a
+ * `fetch` with no signal against a wedged socket neither resolves nor rejects.
+ * Every screen behind one of those stayed on a skeleton for the life of the
+ * window. Workspace, which already passed a signal, gave up at 8.06 s and
+ * painted its degraded state.
+ *
+ * This is a source-level check on purpose. The failure it prevents is somebody
+ * adding the fifty-eighth `fetch(`${BASE}/…`)` a year from now, and no runtime
+ * test of the other fifty-seven would notice.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const RENDERER = path.resolve(__dirname, '..');
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name === '__tests__') continue;
+      out.push(...sourceFiles(p));
+    } else if (/\.tsx?$/.test(e.name)) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+/** `fetch(` calls whose URL is the local daemon, however it is spelled. */
+const DAEMON_FETCH = /(?<![.\w])fetch\(\s*\n?\s*(`\$\{BASE\}|'http:\/\/127\.0\.0\.1:3741|`http:\/\/127\.0\.0\.1:3741)/g;
+
+describe('daemon reads are bounded', () => {
+  it('no renderer file calls bare fetch() against the daemon', () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles(RENDERER)) {
+      // daemon-fetch.ts is the one place allowed to call fetch directly.
+      if (path.basename(file) === 'daemon-fetch.ts') continue;
+      const src = fs.readFileSync(file, 'utf-8');
+      for (const m of src.matchAll(DAEMON_FETCH)) {
+        const line = src.slice(0, m.index).split('\n').length;
+        offenders.push(`${path.relative(RENDERER, file)}:${line}`);
+      }
+    }
+    expect(offenders, 'use daemonFetch() from src/renderer/daemon-fetch.ts').toEqual([]);
+  });
+});

--- a/packages/app/src/renderer/__tests__/perf-marks.test.ts
+++ b/packages/app/src/renderer/__tests__/perf-marks.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+/**
+ * Guard: every screen still declares its first useful paint (TRA-934).
+ *
+ * The per-screen numbers in `docs/perf/screens.json` are produced by
+ * `scripts/perf-screens.mjs` reading these marks. A screen that quietly loses
+ * its `useUsefulPaint` call does not fail anything — it just disappears from
+ * the report, and the next run reads a shorter table as good news.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { markUseful, resetUsefulPaints } from '../perf';
+
+const RENDERER = path.resolve(__dirname, '..');
+
+/** screen id → the file that must mark it. */
+const SCREENS: Record<string, string> = {
+  workspace: 'workspace/Workspace.tsx',
+  clients: 'tabs/Clients.tsx',
+  overview: 'tabs/ProjectOverview.tsx',
+  ask: 'tabs/AskTab.tsx',
+  activity: 'tabs/ToolActivity.tsx',
+  memory: 'tabs/MemoryExplorer.tsx',
+  notebook: 'tabs/Notebook.tsx',
+  insights: 'tabs/Insights.tsx',
+  graph: 'tabs/GraphExplorerGPU.tsx',
+};
+
+describe('useful-paint instrumentation', () => {
+  it.each(Object.entries(SCREENS))('%s marks its first useful paint', (screen, file) => {
+    const src = fs.readFileSync(path.join(RENDERER, file), 'utf-8');
+    // Multi-line call sites are fine; the screen id is what must be there.
+    expect(src).toMatch(new RegExp(`useUsefulPaint\\(\\s*'${screen}'`));
+  });
+
+  it('records a screen once and only once', () => {
+    resetUsefulPaints();
+    markUseful('overview');
+    const first = window.__traceUseful?.overview;
+    markUseful('overview');
+    expect(window.__traceUseful?.overview).toBe(first);
+    expect(typeof first).toBe('number');
+  });
+});

--- a/packages/app/src/renderer/components/ProjectStatsModal.tsx
+++ b/packages/app/src/renderer/components/ProjectStatsModal.tsx
@@ -15,6 +15,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatDate, formatNumber } from '../i18n/format';
+import { daemonFetch } from '../daemon-fetch';
 import { Badge, type Tone } from '../lattice/ui';
 
 const BASE = 'http://127.0.0.1:3741';
@@ -801,7 +802,7 @@ export function ProjectStatsModal({ root, onClose }: ProjectStatsModalProps) {
 
   const fetchPayload = useCallback(async () => {
     try {
-      const res = await fetch(
+      const res = await daemonFetch(
         `${BASE}/api/projects/full-stats?project=${encodeURIComponent(root)}`,
       );
       if (!res.ok) {

--- a/packages/app/src/renderer/components/SetupWizard.tsx
+++ b/packages/app/src/renderer/components/SetupWizard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { t } from '../i18n';
+import { daemonFetch } from '../daemon-fetch';
 import { Icon } from '../lattice/icons';
 import { Badge, Button, Card, StatusDot } from '../lattice/ui';
 import {
@@ -313,7 +314,7 @@ export function SetupWizard({ onClose, initialStep }: SetupWizardProps) {
       // Opening a tab only renders a view of a project the daemon may never
       // have heard of, which is how the wizard used to finish on a clean DMG
       // install with nothing indexed.
-      const res = await fetch(`${BASE}/api/projects`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      const res = await daemonFetch(`${BASE}/api/projects`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ root: selectedProject }),

--- a/packages/app/src/renderer/components/SidebarRow.tsx
+++ b/packages/app/src/renderer/components/SidebarRow.tsx
@@ -9,6 +9,7 @@ import type React from 'react';
 import { Icon } from '../lattice/icons';
 
 export function SidebarRow({
+  navId,
   icon,
   glyph,
   label,
@@ -22,6 +23,10 @@ export function SidebarRow({
   rowRef,
   ...aria
 }: {
+  /** Stable id for the section this row selects, published as `data-nav` so
+      the perf harness can drive navigation without matching translated labels
+      (scripts/perf-screens.mjs). */
+  navId?: string;
   icon?: string;
   glyph?: React.ReactNode;
   label: React.ReactNode;
@@ -39,6 +44,7 @@ export function SidebarRow({
       type="button"
       ref={rowRef}
       className={`ws-sb-row${selected ? ' is-selected' : ''}`}
+      data-nav={navId}
       onClick={onClick}
       onKeyDown={onKeyDown}
       onContextMenu={onContextMenu}

--- a/packages/app/src/renderer/daemon-fetch.ts
+++ b/packages/app/src/renderer/daemon-fetch.ts
@@ -1,0 +1,53 @@
+/**
+ * Every renderer read of the local daemon, with a ceiling on it (TRA-934).
+ *
+ * The daemon is a process that can wedge: its main thread runs synchronous
+ * SQLite, and while it does, it accepts TCP connections and answers none of
+ * them (TRA-922). A `fetch` with no signal against that socket never settles
+ * and never rejects — the screen behind it stays on its skeleton for as long
+ * as the app is open, with no error, no retry and nothing for the user to do.
+ *
+ * Measured 2026-09-05 with the daemon's socket held open and unanswered:
+ * Overview and Activity never produced a useful frame inside 30 s; Workspace,
+ * the one surface that already passed a signal, gave up at 8.06 s and painted
+ * its degraded state. That is the whole difference, and it is one argument.
+ *
+ * The ceiling is not the fix on its own — what is behind it is. A caller that
+ * aborts has to render something honest (a cached snapshot, a stated failure
+ * with a retry), never a skeleton that stops animating.
+ */
+
+export const BASE = 'http://127.0.0.1:3741';
+
+/**
+ * Cap on a daemon read. Deliberately generous: this machine's daemon has been
+ * measured answering `/health` in 5.8 s while indexing, so a tighter ceiling
+ * would abort reads that were going to succeed. It is the *existence* of a
+ * ceiling that was missing, not its value — do not tune this number without a
+ * measurement that says the work legitimately finishes sooner.
+ */
+export const DAEMON_FETCH_TIMEOUT_MS = 8000;
+
+/**
+ * Cap on an MCP tool call issued from Notebook / Insights. Those run real
+ * analysis on demand and legitimately take far longer than a read; the screen
+ * shows a running state throughout. They still get a ceiling, because "running"
+ * forever is the same defect wearing a spinner.
+ */
+export const DAEMON_TOOL_TIMEOUT_MS = 120_000;
+
+/**
+ * `fetch` against the local daemon with a bounded wait.
+ *
+ * An explicit `init.signal` wins — a caller that already owns cancellation
+ * (a debounced search, an unmounting effect) has a better idea of when to stop
+ * than a fixed timer does.
+ */
+export function daemonFetch(
+  url: string,
+  init: RequestInit = {},
+  timeoutMs: number = DAEMON_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+  return fetch(url, { ...init, signal: init.signal ?? AbortSignal.timeout(timeoutMs) });
+}

--- a/packages/app/src/renderer/hooks/useDaemon.ts
+++ b/packages/app/src/renderer/hooks/useDaemon.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { BASE, DAEMON_FETCH_TIMEOUT_MS, daemonFetch } from '../daemon-fetch';
 import { useDocumentVisible } from './useDocumentVisible';
 
 // ── Types (mirrored from api-client.ts — renderer can't import main process modules) ──
@@ -133,14 +134,10 @@ type SSEEvent =
 
 // ── Constants ──────────────────────────────────────────────────────────
 
-const BASE = 'http://127.0.0.1:3741';
-
-/**
- * Cap on daemon reads. A *hung* daemon (accepting the socket but never
- * answering) would otherwise leave `loading` true indefinitely, hiding the
- * DisconnectedBanner — the one control that can restart it (TRA-264).
- */
-export const DAEMON_FETCH_TIMEOUT_MS = 8000;
+/* Re-exported for the surfaces that already import it from here. The ceiling
+   itself, and the reason every daemon read now has one, live in
+   ../daemon-fetch (TRA-264, TRA-934). */
+export { DAEMON_FETCH_TIMEOUT_MS };
 
 // ── Hook ───────────────────────────────────────────────────────────────
 
@@ -155,7 +152,7 @@ export function useDaemon() {
   // Fetch project list
   const fetchProjects = useCallback(async () => {
     try {
-      const res = await fetch(`${BASE}/api/projects`, { signal: AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS) }); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      const res = await daemonFetch(`${BASE}/api/projects`); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
       if (!res.ok) throw new Error(res.statusText);
       const json = await res.json();
       const data: ProjectInfo[] = json.projects ?? json;
@@ -171,7 +168,7 @@ export function useDaemon() {
   // Fetch client list
   const fetchClients = useCallback(async () => {
     try {
-      const res = await fetch(`${BASE}/api/clients`, { signal: AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS) }); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      const res = await daemonFetch(`${BASE}/api/clients`); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
       if (!res.ok) throw new Error(res.statusText);
       const json = await res.json();
       const data: ClientInfo[] = json.clients ?? json;
@@ -184,7 +181,7 @@ export function useDaemon() {
   // Fetch settings + daemon info
   const fetchSettings = useCallback(async () => {
     try {
-      const res = await fetch(`${BASE}/api/settings`, { signal: AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS) }); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      const res = await daemonFetch(`${BASE}/api/settings`); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
       if (!res.ok) throw new Error(res.statusText);
       const data = await res.json();
       setSettings(data);
@@ -380,7 +377,7 @@ export function useDaemon() {
   // Actions
   const addProject = useCallback(async (root: string) => {
     try {
-      await fetch(`${BASE}/api/projects`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      await daemonFetch(`${BASE}/api/projects`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ root }),
@@ -395,7 +392,7 @@ export function useDaemon() {
   const removeProject = useCallback(async (root: string) => {
     let res: Response;
     try {
-      res = await fetch(`${BASE}/api/projects?project=${encodeURIComponent(root)}`, {
+      res = await daemonFetch(`${BASE}/api/projects?project=${encodeURIComponent(root)}`, {
         method: 'DELETE',
       });
     } catch {
@@ -419,7 +416,7 @@ export function useDaemon() {
       prev.map((p) => (p.root === root ? { ...p, status: 'indexing', progress: undefined } : p)),
     );
     try {
-      await fetch(`${BASE}/api/projects/reindex?project=${encodeURIComponent(root)}`, {
+      await daemonFetch(`${BASE}/api/projects/reindex?project=${encodeURIComponent(root)}`, {
         method: 'POST',
       });
     } catch {
@@ -446,7 +443,7 @@ export function useDaemon() {
       for (let i = 0; i < 20; i++) {
         await new Promise((r) => setTimeout(r, 500));
         try {
-          const res = await fetch(`${BASE}/health`, { signal: AbortSignal.timeout(500) }); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+          const res = await daemonFetch(`${BASE}/health`, { signal: AbortSignal.timeout(500) }); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
           if (res.ok) {
             ready = true;
             break;
@@ -472,7 +469,7 @@ export function useDaemon() {
   const updateSettings = useCallback(
     async (patch: Record<string, unknown>) => {
       try {
-        await fetch(`${BASE}/api/settings`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+        await daemonFetch(`${BASE}/api/settings`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(patch),

--- a/packages/app/src/renderer/perf.ts
+++ b/packages/app/src/renderer/perf.ts
@@ -1,0 +1,58 @@
+/**
+ * Time to first *useful* paint, per screen (TRA-934).
+ *
+ * The harness already records `app-first-content` — the moment React commits
+ * anything under #root. That is the shell: sidebar, header, skeletons. It says
+ * nothing about when the user can read an answer, which is the number the
+ * product is actually judged on.
+ *
+ * Each screen declares its own "useful" here: the first commit that renders
+ * data rather than a placeholder, cached data included. A screen that opens on
+ * a stale snapshot IS useful at that moment — that is the whole point of
+ * keeping the snapshot — so `useUsefulPaint` fires then, not when the
+ * revalidation lands.
+ *
+ * Read by `scripts/perf-screens.mjs` over CDP; `window.__traceUseful` exists so
+ * the harness does not have to correlate `performance.mark` entries across a
+ * navigation it did not cause.
+ */
+import { useEffect } from 'react';
+
+export interface UsefulPaints {
+  [screen: string]: number;
+}
+
+declare global {
+  interface Window {
+    __traceUseful?: UsefulPaints | undefined;
+  }
+}
+
+const marked = new Set<string>();
+
+/** Record the first useful paint of `screen`. Idempotent per window. */
+export function markUseful(screen: string): void {
+  if (marked.has(screen)) return;
+  marked.add(screen);
+  const at = performance.now();
+  performance.mark(`useful:${screen}`);
+  window.__traceUseful = { ...(window.__traceUseful ?? {}), [screen]: at };
+}
+
+/** Test seam — the mark is once-per-window, which a test suite is not. */
+export function resetUsefulPaints(): void {
+  marked.clear();
+  window.__traceUseful = undefined;
+}
+
+/**
+ * Mark `screen` useful the first time `ready` is true. In an effect rather
+ * than in render: an effect runs after the commit that produced the frame, so
+ * the timestamp belongs to content that exists, and StrictMode's double render
+ * cannot record the same screen twice.
+ */
+export function useUsefulPaint(screen: string, ready: boolean): void {
+  useEffect(() => {
+    if (ready) markUseful(screen);
+  }, [screen, ready]);
+}

--- a/packages/app/src/renderer/snapshot.ts
+++ b/packages/app/src/renderer/snapshot.ts
@@ -1,0 +1,32 @@
+/**
+ * Last-known-good values, kept across launches (TRA-397, generalised in TRA-934).
+ *
+ * The daemon can take seconds to answer while it indexes — measured on this
+ * machine, every renderer read of `127.0.0.1:3741` blocked for 7.80 s at once
+ * while `curl` against the same socket blocked for 7.799 s, so it is the daemon
+ * holding, not the app. A screen with no snapshot spends that whole window on a
+ * skeleton for numbers that were on disk the entire time.
+ *
+ * The contract: open on the snapshot, revalidate behind it, and say on screen
+ * that the numbers are the last indexed ones until the fresh read lands.
+ */
+
+/** Read a snapshot, or `null` when there is none / it is unusable. */
+export function loadSnapshot<T>(key: string): T | null {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    // Corrupted JSON, or a sandboxed renderer with no storage — start cold.
+    return null;
+  }
+}
+
+export function saveSnapshot(key: string, value: unknown): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Quota or sandbox. A missing snapshot costs one screen of placeholders,
+    // so there is nothing worth reporting to the user here.
+  }
+}

--- a/packages/app/src/renderer/tabs/AIActivity.tsx
+++ b/packages/app/src/renderer/tabs/AIActivity.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { t } from '../i18n';
 import { formatDate, formatNumber, relativeTime } from '../i18n/format';
+import { daemonFetch } from '../daemon-fetch';
 import { Icon } from '../lattice/icons';
 import {
   Badge,
@@ -374,7 +375,7 @@ export function AIActivity({ subTab }: { subTab?: ReactNode }) {
 
   const fetchActivity = useCallback(async () => {
     try {
-      const res = await fetch('http://127.0.0.1:3741/api/ai/activity?limit=100'); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- talks to the app's own local daemon (127.0.0.1), not a remote endpoint.
+      const res = await daemonFetch('http://127.0.0.1:3741/api/ai/activity?limit=100'); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- talks to the app's own local daemon (127.0.0.1), not a remote endpoint.
       if (!res.ok) throw new Error(res.statusText);
       const data = await res.json();
       setEntries(data.entries ?? []);

--- a/packages/app/src/renderer/tabs/AskTab.tsx
+++ b/packages/app/src/renderer/tabs/AskTab.tsx
@@ -12,7 +12,9 @@ import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { relativeTime } from '../i18n/format';
+import { daemonFetch } from '../daemon-fetch';
 import { Icon } from '../lattice/icons';
+import { useUsefulPaint } from '../perf';
 import {
   Button,
   Card,
@@ -144,6 +146,10 @@ export function AskTab({ root }: { root: string }) {
      rule fades in on scroll instead of being painted permanently. */
   const [scrolled, setScrolled] = useState(false);
 
+  /* The thread is the screen. An empty thread with the composer ready is
+     useful; a session still loading is not. */
+  useUsefulPaint('ask', !loadingSession);
+
   const abortRef = useRef<AbortController | null>(null);
   const endRef = useRef<HTMLDivElement>(null);
   const taRef = useRef<HTMLTextAreaElement>(null);
@@ -165,7 +171,7 @@ export function AskTab({ root }: { root: string }) {
     let cancelled = false;
     (async () => {
       try {
-        const r = await fetch(`${BASE}/api/ask/provider?project=${encodeURIComponent(root)}`);
+        const r = await daemonFetch(`${BASE}/api/ask/provider?project=${encodeURIComponent(root)}`);
         if (cancelled || !r.ok) return;
         const d = await r.json();
         if (!cancelled) {
@@ -184,7 +190,7 @@ export function AskTab({ root }: { root: string }) {
   // Load sessions list
   const loadSessions = useCallback(async () => {
     try {
-      const r = await fetch(`${BASE}/api/ask/sessions?project=${encodeURIComponent(root)}`);
+      const r = await daemonFetch(`${BASE}/api/ask/sessions?project=${encodeURIComponent(root)}`);
       if (!r.ok) return;
       const d = await r.json();
       setSessions(d.sessions ?? []);
@@ -206,7 +212,7 @@ export function AskTab({ root }: { root: string }) {
     setError(null);
     setPhase('idle');
     try {
-      const r = await fetch(`${BASE}/api/ask/sessions/${encodeURIComponent(id)}`);
+      const r = await daemonFetch(`${BASE}/api/ask/sessions/${encodeURIComponent(id)}`);
       if (!r.ok) return;
       const d = await r.json();
       setMessages(d.messages ?? []);
@@ -245,7 +251,7 @@ export function AskTab({ root }: { root: string }) {
   // Create a new session
   const createSession = useCallback(async () => {
     try {
-      const r = await fetch(`${BASE}/api/ask/sessions`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      const r = await daemonFetch(`${BASE}/api/ask/sessions`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ project_root: root, title: t('newChat') }),
@@ -261,7 +267,7 @@ export function AskTab({ root }: { root: string }) {
   const deleteSession = useCallback(
     async (id: string) => {
       try {
-        await fetch(`${BASE}/api/ask/sessions/${encodeURIComponent(id)}`, { method: 'DELETE' });
+        await daemonFetch(`${BASE}/api/ask/sessions/${encodeURIComponent(id)}`, { method: 'DELETE' });
         if (activeSessionId === id) {
           setActiveSessionId(null);
           setMessages([]);
@@ -303,7 +309,7 @@ export function AskTab({ root }: { root: string }) {
       setPhase('retrieving');
       setError(null);
       try {
-        const r = await fetch(
+        const r = await daemonFetch(
           `${BASE}/api/ask/sessions/${encodeURIComponent(sessionId)}/slash`,
           {
             method: 'POST',
@@ -354,7 +360,7 @@ export function AskTab({ root }: { root: string }) {
     // Auto-create session if none selected
     if (!sessionId) {
       try {
-        const r = await fetch(`${BASE}/api/ask/sessions`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+        const r = await daemonFetch(`${BASE}/api/ask/sessions`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ project_root: root, title: q.slice(0, 60) }),
@@ -402,7 +408,7 @@ export function AskTab({ root }: { root: string }) {
     abortRef.current = ctrl;
 
     try {
-      const r = await fetch(
+      const r = await daemonFetch(
         `${BASE}/api/ask/sessions/${encodeURIComponent(sessionId)}/messages`,
         {
           method: 'POST',

--- a/packages/app/src/renderer/tabs/Clients.tsx
+++ b/packages/app/src/renderer/tabs/Clients.tsx
@@ -55,6 +55,7 @@ import {
 } from '../lattice/ui';
 import { Skeleton } from '../workspace/components/Skeleton';
 import { type ClientInfo, useDaemon } from '../hooks/useDaemon';
+import { useUsefulPaint } from '../perf';
 
 // ── All supported MCP clients (same order as CLI init) ────────────
 type ClientName =
@@ -470,6 +471,10 @@ export function Clients() {
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [bulk, setBulk] = useState<{ done: number; total: number } | null>(null);
   const [scrolled, setScrolled] = useState(false);
+
+  /* Useful once the client list has anything to show — detection resolved,
+     or a partial list already on screen. */
+  useUsefulPaint('clients', !detecting || detected.length > 0 || statuses.length > 0);
 
   const detectClients = useCallback(async () => {
     setDetecting(true);

--- a/packages/app/src/renderer/tabs/GraphExplorerGPU.tsx
+++ b/packages/app/src/renderer/tabs/GraphExplorerGPU.tsx
@@ -18,7 +18,9 @@ import {
 import { t } from '../i18n';
 import { formatNumber } from '../i18n/format';
 import { FloatingLayer } from '../lattice/FloatingLayer';
+import { daemonFetch } from '../daemon-fetch';
 import { Icon } from '../lattice/icons';
+import { useUsefulPaint } from '../perf';
 import {
   Badge,
   Button,
@@ -862,6 +864,9 @@ export const GraphExplorerGPU = forwardRef<GraphExplorerGPUHandle, Props>(functi
   );
   // The categorical colour key currently painted on the canvas — legend data.
   const [colorKey, setColorKey] = useState<ColorKeyEntry[]>([]);
+
+  /* Nodes on the canvas, or a stated failure. Not the layout settling. */
+  useUsefulPaint('graph', stats !== null || error !== null);
   // Toolbar overflow menu + the anchored filter popover that replaced the
   // second floating control bar.
   const overflowMenu = useMenuAnchor();
@@ -1705,7 +1710,7 @@ export const GraphExplorerGPU = forwardRef<GraphExplorerGPUHandle, Props>(functi
     let lastErr: Error | null = null;
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
       try {
-        const resp = await fetch(`${BASE}/api/projects/graph?${params}`);
+        const resp = await daemonFetch(`${BASE}/api/projects/graph?${params}`);
         if (resp.status === 429) {
           const delay = 400 * 2 ** attempt;
           await new Promise((r) => setTimeout(r, delay));

--- a/packages/app/src/renderer/tabs/Insights.tsx
+++ b/packages/app/src/renderer/tabs/Insights.tsx
@@ -18,6 +18,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useUsefulPaint } from '../perf';
 import { Badge, Button, EmptyState, PopUpButton, SegmentedControl, Toolbar } from '../lattice/ui';
 import {
   INSIGHT_REPORTS,
@@ -191,6 +192,10 @@ export function Insights({
   const focusedState = states[focused];
   const running = focusedState.status === 'running';
   const runLabel = running ? t('running') : focusedState.status === 'ok' ? t('refresh') : t('run');
+
+  /* Reports run on demand, so the screen is useful the moment the picker
+     and the empty state are up — there is nothing to wait for. */
+  useUsefulPaint('insights', !running);
 
   return (
     <div

--- a/packages/app/src/renderer/tabs/MemoryExplorer.tsx
+++ b/packages/app/src/renderer/tabs/MemoryExplorer.tsx
@@ -10,7 +10,9 @@ import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { matchesFilter } from '../components/FilterBar';
 import { formatDate as formatDateIntl, formatNumber } from '../i18n/format';
+import { daemonFetch } from '../daemon-fetch';
 import { Icon } from '../lattice/icons';
+import { useUsefulPaint } from '../perf';
 import {
   Badge,
   Button,
@@ -556,7 +558,7 @@ function DecisionCard({
   const confirm = useMenuAnchor();
 
   const handleEdit = async (values: DecisionFormValues) => {
-    const res = await fetch(`${BASE}/api/projects/decisions/${decision.id}`, {
+    const res = await daemonFetch(`${BASE}/api/projects/decisions/${decision.id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -590,7 +592,7 @@ function DecisionCard({
   const handleInvalidate = async () => {
     setActionPending(true);
     try {
-      const res = await fetch(`${BASE}/api/projects/decisions/${decision.id}/invalidate`, {
+      const res = await daemonFetch(`${BASE}/api/projects/decisions/${decision.id}/invalidate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({}),
@@ -835,11 +837,16 @@ function DecisionsView({ root, subTab }: { root: string; subTab?: ReactNode }) {
   const [decisions, setDecisions] = useState<DecisionRow[]>([]);
   const [stats, setStats] = useState<DecisionStats | null>(null);
   const [total, setTotal] = useState(0);
-  const [loading, setLoading] = useState(false);
+  /* True from the first frame: every one of these views fetches on mount,
+     and starting at false paints the empty state — "nothing here" — for the
+     frame before the rows land (TRA-934). */
+  const [loading, setLoading] = useState(true);
   /* A swallowed fetch failure used to fall through to "No decisions yet",
      inviting you to re-add decisions you already have. Failure is its own
      state (TRA-294). */
   const [failed, setFailed] = useState(false);
+
+  useUsefulPaint('memory', !loading || decisions.length > 0 || failed);
   /* One search field feeds the FTS `q` parameter; one optional exclude field
      hides rows client-side. Both take plain text or /regex/i. This replaces the
      shared FilterBar, whose MATCH / EXCLUDE labels were 10.5px/700 ALL-CAPS
@@ -872,7 +879,7 @@ function DecisionsView({ root, subTab }: { root: string; subTab?: ReactNode }) {
         // the client-side filter do the work after the fetch.
         if (search && !search.startsWith('/')) params.set('q', search);
         if (type) params.set('type', type);
-        const res = await fetch(`${BASE}/api/projects/decisions?${params}`);
+        const res = await daemonFetch(`${BASE}/api/projects/decisions?${params}`);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = (await res.json()) as { decisions: DecisionRow[]; total: number };
         setDecisions(data.decisions);
@@ -888,7 +895,7 @@ function DecisionsView({ root, subTab }: { root: string; subTab?: ReactNode }) {
 
   const fetchStats = useCallback(async () => {
     try {
-      const res = await fetch(
+      const res = await daemonFetch(
         `${BASE}/api/projects/decisions/stats?${new URLSearchParams({ project: root })}`,
       );
       if (res.ok) setStats((await res.json()) as DecisionStats);
@@ -927,7 +934,7 @@ function DecisionsView({ root, subTab }: { root: string; subTab?: ReactNode }) {
   };
 
   const handleAdd = async (values: DecisionFormValues) => {
-    const res = await fetch(`${BASE}/api/projects/decisions`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+    const res = await daemonFetch(`${BASE}/api/projects/decisions`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -1216,7 +1223,7 @@ function CorpusQueryModal({
     setResult(null);
     setPending(true);
     try {
-      const res = await fetch(`${BASE}/api/projects/corpora/${encodeURIComponent(corpusName)}/query`, {
+      const res = await daemonFetch(`${BASE}/api/projects/corpora/${encodeURIComponent(corpusName)}/query`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ project_root: root, query, max_tokens: 4000 }),
@@ -1357,14 +1364,17 @@ function CorpusQueryModal({
 function CorporaView({ root, subTab }: { root: string; subTab?: ReactNode }) {
   const { t } = useTranslation('memory');
   const [corpora, setCorpora] = useState<CorpusItem[]>([]);
-  const [loading, setLoading] = useState(false);
+  /* True from the first frame: every one of these views fetches on mount,
+     and starting at false paints the empty state — "nothing here" — for the
+     frame before the rows land (TRA-934). */
+  const [loading, setLoading] = useState(true);
   const [queryCorpus, setQueryCorpus] = useState<string | null>(null);
   const [deletePending, setDeletePending] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
 
   const fetchCorpora = useCallback(() => {
     setLoading(true);
-    fetch(`${BASE}/api/projects/corpora?${new URLSearchParams({ project: root })}`)
+    daemonFetch(`${BASE}/api/projects/corpora?${new URLSearchParams({ project: root })}`)
       .then((r) => (r.ok ? r.json() : null))
       .then((data: { corpora: CorpusItem[] } | null) => {
         if (data) setCorpora(data.corpora);
@@ -1381,7 +1391,7 @@ function CorporaView({ root, subTab }: { root: string; subTab?: ReactNode }) {
     setDeletePending(name);
     try {
       const params = new URLSearchParams({ project_root: root });
-      const res = await fetch(
+      const res = await daemonFetch(
         `${BASE}/api/projects/corpora/${encodeURIComponent(name)}?${params}`,
         { method: 'DELETE' },
       );
@@ -1556,11 +1566,14 @@ function CorpusDeleteButton({
 function SessionsView({ root, subTab }: { root: string; subTab?: ReactNode }) {
   const { t } = useTranslation('memory');
   const [sessions, setSessions] = useState<MinedSession[]>([]);
-  const [loading, setLoading] = useState(false);
+  /* True from the first frame: every one of these views fetches on mount,
+     and starting at false paints the empty state — "nothing here" — for the
+     frame before the rows land (TRA-934). */
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     setLoading(true);
-    fetch(
+    daemonFetch(
       `${BASE}/api/projects/sessions?${new URLSearchParams({ project: root, limit: '100' })}`,
     )
       .then((r) => (r.ok ? r.json() : null))
@@ -1803,7 +1816,10 @@ function ReviewView({
 }) {
   const { t } = useTranslation('memory');
   const [decisions, setDecisions] = useState<DecisionRow[]>([]);
-  const [loading, setLoading] = useState(false);
+  /* True from the first frame: every one of these views fetches on mount,
+     and starting at false paints the empty state — "nothing here" — for the
+     frame before the rows land (TRA-934). */
+  const [loading, setLoading] = useState(true);
   const [toast, setToast] = useState<ToastState | null>(null);
 
   const fetchPending = useCallback(async () => {
@@ -1814,7 +1830,7 @@ function ReviewView({
         review_status: 'pending',
         limit: '100',
       });
-      const res = await fetch(`${BASE}/api/projects/decisions?${params}`);
+      const res = await daemonFetch(`${BASE}/api/projects/decisions?${params}`);
       if (res.ok) {
         const data = (await res.json()) as { decisions: DecisionRow[]; total: number };
         setDecisions(data.decisions);
@@ -1849,7 +1865,7 @@ function ReviewView({
     onPendingCountChange?.(Math.max(0, decisions.length - 1));
 
     try {
-      const res = await fetch(`${BASE}/api/projects/decisions/${id}/review`, {
+      const res = await daemonFetch(`${BASE}/api/projects/decisions/${id}/review`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status }),
@@ -1949,7 +1965,7 @@ export function MemoryExplorer({ root }: { root: string }) {
   // Cheap stats endpoint, returns the same number ReviewView would compute.
   useEffect(() => {
     let cancelled = false;
-    void fetch(`${BASE}/api/projects/decisions/stats?${new URLSearchParams({ project: root })}`)
+    void daemonFetch(`${BASE}/api/projects/decisions/stats?${new URLSearchParams({ project: root })}`)
       .then((r) => (r.ok ? r.json() : null))
       .then((data: DecisionStats | null) => {
         if (!cancelled && data && typeof data.pending_reviews === 'number') {

--- a/packages/app/src/renderer/tabs/Notebook.tsx
+++ b/packages/app/src/renderer/tabs/Notebook.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
    — without it a test that renders Notebook in isolation gets raw keys. */
 import '../i18n';
 import { Icon } from '../lattice/icons';
+import { useUsefulPaint } from '../perf';
 import {
   Button,
   Card,
@@ -87,6 +88,9 @@ export function Notebook({
   const { t } = useTranslation('notebook');
   const [cells, setCells] = useState<Cell[]>(() => [makeCell()]);
   const [scrolled, setScrolled] = useState(false);
+
+  /* Cells run on demand; nothing is fetched before the first paint. */
+  useUsefulPaint('notebook', true);
 
   const addCell = useCallback(() => {
     setCells((prev) => [...prev, makeCell()]);

--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -28,7 +28,10 @@ import { useDaemon } from '../hooks/useDaemon';
 import { deriveDaemonState } from '../workspace/useWorkspaceProjects';
 import { t } from '../i18n';
 import { formatDate, formatList, formatNumber, relativeTime } from '../i18n/format';
+import { daemonFetch } from '../daemon-fetch';
+import { loadSnapshot, saveSnapshot } from '../snapshot';
 import { Icon } from '../lattice/icons';
+import { useUsefulPaint } from '../perf';
 import {
   Badge,
   Button,
@@ -268,8 +271,21 @@ export function ProjectOverview({
       metricsErrorKind: null,
     }) !== 'ok';
 
-  const [stats, setStats] = useState<ProjectStats | null>(null);
+  /* Open on the last numbers we had for this project rather than on a
+     skeleton. Measured 2026-09-05: every renderer read of the daemon blocked
+     for 7.80 s while it indexed, and this screen spent all of it showing five
+     grey bars for counts that were already on disk (TRA-934). The fresh read
+     is still issued; it replaces these when it lands, and until it does the
+     card says so. */
+  const statsKey = `trace-mcp.overview.stats:${root}`;
+  const [stats, setStats] = useState<ProjectStats | null>(() =>
+    loadSnapshot<ProjectStats>(statsKey),
+  );
   const [statsLoad, setStatsLoad] = useState<Load>('loading');
+  /* Whether the numbers on screen came from the daemon *this* session. False
+     while the snapshot is standing in, and the card says so — a stale answer
+     the user can read beats a skeleton, but only if it admits what it is. */
+  const [statsFresh, setStatsFresh] = useState(false);
   const [coverage, setCoverage] = useState<CoverageReport | null>(null);
   const [coverageLoad, setCoverageLoad] = useState<Load>('loading');
   const [, setRepos] = useState<SubprojectInfo[]>([]);
@@ -284,6 +300,10 @@ export function ProjectOverview({
   const [statsModalOpen, setStatsModalOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
 
+  /* The Index card is the first thing on this screen with a number in it. */
+  /* A snapshot on screen is a useful frame — that is the point of keeping it. */
+  useUsefulPaint('overview', statsLoad !== 'loading' || stats !== null);
+
   const overflowMenu = useMenuAnchor();
   const rowMenu = useMenuAnchor();
   const [rowMenuFor, setRowMenuFor] = useState<ServiceInfo | null>(null);
@@ -296,19 +316,22 @@ export function ProjectOverview({
   const fetchStats = useCallback(async () => {
     setStatsLoad('loading');
     try {
-      const res = await fetch(`${BASE}/api/projects/stats?project=${encodeURIComponent(root)}`);
+      const res = await daemonFetch(`${BASE}/api/projects/stats?project=${encodeURIComponent(root)}`);
       if (!res.ok) throw new Error(String(res.status));
-      setStats(await res.json());
+      const fresh = (await res.json()) as ProjectStats;
+      setStats(fresh);
+      saveSnapshot(statsKey, fresh);
+      setStatsFresh(true);
       setStatsLoad('ready');
     } catch {
       setStatsLoad('failed');
     }
-  }, [root]);
+  }, [root, statsKey]);
 
   const fetchCoverage = useCallback(async () => {
     setCoverageLoad('loading');
     try {
-      const res = await fetch(`${BASE}/api/projects/coverage?project=${encodeURIComponent(root)}`);
+      const res = await daemonFetch(`${BASE}/api/projects/coverage?project=${encodeURIComponent(root)}`);
       if (!res.ok) throw new Error(String(res.status));
       setCoverage(await res.json());
       setCoverageLoad('ready');
@@ -321,7 +344,7 @@ export function ProjectOverview({
     setServicesLoad('loading');
     try {
       const params = new URLSearchParams({ project: root });
-      const res = await fetch(`${BASE}/api/projects/subprojects?${params}`);
+      const res = await daemonFetch(`${BASE}/api/projects/subprojects?${params}`);
       if (!res.ok) throw new Error(String(res.status));
       const data = await res.json();
       setRepos(data.repos ?? []);
@@ -337,7 +360,7 @@ export function ProjectOverview({
       setSmellsLoad('loading');
       try {
         const params = new URLSearchParams({ project: root, category, limit: '500' });
-        const res = await fetch(`${BASE}/api/projects/smells?${params}`);
+        const res = await daemonFetch(`${BASE}/api/projects/smells?${params}`);
         if (!res.ok) throw new Error(String(res.status));
         setSmells(await res.json());
         setSmellsLoad('ready');
@@ -379,7 +402,7 @@ export function ProjectOverview({
     try {
       const folder = await api.selectFolder();
       if (!folder) return;
-      await fetch(`${BASE}/api/projects/subprojects`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      await daemonFetch(`${BASE}/api/projects/subprojects`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ repoPath: folder, project: root }),
@@ -394,7 +417,7 @@ export function ProjectOverview({
 
   const handleRemoveService = async (name: string) => {
     try {
-      const res = await fetch(`${BASE}/api/projects/subprojects?name=${encodeURIComponent(name)}`, {
+      const res = await daemonFetch(`${BASE}/api/projects/subprojects?name=${encodeURIComponent(name)}`, {
         method: 'DELETE',
       });
       if (res.ok) {
@@ -408,7 +431,7 @@ export function ProjectOverview({
 
   const handleUpdateGroup = async (serviceId: number, projectGroup: string | null) => {
     try {
-      const res = await fetch(`${BASE}/api/projects/services`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      const res = await daemonFetch(`${BASE}/api/projects/services`, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ serviceId, projectGroup: projectGroup || null }),
@@ -698,6 +721,18 @@ export function ProjectOverview({
                 <SectionError what={t('errorIndexSummary')} onRetry={fetchStats} />
               ) : stats ? (
                 <>
+                  {!statsFresh && (
+                    /* Same sentence the Workspace uses for the same condition,
+                       from the same key — one wording for "these are the last
+                       indexed numbers", not two. */
+                    <div
+                      role="status"
+                      className="px-3 pt-2 text-[13px]"
+                      style={{ color: 'var(--label-secondary)' }}
+                    >
+                      {t('workspace:busyStale')}
+                    </div>
+                  )}
                   <ListRow
                     label={t('rowStatus')}
                     value={

--- a/packages/app/src/renderer/tabs/ToolActivity.tsx
+++ b/packages/app/src/renderer/tabs/ToolActivity.tsx
@@ -32,7 +32,9 @@ import { useTranslation } from 'react-i18next';
 import { useDocumentVisible } from '../hooks/useDocumentVisible';
 import { t } from '../i18n';
 import { formatDate, formatNumber, relativeTime } from '../i18n/format';
+import { daemonFetch } from '../daemon-fetch';
 import { Icon } from '../lattice/icons';
+import { useUsefulPaint } from '../perf';
 import {
   Badge,
   Button,
@@ -1675,6 +1677,8 @@ export function ToolActivity({
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  /* Useful once the journal feed is up or has produced a row — whichever
+     comes first; an empty-but-connected feed is a real answer. */
   // ── Keyboard navigation state ────────────────────────────────────────
   // Index into the currently-visible `filtered` list (flat order, regardless
   // of group-by-session). -1 means no selection.
@@ -1691,6 +1695,14 @@ export function ToolActivity({
   // appears on scroll instead of being painted permanently.
   const [scrolled, setScrolled] = useState(false);
   const [historyFailed, setHistoryFailed] = useState(false);
+
+  /* Useful once the journal has landed, provably failed, or the live feed is
+     up — whichever comes first. An empty-but-connected feed is a real answer;
+     a skeleton behind an unanswered daemon is not (TRA-934). */
+  useUsefulPaint(
+    'activity',
+    connected || entries.length > 0 || historyFailed || error !== null,
+  );
   const overflow = useMenuAnchor();
 
   // ── Pause / clear / export local controls ────────────────────────────
@@ -1738,7 +1750,7 @@ export function ToolActivity({
 
     const curFetch = (async () => {
       try {
-        const res = await fetch(`${BASE}/api/projects/journal/stats?${curParams}`);
+        const res = await daemonFetch(`${BASE}/api/projects/journal/stats?${curParams}`);
         if (res.ok) {
           const data = (await res.json()) as JournalStats;
           setStats(data);
@@ -1754,7 +1766,7 @@ export function ToolActivity({
     // current stats, so it has its own try/catch and leaves prevStats as-is.
     const prevFetch = (async () => {
       try {
-        const res = await fetch(`${BASE}/api/projects/journal/stats?${prevParams}`);
+        const res = await daemonFetch(`${BASE}/api/projects/journal/stats?${prevParams}`);
         if (res.ok) {
           const data = (await res.json()) as JournalStats;
           setPrevStats(data);
@@ -1839,7 +1851,7 @@ export function ToolActivity({
   const fetchHistory = useCallback(async () => {
     try {
       const params = new URLSearchParams({ project: root, limit: '200' });
-      const res = await fetch(`${BASE}/api/projects/journal?${params}`);
+      const res = await daemonFetch(`${BASE}/api/projects/journal?${params}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       {
         const data = (await res.json()) as JournalEntry[];

--- a/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
@@ -56,6 +56,10 @@ const NO_SMELLS = {
 };
 
 beforeEach(() => {
+  /* The pane keeps its last stats in localStorage (TRA-934), and jsdom shares
+     one store across every test in this file — so a test that fetches stats
+     successfully would otherwise hand its numbers to the next one. */
+  localStorage.clear();
   daemon.projects = [{ root: ROOT, status: 'ready' }];
   daemon.loading = false;
   daemon.connected = true;
@@ -204,6 +208,23 @@ describe('ProjectOverview surface', () => {
     expect(await screen.findByText('Checking…')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Index project' })).toBeNull();
     expect(screen.queryByText('Not indexed')).toBeNull();
+  });
+
+  it('opens on the last known numbers while the daemon is unanswered', async () => {
+    /* TRA-934. Measured on this machine, every renderer read of the daemon
+       blocked for 7.80 s at once while it indexed. Without a snapshot this pane
+       spent all of it on five grey bars for counts that were on disk. With one
+       it opens on the counts and says they are the last indexed ones. */
+    localStorage.setItem(`trace-mcp.overview.stats:${ROOT}`, JSON.stringify(STATS));
+    // Every endpoint hangs — the wedge, not a refusal.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => {})));
+
+    render(<ProjectOverview root={ROOT} />);
+
+    expect(await screen.findByText('337')).toBeTruthy();
+    expect(
+      screen.getByText('The daemon is busy. These are the last indexed numbers.'),
+    ).toBeTruthy();
   });
 
   it('does not call a project the daemon forgot "not indexed"', async () => {

--- a/packages/app/src/renderer/tabs/insights-runtime.ts
+++ b/packages/app/src/renderer/tabs/insights-runtime.ts
@@ -22,6 +22,7 @@
  * was active at import.
  */
 
+import { DAEMON_TOOL_TIMEOUT_MS, daemonFetch } from '../daemon-fetch';
 import { t } from '../i18n';
 
 const BASE = 'http://127.0.0.1:3741';
@@ -409,7 +410,7 @@ export interface InsightsClient {
 
 export const defaultInsightsClient: InsightsClient = {
   async runReport(reportId, root) {
-    const initRes = await fetch(`${BASE}/mcp?project=${encodeURIComponent(root)}`, {
+    const initRes = await daemonFetch(`${BASE}/mcp?project=${encodeURIComponent(root)}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -425,12 +426,12 @@ export const defaultInsightsClient: InsightsClient = {
           clientInfo: { name: 'trace-mcp-insights', version: '0.1.0' },
         },
       }),
-    });
+    }, DAEMON_TOOL_TIMEOUT_MS);
     if (!initRes.ok) throw new Error(t('insights:errorInit', { status: initRes.status }));
     const sessionId = initRes.headers.get('mcp-session-id') ?? '';
     if (!sessionId) throw new Error(t('insights:errorNoSession'));
     await initRes.text().catch(() => '');
-    await fetch(`${BASE}/mcp?project=${encodeURIComponent(root)}`, {
+    await daemonFetch(`${BASE}/mcp?project=${encodeURIComponent(root)}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -438,12 +439,12 @@ export const defaultInsightsClient: InsightsClient = {
         'mcp-session-id': sessionId,
       },
       body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} }),
-    }).then((r) => r.text().catch(() => ''));
+    }, DAEMON_TOOL_TIMEOUT_MS).then((r) => r.text().catch(() => ''));
 
     // Escalate into the report's tool before calling it — see buildLoadToolsCall.
     // A failure here is not fatal: if the tool was already in the preset the
     // call below simply runs, and if it was not, that call reports the real error.
-    await fetch(`${BASE}/mcp?project=${encodeURIComponent(root)}`, {
+    await daemonFetch(`${BASE}/mcp?project=${encodeURIComponent(root)}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -451,11 +452,11 @@ export const defaultInsightsClient: InsightsClient = {
         'mcp-session-id': sessionId,
       },
       body: JSON.stringify(buildLoadToolsCall(reportId)),
-    })
+    }, DAEMON_TOOL_TIMEOUT_MS)
       .then((r) => r.text().catch(() => ''))
       .catch(() => '');
 
-    const callRes = await fetch(`${BASE}/mcp?project=${encodeURIComponent(root)}`, {
+    const callRes = await daemonFetch(`${BASE}/mcp?project=${encodeURIComponent(root)}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -463,7 +464,7 @@ export const defaultInsightsClient: InsightsClient = {
         'mcp-session-id': sessionId,
       },
       body: JSON.stringify(buildRpcCall(reportId, root, 3)),
-    });
+    }, DAEMON_TOOL_TIMEOUT_MS);
     if (!callRes.ok) {
       throw new Error(
         t('insights:errorHttp', {

--- a/packages/app/src/renderer/tabs/notebook-runtime.ts
+++ b/packages/app/src/renderer/tabs/notebook-runtime.ts
@@ -16,6 +16,8 @@
  * re-exports the public API for backwards compatibility.
  */
 
+import { DAEMON_TOOL_TIMEOUT_MS, daemonFetch } from '../daemon-fetch';
+
 const BASE = 'http://127.0.0.1:3741';
 
 // ── Tool catalog ─────────────────────────────────────────────────────
@@ -133,12 +135,12 @@ export const defaultNotebookClient: NotebookClient = {
       const kind = args.kind?.trim() ?? '';
       const params = new URLSearchParams({ project: root, q, limit: '30' });
       if (kind) params.set('kind', kind);
-      const r = await fetch(`${BASE}/api/projects/symbols?${params}`);
+      const r = await daemonFetch(`${BASE}/api/projects/symbols?${params}`);
       if (!r.ok) throw new Error(`HTTP ${r.status}: ${await r.text().catch(() => '')}`);
       return await r.json();
     }
     // JSON-RPC path: initialize a session, then call the tool.
-    const initRes = await fetch(`${BASE}/mcp?project=${encodeURIComponent(root)}`, {
+    const initRes = await daemonFetch(`${BASE}/mcp?project=${encodeURIComponent(root)}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
       body: JSON.stringify({
@@ -151,14 +153,14 @@ export const defaultNotebookClient: NotebookClient = {
           clientInfo: { name: 'trace-mcp-notebook', version: '0.1.0' },
         },
       }),
-    });
+    }, DAEMON_TOOL_TIMEOUT_MS);
     if (!initRes.ok) throw new Error(`init failed: HTTP ${initRes.status}`);
     const sessionId = initRes.headers.get('mcp-session-id') ?? '';
     if (!sessionId) throw new Error('init did not return a session ID');
     // Drain the init response body so the server doesn't keep it open.
     await initRes.text().catch(() => '');
     // Send the notifications/initialized lifecycle message.
-    await fetch(`${BASE}/mcp?project=${encodeURIComponent(root)}`, {
+    await daemonFetch(`${BASE}/mcp?project=${encodeURIComponent(root)}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -166,13 +168,13 @@ export const defaultNotebookClient: NotebookClient = {
         'mcp-session-id': sessionId,
       },
       body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} }),
-    }).then((r) => r.text().catch(() => ''));
+    }, DAEMON_TOOL_TIMEOUT_MS).then((r) => r.text().catch(() => ''));
     // Call the tool.
     const cleanArgs: Record<string, string> = {};
     for (const [k, v] of Object.entries(args)) {
       if (typeof v === 'string' && v.trim() !== '') cleanArgs[k] = v;
     }
-    const callRes = await fetch(`${BASE}/mcp?project=${encodeURIComponent(root)}`, {
+    const callRes = await daemonFetch(`${BASE}/mcp?project=${encodeURIComponent(root)}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -185,7 +187,7 @@ export const defaultNotebookClient: NotebookClient = {
         method: 'tools/call',
         params: { name: tool, arguments: cleanArgs },
       }),
-    });
+    }, DAEMON_TOOL_TIMEOUT_MS);
     if (!callRes.ok) throw new Error(`HTTP ${callRes.status}: ${await callRes.text().catch(() => '')}`);
     const ct = callRes.headers.get('content-type') ?? '';
     let payload: unknown;

--- a/packages/app/src/renderer/workspace/Workspace.tsx
+++ b/packages/app/src/renderer/workspace/Workspace.tsx
@@ -26,6 +26,7 @@ import { t } from '../i18n';
 import { formatNumber } from '../i18n/format';
 import { Button, EmptyState } from '../lattice/ui';
 import { addRecentProject, removeRecentProject } from '../recent-projects';
+import { useUsefulPaint } from '../perf';
 import { DaemonDownPane } from '../components/DaemonDownPane';
 import { AddProjectControl } from './AddProjectControl';
 import { BulkActionsBar } from './BulkActionsBar';
@@ -207,6 +208,9 @@ export function busyMessage(o: {
 export function Workspace() {
   const { t } = useTranslation('workspace');
   const data = useWorkspaceProjects();
+  /* First useful paint: the row list, cached metrics included. Not the
+     revalidated numbers — a snapshot on screen is the product working. */
+  useUsefulPaint('workspace', !data.loading);
 
   // ── UI state ─────────────────────────────────────────────────────────
   const [view, setView] = useState<ViewMode>(() => loadView());

--- a/packages/app/src/renderer/workspace/useWorkspaceProjects.ts
+++ b/packages/app/src/renderer/workspace/useWorkspaceProjects.ts
@@ -18,15 +18,15 @@
  * snapshot, and it says so once rather than escalating through three sentences.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { DAEMON_FETCH_TIMEOUT_MS, useDaemon } from '../hooks/useDaemon';
+import { BASE, DAEMON_FETCH_TIMEOUT_MS, daemonFetch } from '../daemon-fetch';
+import { loadSnapshot, saveSnapshot } from '../snapshot';
+import { useDaemon } from '../hooks/useDaemon';
 import { t } from '../i18n';
 import {
   type ProjectHealthMetrics,
   type ProjectViewModel,
   mergeIntoViewModel,
 } from './types';
-
-const BASE = 'http://127.0.0.1:3741';
 
 export const AUTO_REFRESH_INTERVAL_MS = 300_000; // 5 min — matches backend cache TTL.
 export const STATUS_TRANSITION_DEBOUNCE_MS = 1000;
@@ -43,23 +43,12 @@ export const DEGRADED_GRACE_MS = 1500;
 const LS_METRICS_KEY = 'trace-mcp.workspace.metrics';
 
 export function loadMetricsSnapshot(): ProjectHealthMetrics[] {
-  try {
-    const raw = localStorage.getItem(LS_METRICS_KEY);
-    const parsed = raw ? (JSON.parse(raw) as unknown) : null;
-    return Array.isArray(parsed) ? (parsed as ProjectHealthMetrics[]) : [];
-  } catch {
-    // Corrupted JSON, or a sandboxed renderer with no storage — start cold.
-    return [];
-  }
+  const parsed = loadSnapshot<unknown>(LS_METRICS_KEY);
+  return Array.isArray(parsed) ? (parsed as ProjectHealthMetrics[]) : [];
 }
 
 export function saveMetricsSnapshot(metrics: ProjectHealthMetrics[]): void {
-  try {
-    localStorage.setItem(LS_METRICS_KEY, JSON.stringify(metrics));
-  } catch {
-    // Quota or sandbox. A missing snapshot costs one screen of em dashes, so
-    // there is nothing worth reporting to the user here.
-  }
+  saveSnapshot(LS_METRICS_KEY, metrics);
 }
 
 // ── Exported pure helpers (testable without React) ────────────────────────
@@ -237,7 +226,7 @@ export function classifyMetricsError(err: unknown): MetricsErrorKind {
  */
 export async function fetchMetricsOnce(setters: MetricsSetters): Promise<boolean> {
   try {
-    const res = await fetch(`${BASE}/api/dashboard/projects`, { signal: AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS) }); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+    const res = await daemonFetch(`${BASE}/api/dashboard/projects`); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
     if (!res.ok) {
       setters.setErrorKind('server');
       return false;
@@ -316,7 +305,7 @@ export function useWorkspaceProjects(): UseWorkspaceProjectsResult {
   const refresh = useCallback(async () => {
     setRefreshing(true);
     try {
-      await fetch(`${BASE}/api/dashboard/refresh`, { method: 'POST', signal: AbortSignal.timeout(DAEMON_FETCH_TIMEOUT_MS) }); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
+      await daemonFetch(`${BASE}/api/dashboard/refresh`, { method: 'POST' }); // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
     } catch {
       // Best-effort; still fetch even if invalidation failed.
     }


### PR DESCRIPTION
Closes TRA-934.

The app had no per-screen time-to-first-useful-paint number. `cold_start_ms` in
`docs/perf/baseline.json` answers "when did the shell appear"; it says nothing about when
the user could read an answer. This adds the measurement, then fixes what it found.

All numbers: median of 3, M5 Max, nine live agent sessions, real registry daemon at :3741,
2026-09-05. Harness: `packages/app/scripts/perf-screens.mjs`.

## What was measured

Each screen declares its own useful paint (`useUsefulPaint`, `src/renderer/perf.ts`); the
harness navigates or clicks and reads the marks over CDP. `--wedged` pauses every renderer
request to `127.0.0.1:3741` and never resumes it — the daemon's observed failure shape
(TRA-922), and the only one worth testing, since a *refused* connection fails in
microseconds and every screen already handles that.

Under a wedged daemon:

| Screen | Before | After |
|---|---|---|
| Workspace | 8 064 ms (its own 8 s ceiling) | **67 ms** — opens on the metrics snapshot |
| Overview | **never useful** (> 30 s) | **22 ms** — opens on a new stats snapshot |
| Activity | **never useful** (> 30 s) | **8 307 ms** — bounded, states the failure |
| Memory | 303 ms, but it was the *empty state*: "no decisions yet" over a fetch still in flight | **8 305 ms** — honest, bounded |
| Clients, Ask, Notebook, Insights | ~300 ms | ~300 ms — none read the daemon before first paint |

`never_useful` is now 0 for every screen in every sample.

## What produced that

1. **Every daemon read has a ceiling.** 50 of the renderer's 57 `fetch` calls had none. A
   `fetch` with no signal against a socket that accepts and never answers neither resolves
   nor rejects, so the screen behind it stays on its skeleton for the life of the window —
   no error, no retry, nothing for the user to do. `src/renderer/daemon-fetch.ts` is now
   the only place that calls `fetch` at the daemon.
   The ceiling itself is unchanged at 8 s. This machine's daemon has been measured
   answering `/health` in 5.8 s while indexing, so a tighter one would abort reads that
   were going to succeed — it is the *existence* of a ceiling that was missing, not its
   value. MCP tool calls from Notebook/Insights get their own 120 s ceiling; the Ask
   stream keeps its user-owned `AbortController` and stays unbounded on purpose.
2. **Screens open on their last known numbers.** Workspace already did this for metrics
   (TRA-397). Overview now does it for the index summary through a shared
   `loadSnapshot`/`saveSnapshot` (`src/renderer/snapshot.ts`), and says
   *"The daemon is busy. These are the last indexed numbers."* — the Workspace's existing
   string, same wording for the same condition — until the fresh read lands.
3. **A screen that has not loaded does not claim to be empty.** All four Memory sub-views
   started with `loading: false`, so the frame before their first fetch resolved read as
   "nothing here".

## The 7.8 s cold wait is the daemon's, not the app's

Worth recording because it decides where the rest of the work goes. On a cold profile all
five startup reads start at 52 ms and complete at 7 832 ms — together, to the millisecond.
That is one blocking event releasing all of them, not five slow requests. `curl` against
the same socket at the same moment took 7.799 s, while the same endpoint answers in 0.7 ms
when the daemon is idle. `cold_shell_ms` is 20–80 ms on every screen.

So the app's share of a cold launch is the shell; everything past it is TRA-921's accept
queue. What the app *can* do — bound the wait and have something on screen while it runs
out — is what this does.

## Guards

- `src/renderer/__tests__/daemon-fetch.test.ts` — source-level: fails if a bare `fetch` at
  the daemon reappears anywhere in the renderer.
- `src/renderer/__tests__/perf-marks.test.ts` — fails if a screen loses its useful-paint
  mark, which would otherwise just shorten the report and read as good news.
- `ProjectOverview.test.tsx` — new case: snapshot present, every endpoint hanging, the pane
  shows the numbers and the staleness line.

`pnpm -C packages/app run test` 689 passed · typecheck clean · `check-i18n` clean (no new
strings) · build clean.

## Not done

No token-cost or MCP-contract change. Graph is excluded from the harness: its GPU context
is not reliable in an unmapped window and its settle time is a separate metric.

Agent: Performance Agent
