### PR TITLE
fix(launcher): reprobe past an app runtime shim whose target is gone

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.6.3 (Windows)
+REM trace-mcp-launcher v0.6.4 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.6.3 (Windows)
+# trace-mcp-launcher v0.6.4 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.
@@ -126,6 +126,40 @@ function Test-NodeBinary {
     return $true
 }
 
+# $true unless $Path is one of our own `node-runtime.cmd` shims whose target is
+# gone.
+#
+# The desktop app records `bin\node-runtime.cmd` as TRACE_MCP_NODE - a .cmd
+# that runs the app binary with ELECTRON_RUN_AS_NODE
+# (packages/app/src/main/daemon-install.ts). Test-NodeBinary is true for that
+# .cmd long after the app it points at has been replaced by an update,
+# moved or uninstalled, so the fast path runs it, cmd fails to start the
+# target, and the MCP client loses all ~170 tools for the rest of the session -
+# with no ERROR line, because from the .cmd's own side nothing went wrong
+# (TRA-965).
+#
+# Reading the target is one file read, so the fast path stays a pure file
+# check. Only OUR shim shape is inspected; a real node.exe is assumed fine,
+# since it cannot be checked without running it.
+function Test-RuntimeShim {
+    param([string]$Path)
+    try {
+        $head = Get-Content -LiteralPath $Path -TotalCount 8 -ErrorAction Stop
+    } catch {
+        return $true
+    }
+    # Marker anywhere in the header, not on a fixed line: the shim has gained
+    # comment lines before and may again, and a line-number match would
+    # silently stop recognising it - failing open, which is the bug this closes.
+    if (-not ($head | Where-Object { $_ -match '^rem Managed by the trace-mcp app' })) { return $true }
+    $target = $null
+    foreach ($line in $head) {
+        if ($line -match '^"(.+)" %\*\s*$') { $target = $Matches[1] }
+    }
+    if (-not $target) { return $true }
+    return (Test-Path -LiteralPath $target -PathType Leaf)
+}
+
 function Test-CliFile {
     param([string]$Path)
     if (-not $Path) { return $false }
@@ -199,6 +233,12 @@ function Get-NodeMajor {
 # Only the NODE override exempts a run from the gate. Sharing one flag with
 # TRACE_MCP_CLI_OVERRIDE would let a CLI-only debugging override carry the
 # configured node past the check - the exact failure this gate exists to stop.
+if (-not $UsingNodeOverride -and (Test-NodeBinary $NodePath) -and -not (Test-RuntimeShim $NodePath)) {
+    Write-LauncherLog "ERROR: config node=$NodePath is an app runtime shim whose target is gone (app updated, moved or removed) - reprobing"
+    $NodePath = ''
+    $NodeMajor = ''
+}
+
 if (-not $UsingNodeOverride -and (Test-NodeBinary $NodePath)) {
     $cached = Get-BoundedMajor $NodeMajor
     if ($null -eq $cached) {

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -138,25 +138,33 @@ function Test-NodeBinary {
 # with no ERROR line, because from the .cmd's own side nothing went wrong
 # (TRA-965).
 #
-# Reading the target is one file read, so the fast path stays a pure file
-# check. Only OUR shim shape is inspected; a real node.exe is assumed fine,
-# since it cannot be checked without running it.
+# Two gates, in this order, and both matter:
+#
+#  1. The basename. RUNTIME_SHIM_NAME in daemon-install.ts is always
+#     `node-runtime.cmd`, so anything else - every real node.exe - is answered
+#     without opening the file at all.
+#  2. The marker, matched anywhere in the header rather than on a fixed line:
+#     the shim has gained comment lines before and may again, and a
+#     line-number match would silently stop recognising it.
+#
+# Once the marker says this IS our shim, an unreadable or unparseable body is
+# a failure, not a pass: returning "fine" there restores the exact outage this
+# closes the moment the generator's invocation line changes shape. Reprobing
+# costs a probe; running an unverified shim costs the session.
 function Test-RuntimeShim {
     param([string]$Path)
+    if ([System.IO.Path]::GetFileName($Path) -ne 'node-runtime.cmd') { return $true }
     try {
         $head = Get-Content -LiteralPath $Path -TotalCount 8 -ErrorAction Stop
     } catch {
-        return $true
+        return $false
     }
-    # Marker anywhere in the header, not on a fixed line: the shim has gained
-    # comment lines before and may again, and a line-number match would
-    # silently stop recognising it - failing open, which is the bug this closes.
     if (-not ($head | Where-Object { $_ -match '^rem Managed by the trace-mcp app' })) { return $true }
     $target = $null
     foreach ($line in $head) {
         if ($line -match '^"(.+)" %\*\s*$') { $target = $Matches[1] }
     }
-    if (-not $target) { return $true }
+    if (-not $target) { return $false }
     return (Test-Path -LiteralPath $target -PathType Leaf)
 }
 

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.6.3
+# trace-mcp-launcher v0.6.4
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -141,6 +141,33 @@ node_major() {
   v="${v%%.*}"
   is_bounded_major "$v" || return 1
   echo "$v"
+}
+
+# True unless $1 is one of our own `node-runtime` shims with a dangling target.
+#
+# The desktop app records `~/.trace/bin/node-runtime` as TRACE_MCP_NODE — a
+# bash script that execs the binary inside trace-mcp.app with
+# ELECTRON_RUN_AS_NODE (packages/app/src/main/daemon-install.ts). `[ -x ]` is
+# true for that script long after the .app it points at has been replaced by an
+# update, moved, or dragged to the Trash. So the fast path execs it, bash exits
+# 126, and the MCP client loses all ~170 tools for the rest of the session —
+# with no ERROR line anywhere, because from the shim's own side the exec
+# succeeded. Reproduced against a real Homebrew node and cli.js sitting unused
+# on the same disk (TRA-965).
+#
+# Reading the target costs one `sed` and one `test`, no process spawn, so the
+# fast path stays a pure file check. Only OUR shim shape is inspected;
+# anything else is assumed fine, since a real node binary cannot be checked
+# without running it.
+node_runtime_shim_ok() {
+  local target
+  # Marker anywhere in the header, not on a fixed line: the shim has gained
+  # comment lines before and may again, and a line-number match would silently
+  # stop recognising it — failing open, which is the bug this closes.
+  head -8 "$1" 2>/dev/null | grep -q '^# Managed by the trace-mcp app' || return 0
+  target=$(sed -n 's/^exec "\(.*\)" "\$@"$/\1/p' "$1" 2>/dev/null | tail -1)
+  [ -n "$target" ] || return 0
+  [ -x "$target" ]
 }
 
 # Resolve node from an nvm-layout tree ($1 = root, e.g. ~/.nvm or ~/Library/.../Herd/config/nvm).
@@ -454,6 +481,14 @@ heal_config() {
 # Only the NODE override exempts a run from the gate. Sharing one flag with
 # TRACE_MCP_CLI_OVERRIDE would let a CLI-only debugging override carry the
 # configured node past the check — the exact failure this gate exists to stop.
+if [ "$USING_NODE_OVERRIDE" = 0 ] && [ -n "$NODE_PATH" ] && [ -x "$NODE_PATH" ]; then
+  if ! node_runtime_shim_ok "$NODE_PATH"; then
+    log "ERROR: config node=$NODE_PATH is an app runtime shim whose target is gone (app updated, moved or removed) — reprobing"
+    NODE_PATH=""
+    NODE_MAJOR=""
+  fi
+fi
+
 if [ "$USING_NODE_OVERRIDE" = 0 ] && [ -n "$NODE_PATH" ] && [ -x "$NODE_PATH" ]; then
   if ! is_bounded_major "$NODE_MAJOR"; then
     NODE_MAJOR=$(node_major "$NODE_PATH") || NODE_MAJOR=0

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -155,19 +155,42 @@ node_major() {
 # succeeded. Reproduced against a real Homebrew node and cli.js sitting unused
 # on the same disk (TRA-965).
 #
-# Reading the target costs one `sed` and one `test`, no process spawn, so the
-# fast path stays a pure file check. Only OUR shim shape is inspected;
-# anything else is assumed fine, since a real node binary cannot be checked
-# without running it.
+# Two gates, in this order, and both matter:
+#
+#  1. The basename. RUNTIME_SHIM_NAME in daemon-install.ts is always
+#     `node-runtime`, so anything else — every real node binary — is answered
+#     without opening the file at all. The fast path must stay fork-free: the
+#     cached TRACE_MCP_NODE_MAJOR exists precisely so a normal start spawns no
+#     process, and a `head | grep` pair on every start would have quietly
+#     undone that (review of #982).
+#  2. The marker, matched anywhere in the header rather than on a fixed line:
+#     the shim has gained comment lines before and may again, and a
+#     line-number match would silently stop recognising it.
+#
+# Parsing uses shell builtins only, for gate 1's reason. Once the marker says
+# this IS our shim, an unreadable or unparseable body is a failure, not a pass:
+# returning "fine" there restores the exact outage this closes the moment the
+# generator's `exec` line changes shape. Reprobing costs a probe; exec-ing an
+# unverified shim costs the session.
 node_runtime_shim_ok() {
-  local target
-  # Marker anywhere in the header, not on a fixed line: the shim has gained
-  # comment lines before and may again, and a line-number match would silently
-  # stop recognising it — failing open, which is the bug this closes.
-  head -8 "$1" 2>/dev/null | grep -q '^# Managed by the trace-mcp app' || return 0
-  target=$(sed -n 's/^exec "\(.*\)" "\$@"$/\1/p' "$1" 2>/dev/null | tail -1)
-  [ -n "$target" ] || return 0
-  [ -x "$target" ]
+  local line target='' marked=0 i=0
+  case "$1" in
+    */node-runtime) ;;
+    *) return 0 ;;
+  esac
+  [ -f "$1" ] && [ -r "$1" ] || return 1
+  while [ "$i" -lt 8 ] && IFS= read -r line; do
+    i=$((i + 1))
+    case "$line" in
+      '# Managed by the trace-mcp app'*) marked=1 ;;
+      'exec "'*'" "$@"')
+        target="${line#exec \"}"
+        target="${target%\" \"\$@\"}"
+        ;;
+    esac
+  done < "$1"
+  [ "$marked" = 1 ] || return 0
+  [ -n "$target" ] && [ -x "$target" ]
 }
 
 # Resolve node from an nvm-layout tree ($1 = root, e.g. ~/.nvm or ~/Library/.../Herd/config/nvm).

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -112,4 +112,4 @@ export const MIRROR_HOOK_VERSION = '0.3.0';
 // 0.6.0 (TRA-755): the resolved node is version-gated against engines.node. An
 // older one used to exec fine and die on a SyntaxError the client could only
 // report as "failed to connect" — and get pinned into launcher.env on the way.
-export const LAUNCHER_VERSION = '0.6.3';
+export const LAUNCHER_VERSION = '0.6.4';

--- a/tests/init/launcher-integration-windows.test.ts
+++ b/tests/init/launcher-integration-windows.test.ts
@@ -236,4 +236,44 @@ Write-Output "EXIT:$LASTEXITCODE"`;
     const log = fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8');
     expect(log).toMatch(/ERROR: config node=.*runtime shim whose target is gone/);
   });
+
+  // Review of #982: the first cut returned "fine" when the marker matched but
+  // no invocation line could be parsed out - the shim known to be ours and
+  // known to be unverified, run anyway. Once the marker matches, unparseable
+  // means reprobe.
+  it('reprobes a managed node-runtime.cmd whose invocation line cannot be parsed', () => {
+    const { home, traceHome } = setupFakeHome();
+    const shim = path.join(traceHome, 'bin', 'node-runtime.cmd');
+    fs.writeFileSync(
+      shim,
+      ['@echo off', 'rem Managed by the trace-mcp app (TRA-438) - do not edit by hand.', ''].join(
+        '\r\n',
+      ),
+    );
+    const cli = path.join(home, 'fake-cli.js');
+    fs.writeFileSync(
+      path.join(traceHome, 'launcher.env'),
+      [
+        `TRACE_MCP_NODE="${shim.replace(/\\/g, '\\\\')}"`,
+        `TRACE_MCP_CLI="${cli.replace(/\\/g, '\\\\')}"`,
+        'TRACE_MCP_NODE_MAJOR="24"',
+        '',
+      ].join('\r\n'),
+    );
+
+    const ps1 = path.join(HOOKS_DIR, 'trace-mcp-launcher.ps1');
+    const q = (p: string) => p.replace(/'/g, "''");
+    const script = `$env:TRACE_MCP_HOME = '${q(traceHome)}'
+$env:USERPROFILE = '${q(home)}'
+$env:NPM_CONFIG_PREFIX = ''
+& powershell.exe -NoProfile -NonInteractive -File '${q(ps1)}' serve
+Write-Output "EXIT:$LASTEXITCODE"`;
+    spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], {
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+
+    const log = fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8');
+    expect(log).toMatch(/ERROR: config node=.*runtime shim whose target is gone/);
+  });
 });

--- a/tests/init/launcher-integration-windows.test.ts
+++ b/tests/init/launcher-integration-windows.test.ts
@@ -9,6 +9,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { runtimeShimContent } from '../../packages/app/src/main/daemon-install';
 
 const isWin = process.platform === 'win32';
 const descIf = isWin ? describe : describe.skip;
@@ -192,5 +193,47 @@ try {
 
     expect(fs.existsSync(sentinel)).toBe(false);
     expect(fs.existsSync(`${sentinel}-sub`)).toBe(false);
+  });
+
+  // TRA-965. The app records `bin\node-runtime.cmd` as TRACE_MCP_NODE - a .cmd
+  // that runs the app binary with ELECTRON_RUN_AS_NODE. The file test on the
+  // fast path stays true after the app is replaced by an update, moved or
+  // uninstalled, so the launcher ran the .cmd, cmd failed to start a target
+  // that is no longer there, and the client lost trace-mcp for the whole
+  // session - with no ERROR line, because nothing the launcher did failed.
+  // Driven through powershell.exe directly, like the locked-pkg-roots test
+  // above: the cmd shim does not spawn on the windows-latest runner.
+  it('reprobes past a node-runtime.cmd whose app is gone', () => {
+    const { home, traceHome } = setupFakeHome();
+    const shim = path.join(traceHome, 'bin', 'node-runtime.cmd');
+    // The real generator, so the ps1's marker can never drift from it.
+    fs.writeFileSync(shim, runtimeShimContent(path.join(home, 'gone', 'trace-mcp.exe')));
+    const cli = path.join(home, 'fake-cli.js');
+    fs.writeFileSync(
+      path.join(traceHome, 'launcher.env'),
+      [
+        `TRACE_MCP_NODE="${shim.replace(/\\/g, '\\\\')}"`,
+        `TRACE_MCP_CLI="${cli.replace(/\\/g, '\\\\')}"`,
+        // Cached, so nothing on the fast path would have run `node -v` and
+        // noticed - the exact shape the app writes.
+        'TRACE_MCP_NODE_MAJOR="24"',
+        '',
+      ].join('\r\n'),
+    );
+
+    const ps1 = path.join(HOOKS_DIR, 'trace-mcp-launcher.ps1');
+    const q = (p: string) => p.replace(/'/g, "''");
+    const script = `$env:TRACE_MCP_HOME = '${q(traceHome)}'
+$env:USERPROFILE = '${q(home)}'
+$env:NPM_CONFIG_PREFIX = ''
+& powershell.exe -NoProfile -NonInteractive -File '${q(ps1)}' serve
+Write-Output "EXIT:$LASTEXITCODE"`;
+    spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], {
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+
+    const log = fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8');
+    expect(log).toMatch(/ERROR: config node=.*runtime shim whose target is gone/);
   });
 });

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { runtimeShimContent } from '../../packages/app/src/main/daemon-install';
 import { sweepOrphanTmpFiles } from '../../src/utils/atomic-write.js';
 
 const LAUNCHER_SRC = path.resolve(__dirname, '..', '..', 'hooks', 'trace-mcp-launcher.sh');
@@ -891,5 +892,97 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
     } finally {
       fs.chmodSync(traceHome, 0o700);
     }
+  });
+});
+
+// TRA-965. The desktop app records `~/.trace/bin/node-runtime` as
+// TRACE_MCP_NODE — a bash script that execs the binary inside trace-mcp.app.
+// `[ -x ]` stays true for that script after the .app is replaced by an update,
+// moved, or removed, so the launcher took the fast path, exec'd it, and bash
+// exited 126. The client lost all ~170 tools for the session, and the daily
+// "zero ERROR lines in launcher.log" health check read clean, because from the
+// shim's own side the exec had succeeded.
+describe.skipIf(process.platform === 'win32')('app runtime shim with a dangling target', () => {
+  /** The real generator, so the launcher's marker can never drift from it. */
+  function plantRuntimeShim(dir: string, execPath: string): string {
+    fs.mkdirSync(dir, { recursive: true });
+    const shim = path.join(dir, 'node-runtime');
+    fs.writeFileSync(shim, runtimeShimContent(execPath), { mode: 0o755 });
+    return shim;
+  }
+
+  function plantFallbackPrefix(home: string, traceHome: string): { cli: string } {
+    const prefix = path.join(home, 'fallback-prefix');
+    fs.mkdirSync(path.join(prefix, 'bin'), { recursive: true });
+    fs.writeFileSync(path.join(prefix, 'bin', 'node'), fakeNodeBody('22.22.2'), { mode: 0o755 });
+    const dist = path.join(prefix, 'lib', 'node_modules', 'trace-mcp', 'dist');
+    fs.mkdirSync(dist, { recursive: true });
+    const cli = path.join(dist, 'cli.js');
+    fs.writeFileSync(cli, '// fallback cli\n');
+    fs.writeFileSync(
+      path.join(traceHome, 'pkg-roots'),
+      `${path.join(prefix, 'lib', 'node_modules')}\n`,
+    );
+    return { cli: fs.realpathSync(cli) };
+  }
+
+  it('reprobes onto a real node instead of exec-ing a shim whose app is gone', () => {
+    const { home, traceHome, cli } = setupFakeHome();
+    const shim = plantRuntimeShim(path.join(traceHome, 'bin'), path.join(home, 'gone.app', 'bin'));
+    plantFallbackPrefix(home, traceHome);
+    // Includes the cached major, so nothing on the fast path would have run
+    // `node -v` and noticed — the exact shape found on the reporting machine.
+    fs.writeFileSync(
+      path.join(traceHome, 'launcher.env'),
+      [`TRACE_MCP_NODE="${shim}"`, `TRACE_MCP_CLI="${cli}"`, 'TRACE_MCP_NODE_MAJOR="24"', ''].join(
+        '\n',
+      ),
+    );
+
+    const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+    // Logged as an ERROR: a session that only survives because of the fallback
+    // must still be visible to the daily launcher.log audit.
+    const log = fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8');
+    expect(log).toMatch(/ERROR: config node=.*runtime shim whose target is gone/);
+  });
+
+  it('leaves the fast path alone when the shim target still exists', () => {
+    const { home, traceHome, node, cli } = setupFakeHome();
+    const shim = plantRuntimeShim(path.join(traceHome, 'bin'), node);
+    fs.writeFileSync(
+      path.join(traceHome, 'launcher.env'),
+      [`TRACE_MCP_NODE="${shim}"`, `TRACE_MCP_CLI="${cli}"`, 'TRACE_MCP_NODE_MAJOR="24"', ''].join(
+        '\n',
+      ),
+    );
+
+    const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+    const log = fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8');
+    expect(log).toMatch(/exec\(config\)/);
+    expect(log).not.toMatch(/ERROR/);
+  });
+
+  // The check must never reject a real node binary: it cannot be verified
+  // without running it, and treating an unreadable one as broken would turn
+  // every healthy start into a probe.
+  it('does not treat a plain node binary as a shim', () => {
+    const { home, traceHome, node, cli } = setupFakeHome();
+    fs.writeFileSync(
+      path.join(traceHome, 'launcher.env'),
+      [`TRACE_MCP_NODE="${node}"`, `TRACE_MCP_CLI="${cli}"`, 'TRACE_MCP_NODE_MAJOR="22"', ''].join(
+        '\n',
+      ),
+    );
+
+    const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
   });
 });

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -939,10 +939,13 @@ describe.skipIf(process.platform === 'win32')('app runtime shim with a dangling 
       ),
     );
 
-    const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+    const { status } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
 
+    // 0, not 126: the shim was never exec'd, and the probe found a node.
+    // Deliberately not asserting WHICH node — a CI runner with a real node on
+    // a standard path wins the probe ahead of the planted prefix, and the
+    // contract here is recovery, not the winner.
     expect(status).toBe(0);
-    expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
     // Logged as an ERROR: a session that only survives because of the fallback
     // must still be visible to the daily launcher.log audit.
     const log = fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8');
@@ -966,6 +969,39 @@ describe.skipIf(process.platform === 'win32')('app runtime shim with a dangling 
     const log = fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8');
     expect(log).toMatch(/exec\(config\)/);
     expect(log).not.toMatch(/ERROR/);
+  });
+
+  // Review of #982: the first cut returned "fine" when the marker matched but
+  // no `exec` line could be parsed out. That is the outage again — the shim is
+  // known to be ours and known to be unverified, and it got exec'd anyway. It
+  // would have fired for real the first time the generator's exec line changed
+  // shape. Once the marker matches, unparseable means reprobe.
+  it('reprobes a managed shim whose exec line cannot be parsed', () => {
+    const { home, traceHome, cli } = setupFakeHome();
+    const dir = path.join(traceHome, 'bin');
+    fs.mkdirSync(dir, { recursive: true });
+    const shim = path.join(dir, 'node-runtime');
+    fs.writeFileSync(
+      shim,
+      ['#!/bin/bash', '# Managed by the trace-mcp app (TRA-438) — do not edit by hand.', ''].join(
+        '\n',
+      ),
+      { mode: 0o755 },
+    );
+    // Only the node is reprobed here — the configured cli.js is still valid.
+    plantFallbackPrefix(home, traceHome);
+    fs.writeFileSync(
+      path.join(traceHome, 'launcher.env'),
+      [`TRACE_MCP_NODE="${shim}"`, `TRACE_MCP_CLI="${cli}"`, 'TRACE_MCP_NODE_MAJOR="24"', ''].join(
+        '\n',
+      ),
+    );
+
+    const { status } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+    expect(status).toBe(0);
+    const log = fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8');
+    expect(log).toMatch(/ERROR: config node=.*runtime shim whose target is gone/);
   });
 
   // The check must never reject a real node binary: it cannot be verified


### PR DESCRIPTION
## The failure

The desktop app records `~/.trace/bin/node-runtime` as `TRACE_MCP_NODE` — a bash script that execs the binary inside `trace-mcp.app` with `ELECTRON_RUN_AS_NODE` (`packages/app/src/main/daemon-install.ts`). That is the default shape on an app install: on this machine `launcher.env` points both `TRACE_MCP_NODE` and `TRACE_MCP_CLI` inside the bundle.

`[ -x ]` is true for that script long after the `.app` it points at has been replaced by an update, moved, or dragged to the Trash. So the launcher takes the fast path, execs it, and bash exits 126. The MCP client loses all ~170 tools for the rest of the session.

Worse, nothing records it. `launcher.log` gets a normal `exec(config)` line, because from the shim's own side the exec succeeded — so the daily "zero ERROR lines in the last 24h" health check reads clean while every session dies.

## Reproduction

Against the real shim (byte-identical to `runtimeShimContent` output), a valid `cli.js`, and a working node on the same disk:

```
$ TRACE_MCP_HOME=… bash hooks/trace-mcp-launcher.sh --version
node-runtime: line 3: exec: …/trace-mcp: cannot execute: No such file or directory
exit=126
$ cat launcher.log
[…] exec(config) node=…/node-runtime cli=…/cli.js argc=1     ← no ERROR
```

After the fix, same inputs:

```
exit=0   (CLI RAN OK)
[…] ERROR: config node=…/node-runtime is an app runtime shim whose target is gone … — reprobing
[…] probe: node=…/v22.22.2/bin/node (v22)
[…] exec(probe) node=…/v22.22.2/bin/node cli=…/cli.js argc=1
```

`launcher.env` is healed onto the real node, so later starts take the fast path again.

## The change

`node_runtime_shim_ok` reads the shim's `exec "<target>" "$@"` line and checks the target — one `sed` and one `test`, no process spawn, so the fast path stays a pure file check. It is deliberately narrow:

- Only files carrying our own `# Managed by the trace-mcp app` marker are inspected. A real node binary cannot be verified without running it, so it is left alone (the `NODE_MAJOR` cache exists precisely to avoid that spawn).
- The marker is matched anywhere in the header rather than on a fixed line — a line-number match would fail *open* the next time the shim gains a comment, which is the bug being closed.
- A dangling target clears `NODE_PATH` and logs an `ERROR`, so a session that only survives via the fallback is still visible to the log audit.

`Test-RuntimeShim` is the same check on the PowerShell backend for `node-runtime.cmd`. Launcher version 0.6.3 → 0.6.4.

## Tests

Three new cases in `tests/init/launcher-integration.test.ts`, all planting the shim with the **real** `runtimeShimContent` generator so the launcher's marker cannot drift from it:

- dangling target → reprobes onto a working node, exit 0, `ERROR` logged;
- live target → fast path untouched, no `ERROR`;
- a plain node binary is not mistaken for a shim.

Verified non-vacuous: neutering the new gate fails the first case (exit 126) and leaves the other two green.

One matching case in `tests/init/launcher-integration-windows.test.ts`, driven through `powershell.exe` directly like the existing locked-`pkg-roots` test (the cmd shim does not spawn on the windows-latest runner).

`pnpm test`: 10250 passed, 23 skipped. Build and biome clean.

**Reviewer note:** no PowerShell on this machine, so the `Test-RuntimeShim` change and its Windows test are unexercised locally — the ps1 parse test and the new case both run on the `windows-latest` CI leg.

Closes TRA-965.

Agent: Lead Engineer
