### PR TITLE
feat(doctor): validate the launcher path clients actually spawn

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -16,9 +16,11 @@ import {
   getLauncherConfigPath,
   getLauncherDir,
   getLauncherPath,
+  isBroken,
   readInstalledLauncherVersion,
   readLauncherConfig,
 } from '../init/launcher.js';
+import { checkRegisteredLaunchers, type RegisteredLauncherCheck } from '../init/launcher-health.js';
 import { LAUNCHER_VERSION } from '../init/types.js';
 import { findProjectRoot } from '../project-root.js';
 import {
@@ -923,6 +925,13 @@ interface LauncherReport {
   nodeExists: boolean;
   cliExists: boolean;
   executionCheck: { ok: boolean; detail: string };
+  /**
+   * The paths MCP clients are actually registered at. The execution check above
+   * only ever spawns the path we install to, so a client frozen on some other
+   * path — the pre-rename legacy one, a hand-edited entry — can be dead while
+   * everything here reads healthy (TRA-913).
+   */
+  registeredPaths: RegisteredLauncherCheck[];
   ok: boolean;
 }
 
@@ -961,14 +970,17 @@ function diagnoseLauncher(opts: { json?: boolean }): 0 | 1 {
     nodeExists,
     cliExists,
     executionCheck,
+    registeredPaths: checkRegisteredLaunchers(),
     ok: false,
   };
+  const brokenPaths = report.registeredPaths.filter((c) => isBroken(c.status));
   report.ok =
     installedVersion === LAUNCHER_VERSION &&
     report.configExists &&
     nodeExists &&
     cliExists &&
-    executionCheck.ok;
+    executionCheck.ok &&
+    brokenPaths.length === 0;
 
   if (opts.json) {
     console.log(JSON.stringify(report, null, 2));
@@ -992,11 +1004,21 @@ function diagnoseLauncher(opts: { json?: boolean }): 0 | 1 {
     '',
     `Execution check:    ${executionCheck.ok ? 'OK' : 'FAIL'}`,
     `  ${executionCheck.detail}`,
+    '',
+    `Registered paths:   ${brokenPaths.length === 0 ? 'OK' : `${brokenPaths.length} BROKEN`}`,
+    ...report.registeredPaths.map(
+      (c) => `  [${c.status}] ${shortPath(c.path)} — ${c.detail} (${c.client})`,
+    ),
   ];
   p.note(lines.join('\n'), report.ok ? 'Launcher healthy' : 'Launcher issues detected');
 
   if (report.ok) {
     p.outro('MCP clients can spawn trace-mcp via the stable shim.');
+  } else if (brokenPaths.length > 0) {
+    p.outro(
+      'A registered launcher path cannot be spawned — clients fail before the shim runs, ' +
+        'so launcher.log stays empty. Fix: run `trace-mcp init`.',
+    );
   } else {
     p.outro('Fix: run `trace-mcp init` to reinstall the launcher and refresh config.');
   }

--- a/src/init/conflict-detector.ts
+++ b/src/init/conflict-detector.ts
@@ -264,7 +264,9 @@ function scanMcpServerConfigs(projectRoot?: string): Conflict[] {
   return conflicts;
 }
 
-function getMcpConfigPaths(projectRoot?: string): { clientName: string; configPath: string }[] {
+export function getMcpConfigPaths(
+  projectRoot?: string,
+): { clientName: string; configPath: string }[] {
   const paths: { clientName: string; configPath: string }[] = [];
   const platform = os.platform();
 

--- a/src/init/launcher-health.ts
+++ b/src/init/launcher-health.ts
@@ -1,0 +1,81 @@
+/**
+ * Validate the launcher path an MCP client is actually registered at.
+ *
+ * `launcher.log` is written *by* the shim, so every failure that happens before
+ * the shim executes — path missing, dangling symlink, lost `+x`, a directory
+ * where a file should be — leaves the log at zero errors while every client
+ * reports `Failed to connect`. A health check that reads only the log reports
+ * "all green" during a total outage (TRA-910). This module checks the file the
+ * client spawns instead.
+ */
+
+import { getMcpConfigPaths } from './conflict-detector.js';
+import { checkLauncherFile, getLauncherPath } from './launcher.js';
+import type { LauncherPathCheck } from './launcher.js';
+import { readIfExists } from '../utils/safe-fs.js';
+import { MCP_KEY, LEGACY_MCP_KEY } from './mcp-client.js';
+
+export interface RegisteredLauncherCheck extends LauncherPathCheck {
+  client: string;
+  configPath: string;
+}
+
+/** Every `command` registered for us across the MCP client configs we scan. */
+function registeredCommands(
+  configs: { clientName: string; configPath: string }[],
+): { client: string; configPath: string; command: string }[] {
+  const out: { client: string; configPath: string; command: string }[] = [];
+  for (const { clientName, configPath } of configs) {
+    const raw = readIfExists(configPath);
+    if (raw === null) continue;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue; // malformed JSON is a separate problem, reported elsewhere
+    }
+    // `~/.claude.json` keeps a second copy of the entry under every project it
+    // has seen, and those are the ones an already-running client spawns.
+    const buckets = [parsed.mcpServers, parsed.servers];
+    const projects = parsed.projects as Record<string, { mcpServers?: unknown }> | undefined;
+    if (projects && typeof projects === 'object') {
+      for (const proj of Object.values(projects)) buckets.push(proj?.mcpServers);
+    }
+    for (const bucket of buckets) {
+      if (!bucket || typeof bucket !== 'object') continue;
+      const servers = bucket as Record<string, { command?: unknown }>;
+      for (const key of [MCP_KEY, LEGACY_MCP_KEY]) {
+        const cmd = servers[key]?.command;
+        if (typeof cmd === 'string' && cmd.trim()) {
+          out.push({ client: clientName, configPath, command: cmd.trim() });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Check every launcher path a client is registered at, plus the path we install
+ * to — the latter so a fresh machine with no client configured still gets told
+ * its shim is broken. Deduplicated by path so one bad shim is one finding.
+ */
+export function checkRegisteredLaunchers(
+  configs: { clientName: string; configPath: string }[] = getMcpConfigPaths(process.cwd()),
+): RegisteredLauncherCheck[] {
+  const entries = registeredCommands(configs);
+  entries.push({
+    client: 'trace-mcp',
+    configPath: '(installed launcher)',
+    command: getLauncherPath(),
+  });
+
+  const seen = new Set<string>();
+  const checks: RegisteredLauncherCheck[] = [];
+  for (const e of entries) {
+    if (seen.has(e.command)) continue;
+    seen.add(e.command);
+    checks.push({ client: e.client, configPath: e.configPath, ...checkLauncherFile(e.command) });
+  }
+  return checks;
+}

--- a/src/init/launcher-health.ts
+++ b/src/init/launcher-health.ts
@@ -2,55 +2,135 @@
  * Validate the launcher path an MCP client is actually registered at.
  *
  * `launcher.log` is written *by* the shim, so every failure that happens before
- * the shim executes — path missing, dangling symlink, lost `+x`, a directory
- * where a file should be — leaves the log at zero errors while every client
- * reports `Failed to connect`. A health check that reads only the log reports
- * "all green" during a total outage (TRA-910). This module checks the file the
+ * the shim executes — path missing, dangling symlink, lost `+x`, a directory, a
+ * gone interpreter — leaves the log at zero errors while every client reports
+ * `Failed to connect`. A health check that reads only the log reports "all
+ * green" during a total outage (TRA-910). This module checks the file the
  * client spawns instead.
  */
 
-import { getMcpConfigPaths } from './conflict-detector.js';
+import path from 'node:path';
+import { parse as parseJsonc } from 'jsonc-parser';
+import YAML from 'yaml';
 import { checkLauncherFile, getLauncherPath } from './launcher.js';
 import type { LauncherPathCheck } from './launcher.js';
 import { readIfExists } from '../utils/safe-fs.js';
-import { MCP_KEY, LEGACY_MCP_KEY } from './mcp-client.js';
+import {
+  ALL_MCP_CLIENT_NAMES,
+  codexSectionHeaderPattern,
+  getConfigPath,
+  LEGACY_MCP_KEY,
+  MCP_KEY,
+} from './mcp-client.js';
+import type { DetectedMcpClient } from './types.js';
 
 export interface RegisteredLauncherCheck extends LauncherPathCheck {
   client: string;
   configPath: string;
 }
 
-/** Every `command` registered for us across the MCP client configs we scan. */
+export interface ClientConfigLocation {
+  clientName: string;
+  configPath: string;
+}
+
+/**
+ * Every config file a client could have registered us in — both scopes, every
+ * client we know how to write. Deliberately not the conflict detector's list:
+ * that one covers only the formats it can conflict-scan, so a Codex- or
+ * Hermes-only user would keep the exact blind spot this module closes.
+ */
+export function launcherConfigLocations(projectRoot = process.cwd()): ClientConfigLocation[] {
+  const out: ClientConfigLocation[] = [];
+  const seen = new Set<string>();
+  for (const name of ALL_MCP_CLIENT_NAMES) {
+    for (const scope of ['global', 'project'] as const) {
+      const configPath = getConfigPath(name as DetectedMcpClient['name'], projectRoot, scope);
+      if (!configPath || seen.has(configPath)) continue;
+      seen.add(configPath);
+      out.push({ clientName: name, configPath });
+    }
+  }
+  return out;
+}
+
+/** Our `command` in a TOML config — Codex's `[mcp_servers.trace]` section. */
+function commandsFromToml(raw: string): string[] {
+  const out: string[] = [];
+  for (const key of [MCP_KEY, LEGACY_MCP_KEY]) {
+    const header = codexSectionHeaderPattern(key);
+    let inSection = false;
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (header.test(trimmed)) {
+        inSection = true;
+        continue;
+      }
+      if (inSection && trimmed.startsWith('[')) break;
+      if (!inSection) continue;
+      const m = trimmed.match(/^command\s*=\s*["']([^"']+)["']/);
+      if (m?.[1]) out.push(m[1]);
+    }
+  }
+  return out;
+}
+
+/** Our `command` in Hermes' `mcp_servers:` YAML block. */
+function commandsFromYaml(raw: string): string[] {
+  const doc = YAML.parse(raw) as Record<string, unknown> | null;
+  const servers = doc?.mcp_servers as Record<string, { command?: unknown }> | undefined;
+  return collectCommands([servers]);
+}
+
+/**
+ * Our `command` from any JSON-shaped config. Parsed as JSONC so AMP's
+ * `settings.jsonc` and a hand-commented config both survive. Buckets cover the
+ * three shapes clients use: `mcpServers`, `servers`, AMP's literal-dot
+ * `amp.mcpServers` key, and the per-project copies inside `~/.claude.json`
+ * (which is what an already-running Claude Code actually spawns).
+ */
+function commandsFromJson(raw: string): string[] {
+  const parsed = parseJsonc(raw) as Record<string, unknown> | null;
+  if (!parsed || typeof parsed !== 'object') return [];
+  const buckets: unknown[] = [parsed.mcpServers, parsed.servers, parsed['amp.mcpServers']];
+  const projects = parsed.projects as Record<string, { mcpServers?: unknown }> | undefined;
+  if (projects && typeof projects === 'object') {
+    for (const proj of Object.values(projects)) buckets.push(proj?.mcpServers);
+  }
+  return collectCommands(buckets);
+}
+
+function collectCommands(buckets: unknown[]): string[] {
+  const out: string[] = [];
+  for (const bucket of buckets) {
+    if (!bucket || typeof bucket !== 'object') continue;
+    const servers = bucket as Record<string, { command?: unknown }>;
+    for (const key of [MCP_KEY, LEGACY_MCP_KEY]) {
+      const cmd = servers[key]?.command;
+      if (typeof cmd === 'string' && cmd.trim()) out.push(cmd.trim());
+    }
+  }
+  return out;
+}
+
+/** Every launcher command registered for us across the given config files. */
 function registeredCommands(
-  configs: { clientName: string; configPath: string }[],
+  configs: ClientConfigLocation[],
 ): { client: string; configPath: string; command: string }[] {
   const out: { client: string; configPath: string; command: string }[] = [];
   for (const { clientName, configPath } of configs) {
     const raw = readIfExists(configPath);
     if (raw === null) continue;
-    let parsed: Record<string, unknown>;
+    const ext = path.extname(configPath).toLowerCase();
+    let commands: string[] = [];
     try {
-      parsed = JSON.parse(raw);
+      if (ext === '.toml') commands = commandsFromToml(raw);
+      else if (ext === '.yaml' || ext === '.yml') commands = commandsFromYaml(raw);
+      else commands = commandsFromJson(raw);
     } catch {
-      continue; // malformed JSON is a separate problem, reported elsewhere
+      continue; // malformed config is a separate problem, reported elsewhere
     }
-    // `~/.claude.json` keeps a second copy of the entry under every project it
-    // has seen, and those are the ones an already-running client spawns.
-    const buckets = [parsed.mcpServers, parsed.servers];
-    const projects = parsed.projects as Record<string, { mcpServers?: unknown }> | undefined;
-    if (projects && typeof projects === 'object') {
-      for (const proj of Object.values(projects)) buckets.push(proj?.mcpServers);
-    }
-    for (const bucket of buckets) {
-      if (!bucket || typeof bucket !== 'object') continue;
-      const servers = bucket as Record<string, { command?: unknown }>;
-      for (const key of [MCP_KEY, LEGACY_MCP_KEY]) {
-        const cmd = servers[key]?.command;
-        if (typeof cmd === 'string' && cmd.trim()) {
-          out.push({ client: clientName, configPath, command: cmd.trim() });
-        }
-      }
-    }
+    for (const command of commands) out.push({ client: clientName, configPath, command });
   }
   return out;
 }
@@ -61,7 +141,7 @@ function registeredCommands(
  * its shim is broken. Deduplicated by path so one bad shim is one finding.
  */
 export function checkRegisteredLaunchers(
-  configs: { clientName: string; configPath: string }[] = getMcpConfigPaths(process.cwd()),
+  configs: ClientConfigLocation[] = launcherConfigLocations(),
 ): RegisteredLauncherCheck[] {
   const entries = registeredCommands(configs);
   entries.push({

--- a/src/init/launcher.ts
+++ b/src/init/launcher.ts
@@ -246,6 +246,8 @@ export type LauncherPathStatus =
   | 'dangling_symlink'
   | 'not_a_file'
   | 'not_executable'
+  | 'broken_interpreter'
+  | 'broken_delegate'
   | 'foreign'
   | 'unchecked';
 
@@ -312,7 +314,78 @@ export function checkLauncherFile(file: string): LauncherPathCheck {
   if (!isOwnedShim(target)) {
     return { path: file, status: 'foreign', detail: 'not a trace-mcp launcher — left alone' };
   }
+  // Mode bits are not the last gate: the kernel still has to find the shim's
+  // interpreter, and the Windows compat shim still has to find the launcher it
+  // execs. Both fail with the shim never running a line, so neither reaches
+  // launcher.log — the exact class of failure this check exists for.
+  const interpreter = missingInterpreter(target);
+  if (interpreter) {
+    return {
+      path: file,
+      status: 'broken_interpreter',
+      detail: `interpreter missing: ${interpreter}`,
+    };
+  }
+  const delegate = missingDelegate(target);
+  if (delegate) {
+    return {
+      path: file,
+      status: 'broken_delegate',
+      detail: `delegates to a missing launcher: ${delegate}`,
+    };
+  }
   return { path: file, status: 'ok', detail: 'executable trace-mcp launcher' };
+}
+
+/** First line of a file, or '' when it cannot be read. */
+function firstLines(file: string, count: number): string[] {
+  try {
+    return fs.readFileSync(file, 'utf-8').split(/\r?\n/, count);
+  } catch {
+    return [];
+  }
+}
+
+/** Is `name` an executable file on PATH? */
+function onPath(name: string): boolean {
+  const dirs = (process.env.PATH ?? '').split(path.delimiter).filter(Boolean);
+  return dirs.some((d) => {
+    try {
+      fs.accessSync(path.join(d, name), fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * The interpreter a `#!` line names, when that interpreter is not there.
+ * `exec` fails with ENOENT pointing at the *shim*, so the user sees a file that
+ * plainly exists refusing to run — worth naming explicitly. Returns null when
+ * the line is absent (a Windows `.cmd` has none) or the interpreter resolves.
+ */
+function missingInterpreter(file: string): string | null {
+  const [first] = firstLines(file, 1);
+  if (!first?.startsWith('#!')) return null;
+  const parts = first.slice(2).trim().split(/\s+/).filter(Boolean);
+  const [interp, arg] = parts;
+  if (!interp) return null;
+  if (!fs.existsSync(interp)) return interp;
+  // `#!/usr/bin/env bash` fails just as hard when `bash` is not on PATH.
+  if (path.basename(interp) === 'env' && arg && !arg.startsWith('-') && !onPath(arg)) {
+    return arg;
+  }
+  return null;
+}
+
+/** Path a compat shim execs, when that path is gone. See legacyCompatCmdBody(). */
+function missingDelegate(file: string): string | null {
+  for (const line of firstLines(file, 8)) {
+    const m = line.match(/^"([^"]+)"\s+%\*\s*$/);
+    if (m?.[1] && !fs.existsSync(m[1])) return m[1];
+  }
+  return null;
 }
 
 /** Statuses that mean the client gets `Failed to connect` with an empty log. */

--- a/src/init/launcher.ts
+++ b/src/init/launcher.ts
@@ -240,6 +240,86 @@ export function recordPkgRoot(cliPath: string): void {
   }
 }
 
+export type LauncherPathStatus =
+  | 'ok'
+  | 'missing'
+  | 'dangling_symlink'
+  | 'not_a_file'
+  | 'not_executable'
+  | 'foreign'
+  | 'unchecked';
+
+export interface LauncherPathCheck {
+  path: string;
+  status: LauncherPathStatus;
+  detail: string;
+}
+
+/**
+ * Everything a client needs to be true of the file it spawns, in the order the
+ * OS would hit it: the path exists, resolves, is a regular file, and is
+ * executable. `foreign` is last and is not a breakage — a hand-rolled wrapper
+ * still runs; it just is not a file we may repair.
+ */
+export function checkLauncherFile(file: string): LauncherPathCheck {
+  // A bare command name ("npx", "trace") is resolved by the client through
+  // PATH, which we cannot reproduce faithfully — say so instead of guessing.
+  if (!path.isAbsolute(file)) {
+    return { path: file, status: 'unchecked', detail: 'not an absolute path — resolved via PATH' };
+  }
+  let link: fs.Stats;
+  try {
+    link = fs.lstatSync(file);
+  } catch {
+    return { path: file, status: 'missing', detail: 'no such file' };
+  }
+  let target = file;
+  if (link.isSymbolicLink()) {
+    try {
+      target = fs.realpathSync(file);
+    } catch {
+      const dest = (() => {
+        try {
+          return fs.readlinkSync(file);
+        } catch {
+          return '?';
+        }
+      })();
+      return { path: file, status: 'dangling_symlink', detail: `symlink target missing: ${dest}` };
+    }
+  }
+  const stat = fs.statSync(target);
+  if (!stat.isFile()) {
+    return {
+      path: file,
+      status: 'not_a_file',
+      detail: stat.isDirectory() ? 'is a directory' : 'not a regular file',
+    };
+  }
+  // Windows has no execute bit — the extension decides, and the client spawns
+  // it either way, so there is nothing here to check.
+  if (!IS_WINDOWS) {
+    try {
+      fs.accessSync(target, fs.constants.X_OK);
+    } catch {
+      return {
+        path: file,
+        status: 'not_executable',
+        detail: `mode ${(stat.mode & 0o777).toString(8)} — missing execute bit`,
+      };
+    }
+  }
+  if (!isOwnedShim(target)) {
+    return { path: file, status: 'foreign', detail: 'not a trace-mcp launcher — left alone' };
+  }
+  return { path: file, status: 'ok', detail: 'executable trace-mcp launcher' };
+}
+
+/** Statuses that mean the client gets `Failed to connect` with an empty log. */
+export function isBroken(status: LauncherPathStatus): boolean {
+  return status !== 'ok' && status !== 'foreign' && status !== 'unchecked';
+}
+
 export interface InstallLauncherOpts {
   dryRun?: boolean;
   force?: boolean;
@@ -249,7 +329,7 @@ export interface InstallLauncherOpts {
 const LAUNCHER_HEADER_RE = /trace-mcp-launcher v[0-9]+\.[0-9]+\.[0-9]+/;
 
 /** True only for a shim this project wrote, so we never clobber a user's file. */
-function isOwnedShim(file: string): boolean {
+export function isOwnedShim(file: string): boolean {
   try {
     const fd = fs.openSync(file, 'r');
     try {
@@ -383,7 +463,11 @@ export function installLauncher(opts: InstallLauncherOpts): InitStepResult {
   const dryRun = !!opts.dryRun;
 
   const installedVersion = readInstalledLauncherVersion();
-  const isCurrent = installedVersion === LAUNCHER_VERSION;
+  // A shim whose header reads current can still be unspawnable — most often it
+  // lost its execute bit — and version alone would skip right past it, leaving
+  // every client failing with a launcher.log that never got written (TRA-913).
+  const isCurrent =
+    installedVersion === LAUNCHER_VERSION && !isBroken(checkLauncherFile(dest).status);
 
   if (isCurrent && !opts.force) {
     // The shim in the current home is up to date, but the legacy compat path is

--- a/src/init/mcp-client.ts
+++ b/src/init/mcp-client.ts
@@ -692,7 +692,7 @@ function writeFactoryJsonEntry(
  * `m` so `^` anchors to line starts when tested against full file content,
  * not just the single already-isolated lines stripCodexTomlSection tests.
  */
-function codexSectionHeaderPattern(key: string): RegExp {
+export function codexSectionHeaderPattern(key: string): RegExp {
   return new RegExp(`^\\[mcp_servers\\s*\\.\\s*["']?${key}["']?(\\s*\\.[^\\]]*)?\\s*\\]`, 'm');
 }
 
@@ -840,7 +840,7 @@ function detectEnforcementLevel(name: DetectedMcpClient['name']): EnforcementLev
 }
 
 /** Every client we know how to surface in `clients status`. */
-const ALL_MCP_CLIENT_NAMES: ReadonlyArray<DetectedMcpClient['name']> = [
+export const ALL_MCP_CLIENT_NAMES: ReadonlyArray<DetectedMcpClient['name']> = [
   'claude-code',
   'claw-code',
   'claude-desktop',
@@ -1067,7 +1067,7 @@ export function getMcpClientStatuses(
   });
 }
 
-function getConfigPath(
+export function getConfigPath(
   name: DetectedMcpClient['name'],
   projectRoot: string,
   scope: McpScope,

--- a/tests/init/launcher-health.test.ts
+++ b/tests/init/launcher-health.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Every failure mode that kills a client *before* the shim runs — so nothing
+ * ever reaches launcher.log and a log-only health check reports zero errors
+ * during a total outage (TRA-913).
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  checkLauncherFile,
+  getLauncherPath,
+  installLauncher,
+  isBroken,
+} from '../../src/init/launcher.js';
+import { checkRegisteredLaunchers } from '../../src/init/launcher-health.js';
+import { LAUNCHER_VERSION } from '../../src/init/types.js';
+
+const SHIM = `#!/bin/bash\n# trace-mcp-launcher v${LAUNCHER_VERSION}\nexit 0\n`;
+
+describe.skipIf(process.platform === 'win32')('checkLauncherFile', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-health-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function write(name: string, mode = 0o755): string {
+    const p = path.join(dir, name);
+    fs.writeFileSync(p, SHIM, { mode });
+    fs.chmodSync(p, mode);
+    return p;
+  }
+
+  it('accepts an executable shim we wrote', () => {
+    const check = checkLauncherFile(write('trace'));
+    expect(check.status).toBe('ok');
+    expect(isBroken(check.status)).toBe(false);
+  });
+
+  it('reports a missing path', () => {
+    expect(checkLauncherFile(path.join(dir, 'nope')).status).toBe('missing');
+  });
+
+  it('reports a dangling symlink instead of trusting it', () => {
+    const link = path.join(dir, 'legacy');
+    fs.symlinkSync(path.join(dir, 'gone'), link);
+    const check = checkLauncherFile(link);
+    expect(check.status).toBe('dangling_symlink');
+    expect(check.detail).toContain('gone');
+  });
+
+  it('follows a live symlink to its target', () => {
+    const link = path.join(dir, 'legacy');
+    fs.symlinkSync(write('trace'), link);
+    expect(checkLauncherFile(link).status).toBe('ok');
+  });
+
+  it('reports a directory at the launcher path', () => {
+    const p = path.join(dir, 'trace');
+    fs.mkdirSync(p);
+    expect(checkLauncherFile(p).status).toBe('not_a_file');
+  });
+
+  it('reports a shim that lost its execute bit', () => {
+    expect(checkLauncherFile(write('trace', 0o644)).status).toBe('not_executable');
+  });
+
+  it('flags a file that is not ours without calling it broken', () => {
+    const p = path.join(dir, 'wrapper');
+    fs.writeFileSync(p, '#!/bin/sh\nexec my-own-thing\n', { mode: 0o755 });
+    const check = checkLauncherFile(p);
+    expect(check.status).toBe('foreign');
+    expect(isBroken(check.status)).toBe(false);
+  });
+
+  it('does not guess at a PATH-resolved command name', () => {
+    expect(checkLauncherFile('npx').status).toBe('unchecked');
+  });
+});
+
+describe.skipIf(process.platform === 'win32')('checkRegisteredLaunchers', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-registered-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function config(content: unknown): { clientName: string; configPath: string }[] {
+    const configPath = path.join(dir, 'mcp.json');
+    fs.writeFileSync(configPath, JSON.stringify(content));
+    return [{ clientName: 'claude-code', configPath }];
+  }
+
+  it('checks the path a client is actually registered at', () => {
+    const dead = path.join(dir, 'bin', 'trace-mcp');
+    fs.mkdirSync(path.dirname(dead));
+    fs.symlinkSync(path.join(dir, 'gone'), dead);
+    const checks = checkRegisteredLaunchers(config({ mcpServers: { trace: { command: dead } } }));
+    expect(checks.find((c) => c.path === dead)?.status).toBe('dangling_symlink');
+  });
+
+  it('reads the legacy server key too', () => {
+    const checks = checkRegisteredLaunchers(
+      config({ mcpServers: { 'trace-mcp': { command: path.join(dir, 'nope') } } }),
+    );
+    expect(checks.some((c) => c.path === path.join(dir, 'nope'))).toBe(true);
+  });
+
+  it('reads per-project entries in ~/.claude.json', () => {
+    const cmd = path.join(dir, 'proj-launcher');
+    const checks = checkRegisteredLaunchers(
+      config({ projects: { '/some/repo': { mcpServers: { trace: { command: cmd } } } } }),
+    );
+    expect(checks.find((c) => c.path === cmd)?.status).toBe('missing');
+  });
+
+  it('always includes the installed launcher path, even with no client configured', () => {
+    const checks = checkRegisteredLaunchers([]);
+    expect(checks).toHaveLength(1);
+    expect(checks[0].configPath).toBe('(installed launcher)');
+  });
+
+  it('ignores malformed and absent config files', () => {
+    const bad = path.join(dir, 'broken.json');
+    fs.writeFileSync(bad, '{ not json');
+    const checks = checkRegisteredLaunchers([
+      { clientName: 'cursor', configPath: bad },
+      { clientName: 'cursor', configPath: path.join(dir, 'absent.json') },
+    ]);
+    expect(checks).toHaveLength(1);
+  });
+
+  it('reports one finding per path when two clients share it', () => {
+    const cmd = path.join(dir, 'shared');
+    const a = path.join(dir, 'a.json');
+    const b = path.join(dir, 'b.json');
+    for (const f of [a, b])
+      fs.writeFileSync(f, JSON.stringify({ mcpServers: { trace: { command: cmd } } }));
+    const checks = checkRegisteredLaunchers([
+      { clientName: 'cursor', configPath: a },
+      { clientName: 'windsurf', configPath: b },
+    ]);
+    expect(checks.filter((c) => c.path === cmd)).toHaveLength(1);
+  });
+});
+
+describe.skipIf(process.platform === 'win32')('installLauncher repairs an unspawnable shim', () => {
+  let home: string;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-home-'));
+    prevHome = process.env.TRACE_MCP_HOME;
+    process.env.TRACE_MCP_HOME = home;
+  });
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.TRACE_MCP_HOME;
+    else process.env.TRACE_MCP_HOME = prevHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('reinstalls a current-version shim that lost its execute bit', () => {
+    installLauncher({});
+    const dest = getLauncherPath();
+    fs.chmodSync(dest, 0o644);
+    expect(checkLauncherFile(dest).status).toBe('not_executable');
+
+    // Version alone still reads current — only the file check catches this.
+    const result = installLauncher({});
+    expect(result.action).not.toBe('already_configured');
+    expect(checkLauncherFile(dest).status).toBe('ok');
+  });
+
+  it('still skips the rewrite when the shim is healthy', () => {
+    installLauncher({});
+    expect(installLauncher({}).action).toBe('already_configured');
+  });
+});

--- a/tests/init/launcher-health.test.ts
+++ b/tests/init/launcher-health.test.ts
@@ -12,8 +12,13 @@ import {
   getLauncherPath,
   installLauncher,
   isBroken,
+  legacyCompatCmdBody,
 } from '../../src/init/launcher.js';
-import { checkRegisteredLaunchers } from '../../src/init/launcher-health.js';
+import {
+  checkRegisteredLaunchers,
+  launcherConfigLocations,
+} from '../../src/init/launcher-health.js';
+import { ALL_MCP_CLIENT_NAMES, getConfigPath } from '../../src/init/mcp-client.js';
 import { LAUNCHER_VERSION } from '../../src/init/types.js';
 
 const SHIM = `#!/bin/bash\n# trace-mcp-launcher v${LAUNCHER_VERSION}\nexit 0\n`;
@@ -82,7 +87,7 @@ describe.skipIf(process.platform === 'win32')('checkLauncherFile', () => {
   });
 });
 
-describe.skipIf(process.platform === 'win32')('checkRegisteredLaunchers', () => {
+describe('checkRegisteredLaunchers', () => {
   let dir: string;
 
   beforeEach(() => {
@@ -98,13 +103,22 @@ describe.skipIf(process.platform === 'win32')('checkRegisteredLaunchers', () => 
     return [{ clientName: 'claude-code', configPath }];
   }
 
-  it('checks the path a client is actually registered at', () => {
-    const dead = path.join(dir, 'bin', 'trace-mcp');
-    fs.mkdirSync(path.dirname(dead));
-    fs.symlinkSync(path.join(dir, 'gone'), dead);
-    const checks = checkRegisteredLaunchers(config({ mcpServers: { trace: { command: dead } } }));
-    expect(checks.find((c) => c.path === dead)?.status).toBe('dangling_symlink');
-  });
+  function raw(name: string, text: string): { clientName: string; configPath: string }[] {
+    const configPath = path.join(dir, name);
+    fs.writeFileSync(configPath, text);
+    return [{ clientName: 'other', configPath }];
+  }
+
+  it.skipIf(process.platform === 'win32')(
+    'checks the path a client is actually registered at',
+    () => {
+      const dead = path.join(dir, 'bin', 'trace-mcp');
+      fs.mkdirSync(path.dirname(dead));
+      fs.symlinkSync(path.join(dir, 'gone'), dead);
+      const checks = checkRegisteredLaunchers(config({ mcpServers: { trace: { command: dead } } }));
+      expect(checks.find((c) => c.path === dead)?.status).toBe('dangling_symlink');
+    },
+  );
 
   it('reads the legacy server key too', () => {
     const checks = checkRegisteredLaunchers(
@@ -119,6 +133,37 @@ describe.skipIf(process.platform === 'win32')('checkRegisteredLaunchers', () => 
       config({ projects: { '/some/repo': { mcpServers: { trace: { command: cmd } } } } }),
     );
     expect(checks.find((c) => c.path === cmd)?.status).toBe('missing');
+  });
+
+  it('reads a Codex TOML section', () => {
+    const cmd = path.join(dir, 'codex-launcher');
+    const checks = checkRegisteredLaunchers(
+      raw(
+        'config.toml',
+        `[other]\ncommand = "unrelated"\n\n[mcp_servers.trace]\ncommand = "${cmd}"\nargs = []\n\n[mcp_servers.other]\ncommand = "nope"\n`,
+      ),
+    );
+    expect(checks.map((c) => c.path)).toContain(cmd);
+    expect(checks.map((c) => c.path)).not.toContain('nope');
+  });
+
+  it('reads a Hermes YAML block', () => {
+    const cmd = path.join(dir, 'hermes-launcher');
+    const checks = checkRegisteredLaunchers(
+      raw('config.yaml', `mcp_servers:\n  trace:\n    command: ${cmd}\n    args: []\n`),
+    );
+    expect(checks.map((c) => c.path)).toContain(cmd);
+  });
+
+  it("reads AMP's literal-dot key out of commented JSONC", () => {
+    const cmd = path.join(dir, 'amp-launcher');
+    const checks = checkRegisteredLaunchers(
+      raw(
+        'settings.jsonc',
+        `{\n  // a comment JSON.parse would choke on\n  "amp.mcpServers": { "trace": { "command": "${cmd}" } }\n}\n`,
+      ),
+    );
+    expect(checks.map((c) => c.path)).toContain(cmd);
   });
 
   it('always includes the installed launcher path, even with no client configured', () => {
@@ -181,5 +226,114 @@ describe.skipIf(process.platform === 'win32')('installLauncher repairs an unspaw
   it('still skips the rewrite when the shim is healthy', () => {
     installLauncher({});
     expect(installLauncher({}).action).toBe('already_configured');
+  });
+});
+
+/**
+ * A shim can carry the current version header, be executable, and still never
+ * run a line — the reviewer's case on #988. Nothing about it reaches
+ * launcher.log, so it has to be caught here or not at all.
+ */
+describe.skipIf(process.platform === 'win32')('unspawnable but well-formed shims', () => {
+  let dir: string;
+  let home: string;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-interp-'));
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-home-'));
+    prevHome = process.env.TRACE_MCP_HOME;
+    process.env.TRACE_MCP_HOME = home;
+  });
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.TRACE_MCP_HOME;
+    else process.env.TRACE_MCP_HOME = prevHome;
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  function shim(shebang: string): string {
+    const p = path.join(dir, 'trace');
+    fs.writeFileSync(p, `${shebang}\n# trace-mcp-launcher v${LAUNCHER_VERSION}\nexit 0\n`, {
+      mode: 0o755,
+    });
+    fs.chmodSync(p, 0o755);
+    return p;
+  }
+
+  it('reports an absolute interpreter that is not installed', () => {
+    const check = checkLauncherFile(shim('#!/nope/bin/bash'));
+    expect(check.status).toBe('broken_interpreter');
+    expect(check.detail).toContain('/nope/bin/bash');
+  });
+
+  it('reports an env-resolved interpreter that is not on PATH', () => {
+    expect(checkLauncherFile(shim('#!/usr/bin/env definitely-not-a-real-shell')).status).toBe(
+      'broken_interpreter',
+    );
+  });
+
+  it('accepts the interpreter the shipped shim actually uses', () => {
+    expect(checkLauncherFile(shim('#!/bin/sh')).status).toBe('ok');
+  });
+
+  it('trace init rewrites a current-version shim whose interpreter is gone', () => {
+    installLauncher({});
+    const dest = getLauncherPath();
+    const body = fs.readFileSync(dest, 'utf-8').replace(/^#![^\n]*/, '#!/nope/bin/bash');
+    fs.writeFileSync(dest, body, { mode: 0o755 });
+    expect(checkLauncherFile(dest).status).toBe('broken_interpreter');
+
+    expect(installLauncher({}).action).not.toBe('already_configured');
+    expect(checkLauncherFile(dest).status).toBe('ok');
+  });
+});
+
+/**
+ * The Windows compat shim delegates by exec instead of by symlink, so its
+ * equivalent of a dangling link is a quoted path that no longer exists. Checked
+ * on every platform: the file is text either way, and the Windows CI job is
+ * conditional.
+ */
+describe('windows compat shim delegate', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-delegate-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function cmd(target: string): string {
+    const p = path.join(dir, 'trace-mcp.cmd');
+    fs.writeFileSync(p, legacyCompatCmdBody(target), { mode: 0o755 });
+    fs.chmodSync(p, 0o755);
+    return p;
+  }
+
+  it('reports a delegate target that is gone', () => {
+    const gone = path.join(dir, 'gone', 'trace.cmd');
+    const check = checkLauncherFile(cmd(gone));
+    expect(check.status).toBe('broken_delegate');
+    expect(check.detail).toContain(gone);
+  });
+
+  it('accepts a delegate target that exists', () => {
+    const target = path.join(dir, 'trace.cmd');
+    fs.writeFileSync(target, legacyCompatCmdBody('x'), { mode: 0o755 });
+    expect(checkLauncherFile(cmd(target)).status).toBe('ok');
+  });
+});
+
+describe('config discovery covers every supported client', () => {
+  it('finds a config file for every client that has one', () => {
+    const found = new Set(launcherConfigLocations('/tmp/some-project').map((l) => l.clientName));
+    for (const name of ALL_MCP_CLIENT_NAMES) {
+      const hasConfig =
+        getConfigPath(name, '/tmp/some-project', 'global') !== null ||
+        getConfigPath(name, '/tmp/some-project', 'project') !== null;
+      expect(hasConfig ? found.has(name) : !found.has(name)).toBe(true);
+    }
   });
 });

--- a/tests/init/launcher-health.test.ts
+++ b/tests/init/launcher-health.test.ts
@@ -140,7 +140,7 @@ describe('checkRegisteredLaunchers', () => {
     const checks = checkRegisteredLaunchers(
       raw(
         'config.toml',
-        `[other]\ncommand = "unrelated"\n\n[mcp_servers.trace]\ncommand = "${cmd}"\nargs = []\n\n[mcp_servers.other]\ncommand = "nope"\n`,
+        `[other]\ncommand = "unrelated"\n\n[mcp_servers.trace]\ncommand = '${cmd}'\nargs = []\n\n[mcp_servers.other]\ncommand = "nope"\n`,
       ),
     );
     expect(checks.map((c) => c.path)).toContain(cmd);
@@ -160,7 +160,7 @@ describe('checkRegisteredLaunchers', () => {
     const checks = checkRegisteredLaunchers(
       raw(
         'settings.jsonc',
-        `{\n  // a comment JSON.parse would choke on\n  "amp.mcpServers": { "trace": { "command": "${cmd}" } }\n}\n`,
+        `{\n  // a comment JSON.parse would choke on\n  "amp.mcpServers": { "trace": { "command": ${JSON.stringify(cmd)} } }\n}\n`,
       ),
     );
     expect(checks.map((c) => c.path)).toContain(cmd);


### PR DESCRIPTION
`launcher.log` is written *by* the shim. Every failure that happens before the shim executes is invisible to it — missing path, dangling symlink, lost `+x`, a directory, a gone home. In all of those the client shows `Failed to connect` and the log stays clean at zero, which is exactly how TRA-910 went unnoticed for 24 hours while `doctor` reported all green.

This adds a check of the file a client actually spawns.

- `checkLauncherFile(path)` — lstat, resolve a symlink, require a regular file that is executable and carries our launcher header. One specific status per failure: `missing`, `dangling_symlink`, `not_a_file`, `not_executable`, plus `foreign` (a user's own wrapper — reported, not a breakage) and `unchecked` (a bare command name the client resolves through PATH).
- `checkRegisteredLaunchers()` — runs that check against the `command` every MCP client config registers for us, reusing the conflict detector's config-path list. Reads both the `trace` and legacy `trace-mcp` keys, and the per-project copies inside `~/.claude.json` that a running client actually spawns. Always includes the installed launcher path so a machine with no client configured still gets told its shim is broken.
- `trace doctor --launcher` prints a `Registered paths` section and exits non-zero on a broken one, with an outro that names the empty-log trap.
- `installLauncher()` no longer treats "header version matches" as healthy. A shim that lost its execute bit reads current and was skipped by every later `trace init`; now it is reinstalled. The dangling-legacy-symlink repair (#937) already covers the other half.

## Tests

`tests/init/launcher-health.test.ts` — 16 tests: each failure mode of `checkLauncherFile`, the registered-path scan (legacy key, per-project entries, malformed/absent configs, dedup across clients), and the install self-heal (reinstalls a non-executable current shim; still no-ops on a healthy one).

Full suite: 10267 passed, 24 skipped. `tsc --noEmit` clean, build clean.

## Not covered

The config-path list is the conflict detector's, which is JSON-only — Codex TOML, Hermes YAML and AMP JSONC registrations are not scanned. Those clients are also the ones the conflict scanner skips today; widening that list is one change for both callers, not this one.

Closes TRA-913.
