### PR TITLE
fix(search): reduce instead of spreading the FTS result set (#957)

### DIFF
--- a/src/scoring/retrieval-confidence.ts
+++ b/src/scoring/retrieval-confidence.ts
@@ -14,6 +14,7 @@
  */
 
 import type { FreshnessLevel, FreshnessSummary } from './freshness.js';
+import { minMax } from '../util/minmax.js';
 
 export interface ConfidenceWeights {
   top1_strength: number;
@@ -79,7 +80,7 @@ export function computeRetrievalConfidence(input: ConfidenceInput): ConfidenceBr
 
   const top1 = input.scores[0] ?? 0;
   const top2 = input.scores[1] ?? 0;
-  const maxScore = Math.max(...input.scores);
+  const maxScore = minMax(input.scores).max;
 
   const top1Strength = clamp01(maxScore > 0 ? top1 / maxScore : 0);
   const topGap = clamp01(maxScore > 0 ? Math.max(0, top1 - top2) / maxScore : 0);

--- a/src/tools/navigation/search-dispatcher.ts
+++ b/src/tools/navigation/search-dispatcher.ts
@@ -16,6 +16,7 @@
  */
 import { searchFts as ftsSearch } from '../../db/fts.js';
 import type { FileRow, Store, SymbolRow } from '../../db/store.js';
+import { minMax } from '../../util/minmax.js';
 
 /** Filters accepted by the flat-mode search path. */
 export interface FlatSearchFilters {
@@ -69,8 +70,9 @@ export async function runFlatSearch(
   const fileIds = [...new Set(ftsResults.map((r) => r.fileId))];
   const fileMap = store.getFilesByIds(fileIds);
 
-  const minRank = Math.min(...ftsResults.map((r) => r.rank));
-  const maxRank = Math.max(...ftsResults.map((r) => r.rank));
+  // Reduce, never spread: ftsResults is bounded by the index, not by `limit`
+  // (#957 — every `search` on a 152k-symbol index threw RangeError here).
+  const { min: minRank, max: maxRank } = minMax(ftsResults.map((r) => r.rank));
   const rankSpread = maxRank - minRank || 1;
 
   const heritage = filters.implements || filters.extends;

--- a/src/util/__tests__/minmax.test.ts
+++ b/src/util/__tests__/minmax.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { minMax } from '../minmax.js';
+
+describe('minMax', () => {
+  it('matches Math.min/Math.max on a small array', () => {
+    const xs = [3, -1, 7, 0, 7];
+    expect(minMax(xs)).toEqual({ min: Math.min(...xs), max: Math.max(...xs) });
+  });
+
+  it('returns infinities for an empty array, so a caller must guard', () => {
+    expect(minMax([])).toEqual({
+      min: Number.POSITIVE_INFINITY,
+      max: Number.NEGATIVE_INFINITY,
+    });
+  });
+
+  // The regression: #957 reported `search` returning the bare string
+  // "Maximum call stack size exceeded" for every query against a 152 734-symbol
+  // index. `Math.min(...xs)` throws RangeError past V8's argument limit; the
+  // ranking path built that array from the whole FTS result set, which is
+  // bounded by the index rather than by the caller's `limit`.
+  it('survives an array larger than V8 will accept as arguments', () => {
+    const xs = Array.from({ length: 200_000 }, (_, i) => i % 977);
+    expect(() => Math.min(...xs)).toThrow(RangeError);
+    expect(minMax(xs)).toEqual({ min: 0, max: 976 });
+  });
+});

--- a/src/util/minmax.ts
+++ b/src/util/minmax.ts
@@ -1,0 +1,23 @@
+/**
+ * Min/max over an array without spreading it into a call.
+ *
+ * `Math.min(...xs)` passes every element as a separate argument, so it throws
+ * `RangeError: Maximum call stack size exceeded` once the array exceeds V8's
+ * argument limit (~65k–125k, stack-dependent). That is not a theoretical
+ * ceiling: reported from the field (GitHub #957) as `search` failing on every
+ * query against a 152 734-symbol index, while the same query worked on a small
+ * one — the small index takes the on-the-fly fallback and never reaches the
+ * ranking code.
+ *
+ * Any array whose length is bounded by the index rather than by a `limit` has
+ * to be reduced, not spread.
+ */
+export function minMax(values: readonly number[]): { min: number; max: number } {
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const v of values) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  return { min, max };
+}


### PR DESCRIPTION
## What was wrong

`search` returned the bare string `Maximum call stack size exceeded` — not JSON, not an MCP error envelope — for every query against a large index. Reported in #957 against 10 332 files / 152 734 symbols, deterministic across queries, while `search_text` on the same index returned real hits.

`src/tools/navigation/search-dispatcher.ts` normalised FTS ranks with:

```ts
const minRank = Math.min(...ftsResults.map((r) => r.rank));
const maxRank = Math.max(...ftsResults.map((r) => r.rank));
```

Spread passes every element as a separate function argument, so V8 throws `RangeError` once the array passes its argument limit (~65k–125k, stack-dependent). `ftsResults` is the whole FTS result set — bounded by the size of the index, not by the caller's `limit`, which is applied later during scoring. So the array grows with the repository and the tool breaks at a threshold nobody had crossed in our own testing.

That also explains the reporter's observation that a small repo works: a small index takes the on-the-fly fallback (`"fallback": true, "reason": "Using on-the-fly search — index unavailable or stale"`) and never reaches this code. The bug is not size-dependent behaviour, it is a code path only large indexes enter.

The same pattern was in `src/scoring/retrieval-confidence.ts:82` over `input.scores`, which is also index-bounded. Fixed too.

## What changed

`src/util/minmax.ts` — `minMax(values)` reduces in a loop and returns both bounds in one pass. Both call sites use it.

## Test

`src/util/__tests__/minmax.test.ts`. The regression case builds 200 000 elements and asserts **both** that `Math.min(...xs)` genuinely throws `RangeError` on this runtime and that `minMax` returns the right answer — so the guard fails if anyone reintroduces the spread, and it fails loudly rather than silently passing on a machine with a bigger stack.

- `pnpm test` — 924 files / 10 268 tests, 0 failures
- `pnpm exec tsc --noEmit`, `biome check` — clean

## Not in this PR

#957 also reports `get_change_impact {"file_path": "..."}` answering `'' is not in the index`. The empty `''` says an empty `symbol_id` reached the lookup. Worth noting while investigating: the handler declares `file_path` and `symbol_id` via `optionalNonEmptyString`, but the advertised JSON Schema lists both in `required` — a client obeying the published schema has to send something for `symbol_id`, and `""` is what that produces. Tracked separately as TRA-962; not fixed here because it needs its own repro rather than a guess.

Reported by @msalem89.
