### PR TITLE
docs(registry): drop the tool count from the server.json storefront (TRA-761)

### DIFF
--- a/ops/positioning.md
+++ b/ops/positioning.md
@@ -218,6 +218,27 @@ accurately and with numbers from `counts.yml`. The category claim is carried by
 `trace-mcp.com` and `README.md`, which are the surfaces that can also deliver
 door 2.
 
+**The tool count came out of it anyway (TRA-761, 2026-09-06).** Describing the
+tools is not the same as counting them, and the count was the line's most
+prominent number. Three reasons it went: codegraph (68.7k stars) advertises one
+tool of eight *deliberately*, because presence itself steers mis-picks — so to
+an audience that reads tool count as a context-budget cost, leading with a big
+one advertises the thing our own role presets were built to stop; no install
+ever sees the printed number (`counts.yml` is the registered surface minus
+framework-gated tools — measured 150 / 165 / 172 across three environments, and
+lower again under a preset), which is defensible as documentation and
+misleading as a storefront; and it was stale at 177 against 178 anyway, passing
+only on `readme-claims.test.ts`'s ±5 tolerance. What replaced it is `code graph
+MCP server`, the measured category term from the TRA-950 cluster — a door-1
+phrase on a door-1 channel, the same carve-out this section already makes.
+Languages and frameworks stay: they measure coverage a registry reader is
+actually shopping for, not surface they will pay for. The description reads:
+
+> Code graph MCP server for AI agents: 81 languages, 87 frameworks, 90.6% fewer PR-review tokens
+
+The registry caps `description` at 100 characters (`manifest-sync.test.ts`), so
+anything added here costs something already in the line.
+
 ## Sequencing against the rename
 
 TRA-879 fixed that nothing public may move its name. **Nothing here moves a

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.nikolai-vysotskyi/trace-mcp",
-  "description": "Code intelligence for agents: 81 languages, 87 frameworks, 177 tools, 90.6% fewer PR-review tokens",
+  "description": "Code graph MCP server for AI agents: 81 languages, 87 frameworks, 90.6% fewer PR-review tokens",
   "websiteUrl": "https://trace-mcp.com",
   "repository": {
     "url": "https://github.com/nikolai-vysotskyi/trace-mcp",


### PR DESCRIPTION
Closes TRA-761.

`server.json`'s `description` is the copy mcp.so, Smithery, goose and `modelcontextprotocol/servers` all render. TRA-904 already swapped its savings figure to the measured 90.6%; what was left untouched was its most prominent number — `177 tools`.

**Before**

> Code intelligence for agents: 81 languages, 87 frameworks, 177 tools, 90.6% fewer PR-review tokens

**After** (94 of the registry's 100 characters)

> Code graph MCP server for AI agents: 81 languages, 87 frameworks, 90.6% fewer PR-review tokens

Why the count went:

- codegraph (68.7k★) advertises **one** tool of eight by default, deliberately — presence itself steers mis-picks. Our role presets (TRA-601/602/603) reached the same conclusion. Leading a storefront with 177 sells the thing the product was changed to stop doing, to the audience most likely to read a tool count as a context-budget cost.
- No install sees the printed number. `docs/_data/counts.yml` is explicit that it is the registered surface minus framework-gated tools — 150 / 165 / 172 measured across three environments, lower again under a preset. Defensible as documentation, misleading as a headline.
- It was stale: 177 against `counts.yml`'s 178, passing only on `readme-claims.test.ts`'s ±5 tolerance.

Why `code graph MCP server` replaces it: it is the measured category term from the TRA-950 cluster (`code graph mcp`, 70/mo, LOW competition, already our long-tail rank). `ops/positioning.md` already carves `server.json` out of the position sentence because the registries can only deliver door 1 — this is the same carve-out, using door 1's vocabulary. No name string moves (TRA-879 / rename compatible).

Languages and frameworks stay: they measure coverage a registry reader is shopping for, not surface they will pay for. The 90.6% is unchanged and still read from `docs/_data/pr_context_bench.json`.

`ops/positioning.md` records the decision in the same change, per its own rule.

**Tests:** full suite — 10 248 passed, 1 failure in `tests/ai/onnx.test.ts` (10 s timeout on the first cold ONNX model load in a fresh `node_modules`); passes on its own re-run, unrelated to this diff. Guards specifically covering this file — `manifest-sync`, `readme-claims`, `savings-claims`, `searchable-name`, `category-term` — all green.
