### PR TITLE
fix(app): the Index card's stale line stops asserting a busy daemon (TRA-964)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -675,6 +675,16 @@ statement: what could not be loaded, plus the control that tries again.** Retry 
 the next step and it is already in the row; the invented sentence between them only
 had to be wrong once to cost the reader a diagnosis.
 
+**A string borrowed from another surface carries that surface's verdict.** Project
+Overview's Index card printed the Workspace's `busyStale` — "The daemon is busy. These
+are the last indexed numbers." — whenever its numbers came from the stored snapshot.
+Only the second half is what "stale" knows; the first half is a diagnosis, and on the
+Workspace it is *chosen* from a real busy reading. Here it was asserted 48px above the
+Status row whose whole job is to name the cause, which read "Daemon unreachable", then
+"Not tracked" (TRA-964). Reuse a key only when the borrowing surface knows everything
+the sentence asserts; otherwise take the half you can prove and let the row that holds
+the cause say the rest.
+
 **And "at surface level" is not "when the source is down".** The collapse rule above
 was implemented as a daemon-down branch, so the moment the daemon was up and merely
 answering badly, each section went back to speaking for itself — the same duplication

--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -722,15 +722,16 @@ export function ProjectOverview({
               ) : stats ? (
                 <>
                   {!statsFresh && (
-                    /* Same sentence the Workspace uses for the same condition,
-                       from the same key — one wording for "these are the last
-                       indexed numbers", not two. */
+                    /* Only what `!statsFresh` actually knows: the numbers are
+                       the stored ones. The cause belongs to the Status row
+                       below — the Workspace's `busyStale` asserted a busy
+                       daemon here even when that row said "Not tracked". */
                     <div
                       role="status"
                       className="px-3 pt-2 text-[13px]"
                       style={{ color: 'var(--label-secondary)' }}
                     >
-                      {t('workspace:busyStale')}
+                      {t('staleNumbers')}
                     </div>
                   )}
                   <ListRow

--- a/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
+++ b/packages/app/src/renderer/tabs/__tests__/ProjectOverview.test.tsx
@@ -222,9 +222,27 @@ describe('ProjectOverview surface', () => {
     render(<ProjectOverview root={ROOT} />);
 
     expect(await screen.findByText('337')).toBeTruthy();
-    expect(
-      screen.getByText('The daemon is busy. These are the last indexed numbers.'),
-    ).toBeTruthy();
+    expect(screen.getByText('These are the last indexed numbers.')).toBeTruthy();
+  });
+
+  /* TRA-964. The line borrowed the Workspace's `busyStale`, which asserts a busy
+     daemon — a verdict `!statsFresh` never had. On the shipped build it sat 48px
+     above a Status row reading "Daemon unreachable", and a poll later "Not
+     tracked". One condition, one sentence (DESIGN.md §5): the numbers are stale,
+     the Status row names why. */
+  it('does not claim the daemon is busy above a Status row that says otherwise', async () => {
+    localStorage.setItem(`trace-mcp.overview.stats:${ROOT}`, JSON.stringify(STATS));
+    daemon.projects = [];
+    daemon.loading = false;
+    daemon.connected = true;
+    // The registry forgot the project; every local read hangs, so stats stay stored.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => {})));
+
+    render(<ProjectOverview root={ROOT} />);
+
+    expect(await screen.findByText('Not tracked')).toBeTruthy();
+    expect(screen.getByText('These are the last indexed numbers.')).toBeTruthy();
+    expect(screen.queryByText(/daemon is busy/)).toBeNull();
   });
 
   it('does not call a project the daemon forgot "not indexed"', async () => {

--- a/packages/app/src/shared/i18n/catalog/de/overview.ts
+++ b/packages/app/src/shared/i18n/catalog/de/overview.ts
@@ -24,6 +24,7 @@ export const overview = {
 
   // ── Index ──
   sectionIndex: 'Index',
+  staleNumbers: 'Dies sind die zuletzt indexierten Zahlen.',
   rowStatus: 'Status',
   rowFiles: 'Indexierte Dateien',
   rowSymbols: 'Symbole',

--- a/packages/app/src/shared/i18n/catalog/en/overview.ts
+++ b/packages/app/src/shared/i18n/catalog/en/overview.ts
@@ -32,6 +32,7 @@ export const overview = {
 
   // ── Index ──
   sectionIndex: 'Index',
+  staleNumbers: 'These are the last indexed numbers.',
   rowStatus: 'Status',
   rowFiles: 'Files indexed',
   rowSymbols: 'Symbols',

--- a/packages/app/src/shared/i18n/catalog/es/overview.ts
+++ b/packages/app/src/shared/i18n/catalog/es/overview.ts
@@ -21,6 +21,7 @@ export const overview = {
   menuRemoveService: 'Quitar el servicio…',
 
   sectionIndex: 'Índice',
+  staleNumbers: 'Estas son las últimas cifras indexadas.',
   rowStatus: 'Estado',
   rowFiles: 'Archivos indexados',
   rowSymbols: 'Símbolos',

--- a/packages/app/src/shared/i18n/catalog/fr/overview.ts
+++ b/packages/app/src/shared/i18n/catalog/fr/overview.ts
@@ -21,6 +21,7 @@ export const overview = {
   menuRemoveService: 'Retirer le service…',
 
   sectionIndex: 'Index',
+  staleNumbers: 'Voici les derniers chiffres indexés.',
   rowStatus: 'État',
   rowFiles: 'Fichiers indexés',
   rowSymbols: 'Symboles',

--- a/packages/app/src/shared/i18n/catalog/hi/overview.ts
+++ b/packages/app/src/shared/i18n/catalog/hi/overview.ts
@@ -21,6 +21,7 @@ export const overview = {
   menuRemoveService: 'सर्विस हटाएँ…',
 
   sectionIndex: 'इंडेक्स',
+  staleNumbers: 'ये पिछली बार के इंडेक्स किए आँकड़े हैं।',
   rowStatus: 'स्थिति',
   rowFiles: 'इंडेक्स हुई फ़ाइलें',
   rowSymbols: 'सिंबल',

--- a/packages/app/src/shared/i18n/catalog/ja/overview.ts
+++ b/packages/app/src/shared/i18n/catalog/ja/overview.ts
@@ -21,6 +21,7 @@ export const overview = {
   menuRemoveService: 'サービスを削除…',
 
   sectionIndex: 'インデックス',
+  staleNumbers: '表示中の数値は前回のものです。',
   rowStatus: '状態',
   rowFiles: 'インデックス済みファイル',
   rowSymbols: 'シンボル',

--- a/packages/app/src/shared/i18n/catalog/ko/overview.ts
+++ b/packages/app/src/shared/i18n/catalog/ko/overview.ts
@@ -21,6 +21,7 @@ export const overview = {
   menuRemoveService: '서비스 제거…',
 
   sectionIndex: '인덱스',
+  staleNumbers: '아래는 마지막으로 인덱싱한 수치입니다.',
   rowStatus: '상태',
   rowFiles: '인덱싱된 파일',
   rowSymbols: '심볼',

--- a/packages/app/src/shared/i18n/catalog/pt-BR/overview.ts
+++ b/packages/app/src/shared/i18n/catalog/pt-BR/overview.ts
@@ -21,6 +21,7 @@ export const overview = {
   menuRemoveService: 'Remover serviço…',
 
   sectionIndex: 'Índice',
+  staleNumbers: 'Estes são os últimos números indexados.',
   rowStatus: 'Estado',
   rowFiles: 'Arquivos indexados',
   rowSymbols: 'Símbolos',

--- a/packages/app/src/shared/i18n/catalog/ru/overview.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/overview.ts
@@ -29,6 +29,7 @@ export const overview = {
   menuRemoveService: 'Удалить сервис…',
 
   sectionIndex: 'Индекс',
+  staleNumbers: 'Это последние проиндексированные значения.',
   rowStatus: 'Состояние',
   rowFiles: 'Файлов проиндексировано',
   rowSymbols: 'Символов',

--- a/packages/app/src/shared/i18n/catalog/zh/overview.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/overview.ts
@@ -21,6 +21,7 @@ export const overview = {
   menuRemoveService: '移除服务…',
 
   sectionIndex: '索引',
+  staleNumbers: '以下是上次索引的数字。',
   rowStatus: '状态',
   rowFiles: '已索引文件',
   rowSymbols: '符号',


### PR DESCRIPTION
Fixes TRA-964.

## What was on screen

Project Overview's Index card, on the running Electron window (app 3.18.0), a real project:

```
Index
  The daemon is busy. These are the last indexed numbers.
  Status                                   ● Daemon unreachable
  Files indexed                                       6,641
```

A poll later, same card: the same first line above `Status  Not tracked`. Two verdicts about one daemon, 48px apart.

## Why

`ProjectOverview.tsx` rendered `t('workspace:busyStale')` whenever `!statsFresh`. Only the second half of that string — "These are the last indexed numbers." — is what `!statsFresh` knows. The first half is a diagnosis, and on the Workspace it is *chosen*: `busyMessage()` picks between four sentences from a real busy reading. Project Overview asserted it for every stale reading, directly above the row whose whole job is to name the cause.

## Change

New `overview:staleNumbers` in all ten catalogues — each locale's string is the second half of its own existing `busyStale`, so nothing needed re-translating. The card now reads one sentence about the numbers and one row about the daemon, with no combination in which they can disagree.

Verified on the running window in both appearances (`scripts/electron-cdp.mjs`, stats endpoint blocked so the card falls back to its stored snapshot):

```
Index
  These are the last indexed numbers.
  Status                                   ● Daemon unreachable
```

The regression test asserts the card cannot print "daemon is busy" while its Status row reads "Not tracked"; confirmed to fail against the old code.

`DESIGN.md` gains the rule this is an instance of: a string borrowed from another surface carries that surface's verdict.

Local: `pnpm test` 710/710, `typecheck`, `check:i18n` clean. Reviewed by a second model.

Agent: Design/UX Agent
