### PR TITLE
fix(indexer): remove N+1 signature query + metadata over-fetch in TS/Python call-edge resolvers (TRA-923)

### DIFF
--- a/src/indexer/edge-resolvers/python-calls.ts
+++ b/src/indexer/edge-resolvers/python-calls.ts
@@ -85,10 +85,12 @@ export function resolvePythonCallEdges(state: PipelineState, scope?: ChangeScope
 
   // 3. Build resolution indexes
 
-  // All Python symbols indexed by name → array of {id, symbol_id, file_id, kind, parent_symbol_id}
+  // All Python symbols indexed by name → array of {id, symbol_id, file_id, kind, parent_symbol_id}.
+  // `signature` is fetched here (not per-symbol below) — this query already
+  // runs on the full project on every single-file save.
   const allPySymbols = store.db
     .prepare(`
-    SELECT s.id, s.symbol_id, s.name, s.kind, s.file_id,
+    SELECT s.id, s.symbol_id, s.name, s.kind, s.file_id, s.signature,
            p.symbol_id AS parent_symbol_id
     FROM symbols s
     JOIN files f ON s.file_id = f.id
@@ -101,6 +103,7 @@ export function resolvePythonCallEdges(state: PipelineState, scope?: ChangeScope
     name: string;
     kind: string;
     file_id: number;
+    signature: string | null;
     parent_symbol_id: string | null;
   }>;
 
@@ -145,11 +148,8 @@ export function resolvePythonCallEdges(state: PipelineState, scope?: ChangeScope
   const returnTypeIndex = new Map<string, string>();
   for (const s of allPySymbols) {
     if (s.kind !== 'function' && s.kind !== 'method') continue;
-    const sigRow = store.db.prepare(`SELECT signature FROM symbols WHERE id = ?`).get(s.id) as
-      | { signature: string | null }
-      | undefined;
-    if (!sigRow?.signature) continue;
-    const retMatch = sigRow.signature.match(/-> *([A-Z][A-Za-z0-9_]*)/);
+    if (!s.signature) continue;
+    const retMatch = s.signature.match(/-> *([A-Z][A-Za-z0-9_]*)/);
     if (retMatch) {
       returnTypeIndex.set(s.name, retMatch[1]);
     }

--- a/src/indexer/edge-resolvers/typescript-calls.ts
+++ b/src/indexer/edge-resolvers/typescript-calls.ts
@@ -50,7 +50,7 @@ type SymEntry = {
   kind: string;
   file_id: number;
   parent_symbol_id: string | null;
-  metadata?: string | null;
+  signature: string | null;
   workspace: string | null;
 };
 
@@ -104,10 +104,17 @@ export function resolveTypeScriptCallEdges(state: PipelineState, scope?: ChangeS
 
   if (symbolsWithCalls.length === 0) return;
 
+  // Resolution universe: every TS/JS symbol, needed because a call target can
+  // live in any file. `metadata` is deliberately NOT selected here — it's a
+  // per-symbol JSON blob and this query already runs on the full project on
+  // every single-file save (targets are resolved globally); materializing it
+  // for every symbol just to read `extends` off the ~1% that are classes was
+  // the dominant cost. Classes are fetched separately below, narrowed to rows
+  // that actually carry heritage metadata (idx_symbols_has_heritage).
   const allSyms = store.db
     .prepare(`
-    SELECT s.id, s.symbol_id, s.name, s.kind, s.file_id,
-           p.symbol_id AS parent_symbol_id, s.metadata, f.workspace
+    SELECT s.id, s.symbol_id, s.name, s.kind, s.file_id, s.signature,
+           p.symbol_id AS parent_symbol_id, f.workspace
       FROM symbols s
       JOIN files f ON s.file_id = f.id
       LEFT JOIN symbols p ON s.parent_id = p.id
@@ -145,10 +152,23 @@ export function resolveTypeScriptCallEdges(state: PipelineState, scope?: ChangeS
     }
   }
 
-  // Build class heritage index: class symbol_id → extends class name (unresolved), implements
+  // Build class heritage index: class symbol_id → extends class name (unresolved), implements.
+  // Narrow scan — only classes whose metadata has heritage info, via the same
+  // partial index idx_symbols_has_heritage uses — instead of the metadata blob
+  // of every TS/JS symbol in the project.
   const classExtends = new Map<string, string>();
-  for (const s of allSyms) {
-    if (s.kind !== 'class' || !s.metadata) continue;
+  const classesWithExtends = store.db
+    .prepare(`
+    SELECT s.symbol_id, s.metadata
+      FROM symbols s
+      JOIN files f ON s.file_id = f.id
+     WHERE f.language IN ${TS_JS_LANGS}
+       AND s.kind = 'class'
+       AND s.metadata IS NOT NULL
+       AND json_extract(s.metadata, '$.extends') IS NOT NULL
+  `)
+    .all() as Array<{ symbol_id: string; metadata: string }>;
+  for (const s of classesWithExtends) {
     try {
       const meta = JSON.parse(s.metadata) as Record<string, unknown>;
       if (typeof meta.extends === 'string') classExtends.set(s.symbol_id, meta.extends);
@@ -159,14 +179,12 @@ export function resolveTypeScriptCallEdges(state: PipelineState, scope?: ChangeS
 
   // Build return-type index from signatures: funcName → type
   // `function getUser(): User` / `const getUser = (): User => ...`
+  // `signature` is already on the allSyms row (see query above) — no per-symbol query.
   const returnTypeIndex = new Map<string, string>();
   for (const s of allSyms) {
     if (s.kind !== 'function' && s.kind !== 'method') continue;
-    const row = store.db.prepare(`SELECT signature FROM symbols WHERE id = ?`).get(s.id) as
-      | { signature: string | null }
-      | undefined;
-    if (!row?.signature) continue;
-    const m = row.signature.match(/\):\s*(?:Promise<)?([A-Z][A-Za-z0-9_]*)/);
+    if (!s.signature) continue;
+    const m = s.signature.match(/\):\s*(?:Promise<)?([A-Z][A-Za-z0-9_]*)/);
     if (m) returnTypeIndex.set(s.name, m[1]);
   }
 


### PR DESCRIPTION
## Summary
- `resolveTypeScriptCallEdges` and `resolvePythonCallEdges` re-query the whole project's symbol universe on every single-file save — that part is unavoidable (cross-file call resolution needs it), but two things inside that scan were pure waste:
  - a `SELECT signature FROM symbols WHERE id = ?` run once per function/method **in the entire project**, instead of selecting `signature` once in the batch query
  - (TS only) `metadata` fetched for **every** TS/JS symbol just to read `extends` off the ~1% that are classes
- Both are fixed: `signature` is added to the existing universe `SELECT`; class heritage metadata is now a separate query narrowed to `kind = 'class'` with heritage metadata present (matches the existing `idx_symbols_has_heritage` partial index) instead of every symbol's blob.
- No behavior change — same edges produced (verified via existing resolver/pipeline tests), just fewer round trips and less data materialized per pass.

## Test plan
- [x] `pnpm run build` (tsc + tsup) — clean
- [x] `pnpm run lint` (`tsc --noEmit`) — clean
- [x] `pnpm exec biome check` on both changed files — clean
- [x] `pnpm run test --run` — 918 files / 10213 tests passed (1 pre-existing, unrelated flaky timeout in `security-scan-precision.test.ts` under full-suite parallel load — reproduced on `master` before this change too, passes standalone)
- [x] Targeted resolver/pipeline suites (`python-resolution`, `incremental-edge-resolution`, `get_call_graph`, `method-impact-repro`, `cha`, `metadata-existence-index`, `dataflow`, `traverse-graph`, `graph-query`) — all green, edge counts unchanged
- [x] Measured before/after on trace-mcp's own index (1064 TS/JS files, 5435 function/method symbols): `resolveTypeScriptCallEdges` for a one-file scope drops from a 37.76ms to a 16.54ms median (15 iters), identical edge output