### PR TITLE
docs(antipatterns): TRA-944 — leave detectMemoryLeak's LIKE group unindexed, record the measurement

### DIFF
--- a/src/tools/quality/antipatterns.ts
+++ b/src/tools/quality/antipatterns.ts
@@ -995,6 +995,18 @@ function detectMemoryLeak(store: Store, data: PreFetchedData): AntipatternFindin
   // Strategy 1: Find cache-like variables/properties (Map/Set declarations or
   // name-based hints) and verify growth vs. cleanup via callSites in the same file.
   // Name patterns use word-endings to avoid matching `useStore`, `restoreX`, etc.
+  //
+  // TRA-944: the LIKE group below is deliberately left unindexed. SQLite seeks
+  // idx_symbols_kind for `kind IN (...)` (verified with EXPLAIN QUERY PLAN both
+  // with and without sqlite_stat1), then applies the LIKE patterns to that
+  // subset only. Measured on the largest real index on hand (59k symbols /
+  // 546 MB, ~41k of them variable/property/constant): 45-75 ms. An 8x synthetic
+  // copy (473k symbols): ~210 ms, i.e. linear, no cliff. Strategy 2 below reads
+  // and JSON-parses ~7 MB of callSites metadata on that same DB, so it dominates
+  // this detector's cost by an order of magnitude. Neither an FTS5/trigram index
+  // (new schema surface + migration) nor narrowing the candidate set (changes
+  // which rows the detector sees, i.e. false negatives) buys anything here.
+  // Revisit only if this query shows up in an actual profile.
   const cacheSymbols = store.db
     .prepare(`
     SELECT s.id, s.name, s.kind, s.symbol_id, s.line_start, s.signature,


### PR DESCRIPTION
Closes the TRA-944 design call: **leave the predicate as it is**, and record why in the code so the next audit run doesn't re-file it.

## Measurement

`detectMemoryLeak`'s Strategy 1 predicate, run against real indexes with `sqlite3 .timer on` (3 runs each, warm):

| DB | symbols | var/prop/const | time |
|---|---|---|---|
| largest real index on hand (546 MB) | 59,176 | 40,665 | 45–75 ms |
| 8x synthetic copy of the same DB | 473,408 | ~325k | ~210 ms |

`EXPLAIN QUERY PLAN` seeks `idx_symbols_kind (kind=?)` on a fresh DB with no `sqlite_stat1` — i.e. under the pre-`ANALYZE` condition these queries actually run in — and stays index-driven with stats present. Scaling is linear; no cliff.

For contrast, Strategy 2 in the same function pulls 11,635 rows and ~7 MB of `callSites` metadata off that DB and `JSON.parse`s all of it in JS. That, plus the per-file `getSymbolsByFile` walk, is where this detector's cost actually lives — an order of magnitude past the 50 ms SQL.

## Decision

Both options from the issue are net-negative at this cost:

- **FTS5/trigram index over `name`/`signature`** — new schema surface plus a migration, to save tens of milliseconds off a detector that isn't hot.
- **Narrow the candidate set before the LIKE filter** — changes which rows the detector considers, so it trades real false negatives for the same non-gain.

Comment-only diff: `src/tools/quality/antipatterns.ts` now carries the numbers, the query plan, and the revisit condition (this query showing up in an actual profile).

## Test evidence

`npx vitest run tests/tools/antipatterns.test.ts` → 49 passed. `biome ci` clean on the changed file. No behavior change.
