### PR TITLE
fix(app): stop comparing KPI tiles against a baseline minutes old (TRA-958)

### DIFF
--- a/packages/app/src/renderer/workspace/__tests__/kpiBaseline.test.ts
+++ b/packages/app/src/renderer/workspace/__tests__/kpiBaseline.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { BASELINE_MAX_AGE_MS, rollBaseline } from '../kpiBaseline';
+import { BASELINE_MAX_AGE_MS, BASELINE_MIN_AGE_MS, rollBaseline } from '../kpiBaseline';
 import { relativeTime } from '../../i18n/format';
 import type { WorkspaceKpis } from '../types';
 
@@ -23,7 +23,7 @@ describe('rollBaseline', () => {
   });
 
   it("keeps today's snapshot and compares against it", () => {
-    const stored = { at: at(NOW - 60_000), kpis: kpis(8) };
+    const stored = { at: at(NOW - BASELINE_MIN_AGE_MS - 1), kpis: kpis(8) };
     const { previous, next } = rollBaseline(NOW, stored, kpis(10));
     expect(previous).toBe(stored);
     expect(next).toBeNull();
@@ -34,6 +34,16 @@ describe('rollBaseline', () => {
     const { previous, next } = rollBaseline(NOW, stored, kpis(10));
     expect(previous).toBe(stored);
     expect(next?.kpis.totalProjects).toBe(10);
+  });
+
+  /* The first launch stores a baseline and would otherwise compare against it
+     on the next frame: "No change vs 2 seconds ago" is a caption about when the
+     app was opened, not about the workspace (TRA-958). */
+  it('shows no delta against a snapshot taken minutes ago, and does not re-stamp it', () => {
+    const stored = { at: at(NOW - 2_000), kpis: kpis(8) };
+    const { previous, next } = rollBaseline(NOW, stored, kpis(10));
+    expect(previous).toBeNull();
+    expect(next).toBeNull();
   });
 
   it('discards a corrupt or future-dated snapshot instead of inventing a delta', () => {
@@ -48,7 +58,7 @@ describe('rollBaseline', () => {
      indistinguishable once stored. It is also useless when it is genuine: the
      only delta it can produce is the value itself (TRA-458). */
   it('never compares against an empty snapshot', () => {
-    const stored = { at: at(NOW - 60_000), kpis: kpis(0) };
+    const stored = { at: at(NOW - BASELINE_MIN_AGE_MS - 1), kpis: kpis(0) };
     const { previous, next } = rollBaseline(NOW, stored, kpis(53));
     expect(previous).toBeNull();
     expect(next?.kpis.totalProjects).toBe(53);

--- a/packages/app/src/renderer/workspace/kpiBaseline.ts
+++ b/packages/app/src/renderer/workspace/kpiBaseline.ts
@@ -19,6 +19,17 @@ export interface KpiBaseline {
 
 export const LS_BASELINE_KEY = 'trace-mcp.workspace.kpi-baseline';
 export const BASELINE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+/**
+ * A snapshot this young is not history yet (TRA-958).
+ *
+ * The first launch stores a baseline and then compares against it on the very
+ * next frame, so every tile prints "No change vs 2 seconds ago" — a caption
+ * about when the app was opened, not about the workspace. It photographs the
+ * harness: the docs capture script hit exactly this, shipping a dark-theme
+ * screenshot whose three headline tiles all said it. Below this age the tile
+ * falls back to its footnote, which is a statement about the workspace.
+ */
+export const BASELINE_MIN_AGE_MS = 60 * 60 * 1000;
 
 export interface BaselineRoll {
   /** Snapshot to compare today's numbers against; null when we have none yet. */
@@ -46,6 +57,7 @@ function isComparable(b: KpiBaseline | null): b is KpiBaseline {
  * Decide which baseline to show and which to store.
  *
  *  - nothing comparable stored → start tracking now, show no delta yet
+ *  - stored minutes ago        → keep it, show no delta yet
  *  - stored today              → compare against it, keep it
  *  - stored earlier            → compare against it, then replace it
  */
@@ -59,6 +71,8 @@ export function rollBaseline(
   if (!isComparable(stored)) return { previous: null, next: fresh };
   const age = nowMs - Date.parse(stored.at);
   if (!Number.isFinite(age) || age < 0) return { previous: null, next: fresh };
+  // Keep it rather than re-stamping it — an overwritten `at` never matures.
+  if (age < BASELINE_MIN_AGE_MS) return { previous: null, next: null };
   if (age >= BASELINE_MAX_AGE_MS) return { previous: stored, next: fresh };
   return { previous: stored, next: null };
 }


### PR DESCRIPTION
Fixes the "No change vs 2 seconds ago" captions on the Workspace headline tiles (TRA-958).

## The defect

`WorkspaceHeader` rolls a KPI baseline on the first frame that has a real reading, then compares the current KPIs against it immediately. On a first launch — or in any sandbox with a wiped profile — the "previous" snapshot is seconds old, every delta is zero, and all three tiles print `No change vs 2 seconds ago`. That caption describes when the app was opened, not the workspace.

`scripts/capture-screenshots.mjs` captures light before dark in one profile, so the light pass writes the baseline and the dark pass photographs the artefact. `docs/images/app-dark-projects.webp` ships it today, next to a light frame of the same surface whose tiles read "tracking from today", "1,264 per project", "5 per file".

## The fix

Fix direction (1) from the issue, in `kpiBaseline.ts`: a snapshot younger than `BASELINE_MIN_AGE_MS` (1 hour) is not history yet. `rollBaseline` returns no delta for it and keeps it stored rather than re-stamping `at` — an overwritten timestamp would never mature. Tiles with no delta already fall back to their footnote (`KpiTile`), which is a statement about the workspace.

This fixes the real app on the day a user installs it, not just the capture harness.

## Tests

`packages/app/src/renderer/workspace/__tests__/kpiBaseline.test.ts` — new case: no delta against a 2-second-old snapshot, and it is not re-stamped. Two existing cases that used a 1-minute-old baseline to mean "stored today" now use `BASELINE_MIN_AGE_MS + 1`.

App suite: 70 files, 702 tests passed. `tsc --noEmit` clean. The root suite excludes `packages/app` and is untouched by this diff.

## Not in this PR

Re-running the capture script and re-committing `docs/images/`. The script activates the app and owns the screen for the run (it says so in its own header, TRA-403), and the workspace rule is that a run must not seize the screen while someone is at the keyboard. Left to a Design/UX capture run after this lands.

Agent: Lead Engineer
