### PR TITLE
docs(seo): retarget the comparisons hub at the Serena/Repomix query cluster

### DIFF
--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -1,10 +1,10 @@
 ---
-title: "Code Graph MCP Servers Compared: 20+ alternatives"
+title: "Serena, Repomix & 20+ Code Graph MCP Servers Compared"
 description: "trace-mcp vs Repomix, Serena, codebase-memory-mcp and 20+ MCP code-graph tools: capabilities, language support, GitHub stars. Last verified September 2026."
-updated: 2026-09-04
+updated: 2026-09-06
 ---
 
-# How trace-mcp compares
+# Serena, Repomix and 20+ code graph MCP servers compared
 
 <script type="application/ld+json">
 {

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -1,7 +1,7 @@
 ---
 title: "Serena, Repomix & 20+ Code Graph MCP Servers Compared"
 description: "trace-mcp vs Repomix, Serena, codebase-memory-mcp and 20+ MCP code-graph tools: capabilities, language support, GitHub stars. Last verified September 2026."
-updated: 2026-09-06
+updated: 2026-09-04
 ---
 
 # Serena, Repomix and 20+ code graph MCP servers compared

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -566,7 +566,7 @@ which excludes the framework-specific rows.
 
 ---
 
-# How trace-mcp compares
+# Serena, Repomix and 20+ code graph MCP servers compared
 
 Source: https://trace-mcp.com/comparisons.html
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,7 +11,7 @@ layout: null
 
 - [Tools reference](https://trace-mcp.com/tools-reference.html): Full list of the {{ site.data.counts.tools }} MCP tools and {{ site.data.counts.resources }} resources trace-mcp exposes, registered dynamically per detected framework.
 - [Tool index](https://trace-mcp.com/tools-index.html): Alphabetical index of every MCP tool with its one-line description, generated from the server's own registrations.
-- [How trace-mcp compares](https://trace-mcp.com/comparisons.html): Feature-by-feature comparison against other code-graph and code-intelligence MCP servers.
+- [Serena, Repomix and 20+ code graph MCP servers compared](https://trace-mcp.com/comparisons.html): Feature-by-feature comparison against other code-graph and code-intelligence MCP servers.
 - [trace-mcp vs Repomix](https://trace-mcp.com/vs/repomix.html): Head-to-head against Repomix — packing a repository into one prompt vs indexing it into a queryable graph, and when Repomix is the better pick.
 - [trace-mcp vs Serena](https://trace-mcp.com/vs/serena.html): Head-to-head against Serena — a live LSP proxy vs a precomputed framework-aware graph.
 - [trace-mcp vs codebase-memory-mcp](https://trace-mcp.com/vs/codebase-memory-mcp.html): Head-to-head against the closest peer — same knowledge-graph premise, opposite bets on language breadth vs framework depth.


### PR DESCRIPTION
## What

Retargets `docs/comparisons.md` — title and H1 — at the competitor entities people actually search for, and syncs the two generated files that mirror the title.

## Why (measured, 2026-09-06)

**GSC URL Inspection — the whole `/vs/` spoke cluster is invisible to Google:**

| URL | Coverage state |
|---|---|
| `/vs/serena.html` | URL is unknown to Google |
| `/vs/repomix.html` | URL is unknown to Google |
| `/vs/repomix-vs-codegraph.html` | URL is unknown to Google |
| `/vs/codebase-memory-mcp.html` | URL is unknown to Google |
| `/vs/codegraph.html` | Discovered – currently not indexed |
| `/vs/context-mode.html` | Discovered – currently not indexed |
| `/comparisons.html` | **Submitted and indexed** (crawled 2026-08-29) |

GSC search performance, 2026-08-07 → 2026-09-05: none of the six spokes recorded a single impression. `comparisons.html` recorded 149 impressions, avg position 7.3, and every non-brand click the site earned (`"codegraphcontext"` ×2 at pos 1.5, `codegraph vs serena` ×1 at pos 1).

So the hub is the only surface in this cluster that can reach a query today — and its title was `Code Graph MCP Servers Compared: 20+ alternatives` with H1 `How trace-mcp compares`. Neither named a competitor.

**DataForSEO Keywords Data (US/en, live 2026-09-06):** `serena mcp` 2,400/mo, LOW competition, $12.45 CPC — roughly 10× every other reachable term measured. `codebase memory mcp` 880, `codegraphcontext` 210, `claude code token usage` 260, `repomix mcp` 50, `code graph mcp` 70.

## Not in this PR

Fixing spoke indexation. Every on-site lever is already pulled — sitemap entries present, robots allows, self-referencing canonicals, 4 in-body contextual links from the indexed hub to `/vs/serena.html`, and all six linked from the GitHub README. Google still hasn't crawled four of them. That is domain crawl demand, not markup, and it needs its own issue.

## Verification

`pnpm exec vitest run tests/docs` — 19 files, 248 passed, 4 skipped, 0 failed.
