### PR TITLE
test(design-tokens): cover parseColor edge cases directly

### DIFF
--- a/packages/app/src/renderer/styles/__tests__/tokens.test.ts
+++ b/packages/app/src/renderer/styles/__tests__/tokens.test.ts
@@ -12,6 +12,7 @@ import {
   contrast,
   contrastFailures,
   contrastTable,
+  parseColor,
   tokenGuard,
   tokenGuardCounts,
 } from '../../../../scripts/design-tokens.mjs';
@@ -31,6 +32,27 @@ describe('design tokens', () => {
 
   it('clears WCAG AA for every readable text token in both appearances', () => {
     expect(contrastFailures(contrastTable(tokensCss))).toEqual([]);
+  });
+
+  /* Every colour in tokens.css is 6-digit hex, so the 3-digit shorthand branch
+     of parseColor is never exercised by the checks above — a bug in it would
+     ship silently. Assert the expansion directly instead of hoping a future
+     token happens to use the short form. */
+  it('parses 3-digit hex as the same colour as its 6-digit expansion', () => {
+    expect(parseColor('#0f0')).toEqual(parseColor('#00ff00'));
+    expect(parseColor('#0f0')).toEqual([0, 255, 0, 1]);
+  });
+
+  it('defaults rgb() with no alpha channel to fully opaque', () => {
+    expect(parseColor('rgb(10 20 30)')).toEqual([10, 20, 30, 1]);
+  });
+
+  it('parses comma-separated rgba(), not just the space/slash form', () => {
+    expect(parseColor('rgba(10, 20, 30, 0.4)')).toEqual([10, 20, 30, 0.4]);
+  });
+
+  it('rejects a colour it cannot parse instead of returning garbage', () => {
+    expect(() => parseColor('not-a-colour')).toThrow('unsupported colour');
   });
 
   it('honours reduced motion, reduced transparency and increased contrast', () => {


### PR DESCRIPTION
## Summary

Coverage-gap fill from a scheduled Test & Quality Health audit (TRA-954). `self_audit` flagged `packages/app/scripts/design-tokens.mjs` exports as untested; `contrast`/`contrastTable`/`tokenGuard` already have real assertions in `tokens.test.ts`, but `parseColor` was only ever exercised indirectly through whatever colours happen to live in `tokens.css` — which is 100% 6-digit hex, so the 3-digit shorthand, no-alpha `rgb()`, and comma-separated `rgba()` branches had zero coverage. A bug in any of those would ship silently.

- Added 4 direct `parseColor` assertions (3-digit hex expansion, no-alpha default, comma-form rgba, invalid input throws).
- Verified each new test actually fails when the underlying logic breaks (manually broke the hex-expansion branch, confirmed the new test caught it, reverted).
- No production code changed.

## Test plan

- [x] `pnpm test` in `packages/app` — 705 passed
- [x] `pnpm test` at repo root — 10248 tests, all green (two `launcher-integration.test.ts` tests flaked under full-suite parallel load in an earlier run; reproduced once, passed clean on rerun — reported separately as TRA-959, unrelated to this change)
- [x] `pnpm run build` / `pnpm run typecheck` — clean