### PR TITLE
fix(tools): get_change_impact's optional params publish as actually optional (TRA-962)

### DIFF
--- a/src/tools/analysis/impact.ts
+++ b/src/tools/analysis/impact.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { type BudgetExceeded, type BudgetGuard, forTool } from '../../compute-guard.js';
 import type { Store, SymbolRow } from '../../db/store.js';
-import { err, notFound, ok, type TraceMcpResult } from '../../errors.js';
+import { err, notFound, ok, type TraceMcpResult, validationError } from '../../errors.js';
 import { safeGitEnv } from '../../utils/git-env.js';
 import { isGitRepo } from '../git/git-analysis.js';
 import { getChaNodeIds } from '../shared/cha.js';
@@ -501,7 +501,12 @@ export function getChangeImpact(
     }
     startNodeIds = [...new Set(startNodeIds)];
   } else {
-    return err(notFound('', ['Provide either filePath, symbolId, or symbolIds']));
+    // Not "not found" — nothing to look up was given in the first place.
+    return err(
+      validationError(
+        'No file_path, symbol_id, fqn, or symbol_ids provided — specify at least one',
+      ),
+    );
   }
 
   // Pennant feature flag check

--- a/src/tools/register/_zod-helpers.ts
+++ b/src/tools/register/_zod-helpers.ts
@@ -13,6 +13,18 @@
  * before zod's own validation runs, so a `""` argument behaves identically
  * to omitting the field. Callers can drop them in wherever they previously
  * had `z.string().max(N).optional()`.
+ *
+ * These used to be built as bare `z.preprocess(coerce, inner.optional())`,
+ * with no outer `.optional()`. Zod v4 tracks a schema's input-side
+ * optionality (`_zod.optin`) separately from its output-side optionality
+ * (`_zod.optout`); for a preprocess pipe, `optin` comes from the *coercion*
+ * function's schema, which has no way to statically declare "may be
+ * omitted". The MCP SDK's zod-v4 JSON Schema conversion renders a tool's
+ * published `inputSchema` using that input-side view, so every field built
+ * this way was advertised to clients as `required` even though the runtime
+ * schema happily accepted an omitted value (TRA-962). Wrapping the whole
+ * pipe in an outer `.optional()` fixes this: `ZodOptional` sets both optin
+ * and optout unconditionally, regardless of what it wraps.
  */
 import { z } from 'zod';
 
@@ -29,10 +41,8 @@ function emptyToUndef<A>(v: unknown): A | undefined {
  * file_pattern: optionalNonEmptyString(512).describe('Glob filter ...')
  * ```
  */
-export function optionalNonEmptyString(
-  maxLen = 1024,
-): z.ZodPipe<z.ZodTransform<string | undefined, unknown>, z.ZodOptional<z.ZodString>> {
-  return z.preprocess(emptyToUndef<string>, z.string().max(maxLen).optional());
+export function optionalNonEmptyString(maxLen = 1024) {
+  return z.preprocess(emptyToUndef<string>, z.string().max(maxLen).optional()).optional();
 }
 
 /**
@@ -43,11 +53,6 @@ export function optionalNonEmptyString(
  * kind: optionalEnum(['function','class','method']).describe('Symbol kind filter')
  * ```
  */
-export function optionalEnum<const T extends readonly [string, ...string[]]>(
-  values: T,
-): z.ZodPipe<
-  z.ZodTransform<T[number] | undefined, unknown>,
-  z.ZodOptional<z.ZodEnum<z.core.util.ToEnum<T[number]>>>
-> {
-  return z.preprocess(emptyToUndef<T[number]>, z.enum(values).optional());
+export function optionalEnum<const T extends readonly [string, ...string[]]>(values: T) {
+  return z.preprocess(emptyToUndef<T[number]>, z.enum(values).optional()).optional();
 }

--- a/tests/server/optional-params-schema-required.test.ts
+++ b/tests/server/optional-params-schema-required.test.ts
@@ -1,0 +1,115 @@
+/**
+ * TRA-962 — `get_change_impact({ file_path })` alone (no symbol_id) worked
+ * fine against the raw handler, but the JSON Schema published to MCP clients
+ * via `tools/list` listed `file_path` AND `symbol_id` as `required`, even
+ * though both are optional in the zod schema and at runtime.
+ *
+ * Root cause: `optionalNonEmptyString`/`optionalEnum` were built as
+ * `z.preprocess(coerce, inner.optional())` — the `.optional()` lived *inside*
+ * the preprocess pipe. The MCP SDK's zod-v4 JSON Schema conversion renders a
+ * tool's `inputSchema` from the *input* side of that pipe, which has no way
+ * to express "optional" for an arbitrary transform, so every field built
+ * this way published as `required` regardless of its real optionality.
+ *
+ * This drives a real MCP `Client` over an in-memory transport — the same way
+ * an external client sees the server — rather than calling the registered
+ * zod schema or the tool handler directly, since the discrepancy only shows
+ * up in what's advertised over the wire.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { describe, expect, it } from 'vitest';
+import { TraceMcpConfigSchema } from '../../src/config.js';
+import { initializeDatabase } from '../../src/db/schema.js';
+import { Store } from '../../src/db/store.js';
+import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import { ProgressState } from '../../src/progress.js';
+import { createServer } from '../../src/server/server.js';
+
+async function bootServer() {
+  const db = initializeDatabase(':memory:');
+  const store = new Store(db);
+
+  const targetFile = store.insertFile('src/target.ts', 'typescript', 'h-target', 200);
+  store.insertSymbol(targetFile, {
+    symbolId: 'src/target.ts::Target#function',
+    name: 'Target',
+    kind: 'function',
+    fqn: 'Target',
+    byteStart: 0,
+    byteEnd: 80,
+    lineStart: 1,
+    lineEnd: 10,
+  });
+
+  const registry = PluginRegistry.createWithDefaults();
+  const progress = new ProgressState(db);
+  const config = TraceMcpConfigSchema.parse({ tools: { preset: 'full' } });
+  const handle = createServer(store, registry, config, process.cwd(), progress, {});
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'tra-962-probe', version: '1.0.0' });
+  await Promise.all([handle.server.connect(serverTransport), client.connect(clientTransport)]);
+
+  return {
+    client,
+    async dispose() {
+      await client.close().catch(() => {});
+      handle.dispose();
+      db.close();
+    },
+  };
+}
+
+describe('TRA-962: published inputSchema.required matches real optionality', () => {
+  it('get_change_impact does not list file_path/symbol_id as required', async () => {
+    const { client, dispose } = await bootServer();
+    try {
+      const { tools } = await client.listTools();
+      const tool = tools.find((t) => t.name === 'get_change_impact');
+      expect(tool).toBeDefined();
+      const required = (tool?.inputSchema as { required?: string[] } | undefined)?.required ?? [];
+      expect(required).not.toContain('file_path');
+      expect(required).not.toContain('symbol_id');
+      expect(required).not.toContain('fqn');
+      expect(required).not.toContain('symbol_ids');
+    } finally {
+      await dispose();
+    }
+  });
+
+  it('calling with only file_path over the real transport succeeds (no NOT_FOUND on an empty id)', async () => {
+    const { client, dispose } = await bootServer();
+    try {
+      const result = await client.callTool({
+        name: 'get_change_impact',
+        arguments: { file_path: 'src/target.ts' },
+      });
+      expect(result.isError).toBeFalsy();
+      const text = (result.content as Array<{ type: string; text?: string }>)[0]?.text ?? '';
+      expect(text).not.toMatch(/'' is not in the index/);
+      const parsed = JSON.parse(text);
+      expect(parsed.target?.path).toBe('src/target.ts');
+    } finally {
+      await dispose();
+    }
+  });
+
+  // Confirms the fix lives in the shared helper, not a get_change_impact-only
+  // patch: get_symbol takes the same optional symbol_id/fqn pair and had the
+  // identical drift before the fix (both fields are optional — either one
+  // alone is a valid, complete call).
+  it('get_symbol also does not list symbol_id/fqn as required', async () => {
+    const { client, dispose } = await bootServer();
+    try {
+      const { tools } = await client.listTools();
+      const tool = tools.find((t) => t.name === 'get_symbol');
+      expect(tool).toBeDefined();
+      const required = (tool?.inputSchema as { required?: string[] } | undefined)?.required ?? [];
+      expect(required).not.toContain('symbol_id');
+      expect(required).not.toContain('fqn');
+    } finally {
+      await dispose();
+    }
+  });
+});

--- a/tests/tools/behavioural/get-change-impact.behavioural.test.ts
+++ b/tests/tools/behavioural/get-change-impact.behavioural.test.ts
@@ -130,4 +130,15 @@ describe('getChangeImpact() — behavioural contract', () => {
     expect(impact.totalAffected).toBe(0);
     expect(impact.risk.level).toBe('low');
   });
+
+  // TRA-962: calling with none of filePath/symbolId/fqn/symbolIds is a caller
+  // mistake ("you gave me nothing to look up"), not a lookup miss ("I looked
+  // and found nothing"). It must not surface as NOT_FOUND with an empty id.
+  it('no identifying param at all → VALIDATION_ERROR, not NOT_FOUND with an empty id', () => {
+    const result = getChangeImpact(ctx.store, {});
+    expect(result.isErr()).toBe(true);
+    const error = result._unsafeUnwrapErr();
+    expect(error.code).toBe('VALIDATION_ERROR');
+    expect('message' in error && error.message).toMatch(/file_path|symbol_id|fqn|symbol_ids/);
+  });
 });


### PR DESCRIPTION
## Summary

Second half of #957 (first half fixed `search`'s stack overflow in #976). Fixes the reported `get_change_impact({file_path})` → `{"error":{"code":"NOT_FOUND","message":"'' is not in the index"}}`.

Root cause confirmed via a real MCP `Client` over `InMemoryTransport` (not the handler function directly, per the issue's ask): `optionalNonEmptyString`/`optionalEnum` (`src/tools/register/_zod-helpers.ts`) built their fields as `z.preprocess(coerce, inner.optional())`, with the `.optional()` living *inside* the pipe. Zod v4 tracks a schema's input-side optionality (`_zod.optin`) separately from output-side optionality (`_zod.optout`); for a bare preprocess pipe, `optin` comes from the coercion function's schema, which has no way to statically declare "may be omitted". The MCP SDK renders a tool's published `inputSchema` from that input-side view (`toJsonSchemaCompat(..., { pipeStrategy: 'input' })`), so **every field built with these helpers — across all 11 tool registration files that use them — was published to clients as `required`, even though the runtime schema always accepted an omitted value.**

A client honestly following the published schema for `get_change_impact` has to send *something* for `symbol_id`, and a synthesized `""` reproduces exactly the reported error.

Fix: wrap the whole preprocess pipe in an outer `.optional()`. `ZodOptional` sets both `optin` and `optout` unconditionally, regardless of what it wraps — this corrects the published `inputSchema.required` without changing any runtime coercion behavior (empty string / null / omitted all still normalize to "no filter").

I verified this doesn't regress the io:`'output'` direction — a naive `.nullish().transform()` rewrite (my first attempt) passed the `io:'input'` check but crashed `z.toJSONSchema()`'s default `io:'output'` mode (`Transforms cannot be represented in JSON Schema`), which this repo's own schema-budget/preset-surface/client-profile tests rely on. The `.preprocess(...).optional()` shape is correct on both sides.

Also, per the issue's third ask: `get_change_impact()` called with none of `file_path`/`symbol_id`/`fqn`/`symbol_ids` returned `NOT_FOUND` on an empty id (`'' is not in the index`) — a caller-side "you gave me nothing to look up" mistake, not a lookup miss ("I looked and found nothing"). It now returns a `VALIDATION_ERROR` naming the accepted parameters.

## Test plan

- [x] New regression test drives a real `McpServer` + `Client` over `InMemoryTransport` (`tests/server/optional-params-schema-required.test.ts`): confirms `get_change_impact`'s and `get_symbol`'s published `inputSchema.required` no longer lists the optional id/path fields, and that calling `get_change_impact` with only `file_path` over the real transport succeeds.
- [x] New unit test for the `VALIDATION_ERROR` on zero identifying params (`tests/tools/behavioural/get-change-impact.behavioural.test.ts`).
- [x] Existing `tests/tools/zod-helpers.test.ts` (coercion semantics) passes unchanged.
- [x] `pnpm run build` — clean.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm run test` (full suite, 10269 tests) — all green; one unrelated timeout (`daemon-full-surface.test.ts`) reproduced only under full-suite parallel load and passed cleanly in isolation (2.3s vs its 10s budget) — pre-existing flakiness, not a regression from this change.
- [x] `biome check` on all changed files — clean.