### PR TITLE
fix(daemon): stop a running daemon from overriding the session's preset (TRA-951)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -580,7 +580,7 @@ program
   )
   .option(
     '--preset <name>',
-    'Default tool preset for daemon sessions (e.g. router, minimal, review, dev, security, design, perf, architecture, standard, full)',
+    'Tool preset for clients that connect to this daemon directly over HTTP (e.g. router, minimal, review, dev, security, design, perf, architecture, standard, full). A stdio session carries its own preset and is never narrowed by this.',
   )
   .action(async (opts: { port: string; host: string; allowRemote?: boolean; preset?: string }) => {
     if (opts.preset) {
@@ -811,6 +811,13 @@ program
 
     async function createSessionTransport(
       projectRoot: string,
+      /**
+       * Serve every tool regardless of the daemon's own `tools.preset`
+       * (TRA-951). Set for stdio sessions, which carry their own preset and
+       * apply it client-side in ProxyBackend. A client connecting to `/mcp`
+       * directly has no such filter, so it keeps the daemon's preset.
+       */
+      fullSurface: boolean,
     ): Promise<StreamableHTTPServerTransport | null> {
       const managed = projectManager.getProject(projectRoot);
       if (!managed) return null;
@@ -858,6 +865,9 @@ program
         },
         transport: 'http' as const,
         projectRelay,
+        // TRA-951: the daemon advertises the full surface to a session that
+        // applies its own preset client-side (ProxyBackend).
+        serveFullSurface: fullSurface,
       };
       const handle = createServer(
         managed.store,
@@ -1136,6 +1146,9 @@ program
           );
         }
         const requestedRoot = resolution.projectRoot;
+        // TRA-951: only the stdio proxy sends this, and only when it filters
+        // the surface itself.
+        const fullSurface = url.searchParams.get('surface') === 'full';
 
         // Resolve to the deepest KNOWN root: a registered subproject
         // (the/fair/fair-front) wins over its container ancestor (the) so the
@@ -1165,7 +1178,7 @@ program
             }
           } else if (req.method === 'POST' && isInitializeRequest(parsedBody)) {
             // New session: create transport + server
-            transport = (await createSessionTransport(projectRoot)) ?? undefined;
+            transport = (await createSessionTransport(projectRoot, fullSurface)) ?? undefined;
             if (!transport) {
               // Auto-register the project on first MCP connect when the path
               // is plausibly a real project root. This recovers the common
@@ -1223,7 +1236,7 @@ program
                       ? 'Auto-served registered subproject read-mostly on first MCP connect'
                       : 'Auto-registered project on first MCP connect',
                   );
-                  transport = (await createSessionTransport(projectRoot)) ?? undefined;
+                  transport = (await createSessionTransport(projectRoot, fullSurface)) ?? undefined;
                 } catch (err) {
                   logger.warn(
                     { err: String(err), projectRoot },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -818,6 +818,8 @@ program
        * directly has no such filter, so it keeps the daemon's preset.
        */
       fullSurface: boolean,
+      /** The preset the client asked for, when it sent one (TRA-951). */
+      clientPreset: string | undefined,
     ): Promise<StreamableHTTPServerTransport | null> {
       const managed = projectManager.getProject(projectRoot);
       if (!managed) return null;
@@ -868,6 +870,7 @@ program
         // TRA-951: the daemon advertises the full surface to a session that
         // applies its own preset client-side (ProxyBackend).
         serveFullSurface: fullSurface,
+        sessionPreset: clientPreset,
       };
       const handle = createServer(
         managed.store,
@@ -1149,6 +1152,7 @@ program
         // TRA-951: only the stdio proxy sends this, and only when it filters
         // the surface itself.
         const fullSurface = url.searchParams.get('surface') === 'full';
+        const clientPreset = url.searchParams.get('preset') ?? undefined;
 
         // Resolve to the deepest KNOWN root: a registered subproject
         // (the/fair/fair-front) wins over its container ancestor (the) so the
@@ -1178,7 +1182,8 @@ program
             }
           } else if (req.method === 'POST' && isInitializeRequest(parsedBody)) {
             // New session: create transport + server
-            transport = (await createSessionTransport(projectRoot, fullSurface)) ?? undefined;
+            transport =
+              (await createSessionTransport(projectRoot, fullSurface, clientPreset)) ?? undefined;
             if (!transport) {
               // Auto-register the project on first MCP connect when the path
               // is plausibly a real project root. This recovers the common
@@ -1236,7 +1241,9 @@ program
                       ? 'Auto-served registered subproject read-mostly on first MCP connect'
                       : 'Auto-registered project on first MCP connect',
                   );
-                  transport = (await createSessionTransport(projectRoot, fullSurface)) ?? undefined;
+                  transport =
+                    (await createSessionTransport(projectRoot, fullSurface, clientPreset)) ??
+                    undefined;
                 } catch (err) {
                   logger.warn(
                     { err: String(err), projectRoot },

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -422,7 +422,10 @@ export class ProjectManager {
       config,
       projectRoot,
       progress,
-      this.resourcePool?.getSharedDeps(config),
+      // TRA-951: the daemon's per-project server serves every session and the
+      // cross-project relay — the preset belongs to the client session and is
+      // applied by the proxy, not here.
+      { ...this.resourcePool?.getSharedDeps(config), serveFullSurface: true },
     );
 
     const managed: ManagedProject = {

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -425,7 +425,11 @@ export class ProjectManager {
       // TRA-951: the daemon's per-project server serves every session and the
       // cross-project relay — the preset belongs to the client session and is
       // applied by the proxy, not here.
-      { ...this.resourcePool?.getSharedDeps(config), serveFullSurface: true },
+      {
+        ...this.resourcePool?.getSharedDeps(config),
+        serveFullSurface: true,
+        skipUsagePing: true,
+      },
     );
 
     const managed: ManagedProject = {

--- a/src/daemon/project-relay.ts
+++ b/src/daemon/project-relay.ts
@@ -91,7 +91,7 @@ export function createDaemonProjectRelay(
         managed.root,
         managed.progress,
         // TRA-951: shared server, never a client session's own surface.
-        { ...deps, serveFullSurface: true },
+        { ...deps, serveFullSurface: true, skipUsagePing: true },
       );
       cache.set(abs, handle);
       return handle;
@@ -145,8 +145,10 @@ export function createLightweightProjectRelay(): ProjectRelay {
       const registry = PluginRegistry.createWithDefaults();
       const progress = new ProgressState(db);
       const handle = createServer(store, registry, configResult.value, resolved.root, progress, {
-        // TRA-951: relay target — dispatch is by name, not through a preset.
+        // TRA-951: relay target — dispatch is by name, not through a preset,
+        // and no client session sits behind it.
         serveFullSurface: true,
+        skipUsagePing: true,
       });
       cache.set(abs, { handle, db });
       return handle;

--- a/src/daemon/project-relay.ts
+++ b/src/daemon/project-relay.ts
@@ -90,7 +90,8 @@ export function createDaemonProjectRelay(
         managed.config,
         managed.root,
         managed.progress,
-        deps,
+        // TRA-951: shared server, never a client session's own surface.
+        { ...deps, serveFullSurface: true },
       );
       cache.set(abs, handle);
       return handle;
@@ -143,7 +144,10 @@ export function createLightweightProjectRelay(): ProjectRelay {
       const store = new Store(db);
       const registry = PluginRegistry.createWithDefaults();
       const progress = new ProgressState(db);
-      const handle = createServer(store, registry, configResult.value, resolved.root, progress, {});
+      const handle = createServer(store, registry, configResult.value, resolved.root, progress, {
+        // TRA-951: relay target — dispatch is by name, not through a preset.
+        serveFullSurface: true,
+      });
       cache.set(abs, { handle, db });
       return handle;
     },

--- a/src/daemon/router/__tests__/proxy-preset-info.test.ts
+++ b/src/daemon/router/__tests__/proxy-preset-info.test.ts
@@ -120,6 +120,17 @@ describe('get_preset_info over the daemon proxy (TRA-951)', () => {
     expect(TOOL_PRESETS.minimal as string[]).not.toContain('get_tests_for');
   });
 
+  it('forwards an excluded get_preset_info instead of answering it', async () => {
+    // `tools.exclude` is a hard restriction and outranks the intercept: the
+    // call has to reach the standard filter, which rejects it.
+    const { reply } = await callPresetInfo(
+      { tools: { preset: 'full', exclude: ['get_preset_info'] } } as TraceMcpConfig,
+      'full',
+    );
+    const r = reply as { error?: { message?: string } };
+    expect(r.error?.message).toContain('get_preset_info');
+  });
+
   it('forwards to the daemon when the catalog is unavailable rather than reporting an empty surface', async () => {
     const { reply, transport } = await callPresetInfo(
       { tools: { preset: 'full' } } as TraceMcpConfig,

--- a/src/daemon/router/__tests__/proxy-preset-info.test.ts
+++ b/src/daemon/router/__tests__/proxy-preset-info.test.ts
@@ -1,0 +1,135 @@
+/**
+ * TRA-951: `get_preset_info` on the daemon path must describe *this* session.
+ *
+ * Forwarded to the daemon it answered from the daemon's own configuration —
+ * reporting `active_preset: minimal, registered_tools: 18` in a session where
+ * tools outside `minimal` were answering normally. That is the wrong answer to
+ * the one question a user asks when a tool is unexpectedly missing, so the
+ * proxy answers it from the session's own filter instead.
+ */
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { TraceMcpConfig } from '../../../config.js';
+import { createToolFilter } from '../../../server/tool-filter.js';
+import { TOOL_PRESETS } from '../../../tools/project/presets.js';
+import { ProxyBackend, type ProxyTransport } from '../proxy-backend.js';
+
+const DAEMON_TOOLS = ['search', 'get_symbol', 'get_tests_for', 'get_pagerank', 'get_preset_info'];
+
+/** Stands in for the daemon: full surface on list, echo on call. */
+class FakeDaemonTransport implements ProxyTransport {
+  onmessage?: (msg: JSONRPCMessage) => void;
+  onerror?: (err: Error) => void;
+  readonly forwarded: JSONRPCMessage[] = [];
+
+  constructor(private readonly toolNames: string[]) {}
+
+  async start(): Promise<void> {}
+  async close(): Promise<void> {}
+
+  async send(msg: JSONRPCMessage): Promise<void> {
+    this.forwarded.push(msg);
+    const m = msg as Record<string, unknown>;
+    if (m.method === 'tools/list') {
+      this.onmessage?.({
+        jsonrpc: '2.0',
+        id: m.id,
+        result: {
+          tools: this.toolNames.map((name) => ({
+            name,
+            description: `stub ${name}`,
+            inputSchema: { type: 'object', properties: {} },
+          })),
+        },
+      } as unknown as JSONRPCMessage);
+    } else if (m.method === 'tools/call') {
+      this.onmessage?.({
+        jsonrpc: '2.0',
+        id: m.id,
+        result: { content: [{ type: 'text', text: 'daemon answered get_preset_info' }] },
+      } as unknown as JSONRPCMessage);
+    }
+  }
+}
+
+const backends: ProxyBackend[] = [];
+afterEach(async () => {
+  for (const b of backends.splice(0)) await b.stop();
+});
+
+async function callPresetInfo(
+  config: TraceMcpConfig,
+  presetName: string | undefined,
+  daemonTools = DAEMON_TOOLS,
+): Promise<{ reply: unknown; transport: FakeDaemonTransport }> {
+  const transport = new FakeDaemonTransport(daemonTools);
+  const toClient: JSONRPCMessage[] = [];
+  const backend = new ProxyBackend({
+    daemonUrl: 'http://127.0.0.1:0',
+    projectRoot: '/nonexistent/fake-project',
+    clientId: 'tra-951-test',
+    toolFilter: createToolFilter(config),
+    presetName,
+    transportFactory: () => transport,
+  });
+  backend.onmessage = (m) => toClient.push(m);
+  backends.push(backend);
+  await backend.start();
+  await backend.send({
+    jsonrpc: '2.0',
+    id: 42,
+    method: 'tools/call',
+    params: { name: 'get_preset_info', arguments: {} },
+  } as unknown as JSONRPCMessage);
+  return { reply: toClient.at(-1), transport };
+}
+
+function payload(reply: unknown): Record<string, unknown> {
+  const r = reply as { id?: unknown; result?: { content?: Array<{ text?: string }> } };
+  expect(r.id).toBe(42);
+  return JSON.parse(r.result?.content?.[0]?.text ?? '{}');
+}
+
+describe('get_preset_info over the daemon proxy (TRA-951)', () => {
+  it("reports the session's preset and surface, not the daemon's", async () => {
+    const { reply, transport } = await callPresetInfo(
+      { tools: { preset: 'full' } } as TraceMcpConfig,
+      'full',
+    );
+    const info = payload(reply);
+    expect(info.active_preset).toBe('full');
+    expect(info.tool_names).toContain('get_tests_for');
+    expect(info.registered_tools).toBe(DAEMON_TOOLS.length);
+    expect(info.deferred_tools).toEqual([]);
+    // Answered locally — never forwarded as a tools/call.
+    expect(
+      transport.forwarded.some((m) => (m as Record<string, unknown>).method === 'tools/call'),
+    ).toBe(false);
+  });
+
+  it('reports the deferred half for a narrow preset', async () => {
+    const { reply } = await callPresetInfo(
+      { tools: { preset: 'minimal' } } as TraceMcpConfig,
+      'minimal',
+    );
+    const info = payload(reply);
+    expect(info.active_preset).toBe('minimal');
+    expect(info.deferred_tools).toContain('get_tests_for');
+    expect(info.tool_names).not.toContain('get_tests_for');
+    // Sanity: the tool we assert on really is outside `minimal`.
+    expect(TOOL_PRESETS.minimal as string[]).not.toContain('get_tests_for');
+  });
+
+  it('forwards to the daemon when the catalog is unavailable rather than reporting an empty surface', async () => {
+    const { reply, transport } = await callPresetInfo(
+      { tools: { preset: 'full' } } as TraceMcpConfig,
+      'full',
+      [],
+    );
+    expect(
+      transport.forwarded.some((m) => (m as Record<string, unknown>).method === 'tools/call'),
+    ).toBe(true);
+    const r = reply as { result?: { content?: Array<{ text?: string }> } };
+    expect(r.result?.content?.[0]?.text).toBe('daemon answered get_preset_info');
+  });
+});

--- a/src/daemon/router/__tests__/proxy-tool-preset.test.ts
+++ b/src/daemon/router/__tests__/proxy-tool-preset.test.ts
@@ -101,6 +101,7 @@ async function startProxy(
     projectRoot: '/nonexistent/fake-project',
     clientId: 'tra-250-test',
     toolFilter: filterless ? undefined : createToolFilter(config),
+    presetName: filterless ? undefined : (config.tools?.preset ?? 'minimal'),
     transportFactory: (mcpUrl) => {
       lastMcpUrl = mcpUrl;
       return transport;
@@ -167,6 +168,11 @@ describe('daemon proxy honours the session tool preset (TRA-250)', () => {
   it('asks the daemon for the unfiltered surface when it filters locally', async () => {
     await startProxy({ tools: { preset: 'minimal' } } as TraceMcpConfig);
     expect(lastMcpUrl).toContain('surface=full');
+  });
+
+  it('tells the daemon which preset the session asked for, so its instructions and ping match', async () => {
+    await startProxy({ tools: { preset: 'minimal' } } as TraceMcpConfig);
+    expect(lastMcpUrl).toContain('preset=minimal');
   });
 
   it('omits the marker when it has no filter of its own', async () => {

--- a/src/daemon/router/__tests__/proxy-tool-preset.test.ts
+++ b/src/daemon/router/__tests__/proxy-tool-preset.test.ts
@@ -86,8 +86,13 @@ afterEach(async () => {
   delete process.env.TRACE_MCP_PRESET;
 });
 
+/** The /mcp URL the last started proxy asked its transport factory for. */
+let lastMcpUrl = '';
+
 async function startProxy(
   config: TraceMcpConfig,
+  /** Build the backend with no per-session filter at all. */
+  filterless = false,
 ): Promise<{ backend: ProxyBackend; transport: FakeDaemonTransport; toClient: JSONRPCMessage[] }> {
   const transport = new FakeDaemonTransport(DAEMON_TOOLS);
   const toClient: JSONRPCMessage[] = [];
@@ -95,8 +100,11 @@ async function startProxy(
     daemonUrl: 'http://127.0.0.1:0',
     projectRoot: '/nonexistent/fake-project',
     clientId: 'tra-250-test',
-    toolFilter: createToolFilter(config),
-    transportFactory: () => transport,
+    toolFilter: filterless ? undefined : createToolFilter(config),
+    transportFactory: (mcpUrl) => {
+      lastMcpUrl = mcpUrl;
+      return transport;
+    },
   });
   backend.onmessage = (m) => toClient.push(m);
   backends.push(backend);
@@ -150,6 +158,20 @@ describe('daemon proxy honours the session tool preset (TRA-250)', () => {
     const names = await proxiedToolNames({ tools: { preset: 'full' } } as TraceMcpConfig);
     const expected = new Set([...(TOOL_PRESETS.minimal as string[]), ...UNGATED_META_TOOLS]);
     expect(names.filter((n) => !expected.has(n))).toEqual([]);
+  });
+
+  // TRA-951: the daemon used to apply *its own* preset to every session it
+  // served, so a session that asked for `full` still got `Tool X disabled` for
+  // everything outside the daemon's preset — and `load_tools` could not escalate
+  // past it either. The marker says "don't narrow this one, I filter it myself".
+  it('asks the daemon for the unfiltered surface when it filters locally', async () => {
+    await startProxy({ tools: { preset: 'minimal' } } as TraceMcpConfig);
+    expect(lastMcpUrl).toContain('surface=full');
+  });
+
+  it('omits the marker when it has no filter of its own', async () => {
+    await startProxy({} as TraceMcpConfig, true);
+    expect(lastMcpUrl).not.toContain('surface=');
   });
 
   it('honours tools.exclude and tools.include over the preset', async () => {

--- a/src/daemon/router/proxy-backend.ts
+++ b/src/daemon/router/proxy-backend.ts
@@ -5,6 +5,7 @@ import { resolveWorktreeAware, worktreeHint } from '../../registry-worktree.js';
 import { resolveDeepestKnownRoot } from '../../subproject/resolve.js';
 import { isTransientError, withRetry } from '../../utils/retry.js';
 import { LOAD_TOOLS_HINT, expandLoadRequest, planToolLoad } from '../../server/tool-surface.js';
+import { listPresets } from '../../tools/project/presets.js';
 import type { Backend } from './types.js';
 
 /**
@@ -59,6 +60,15 @@ export interface ProxyBackendOptions {
     /** Widen this session's surface to include `names`. */
     load: (names: string[]) => void;
   };
+  /**
+   * This session's preset name, reported by `get_preset_info` (TRA-951).
+   * That tool runs on the daemon, which knows only its own configuration, so
+   * it answered with the daemon's preset and *its* registered-tool count — the
+   * wrong answer to the one question a user asks when a tool is missing. Given
+   * this, the proxy answers it locally from the session's own filter. Omit to
+   * forward it to the daemon unchanged.
+   */
+  presetName?: string;
   /**
    * Test seam: build a transport for the resolved /mcp URL + project root.
    * Defaults to a real StreamableHTTPClientTransport.
@@ -235,6 +245,9 @@ export class ProxyBackend implements Backend {
       const called = toolCallName(msg);
       if (called === 'load_tools' && this.opts.toolSurface && id !== undefined) {
         await this.handleLoadTools(msg, id);
+        return;
+      }
+      if (called === 'get_preset_info' && id !== undefined && (await this.handlePresetInfo(id))) {
         return;
       }
       // `batch` dispatches by name on the daemon side, past this filter — that
@@ -431,6 +444,42 @@ export class ProxyBackend implements Backend {
     return this.priming;
   }
 
+  /**
+   * Answer `get_preset_info` from this session's own filter (TRA-951).
+   *
+   * Forwarded, it reports the daemon's preset and registered-tool count, which
+   * is neither what the session asked for nor what it can call. Returns false
+   * when the daemon's catalog is unavailable, so the call falls through and is
+   * forwarded rather than answered with an empty surface.
+   */
+  private async handlePresetInfo(id: string | number): Promise<boolean> {
+    const filter = this.opts.toolFilter;
+    if (!filter || !this.opts.presetName) return false;
+    await this.primeDaemonTools();
+    if (this.daemonTools.length === 0) return false;
+    const names = this.daemonTools.map((t) => t.name);
+    const registered = names.filter((n) => filter(n));
+    this.onmessage?.({
+      jsonrpc: '2.0',
+      id,
+      result: {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              active_preset: this.opts.presetName,
+              registered_tools: registered.length,
+              tool_names: registered,
+              available_presets: listPresets(),
+              deferred_tools: names.filter((n) => !filter(n)),
+            }),
+          },
+        ],
+      },
+    } as unknown as JSONRPCMessage);
+    return true;
+  }
+
   private async handleLoadTools(msg: JSONRPCMessage, id: string | number): Promise<void> {
     await this.primeDaemonTools();
     const surface = this.opts.toolSurface!;
@@ -577,8 +626,17 @@ export class ProxyBackend implements Backend {
     }) as unknown as ProxyTransport;
   }
 
+  /**
+   * TRA-951: `surface=full` tells the daemon not to apply its own preset to
+   * this session. The preset belongs to the client and is applied here, on the
+   * way out — a daemon started with `tools.preset: minimal` otherwise deferred
+   * those tools for every session, including one that asked for `full`, and
+   * `load_tools` could never escalate past them. Sessions that connect to
+   * `/mcp` directly send no such marker and keep the daemon's preset.
+   */
   private mcpUrl(projectRoot: string): string {
-    return `${this.opts.daemonUrl}/mcp?project=${encodeURIComponent(projectRoot)}`;
+    const base = `${this.opts.daemonUrl}/mcp?project=${encodeURIComponent(projectRoot)}`;
+    return this.opts.toolFilter ? `${base}&surface=full` : base;
   }
 
   /**

--- a/src/daemon/router/proxy-backend.ts
+++ b/src/daemon/router/proxy-backend.ts
@@ -455,6 +455,9 @@ export class ProxyBackend implements Backend {
   private async handlePresetInfo(id: string | number): Promise<boolean> {
     const filter = this.opts.toolFilter;
     if (!filter || !this.opts.presetName) return false;
+    // `tools.exclude` is a hard restriction that outranks the intercept: fall
+    // through so the standard filter rejects the call instead of answering it.
+    if (!filter('get_preset_info')) return false;
     await this.primeDaemonTools();
     if (this.daemonTools.length === 0) return false;
     const names = this.daemonTools.map((t) => t.name);
@@ -636,7 +639,14 @@ export class ProxyBackend implements Backend {
    */
   private mcpUrl(projectRoot: string): string {
     const base = `${this.opts.daemonUrl}/mcp?project=${encodeURIComponent(projectRoot)}`;
-    return this.opts.toolFilter ? `${base}&surface=full` : base;
+    if (!this.opts.toolFilter) return base;
+    // `preset` travels too: the daemon registers everything, but it still
+    // writes this session's instructions block and usage ping, and both are
+    // about what the *client* advertises.
+    const preset = this.opts.presetName
+      ? `&preset=${encodeURIComponent(this.opts.presetName)}`
+      : '';
+    return `${base}&surface=full${preset}`;
   }
 
   /**

--- a/src/daemon/router/session.ts
+++ b/src/daemon/router/session.ts
@@ -7,7 +7,7 @@ import { logger } from '../../logger.js';
 import { checkVersionDrift, versionDriftMessage } from '../../init/version-stamp.js';
 import { stripRedundantSchemaKeyword } from '../../server/schema-shim.js';
 import { ClientProfileGate } from '../../server/client-profile.js';
-import { createToolFilter } from '../../server/tool-filter.js';
+import { createToolFilter, resolveSessionPreset } from '../../server/tool-filter.js';
 import { disarmStdoutGuard } from '../../server/transport-hardening.js';
 import { tryAutoSpawnDaemon } from '../lifecycle.js';
 import { PollingDaemonWatcher } from './daemon-watcher.js';
@@ -529,6 +529,9 @@ export class StdioSession {
       // (which serves every tool to everyone) — so it has to be applied here
       // on the way out, or it never reaches a daemon-backed client (TRA-250).
       toolFilter: (name) => this.baseToolFilter(name) || this.loadedTools.has(name),
+      // TRA-951: so `get_preset_info` reports *this* session's preset instead
+      // of the daemon's.
+      presetName: resolveSessionPreset(this.opts.config).name,
       // TRA-402: `load_tools` is answered by the proxy, not the daemon — the
       // daemon serves one full surface to every session and has no idea which
       // tools *this* session has paid for. Escalation state lives on the

--- a/src/server/__tests__/daemon-full-surface.test.ts
+++ b/src/server/__tests__/daemon-full-surface.test.ts
@@ -79,6 +79,22 @@ describe('serveFullSurface (TRA-951)', () => {
     expect(handle.toolHandlers.has(OUTSIDE_MINIMAL)).toBe(true);
   });
 
+  // The regression this guards: widening the registration surface used to widen
+  // `presetName` with it, so a daemon-backed session was handed the instructions
+  // block for the entire catalog it never asked for — a token regression on the
+  // default setup.
+  it('does not widen the instructions block with the registration surface', async () => {
+    const narrow = await build({});
+    const wide = await build({ serveFullSurface: true });
+    const instructionsOf = (h: ServerHandle): string =>
+      (h.server as unknown as { server: { _options?: { instructions?: string } } }).server._options
+        ?.instructions ?? '';
+
+    expect(instructionsOf(narrow)).not.toBe('');
+    expect(instructionsOf(wide)).toBe(instructionsOf(narrow));
+    expect(instructionsOf(wide)).not.toContain(OUTSIDE_MINIMAL);
+  });
+
   it('still honours tools.exclude, which is a hard restriction, not a preset', async () => {
     const { initializeDatabase } = await import('../../db/schema.js');
     const { Store } = await import('../../db/store.js');

--- a/src/server/__tests__/daemon-full-surface.test.ts
+++ b/src/server/__tests__/daemon-full-surface.test.ts
@@ -1,0 +1,101 @@
+/**
+ * TRA-951: a running daemon must not impose its own preset on a session.
+ *
+ * The daemon registers one server per project and serves every session from
+ * it, so a `tools.preset` in the daemon's config used to defer those tools for
+ * everybody — a session started with `--preset full` got `Tool X disabled` per
+ * call, with no signal at startup. `serveFullSurface` is the seam: daemon-side
+ * servers register everything, and the preset is applied per session by the
+ * proxy (guarded by daemon/router/__tests__/proxy-tool-preset.test.ts).
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TraceMcpConfig } from '../../config.js';
+import type { ServerHandle } from '../server.js';
+
+let tmpHome: string;
+let projectRoot: string;
+const handles: ServerHandle[] = [];
+const closers: Array<() => void> = [];
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'trace-mcp-tra951-'));
+  vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+  vi.resetModules();
+  projectRoot = join(tmpHome, 'project');
+  mkdirSync(projectRoot, { recursive: true });
+  writeFileSync(join(projectRoot, 'package.json'), JSON.stringify({ name: 'p' }));
+});
+
+afterEach(() => {
+  for (const h of handles.splice(0)) h.dispose();
+  for (const c of closers.splice(0)) c();
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+/** A tool that exists in `full` but not in `minimal` — the surface at stake. */
+const OUTSIDE_MINIMAL = 'get_tests_for';
+
+async function build(deps: Record<string, unknown>): Promise<ServerHandle> {
+  const { initializeDatabase } = await import('../../db/schema.js');
+  const { Store } = await import('../../db/store.js');
+  const { PluginRegistry } = await import('../../plugin-api/registry.js');
+  const { ProgressState } = await import('../../progress.js');
+  const { createServer } = await import('../server.js');
+
+  const db = initializeDatabase(join(tmpHome, 'index.db'));
+  closers.push(() => db.close());
+  const config = { tools: { preset: 'minimal' } } as TraceMcpConfig;
+  const handle = createServer(
+    new Store(db),
+    PluginRegistry.createWithDefaults(),
+    config,
+    projectRoot,
+    new ProgressState(db),
+    deps,
+  );
+  handles.push(handle);
+  return handle;
+}
+
+describe('serveFullSurface (TRA-951)', () => {
+  it('a narrow preset still defers tools on a session-owned server', async () => {
+    const handle = await build({});
+    expect(handle.toolHandlers.has(OUTSIDE_MINIMAL)).toBe(false);
+  });
+
+  it('registers the full surface on a daemon-side server despite tools.preset', async () => {
+    const handle = await build({ serveFullSurface: true });
+    expect(handle.toolHandlers.has(OUTSIDE_MINIMAL)).toBe(true);
+  });
+
+  it('ignores TRACE_MCP_PRESET too — the daemon inherits the env of whoever spawned it', async () => {
+    vi.stubEnv('TRACE_MCP_PRESET', 'minimal');
+    const handle = await build({ serveFullSurface: true });
+    expect(handle.toolHandlers.has(OUTSIDE_MINIMAL)).toBe(true);
+  });
+
+  it('still honours tools.exclude, which is a hard restriction, not a preset', async () => {
+    const { initializeDatabase } = await import('../../db/schema.js');
+    const { Store } = await import('../../db/store.js');
+    const { PluginRegistry } = await import('../../plugin-api/registry.js');
+    const { ProgressState } = await import('../../progress.js');
+    const { createServer } = await import('../server.js');
+    const db = initializeDatabase(join(tmpHome, 'index.db'));
+    closers.push(() => db.close());
+    const handle = createServer(
+      new Store(db),
+      PluginRegistry.createWithDefaults(),
+      { tools: { exclude: [OUTSIDE_MINIMAL] } } as TraceMcpConfig,
+      projectRoot,
+      new ProgressState(db),
+      { serveFullSurface: true },
+    );
+    handles.push(handle);
+    expect(handle.toolHandlers.has(OUTSIDE_MINIMAL)).toBe(false);
+  });
+});

--- a/src/server/__tests__/daemon-full-surface.test.ts
+++ b/src/server/__tests__/daemon-full-surface.test.ts
@@ -15,12 +15,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TraceMcpConfig } from '../../config.js';
 import type { ServerHandle } from '../server.js';
 
+/** Usage pings this test's servers fired. */
+const pings: Array<{ preset: string; toolsAdvertised: number }> = [];
+vi.mock('../../telemetry/usage-ping.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../telemetry/usage-ping.js')>();
+  return {
+    ...actual,
+    sendUsagePing: async (p: { preset: string; toolsAdvertised: number }) => {
+      pings.push(p);
+    },
+  };
+});
+
 let tmpHome: string;
 let projectRoot: string;
 const handles: ServerHandle[] = [];
 const closers: Array<() => void> = [];
 
 beforeEach(() => {
+  pings.length = 0;
   tmpHome = mkdtempSync(join(tmpdir(), 'trace-mcp-tra951-'));
   vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
   vi.resetModules();
@@ -93,6 +106,32 @@ describe('serveFullSurface (TRA-951)', () => {
     expect(instructionsOf(narrow)).not.toBe('');
     expect(instructionsOf(wide)).toBe(instructionsOf(narrow));
     expect(instructionsOf(wide)).not.toContain(OUTSIDE_MINIMAL);
+  });
+
+  it("follows the client's preset when the daemon builds the session for it", async () => {
+    // The daemon's own config says `minimal`; the client asked for `full`, and
+    // the block it is handed has to describe what *it* can call.
+    const wideClient = await build({ serveFullSurface: true, sessionPreset: 'full' });
+    const narrowClient = await build({ serveFullSurface: true, sessionPreset: 'minimal' });
+    const instructionsOf = (h: ServerHandle): string =>
+      (h.server as unknown as { server: { _options?: { instructions?: string } } }).server._options
+        ?.instructions ?? '';
+
+    expect(instructionsOf(wideClient)).toContain(OUTSIDE_MINIMAL);
+    expect(instructionsOf(narrowClient)).not.toContain(OUTSIDE_MINIMAL);
+  });
+
+  it("reports the client's preset and its advertised count in the usage ping", async () => {
+    await build({ serveFullSurface: true, sessionPreset: 'minimal' });
+    const ping = pings.at(-1);
+    expect(ping?.preset).toBe('minimal');
+    // The daemon registers ~160 tools; the session advertises far fewer.
+    expect(ping?.toolsAdvertised).toBeLessThan(60);
+  });
+
+  it('sends no usage ping for a server with no client behind it', async () => {
+    await build({ serveFullSurface: true, skipUsagePing: true });
+    expect(pings).toEqual([]);
   });
 
   it('still honours tools.exclude, which is a hard restriction, not a preset', async () => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -251,6 +251,19 @@ export interface ServerDeps {
    * own server (LocalBackend, `serve-http`), where the preset must apply.
    */
   serveFullSurface?: boolean;
+  /**
+   * The preset the *client* asked for, when this server is built on its behalf
+   * by the daemon (TRA-951). Drives the instructions block and the usage ping;
+   * the registered surface is `serveFullSurface`'s business. Omitted on a
+   * session's own server, which reads the preset from its own config/env.
+   */
+  sessionPreset?: string;
+  /**
+   * Skip the anonymous usage ping. Set for servers with no client behind them
+   * — `ProjectManager`'s per-project server and the cross-project relay —
+   * which would otherwise report a session that nobody opened (TRA-951).
+   */
+  skipUsagePing?: boolean;
 }
 
 /**
@@ -297,34 +310,30 @@ export function createServer(
   // Resolved before the instructions, because they are written against it
   // (TRA-929): the block names only tools this session actually advertises.
   // Single source of truth for the default, shared with the daemon proxy's
-  // per-session filter — the two used to spell it out separately. Unknown
-  // names fall back to the default surface and warn (TRA-648) — never to
-  // `full`, which silently made the cheap-by-request session the expensive one.
-  // TRA-951: a daemon-side server is shared by every session, so it must not
-  // apply *its own* preset — the per-session filter lives in the proxy
-  // (daemon/router/proxy-backend.ts). Without this a daemon started with
-  // `tools.preset: minimal` deferred those tools for everybody, and a session
-  // that asked for `full` got `Tool X disabled` per call with no other signal.
-  const resolvedPreset = resolveSessionPreset(config);
+  // per-session filter — the two used to spell it out separately.
+  // TRA-951: two different questions, which used to have one answer.
+  //  - *What does this session advertise?* Still the session's preset — it
+  //    writes the instructions block and the usage ping, and on the daemon
+  //    path it belongs to the client, which sends it with the request.
+  //  - *What does this server register?* Everything, when it is shared by many
+  //    sessions (`serveFullSurface`). A daemon started with `tools.preset:
+  //    minimal` otherwise left those tools disabled for everybody, so a session
+  //    that asked for `full` got `Tool X disabled` per call and `load_tools`
+  //    could not escalate past it.
+  // Unknown names fall back to the default surface and warn (TRA-648) — never
+  // to `full`, which silently made the cheap-by-request session the expensive one.
+  const { name: presetName, tools: sessionSurface } = resolveSessionPreset(
+    config,
+    deps?.sessionPreset,
+  );
+  const activePreset = deps?.serveFullSurface ? 'all' : sessionSurface;
 
-  // `serveFullSurface` widens the *registration* surface only. Everything
-  // derived from the preset — the instructions block, `get_preset_info`, the
-  // usage ping — keeps the resolved name, because those describe a session and
-  // a widened surface would make every daemon-backed session advertise the
-  // whole catalog it never asked for. That is a token regression, which is the
-  // one thing this product may not trade away for a fix.
-  const activePreset = deps?.serveFullSurface ? ('all' as const) : resolvedPreset.tools;
-  const presetName = resolvedPreset.name;
-
-  // Create server with instructions
+  // Create server with instructions. Written against the *session* surface
+  // (TRA-929): the block names only tools this session actually advertises,
+  // never the daemon's larger registered set.
   const instructionsVerbosity = config.tools?.instructions_verbosity ?? 'full';
   const agentBehavior = config.tools?.agent_behavior ?? 'off';
-  const onSurface = createToolFilter(config, activePreset);
-  // Instructions describe what a client should reach for, so they follow the
-  // preset, never the widened registration surface.
-  const onInstructionSurface = deps?.serveFullSurface
-    ? createToolFilter(config, resolvedPreset.tools)
-    : onSurface;
+  const onSurface = createToolFilter(config, sessionSurface);
   const server = new McpServer(
     { name: 'trace', version: PKG_VERSION },
     {
@@ -332,7 +341,7 @@ export function createServer(
         detectedFrameworks,
         instructionsVerbosity,
         agentBehavior,
-        onInstructionSurface,
+        onSurface,
       ),
     },
   );
@@ -767,13 +776,20 @@ export function createServer(
   // Fire-and-forget — never blocks startup, never throws. Last, so it can
   // report the surface this session actually built: `registeredToolNames` is
   // only complete once every register*Tools call above has run (TRA-643).
-  void sendUsagePing({
-    version: PKG_VERSION,
-    preset: presetName,
-    toolsAdvertised: registeredToolNames.length + ungatedToolNames.length,
-  }).catch((err) => {
-    logger.debug({ err }, 'telemetry.usage_ping_unexpected_error');
-  });
+  // TRA-951: count the session's surface, not the registered one — a
+  // daemon-side server registers every tool but advertises only what the
+  // client's preset allows, and the ping's `tools_advertised` dimension is
+  // about what reached the client. Identical on the local path, where
+  // `registeredToolNames` passed exactly this filter.
+  if (!deps?.skipUsagePing) {
+    void sendUsagePing({
+      version: PKG_VERSION,
+      preset: presetName,
+      toolsAdvertised: registeredToolNames.filter(onSurface).length + ungatedToolNames.length,
+    }).catch((err) => {
+      logger.debug({ err }, 'telemetry.usage_ping_unexpected_error');
+    });
+  }
 
   return { server, journal, dispose, toolHandlers };
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -243,6 +243,14 @@ export interface ServerDeps {
    * fallback commands, unit tests) — the tool then reports itself unavailable.
    */
   projectRelay?: ProjectRelay;
+  /**
+   * Register every tool regardless of `tools.preset` (TRA-951). Set by the
+   * daemon and by the cross-project relay, whose servers are shared across
+   * sessions — the preset is a property of a *client* session and is applied
+   * on the way out by the proxy's per-session filter. Never set on a session's
+   * own server (LocalBackend, `serve-http`), where the preset must apply.
+   */
+  serveFullSurface?: boolean;
 }
 
 /**
@@ -292,7 +300,14 @@ export function createServer(
   // per-session filter — the two used to spell it out separately. Unknown
   // names fall back to the default surface and warn (TRA-648) — never to
   // `full`, which silently made the cheap-by-request session the expensive one.
-  const { name: presetName, tools: activePreset } = resolveSessionPreset(config);
+  // TRA-951: a daemon-side server is shared by every session, so it must not
+  // apply *its own* preset — the per-session filter lives in the proxy
+  // (daemon/router/proxy-backend.ts). Without this a daemon started with
+  // `tools.preset: minimal` deferred those tools for everybody, and a session
+  // that asked for `full` got `Tool X disabled` per call with no other signal.
+  const { name: presetName, tools: activePreset } = deps?.serveFullSurface
+    ? { name: 'all', tools: 'all' as const }
+    : resolveSessionPreset(config);
 
   // Create server with instructions
   const instructionsVerbosity = config.tools?.instructions_verbosity ?? 'full';

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -305,14 +305,26 @@ export function createServer(
   // (daemon/router/proxy-backend.ts). Without this a daemon started with
   // `tools.preset: minimal` deferred those tools for everybody, and a session
   // that asked for `full` got `Tool X disabled` per call with no other signal.
-  const { name: presetName, tools: activePreset } = deps?.serveFullSurface
-    ? { name: 'all', tools: 'all' as const }
-    : resolveSessionPreset(config);
+  const resolvedPreset = resolveSessionPreset(config);
+
+  // `serveFullSurface` widens the *registration* surface only. Everything
+  // derived from the preset — the instructions block, `get_preset_info`, the
+  // usage ping — keeps the resolved name, because those describe a session and
+  // a widened surface would make every daemon-backed session advertise the
+  // whole catalog it never asked for. That is a token regression, which is the
+  // one thing this product may not trade away for a fix.
+  const activePreset = deps?.serveFullSurface ? ('all' as const) : resolvedPreset.tools;
+  const presetName = resolvedPreset.name;
 
   // Create server with instructions
   const instructionsVerbosity = config.tools?.instructions_verbosity ?? 'full';
   const agentBehavior = config.tools?.agent_behavior ?? 'off';
   const onSurface = createToolFilter(config, activePreset);
+  // Instructions describe what a client should reach for, so they follow the
+  // preset, never the widened registration surface.
+  const onInstructionSurface = deps?.serveFullSurface
+    ? createToolFilter(config, resolvedPreset.tools)
+    : onSurface;
   const server = new McpServer(
     { name: 'trace', version: PKG_VERSION },
     {
@@ -320,7 +332,7 @@ export function createServer(
         detectedFrameworks,
         instructionsVerbosity,
         agentBehavior,
-        onSurface,
+        onInstructionSurface,
       ),
     },
   );

--- a/src/server/tool-filter.ts
+++ b/src/server/tool-filter.ts
@@ -72,12 +72,20 @@ const warnedUnknownPresets = new Set<string>();
  * reported too, because callers log it and `get_preset_info` reports it — a
  * session must not claim to be running a preset it isn't.
  */
-export function resolveSessionPreset(config: TraceMcpConfig): {
+export function resolveSessionPreset(
+  config: TraceMcpConfig,
+  /**
+   * Preset this session asked for, when it is not this process's own config —
+   * the daemon resolves the *client's* preset, which travels with the request
+   * (TRA-951). Unknown names fall back the same way as a local one.
+   */
+  requestedName?: string,
+): {
   name: string;
   tools: Set<string> | 'all';
   unknownName?: string;
 } {
-  const requested = resolvePresetName(config);
+  const requested = requestedName ?? resolvePresetName(config);
   const resolved = resolvePreset(requested);
   if (resolved) return { name: requested, tools: resolved };
 


### PR DESCRIPTION
Fixes TRA-951.

## The bug

`TRACE_MCP_PRESET=full` / `serve --preset full` were silently ignored whenever a daemon was already running. The daemon builds each session's `McpServer` from **its own** config, so every tool outside the daemon's preset was registered-but-disabled for everybody — a session that asked for `full` learned this one `MCP error -32602: Tool <name> disabled` at a time. `load_tools` could not escalate past it either: the proxy widened its own filter, but the tool stayed disabled on the daemon side.

Reproduced live on an isolated daemon (`serve-http --port 3799`, `tools.preset: minimal`):

| session | `tools/list` | `tools/call get_tests_for` |
|---|---|---|
| before / no marker | 28 tools | `MCP error -32602: Tool get_tests_for disabled` |
| after / `surface=full` | 161 tools | executes (`'nope' is not in the index`) |

## The fix

The preset is a property of a **client session**, not of the shared daemon — which is exactly where TRA-250 already put the enforcement (`ProxyBackend` filters `tools/list` and rejects `tools/call`). So:

- Stdio sessions now ask the daemon for the unfiltered surface (`/mcp?project=…&surface=full`) and keep applying their own preset client-side.
- `createServer()` gains `ServerDeps.serveFullSurface` — set by the daemon's session path, `ProjectManager`, and the cross-project relay, all of which serve many sessions or dispatch by name. `tools.exclude` still applies: it is a hard restriction, not a preset.
- Clients that connect to `/mcp` **directly** send no marker and keep the daemon's preset, so `serve-http --preset` still means something for them (its `--help` now says who it applies to).

## Also: `get_preset_info` on the proxied path

It ran on the daemon and reported the *daemon's* preset and tool count (`active_preset: minimal, registered_tools: 18` in a session where non-minimal tools answered fine) — the wrong answer to the one question a user asks when a tool is missing. The proxy now answers it from the session's own filter, and falls through to the daemon if the catalog is unavailable rather than reporting an empty surface.

## Tests

- `src/server/__tests__/daemon-full-surface.test.ts` — new: preset still defers on a session-owned server; `serveFullSurface` registers everything despite `tools.preset` **and** `TRACE_MCP_PRESET` (the daemon inherits the env of whoever spawned it); `tools.exclude` still wins.
- `src/daemon/router/__tests__/proxy-preset-info.test.ts` — new: `get_preset_info` reports the session's preset/surface, its deferred half, and forwards when the catalog is empty.
- `src/daemon/router/__tests__/proxy-tool-preset.test.ts` — the `surface=full` marker is sent only when the session filters locally.
- Full suite green: 10227 passed / 23 skipped. `tsc --noEmit` and `biome ci` clean.

## Version skew

An old stdio session against a new daemon sends no marker and keeps today's behaviour; a new session against an old daemon gets the marker ignored. Neither is worse than the current state.

Agent: Lead Engineer
