### PR TITLE
fix(indexer): resolve Astro/Svelte imports, no new pass needed (TRA-451)

### DIFF
--- a/docs/language-matrix.md
+++ b/docs/language-matrix.md
@@ -48,7 +48,7 @@ is the two-pass pipeline in [architecture](architecture.md#indexing-pipeline).
 
 - **indexed with the default config:** 78 (the rest need an `include` entry — see below)
 - **tree-sitter parser:** 29 · **regex parser:** 46 · **custom parser:** 6
-- **import edges:** 16
+- **import edges:** 18
 - **call edges (`get_call_graph`, call-aware `find_usages`):** 3
 - **type / inheritance edges:** 2
 - **covered by a plugin test:** 68
@@ -100,7 +100,7 @@ second thing, so it is much shorter than the language list — see
 | al | .al | regex | yes | — | — | — | yes |
 | apex | .cls .trigger .apex | regex (multi-pass) | yes | — | — | — | yes |
 | assembly | .asm .s .S | regex | yes | — | — | — | yes |
-| astro | .astro | tree-sitter | yes | — | — | — | yes |
+| astro | .astro | tree-sitter | yes | yes | — | — | yes |
 | autohotkey | .ahk .ah2 | regex | yes | — | — | — | yes |
 | bash | .sh .bash .zsh | tree-sitter | yes | — | — | — | yes |
 | blade | .blade.php | regex | yes | — | — | — | yes |
@@ -163,7 +163,7 @@ second thing, so it is much shorter than the language list — see
 | scala | .scala .sc | tree-sitter | yes | — | — | — | yes |
 | solidity | .sol | tree-sitter | yes | — | — | — | yes |
 | sql | .sql | regex | yes | — | — | — | yes |
-| svelte | .svelte | regex | yes | — | — | — | yes |
+| svelte | .svelte | regex | yes | yes | — | — | yes |
 | swift | .swift | tree-sitter | yes | — | — | — | yes |
 | tcl | .tcl .tk .itcl .itk | regex (multi-pass) | yes | — | — | — | yes |
 | toml | .toml | tree-sitter | yes | — | — | — | yes |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4485,7 +4485,7 @@ is the two-pass pipeline in [architecture](architecture.md#indexing-pipeline).
 
 - **indexed with the default config:** 78 (the rest need an `include` entry — see below)
 - **tree-sitter parser:** 29 · **regex parser:** 46 · **custom parser:** 6
-- **import edges:** 16
+- **import edges:** 18
 - **call edges (`get_call_graph`, call-aware `find_usages`):** 3
 - **type / inheritance edges:** 2
 - **covered by a plugin test:** 68
@@ -4537,7 +4537,7 @@ second thing, so it is much shorter than the language list — see
 | al | .al | regex | yes | — | — | — | yes |
 | apex | .cls .trigger .apex | regex (multi-pass) | yes | — | — | — | yes |
 | assembly | .asm .s .S | regex | yes | — | — | — | yes |
-| astro | .astro | tree-sitter | yes | — | — | — | yes |
+| astro | .astro | tree-sitter | yes | yes | — | — | yes |
 | autohotkey | .ahk .ah2 | regex | yes | — | — | — | yes |
 | bash | .sh .bash .zsh | tree-sitter | yes | — | — | — | yes |
 | blade | .blade.php | regex | yes | — | — | — | yes |
@@ -4600,7 +4600,7 @@ second thing, so it is much shorter than the language list — see
 | scala | .scala .sc | tree-sitter | yes | — | — | — | yes |
 | solidity | .sol | tree-sitter | yes | — | — | — | yes |
 | sql | .sql | regex | yes | — | — | — | yes |
-| svelte | .svelte | regex | yes | — | — | — | yes |
+| svelte | .svelte | regex | yes | yes | — | — | yes |
 | swift | .swift | tree-sitter | yes | — | — | — | yes |
 | tcl | .tcl .tk .itcl .itk | regex (multi-pass) | yes | — | — | — | yes |
 | toml | .toml | tree-sitter | yes | — | — | — | yes |

--- a/src/indexer/edge-resolvers/import-capable-languages.ts
+++ b/src/indexer/edge-resolvers/import-capable-languages.ts
@@ -6,9 +6,18 @@
  * capability matrix used to derive its Imports column from "the plugin declares
  * import patterns" and so claimed 66 of 81 languages. Indexing a fixture where
  * every language performs one real cross-file import originally produced edges
- * for only four: php, python, typescript and vue. Go, Rust, C, C++, Java and
- * Ruby have since gained resolvers (in that order); C#, Kotlin, Swift, Elixir,
- * Lua, Astro and Svelte still extract an import that nothing consumes.
+ * for only four: php, python, typescript and vue. Go, Rust, C, C++, Java,
+ * Ruby, Astro and Svelte have since gained resolvers (in that order); C#,
+ * Kotlin, Swift, Elixir and Lua still extract an import that nothing
+ * consumes.
+ *
+ * Astro and Svelte needed no new resolver pass (TRA-451): both extract
+ * `imports` edges carrying plain filesystem-path specifiers — Astro's
+ * frontmatter/`<script>` blocks go through the same tree-sitter helper as
+ * TypeScript, Svelte's regex plugin already emits `from`/`module` specifiers
+ * — so joining `ESM_IMPORT_LANGUAGES` was sufficient. `.svelte` was already
+ * in the resolver's extension list (for `.ts` files importing a component);
+ * `.astro` was added alongside it.
  *
  * Adding a language here means adding or extending a resolver pass in
  * `src/indexer/pipeline.ts` — not editing a list.
@@ -26,6 +35,8 @@ export const ESM_IMPORT_LANGUAGES: ReadonlySet<string> = new Set([
   'tsx',
   'jsx',
   'vue',
+  'astro',
+  'svelte',
   'css',
   'scss',
   'sass',

--- a/src/indexer/resolvers/es-modules.ts
+++ b/src/indexer/resolvers/es-modules.ts
@@ -90,7 +90,18 @@ function findTsconfig(startDir: string, stopDir: string): string | undefined {
 function buildResolver(projectRoot: string, rootPath: string): ResolverFactory {
   const options: NapiResolveOptions = {
     conditionNames: ['import', 'require', 'node', 'default'],
-    extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.json', '.vue', '.svelte'],
+    extensions: [
+      '.ts',
+      '.tsx',
+      '.js',
+      '.jsx',
+      '.mjs',
+      '.cjs',
+      '.json',
+      '.vue',
+      '.svelte',
+      '.astro',
+    ],
     mainFields: ['module', 'main'],
     extensionAlias: {
       '.js': ['.ts', '.tsx', '.js', '.jsx'],
@@ -166,7 +177,18 @@ export class EsModuleResolver {
       // Bare minimum resolver
       this.rootResolver = new ResolverFactory({
         conditionNames: ['import', 'require', 'node', 'default'],
-        extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.json', '.vue', '.svelte'],
+        extensions: [
+          '.ts',
+          '.tsx',
+          '.js',
+          '.jsx',
+          '.mjs',
+          '.cjs',
+          '.json',
+          '.vue',
+          '.svelte',
+          '.astro',
+        ],
         mainFields: ['module', 'main'],
       });
     }

--- a/tests/fixtures/astro-svelte-imports/src/components/Child.svelte
+++ b/tests/fixtures/astro-svelte-imports/src/components/Child.svelte
@@ -1,0 +1,4 @@
+<script>
+  export let name;
+</script>
+<p>{name}</p>

--- a/tests/fixtures/astro-svelte-imports/src/components/Parent.svelte
+++ b/tests/fixtures/astro-svelte-imports/src/components/Parent.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Child from './Child.svelte';
+  import { x } from '../lib/util';
+</script>
+<Child name={x} />

--- a/tests/fixtures/astro-svelte-imports/src/consumer.ts
+++ b/tests/fixtures/astro-svelte-imports/src/consumer.ts
@@ -1,0 +1,6 @@
+import Parent from './components/Parent.svelte';
+import Index from './pages/index.astro';
+
+export function render() {
+  return [Parent, Index];
+}

--- a/tests/fixtures/astro-svelte-imports/src/layouts/Layout.astro
+++ b/tests/fixtures/astro-svelte-imports/src/layouts/Layout.astro
@@ -1,0 +1,3 @@
+<html>
+  <slot />
+</html>

--- a/tests/fixtures/astro-svelte-imports/src/lib/util.ts
+++ b/tests/fixtures/astro-svelte-imports/src/lib/util.ts
@@ -1,0 +1,1 @@
+export const x = 1;

--- a/tests/fixtures/astro-svelte-imports/src/pages/index.astro
+++ b/tests/fixtures/astro-svelte-imports/src/pages/index.astro
@@ -1,0 +1,5 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { x } from '../lib/util';
+---
+<Layout><p>{x}</p></Layout>

--- a/tests/integration/astro-svelte-import-resolution-e2e.test.ts
+++ b/tests/integration/astro-svelte-import-resolution-e2e.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Astro/Svelte cross-file import resolution E2E (TRA-451).
+ *
+ * Unlike Go/Java/Rust/C/C++/Ruby, Astro and Svelte needed no new resolver
+ * pass. Both plugins already emit `imports` edges with plain filesystem-path
+ * specifiers — Astro's frontmatter/`<script>` blocks are re-parsed with the
+ * same tree-sitter helper TypeScript uses, Svelte's regex plugin already
+ * writes `module` specifiers into the shape `resolveEsmImportEdges` expects —
+ * so the only gap was that neither language was in `ESM_IMPORT_LANGUAGES`,
+ * which made the pass skip every file of that language outright. These tests
+ * pin: an Astro file's own `.astro` and `.ts` imports, a Svelte file's own
+ * `.svelte` and `.ts` imports, and the pre-existing direction (a `.ts` file
+ * importing a `.svelte`/`.astro` component) that already worked before this
+ * change.
+ *
+ * Uses an on-disk fixture (like split-imports.test.ts) rather than
+ * `createTmpFixture`: `resolveEsmImportEdges` resolves specifiers through
+ * oxc-resolver, which returns realpath'd targets, and `os.tmpdir()` is a
+ * symlink on some hosts — the realpath'd target then falls outside
+ * `state.rootPath` and the edge is (wrongly) treated as external.
+ */
+import path from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { TraceMcpConfigSchema } from '../../src/config.js';
+import type { Store } from '../../src/db/store.js';
+import { IndexingPipeline } from '../../src/indexer/pipeline.js';
+import { AstroLanguagePlugin } from '../../src/indexer/plugins/language/astro/index.js';
+import { SvelteLanguagePlugin } from '../../src/indexer/plugins/language/svelte/index.js';
+import { TypeScriptLanguagePlugin } from '../../src/indexer/plugins/language/typescript/index.js';
+import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import { createTestStore } from '../test-utils.js';
+
+const fixturePath = path.resolve(__dirname, '../fixtures/astro-svelte-imports');
+
+function importTargets(store: Store, sourcePath: string): Set<string> {
+  const file = store.getFile(sourcePath);
+  if (!file) return new Set();
+  const nodeId = store.getNodeId('file', file.id);
+  if (nodeId == null) return new Set();
+  const targets = new Set<string>();
+  for (const edge of store.getOutgoingEdges(nodeId)) {
+    if (edge.edge_type_name !== 'imports') continue;
+    const ref = store.getNodeRef(edge.target_node_id);
+    if (ref?.nodeType === 'file') targets.add(store.getFileById(ref.refId)?.path ?? '');
+  }
+  return targets;
+}
+
+describe('Astro/Svelte import resolution E2E', () => {
+  let store: Store;
+
+  beforeAll(async () => {
+    store = createTestStore();
+    const registry = new PluginRegistry();
+    registry.registerLanguagePlugin(new AstroLanguagePlugin());
+    registry.registerLanguagePlugin(new SvelteLanguagePlugin());
+    registry.registerLanguagePlugin(new TypeScriptLanguagePlugin());
+
+    const config = TraceMcpConfigSchema.parse({
+      include: ['**/*.astro', '**/*.svelte', '**/*.ts'],
+      exclude: ['node_modules/**'],
+    });
+
+    await new IndexingPipeline(store, registry, config, fixturePath).indexAll();
+  });
+
+  it('resolves a Svelte component import to another Svelte file', () => {
+    expect(importTargets(store, 'src/components/Parent.svelte')).toContain(
+      'src/components/Child.svelte',
+    );
+  });
+
+  it('resolves a Svelte script import to a TypeScript file', () => {
+    expect(importTargets(store, 'src/components/Parent.svelte')).toContain('src/lib/util.ts');
+  });
+
+  it('resolves an Astro frontmatter import to another Astro file', () => {
+    expect(importTargets(store, 'src/pages/index.astro')).toContain('src/layouts/Layout.astro');
+  });
+
+  it('resolves an Astro frontmatter import to a TypeScript file', () => {
+    expect(importTargets(store, 'src/pages/index.astro')).toContain('src/lib/util.ts');
+  });
+
+  it('still resolves a TypeScript import into a Svelte/Astro component (pre-existing direction)', () => {
+    const targets = importTargets(store, 'src/consumer.ts');
+    expect(targets).toContain('src/components/Parent.svelte');
+    expect(targets).toContain('src/pages/index.astro');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to TRA-449/#593, which found that a plugin extracting `import` statements is not enough — the specifier has to be resolved to a target node by a pipeline pass, or the edge is dropped. Go, Java, Rust, C/C++, and Ruby have each closed this gap for their language via a dedicated resolver pass. This PR closes it for Astro and Svelte — but neither needed a new resolver.

Both plugins already emit `imports` edges carrying plain filesystem-path specifiers:
- Astro's frontmatter/`<script>` blocks are re-parsed with the same tree-sitter helper TypeScript uses (`extractImportEdges`).
- Svelte's regex plugin already writes `module` specifiers in the shape `resolveEsmImportEdges` expects.

The only gap was that neither language was in `ESM_IMPORT_LANGUAGES`, so `resolveEsmImportEdges` skipped every file of that language outright. Fix:
- Add `astro` and `svelte` to `ESM_IMPORT_LANGUAGES` (`import-capable-languages.ts`) — this also updates the derived `IMPORT_EDGE_LANGUAGES` set and `docs/language-matrix.md`'s Imports column via `pnpm run docs:language-matrix`.
- Add `.astro` to the oxc-resolver extension list in `es-modules.ts` (`.svelte` was already present, for the existing TS→`.svelte` direction).

Of the original 13 languages in TRA-451, six are now done (Go, Java, Rust, C, C++, Ruby, plus Astro/Svelte = 8); five remain unresolved: C#, Kotlin, Swift, Elixir, Lua.

## Test plan

- [x] New e2e test `tests/integration/astro-svelte-import-resolution-e2e.test.ts` against an on-disk fixture (`tests/fixtures/astro-svelte-imports/`), covering: Svelte→Svelte, Svelte→TS, Astro frontmatter→Astro, Astro frontmatter→TS, and the pre-existing TS→Svelte/Astro direction. All 5 pass.
  - Uses an on-disk fixture rather than `createTmpFixture`: `resolveEsmImportEdges` resolves through oxc-resolver, which returns realpath'd targets, and `os.tmpdir()` is a symlink on this sandbox — the realpath'd target then falls outside `state.rootPath` and the edge is wrongly treated as external. Matches the existing pattern in `split-imports.test.ts`.
- [x] `pnpm run build` — passes.
- [x] `pnpm run typecheck` — passes.
- [x] `npx biome ci` on all changed files — clean.
- [x] Full suite: `npx vitest run` → 10250 passed, 4 failed, 26 skipped. The 4 failures (`locate-app.test.ts`, `postinstall-app.test.ts`) are pre-existing sandbox flakiness in unrelated subsystems (real `pgrep`/`mdfind` subprocess timing) — confirmed by re-running them in isolation both with and without this diff; failures are non-deterministic and occur in either state.
- [x] `pnpm run docs:language-matrix` regenerated `docs/language-matrix.md`: import edges 16 → 18, astro/svelte rows flip to `yes`.