### PR TITLE
fix(quality): index the metadata-existence checks in antipatterns.ts (TRA-940)

### DIFF
--- a/src/tools/quality/antipatterns.ts
+++ b/src/tools/quality/antipatterns.ts
@@ -662,7 +662,7 @@ function detectEventListenerLeak(store: Store, data: PreFetchedData): Antipatter
     FROM symbols s
     JOIN files f ON s.file_id = f.id
     WHERE s.metadata IS NOT NULL
-      AND s.metadata LIKE '%"callSites"%'
+      AND json_extract(s.metadata, '$.callSites') IS NOT NULL
       AND f.gitignored = 0
   `)
     .all() as Array<{
@@ -1077,7 +1077,7 @@ function detectMemoryLeak(store: Store, data: PreFetchedData): AntipatternFindin
     FROM symbols s
     JOIN files f ON s.file_id = f.id
     WHERE s.metadata IS NOT NULL
-      AND s.metadata LIKE '%"callSites"%'
+      AND json_extract(s.metadata, '$.callSites') IS NOT NULL
       AND f.gitignored = 0
   `)
     .all() as Array<{
@@ -1465,7 +1465,7 @@ export function detectAntipatterns(
     FROM symbols s
     JOIN files f ON s.file_id = f.id
     WHERE s.metadata IS NOT NULL
-      AND s.metadata LIKE '%"callSites"%'
+      AND json_extract(s.metadata, '$.callSites') IS NOT NULL
       AND f.gitignored = 0
   `)
         .get() as { n: number } | undefined

--- a/tests/db/metadata-existence-index.test.ts
+++ b/tests/db/metadata-existence-index.test.ts
@@ -116,3 +116,69 @@ describe('metadata-existence partial indexes (TRA-924)', () => {
     expect(hasBareTableScan(lines)).toBe(false);
   });
 });
+
+// TRA-940 follow-up: src/tools/quality/antipatterns.ts had three more
+// occurrences of the same `metadata LIKE '%"callSites"%'` pattern that
+// TRA-924 didn't cover (it named only the 5 edge-resolver files). Fixed by
+// reusing the same idx_symbols_call_sites partial index -- no new migration.
+describe('antipatterns.ts callSites queries avoid a bare symbols scan (TRA-940)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = initializeDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function planLines(sql: string): string[] {
+    const plan = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all() as Array<{ detail: string }>;
+    return plan.map((p) => p.detail);
+  }
+
+  function hasBareTableScan(lines: string[]): boolean {
+    return lines.some((l) => /^SCAN s$/.test(l));
+  }
+
+  it('event-listener-leak callSites query seeks idx_symbols_call_sites', () => {
+    const lines = planLines(`
+      SELECT s.id, s.file_id, s.symbol_id, s.name, s.kind, s.parent_id, s.line_start, s.metadata,
+             f.path as file_path
+      FROM symbols s
+      JOIN files f ON s.file_id = f.id
+      WHERE s.metadata IS NOT NULL
+        AND json_extract(s.metadata, '$.callSites') IS NOT NULL
+        AND f.gitignored = 0
+    `);
+    expect(lines.join(' | ')).toContain('idx_symbols_call_sites');
+    expect(hasBareTableScan(lines)).toBe(false);
+  });
+
+  it('memory-leak handler-candidates callSites query seeks idx_symbols_call_sites', () => {
+    const lines = planLines(`
+      SELECT s.id, s.file_id, s.symbol_id, s.name, s.line_start, s.metadata,
+             f.path as file_path
+      FROM symbols s
+      JOIN files f ON s.file_id = f.id
+      WHERE s.metadata IS NOT NULL
+        AND json_extract(s.metadata, '$.callSites') IS NOT NULL
+        AND f.gitignored = 0
+    `);
+    expect(lines.join(' | ')).toContain('idx_symbols_call_sites');
+    expect(hasBareTableScan(lines)).toBe(false);
+  });
+
+  it('callSiteFileCount query seeks idx_symbols_call_sites', () => {
+    const lines = planLines(`
+      SELECT COUNT(DISTINCT s.file_id) AS n
+      FROM symbols s
+      JOIN files f ON s.file_id = f.id
+      WHERE s.metadata IS NOT NULL
+        AND json_extract(s.metadata, '$.callSites') IS NOT NULL
+        AND f.gitignored = 0
+    `);
+    expect(lines.join(' | ')).toContain('idx_symbols_call_sites');
+    expect(hasBareTableScan(lines)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- `src/tools/quality/antipatterns.ts` had three more occurrences (lines 665, 1080, 1468) of the leading-wildcard `metadata LIKE '%"callSites"%'` predicate that #952/TRA-924 fixed in the edge resolvers (typescript-calls, python-calls, typescript-types, python-types, python-heritage) but explicitly flagged as out of scope there — TRA-924 named only those 5 files.
- Replaced each with `json_extract(s.metadata, '$.callSites') IS NOT NULL`, which the existing `idx_symbols_call_sites` partial index (schema v32) already serves — no new migration needed.

### Out of scope (follow-up filed)
TRA-940 also named a related group in the same file (lines 1004–1013): `s.signature LIKE '%new Map%'`, `'%: Map<%'`, `s.name LIKE '%Cache'`, `'%Registry'`, `'%Pool'`. Checked with `EXPLAIN QUERY PLAN` on a fresh DB: this query already seeks `idx_symbols_kind` for the `s.kind IN (...)` filter (not a bare `SCAN s`), but the residual LIKE/suffix predicates over that kind-filtered set can't be served by a B-tree index (leading wildcard / suffix match). Fixing it needs either an FTS5-style index or narrowing the candidate set — a design decision, not a mechanical index add — so I filed a scoped follow-up for Lead Engineer instead of guessing.

## Test plan
- Added 3 new `EXPLAIN QUERY PLAN` regression tests to `tests/db/metadata-existence-index.test.ts` (mirroring the existing TRA-924 tests) asserting the antipatterns.ts callSites queries seek `idx_symbols_call_sites` instead of a bare `symbols` scan.
- `pnpm run build` — passes.
- `pnpm run lint` (`tsc --noEmit`) — passes.
- `pnpm test` — full suite: 919 files / 10217 tests passed, 22 pre-existing skips, 0 failures.

Closes TRA-940.