### PR TITLE
docs: make the home page eligible for the code graph mcp cluster

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,12 +13,12 @@ updated: 2026-09-04
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 
   <!-- ── Primary Meta ── -->
-  <title>trace-mcp — precomputed code intelligence for AI coding agents</title>
+  <title>trace-mcp — code graph MCP server for AI coding agents</title>
   <!-- Front-loaded on the SEO Agent's measurement: Google truncates this around
        155 characters, and the previous wording shared its first 133 with the old
        one, so the number was cut mid-word in the snippet. The 155-char cut now
        lands after "we don't own". -->
-  <meta name="description" content="{{ site.data.pr_context_bench.median_savings_pct }}% fewer input tokens to review a pull request — median over {{ site.data.pr_context_bench.pr_count }} merged pull requests in open-source repos we don't own. trace-mcp indexes your codebase once so AI agents stop re-reading the same files. Open source, local-first, MCP-native.">
+  <meta name="description" content="{{ site.data.pr_context_bench.median_savings_pct }}% fewer input tokens to review a pull request — median over {{ site.data.pr_context_bench.pr_count }} merged pull requests in open-source repos we don't own. trace-mcp is a code graph MCP server: it indexes your codebase once so AI agents stop re-reading the same files. Open source, local-first, MCP-native.">
   <meta name="keywords" content="ai execution layer, recomputation, context bloat, token reduction, ai agents, mcp, model context protocol, code intelligence, code graph, llm developer tools, agent observability, agent optimization, claude code, cursor, windsurf, dependency graph, tree-sitter, lsp">
   <meta name="author" content="Nikolai Vysotskyi">
   <meta name="robots" content="index, follow, max-image-preview:large">
@@ -59,7 +59,7 @@ updated: 2026-09-04
   <meta property="og:site_name" content="trace-mcp">
   <meta property="og:locale" content="en_US">
   <meta property="og:url" content="https://trace-mcp.com/">
-  <meta property="og:title" content="trace-mcp — precomputed code intelligence for AI coding agents">
+  <meta property="og:title" content="trace-mcp — code graph MCP server for AI coding agents">
   <meta property="og:description" content="A structured map of your codebase for AI agents. Stop paying for the same re-reads every turn. {{ site.data.pr_context_bench.median_savings_pct }}% fewer input tokens to review a pull request, measured on {{ site.data.pr_context_bench.pr_count }} merged PRs in open-source repos.">
   <meta property="og:image" content="https://trace-mcp.com/og-image.png">
   <meta property="og:image:secure_url" content="https://trace-mcp.com/og-image.png">
@@ -70,7 +70,7 @@ updated: 2026-09-04
 
   <!-- ── Twitter / X Card ── -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="trace-mcp — precomputed code intelligence for AI coding agents">
+  <meta name="twitter:title" content="trace-mcp — code graph MCP server for AI coding agents">
   <meta name="twitter:description" content="A structured map of your codebase for AI agents. {{ site.data.pr_context_bench.median_savings_pct }}% fewer input tokens to review a pull request, measured on {{ site.data.pr_context_bench.pr_count }} merged PRs in open-source repos. Open source, local-first.">
   <meta name="twitter:image" content="https://trace-mcp.com/og-image.png">
   <meta name="twitter:image:alt" content="trace-mcp graph explorer visualizing symbol connections across a codebase">
@@ -81,7 +81,7 @@ updated: 2026-09-04
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "trace-mcp",
-    "alternateName": "trace-mcp — precomputed code intelligence for AI coding agents",
+    "alternateName": "trace-mcp — code graph MCP server for AI coding agents",
     "description": "AI agents recompute the same work every turn — re-reading files, re-traversing dependencies, re-inflating context. trace-mcp makes them reuse instead. A median {{ site.data.pr_context_bench.median_savings_pct }}% fewer input tokens to review a pull request, measured on {{ site.data.pr_context_bench.pr_count }} merged pull requests across {{ site.data.pr_context_bench.repo_count }} open-source repositories. Framework-aware dependency graph via MCP, {{ site.data.counts.languages }} languages, {{ site.data.counts.frameworks }} integrations.",
     "url": "https://trace-mcp.com/",
     "image": "https://trace-mcp.com/og-image.png",
@@ -2451,7 +2451,7 @@ updated: 2026-09-04
       <div class="section-meta">
         <div class="section-meta-tag"><span class="label">003 / Product View</span></div>
         <div>
-          <h2 class="section-title">A structured model of your codebase <span class="em">that agents can use.</span></h2>
+          <h2 class="section-title">A code graph of your repository <span class="em">that agents can use.</span></h2>
           <p class="section-lede">An AI agent reading <code>UserController.php</code> sees a class. trace-mcp sees the route that hits it, the form request that validates input, the model it touches, the page it renders, the components rendered inside.</p>
         </div>
       </div>

--- a/ops/positioning.md
+++ b/ops/positioning.md
@@ -257,6 +257,54 @@ ordinary issue, not part of this pass. Ordered by how much a reader sees it.
 | Directory listings (`ops/distribution.md`) | Only where copy is ours to edit, and **only together with the rename** | See Sequencing |
 | `docs/ROADMAP.md` item 8 | Superseded by this file | Roadmap autopilot's next revision |
 
+## The `<title>` is a door, not the position (TRA-950, 2026-09-05)
+
+The position sentence above has the same defect the old headline had, and it is
+worth naming before someone spends a quarter on it: **it contains nothing anyone
+searches for.** DataForSEO (Google Ads, US/English, 2026-09-05) returns no volume
+record at all for `precomputed code intelligence` or `code intelligence for ai
+agents`, and it returns none for the new sentence's vocabulary either. GSC for
+`sc-domain:trace-mcp.com`, 2026-08-06 → 2026-09-04, shows the bill: the home
+page's two largest non-brand impression sources were `traceix mcp` (61) and `mcp
+tracing` (50) — 111 impressions, zero clicks, both name lookalikes Google matched
+because there was no category phrase on the page to match instead.
+
+So the two requirements are real and they are not the same requirement:
+
+- The **hero sentence** answers "what is this", to a reader who is already here.
+- The **`<title>`, meta description and section headings** answer "is this the
+  kind of thing I typed", to a reader who is not here yet.
+
+The resolution, and the precedent to follow next time they collide: **the title
+carries the measured category term, the hero carries the position.** The home
+page title is now `trace-mcp — code graph MCP server for AI coding agents`.
+
+That is the same carve-out this file already makes for `server.json` under
+Doors, for the same reason — a channel that can only deliver door 1 gets
+described in door 1's words. A Google SERP for `code graph mcp` is that kind of
+channel. The reader arriving on it is looking for a code graph MCP server, we
+are one, and the page they land on is free to tell them we are more. The title
+is the door; the page is the pitch.
+
+Chosen cluster and why not a bigger one: `code graph mcp` / `codegraph mcp`
+(70/mo each, 10 → 140 and 10 → 260 over twelve months, LOW competition) has a
+live top-20 of standalone product sites — `code-review-graph.com` at 6,
+`depgraph.ai` at 13, `codecontextgraph.com` at 16 — and we already rank #1–2 on
+its long tail from `comparisons.html` (`serena mcp vs codegraph`, `codegraph vs
+serena`, `repomix vs codegraph`). Every non-brand click the site earned in those
+30 days came from this vocabulary. `claude code mcp server` is 12× the volume
+and was rejected: its top-10 is Anthropic's docs plus listicles, no single
+product homepage ranks, and the way into that SERP is being listed inside those
+articles — outreach, not a page.
+
+**What this does not license.** The head term went onto the title, the meta
+description, and the Product View section heading — the graph's own section,
+where it is exactly accurate. It did **not** go into the hero subhead, which
+TRA-950 originally proposed. That sentence is the position claim's instance and
+narrowing it to the graph is the specific move this file exists to prevent.
+`tests/docs/category-term.test.ts` guards the three placements that stayed;
+`tests/docs/searchable-name.test.ts` guards the brand string alongside it.
+
 ## Open
 
 - **Door 2 has no measured pitch yet.** Mirrors are verified not to break the

--- a/tests/docs/category-term.test.ts
+++ b/tests/docs/category-term.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The home page has to name its category in the words people type.
+ *
+ * DataForSEO (Google Ads, US/English, 2026-09-05) returns no volume record at
+ * all for `precomputed code intelligence` or `code intelligence for ai agents`
+ * — they are our coinages, so the only distinctive indexable token on the page
+ * was the brand string. GSC for the same 30 days shows what that costs: the two
+ * largest non-brand impression sources on the home page were `traceix mcp` (61)
+ * and `mcp tracing` (50), 111 impressions and zero clicks, both name lookalikes
+ * Google matched because there was no category phrase to match instead.
+ *
+ * `code graph mcp` (70/mo, 10 → 140 over twelve months, LOW competition) is the
+ * cluster we can actually win: its live top-20 is standalone product sites, not
+ * listicles, and `comparisons.html` already ranks #1–2 on that vocabulary's long
+ * tail. This test guards eligibility for its head term — a copy pass that
+ * reverts these strings to positioning prose would take it away silently, with
+ * no other test failing. (TRA-950)
+ */
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const index = readFileSync(join(REPO_ROOT, 'docs/index.html'), 'utf-8');
+
+describe('the home page names the code graph category', () => {
+  it('the title and og:title carry the head term', () => {
+    expect(index).toMatch(/<title>[^<]*code graph MCP server[^<]*<\/title>/);
+    expect(index).toMatch(/property="og:title" content="[^"]*code graph MCP server[^"]*"/);
+  });
+
+  it('the meta description carries it, not only the number', () => {
+    expect(index).toMatch(/name="description" content="[^"]*code graph MCP server[^"]*"/);
+  });
+
+  it('the visible body copy carries it, not only the metadata', () => {
+    // Tags stripped: metadata alone matches the SERP snippet while the page a
+    // visitor lands on says something else, which is what Google demotes. It
+    // lives on the graph section's own heading, not in the hero — the hero
+    // sentence is the position claim and `ops/positioning.md` forbids narrowing
+    // it back to the graph.
+    const body = index.slice(index.indexOf('<body'));
+    const visible = body.replace(/<script[\s\S]*?<\/script>/g, '').replace(/<[^>]+>/g, ' ');
+    expect(visible).toMatch(/code graph/i);
+  });
+});


### PR DESCRIPTION
Makes the home page eligible for the `code graph mcp` cluster (TRA-950, SEO Agent's measurement).

## The finding

The home page never named its category in words anyone searches for. DataForSEO (Google Ads, US/English, 2026-09-05) returns **no volume record at all** for `precomputed code intelligence` or `code intelligence for ai agents` — our coinages — so the only distinctive indexable token on the page was the brand string. GSC for `sc-domain:trace-mcp.com`, 2026-08-06 → 2026-09-04, shows what that costs: the two largest non-brand impression sources on the home page were `traceix mcp` (61) and `mcp tracing` (50) — 111 impressions, **zero clicks**, both name lookalikes Google matched because there was no category phrase to match instead.

## Cluster choice

`code graph mcp` / `codegraph mcp`: 70/mo each, 10 → 140 and 10 → 260 over twelve months, LOW competition. Its live top-20 is standalone product sites (`code-review-graph.com` at 6, `depgraph.ai` at 13, `codecontextgraph.com` at 16), and `comparisons.html` already ranks **#1–2 on that vocabulary's long tail** — every non-brand click the site earned in those 30 days came from it.

`claude code mcp server` is 12× the volume and was rejected: its top-10 is Anthropic's docs plus listicles, no single-product homepage ranks, and the way in is being listed *inside* those articles — outreach, not a page.

## What changed

Text only, no new pages, no layout change:

- `<title>`, `og:title`, `twitter:title`, JSON-LD `alternateName` → `trace-mcp — code graph MCP server for AI coding agents`. Brand string stays first (97% of clicks depend on it — TRA-907).
- `<meta name="description">` — head term added to the first clause; the measured 90.6% figure and the 155-char truncation point are untouched.
- Product View `<h2>` — `A structured model of your codebase` → `A code graph of your repository`. The graph's own section, where the term is exactly accurate.

## One deviation from the issue, and why

TRA-950 item 3 also proposed changing the hero subhead (`indexes your repository` → `builds a code graph of your repository`). **Dropped.** `ops/positioning.md` (TRA-906, landed the same day) reserves that exact sentence as the position claim's instance and explicitly forbids narrowing it back to the graph — "do not let the illustration narrow the claim back to the graph, which is how the surfaces got here in the first place." The README first screen carries it verbatim, so it stayed too.

The SEO requirement behind item 3 is real — a title claiming a term the body never uses gets demoted — so the head term went into visible copy on the Product View heading instead. Both requirements are met without either agent's decision being overridden.

That resolution is recorded in `ops/positioning.md`, which mandates being updated in the same change that moves a public claim: **the title carries the measured category term, the hero carries the position.** It is the same carve-out that file already makes for `server.json` under Doors — a channel that can only deliver door 1 gets described in door 1's words. A Google SERP for `code graph mcp` is that kind of channel.

## Test evidence

New `tests/docs/category-term.test.ts` guards the three placements, in the style of the sibling `searchable-name.test.ts` (which guards the brand string this change had to preserve). Verified it actually fails: reverting `docs/index.html` turns all three red, restoring it turns them green.

Full suite green — 10,222 passed / 22 skipped. `pnpm typecheck` and `pnpm build` clean.

Refs TRA-950
