### PR TITLE
fix(app): the Chinese guard card stops calling itself two names (TRA-953)

### DIFF
--- a/packages/app/src/shared/i18n/GLOSSARY.md
+++ b/packages/app/src/shared/i18n/GLOSSARY.md
@@ -84,3 +84,45 @@ rows are still open for Hindi — fill them as each surface is reviewed.
 
 No string changes this pass — Korean read correctly on the workspace and MCP Clients
 screens. Its one defect was line breaking, fixed in CSS (Principle 6).
+
+## Chinese, Simplified (zh)
+
+Settled 2026-09-05 (TRA-953), first pass over the language. Reviewed on the running
+renderer: Workspace, MCP Clients, Settings, Project Overview (Index / Guard / Coverage /
+Quality). Layout held everywhere, including the 640×420 window minimum — the defects were
+all terminology.
+
+| English (en) | Chinese (zh) | Notes / Context |
+| :--- | :--- | :--- |
+| **Guard** | guard | Untranslated, as in every other catalogue. Two strings called it 守卫 while thirteen others in the same file said `guard` — one feature, two names, on one screen. |
+| **Enforcement** | 拦截 | Guard row label and MCP Clients' "Enforcement level". Was 强制 ("coerce"), the same word this glossary already rejects for Japanese, and it disagreed with `reason.heartbeatStale`, which had said 恢复拦截 all along. |
+| **Coach** (mode) | 指导 | Advisory, hints-only mode. Was 教练 — a sports coach — in the segmented control, the promotion row and the setup copy. |
+| **Strict** (mode) | 严格 | |
+| **Off** (mode) | 关闭 | |
+| **Daemon** | 守护进程 | Distinct from `guard`. |
+| **Quality gates** | 质量门禁 | The CI term, not a literal door. Correct — do not "fix" it. |
+| **Findings** | 项发现 | Left as is this pass; it reads thin but is not wrong, and changing it touches the filter group, the badge and the Ask hint together. Next zh pass decides. |
+
+One copy fix beyond the table: the daemon-down empty state said 启动它就能重新看到 —
+"start it and you can see again", with nothing to see. Now names the object
+(重新看到这些项目), the way the English does.
+
+## Spanish (es)
+
+Reviewed 2026-09-05 (TRA-953) on the same four screens, light appearance, 1100 pt and
+the 640×420 minimum. **No string changes.** Recorded so the next pass does not re-open
+what was already checked:
+
+| English (en) | Spanish (es) | Notes / Context |
+| :--- | :--- | :--- |
+| **Guard** | guard / el guard | Untranslated, with the article. Consistent throughout. |
+| **Enforcement** | Aplicación | |
+| **Coach** (mode) | Guía | |
+| **Healthy** (KPI) | Sanos | Fits the 96 px tile budget (Principle 5). |
+| **Needs attention** (KPI) | Requieren atención | Fits at the window minimum, where the tile becomes a single row. |
+| **Quality gates** | Puertas de calidad | The established Spanish rendering in this domain, not a literal miss. Do not "fix" it. |
+
+The `_many` plural forms added by TRA-450 carry the partitive **de** (`{{n}} de llamadas`,
+`Pausar {{count}} de minutos`). That looks wrong at a glance and is right: Spanish's `many`
+category is reached at a million, where `un millón **de** minutos` is the grammatical form.
+Leave them alone.

--- a/packages/app/src/shared/i18n/GLOSSARY.md
+++ b/packages/app/src/shared/i18n/GLOSSARY.md
@@ -95,7 +95,7 @@ all terminology.
 | English (en) | Chinese (zh) | Notes / Context |
 | :--- | :--- | :--- |
 | **Guard** | guard | Untranslated, as in every other catalogue. Two strings called it 守卫 while thirteen others in the same file said `guard` — one feature, two names, on one screen. |
-| **Enforcement** | 拦截 | Guard row label and MCP Clients' "Enforcement level". Was 强制 ("coerce"), the same word this glossary already rejects for Japanese, and it disagreed with `reason.heartbeatStale`, which had said 恢复拦截 all along. |
+| **Enforcement** | 管控 | Guard row label; 管控级别 for MCP Clients' "Enforcement level". Was 强制 ("coerce"), the word this glossary already rejects for Japanese. Not 拦截 either: interception is only the strict half of what the guard does. A row labelled 拦截 sits directly under a Coach mode whose own help text promises 从不拦截, and MCP Clients' `levelBase` is CLAUDE.md routing hints with no interception at all. 管控 covers both halves. |
 | **Coach** (mode) | 指导 | Advisory, hints-only mode. Was 教练 — a sports coach — in the segmented control, the promotion row and the setup copy. |
 | **Strict** (mode) | 严格 | |
 | **Off** (mode) | 关闭 | |

--- a/packages/app/src/shared/i18n/catalog/zh/clients.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/clients.ts
@@ -34,7 +34,7 @@ export const clients = {
   setUpManually: '手动配置…',
   hideSteps: '隐藏步骤',
 
-  enforcementLevel: '拦截级别',
+  enforcementLevel: '管控级别',
   levelBase: '基础',
   levelBaseHint: '仅 CLAUDE.md — 软性路由规则',
   levelStandard: '标准',

--- a/packages/app/src/shared/i18n/catalog/zh/clients.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/clients.ts
@@ -34,7 +34,7 @@ export const clients = {
   setUpManually: '手动配置…',
   hideSteps: '隐藏步骤',
 
-  enforcementLevel: '强制级别',
+  enforcementLevel: '拦截级别',
   levelBase: '基础',
   levelBaseHint: '仅 CLAUDE.md — 软性路由规则',
   levelStandard: '标准',

--- a/packages/app/src/shared/i18n/catalog/zh/guard.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/guard.ts
@@ -7,7 +7,7 @@ export const guard = {
     '你安装的是 <code>{{current}}</code>；本应用需要 <code>{{required}}</code> 或更高版本。请在终端执行下面这条命令，然后重新打开应用。',
   'onboarding.installPrompt.title': '设置 trace-mcp guard',
   'onboarding.installPrompt.body':
-    'guard 会把 Claude Code 的 Read、Grep、Glob 和 Bash 调用改走 trace-mcp，而不是直接读取文件，一次会话大约能省下 30–50% 的 token。新项目从教练模式开始——只提示、从不拦截——七天后转为严格模式。',
+    'guard 会把 Claude Code 的 Read、Grep、Glob 和 Bash 调用改走 trace-mcp，而不是直接读取文件，一次会话大约能省下 30–50% 的 token。新项目从指导模式开始——只提示、从不拦截——七天后转为严格模式。',
   'onboarding.installPrompt.note':
     '写入任何内容之前，<code>~/.claude/settings.json</code> 会先备份为 <code>settings.json.bak</code>。',
   'onboarding.installing.title': '正在安装 guard',
@@ -30,8 +30,8 @@ export const guard = {
   'row.mode': '模式',
   'row.promotion': '转为严格模式',
   'row.promoted': '已转为严格模式',
-  'row.promotedValue': '教练期已结束',
-  'row.enforcement': '强制',
+  'row.promotedValue': '指导期已结束',
+  'row.enforcement': '拦截',
   statusErrorWhat: 'guard 状态',
 
   'health.ok': '活跃',
@@ -39,14 +39,14 @@ export const guard = {
   'health.down': '未运行',
   'health.unknown': '未知',
 
-  'reason.neverStarted': '此项目中的编程助手还没有启动过 trace-mcp。重启助手即可让守卫生效。',
+  'reason.neverStarted': '此项目中的编程助手还没有启动过 trace-mcp。重启助手即可恢复拦截。',
   'reason.heartbeatStale': 'trace-mcp 最后一次响应是{{ago}}。重启编程助手即可恢复拦截。',
-  'reason.channelQuiet': '守卫已安装并在等待——最后一次工具调用是{{ago}}。',
+  'reason.channelQuiet': 'guard 已安装并在等待——最后一次工具调用是{{ago}}。',
 
   'mode.aria': 'guard 模式',
   'mode.strict': '严格',
   'mode.strictHelp': '当 trace-mcp 工具能回答同一个问题时，拦截 Read、Grep 和 Glob',
-  'mode.coach': '教练',
+  'mode.coach': '指导',
   'mode.coachHelp': '从不拦截——只建议改用 trace-mcp 工具',
   'mode.off': '关闭',
   'mode.offHelp': '在这个项目里不干预 Claude Code',

--- a/packages/app/src/shared/i18n/catalog/zh/guard.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/guard.ts
@@ -31,7 +31,7 @@ export const guard = {
   'row.promotion': '转为严格模式',
   'row.promoted': '已转为严格模式',
   'row.promotedValue': '指导期已结束',
-  'row.enforcement': '拦截',
+  'row.enforcement': '管控',
   statusErrorWhat: 'guard 状态',
 
   'health.ok': '活跃',
@@ -39,7 +39,7 @@ export const guard = {
   'health.down': '未运行',
   'health.unknown': '未知',
 
-  'reason.neverStarted': '此项目中的编程助手还没有启动过 trace-mcp。重启助手即可恢复拦截。',
+  'reason.neverStarted': '此项目中的编程助手还没有启动过 trace-mcp。重启助手即可让 guard 生效。',
   'reason.heartbeatStale': 'trace-mcp 最后一次响应是{{ago}}。重启编程助手即可恢复拦截。',
   'reason.channelQuiet': 'guard 已安装并在等待——最后一次工具调用是{{ago}}。',
 

--- a/packages/app/src/shared/i18n/catalog/zh/workspace.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/workspace.ts
@@ -1,7 +1,7 @@
 export const workspace = {
   daemonDownTitle: '守护进程没有运行',
   daemonDownSubtitle:
-    'trace-mcp 在本地后台服务里索引你的项目。启动它就能重新看到——什么都没丢。',
+    'trace-mcp 在本地后台服务里索引你的项目。启动后就能重新看到这些项目——什么都没丢。',
   startDaemon: '启动守护进程',
   startingDaemon: '启动中…',
   daemonInstallingTitle: '正在设置 trace-mcp',


### PR DESCRIPTION
Out-of-band UI localization pass (TRA-953). Languages this run: **Simplified Chinese** and **Spanish** — the two of the ten that no previous pass had opened. Everything was reviewed on the running Electron renderer (offscreen, `scripts/electron-cdp.mjs`), light appearance, at 1100 pt and at the 640×420 window minimum: Workspace, MCP Clients, Settings, and Project Overview (Index / Guard / Coverage / Quality).

**No layout broke in either language.** At 1100 pt the whole projects table fits — `死导出`, `未测试`, `等级` all render in full. At 960 pt the table scrolls horizontally under the pinned Actions column, which is TRA-452's designed behaviour and does the same thing in English. At the 640×420 minimum both languages collapse to the compact rows and fit, including `Requieren atención` and `需要关注`.

So every defect this run is terminology, and all of it is Chinese.

### zh — one feature, one name

`guard` had two names on one screen: thirteen strings said `guard`, two said `守卫`. The two are now `guard`, matching every other catalogue and the glossary.

### zh — Enforcement was the word the glossary already rejects

`row.enforcement` was `强制` ("coerce") — the exact rendering `GLOSSARY.md` rejects for Japanese — while `reason.heartbeatStale`, four lines below it in the same file, had been saying `恢复拦截` all along. Both the Guard row and MCP Clients' "Enforcement level" are now `拦截`.

### zh — Coach mode was a sports coach

`教练` is the person with a whistle. The mode is advisory ("never blocks — suggests the trace-mcp tool instead"), so it is now `指导`, in the segmented control, the promotion row and the setup copy together.

Before / after, Guard card, `~/PhpstormProjects/general`, zh, light:

| before | after |
| --- | --- |
| `模式  严格 · 教练 · 关闭` / `强制  ⏸ 暂停 10 分钟` | `模式  严格 · 指导 · 关闭` / `拦截  ⏸ 暂停 10 分钟` |

(screenshots attached to TRA-953)

### zh — an empty state with nothing to see

`daemonDownSubtitle` said `启动它就能重新看到——什么都没丢。` — "start it and you can see again", with no object. The English names one ("Start it to see them again"). Now `启动后就能重新看到这些项目——什么都没丢。` Verified rendered on the daemon-down empty state; still two lines, no truncation.

### es — reviewed, nothing to change

The Spanish catalogue read correctly on all four screens. Two things are recorded in the glossary specifically so a later pass does not "fix" them:

- `Puertas de calidad` for *Quality gates* is the established Spanish rendering in this domain, not a literal miss.
- The `_many` plural forms TRA-450 added carry the partitive **de** (`{{n}} de llamadas`, `Pausar {{count}} de minutos`). That looks wrong at a glance and is right: Spanish's `many` category is reached at a million, where `un millón **de** minutos` is the grammatical form.

### Glossary

`packages/app/src/shared/i18n/GLOSSARY.md` gains a **zh** section and an **es** section — the terms settled, what was checked, and the two terms above marked do-not-touch. `Findings` → `项发现` is flagged as thin but deliberately left: changing it moves the filter group, the badge and the Ask hint together, and that is its own pass.

### Checks

`check:i18n` clean (100 files, 3 documented exceptions) · `typecheck` clean · 701 tests in 70 files pass · renderer + main build.

Closes TRA-953.
