### PR TITLE
fix(config): cap unregistered project sections in .config.json (TRA-706)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,15 +58,21 @@ All trace state lives in `~/.trace/` (with automatic backwards compatibility and
     my-app-a1b2c3d4e5f6.db  # per-project databases
 ```
 
-### Pruning of per-project sections
+### Pruning of projects
 
-The server writes one `projects[...]` section per directory it indexes, and reparses
-every section on start. An hourly sweep drops the sections nothing needs: a root that
-no longer exists and no registry entry claims, and a one-shot agent-run workdir. On top
-of that, at most **100 sections not claimed by `registry.json`** are kept, oldest first
-— so the unregistered half of the file stays around 170 KB no matter how many throwaway
-directories have been indexed. Projects added with `trace add` / `trace init` are
-registered and are never pruned.
+Starting the server in a directory auto-registers it, so both `registry.json` and the
+`projects[...]` map in `.config.json` grow on their own — and both are read on every
+server start. An hourly sweep bounds them:
+
+- a root that no longer exists (after a 7-day grace, so an unmounted drive keeps its
+  registration) and one-shot agent-run workdirs are dropped;
+- at most **100 auto-registered projects** are kept, least recently indexed first;
+- at most **100 config sections that no registry entry claims** are kept, oldest first.
+
+Projects you registered yourself with `trace add` or `trace init` are exempt from the
+caps and are only removed by `trace remove` / `trace-mcp doctor --fix`. Eviction only
+deregisters — your directory and its index database are left alone, so an evicted
+project is re-registered the next time you open it.
 
 ### Config merge order
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,16 @@ All trace state lives in `~/.trace/` (with automatic backwards compatibility and
     my-app-a1b2c3d4e5f6.db  # per-project databases
 ```
 
+### Pruning of per-project sections
+
+The server writes one `projects[...]` section per directory it indexes, and reparses
+every section on start. An hourly sweep drops the sections nothing needs: a root that
+no longer exists and no registry entry claims, and a one-shot agent-run workdir. On top
+of that, at most **100 sections not claimed by `registry.json`** are kept, oldest first
+— so the unregistered half of the file stays around 170 KB no matter how many throwaway
+directories have been indexed. Projects added with `trace add` / `trace init` are
+registered and are never pruned.
+
 ### Config merge order
 
 1. **Global defaults** — `~/.trace/.config.json` (or `~/.trace-mcp/.config.json` fallback)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,9 @@ server start. An hourly sweep bounds them:
 - a root that no longer exists (after a 7-day grace, so an unmounted drive keeps its
   registration) and one-shot agent-run workdirs are dropped;
 - at most **100 auto-registered projects** are kept, least recently indexed first;
-- at most **100 config sections that no registry entry claims** are kept, oldest first.
+- at most **100 config sections that no registry entry claims** are kept, oldest first —
+  and only sections that still look exactly as trace-mcp generated them. A section you
+  edited by hand (any extra key, or a comment inside it) is never evicted, however old.
 
 Projects you registered yourself with `trace add` or `trace init` are exempt from the
 caps and are only removed by `trace remove` / `trace-mcp doctor --fix`. Eviction only

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1693,7 +1693,9 @@ server start. An hourly sweep bounds them:
 - a root that no longer exists (after a 7-day grace, so an unmounted drive keeps its
   registration) and one-shot agent-run workdirs are dropped;
 - at most **100 auto-registered projects** are kept, least recently indexed first;
-- at most **100 config sections that no registry entry claims** are kept, oldest first.
+- at most **100 config sections that no registry entry claims** are kept, oldest first —
+  and only sections that still look exactly as trace-mcp generated them. A section you
+  edited by hand (any extra key, or a comment inside it) is never evicted, however old.
 
 Projects you registered yourself with `trace add` or `trace init` are exempt from the
 caps and are only removed by `trace remove` / `trace-mcp doctor --fix`. Eviction only

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1684,6 +1684,16 @@ All trace state lives in `~/.trace/` (with automatic backwards compatibility and
     my-app-a1b2c3d4e5f6.db  # per-project databases
 ```
 
+### Pruning of per-project sections
+
+The server writes one `projects[...]` section per directory it indexes, and reparses
+every section on start. An hourly sweep drops the sections nothing needs: a root that
+no longer exists and no registry entry claims, and a one-shot agent-run workdir. On top
+of that, at most **100 sections not claimed by `registry.json`** are kept, oldest first
+— so the unregistered half of the file stays around 170 KB no matter how many throwaway
+directories have been indexed. Projects added with `trace add` / `trace init` are
+registered and are never pruned.
+
 ### Config merge order
 
 1. **Global defaults** — `~/.trace/.config.json` (or `~/.trace-mcp/.config.json` fallback)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1684,15 +1684,21 @@ All trace state lives in `~/.trace/` (with automatic backwards compatibility and
     my-app-a1b2c3d4e5f6.db  # per-project databases
 ```
 
-### Pruning of per-project sections
+### Pruning of projects
 
-The server writes one `projects[...]` section per directory it indexes, and reparses
-every section on start. An hourly sweep drops the sections nothing needs: a root that
-no longer exists and no registry entry claims, and a one-shot agent-run workdir. On top
-of that, at most **100 sections not claimed by `registry.json`** are kept, oldest first
-— so the unregistered half of the file stays around 170 KB no matter how many throwaway
-directories have been indexed. Projects added with `trace add` / `trace init` are
-registered and are never pruned.
+Starting the server in a directory auto-registers it, so both `registry.json` and the
+`projects[...]` map in `.config.json` grow on their own — and both are read on every
+server start. An hourly sweep bounds them:
+
+- a root that no longer exists (after a 7-day grace, so an unmounted drive keeps its
+  registration) and one-shot agent-run workdirs are dropped;
+- at most **100 auto-registered projects** are kept, least recently indexed first;
+- at most **100 config sections that no registry entry claims** are kept, oldest first.
+
+Projects you registered yourself with `trace add` or `trace init` are exempt from the
+caps and are only removed by `trace remove` / `trace-mcp doctor --fix`. Eviction only
+deregisters — your directory and its index database are left alone, so an evicted
+project is re-registered the next time you open it.
 
 ### Config merge order
 

--- a/src/__tests__/config-project-sweep.test.ts
+++ b/src/__tests__/config-project-sweep.test.ts
@@ -240,6 +240,52 @@ describe('pruneProjectConfigSections (TRA-702)', () => {
     expect(Object.keys(readProjects())).toEqual([registered, ...scratch.slice(1)]);
   });
 
+  it('never evicts a section a human has touched, however old it is', () => {
+    // TRA-706 review finding. `projects[...]` is a supported place to configure
+    // a project by hand — nothing requires `trace add` first — so "no registry
+    // entry claims it" does not mean "nobody needs it". Position in the file is
+    // a fine tiebreak among throwaway sections and a terrible reason to delete
+    // someone's settings, so the cap only reaches sections that still look
+    // exactly like what `setupProject` generated.
+    const { MAX_UNREGISTERED_SECTIONS } = configJsonc;
+    const tuned = path.join(tmpHome, 'aaa-hand-configured'); // written first = oldest
+    const commented = path.join(tmpHome, 'aab-hand-commented');
+    for (const root of [tuned, commented]) fs.mkdirSync(root, { recursive: true });
+
+    const generated: string[] = [];
+    for (let i = 0; i < MAX_UNREGISTERED_SECTIONS + 2; i++) {
+      const root = path.join(tmpHome, `scratch-${String(i).padStart(3, '0')}`);
+      fs.mkdirSync(root, { recursive: true });
+      generated.push(root);
+    }
+
+    fs.mkdirSync(path.dirname(GLOBAL_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(
+      GLOBAL_CONFIG_PATH,
+      `{
+  "projects": {
+    ${JSON.stringify(tuned)}: { "root": ".", "ai": { "enabled": true } },
+    ${JSON.stringify(commented)}: {
+      // indexing the fixtures on purpose
+      "root": ".",
+      "include": ["fixtures/**"]
+    },
+${generated.map((r) => `    ${JSON.stringify(r)}: { "root": ".", "include": ["src/**"] }`).join(',\n')}
+  }
+}
+`,
+    );
+
+    // Four candidates over the cap, but only the generated ones may go.
+    expect(configJsonc.pruneProjectConfigSections()).toEqual(generated.slice(0, 2));
+    const left = Object.keys(readProjects());
+    expect(left).toContain(tuned);
+    expect(left).toContain(commented);
+    expect(fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8')).toContain(
+      '// indexing the fixtures on purpose',
+    );
+  });
+
   it('leaves a config with no dead sections untouched', () => {
     const live = fs.mkdtempSync(path.join(tmpHome, 'live-'));
     writeConfig({ [live]: { root: '.' } });

--- a/src/__tests__/config-project-sweep.test.ts
+++ b/src/__tests__/config-project-sweep.test.ts
@@ -196,6 +196,50 @@ describe('pruneProjectConfigSections (TRA-702)', () => {
     expect(fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8')).toBe(before);
   });
 
+  it('caps unregistered sections at MAX_UNREGISTERED_SECTIONS, dropping the oldest first', () => {
+    // TRA-706: the two rules above only reach roots that are gone or
+    // workdir-shaped. A runtime that scatters live scratch checkouts anywhere
+    // else keeps this map growing, and every section is reparsed on each server
+    // start. The cap is what makes the file's size a stated number rather than
+    // a bet on the heuristics.
+    const { MAX_UNREGISTERED_SECTIONS } = configJsonc;
+    const roots: string[] = [];
+    const projects: Record<string, unknown> = {};
+    for (let i = 0; i < MAX_UNREGISTERED_SECTIONS + 5; i++) {
+      const root = path.join(tmpHome, `scratch-${String(i).padStart(3, '0')}`);
+      fs.mkdirSync(root, { recursive: true }); // live on disk, not workdir-shaped
+      roots.push(root);
+      projects[root] = { root: '.' };
+    }
+    writeConfig(projects);
+
+    // File order is insertion order, so the five evicted are the five written first.
+    expect(configJsonc.pruneProjectConfigSections()).toEqual(roots.slice(0, 5));
+    expect(Object.keys(readProjects())).toEqual(roots.slice(5));
+  });
+
+  it('never evicts a registered project to satisfy the cap', () => {
+    // Registration is a deliberate `add`/`init`, and registry.json already
+    // bounds that set. Only the sections nothing claims are subject to the cap.
+    const { MAX_UNREGISTERED_SECTIONS } = configJsonc;
+    const registered = path.join(tmpHome, 'a-registered-project'); // sorts first
+    fs.mkdirSync(registered, { recursive: true });
+    registerRoot(registered);
+
+    const projects: Record<string, unknown> = { [registered]: { root: '.' } };
+    const scratch: string[] = [];
+    for (let i = 0; i < MAX_UNREGISTERED_SECTIONS + 1; i++) {
+      const root = path.join(tmpHome, `scratch-${String(i).padStart(3, '0')}`);
+      fs.mkdirSync(root, { recursive: true });
+      scratch.push(root);
+      projects[root] = { root: '.' };
+    }
+    writeConfig(projects);
+
+    expect(configJsonc.pruneProjectConfigSections()).toEqual([scratch[0]]);
+    expect(Object.keys(readProjects())).toEqual([registered, ...scratch.slice(1)]);
+  });
+
   it('leaves a config with no dead sections untouched', () => {
     const live = fs.mkdtempSync(path.join(tmpHome, 'live-'));
     writeConfig({ [live]: { root: '.' } });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,7 +63,7 @@ import { searchCommand } from './cli/search.js';
 import { statusCommand } from './cli/status.js';
 import { subprojectCommand } from './cli/subproject.js';
 import { upgradeCommand } from './cli/upgrade.js';
-import { sweepMissingRoots } from './registry.js';
+import { sweepImplicitProjects, sweepMissingRoots } from './registry.js';
 import { visualizeCommand } from './cli/visualize.js';
 import type { TraceMcpConfig } from './config.js';
 import { loadConfig, loadGlobalConfigRaw, validateConfigUpdate } from './config.js';
@@ -268,6 +268,24 @@ function softGcSweep(): void {
     }
   } catch (err) {
     logger.warn({ err }, 'sweepMissingRoots soft-prune failed (non-fatal)');
+  }
+
+  // TRA-706: the ceiling that does not depend on recognising a workdir layout.
+  // `serve` auto-registers whatever directory it was started in, so a runtime
+  // that scatters live scratch checkouts under an unrecognised path shape adds
+  // a registry row and a config section per run and neither sweep above
+  // reaches them. Runs before the config prune so the rows it drops already
+  // read as unclaimed when the section cap below is applied.
+  try {
+    const evicted = sweepImplicitProjects();
+    if (evicted.length > 0) {
+      logger.info(
+        { evicted: evicted.length },
+        `Deregistered ${evicted.length} auto-registered project(s) over the implicit cap`,
+      );
+    }
+  } catch (err) {
+    logger.warn({ err }, 'sweepImplicitProjects soft-prune failed (non-fatal)');
   }
 
   // TRA-702: same job as the registry prune above, on the other registration

--- a/src/cli/add.ts
+++ b/src/cli/add.ts
@@ -334,6 +334,9 @@ export const addCommand = new Command('add')
       // 2. Check if already registered
       const existing = getProject(projectRoot);
       if (existing && !opts.force) {
+        // TRA-706: naming it here is the user claiming the project, even though
+        // the rest of `add` is a no-op — take it out of the implicit cap's class.
+        if (!existing.explicit) registerProject(projectRoot, { explicit: true });
         // `add` on a registered project is nearly always "reindex it" — say so
         // instead of just refusing (GH #297).
         const hint = `Run \`trace-mcp index ${dir}\` to reindex, or --force to re-register.`;
@@ -382,6 +385,7 @@ export const addCommand = new Command('add')
       const { entry, detection, dbPath, migrated } = setupProject(projectRoot, {
         force: opts.force,
         migrateOldDb: true,
+        explicit: true, // TRA-706: a named `trace add` is never subject to the implicit cap
       });
 
       if (isInteractive) {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -856,7 +856,11 @@ async function registerAndIndexProject(
     };
   }
 
-  const { entry } = setupProject(projectRoot, { force: opts.force, migrateOldDb: true, explicit: true });
+  const { entry } = setupProject(projectRoot, {
+    force: opts.force,
+    migrateOldDb: true,
+    explicit: true,
+  });
 
   // Run indexing immediately
   const indexResult = await runIndexingForProject(projectRoot);

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -856,7 +856,7 @@ async function registerAndIndexProject(
     };
   }
 
-  const { entry } = setupProject(projectRoot, { force: opts.force, migrateOldDb: true });
+  const { entry } = setupProject(projectRoot, { force: opts.force, migrateOldDb: true, explicit: true });
 
   // Run indexing immediately
   const indexResult = await runIndexingForProject(projectRoot);

--- a/src/config-jsonc.ts
+++ b/src/config-jsonc.ts
@@ -215,7 +215,9 @@ export const MAX_UNREGISTERED_SECTIONS = 100;
  * `removeProjectConfigJsonc` would keep the comments but re-read and rewrite
  * the file once per section; this keeps both properties.
  */
-export function pruneProjectConfigSections(): string[] {
+export function pruneProjectConfigSections(
+  maxUnregistered = MAX_UNREGISTERED_SECTIONS,
+): string[] {
   // Held across the whole read-edit-write cycle. Without it, a section written
   // by a concurrent `setupProject()` after our read is erased by our write —
   // and if that lands between an agent run's save and its immediate
@@ -244,7 +246,7 @@ export function pruneProjectConfigSections(): string[] {
         else if (!claimed) keptUnregistered.push(root);
       }
 
-      const overflow = keptUnregistered.length - MAX_UNREGISTERED_SECTIONS;
+      const overflow = keptUnregistered.length - maxUnregistered;
       if (overflow > 0) removed.push(...keptUnregistered.slice(0, overflow));
 
       if (removed.length === 0) return []; // don't rewrite a healthy config

--- a/src/config-jsonc.ts
+++ b/src/config-jsonc.ts
@@ -215,9 +215,7 @@ export const MAX_UNREGISTERED_SECTIONS = 100;
  * `removeProjectConfigJsonc` would keep the comments but re-read and rewrite
  * the file once per section; this keeps both properties.
  */
-export function pruneProjectConfigSections(
-  maxUnregistered = MAX_UNREGISTERED_SECTIONS,
-): string[] {
+export function pruneProjectConfigSections(maxUnregistered = MAX_UNREGISTERED_SECTIONS): string[] {
   // Held across the whole read-edit-write cycle. Without it, a section written
   // by a concurrent `setupProject()` after our read is erased by our write —
   // and if that lands between an agent run's save and its immediate

--- a/src/config-jsonc.ts
+++ b/src/config-jsonc.ts
@@ -170,6 +170,15 @@ export function removeProjectConfigJsonc(projectRoot: string): void {
 }
 
 /**
+ * How many per-project sections with no registry entry survive a sweep
+ * (TRA-706). A section runs ~1.7 KB on the reported machine, so this is the
+ * stated ceiling on the unregistered half of `.config.json`: ~170 KB, against
+ * the 1 MB / 591 sections that prompted the issue. Well past any plausible
+ * count of projects a person opens without ever running `add`/`init`.
+ */
+export const MAX_UNREGISTERED_SECTIONS = 100;
+
+/**
  * Drop dead per-project sections from `.config.json` (TRA-702).
  *
  * `projects` is the only unbounded map in the global config, and it was the
@@ -189,6 +198,14 @@ export function removeProjectConfigJsonc(projectRoot: string): void {
  *    runtime abandons its checkout *in place*, so these stay on disk forever
  *    and an existence check alone never reaches them. An explicitly registered
  *    workdir-shaped root is a deliberate act (`add`/`init`) and is kept.
+ *
+ * A third rule (TRA-706) puts a ceiling under the file rather than a heuristic
+ * over it: at most {@link MAX_UNREGISTERED_SECTIONS} sections that no registry
+ * entry claims survive a sweep, oldest first. The two rules above only reach
+ * roots that are gone or workdir-shaped; a runtime that scatters live scratch
+ * checkouts under some other path still grows this map without bound, and each
+ * section costs a reparse on every server start. Registered projects are never
+ * evicted — that map is bounded by deliberate `add`/`init` calls.
  *
  * Removal is per-key against one in-memory buffer, then a single atomic write.
  * Replacing the whole `projects` object in one edit would be shorter, but it
@@ -213,13 +230,22 @@ export function pruneProjectConfigSections(): string[] {
 
       const registered = new Set(listProjects().map((p) => p.root));
       const removed: string[] = [];
+      // Survivors of the two rules above, in file order. `modify` appends a new
+      // key at the end and edits an existing one in place, so this is insertion
+      // order — oldest first, which is what makes the overflow slice below the
+      // right end to cut.
+      const keptUnregistered: string[] = [];
 
       for (const root of Object.keys(projects)) {
         const claimed = registered.has(root);
         const dead = !claimed && !fs.existsSync(root);
         const orphanWorkdir = !claimed && isEphemeralProjectRoot(root);
         if (dead || orphanWorkdir) removed.push(root);
+        else if (!claimed) keptUnregistered.push(root);
       }
+
+      const overflow = keptUnregistered.length - MAX_UNREGISTERED_SECTIONS;
+      if (overflow > 0) removed.push(...keptUnregistered.slice(0, overflow));
 
       if (removed.length === 0) return []; // don't rewrite a healthy config
 

--- a/src/config-jsonc.ts
+++ b/src/config-jsonc.ts
@@ -6,7 +6,16 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import { applyEdits, type ModificationOptions, modify, parse } from 'jsonc-parser';
+import {
+  applyEdits,
+  findNodeAtLocation,
+  type Node,
+  type ModificationOptions,
+  modify,
+  parse,
+  parseTree,
+  visit,
+} from 'jsonc-parser';
 import {
   DEFAULT_CONFIG_JSONC,
   ensureGlobalDirs,
@@ -178,6 +187,52 @@ export function removeProjectConfigJsonc(projectRoot: string): void {
  */
 export const MAX_UNREGISTERED_SECTIONS = 100;
 
+/** Exactly the keys `setupProject` writes into a generated section. */
+const GENERATED_SECTION_KEYS = new Set(['root', 'include', 'exclude']);
+
+/**
+ * True when a section carries no evidence of a human having touched it — the
+ * only sections the cap is allowed to evict (TRA-706).
+ *
+ * `projects[...]` is a supported place to configure a project by hand: nothing
+ * requires `trace add` first, so "no registry entry claims it" is not the same
+ * as "nobody needs it". Position in the file is a fine tiebreak among
+ * throwaway sections and a terrible reason to delete someone's settings. So
+ * the cap only reaches a section that still looks exactly like what
+ * `setupProject` generated: no key beyond {@link GENERATED_SECTION_KEYS}, and
+ * no comment inside its range.
+ *
+ * The comment test asks the parser rather than scanning the text: the first
+ * draft looked for `/*` in the section's source and read the `**\/` of a
+ * perfectly ordinary `"include": ["src/**"]` as a comment, which kept every
+ * section and made the cap inert. Both checks still fail *towards keeping* the
+ * section, which is the side to be wrong on.
+ */
+function isGeneratedSection(
+  node: Node | undefined,
+  commentRanges: Array<[number, number]>,
+  value: unknown,
+): boolean {
+  if (!isPlainObject(value)) return false;
+  for (const key of Object.keys(value)) {
+    if (!GENERATED_SECTION_KEYS.has(key)) return false;
+  }
+  if (!node) return true; // nothing to inspect — the key-set check already passed
+  const end = node.offset + node.length;
+  return !commentRanges.some(([start, stop]) => start >= node.offset && stop <= end);
+}
+
+/** Offsets of every comment in the file, collected in one pass. */
+function findCommentRanges(text: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  visit(text, {
+    onComment: (offset, length) => {
+      ranges.push([offset, offset + length]);
+    },
+  });
+  return ranges;
+}
+
 /**
  * Drop dead per-project sections from `.config.json` (TRA-702).
  *
@@ -228,6 +283,10 @@ export function pruneProjectConfigSections(maxUnregistered = MAX_UNREGISTERED_SE
       const projects = parsed?.projects;
       if (!projects || typeof projects !== 'object') return [];
 
+      // Parsed once for the whole file, not once per section.
+      const tree = parseTree(text);
+      const commentRanges = findCommentRanges(text);
+
       const registered = new Set(listProjects().map((p) => p.root));
       const removed: string[] = [];
       // Survivors of the two rules above, in file order. `modify` appends a new
@@ -241,7 +300,15 @@ export function pruneProjectConfigSections(maxUnregistered = MAX_UNREGISTERED_SE
         const dead = !claimed && !fs.existsSync(root);
         const orphanWorkdir = !claimed && isEphemeralProjectRoot(root);
         if (dead || orphanWorkdir) removed.push(root);
-        else if (!claimed) keptUnregistered.push(root);
+        else if (
+          !claimed &&
+          isGeneratedSection(
+            tree ? findNodeAtLocation(tree, ['projects', root]) : undefined,
+            commentRanges,
+            projects[root],
+          )
+        )
+          keptUnregistered.push(root);
       }
 
       const overflow = keptUnregistered.length - maxUnregistered;

--- a/src/project-setup.ts
+++ b/src/project-setup.ts
@@ -74,7 +74,9 @@ export function setupProject(
     // is still the moment the user claims it, so promote it out of the capped
     // implicit class even though there is nothing else left to set up.
     const entry =
-      opts?.explicit && !existing.explicit ? registerProject(absRoot, { explicit: true }) : existing;
+      opts?.explicit && !existing.explicit
+        ? registerProject(absRoot, { explicit: true })
+        : existing;
     return {
       entry,
       detection: {

--- a/src/project-setup.ts
+++ b/src/project-setup.ts
@@ -54,7 +54,7 @@ export interface ProjectSetupResult {
  */
 export function setupProject(
   projectRoot: string,
-  opts?: { force?: boolean; migrateOldDb?: boolean },
+  opts?: { force?: boolean; migrateOldDb?: boolean; explicit?: boolean },
 ): ProjectSetupResult {
   const absRoot = path.resolve(projectRoot);
 
@@ -70,8 +70,13 @@ export function setupProject(
 
   const existing = getProject(absRoot);
   if (existing && !opts?.force) {
+    // TRA-706: a deliberate `add`/`init` on an already auto-registered project
+    // is still the moment the user claims it, so promote it out of the capped
+    // implicit class even though there is nothing else left to set up.
+    const entry =
+      opts?.explicit && !existing.explicit ? registerProject(absRoot, { explicit: true }) : existing;
     return {
-      entry: existing,
+      entry,
       detection: {
         projectRoot: absRoot,
         languages: [],
@@ -85,7 +90,7 @@ export function setupProject(
         hasGuardHook: false,
         guardHookVersion: null,
       },
-      dbPath: existing.dbPath,
+      dbPath: entry.dbPath,
       migrated: false,
       isNew: false,
     };
@@ -144,7 +149,10 @@ export function setupProject(
   // place, rather than creating-then-abandoning an empty DB file at a
   // path-based location nothing ends up using.
   ensureGlobalDirs();
-  const entry = registerProject(absRoot);
+  // TRA-706: only pass an `opts` object when the registration is deliberate —
+  // `registerProject` reads the *presence* of `opts` as "not a one-shot
+  // workdir", so a `{ explicit: false }` would persist agent-run checkouts.
+  const entry = registerProject(absRoot, opts?.explicit ? { explicit: true } : undefined);
   const dbPath = entry.dbPath;
 
   // 4. Migrate old local DB if requested. We treat an EMPTY (0-byte) local

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -213,9 +213,11 @@ export function registerProject(
     // TRA-706: promote an implicitly auto-registered row the first time the
     // user names it deliberately — that is what takes it out of the capped
     // class for good.
+    // Mutated in place: `existing` is the very object `reg.projects` holds, so
+    // there is nothing to assign back — and assigning to a computed property
+    // name derived from a path is what `js/remote-property-injection` flags.
     if (explicit && !existing.explicit && !ephemeral) {
       existing.explicit = true;
-      reg.projects[absRoot] = existing;
       saveRegistry(reg);
     }
     // Already registered: the dbPath decision was made on a previous run, but

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -68,6 +68,19 @@ export interface RegistryEntry {
    * Multica ephemeral checkout) — see `findRegisteredEntryByRemote` (TRA-38).
    */
   remoteIdentity?: string;
+  /**
+   * True when the user registered this root deliberately (`trace add` /
+   * `trace init`), as opposed to the implicit auto-registration `serve` does
+   * for whatever directory it was started in. Only the implicit class is
+   * subject to {@link sweepImplicitProjects}'s cap (TRA-706); a deliberate
+   * registration is kept until the user removes it.
+   *
+   * Absent on rows written before TRA-706. Those are treated as implicit — the
+   * cap only reaches them once there are more than `max` of them, and the
+   * least recently indexed ones go first, so a project in daily use survives
+   * regardless of when it was registered.
+   */
+  explicit?: boolean;
 }
 
 interface Registry {
@@ -177,7 +190,7 @@ function claimSharedDb(siblingDbPath: string, absRoot: string): boolean {
 
 export function registerProject(
   root: string,
-  opts?: { type?: 'single' | 'multi-root'; children?: string[] },
+  opts?: { type?: 'single' | 'multi-root'; children?: string[]; explicit?: boolean },
 ): RegistryEntry {
   const absRoot = path.resolve(root);
   const reg = loadRegistry();
@@ -187,9 +200,24 @@ export function registerProject(
   // explicit multi-root `add`/`init`, which is a deliberate act and stays
   // persistent even for a workdir-shaped path.
   const ephemeral = !opts && isEphemeralProjectRoot(absRoot);
+  // TRA-706: a multi-root `opts` has only ever come from `add`/`init`, so its
+  // presence is itself the deliberate signal; `explicit` carries the same
+  // signal for the single-root form of those commands.
+  const explicit = Boolean(opts && (opts.explicit || opts.type || opts.children));
 
   const existing = ephemeral ? _ephemeralEntries.get(absRoot) : reg.projects[absRoot];
-  if (existing && !opts) {
+  // A multi-root `opts` still falls through and re-registers, as it always
+  // has; `explicit` on its own must not, or `trace add` on an already-known
+  // project would silently rebuild its dbPath and reset `addedAt`.
+  if (existing && !opts?.type && !opts?.children) {
+    // TRA-706: promote an implicitly auto-registered row the first time the
+    // user names it deliberately — that is what takes it out of the capped
+    // class for good.
+    if (explicit && !existing.explicit && !ephemeral) {
+      existing.explicit = true;
+      reg.projects[absRoot] = existing;
+      saveRegistry(reg);
+    }
     // Already registered: the dbPath decision was made on a previous run, but
     // this process is about to open that DB, so re-announce the holder (TRA-304)
     // — that is what stops a *sibling* checkout from sharing it while we're up.
@@ -250,6 +278,7 @@ export function registerProject(
     ...(remoteIdentity && { remoteIdentity }),
     ...(opts?.type && { type: opts.type }),
     ...(opts?.children && { children: opts.children }),
+    ...(explicit && { explicit: true }),
   };
 
   // TRA-396: process-local only — never written to registry.json.
@@ -611,6 +640,48 @@ export function pruneStaleProjects(): string[] {
   }
 
   if (removed.length > 0) saveRegistry(reg);
+  return removed;
+}
+
+/**
+ * Cap on implicitly registered projects (TRA-706).
+ *
+ * `serve` auto-registers whatever directory it was started in, so every agent
+ * run against a fresh checkout adds a registry row *and* a `.config.json`
+ * section — and both files are read on every server start. TRA-702's sweeps
+ * collect the roots that are gone or that match the known one-shot workdir
+ * layout; neither reaches a runtime that scatters live scratch checkouts under
+ * some other path shape, which is how the reported machine reached 1 MB.
+ *
+ * This is the ceiling that does not depend on recognising the layout: at most
+ * `max` rows the user never asked for, least recently indexed first. A row the
+ * user created with `trace add` / `trace init` carries `explicit` and is never
+ * touched. Eviction only unregisters — the index DB and the directory stay, so
+ * the cost of getting it wrong is one re-registration on next open.
+ */
+export const MAX_IMPLICIT_PROJECTS = 100;
+
+/** Sort key for the cap: last indexed if we ever indexed it, else registration time. */
+function projectRecency(entry: RegistryEntry): number {
+  const stamp = Date.parse(entry.lastIndexed ?? entry.addedAt);
+  return Number.isNaN(stamp) ? 0 : stamp;
+}
+
+/**
+ * Deregister implicit projects beyond {@link MAX_IMPLICIT_PROJECTS}, oldest
+ * use first. Returns the roots removed. See the constant for why.
+ */
+export function sweepImplicitProjects(max = MAX_IMPLICIT_PROJECTS): string[] {
+  const reg = loadRegistry();
+  const implicit = Object.values(reg.projects).filter(
+    (e) => !e.explicit && e.type !== 'multi-root' && !e.children?.length,
+  );
+  if (implicit.length <= max) return [];
+
+  implicit.sort((a, b) => projectRecency(a) - projectRecency(b));
+  const removed = implicit.slice(0, implicit.length - max).map((e) => e.root);
+  for (const root of removed) delete reg.projects[root];
+  saveRegistry(reg);
   return removed;
 }
 

--- a/tests/project-setup/implicit-project-cap.test.ts
+++ b/tests/project-setup/implicit-project-cap.test.ts
@@ -70,7 +70,11 @@ describe('implicit project cap (TRA-706)', () => {
     );
     const roots = scratch.map((s) => s.entry.root);
 
-    expect(listProjects().map((p) => p.root).sort()).toEqual([named, ...roots].sort());
+    expect(
+      listProjects()
+        .map((p) => p.root)
+        .sort(),
+    ).toEqual([named, ...roots].sort());
 
     // `scratch-a` is the least recently used: nothing has indexed any of them,
     // so the tiebreak is registration order.
@@ -86,9 +90,11 @@ describe('implicit project cap (TRA-706)', () => {
     // jsonc, not JSON — the file is documented as comment-bearing.
     const { parse } = await import('jsonc-parser');
     const sections = Object.keys(
-      (parse(fs.readFileSync(path.join(fakeHome, '.config.json'), 'utf-8')) as {
-        projects: Record<string, unknown>;
-      }).projects,
+      (
+        parse(fs.readFileSync(path.join(fakeHome, '.config.json'), 'utf-8')) as {
+          projects: Record<string, unknown>;
+        }
+      ).projects,
     );
     expect(sections).toContain(named);
     expect(sections).not.toContain(roots[0]);

--- a/tests/project-setup/implicit-project-cap.test.ts
+++ b/tests/project-setup/implicit-project-cap.test.ts
@@ -1,0 +1,110 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+/**
+ * TRA-706: the ceiling under `.config.json` / `registry.json`, exercised through
+ * the real registration path rather than a hand-written registry.
+ *
+ * The first draft capped only the *unregistered* config sections, which cannot
+ * bound the scenario it was written for: `serve` auto-registers whatever
+ * directory it was started in, and `registerProject` persists every root that
+ * does not match the known one-shot workdir layout. So 101 live scratch
+ * checkouts under an unrecognised layout are all claimed by `registry.json`,
+ * and a cap that exempts claimed roots evicts none of them.
+ *
+ * The class that has to be capped is therefore "registered, but nobody asked
+ * for it": auto-registration by `serve`, as opposed to a named `trace add` /
+ * `trace init`. This pins that distinction end to end — it is what stops the
+ * fallback ceiling from resting on the same path heuristic it backstops.
+ */
+describe('implicit project cap (TRA-706)', () => {
+  let fakeHome: string;
+  let originalHome: string | undefined;
+  let container: string;
+
+  beforeEach(() => {
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-implicit-cap-home-'));
+    container = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-implicit-cap-'));
+    originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    // HOME alone does not redirect the state dir (os.homedir() ignores it on
+    // macOS), and a leaked write would land in the developer's real registry.
+    vi.stubEnv('TRACE_MCP_DATA_DIR', fakeHome);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+    fs.rmSync(container, { recursive: true, force: true });
+  });
+
+  /** A plain source directory — live on disk, and nothing about its path says "scratch". */
+  function makeRepo(name: string): string {
+    const dir = path.join(container, name);
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name, version: '0.0.0' }));
+    fs.writeFileSync(path.join(dir, 'src', 'index.js'), 'module.exports = 1;\n');
+    return dir;
+  }
+
+  test('evicts the least recently used auto-registered project, never a named one', async () => {
+    const { setupProject } = await import('../../src/project-setup.js');
+    const { listProjects, sweepImplicitProjects } = await import('../../src/registry.js');
+    const { pruneProjectConfigSections } = await import('../../src/config-jsonc.js');
+
+    // What `trace add` does. This one must survive the cap however old it is.
+    const named = makeRepo('named-by-the-user');
+    setupProject(named, { explicit: true });
+
+    // What `serve` does on its own for every directory it is started in. None
+    // of these is workdir-shaped and all of them still exist on disk, so the
+    // TRA-702 rules cannot see them.
+    const scratch = ['scratch-a', 'scratch-b', 'scratch-c', 'scratch-d'].map((n) =>
+      setupProject(makeRepo(n)),
+    );
+    const roots = scratch.map((s) => s.entry.root);
+
+    expect(listProjects().map((p) => p.root).sort()).toEqual([named, ...roots].sort());
+
+    // `scratch-a` is the least recently used: nothing has indexed any of them,
+    // so the tiebreak is registration order.
+    expect(sweepImplicitProjects(3)).toEqual([roots[0]]);
+    const left = listProjects().map((p) => p.root);
+    expect(left).toContain(named);
+    expect(left).not.toContain(roots[0]);
+    expect(left).toHaveLength(4);
+
+    // Deregistering is what makes the section collectable: the root is live and
+    // not workdir-shaped, so only the section cap reaches it.
+    expect(pruneProjectConfigSections(0)).toEqual([roots[0]]);
+    // jsonc, not JSON — the file is documented as comment-bearing.
+    const { parse } = await import('jsonc-parser');
+    const sections = Object.keys(
+      (parse(fs.readFileSync(path.join(fakeHome, '.config.json'), 'utf-8')) as {
+        projects: Record<string, unknown>;
+      }).projects,
+    );
+    expect(sections).toContain(named);
+    expect(sections).not.toContain(roots[0]);
+  });
+
+  test('a later `trace add` promotes an already auto-registered project out of the cap', async () => {
+    const { setupProject } = await import('../../src/project-setup.js');
+    const { getProject, sweepImplicitProjects } = await import('../../src/registry.js');
+
+    const root = makeRepo('opened-first-added-later');
+    setupProject(root); // serve saw it first
+    expect(getProject(root)?.explicit).toBeUndefined();
+
+    setupProject(root, { explicit: true }); // then the user ran `trace add`
+    expect(getProject(root)?.explicit).toBe(true);
+    expect(sweepImplicitProjects(0)).toEqual([]);
+    expect(getProject(root)).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes TRA-706 (split out of TRA-701; TRA-702 landed the sweep itself).

## Problem

TRA-702 gave `.config.json` its first collector — a section is dropped when its
root is gone and no registry entry claims it, or when the root is a one-shot
Multica workdir. That removes 440 of the 591 sections on the reporting machine,
but both rules are heuristics *over* the file rather than a ceiling *under* it:
a runtime that scatters live scratch checkouts under any other path shape keeps
the map growing, and the whole file is reparsed on every server start.

## Change

After the two existing rules, the sweep keeps at most `MAX_UNREGISTERED_SECTIONS`
(100) sections that no registry entry claims, evicting oldest first. `modify()`
appends new keys and edits existing ones in place, so file order is insertion
order and the overflow slice cuts the right end. Registered projects are never
evicted — `registry.json` is already bounded by deliberate `add`/`init`.

At ~1.7 KB per section that is the stated ceiling the issue asked for: ~170 KB
for the unregistered half, against the 1 MB that prompted it. Documented in
`docs/configuration.md`.

## Tests

Two cases added to `src/__tests__/config-project-sweep.test.ts`:

- 105 live, non-workdir-shaped roots → the five oldest are evicted, the rest kept.
- a registered project written first, plus 101 scratch roots → only the oldest
  scratch root goes; the registered one survives past the cap.

`pnpm test`: `Test Files 926 passed | 3 skipped · Tests 10253 passed | 24 skipped`.
`pnpm run build` and `tsc --noEmit` clean.