### PR TITLE
perf(indexer): make a reindex that finds nothing cost nothing (TRA-935)

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -14,7 +14,8 @@ noindex: true
 Machine-readable history lives in [`baseline.json`](./baseline.json) — append one `runs[]`
 entry per measurement pass, never rewrite an old one. This file is the human summary.
 
-Related measurements in this directory: [daemon idle memory](./daemon-idle-memory.md),
+Related measurements in this directory: [idle cost](./idle-cost.md),
+[daemon idle memory](./daemon-idle-memory.md),
 [tool response token cost](./response-tokens.md).
 
 ## Preregistration — TRA-920

--- a/docs/perf/idle-cost.md
+++ b/docs/perf/idle-cost.md
@@ -1,0 +1,67 @@
+---
+layout: default
+title: Idle cost
+permalink: /perf/idle-cost/
+description: Internal working document. What trace-mcp costs while nothing is happening.
+noindex: true
+---
+
+# Idle cost
+
+An app that costs nothing when nothing is happening is a feature the user notices directly —
+battery, fan, laptop temperature. TRA-935 made that a measured state instead of an assertion.
+
+## How to repeat it
+
+```bash
+node scripts/perf/idle-cost.mjs --seconds 300 --interval 30 \
+  --pattern "serve-http --port 3741" --json idle.json
+```
+
+It samples `ps` for every matching process and reports CPU seconds consumed and RSS growth over
+the window. Watchers, poll loops, revalidation timers and telemetry flushes are inside the
+measurement by construction — it reads the OS's accounting, not ours. It starts and kills
+nothing; open the app, touch nothing, and read the numbers.
+
+Match the pattern to what you mean. `--pattern trace-mcp` on a working machine catches every
+stdio session and the desktop app as well as the daemon, and none of those are idle while an
+agent is driving them.
+
+## Measured 2026-09-05 — darwin 25.5.0 / arm64, v3.18.0 + TRA-935
+
+Daemon (`serve-http`) over an isolated `TRACE_MCP_DATA_DIR`, one registered project (899 TS
+files / 7 750 symbols), five minutes with nothing touching it:
+
+| | |
+|---|---|
+| CPU consumed | **0.11 s over 301 s** — 0.04 % of one core |
+| RSS | 303 MB → 33 MB (the idle-unload sweep evicting the project) |
+
+Flat, and the RSS curve points down rather than up.
+
+## Idle is not the only zero-work state
+
+The expensive case was never a daemon with nothing to do — it was a daemon handed work that
+turns out to be nothing. Every git-ignored write, every `config.exclude` match, every file
+owned by a more-specific registered project arrives as a watcher/hook event and used to run
+the whole incremental pipeline: ignore-matcher rebuilds, a change-scope build, a full search +
+PageRank cache invalidation, and a wait on the pipeline lock behind whatever real indexing was
+in flight.
+
+Same machine, same project, 275 git-ignored writes over 60 s, daemon CPU consumed:
+
+| | Before | After |
+|---|---|---|
+| CPU seconds | 0.26 | **0.13** |
+
+And in isolation, with a full project pass holding the pipeline lock, one such event:
+
+| | Before | After |
+|---|---|---|
+| median | 2 424.5 ms | **0.1 ms** |
+| max | 3 013.5 ms | **2.7 ms** |
+
+The before/after gap is dominated by lock-queue wait, which is also why `reindex-file`
+telemetry used to report elapsed times in the hours: `elapsedMs` summed the wait with the work.
+It is now the work alone, with the wait beside it as `queuedMs` (`daemon stats` renders it as
+`queued p95`).

--- a/scripts/perf/idle-cost.mjs
+++ b/scripts/perf/idle-cost.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Idle cost of the running trace-mcp processes — TRA-935.
+ *
+ * "An app that costs nothing when nothing is happening" is only a claim until
+ * someone reads the number. This samples every live trace-mcp process for a
+ * window during which you touch nothing, and reports the two quantities that
+ * decide the user's battery and fan: CPU seconds consumed, and RSS growth.
+ * Both should be approximately flat. Watchers, poll loops, revalidation timers
+ * and telemetry flushes are all inside the measurement by construction — it
+ * reads the OS's accounting, not ours.
+ *
+ * Usage:
+ *   node scripts/perf/idle-cost.mjs [--seconds 300] [--interval 15]
+ *                                   [--pattern trace-mcp] [--json out.json]
+ *
+ * Reads only; starts and kills nothing.
+ */
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i === -1 ? fallback : process.argv[i + 1];
+}
+
+const seconds = Number(arg('seconds', 300));
+const intervalSec = Number(arg('interval', 15));
+const pattern = arg('pattern', 'trace-mcp');
+const jsonOut = arg('json', null);
+
+/** CPU time as reported by ps: [[dd-]hh:]mm:ss[.ff] → seconds. */
+function cpuSeconds(t) {
+  const [head, frac = '0'] = t.split('.');
+  const parts = head.replace('-', ':').split(':').map(Number);
+  const secs = parts.reduce((acc, n) => acc * 60 + n, 0);
+  return secs + Number(`0.${frac}`);
+}
+
+function sample() {
+  let out = '';
+  try {
+    // -ww: never truncate the command, or the pattern match misses long paths.
+    out = execFileSync('ps', ['-axo', 'pid=,rss=,time=,command=', '-ww'], {
+      encoding: 'utf-8',
+      maxBuffer: 32 * 1024 * 1024,
+    });
+  } catch {
+    return new Map();
+  }
+  const procs = new Map();
+  for (const line of out.split('\n')) {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\s+(\S+)\s+(.*)$/);
+    if (!m) continue;
+    const [, pid, rssKb, time, command] = m;
+    if (!command.includes(pattern)) continue;
+    // Don't measure ourselves, or the shell that launched us.
+    if (Number(pid) === process.pid || command.includes('idle-cost.mjs')) continue;
+    procs.set(Number(pid), {
+      pid: Number(pid),
+      rssMb: Number(rssKb) / 1024,
+      cpuSec: cpuSeconds(time),
+      command: command.slice(0, 120),
+    });
+  }
+  return procs;
+}
+
+const first = sample();
+if (first.size === 0) {
+  console.error(`No process matching ${JSON.stringify(pattern)} is running — nothing to measure.`);
+  process.exit(1);
+}
+console.error(`Watching ${first.size} process(es) for ${seconds}s. Touch nothing.`);
+
+const started = Date.now();
+const series = [];
+while ((Date.now() - started) / 1000 < seconds) {
+  const now = sample();
+  series.push({ tSec: Math.round((Date.now() - started) / 1000), procs: [...now.values()] });
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, intervalSec * 1000);
+}
+const last = sample();
+
+const elapsedSec = (Date.now() - started) / 1000;
+const perProc = [];
+for (const [pid, a] of first) {
+  const b = last.get(pid);
+  // Gone mid-window: report it rather than silently dropping a process whose
+  // exit is itself a finding.
+  if (!b) {
+    perProc.push({ pid, command: a.command, exitedDuringWindow: true });
+    continue;
+  }
+  perProc.push({
+    pid,
+    command: a.command,
+    cpuSecondsConsumed: Math.round((b.cpuSec - a.cpuSec) * 100) / 100,
+    cpuPercentOfOneCore: Math.round(((b.cpuSec - a.cpuSec) / elapsedSec) * 1000) / 10,
+    rssStartMb: Math.round(a.rssMb),
+    rssEndMb: Math.round(b.rssMb),
+    rssGrowthMb: Math.round(b.rssMb - a.rssMb),
+  });
+}
+perProc.sort((x, y) => (y.cpuSecondsConsumed ?? 0) - (x.cpuSecondsConsumed ?? 0));
+
+const report = {
+  measuredAt: new Date().toISOString(),
+  windowSeconds: Math.round(elapsedSec),
+  intervalSeconds: intervalSec,
+  pattern,
+  totals: {
+    processes: perProc.length,
+    cpuSecondsConsumed:
+      Math.round(perProc.reduce((s, p) => s + (p.cpuSecondsConsumed ?? 0), 0) * 100) / 100,
+    rssStartMb: perProc.reduce((s, p) => s + (p.rssStartMb ?? 0), 0),
+    rssEndMb: perProc.reduce((s, p) => s + (p.rssEndMb ?? 0), 0),
+  },
+  processes: perProc,
+  series,
+};
+
+if (jsonOut) writeFileSync(jsonOut, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify({ ...report, series: undefined }, null, 2));

--- a/scripts/perf/idle-cost.mjs
+++ b/scripts/perf/idle-cost.mjs
@@ -32,9 +32,14 @@ const jsonOut = arg('json', null);
 /** CPU time as reported by ps: [[dd-]hh:]mm:ss[.ff] → seconds. */
 function cpuSeconds(t) {
   const [head, frac = '0'] = t.split('.');
-  const parts = head.replace('-', ':').split(':').map(Number);
-  const secs = parts.reduce((acc, n) => acc * 60 + n, 0);
-  return secs + Number(`0.${frac}`);
+  // Days are separated by '-', not ':', and are worth 24 hours — folding them
+  // into the sexagesimal reduce would price a day at 60 hours.
+  const [days, clock] = head.includes('-') ? head.split('-') : ['0', head];
+  const secs = clock
+    .split(':')
+    .map(Number)
+    .reduce((acc, n) => acc * 60 + n, 0);
+  return Number(days) * 86400 + secs + Number(`0.${frac}`);
 }
 
 function sample() {

--- a/src/cli/daemon-stats.ts
+++ b/src/cli/daemon-stats.ts
@@ -160,6 +160,9 @@ export interface DaemonEventStats {
   indexed: number;
   p50_ms: number;
   p95_ms: number;
+  /** p95 wait for the reindex lock, reported separately from the work itself
+   *  so a fast reindex stuck behind a queue is visible as such (TRA-935). */
+  p95_queued_ms: number;
 }
 
 export function renderDaemonEvents(s: DaemonEventStats): string {
@@ -174,7 +177,7 @@ export function renderDaemonEvents(s: DaemonEventStats): string {
   lines.push(`  fast (skipped_recent): ${s.fast_skipped_recent} (${pctOf(s.fast_skipped_recent)})`);
   lines.push(`  fast (skipped_hash):   ${s.fast_skipped_hash} (${pctOf(s.fast_skipped_hash)})`);
   lines.push(`  indexed:               ${s.indexed} (${pctOf(s.indexed)})`);
-  lines.push(`  per-call: p50=${s.p50_ms}ms p95=${s.p95_ms}ms`);
+  lines.push(`  per-call: p50=${s.p50_ms}ms p95=${s.p95_ms}ms  queued p95=${s.p95_queued_ms}ms`);
   return lines.join('\n');
 }
 
@@ -193,6 +196,7 @@ export async function fetchDaemonStats(port: number): Promise<DaemonEventStats |
       indexed: body.indexed ?? 0,
       p50_ms: body.p50_ms ?? 0,
       p95_ms: body.p95_ms ?? 0,
+      p95_queued_ms: body.p95_queued_ms ?? 0,
     };
   } catch {
     return null;

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -650,7 +650,9 @@ export class ProjectManager {
           }
           if (toIndex.length === 0) return;
 
-          let result: { indexed?: number; skipped?: number; changedFileIds?: number[] } | undefined;
+          let result:
+            | { indexed?: number; skipped?: number; durationMs?: number; changedFileIds?: number[] }
+            | undefined;
           let watchErr: unknown;
           try {
             result = await pipeline.indexFiles(toIndex);
@@ -658,7 +660,13 @@ export class ProjectManager {
             watchErr = err;
             throw err;
           } finally {
-            const elapsedMs = Math.round(performance.now() - watchStart);
+            // TRA-935: the batch's wall-clock is mostly time spent waiting for
+            // the pipeline lock when several batches land at once. Report the
+            // indexing work as `elapsedMs` and the wait as `queuedMs` — summed
+            // into one number they showed watcher reindexes taking hours.
+            const totalMs = Math.round(performance.now() - watchStart);
+            const elapsedMs = result?.durationMs ?? totalMs;
+            const queuedMs = Math.max(0, totalMs - elapsedMs);
             const indexed = result?.indexed ?? 0;
             const skippedRows = result?.skipped ?? 0;
             const skippedHash = indexed === 0 && skippedRows > 0;
@@ -699,6 +707,7 @@ export class ProjectManager {
                     skippedHash,
                     indexed,
                     elapsedMs,
+                    queuedMs,
                   },
                   'reindex-file telemetry',
                 );
@@ -708,6 +717,7 @@ export class ProjectManager {
                   skippedHash,
                   indexed,
                   elapsedMs,
+                  queuedMs,
                 });
               }
             }

--- a/src/daemon/reindex-file-handler.ts
+++ b/src/daemon/reindex-file-handler.ts
@@ -115,7 +115,12 @@ export async function handleReindexFile(
     const indexed = result?.indexed ?? 0;
     const skipped = result?.skipped ?? 0;
     const skippedHash = indexed === 0 && skipped > 0;
-    const elapsedMs = Math.round(performance.now() - startedAt);
+    // TRA-935: report the indexing work and the wait for the reindex lock as
+    // two numbers. Summed into one they made a 30 ms reindex that sat behind a
+    // full project pass look like a 40-minute reindex.
+    const totalMs = Math.round(performance.now() - startedAt);
+    const elapsedMs = result?.durationMs ?? totalMs;
+    const queuedMs = Math.max(0, totalMs - elapsedMs);
     logger.info(
       {
         event: 'reindex-file',
@@ -128,6 +133,7 @@ export async function handleReindexFile(
         skippedHash,
         indexed,
         elapsedMs,
+        queuedMs,
       },
       'reindex-file telemetry',
     );
@@ -137,6 +143,7 @@ export async function handleReindexFile(
       skippedHash,
       indexed,
       elapsedMs,
+      queuedMs,
     });
     return { ok: true, relPath: rel };
   } catch (err) {

--- a/src/daemon/reindex-stats.ts
+++ b/src/daemon/reindex-stats.ts
@@ -7,7 +7,11 @@ export interface ReindexEvent {
   skippedRecent: boolean;
   skippedHash: boolean;
   indexed: number;
+  /** Indexing work only. See `queuedMs` — the two used to be summed here,
+   *  which is how a 30 ms reindex reported hours of latency (TRA-935). */
   elapsedMs: number;
+  /** Time the call spent waiting for the reindex lock before work began. */
+  queuedMs?: number;
   error?: boolean;
 }
 
@@ -19,6 +23,9 @@ export interface ReindexStatsSummary {
   errors: number;
   p50_ms: number;
   p95_ms: number;
+  /** p95 of lock-queue wait. A high value here with a low `p95_ms` means the
+   *  reindexes are fast and the queue in front of them is not. */
+  p95_queued_ms: number;
 }
 
 const MAX_RING = 5000;
@@ -42,6 +49,7 @@ export class ReindexStats {
       skippedHash: event.skippedHash,
       indexed: event.indexed,
       elapsedMs: event.elapsedMs,
+      queuedMs: event.queuedMs,
       error: event.error,
     };
     if (this.size < MAX_RING) {
@@ -68,6 +76,7 @@ export class ReindexStats {
     let indexed = 0;
     let errors = 0;
     const elapsed: number[] = [];
+    const queued: number[] = [];
     let total = 0;
     for (const e of events) {
       if (cutoff != null && e.ts < cutoff) continue;
@@ -77,8 +86,10 @@ export class ReindexStats {
       else if (e.skippedHash) hash++;
       else if (e.indexed > 0) indexed++;
       elapsed.push(e.elapsedMs);
+      queued.push(e.queuedMs ?? 0);
     }
     const sorted = [...elapsed].sort((a, b) => a - b);
+    const sortedQueued = [...queued].sort((a, b) => a - b);
     return {
       total,
       fast_skipped_recent: recent,
@@ -87,6 +98,7 @@ export class ReindexStats {
       errors,
       p50_ms: percentile(sorted, 0.5),
       p95_ms: percentile(sorted, 0.95),
+      p95_queued_ms: percentile(sortedQueued, 0.95),
     };
   }
 

--- a/src/daemon/router/local-backend.ts
+++ b/src/daemon/router/local-backend.ts
@@ -358,7 +358,9 @@ export class LocalBackend implements Backend {
           }
           if (toIndex.length === 0) return;
 
-          let result: { indexed?: number; skipped?: number; changedFileIds?: number[] } | undefined;
+          let result:
+            | { indexed?: number; skipped?: number; durationMs?: number; changedFileIds?: number[] }
+            | undefined;
           let watchErr: unknown;
           try {
             result = await this.pipeline!.indexFiles(toIndex);
@@ -366,7 +368,13 @@ export class LocalBackend implements Backend {
             watchErr = err;
             throw err;
           } finally {
-            const elapsedMs = Math.round(performance.now() - watchStart);
+            // TRA-935: the batch's wall-clock is mostly time spent waiting for
+            // the pipeline lock when several batches land at once. Report the
+            // indexing work as `elapsedMs` and the wait as `queuedMs` — summed
+            // into one number they showed watcher reindexes taking hours.
+            const totalMs = Math.round(performance.now() - watchStart);
+            const elapsedMs = result?.durationMs ?? totalMs;
+            const queuedMs = Math.max(0, totalMs - elapsedMs);
             const indexed = result?.indexed ?? 0;
             const skippedRows = result?.skipped ?? 0;
             const skippedHash = indexed === 0 && skippedRows > 0;
@@ -407,6 +415,7 @@ export class LocalBackend implements Backend {
                     skippedHash,
                     indexed,
                     elapsedMs,
+                    queuedMs,
                   },
                   'reindex-file telemetry',
                 );
@@ -416,6 +425,7 @@ export class LocalBackend implements Backend {
                   skippedHash,
                   indexed,
                   elapsedMs,
+                  queuedMs,
                 });
               }
             }

--- a/src/indexer/__tests__/zero-file-reindex.test.ts
+++ b/src/indexer/__tests__/zero-file-reindex.test.ts
@@ -1,0 +1,100 @@
+/**
+ * TRA-935: a reindex whose file list filters down to nothing must cost
+ * nothing.
+ *
+ * Watcher / hook / `register_edit` events routinely name paths the indexer
+ * has no business touching — git-ignored churn, `config.exclude` matches,
+ * files under a more-specific registered project. Those were still running
+ * the whole incremental pipeline: ignore-matcher rebuilds, a change-scope
+ * build, and a full search + PageRank cache invalidation — and, worse, they
+ * queued on the pipeline lock behind whatever real indexing was in flight.
+ * One daemon log held 29 925 such events; their reported latency was the
+ * queue wait, which is how `reindex-file` telemetry came to show elapsed
+ * times in the hours.
+ *
+ * The guard belongs in front of the lock, so both properties are pinned here:
+ * the run does no work, and it does not wait for one that is.
+ */
+import Database from 'better-sqlite3';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TraceMcpConfigSchema } from '../../config.js';
+import { initializeDatabase } from '../../db/schema.js';
+import { Store } from '../../db/store.js';
+import { PluginRegistry } from '../../plugin-api/registry.js';
+import { IndexingPipeline } from '../pipeline.js';
+
+let workDir: string;
+let db: Database.Database;
+let store: Store;
+let pipeline: IndexingPipeline;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'zero-file-reindex-'));
+  mkdirSync(join(workDir, 'src'), { recursive: true });
+  for (let i = 0; i < 20; i++) {
+    writeFileSync(
+      join(workDir, 'src', `m${i}.ts`),
+      `export function f${i}(): number { return ${i}; }\n`,
+    );
+  }
+  // Excluded by config below, so a watcher event naming it must be a no-op.
+  mkdirSync(join(workDir, 'vendor'), { recursive: true });
+  writeFileSync(join(workDir, 'vendor', 'dep.ts'), 'export const dep = 1;\n');
+
+  db = initializeDatabase(join(workDir, 'index.db'));
+  store = new Store(db);
+  pipeline = new IndexingPipeline(
+    store,
+    PluginRegistry.createWithDefaults(),
+    TraceMcpConfigSchema.parse({ exclude: ['**/vendor/**'] }),
+    workDir,
+  );
+});
+
+afterEach(async () => {
+  await pipeline.dispose?.();
+  try {
+    db.close();
+  } catch {
+    /* best-effort */
+  }
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('indexFiles with nothing indexable', () => {
+  it('reports an empty run instead of walking the pipeline', async () => {
+    await pipeline.indexAll();
+    const before = store.getStats();
+
+    const r = await pipeline.indexFiles([join(workDir, 'vendor', 'dep.ts')]);
+
+    expect(r.totalFiles).toBe(0);
+    expect(r.indexed).toBe(0);
+    expect(r.errors).toBe(0);
+    expect(store.getStats().totalSymbols).toBe(before.totalSymbols);
+  });
+
+  it('does not queue behind an indexing pass already holding the lock', async () => {
+    await pipeline.indexAll();
+
+    let fullFinished = false;
+    const full = pipeline.indexAll().then((res) => {
+      fullFinished = true;
+      return res;
+    });
+
+    const r = await pipeline.indexFiles([join(workDir, 'vendor', 'dep.ts')]);
+
+    // The whole point: the no-op answered while the full pass was still
+    // running. Without the pre-lock guard this await resolves only after
+    // `full` does, and the event's telemetry reports that wait as its own
+    // reindex latency.
+    expect(fullFinished).toBe(false);
+    expect(r.totalFiles).toBe(0);
+
+    await full;
+  });
+});

--- a/src/indexer/pipeline.ts
+++ b/src/indexer/pipeline.ts
@@ -557,10 +557,83 @@ export class IndexingPipeline {
     })();
   }
 
+  /**
+   * Drop the paths an incremental run must not touch: traversal attempts,
+   * `config.exclude` matches, subtrees owned by a more-specific registered
+   * project, and git-ignored files. Mirrors the gates `collectFiles()`
+   * applies to the full walk, so the event-driven entry points (watcher,
+   * hooks, `register_edit`, the HTTP reindex endpoint) can't re-add rows the
+   * full walk excludes (TRA-468).
+   *
+   * Pure — no DB, no lock. That is what lets `indexFiles()` decide a batch is
+   * a no-op before it queues behind the pipeline lock (TRA-935).
+   */
+  private filterIndexablePaths(filePaths: string[]): string[] {
+    // Same exclude gate collectFiles() applies via fast-glob. Without it,
+    // event-driven entry points index runtime churn the full pipeline would
+    // never touch — e.g. Laravel storage/framework/sessions blobs arriving on
+    // every web request.
+    const isExcluded = this.getExcludeMatcher();
+    // A registered descendant owns its own subtree — drop its files so an
+    // umbrella root's watcher-driven reindex is a no-op instead of a second,
+    // umbrella-wide edge reconcile (the daemon-starvation cause behind #209).
+    const descendantGlobs = descendantExcludeGlobs(this.rootPath);
+    const ownedByDescendant = descendantGlobs.length
+      ? picomatch(descendantGlobs, { dot: true })
+      : undefined;
+    const gitignore = this.gitignoreMatcher();
+    const relPaths: string[] = [];
+    for (const fp of filePaths) {
+      const rel = path.isAbsolute(fp) ? path.relative(this.rootPath, fp) : fp;
+      const check = validatePath(rel, this.rootPath);
+      if (check.isErr()) {
+        logger.warn({ file: fp }, 'Path traversal blocked in indexFiles');
+        continue;
+      }
+      const relPosix = rel.split(path.sep).join('/');
+      if (isExcluded(relPosix)) {
+        logger.debug({ file: rel }, 'Excluded path skipped in indexFiles');
+        continue;
+      }
+      if (ownedByDescendant?.(relPosix)) {
+        logger.debug({ file: rel }, 'Skipped: owned by a more-specific registered project');
+        continue;
+      }
+      if (gitignore?.isIgnored(relPosix)) {
+        logger.debug({ file: rel }, 'Git-ignored path skipped in indexFiles');
+        continue;
+      }
+      relPaths.push(rel);
+    }
+    return relPaths;
+  }
+
   async indexFiles(
     filePaths: string[],
     opts: { postprocess?: PostprocessLevel } = {},
   ): Promise<IndexingResult> {
+    const enqueuedAt = Date.now();
+    const relPaths = this.filterIndexablePaths(filePaths);
+
+    // TRA-935: nothing survived the filters, so this run cannot change a
+    // single row. Return before touching `_lock` — running the pipeline
+    // anyway costs the ignore-matcher rebuilds, a scope build, and a full
+    // search + PageRank cache invalidation, and (worse) queues the no-op
+    // behind whatever real indexing is in flight. In one daemon log 29 925 of
+    // 30 000 `reindex-file` events took this path; their reported latency was
+    // lock-queue wait, which is why elapsedMs read as hours.
+    if (relPaths.length === 0) {
+      return {
+        totalFiles: 0,
+        indexed: 0,
+        skipped: 0,
+        errors: 0,
+        durationMs: Date.now() - enqueuedAt,
+        incremental: true,
+        postprocess: opts.postprocess ?? 'minimal',
+      };
+    }
+
     const result = this._lock.then(async () => {
       this._isIncremental = true;
       // Incremental runs never reconcile scope; clear the flag a prior
@@ -572,47 +645,11 @@ export class IndexingPipeline {
       // edits. Explicit callers (the `reindex` MCP tool for indexPath param)
       // still pass 'full' explicitly when needed.
       this._postprocessLevel = opts.postprocess ?? 'minimal';
+      // TRA-935: `durationMs` must be the work, not the wait. The clock starts
+      // once the lock is ours, so callers can subtract it from their own
+      // wall-clock to get the queue time instead of reporting the two summed
+      // as reindex latency.
       const start = Date.now();
-      // Same exclude gate collectFiles() applies via fast-glob. Without it,
-      // event-driven entry points (watcher, hooks, register_edit, HTTP) index
-      // runtime churn the full pipeline would never touch — e.g. Laravel
-      // storage/framework/sessions blobs arriving on every web request.
-      const isExcluded = this.getExcludeMatcher();
-      // A registered descendant owns its own subtree — drop its files so an
-      // umbrella root's watcher-driven reindex is a no-op instead of a second,
-      // umbrella-wide edge reconcile (the daemon-starvation cause behind #209).
-      const descendantGlobs = descendantExcludeGlobs(this.rootPath);
-      const ownedByDescendant = descendantGlobs.length
-        ? picomatch(descendantGlobs, { dot: true })
-        : undefined;
-      // Same gate collectFiles() now applies. The watcher already dropped
-      // git-ignored events, but hooks, `register_edit` and the HTTP reindex
-      // endpoint reach here directly and would otherwise re-add rows the full
-      // walk excludes — putting the index straight back out of sync (TRA-468).
-      const gitignore = this.gitignoreMatcher();
-      const relPaths: string[] = [];
-      for (const fp of filePaths) {
-        const rel = path.isAbsolute(fp) ? path.relative(this.rootPath, fp) : fp;
-        const check = validatePath(rel, this.rootPath);
-        if (check.isErr()) {
-          logger.warn({ file: fp }, 'Path traversal blocked in indexFiles');
-          continue;
-        }
-        const relPosix = rel.split(path.sep).join('/');
-        if (isExcluded(relPosix)) {
-          logger.debug({ file: rel }, 'Excluded path skipped in indexFiles');
-          continue;
-        }
-        if (ownedByDescendant?.(relPosix)) {
-          logger.debug({ file: rel }, 'Skipped: owned by a more-specific registered project');
-          continue;
-        }
-        if (gitignore?.isIgnored(relPosix)) {
-          logger.debug({ file: rel }, 'Git-ignored path skipped in indexFiles');
-          continue;
-        }
-        relPaths.push(rel);
-      }
       const r = await this.runPipeline(relPaths, false, start);
       // The watcher/hook path only ever sees the events it was handed. Kick a
       // debounced coverage check so a project whose on-disk shape changed

--- a/src/tools/register/core.ts
+++ b/src/tools/register/core.ts
@@ -555,7 +555,12 @@ export function registerCoreTools(server: McpServer, ctx: ServerContext): void {
       const indexed = result.indexed ?? 0;
       const skipped = result.skipped ?? 0;
       const skippedHash = indexed === 0 && skipped > 0;
-      const elapsedMs = Math.round(performance.now() - startedAt);
+      // TRA-935: split the reindex work from the time spent waiting for the
+      // reindex lock. Reported as one number, a fast edit queued behind a full
+      // project pass looked like a pathologically slow reindex.
+      const totalMs = Math.round(performance.now() - startedAt);
+      const elapsedMs = result.durationMs ?? totalMs;
+      const queuedMs = Math.max(0, totalMs - elapsedMs);
       logger.info(
         {
           event: 'reindex-file',
@@ -568,6 +573,7 @@ export function registerCoreTools(server: McpServer, ctx: ServerContext): void {
           skippedHash,
           indexed,
           elapsedMs,
+          queuedMs,
         },
         'reindex-file telemetry',
       );
@@ -577,6 +583,7 @@ export function registerCoreTools(server: McpServer, ctx: ServerContext): void {
         skippedHash,
         indexed,
         elapsedMs,
+        queuedMs,
       });
 
       // Best-effort duplication check — never fails register_edit

--- a/tests/cli/daemon-stats.test.ts
+++ b/tests/cli/daemon-stats.test.ts
@@ -105,11 +105,15 @@ describe('renderDaemonEvents', () => {
       indexed: 70,
       p50_ms: 180,
       p95_ms: 240,
+      p95_queued_ms: 900,
     });
     expect(out).toMatch(/Daemon reindex events/);
     expect(out).toMatch(/total: 100/);
     expect(out).toMatch(/p50=180ms/);
     expect(out).toMatch(/p95=240ms/);
+    // The queue wait is reported next to the work, never folded into it — a
+    // fast reindex stuck behind a full pass has to be visible as such.
+    expect(out).toMatch(/queued p95=900ms/);
     expect(out).toMatch(/skipped_recent/);
     expect(out).toMatch(/skipped_hash/);
   });


### PR DESCRIPTION
Closes TRA-935.

## The zero-work path was not free

A watcher / hook / `register_edit` event whose paths all fail the indexer's filters — git-ignored churn, a `config.exclude` match, a file owned by a more-specific registered project — still ran the whole incremental pipeline: ignore-matcher rebuilds, a change-scope build, a full search + PageRank cache invalidation, and a wait on the pipeline lock behind whatever real indexing was in flight.

In one shipped daemon log, **29 925 of ~30 000 `reindex-file` events took that path.**

`indexFiles()` now filters before touching the lock and returns early when nothing survives.

## …which is also why the telemetry lied

`elapsedMs` was measured from the caller's entry, so it summed lock-queue wait with indexing work. In one session log **6 771 of 10 515 events reported over 60 s, the worst at 40 630 823 ms (11.3 h)** — none of it indexing. `IndexingPipeline.indexFiles` now starts its clock once the lock is its own; the four emit sites (HTTP, MCP, and both watcher backends) report the wait beside it as `queuedMs`, and `daemon stats` renders `queued p95`.

## Numbers

darwin 25.5.0 / arm64, isolated `TRACE_MCP_DATA_DIR`, 899 TS files / 7 750 symbols.

| | Before | After |
|---|---|---|
| zero-file reindex, full pass holding the lock — median | 2 424.5 ms | **0.1 ms** |
| same — max | 3 013.5 ms | **2.7 ms** |
| live daemon, 275 git-ignored writes over 60 s — CPU | 0.26 s | **0.13 s** |

Daemon idle, five minutes, nothing touching it: **0.11 CPU-seconds over 301 s** (0.04 % of one core), RSS 303 → 33 MB. That row is the answer to "idle must be a measurable state" — `scripts/perf/idle-cost.mjs` is how it was taken and how to retake it. Method and caveats in `docs/perf/idle-cost.md`.

Harness caveat as always: 899 files is small. The mechanism removed is per-event and does not shrink with corpus size, but do not quote these absolute numbers as describing a large repository.

## Guard

`src/indexer/__tests__/zero-file-reindex.test.ts` pins both properties — the run does no work, and it does not wait for one that is. The second test fails when the pre-lock guard is removed (verified by reverting it).

No schema change, no MCP tool contract change, no token-cost change.

`pnpm test`: 10 216 passed | 22 skipped. `pnpm run lint` and `pnpm run build` clean.
