### PR TITLE
fix(app): tell a busy daemon from a missing one (TRA-939)

### DIFF
--- a/packages/app/src/main/__tests__/daemon-install.test.ts
+++ b/packages/app/src/main/__tests__/daemon-install.test.ts
@@ -445,6 +445,9 @@ describe('a live but unanswering daemon', () => {
     'reports a busy daemon, not a failed install, and does not spend the cold-start budget',
     async () => {
       const port = await wedgedListener();
+      // First run installs; the second changes nothing, so the daemon holding
+      // the port on entry is one that was already there — busy, not starting.
+      await run(port, { probeHealth: async () => true });
       const started = Date.now();
       const result = await run(port, { busyTimeoutMs: 300 });
       const elapsed = Date.now() - started;
@@ -454,8 +457,41 @@ describe('a live but unanswering daemon', () => {
       expect(message).toContain('busy');
       expect(message).not.toContain('never answered');
       // The regression this guards: 30 s of "Setting up trace-mcp" over an
-      // index that was readable on disk the whole time.
-      expect(elapsed).toBeLessThan(5_000);
+      // index that was readable on disk the whole time. The ceiling is the
+      // budget itself — a poll that outlives it is the bug next door.
+      expect(elapsed).toBeLessThan(1_500);
+    },
+  );
+
+  it.runIf(process.platform === 'darwin')(
+    'still gives a daemon it just restarted the full cold-start budget',
+    async () => {
+      const port = await wedgedListener();
+      const started = Date.now();
+      // A first run: this one installs and starts the daemon, so a held port
+      // means "coming up", and cutting the wait short would call a cold start
+      // busy. The verdict is still "busy", never "install failed".
+      const result = await run(port, { healthTimeoutMs: 600, busyTimeoutMs: 10 });
+      expect(result.state.phase).toBe('unresponsive');
+      expect(Date.now() - started).toBeGreaterThanOrEqual(600);
+    },
+  );
+
+  it.runIf(process.platform === 'darwin')(
+    'calls a daemon that died during the wait missing, not busy',
+    async () => {
+      const port = await wedgedListener();
+      await run(port, { probeHealth: async () => true });
+      const result = await run(port, {
+        busyTimeoutMs: 100,
+        probeHealth: async () => {
+          // The daemon exits while we wait: the port is free by the time the
+          // verdict is written, and the verdict has to follow.
+          for (const srv of servers.splice(0)) await new Promise<void>((r) => srv.close(() => r()));
+          return false;
+        },
+      });
+      expect(result.state.phase).toBe('failed');
     },
   );
 

--- a/packages/app/src/main/__tests__/daemon-install.test.ts
+++ b/packages/app/src/main/__tests__/daemon-install.test.ts
@@ -6,12 +6,15 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import net from 'node:net';
 import {
   compareVersions,
   decideTakeover,
   bundledServerDir,
   ensureDaemonInstalled,
+  type EnsureOptions,
   generatePlist,
+  isPortHeld,
   launcherEnvContent,
   PLIST_MARKER,
   readLauncherEnv,
@@ -237,7 +240,7 @@ describe('ensureDaemonInstalled', () => {
   let bootstrapped: boolean;
   const previousHome = process.env.TRACE_MCP_HOME;
 
-  const run = (appVersion: string) =>
+  const run = (appVersion: string, extra: Partial<EnsureOptions> = {}) =>
     ensureDaemonInstalled({
       appVersion,
       execPath: '/Applications/trace-mcp.app/Contents/MacOS/trace-mcp',
@@ -251,6 +254,7 @@ describe('ensureDaemonInstalled', () => {
       },
       probeHealth: async () => true,
       log: () => {},
+      ...extra,
     });
 
   beforeEach(() => {
@@ -373,5 +377,96 @@ describe('ensureDaemonInstalled', () => {
     expect(result.changed).toBe(false);
     expect(calls).toEqual([]);
     expect(fs.existsSync(path.join(home, 'launcher.env'))).toBe(false);
+  });
+});
+
+/* TRA-939: a daemon that holds the port and does not answer is a different
+   state from a daemon that was never installed, and the app used to call both
+   "Setup didn't finish" after spending 30 s finding out. */
+describe('a live but unanswering daemon', () => {
+  let home: string;
+  let resources: string;
+  let launchAgent: string;
+  const previousHome = process.env.TRACE_MCP_HOME;
+  const servers: net.Server[] = [];
+
+  /** A socket that holds the port and never answers — the wedged daemon. */
+  const wedgedListener = async (): Promise<number> => {
+    const srv = net.createServer();
+    servers.push(srv);
+    await new Promise<void>((r) => srv.listen({ port: 0, host: '127.0.0.1', backlog: 1 }, r));
+    srv.on('connection', () => {
+      /* accepted, never answered */
+    });
+    return (srv.address() as net.AddressInfo).port;
+  };
+
+  const run = (port: number, extra: Partial<EnsureOptions> = {}) =>
+    ensureDaemonInstalled({
+      appVersion: '3.7.0',
+      execPath: '/Applications/trace-mcp.app/Contents/MacOS/trace-mcp',
+      resourcesPath: resources,
+      launchAgentPath: launchAgent,
+      port,
+      runLaunchctl: () => ({ ok: false, stderr: '' }),
+      log: () => {},
+      ...extra,
+    });
+
+  beforeEach(() => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-wedge-'));
+    home = path.join(tmp, 'home');
+    resources = path.join(tmp, 'Resources');
+    launchAgent = path.join(tmp, 'com.trace-mcp.server.plist');
+    fs.mkdirSync(path.join(resources, 'server', 'dist'), { recursive: true });
+    fs.mkdirSync(path.join(resources, 'server', 'hooks'), { recursive: true });
+    fs.writeFileSync(path.join(resources, 'server', 'dist', 'cli.js'), '');
+    fs.writeFileSync(path.join(resources, 'server', 'hooks', 'trace-mcp-launcher.sh'), '#!/bin/bash\n');
+    process.env.TRACE_MCP_HOME = home;
+  });
+
+  afterEach(() => {
+    for (const s of servers.splice(0)) s.close();
+    if (previousHome === undefined) delete process.env.TRACE_MCP_HOME;
+    else process.env.TRACE_MCP_HOME = previousHome;
+  });
+
+  it('tells a held port from a free one by binding, not by connecting', async () => {
+    const port = await wedgedListener();
+    expect(await isPortHeld(port)).toBe(true);
+    const free = net.createServer();
+    await new Promise<void>((r) => free.listen({ port: 0, host: '127.0.0.1' }, r));
+    const freePort = (free.address() as net.AddressInfo).port;
+    await new Promise<void>((r) => free.close(() => r()));
+    expect(await isPortHeld(freePort)).toBe(false);
+  });
+
+  it.runIf(process.platform === 'darwin')(
+    'reports a busy daemon, not a failed install, and does not spend the cold-start budget',
+    async () => {
+      const port = await wedgedListener();
+      const started = Date.now();
+      const result = await run(port, { busyTimeoutMs: 300 });
+      const elapsed = Date.now() - started;
+
+      expect(result.state.phase).toBe('unresponsive');
+      const message = (result.state as { message: string }).message;
+      expect(message).toContain('busy');
+      expect(message).not.toContain('never answered');
+      // The regression this guards: 30 s of "Setting up trace-mcp" over an
+      // index that was readable on disk the whole time.
+      expect(elapsed).toBeLessThan(5_000);
+    },
+  );
+
+  it.runIf(process.platform === 'darwin')('still calls it failed when nothing is listening', async () => {
+    const free = net.createServer();
+    await new Promise<void>((r) => free.listen({ port: 0, host: '127.0.0.1' }, r));
+    const port = (free.address() as net.AddressInfo).port;
+    await new Promise<void>((r) => free.close(() => r()));
+
+    const result = await run(port, { healthTimeoutMs: 200 });
+    expect(result.state.phase).toBe('failed');
+    expect((result.state as { message: string }).message).toContain('nothing is listening');
   });
 });

--- a/packages/app/src/main/daemon-install.ts
+++ b/packages/app/src/main/daemon-install.ts
@@ -401,6 +401,9 @@ export function isPortHeld(port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const probe = net.createServer();
     probe.once('error', (err: NodeJS.ErrnoException) => {
+      // Only EADDRINUSE proves a listener. Any other bind failure (EACCES on a
+      // locked-down machine) is not evidence of one, and answering "held" on it
+      // would call a machine with no daemon busy.
       resolve(err.code === 'EADDRINUSE');
     });
     probe.listen({ port, host: '127.0.0.1', exclusive: true }, () => {
@@ -424,7 +427,10 @@ async function waitForHealth(port: number, timeoutMs: number): Promise<boolean> 
   while (Date.now() < deadline) {
     const ok = await new Promise<boolean>((resolve) => {
       const req = http.get(
-        { host: '127.0.0.1', port, path: '/health', timeout: 2000 },
+        // Bounded by whatever is left of the budget as well as by its own
+        // ceiling: a 2 s poll started at 4.9 s of a 5 s budget otherwise runs
+        // the wait 35% past the number the caller asked for.
+        { host: '127.0.0.1', port, path: '/health', timeout: Math.min(2000, Math.max(1, deadline - Date.now())) },
         (res) => {
           res.resume();
           resolve(res.statusCode === 200);
@@ -595,6 +601,13 @@ export async function ensureDaemonInstalled(opts: EnsureOptions): Promise<Ensure
   // CLI has migrated and `trace-mcp` on one it has not.
   const shimPath = getLauncherShimPath(home);
 
+  /* Was a daemon already answering for this port before we touched launchd?
+     Asked here, not after the restart: a daemon we just kickstarted binds its
+     socket in milliseconds and only becomes healthy once it has loaded its
+     index, so "port held" after the restart says nothing about whether the
+     wait is a cold start or a wedge. Before the restart it says exactly that. */
+  const heldOnEntry = await isPortHeld(port);
+
   let plistCurrent = false;
   try {
     plistCurrent = fs.readFileSync(plist, 'utf-8').includes(PLIST_MARKER);
@@ -638,21 +651,23 @@ export async function ensureDaemonInstalled(opts: EnsureOptions): Promise<Ensure
     return { state: { phase: 'ready' }, changed, reason: decision.reason };
   }
 
-  /* A daemon that is already listening is not being waited *for* — it is
-     there. Give it a short grace period rather than the full cold-start budget:
-     30 s of "Setting up trace-mcp" on a screen whose data has been on disk the
-     whole time is the defect, and the surfaces revalidate on their own once it
-     answers (TRA-939). */
-  const held = await isPortHeld(port);
-  const budget = held ? (opts.busyTimeoutMs ?? 5_000) : (opts.healthTimeoutMs ?? 30_000);
+  /* A daemon that was already listening before we started is not being waited
+     *for* — it is there, and busy. Give it a short grace period rather than the
+     full cold-start budget: 30 s of "Setting up trace-mcp" on a screen whose
+     data has been on disk the whole time is the defect, and the surfaces
+     revalidate on their own once it answers (TRA-939). One we just started gets
+     the whole 30 s, because loading an index legitimately takes that long. */
+  const busy = heldOnEntry && !changed;
+  const budget = busy ? (opts.busyTimeoutMs ?? 5_000) : (opts.healthTimeoutMs ?? 30_000);
   const healthy = await (opts.probeHealth ?? waitForHealth)(port, budget);
   if (healthy) {
     log('daemon install: /health responding');
     return { state: { phase: 'ready' }, changed, reason: decision.reason };
   }
-  /* Ask again after the wait: a daemon that came up during the probe but is
-     too busy to answer still gets called busy, not missing. */
-  if (held || (await isPortHeld(port))) {
+  /* Ask again, always: the answer that matters is whether a daemon is holding
+     the port *now*. One that came up during the wait is busy, and one that died
+     during it is missing — neither is knowable from the state on entry. */
+  if (await isPortHeld(port)) {
     const message = `The daemon is running and holding port ${port}, but it has not answered /health for ${Math.round(budget / 1000)}s — most likely busy indexing. Nothing needs reinstalling. See ${path.join(home, 'daemon.log')}.`;
     log(`daemon install: ${message}`);
     return { state: { phase: 'unresponsive', message }, changed, reason: decision.reason };

--- a/packages/app/src/main/daemon-install.ts
+++ b/packages/app/src/main/daemon-install.ts
@@ -31,6 +31,7 @@ import {
 } from 'node:child_process';
 import fs from 'node:fs';
 import http from 'node:http';
+import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import {
@@ -125,6 +126,10 @@ export type DaemonSetupState =
   | { phase: 'idle' }
   | { phase: 'installing' }
   | { phase: 'ready' }
+  /* The daemon exists, holds the port and did not answer in time — busy, not
+     missing (TRA-939). A different cause and a different cure from `failed`:
+     nothing here needs reinstalling, so this state offers no repair button. */
+  | { phase: 'unresponsive'; message: string }
   | { phase: 'failed'; message: string };
 
 // ── filesystem layer ─────────────────────────────────────────────────
@@ -379,8 +384,43 @@ function plistPath(): string {
   return path.join(os.homedir(), 'Library', 'LaunchAgents', `${PLIST_LABEL}.plist`);
 }
 
+/**
+ * Is something already listening on this port?
+ *
+ * Asked by binding, not by connecting: a wedged daemon's accept queue is full,
+ * so a connect attempt sits in SYN_SENT and answers nothing — which is exactly
+ * the state we are trying to name. A bind that fails with EADDRINUSE proves a
+ * LISTEN socket is held without adding one more connection to the queue.
+ *
+ * ponytail: this holds the port for the ~1 ms of a successful bind, so a daemon
+ * binding in exactly that window would see EADDRINUSE and be restarted by
+ * launchd. Called twice per launch at most; if that ever shows up in the logs,
+ * the upgrade path is reading the LISTEN table (`lsof`/`netstat`) instead.
+ */
+export function isPortHeld(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = net.createServer();
+    probe.once('error', (err: NodeJS.ErrnoException) => {
+      resolve(err.code === 'EADDRINUSE');
+    });
+    probe.listen({ port, host: '127.0.0.1', exclusive: true }, () => {
+      probe.close(() => resolve(false));
+    });
+  });
+}
+
+/**
+ * Poll /health until it answers or the budget runs out.
+ *
+ * The wait between attempts doubles (TRA-939). A fixed 500 ms poll spent the
+ * whole 30 s budget opening 60 connections into an accept queue that was
+ * already full — the client's retries were part of what kept it full. Backing
+ * off costs nothing when the daemon is coming up in a second or two, and stops
+ * the app from making a busy daemon busier.
+ */
 async function waitForHealth(port: number, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
+  let wait = 250;
   while (Date.now() < deadline) {
     const ok = await new Promise<boolean>((resolve) => {
       const req = http.get(
@@ -397,7 +437,8 @@ async function waitForHealth(port: number, timeoutMs: number): Promise<boolean> 
       });
     });
     if (ok) return true;
-    await new Promise((r) => setTimeout(r, 500));
+    await new Promise((r) => setTimeout(r, Math.min(wait, Math.max(0, deadline - Date.now()))));
+    wait = Math.min(wait * 2, 4000);
   }
   return false;
 }
@@ -412,6 +453,9 @@ export interface EnsureOptions {
   port?: number;
   /** How long to wait for /health before calling the install failed. */
   healthTimeoutMs?: number;
+  /** How long to wait when the port is already held — a daemon that exists is
+      not being waited for, it is being given a moment. */
+  busyTimeoutMs?: number;
   log?: (message: string) => void;
   /* Seams, so the idempotence and file-layout tests can run without touching
      the machine's real LaunchAgents directory or its launchd domain. */
@@ -594,12 +638,26 @@ export async function ensureDaemonInstalled(opts: EnsureOptions): Promise<Ensure
     return { state: { phase: 'ready' }, changed, reason: decision.reason };
   }
 
-  const healthy = await (opts.probeHealth ?? waitForHealth)(port, opts.healthTimeoutMs ?? 30_000);
+  /* A daemon that is already listening is not being waited *for* — it is
+     there. Give it a short grace period rather than the full cold-start budget:
+     30 s of "Setting up trace-mcp" on a screen whose data has been on disk the
+     whole time is the defect, and the surfaces revalidate on their own once it
+     answers (TRA-939). */
+  const held = await isPortHeld(port);
+  const budget = held ? (opts.busyTimeoutMs ?? 5_000) : (opts.healthTimeoutMs ?? 30_000);
+  const healthy = await (opts.probeHealth ?? waitForHealth)(port, budget);
   if (healthy) {
     log('daemon install: /health responding');
     return { state: { phase: 'ready' }, changed, reason: decision.reason };
   }
-  const message = `The daemon was installed but never answered on port ${port}. See ${path.join(home, 'daemon.log')}.`;
+  /* Ask again after the wait: a daemon that came up during the probe but is
+     too busy to answer still gets called busy, not missing. */
+  if (held || (await isPortHeld(port))) {
+    const message = `The daemon is running and holding port ${port}, but it has not answered /health for ${Math.round(budget / 1000)}s — most likely busy indexing. Nothing needs reinstalling. See ${path.join(home, 'daemon.log')}.`;
+    log(`daemon install: ${message}`);
+    return { state: { phase: 'unresponsive', message }, changed, reason: decision.reason };
+  }
+  const message = `The daemon was installed but nothing is listening on port ${port}. See ${path.join(home, 'daemon.log')}.`;
   log(`daemon install: ${message}`);
   return { state: { phase: 'failed', message }, changed, reason: decision.reason };
 }

--- a/packages/app/src/renderer/components/DaemonDownPane.tsx
+++ b/packages/app/src/renderer/components/DaemonDownPane.tsx
@@ -24,6 +24,7 @@ type SetupState =
   | { phase: 'idle' }
   | { phase: 'installing' }
   | { phase: 'ready' }
+  | { phase: 'unresponsive'; message: string }
   | { phase: 'failed'; message: string };
 
 /** Follow the main process's daemon-install progress. `idle` outside Electron. */
@@ -63,6 +64,20 @@ export function DaemonDownPane({
         iconSize={32}
         title={t('daemonInstallingTitle')}
         subtitle={t('daemonInstallingSubtitle')}
+      />
+    );
+  }
+
+  /* Live but not answering. No repair button: there is nothing broken to
+     repair, and "Try again" here would reinstall a working daemon (TRA-939).
+     The surfaces behind this pane keep revalidating, so it clears itself. */
+  if (setup.phase === 'unresponsive') {
+    return (
+      <EmptyState
+        icon="cable"
+        iconSize={32}
+        title={t('daemonBusyTitle')}
+        subtitle={setup.message}
       />
     );
   }

--- a/packages/app/src/renderer/components/SetupWizard.tsx
+++ b/packages/app/src/renderer/components/SetupWizard.tsx
@@ -79,7 +79,9 @@ export function SetupWizard({ onClose, initialStep }: SetupWizardProps) {
       if (window.electronAPI?.daemonSetupState) {
         const state = await window.electronAPI.daemonSetupState();
         if (cancelled) return;
-        if (state?.phase === 'ready') {
+        // A busy daemon is an installed daemon — the wizard's question is
+        // whether one exists, not whether it is idle right now (TRA-939).
+        if (state?.phase === 'ready' || state?.phase === 'unresponsive') {
           setDaemonState({ phase: 'ready' });
           setStep('clients');
           return;
@@ -111,7 +113,7 @@ export function SetupWizard({ onClose, initialStep }: SetupWizardProps) {
     // Listen for live daemon setup state updates
     const unsubscribe = window.electronAPI?.onDaemonSetupState?.((state) => {
       if (cancelled) return;
-      if (state.phase === 'ready') {
+      if (state.phase === 'ready' || state.phase === 'unresponsive') {
         setDaemonState({ phase: 'ready' });
         setStep('clients');
       } else if (state.phase === 'installing') {
@@ -335,7 +337,7 @@ export function SetupWizard({ onClose, initialStep }: SetupWizardProps) {
     setDaemonState({ phase: 'installing' });
     try {
       const result = await window.electronAPI?.retryDaemonSetup?.();
-      if (result?.phase === 'ready') {
+      if (result?.phase === 'ready' || result?.phase === 'unresponsive') {
         setDaemonState({ phase: 'ready' });
         setStep('clients');
       } else if (result?.phase === 'failed') {

--- a/packages/app/src/renderer/electron.d.ts
+++ b/packages/app/src/renderer/electron.d.ts
@@ -7,6 +7,7 @@ type DaemonSetupState =
   | { phase: 'idle' }
   | { phase: 'installing' }
   | { phase: 'ready' }
+  | { phase: 'unresponsive'; message: string }
   | { phase: 'failed'; message: string };
 
 declare global {

--- a/packages/app/src/shared/i18n/catalog/de/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/de/workspace.ts
@@ -7,6 +7,7 @@ export const workspace = {
   startingDaemon: 'Wird gestartet…',
   daemonInstallingTitle: 'trace-mcp wird eingerichtet',
   daemonInstallingSubtitle: 'Der Hintergrunddienst, der deine Projekte indexiert, wird installiert. Das passiert einmal und dauert ein paar Sekunden.',
+  daemonBusyTitle: 'Der Dienst ist beschäftigt',
   daemonInstallFailedTitle: 'Einrichtung nicht abgeschlossen',
   daemonInstallRetry: 'Erneut versuchen',
   daemonInstallRetrying: 'Wird eingerichtet…',

--- a/packages/app/src/shared/i18n/catalog/en/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/en/workspace.ts
@@ -15,6 +15,7 @@ export const workspace = {
   startingDaemon: 'Starting…',
   daemonInstallingTitle: 'Setting up trace-mcp',
   daemonInstallingSubtitle: 'Installing the background service that indexes your projects. This happens once, and takes a few seconds.',
+  daemonBusyTitle: 'The daemon is busy',
   daemonInstallFailedTitle: "Setup didn't finish",
   daemonInstallRetry: 'Try again',
   daemonInstallRetrying: 'Setting up…',

--- a/packages/app/src/shared/i18n/catalog/es/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/es/workspace.ts
@@ -6,6 +6,7 @@ export const workspace = {
   startingDaemon: 'Arrancando…',
   daemonInstallingTitle: 'Configurando trace-mcp',
   daemonInstallingSubtitle: 'Instalando el servicio en segundo plano que indexa tus proyectos. Ocurre una sola vez y tarda unos segundos.',
+  daemonBusyTitle: 'El servicio está ocupado',
   daemonInstallFailedTitle: 'La configuración no terminó',
   daemonInstallRetry: 'Reintentar',
   daemonInstallRetrying: 'Configurando…',

--- a/packages/app/src/shared/i18n/catalog/fr/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/fr/workspace.ts
@@ -6,6 +6,7 @@ export const workspace = {
   startingDaemon: 'Démarrage…',
   daemonInstallingTitle: 'Configuration de trace-mcp',
   daemonInstallingSubtitle: "Installation du service d'arrière-plan qui indexe vos projets. Cela n'arrive qu'une fois et prend quelques secondes.",
+  daemonBusyTitle: 'Le service est occupé',
   daemonInstallFailedTitle: "La configuration n'est pas allée au bout",
   daemonInstallRetry: 'Réessayer',
   daemonInstallRetrying: 'Configuration…',

--- a/packages/app/src/shared/i18n/catalog/hi/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/hi/workspace.ts
@@ -6,6 +6,7 @@ export const workspace = {
   startingDaemon: 'शुरू हो रहा है…',
   daemonInstallingTitle: 'trace-mcp सेट किया जा रहा है',
   daemonInstallingSubtitle: 'आपके प्रोजेक्ट इंडेक्स करने वाली बैकग्राउंड सेवा इंस्टॉल हो रही है। यह एक ही बार होता है और कुछ सेकंड लेता है।',
+  daemonBusyTitle: 'सेवा व्यस्त है',
   daemonInstallFailedTitle: 'सेटअप पूरा नहीं हुआ',
   daemonInstallRetry: 'फिर कोशिश करें',
   daemonInstallRetrying: 'सेट हो रहा है…',

--- a/packages/app/src/shared/i18n/catalog/ja/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/ja/workspace.ts
@@ -6,6 +6,7 @@ export const workspace = {
   startingDaemon: '起動中…',
   daemonInstallingTitle: 'trace-mcp をセットアップしています',
   daemonInstallingSubtitle: 'プロジェクトをインデックスするバックグラウンドサービスをインストールしています。初回のみ、数秒で終わります。',
+  daemonBusyTitle: 'サービスが混み合っています',
   daemonInstallFailedTitle: 'セットアップが完了しませんでした',
   daemonInstallRetry: 'もう一度試す',
   daemonInstallRetrying: 'セットアップ中…',

--- a/packages/app/src/shared/i18n/catalog/ko/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/ko/workspace.ts
@@ -6,6 +6,7 @@ export const workspace = {
   startingDaemon: '시작하는 중…',
   daemonInstallingTitle: 'trace-mcp 설정 중',
   daemonInstallingSubtitle: '프로젝트를 인덱싱하는 백그라운드 서비스를 설치하고 있습니다. 최초 한 번만 진행되며 몇 초 걸립니다.',
+  daemonBusyTitle: '서비스가 사용 중입니다',
   daemonInstallFailedTitle: '설정을 끝내지 못했습니다',
   daemonInstallRetry: '다시 시도',
   daemonInstallRetrying: '설정 중…',

--- a/packages/app/src/shared/i18n/catalog/pt-BR/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/pt-BR/workspace.ts
@@ -6,6 +6,7 @@ export const workspace = {
   startingDaemon: 'Iniciando…',
   daemonInstallingTitle: 'Configurando o trace-mcp',
   daemonInstallingSubtitle: 'Instalando o serviço em segundo plano que indexa seus projetos. Isso acontece uma vez e leva alguns segundos.',
+  daemonBusyTitle: 'O serviço está ocupado',
   daemonInstallFailedTitle: 'A configuração não terminou',
   daemonInstallRetry: 'Tentar de novo',
   daemonInstallRetrying: 'Configurando…',

--- a/packages/app/src/shared/i18n/catalog/ru/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/workspace.ts
@@ -13,6 +13,7 @@ export const workspace = {
   startingDaemon: 'Запуск…',
   daemonInstallingTitle: 'Настройка trace-mcp',
   daemonInstallingSubtitle: 'Устанавливаем фоновую службу, которая индексирует проекты. Это делается один раз и занимает несколько секунд.',
+  daemonBusyTitle: 'Служба занята',
   daemonInstallFailedTitle: 'Настройка не завершилась',
   daemonInstallRetry: 'Повторить',
   daemonInstallRetrying: 'Настраиваем…',

--- a/packages/app/src/shared/i18n/catalog/zh/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/workspace.ts
@@ -6,6 +6,7 @@ export const workspace = {
   startingDaemon: '启动中…',
   daemonInstallingTitle: '正在设置 trace-mcp',
   daemonInstallingSubtitle: '正在安装为项目建立索引的后台服务。只会进行一次，需要几秒钟。',
+  daemonBusyTitle: '服务正忙',
   daemonInstallFailedTitle: '设置未完成',
   daemonInstallRetry: '重试',
   daemonInstallRetrying: '设置中…',


### PR DESCRIPTION
## What was wrong

A daemon that is alive, holding port 3741 and too busy to answer `/health` was reported as
`Setup didn't finish — The daemon was installed but never answered on port 3741`, above a
button that reinstalls a working install. Wrong diagnosis, wrong cure, and the app spent
30 s and 60 connect attempts arriving at it — retrying into the very accept queue whose
being full is the symptom (14 sockets in `SYN_SENT` from one PID, 37 in total, measured
2026-09-05).

`ensureDaemonInstalled` had exactly one failure branch, so "no daemon" and "busy daemon"
came out as the same sentence — even though the causes (TRA-938 fd exhaustion, TRA-922
blocked event loop) and the cures are nothing alike.

## What changed

- `isPortHeld()` — asks by **binding**, not connecting. A connect into a full accept queue
  sits in `SYN_SENT` and is the symptom, not a probe; a bind that fails `EADDRINUSE` proves
  a LISTEN socket without adding a connection to the queue. Asked **before** any launchd
  action: a daemon we just kickstarted binds in milliseconds and only answers once its index
  is loaded, so "held" after a restart says nothing about which state we are in.
- New `unresponsive` phase, distinct from `failed`, with a factual message —
  *"The daemon is running and holding port 3741, but it has not answered /health for Ns —
  most likely busy indexing. Nothing needs reinstalling."* `DaemonDownPane` renders it as
  "The daemon is busy" **with no repair button**; `SetupWizard` treats it as an installed
  daemon and moves on instead of hanging on "Setting up trace-mcp" forever.
- A daemon that was already listening and that we did not restart gets a 5 s grace period
  instead of the 30 s cold-start budget. One we started keeps the full 30 s — loading an
  index legitimately takes that long, and cutting it short would relabel a cold start "busy".
- The health poll backs off (250 ms doubling to 4 s) and each attempt is bounded by the
  remaining budget, so a wait cannot outlive the number the caller asked for.

## Numbers

Measured against a listener that holds the port and never answers (`node`, macOS, M5 Max):

| | before | after |
|---|---|---|
| Verdict on an already-running busy daemon | 30 296 ms | 5 002 ms |
| Connect attempts in that window | 60 | 5 |
| Connect attempts over a full 30 s cold-start wait | 60 | 11 |
| Verdict text | "Setup didn't finish" + reinstall button | "The daemon is busy", no button |

Regression guards in `daemon-install.test.ts`: busy → `unresponsive` inside its budget;
a daemon we just restarted still gets the full budget; one that dies mid-wait is `failed`,
not busy; `isPortHeld` separates a held port from a free one.

`pnpm test` in `packages/app`: 693 passed, 1 pre-existing unrelated failure
(`stage-server.test.ts` wants `@ast-grep/napi-darwin-x64`, absent from this machine's
install; fails identically on the base commit). `tsc --noEmit` and `pnpm run build` clean.

## Not in this PR

Serving Overview/Graph/Insights from the on-disk index while the daemon is unreachable is
TRA-934's contract; Workspace already does it, Project Overview does not. Left out rather
than smuggled in here.

Closes TRA-939.
