### PR TITLE
fix(server): stop an orphaned server spinning forever on a dead log pipe (TRA-921)

### DIFF
--- a/docs/perf/idle-cost.md
+++ b/docs/perf/idle-cost.md
@@ -65,3 +65,47 @@ The before/after gap is dominated by lock-queue wait, which is also why `reindex
 telemetry used to report elapsed times in the hours: `elapsedMs` summed the wait with the work.
 It is now the work alone, with the wait beside it as `queuedMs` (`daemon stats` renders it as
 `queued p95`).
+
+## The most expensive idle process is the one nobody owns
+
+Measured 2026-09-06 on the M5 Max. A `serve-http` daemon left over from an earlier benchmark run
+(port 37497, in another agent's workdir) was holding **517 MB and 97% of a core, with zero
+clients, 5h56m after its parent exited** — 356 minutes of CPU spent on nothing.
+
+`sample(1)` on it, and again on a fresh reproduction, showed the same loop and no SQLite at all:
+
+```
+uv__run_check
+  node::Environment::CheckImmediate
+    v8::internal::Isolate::ReportPendingMessages
+      node::errors::TriggerUncaughtException
+        v8::internal::Accessors::ErrorStackGetter
+          v8::internal::ErrorUtils::FormatStackTrace   <- and round again
+```
+
+The mechanism: when the parent that owned our stdout/stderr pipe exits without killing us, every
+write to those fds fails with `EPIPE`. The `uncaughtException` safety net in
+`src/server/process-safety-net.ts` exists to keep a long-lived server alive through stray errors,
+and it does that by *logging* — to the same dead pipe. That write throws `EPIPE`, which re-enters
+the handler, which formats a stack trace, which logs, forever. The process never exits and never
+releases its port.
+
+Reproduction, deterministic in about six seconds:
+
+```js
+const child = spawn('node', [CLI, 'serve-http', '-p', PORT], {
+  stdio: ['ignore', 'pipe', 'pipe'], detached: true,
+});
+child.unref();
+setTimeout(() => { child.stdout.destroy(); child.stderr.destroy(); }, 6000);
+```
+
+| Orphaned `serve-http`, 17 s after the pipes close | Before | After |
+|---|---|---|
+| CPU | 88–106% | process has exited |
+| RSS | 853 MB | 0 |
+| Lifetime | unbounded | ends at the first `EPIPE` |
+
+The fix is to treat a dead log sink as the one error the safety net must not swallow: there is
+nowhere left to report to, so the process leaves. Guarded by
+`src/server/__tests__/process-safety-net.test.ts`.

--- a/docs/perf/idle-cost.md
+++ b/docs/perf/idle-cost.md
@@ -84,11 +84,16 @@ uv__run_check
 ```
 
 The mechanism: when the parent that owned our stdout/stderr pipe exits without killing us, every
-write to those fds fails with `EPIPE`. The `uncaughtException` safety net in
+write to those fds fails with `EPIPE` — emitted as an `error` event on the stream. Nothing listened
+for it, so it became an uncaught exception. The `uncaughtException` safety net in
 `src/server/process-safety-net.ts` exists to keep a long-lived server alive through stray errors,
-and it does that by *logging* — to the same dead pipe. That write throws `EPIPE`, which re-enters
-the handler, which formats a stack trace, which logs, forever. The process never exits and never
-releases its port.
+and it does that by *logging* — the logger's destination is `process.stderr`, the same dead pipe.
+That write fails again, re-enters the handler, formats a stack trace, logs, forever. The process
+never exits and never releases its port.
+
+An instrumented run of the reproduction settles where the error is raised: with an `error` listener
+attached to `process.stderr`, every failure arrives there and the `uncaughtException` handler never
+fires at all. That is what makes the fix narrow — see below.
 
 Reproduction, deterministic in about six seconds:
 
@@ -106,6 +111,10 @@ setTimeout(() => { child.stdout.destroy(); child.stderr.destroy(); }, 6000);
 | RSS | 853 MB | 0 |
 | Lifetime | unbounded | ends at the first `EPIPE` |
 
-The fix is to treat a dead log sink as the one error the safety net must not swallow: there is
-nowhere left to report to, so the process leaves. Guarded by
+The fix listens on `process.stdout` and `process.stderr` themselves and exits on a broken pipe
+there. The stream that raised the error is the proof of ownership, which matters: `EPIPE` and
+friends are generic codes that any socket can raise, and exiting on the code alone would take a
+healthy daemon down over an unrelated HTTP response. Any other write failure on those streams
+(`ENOSPC`, `EACCES`) is still swallowed — a logger must not stop the server, which is the call
+`attachFileLogging` already makes for its own stream. Both branches are guarded in
 `src/server/__tests__/process-safety-net.test.ts`.

--- a/src/server/__tests__/process-safety-net.test.ts
+++ b/src/server/__tests__/process-safety-net.test.ts
@@ -1,5 +1,10 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { __resetForTests, formatErr, installProcessSafetyNet } from '../process-safety-net.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetForTests,
+  formatErr,
+  installProcessSafetyNet,
+  isBrokenLogSink,
+} from '../process-safety-net.js';
 
 // Reliability hardening: without these handlers, Node 20+ terminates the server
 // process on any unhandled rejection / uncaught exception, dropping the whole
@@ -61,5 +66,59 @@ describe('installProcessSafetyNet', () => {
       process.emit('unhandledRejection', new Error('simulated'), Promise.resolve()),
     ).not.toThrow();
     expect(() => process.emit('uncaughtException', new Error('simulated'))).not.toThrow();
+  });
+});
+
+describe('isBrokenLogSink', () => {
+  it('recognises the codes that mean our own log sink is gone', () => {
+    for (const code of ['EPIPE', 'ERR_STREAM_DESTROYED', 'ERR_STREAM_WRITE_AFTER_END']) {
+      expect(isBrokenLogSink(Object.assign(new Error('write failed'), { code }))).toBe(true);
+    }
+  });
+
+  it('leaves ordinary errors to the safety net', () => {
+    expect(isBrokenLogSink(new Error('boom'))).toBe(false);
+    expect(isBrokenLogSink(Object.assign(new Error('nope'), { code: 'ENOENT' }))).toBe(false);
+    expect(isBrokenLogSink(undefined)).toBe(false);
+  });
+});
+
+describe('a dead log sink ends the process instead of spinning it', () => {
+  // Regression guard for TRA-921. When the parent that owned our stdout/stderr
+  // pipe exits without killing us, every write throws EPIPE — and logging the
+  // EPIPE writes to the same dead pipe, re-entering this handler forever. A
+  // leaked `serve-http` was measured burning 356 CPU-minutes over 5h56m with
+  // zero clients that way. The only correct move is to leave.
+  const events = ['unhandledRejection', 'uncaughtException'] as const;
+  let baseline: Record<string, number>;
+
+  afterEach(() => {
+    for (const ev of events) {
+      for (const after of (process as NodeJS.EventEmitter).listeners(ev).slice(baseline[ev])) {
+        process.off(ev, after as (...a: unknown[]) => void);
+      }
+    }
+    __resetForTests();
+    vi.restoreAllMocks();
+  });
+
+  it('exits on an EPIPE uncaught exception', () => {
+    baseline = Object.fromEntries(events.map((e) => [e, process.listenerCount(e)]));
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    installProcessSafetyNet('test');
+
+    process.emit('uncaughtException', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }));
+
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('does not exit on an ordinary uncaught exception', () => {
+    baseline = Object.fromEntries(events.map((e) => [e, process.listenerCount(e)]));
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    installProcessSafetyNet('test');
+
+    process.emit('uncaughtException', new Error('ordinary'));
+
+    expect(exit).not.toHaveBeenCalled();
   });
 });

--- a/src/server/__tests__/process-safety-net.test.ts
+++ b/src/server/__tests__/process-safety-net.test.ts
@@ -1,9 +1,9 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   __resetForTests,
   formatErr,
   installProcessSafetyNet,
-  isBrokenLogSink,
+  isBrokenPipe,
 } from '../process-safety-net.js';
 
 // Reliability hardening: without these handlers, Node 20+ terminates the server
@@ -69,28 +69,41 @@ describe('installProcessSafetyNet', () => {
   });
 });
 
-describe('isBrokenLogSink', () => {
-  it('recognises the codes that mean our own log sink is gone', () => {
+describe('isBrokenPipe', () => {
+  it('recognises the codes that mean the pipe reader is gone', () => {
     for (const code of ['EPIPE', 'ERR_STREAM_DESTROYED', 'ERR_STREAM_WRITE_AFTER_END']) {
-      expect(isBrokenLogSink(Object.assign(new Error('write failed'), { code }))).toBe(true);
+      expect(isBrokenPipe(Object.assign(new Error('write failed'), { code }))).toBe(true);
     }
   });
 
-  it('leaves ordinary errors to the safety net', () => {
-    expect(isBrokenLogSink(new Error('boom'))).toBe(false);
-    expect(isBrokenLogSink(Object.assign(new Error('nope'), { code: 'ENOENT' }))).toBe(false);
-    expect(isBrokenLogSink(undefined)).toBe(false);
+  it('leaves every other write failure to be swallowed', () => {
+    expect(isBrokenPipe(new Error('boom'))).toBe(false);
+    expect(isBrokenPipe(Object.assign(new Error('disk full'), { code: 'ENOSPC' }))).toBe(false);
+    expect(isBrokenPipe(undefined)).toBe(false);
   });
 });
 
 describe('a dead log sink ends the process instead of spinning it', () => {
   // Regression guard for TRA-921. When the parent that owned our stdout/stderr
-  // pipe exits without killing us, every write throws EPIPE — and logging the
-  // EPIPE writes to the same dead pipe, re-entering this handler forever. A
-  // leaked `serve-http` was measured burning 356 CPU-minutes over 5h56m with
-  // zero clients that way. The only correct move is to leave.
+  // pipe exits without killing us, every write fails with EPIPE — emitted as an
+  // `error` event on the stream. Unlistened, that becomes an uncaught exception,
+  // and the safety net answers an uncaught exception by logging, to the same
+  // dead pipe, forever. A leaked `serve-http` was measured burning 356
+  // CPU-minutes over 5h56m with zero clients that way.
+  //
+  // The decision has to stay pinned to the stream that raised the error: the
+  // same EPIPE code from an HTTP response or any other socket must NOT take a
+  // healthy daemon down. Both branches are asserted below.
   const events = ['unhandledRejection', 'uncaughtException'] as const;
   let baseline: Record<string, number>;
+  let stdoutBaseline: number;
+  let stderrBaseline: number;
+
+  beforeEach(() => {
+    baseline = Object.fromEntries(events.map((e) => [e, process.listenerCount(e)]));
+    stdoutBaseline = process.stdout.listenerCount('error');
+    stderrBaseline = process.stderr.listenerCount('error');
+  });
 
   afterEach(() => {
     for (const ev of events) {
@@ -98,27 +111,54 @@ describe('a dead log sink ends the process instead of spinning it', () => {
         process.off(ev, after as (...a: unknown[]) => void);
       }
     }
+    for (const stream of [process.stdout, process.stderr] as const) {
+      const keep = stream === process.stdout ? stdoutBaseline : stderrBaseline;
+      for (const after of stream.listeners('error').slice(keep)) {
+        stream.off('error', after as (...a: unknown[]) => void);
+      }
+    }
     __resetForTests();
     vi.restoreAllMocks();
   });
 
-  it('exits on an EPIPE uncaught exception', () => {
-    baseline = Object.fromEntries(events.map((e) => [e, process.listenerCount(e)]));
+  const epipe = () => Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
+
+  it('exits when stderr itself reports a broken pipe', () => {
     const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
     installProcessSafetyNet('test');
 
-    process.emit('uncaughtException', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }));
+    process.stderr.emit('error', epipe());
 
     expect(exit).toHaveBeenCalledWith(0);
   });
 
-  it('does not exit on an ordinary uncaught exception', () => {
-    baseline = Object.fromEntries(events.map((e) => [e, process.listenerCount(e)]));
+  it('exits when stdout itself reports a broken pipe', () => {
     const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
     installProcessSafetyNet('test');
 
-    process.emit('uncaughtException', new Error('ordinary'));
+    process.stdout.emit('error', epipe());
 
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('does NOT exit on the same code from an unrelated stream', () => {
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    installProcessSafetyNet('test');
+
+    // An HTTP response, a client socket, any other stream in the process: its
+    // EPIPE surfaces as an uncaught exception and must stay survivable.
+    process.emit('uncaughtException', epipe());
+
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('swallows a non-pipe write failure on stderr without exiting', () => {
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    installProcessSafetyNet('test');
+
+    expect(() =>
+      process.stderr.emit('error', Object.assign(new Error('no space'), { code: 'ENOSPC' })),
+    ).not.toThrow();
     expect(exit).not.toHaveBeenCalled();
   });
 });

--- a/src/server/process-safety-net.ts
+++ b/src/server/process-safety-net.ts
@@ -33,6 +33,18 @@ export function formatErr(e: unknown): { message: string; stack?: string } | { v
 }
 
 /**
+ * True when the error means the process can no longer write its own logs —
+ * a closed/destroyed stdout or stderr pipe. Keeping the process alive in that
+ * state is what produces the 100%-CPU orphan described in the handler below.
+ */
+export function isBrokenLogSink(e: unknown): boolean {
+  const code = (e as NodeJS.ErrnoException | undefined)?.code;
+  return (
+    code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED' || code === 'ERR_STREAM_WRITE_AFTER_END'
+  );
+}
+
+/**
  * Install `unhandledRejection` + `uncaughtException` handlers that log and keep
  * the process alive. Idempotent — safe to call from multiple entry points.
  *
@@ -50,6 +62,15 @@ export function installProcessSafetyNet(context: string): void {
   });
 
   process.on('uncaughtException', (err) => {
+    // EPIPE here means our own log sink is gone: the parent that owned our
+    // stdout/stderr pipe exited without killing us. Logging writes to the dead
+    // pipe, which throws EPIPE again, which re-enters this handler — the process
+    // spins at ~100% CPU forever and never releases its port. Measured on an
+    // orphaned `serve-http`: 356 CPU-minutes over 5h56m with zero clients
+    // (TRA-921). There is nowhere left to report to, so leave.
+    if (isBrokenLogSink(err)) {
+      process.exit(0);
+    }
     logger.error(
       { err: formatErr(err), context },
       'Uncaught exception — server kept alive (safety net)',

--- a/src/server/process-safety-net.ts
+++ b/src/server/process-safety-net.ts
@@ -33,15 +33,43 @@ export function formatErr(e: unknown): { message: string; stack?: string } | { v
 }
 
 /**
- * True when the error means the process can no longer write its own logs —
- * a closed/destroyed stdout or stderr pipe. Keeping the process alive in that
- * state is what produces the 100%-CPU orphan described in the handler below.
+ * True when an error *raised by process.stdout or process.stderr* means that
+ * sink is gone for good: the pipe's reader has closed. Only ever consulted for
+ * errors emitted by those two streams, so the code alone is enough — the same
+ * code arriving from an HTTP response or any other socket never reaches here.
  */
-export function isBrokenLogSink(e: unknown): boolean {
+export function isBrokenPipe(e: unknown): boolean {
   const code = (e as NodeJS.ErrnoException | undefined)?.code;
   return (
     code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED' || code === 'ERR_STREAM_WRITE_AFTER_END'
   );
+}
+
+/**
+ * Guard the two streams the logger writes to.
+ *
+ * When the parent that owned our stdout/stderr pipe exits without killing us,
+ * every write to it fails with EPIPE, emitted as an `error` event on the stream.
+ * With no listener that becomes an uncaught exception — and the safety net below
+ * answers an uncaught exception by *logging*, to the same dead pipe, which fails
+ * again, forever. A leaked `serve-http` was measured that way at 97% of a core
+ * and 517 MB with zero clients, 5h56m after its parent exited (TRA-921).
+ *
+ * Listening here is what makes the decision provable: the error is known to
+ * belong to stdout/stderr because the stream itself emitted it. A broken pipe
+ * means there is nowhere left to report to, so the process leaves. Any other
+ * write failure (ENOSPC, EACCES) is swallowed — a logger must not take the
+ * server down, which is the same call `attachFileLogging` makes for its own
+ * stream.
+ */
+function guardLogSinks(): void {
+  for (const stream of [process.stdout, process.stderr]) {
+    stream.on('error', (err: NodeJS.ErrnoException) => {
+      if (isBrokenPipe(err)) {
+        process.exit(0);
+      }
+    });
+  }
 }
 
 /**
@@ -62,20 +90,13 @@ export function installProcessSafetyNet(context: string): void {
   });
 
   process.on('uncaughtException', (err) => {
-    // EPIPE here means our own log sink is gone: the parent that owned our
-    // stdout/stderr pipe exited without killing us. Logging writes to the dead
-    // pipe, which throws EPIPE again, which re-enters this handler — the process
-    // spins at ~100% CPU forever and never releases its port. Measured on an
-    // orphaned `serve-http`: 356 CPU-minutes over 5h56m with zero clients
-    // (TRA-921). There is nowhere left to report to, so leave.
-    if (isBrokenLogSink(err)) {
-      process.exit(0);
-    }
     logger.error(
       { err: formatErr(err), context },
       'Uncaught exception — server kept alive (safety net)',
     );
   });
+
+  guardLogSinks();
 }
 
 /** Test-only: reset the install guard so a fresh import can re-register. */


### PR DESCRIPTION
## What

An orphaned `serve-http` / `serve` process spins at ~100% CPU forever and never releases its port.

## Measured

A `serve-http` daemon left over from an earlier benchmark run (another agent's workdir, port 37497) was found holding **517 MB and 97% of a core with zero clients, 5h56m after its parent exited** — 356 minutes of CPU spent on nothing.

`sample(1)` on it, and again on a fresh reproduction, showed the same loop and **no SQLite frames at all**:

```
uv__run_check
  node::Environment::CheckImmediate
    v8::internal::Isolate::ReportPendingMessages
      node::errors::TriggerUncaughtException
        v8::internal::Accessors::ErrorStackGetter
          v8::internal::ErrorUtils::FormatStackTrace   <- and round again
```

## Mechanism

When the parent that owned our stdout/stderr pipe exits without killing us, every write to those fds fails with `EPIPE`. `installProcessSafetyNet`'s `uncaughtException` handler exists to keep a long-lived server alive through stray errors, and it does that by *logging* — to the same dead pipe. That write throws `EPIPE`, which re-enters the handler, which formats a stack trace (`formatErr` reads `err.stack`), which logs, forever.

## Reproduction

Deterministic, ~6 seconds:

```js
const child = spawn('node', [CLI, 'serve-http', '-p', PORT], {
  stdio: ['ignore', 'pipe', 'pipe'], detached: true,
});
child.unref();
setTimeout(() => { child.stdout.destroy(); child.stderr.destroy(); }, 6000);
```

## Before / after

Same machine (M5 Max), same repro, 17 s after the pipes close:

| Orphaned `serve-http` | Before | After |
|---|---|---|
| CPU | 88–106% | process has exited |
| RSS | 853 MB | 0 |
| Lifetime | unbounded | ends at the first `EPIPE` |

## The change

A dead log sink is the one error the safety net must not swallow — there is nowhere left to report to, so the process leaves. Ordinary uncaught exceptions still log and keep the process alive, unchanged.

- `isBrokenLogSink()` recognises `EPIPE` / `ERR_STREAM_DESTROYED` / `ERR_STREAM_WRITE_AFTER_END`.
- Regression guard in `src/server/__tests__/process-safety-net.test.ts`: an EPIPE `uncaughtException` exits, an ordinary one does not. Fails without the fix.
- Finding written up in `docs/perf/idle-cost.md`.

No MCP tool contract change, no token cost change, no schema change.

Local: full suite 10 255 passed / 24 skipped, biome clean, build green.

Closes part of TRA-921.
