### PR TITLE
perf(session): measure the per-session baseline instead of guessing at it (TRA-925)

### DIFF
--- a/docs/perf/session-baseline.md
+++ b/docs/perf/session-baseline.md
@@ -1,0 +1,87 @@
+---
+layout: default
+title: Per-session baseline cost
+permalink: /perf/session-baseline/
+description: Internal working document. What one trace-mcp stdio session costs before it does any work, and where that cost comes from.
+noindex: true
+---
+
+# Per-session baseline cost (TRA-925)
+
+What one stdio session costs before it does any real work, and where that cost
+actually comes from. Measured on macOS 15 / M5 Max, Node 22.22, trace-mcp
+v3.18.0 (`61ba971a`), on a machine also running the daemon and other sessions
+(so absolute numbers carry a few percent of noise; the split between the
+components does not).
+
+Harnesses in this repo:
+
+- `scripts/perf/local-backend-baseline.ts` — starts one `LocalBackend` and
+  reports start latency, RSS and thread count once `start()` resolves.
+- `scripts/perf/session-index-cost.ts` — full index of a project through the
+  session's own pipeline at a given `WORKERS=` count; reports wall time, peak
+  RSS (worker threads included — they live in the session's RSS) and threads.
+- `scripts/perf/extract-worker-rss.mjs` — per-worker RSS (TRA-811).
+
+## Measured baseline
+
+| Scenario | RSS | Threads | start() |
+|---|---|---|---|
+| Fresh stdio session, trivial project, 15 s after `initialize` (`dist/cli.js serve`) | 216 MB | 12 | — |
+| `LocalBackend` read-only (dangerous root), 2 s after start | 233 MB | 13 | 120 ms |
+| `LocalBackend` full mode on this repo, 2 s after start | 349 MB | 14 | 84 ms |
+| Full index of this repo (2 285 files, 11 180 symbols), peak | 390–450 MB | 11 | 9–15 s |
+
+The 884 MB / 21 threads in the TRA-925 report is not the *baseline* — it is a
+session that has been indexing. Sessions in the field were observed at
+386–864 MB after minutes of work; a fresh one starts at ~216 MB.
+
+## Where the baseline goes
+
+Per-step RSS of the session bootstrap (`src/` via tsx; process boots at 73 MB):
+
+| Step | ΔRSS | Δt |
+|---|---|---|
+| import config module | +20 MB | 62 ms |
+| loadConfig() | +1 MB | 7 ms |
+| import db + `initializeDatabase` + `Store` | +6 MB | 16 ms |
+| **import PluginRegistry (pulls all language + integration plugins)** | **+65 MB** | **158 ms** |
+| `PluginRegistry.createWithDefaults()` | +0.1 MB | 1 ms |
+| `ProgressState`, `ExtractPool`, `IndexingPipeline`, `FileWatcher` | +0.2 MB | 3 ms |
+| import indexing pipeline module | +6 MB | 32 ms |
+| `createAIProvider` | +0.7 MB | 7 ms |
+
+Same shape in the shipped bundle: `import('./dist/index.js')` alone costs
+**116 MB RSS / 327 ms**, before a single object exists.
+
+Two conclusions, both of which contradict the issue's original diagnosis:
+
+1. **Eager construction of the full stack costs ~7 MB and ~21 ms**, not
+   "~500 ms". Making it lazy behind the `readOnly` decision would buy ~3 % of
+   the baseline. Not worth the branching.
+2. **`ExtractPool` spawns no worker threads at construction** — spawn is lazy
+   since TRA-811 (first `extract()`), so a read-only or proxying session never
+   pays for workers at all. Guarded by
+   `tests/perf/extract-pool-lazy-spawn.test.ts`.
+
+The real per-session floor is **module-graph evaluation** — every session
+evaluates the whole 11.8 MB bundle. The language-plugin barrel
+(`src/indexer/plugins/language/all.ts`, ~120 plugins) is the largest single
+slice: making it a dynamic import cuts `dist/index.js` load from 155 MB / 327 ms
+to 145 MB / 218 ms.
+
+Useful finding for whoever does that work: **esbuild wraps dynamically-imported
+internal modules in a lazy `__esm` initializer even with `splitting: false`**,
+so deferring evaluation does not require changing the bundle shape — only
+turning the static import into `await import()` and threading the await through
+the (few) language-plugin call sites.
+
+## Worker count is not the lever on this corpus
+
+`WORKERS=` 1 / 2 / 4 over 2 285 files: 9–15 s wall and 390–450 MB peak in every
+configuration, with the spread dominated by machine noise. Peak RSS during a
+real index is dominated by the main-thread pipeline, not by pool size — even
+though an idle keepAlive worker holding parsed grammars costs ~62 MB
+(`extract-worker-rss.mjs`, 4 workers: +154 MB spawned, +249 MB after one parse
+each). Cutting the default pool size would trade throughput for nothing
+measurable here.

--- a/docs/perf/session-baseline.md
+++ b/docs/perf/session-baseline.md
@@ -8,33 +8,37 @@ noindex: true
 
 # Per-session baseline cost (TRA-925)
 
-What one stdio session costs before it does any real work, and where that cost
-actually comes from. Measured on macOS 15 / M5 Max, Node 22.22, trace-mcp
-v3.18.0 (`61ba971a`), on a machine also running the daemon and other sessions
-(so absolute numbers carry a few percent of noise; the split between the
-components does not).
+What one stdio session costs before it does any real work, what it costs once
+it starts indexing, and where each of those goes. Measured on macOS 15 / M5
+Max, Node 22.22, trace-mcp v3.18.0 (`61ba971a`), on a machine also running the
+daemon and other sessions — absolute numbers carry a few percent of noise, the
+split between components does not.
 
-Harnesses in this repo:
+Harnesses in this repo (all require `pnpm run build` first — unbundled runs
+resolve no extract-worker entry and silently measure in-process extraction
+instead):
 
-- `scripts/perf/local-backend-baseline.ts` — starts one `LocalBackend` and
-  reports start latency, RSS and thread count once `start()` resolves.
-- `scripts/perf/session-index-cost.ts` — full index of a project through the
-  session's own pipeline at a given `WORKERS=` count; reports wall time, peak
-  RSS (worker threads included — they live in the session's RSS) and threads.
+- `scripts/perf/local-backend-baseline.ts` — one `LocalBackend`; start latency,
+  RSS and threads at the instant `start()` resolves and again 2 s later.
+- `scripts/perf/session-index-cost.ts` — full index at a given `WORKERS=`;
+  wall time, peak RSS (worker threads included — they live in the session's
+  RSS) and peak threads.
 - `scripts/perf/extract-worker-rss.mjs` — per-worker RSS (TRA-811).
 
 ## Measured baseline
 
 | Scenario | RSS | Threads | start() |
 |---|---|---|---|
-| Fresh stdio session, trivial project, 15 s after `initialize` (`dist/cli.js serve`) | 216 MB | 12 | — |
-| `LocalBackend` read-only (dangerous root), 2 s after start | 233 MB | 13 | 120 ms |
-| `LocalBackend` full mode on this repo, 2 s after start | 349 MB | 14 | 84 ms |
-| Full index of this repo (2 285 files, 11 180 symbols), peak | 390–450 MB | 11 | 9–15 s |
+| Session proxying to a healthy daemon, peak over 65 s (`dist/cli.js serve`) | 166–174 MB | 12 | — |
+| `LocalBackend` read-only (dangerous root), at `start()` and 2 s later | 217–276 MB | 12–13 | 87–144 ms |
+| `LocalBackend` full mode on this repo, **at `start()`** | 222 MB | 14 | 101 ms |
+| Same, 2 s later — background `indexAll()` in flight, not a baseline | 350 MB | 14 | — |
+| Full index of this repo (2 285 files / 11 180 symbols), 4 workers, peak | 836–881 MB | 15–20 | 4.3–5.6 s |
 
-The 884 MB / 21 threads in the TRA-925 report is not the *baseline* — it is a
-session that has been indexing. Sessions in the field were observed at
-386–864 MB after minutes of work; a fresh one starts at ~216 MB.
+**The 884 MB / 21 threads in the TRA-925 report reproduces exactly — but it is
+not a baseline.** It is a session in the middle of indexing with a four-worker
+extract pool. A session that has not indexed sits at ~170–220 MB / 12–14
+threads.
 
 ## Where the baseline goes
 
@@ -43,7 +47,7 @@ Per-step RSS of the session bootstrap (`src/` via tsx; process boots at 73 MB):
 | Step | ΔRSS | Δt |
 |---|---|---|
 | import config module | +20 MB | 62 ms |
-| loadConfig() | +1 MB | 7 ms |
+| `loadConfig()` | +1 MB | 7 ms |
 | import db + `initializeDatabase` + `Store` | +6 MB | 16 ms |
 | **import PluginRegistry (pulls all language + integration plugins)** | **+65 MB** | **158 ms** |
 | `PluginRegistry.createWithDefaults()` | +0.1 MB | 1 ms |
@@ -54,34 +58,62 @@ Per-step RSS of the session bootstrap (`src/` via tsx; process boots at 73 MB):
 Same shape in the shipped bundle: `import('./dist/index.js')` alone costs
 **116 MB RSS / 327 ms**, before a single object exists.
 
-Two conclusions, both of which contradict the issue's original diagnosis:
+So the two mechanisms TRA-925 blamed for the baseline are not it:
 
 1. **Eager construction of the full stack costs ~7 MB and ~21 ms**, not
-   "~500 ms". Making it lazy behind the `readOnly` decision would buy ~3 % of
-   the baseline. Not worth the branching.
+   "~500 ms". Deferring it behind the `readOnly` decision would buy ~3 % of the
+   baseline; the comment claiming otherwise is corrected in
+   `src/daemon/router/local-backend.ts`.
 2. **`ExtractPool` spawns no worker threads at construction** — spawn is lazy
    since TRA-811 (first `extract()`), so a read-only or proxying session never
    pays for workers at all. Guarded by
    `tests/perf/extract-pool-lazy-spawn.test.ts`.
 
-The real per-session floor is **module-graph evaluation** — every session
-evaluates the whole 11.8 MB bundle. The language-plugin barrel
+The per-session *floor* is module-graph evaluation: every session evaluates the
+whole 11.8 MB bundle. The language-plugin barrel
 (`src/indexer/plugins/language/all.ts`, ~120 plugins) is the largest single
-slice: making it a dynamic import cuts `dist/index.js` load from 155 MB / 327 ms
-to 145 MB / 218 ms.
+slice — making it a dynamic import cut `dist/index.js` load from 155 MB /
+327 ms to 145 MB / 218 ms in a throwaway build. Useful finding for whoever does
+that work: **esbuild wraps dynamically-imported internal modules in a lazy
+`__esm` initializer even with `splitting: false`**, so deferring evaluation
+does not require changing the bundle shape — only turning static imports into
+`await import()` and threading the await through the call sites.
 
-Useful finding for whoever does that work: **esbuild wraps dynamically-imported
-internal modules in a lazy `__esm` initializer even with `splitting: false`**,
-so deferring evaluation does not require changing the bundle shape — only
-turning the static import into `await import()` and threading the await through
-the (few) language-plugin call sites.
+## Worker count is the lever once a session indexes
 
-## Worker count is not the lever on this corpus
+Full index of this repo, two runs per configuration:
 
-`WORKERS=` 1 / 2 / 4 over 2 285 files: 9–15 s wall and 390–450 MB peak in every
-configuration, with the spread dominated by machine noise. Peak RSS during a
-real index is dominated by the main-thread pipeline, not by pool size — even
-though an idle keepAlive worker holding parsed grammars costs ~62 MB
-(`extract-worker-rss.mjs`, 4 workers: +154 MB spawned, +249 MB after one parse
-each). Cutting the default pool size would trade throughput for nothing
-measurable here.
+| Workers | Wall time | Peak RSS | Peak threads |
+|---|---|---|---|
+| 4 (previous session default) | 4.3 s / 5.6 s | 836 MB / 881 MB | 15 / 20 |
+| 2 (**current session default**) | 6.2 s / 7.6 s | 630 MB / 634 MB | 13 / 13 |
+| 1 | 9.8 s / 10.7 s | 448 MB / 450 MB | 12 / 12 |
+
+Each live worker holds its own V8 isolate, tree-sitter WASM and every grammar
+it has touched — ~62 MB after one parse (`extract-worker-rss.mjs`: 4 workers,
++154 MB spawned, +249 MB after one parse each). Those threads are inside the
+session's RSS, which is why a four-worker session reaches 880 MB.
+
+`LocalBackend` therefore runs **2** workers instead of `min(4, cpus/2)`
+(`SESSION_EXTRACT_WORKERS`): −205 MB and −7 threads per indexing session for
++1.9 s of one-off indexing on this corpus. A fallback session indexes one
+project for one client, and during a daemon outage every client runs one — nine
+of them at 4 workers is ~7.9 GB, which is the ~6 GB originally reported. The
+daemon, which indexes on behalf of everyone, keeps its 4-worker pool, and an
+explicit `indexer.workers` still wins over both.
+
+Cost of the trade: on a repository several times this size the extra wall time
+scales with it (roughly +40 % of index time), and it is paid once per session
+start in the daemonless path only. Sessions proxying to a healthy daemon index
+nothing and are unaffected.
+
+## Earlier revision of this document was wrong here
+
+The first version of this page reported "worker count is not the lever: 1 / 2 /
+4 all land at 9–15 s and 390–450 MB". That measurement ran under `tsx`, where
+`resolveWorkerEntry()` finds no `extract-worker.js` next to the source module,
+so `pool.available` was `false` and all three configurations silently ran
+single-threaded in-process extraction — the numbers were three repeats of the
+same run. Caught in review by Reviewer B. The harness now requires an explicit
+built worker entry and throws when the pool is unavailable, so that failure
+cannot recur silently.

--- a/scripts/perf/local-backend-baseline.ts
+++ b/scripts/perf/local-backend-baseline.ts
@@ -2,8 +2,10 @@
  * TRA-925 measurement harness: per-session baseline cost of one LocalBackend.
  *
  * Starts a single LocalBackend against a root and reports start latency, RSS
- * and thread count once start() resolves — the "before any work" cost the
- * issue is about. Two modes:
+ * and thread count. Sampled twice: at the instant start() resolves, and 2 s
+ * later. Only the first sample is a baseline — on a real project root start()
+ * kicks off indexAll() in the background, so the second sample is indexing in
+ * flight, not idle cost. Two modes:
  *
  *   full     — a real project root (indexing stack live)
  *   readonly — a dangerous root, which LocalBackend serves read-only
@@ -46,22 +48,25 @@ const backend = new LocalBackend({
   sharedDbPath: path.join(indexRoot, 'index.db'),
 });
 
-const t0 = performance.now();
-await backend.start();
-const startMs = performance.now() - t0;
-
-// Let anything start() kicked off settle for a moment, then sample.
-await new Promise((r) => setTimeout(r, 2000));
-const mem = process.memoryUsage();
-console.log(
-  JSON.stringify({
-    root: projectRoot,
-    startMs: Math.round(startMs),
+const sample = () => {
+  const mem = process.memoryUsage();
+  return {
     rssMB: +(mem.rss / 1024 / 1024).toFixed(1),
     heapUsedMB: +(mem.heapUsed / 1024 / 1024).toFixed(1),
     externalMB: +(mem.external / 1024 / 1024).toFixed(1),
     threads: threadCount(),
-  }),
-);
+  };
+};
+
+const t0 = performance.now();
+await backend.start();
+const startMs = performance.now() - t0;
+const atStart = sample();
+// Second sample: on a project root this is background indexing in flight.
+await new Promise((r) => setTimeout(r, 2000));
+const after2s = sample();
+
+console.log(JSON.stringify({ root: projectRoot, startMs: Math.round(startMs), atStart, after2s }));
 await backend.stop();
+fs.rmSync(indexRoot, { recursive: true, force: true });
 process.exit(0);

--- a/scripts/perf/local-backend-baseline.ts
+++ b/scripts/perf/local-backend-baseline.ts
@@ -1,0 +1,67 @@
+/**
+ * TRA-925 measurement harness: per-session baseline cost of one LocalBackend.
+ *
+ * Starts a single LocalBackend against a root and reports start latency, RSS
+ * and thread count once start() resolves — the "before any work" cost the
+ * issue is about. Two modes:
+ *
+ *   full     — a real project root (indexing stack live)
+ *   readonly — a dangerous root, which LocalBackend serves read-only
+ *
+ * Usage: tsx scripts/perf/local-backend-baseline.ts [root] [--json]
+ * Threads are read from `ps -M` (macOS) / /proc/self/status (Linux).
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadConfig } from '../../src/config.js';
+import { LocalBackend } from '../../src/daemon/router/local-backend.js';
+
+function threadCount(): number {
+  try {
+    if (process.platform === 'darwin') {
+      const out = execFileSync('ps', ['-M', String(process.pid)], { encoding: 'utf8' });
+      return out.trim().split('\n').length - 1; // minus header
+    }
+    const status = fs.readFileSync('/proc/self/status', 'utf8');
+    return Number(/Threads:\s+(\d+)/.exec(status)?.[1] ?? 0);
+  } catch {
+    return -1;
+  }
+}
+
+const args = process.argv.slice(2).filter((a) => a !== '--json');
+const projectRoot = path.resolve(args[0] ?? process.cwd());
+const indexRoot = path.join(os.tmpdir(), `tra925-${process.pid}`);
+fs.mkdirSync(indexRoot, { recursive: true });
+
+const configResult = await loadConfig(projectRoot);
+if (configResult.isErr()) throw configResult.error;
+const config = configResult.value;
+const backend = new LocalBackend({
+  projectRoot,
+  indexRoot,
+  config,
+  sharedDbPath: path.join(indexRoot, 'index.db'),
+});
+
+const t0 = performance.now();
+await backend.start();
+const startMs = performance.now() - t0;
+
+// Let anything start() kicked off settle for a moment, then sample.
+await new Promise((r) => setTimeout(r, 2000));
+const mem = process.memoryUsage();
+console.log(
+  JSON.stringify({
+    root: projectRoot,
+    startMs: Math.round(startMs),
+    rssMB: +(mem.rss / 1024 / 1024).toFixed(1),
+    heapUsedMB: +(mem.heapUsed / 1024 / 1024).toFixed(1),
+    externalMB: +(mem.external / 1024 / 1024).toFixed(1),
+    threads: threadCount(),
+  }),
+);
+await backend.stop();
+process.exit(0);

--- a/scripts/perf/session-index-cost.ts
+++ b/scripts/perf/session-index-cost.ts
@@ -1,0 +1,73 @@
+/**
+ * TRA-925: memory/throughput cost of one stdio session's ExtractPool.
+ *
+ * Runs a full index of a project through the same pipeline a fallback session
+ * uses, with a given worker count, and reports wall time, peak RSS and thread
+ * count. Peak RSS is sampled from `ps`, so it includes worker-thread heaps —
+ * which is the whole point: worker threads live inside the session's RSS.
+ *
+ * Usage: WORKERS=4 tsx scripts/perf/session-index-cost.ts [root]
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadConfig } from '../../src/config.js';
+import { initializeDatabase } from '../../src/db/schema.js';
+import { Store } from '../../src/db/store.js';
+import { ExtractPool } from '../../src/indexer/extract-pool.js';
+import { IndexingPipeline } from '../../src/indexer/pipeline.js';
+import { SqliteTaskCache } from '../../src/pipeline/index.js';
+import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import { ProgressState } from '../../src/progress.js';
+
+const rssMB = () => Number(execFileSync('ps', ['-o', 'rss=', '-p', String(process.pid)])) / 1024;
+const threads = () =>
+  execFileSync('ps', ['-M', String(process.pid)], { encoding: 'utf8' })
+    .trim()
+    .split('\n').length - 1;
+
+const root = path.resolve(process.argv[2] ?? process.cwd());
+const workers = Number(process.env.WORKERS ?? 4);
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tra925-'));
+const configResult = await loadConfig(root);
+if (configResult.isErr()) throw configResult.error;
+const config = configResult.value;
+
+const db = initializeDatabase(path.join(dir, 'index.db'));
+const store = new Store(db);
+const registry = PluginRegistry.createWithDefaults();
+const progress = new ProgressState(db);
+const pool = new ExtractPool({ keepAlive: true, size: workers });
+const pipeline = new IndexingPipeline(store, registry, config, root, progress, {
+  extractPool: pool,
+  taskCache: new SqliteTaskCache(db),
+});
+
+let peak = 0;
+let peakThreads = 0;
+const sampler = setInterval(() => {
+  peak = Math.max(peak, rssMB());
+  peakThreads = Math.max(peakThreads, threads());
+}, 250);
+
+const t0 = performance.now();
+await pipeline.indexAll();
+const ms = Math.round(performance.now() - t0);
+clearInterval(sampler);
+peak = Math.max(peak, rssMB());
+
+console.log(
+  JSON.stringify({
+    root,
+    workers,
+    indexMs: ms,
+    files: store.db.prepare('SELECT COUNT(*) c FROM files').get() as unknown,
+    symbols: store.db.prepare('SELECT COUNT(*) c FROM symbols').get() as unknown,
+    peakRssMB: +peak.toFixed(1),
+    peakThreads,
+  }),
+);
+await pipeline.dispose();
+await pool.terminate();
+process.exit(0);

--- a/scripts/perf/session-index-cost.ts
+++ b/scripts/perf/session-index-cost.ts
@@ -6,12 +6,17 @@
  * count. Peak RSS is sampled from `ps`, so it includes worker-thread heaps —
  * which is the whole point: worker threads live inside the session's RSS.
  *
- * Usage: WORKERS=4 tsx scripts/perf/session-index-cost.ts [root]
+ * Requires `pnpm run build` first: unbundled runs resolve no worker entry, and
+ * the pipeline then falls back to in-process extraction — which would make
+ * every worker count measure the same thing.
+ *
+ * Usage: pnpm run build && WORKERS=4 tsx scripts/perf/session-index-cost.ts [root]
  */
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { loadConfig } from '../../src/config.js';
 import { initializeDatabase } from '../../src/db/schema.js';
 import { Store } from '../../src/db/store.js';
@@ -38,14 +43,22 @@ const db = initializeDatabase(path.join(dir, 'index.db'));
 const store = new Store(db);
 const registry = PluginRegistry.createWithDefaults();
 const progress = new ProgressState(db);
-const pool = new ExtractPool({ keepAlive: true, size: workers });
+const workerEntry = pathToFileURL(
+  path.resolve(import.meta.dirname, '../../dist/extract-worker.js'),
+);
+if (!fs.existsSync(workerEntry)) {
+  throw new Error(`no worker entry at ${workerEntry.pathname} — run \`pnpm run build\` first`);
+}
+const pool = new ExtractPool({ keepAlive: true, size: workers, workerEntry });
+if (!pool.available)
+  throw new Error('extract pool unavailable — would measure in-process extraction');
 const pipeline = new IndexingPipeline(store, registry, config, root, progress, {
   extractPool: pool,
   taskCache: new SqliteTaskCache(db),
 });
 
-let peak = 0;
-let peakThreads = 0;
+let peak = rssMB();
+let peakThreads = threads();
 const sampler = setInterval(() => {
   peak = Math.max(peak, rssMB());
   peakThreads = Math.max(peakThreads, threads());
@@ -56,6 +69,7 @@ await pipeline.indexAll();
 const ms = Math.round(performance.now() - t0);
 clearInterval(sampler);
 peak = Math.max(peak, rssMB());
+peakThreads = Math.max(peakThreads, threads());
 
 console.log(
   JSON.stringify({
@@ -70,4 +84,5 @@ console.log(
 );
 await pipeline.dispose();
 await pool.terminate();
+fs.rmSync(dir, { recursive: true, force: true });
 process.exit(0);

--- a/src/daemon/router/local-backend.ts
+++ b/src/daemon/router/local-backend.ts
@@ -153,7 +153,10 @@ export class LocalBackend implements Backend {
       );
     }
 
-    // Build all full-mode resources up-front — cheap (~500ms) compared to indexing.
+    // Build all full-mode resources up-front. Measured at ~7 MB / ~21 ms for the
+    // whole stack (TRA-925, docs/perf/session-baseline.md) — the session's real
+    // baseline is module evaluation, which has already happened by this point,
+    // so deferring these constructors behind `readOnly` would buy nothing.
     this.db = initializeDatabase(this.dbPath);
     writeServerPid(this.db);
     this.store = new Store(this.db);

--- a/src/daemon/router/local-backend.ts
+++ b/src/daemon/router/local-backend.ts
@@ -38,6 +38,9 @@ import type { ProjectRelay } from '../../server/types.js';
 import { seedSessionDbFromShared, sweepOrphanedSessionDbs } from './session-db.js';
 import type { Backend } from './types.js';
 
+/** Extract workers a fallback session runs — see the pool construction below. */
+const SESSION_EXTRACT_WORKERS = 2;
+
 const AI_COALESCE_WAIT_MS = 5_000;
 
 export interface LocalBackendOptions {
@@ -164,7 +167,14 @@ export class LocalBackend implements Backend {
     this.progress = new ProgressState(this.db);
     this.extractPool = new ExtractPool({
       keepAlive: true,
-      size: config.indexer?.workers,
+      // Half the daemon's pool. A fallback session indexes one project for one
+      // client, and its worker threads live inside its own RSS: measured on
+      // this repo (2 285 files), 4 workers peak at 836-881 MB / 20 threads
+      // against 630 MB / 13 threads at 2, for 4.3 s vs 6.2 s of indexing
+      // (TRA-925, docs/perf/session-baseline.md). During a daemon outage every
+      // client runs one of these, so ~205 MB per session buys more than 1.9 s
+      // of one-off indexing. The daemon, which indexes for everyone, keeps 4.
+      size: config.indexer?.workers ?? SESSION_EXTRACT_WORKERS,
     });
     // Daemon-style long-lived process: use the SQLite-backed task cache so
     // pass outputs persist on disk rather than accumulating in resident set.

--- a/src/indexer/extract-pool.ts
+++ b/src/indexer/extract-pool.ts
@@ -91,6 +91,12 @@ const DEFAULT_KEEPALIVE_WORKER_COUNT = Math.max(1, Math.min(4, Math.floor(os.cpu
 
 export interface ExtractPoolOptions {
   size?: number;
+  /** Override the bundled worker entry. Only measurement harnesses and tests
+   *  pass this — they run unbundled (tsx/vitest), where `./extract-worker.js`
+   *  does not exist next to this module, so the pool would silently report
+   *  itself unavailable and every measurement would be of in-process
+   *  extraction instead (TRA-925). */
+  workerEntry?: URL;
   /** When true, use the long daemon-mode idle window instead of the short CLI
    *  one, so workers stay warm across bursty edits. CLI/tests pass false so the
    *  process can exit cleanly the moment the pool drains. */
@@ -180,7 +186,7 @@ export class ExtractPool {
     const o: ExtractPoolOptions = typeof opts === 'number' ? { size: opts } : opts;
     this.keepAlive = o.keepAlive ?? false;
     this.size = o.size ?? (this.keepAlive ? DEFAULT_KEEPALIVE_WORKER_COUNT : DEFAULT_WORKER_COUNT);
-    this.workerEntry = resolveWorkerEntry();
+    this.workerEntry = o.workerEntry ?? resolveWorkerEntry();
   }
 
   /** True when workers are usable in the current runtime (bundled build). */

--- a/tests/perf/extract-pool-lazy-spawn.test.ts
+++ b/tests/perf/extract-pool-lazy-spawn.test.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { ExtractPool } from '../../src/indexer/extract-pool.js';
 
@@ -6,7 +7,15 @@ describe('ExtractPool spawn is lazy (TRA-925)', () => {
     // A read-only / proxying session builds the indexing stack but never
     // extracts. Each live worker costs ~62 MB of the session's RSS, so
     // construction must stay free — see docs/perf/session-baseline.md.
-    const pool = new ExtractPool({ keepAlive: true, size: 4 });
+    //
+    // The explicit workerEntry matters: unbundled (vitest) runs resolve no
+    // entry, and ensureStarted() returns early when there is none — so without
+    // it this assertion would hold even if the constructor spawned eagerly.
+    const entry = pathToFileURL(
+      fileURLToPath(new URL('../../dist/extract-worker.js', import.meta.url)),
+    );
+    const pool = new ExtractPool({ keepAlive: true, size: 4, workerEntry: entry });
+    expect(pool.available).toBe(true);
     expect((pool as unknown as { workers: unknown[] }).workers).toHaveLength(0);
     await pool.terminate();
   });

--- a/tests/perf/extract-pool-lazy-spawn.test.ts
+++ b/tests/perf/extract-pool-lazy-spawn.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { ExtractPool } from '../../src/indexer/extract-pool.js';
+
+describe('ExtractPool spawn is lazy (TRA-925)', () => {
+  it('constructing a keepAlive pool spawns no worker threads', async () => {
+    // A read-only / proxying session builds the indexing stack but never
+    // extracts. Each live worker costs ~62 MB of the session's RSS, so
+    // construction must stay free — see docs/perf/session-baseline.md.
+    const pool = new ExtractPool({ keepAlive: true, size: 4 });
+    expect((pool as unknown as { workers: unknown[] }).workers).toHaveLength(0);
+    await pool.terminate();
+  });
+});


### PR DESCRIPTION
## What

TRA-925 reported "884 MB and 21 threads before any work" per stdio session and proposed lazy construction of the indexing stack behind `readOnly`. I measured before changing anything. The report's *number* reproduces exactly — but not as a baseline, and not for the reason the issue gave.

Measured on macOS 15 / M5 Max, Node 22.22, v3.18.0 (`61ba971a`), machine also running the daemon and other sessions.

## The 884 MB is a session mid-index, and worker count is the lever

Full index of this repo (2 285 files / 11 180 symbols), two runs per configuration:

| Workers | Wall time | Peak RSS | Peak threads |
|---|---|---|---|
| 4 (previous session default) | 4.3 s / 5.6 s | 836 MB / 881 MB | 15 / 20 |
| **2 (new session default)** | 6.2 s / 7.6 s | 630 MB / 634 MB | 13 / 13 |
| 1 | 9.8 s / 10.7 s | 448 MB / 450 MB | 12 / 12 |

Each live worker holds its own V8 isolate, tree-sitter WASM and every grammar it touched (~62 MB after one parse), and those threads live inside the session's RSS.

So `LocalBackend` now runs **2** workers instead of `min(4, cpus/2)`: **−205 MB and −7 threads per indexing session for +1.9 s of one-off indexing** on this corpus. During a daemon outage every client runs one of these — nine at 4 workers is ~7.9 GB, which is the ~6 GB originally reported. The daemon, which indexes for everyone, keeps its 4-worker pool; an explicit `indexer.workers` still wins over both.

A session that has *not* indexed is ~170–220 MB / 12–14 threads:

| Scenario | RSS | Threads | start() |
|---|---|---|---|
| Proxying to a healthy daemon, peak over 65 s | 166–174 MB | 12 | — |
| `LocalBackend` read-only (dangerous root) | 217–276 MB | 12–13 | 87–144 ms |
| `LocalBackend` full mode, **at `start()`** | 222 MB | 14 | 101 ms |
| Same, 2 s later (background `indexAll()` in flight) | 350 MB | 14 | — |

## The issue's two named causes are not causes

Bootstrap attribution (process boots at 73 MB):

| Step | ΔRSS | Δt |
|---|---|---|
| import config | +20 MB | 62 ms |
| import db + `initializeDatabase` + `Store` | +6 MB | 16 ms |
| **import PluginRegistry (~120 language + integration plugins)** | **+65 MB** | **158 ms** |
| `createWithDefaults()` + `ProgressState` + `ExtractPool` + `IndexingPipeline` + `FileWatcher` + `createAIProvider` | **+1 MB** | **12 ms** |

1. **Eager construction costs ~7 MB / ~21 ms**, not "~500 ms" — deferring it behind `readOnly` buys ~3 % of the baseline. Comment corrected in place.
2. **`ExtractPool` spawns no workers at construction** (lazy since TRA-811), so a read-only or proxying session never pays for workers at all. Now guarded by a test that actually bites.
3. The remaining floor is **module-graph evaluation**: `import('./dist/index.js')` is 116 MB / 327 ms before any object exists. Deferring the language-plugin barrel cut that to 145 MB / 218 ms in a throwaway build — worth a separate bundle issue, not this one. Recorded there: **esbuild wraps dynamically-imported internal modules in a lazy `__esm` initializer even with `splitting: false`**, so that work does not need a bundle-shape change.

## Review round 1 (Reviewer B) — what it caught

The first revision of this PR concluded "worker count is not the lever". That was a harness artefact: `session-index-cost.ts` ran under `tsx`, where `resolveWorkerEntry()` finds no `extract-worker.js` next to the source module, so `pool.available` was `false` and `WORKERS=1/2/4` were three repeats of the same single-threaded run. Re-measured with a real pool, the conclusion reverses — and it is what produced the change in this PR. Also fixed from that review:

- `ExtractPoolOptions.workerEntry` so harnesses/tests can point at the built worker; the harness now throws when the pool is unavailable instead of silently measuring in-process extraction.
- `tests/perf/extract-pool-lazy-spawn.test.ts` passed vacuously (no worker entry under vitest ⇒ `ensureStarted()` returned early). It now supplies an entry, and I verified it fails when the constructor is made to spawn eagerly.
- `local-backend-baseline.ts` samples at `start()` as well as 2 s later — the 349 MB figure was background indexing in flight, not a baseline.
- Both harnesses clean up their temp dirs; peak threads sampled outside the interval.

## Changes

- `src/daemon/router/local-backend.ts` — `SESSION_EXTRACT_WORKERS = 2`; corrected "~500 ms" comment.
- `src/indexer/extract-pool.ts` — optional `workerEntry` override (no default behaviour change).
- `scripts/perf/local-backend-baseline.ts`, `scripts/perf/session-index-cost.ts` — the two harnesses.
- `docs/perf/session-baseline.md` — numbers, method, conclusions, and the retraction of the wrong first version.
- `tests/perf/extract-pool-lazy-spawn.test.ts` — guards lazy spawn.

Full suite green locally (10 216 passed).

Closes TRA-925.
