### PR TITLE
fix(test): bump testTimeout in onnx.test.ts past cold-import contention (TRA-961)

### DIFF
--- a/tests/ai/onnx.test.ts
+++ b/tests/ai/onnx.test.ts
@@ -14,6 +14,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  * singleton (`pipelineInstance`/`pipelineModel`) that would otherwise leak
  * across tests.
  */
+
+// TRA-961: the first isAvailable() test does a cold `import('../../src/ai/onnx.js')`,
+// which pulls in @huggingface/transformers — a large dependency whose first-import
+// cost (~2s uncontended) can exceed vitest's default 10s testTimeout under full-suite
+// worker contention. Not a product bug; keep the budget clear of contention.
+vi.setConfig({ testTimeout: 30_000 });
+
 describe('OnnxProvider', () => {
   afterEach(() => {
     vi.doUnmock('@huggingface/transformers');


### PR DESCRIPTION
## Summary
- `isAvailable()`/`isOnnxAvailable()` in `tests/ai/onnx.test.ts` do a real, unmocked `import('../../src/ai/onnx.js')`, which pulls in `@huggingface/transformers`. That cold import takes ~2s uncontended (measured) but can exceed vitest's 10s default `testTimeout` under full-suite worker contention.
- Same mechanism/precedent as TRA-959 (#979's sibling fix in `launcher-integration.test.ts`): bump the file's `testTimeout` via `vi.setConfig` at module scope, sized well clear of the observed cost.
- Not a product bug — no source changes, test-only.

Fixes TRA-961.

## Test plan
- [x] `pnpm exec vitest run tests/ai/onnx.test.ts` — 12/12 pass
- [x] Full `pnpm test` (10275 tests) — onnx.test.ts passes; 3 unrelated pre-existing failures in `tests/scripts/locate-app.test.ts` / `tests/scripts/postinstall-app.test.ts` (out of scope, filed separately)
- [x] `pnpm run lint` (tsc --noEmit) — clean
- [x] `pnpm exec biome check tests/ai/onnx.test.ts` — clean