### PR TITLE
test(launcher): give the node-probe tests a budget that clears CI contention

### DIFF
--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -25,17 +25,21 @@ const LAUNCHER_TIMEOUT_MS = 30_000;
 // the spawn budget above — otherwise vitest's default 10s caps it back down.
 vi.setConfig({ testTimeout: LAUNCHER_TIMEOUT_MS + 5_000 });
 
+function assertNotKilled(result: { signal: NodeJS.Signals | null }, args: string[]) {
+  if (result.signal) {
+    throw new Error(
+      `launcher killed by ${result.signal} after ${LAUNCHER_TIMEOUT_MS}ms (args: ${args.join(' ')})`,
+    );
+  }
+}
+
 function runLauncher(env: Record<string, string>, args: string[] = ['serve']): RunResult {
   const result = spawnSync(LAUNCHER_SRC, args, {
     env: { ...env, PATH: '/usr/bin:/bin' }, // minimal PATH, no node visible
     encoding: 'utf-8',
     timeout: LAUNCHER_TIMEOUT_MS,
   });
-  if (result.signal) {
-    throw new Error(
-      `launcher killed by ${result.signal} after ${LAUNCHER_TIMEOUT_MS}ms (args: ${args.join(' ')})`,
-    );
-  }
+  assertNotKilled(result, args);
   return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
 }
 
@@ -365,6 +369,7 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
           encoding: 'utf-8',
           timeout: LAUNCHER_TIMEOUT_MS,
         });
+        assertNotKilled(result, ['serve']);
 
         expect(result.status).toBe(0);
         expect(fs.existsSync(sentinel)).toBe(false);
@@ -387,6 +392,7 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
         encoding: 'utf-8',
         timeout: LAUNCHER_TIMEOUT_MS,
       });
+      assertNotKilled(result, ['serve']);
 
       expect(result.stdout.trim()).toBe('NODE_PATH_ENV:/client/bin:/usr/bin:/bin');
     });

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -2,7 +2,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { sweepOrphanTmpFiles } from '../../src/utils/atomic-write.js';
 
 const LAUNCHER_SRC = path.resolve(__dirname, '..', '..', 'hooks', 'trace-mcp-launcher.sh');
@@ -14,12 +14,28 @@ interface RunResult {
   stderr: string;
 }
 
+// TRA-959: the probe tests plant several candidate node installs and the launcher
+// execs `node -v` on each, so under full-suite worker contention this walk used to
+// blow a 5s budget and get SIGTERM'd — surfacing as `status: null` and an assertion
+// failure that read like a launcher bug. The budget is a hang guard, not a perf
+// assertion: keep it well clear of contention, and report a kill as a kill.
+const LAUNCHER_TIMEOUT_MS = 30_000;
+
+// Every test here shells out to the launcher, so the per-test budget has to clear
+// the spawn budget above — otherwise vitest's default 10s caps it back down.
+vi.setConfig({ testTimeout: LAUNCHER_TIMEOUT_MS + 5_000 });
+
 function runLauncher(env: Record<string, string>, args: string[] = ['serve']): RunResult {
   const result = spawnSync(LAUNCHER_SRC, args, {
     env: { ...env, PATH: '/usr/bin:/bin' }, // minimal PATH, no node visible
     encoding: 'utf-8',
-    timeout: 5000,
+    timeout: LAUNCHER_TIMEOUT_MS,
   });
+  if (result.signal) {
+    throw new Error(
+      `launcher killed by ${result.signal} after ${LAUNCHER_TIMEOUT_MS}ms (args: ${args.join(' ')})`,
+    );
+  }
   return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
 }
 
@@ -347,7 +363,7 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
         const result = spawnSync(LAUNCHER_SRC, ['serve'], {
           env: { HOME: home, TRACE_MCP_HOME: traceHome, PATH: `${hostileBin}:/usr/bin:/bin` },
           encoding: 'utf-8',
-          timeout: 5000,
+          timeout: LAUNCHER_TIMEOUT_MS,
         });
 
         expect(result.status).toBe(0);
@@ -369,7 +385,7 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
       const result = spawnSync(LAUNCHER_SRC, ['serve'], {
         env: { HOME: home, TRACE_MCP_HOME: traceHome, PATH: '/client/bin:/usr/bin:/bin' },
         encoding: 'utf-8',
-        timeout: 5000,
+        timeout: LAUNCHER_TIMEOUT_MS,
       });
 
       expect(result.stdout.trim()).toBe('NODE_PATH_ENV:/client/bin:/usr/bin:/bin');


### PR DESCRIPTION
Fixes the flake reported in TRA-959.

## What was happening

`runLauncher()` hardcoded `spawnSync(..., { timeout: 5000 })`. The two `node version gate` tests plant several real candidate node installs (nvm tree, Volta, homebrew paths) and set `TRACE_MCP_NODE_MIN_MAJOR: '99'`, so the launcher's probe execs `node -v` on each candidate before concluding none qualify. Under full-suite worker contention that walk exceeded 5s and the process was SIGTERM'd by `spawnSync`'s own timeout — surfacing as `status: null` and an assertion failure that read like a launcher bug.

## Fix

- `LAUNCHER_TIMEOUT_MS = 30_000` for all three `spawnSync` call sites in the file. The budget is a hang guard, not a perf assertion, so it should sit well clear of contention.
- Per-file `vi.setConfig({ testTimeout: 35_000 })` — without it vitest's 10s default caps the spawn budget back down.
- `runLauncher()` throws when `result.signal` is set, so a genuine hang is reported as a kill instead of masquerading as a wrong exit code. That is the part that cost the diagnosis time.

Rejected the alternatives from the issue: capping the vitest thread pool changes CI timing repo-wide for one file's problem, and stubbing the probe subprocesses would delete the only test we have that exercises the real multi-candidate probe walk end to end.

## Test evidence

- `npx vitest run tests/init/launcher-integration.test.ts` — 44 passed, 16.9s.
- `pnpm test` (10248 tests) twice: launcher file green in both. Run 1 had one unrelated failure — `tests/ai/onnx.test.ts` timing out at 10s on the cold dynamic import of `@huggingface/transformers` — which passed on run 2. Same flake shape, different test; filed separately, not fixed here.
- `pnpm typecheck` and `biome ci` clean.
