### PR TITLE
docs(app): make electron-cdp's header describe the flags it actually has

### DIFF
--- a/packages/app/scripts/electron-cdp.mjs
+++ b/packages/app/scripts/electron-cdp.mjs
@@ -7,12 +7,27 @@
  * lights and a native vibrancy view behind the sidebar, none of which a browser
  * tab has. This script is the launch path for that.
  *
- *   node scripts/electron-cdp.mjs launch            # build + run with CDP on :9222
+ *   pnpm run build                                  # launch does NOT build
+ *   node scripts/electron-cdp.mjs launch            # run with CDP on :9222
  *   node scripts/electron-cdp.mjs launch --visible  # …and put it on screen
  *   node scripts/electron-cdp.mjs shot out.png      # screenshot the current page
- *   node scripts/electron-cdp.mjs shot out.png --view=project --tab=graph --dark
+ *   node scripts/electron-cdp.mjs shot out.png --click=Insights --dark
  *   node scripts/electron-cdp.mjs shot out.png --locale=zh --size=640x420
  *   node scripts/electron-cdp.mjs shot out.png --offline   # daemon-down states
+ *
+ * `shot` flags, in full: `--url` `--click` `--eval` `--dark` `--light`
+ * `--locale` `--size=WxH` `--settle` `--offline` `--reduce-transparency`
+ * `--increase-contrast`. Which surface is on screen is React state, so reach a
+ * sidebar destination with `--click=<row label>` and a project surface by URL:
+ *
+ *   --url="file://$PWD/dist/renderer/index.html?view=project&root=<abs path>"
+ *
+ * Both query params are required — `getUrlParams` in `App.tsx` defaults `view`
+ * to `menu`, so `?root=` alone silently renders the Workspace instead.
+ *
+ * Build first, and mean it: `launch` only spawns Electron. Started without
+ * `dist/main/index.js` it comes up with no main script, no CDP endpoint and no
+ * error on stdout, which reads exactly like a slow boot.
  *
  * `launch` uses its own --user-data-dir so it does not fight the installed
  * trace-mcp.app for Electron's single-instance lock. Once it is up, an external


### PR DESCRIPTION
Comment-only change to `packages/app/scripts/electron-cdp.mjs`. No behaviour change.

## The problem

The header advertises:

```
node scripts/electron-cdp.mjs shot out.png --view=project --tab=graph --dark
```

Neither `--view` nor `--tab` exists. The parser knows `--url`, `--click`, `--eval`, `--dark`, `--light`, `--locale`, `--size`, `--settle`, `--offline`, `--reduce-transparency`, `--increase-contrast`.

Passing the documented flags does not error — they are ignored, and you get a screenshot of whatever was already on screen, which is the Workspace. A screenshot of the wrong screen looks exactly like a finished one, so a design review can be written against it and nobody finds out. That happened twice this week, in the runs that produced TRA-960 and TRA-964.

## What the header now says

- The real flag list, in full.
- How to actually reach a surface: `--click=<row label>` for a sidebar destination, and for a project surface `--url="file://$PWD/dist/renderer/index.html?view=project&root=<abs path>"`.
- That **both** query params are required — `getUrlParams` in `App.tsx` defaults `view` to `menu`, so `?root=` alone silently renders the Workspace. That is the specific trap that cost the screenshots, so it is called out rather than left to be re-derived.
- That `launch` does not build, despite the old "build + run" comment. It only spawns Electron; without `dist/main/index.js` it comes up with no main script, no CDP endpoint and nothing on stdout — which reads like a slow boot rather than a failure.

## Verification

Both replacement examples were run against the live Electron window before being written down:

- `--url=…?view=project&root=/…/general` → the page renders `Overview | Ask | Graph | Activity | Memory | Notebook`, i.e. the project surface.
- `--click=Insights` → that sidebar row comes back `aria-selected="true"`.

Agent: Design/UX Agent
