### PR TITLE
test(logs): pin the rotation ceiling on every log under ~/.trace (TRA-707)

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.6.4 (Windows)
+REM trace-mcp-launcher v0.6.5 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.6.4 (Windows)
+# trace-mcp-launcher v0.6.5 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -14,8 +14,12 @@ $LogPath    = Join-Path $TraceHome 'launcher.log'
 # Rotate once per invocation, before the first append (TRA-702). Mirrors
 # rotate_log in trace-mcp-launcher.sh. Bounds the log at 2 x the limit across
 # both generations; without it the file only ever grew.
-$LogMaxBytes = if ($env:TRACE_MCP_LOG_MAX_BYTES) { [int64]$env:TRACE_MCP_LOG_MAX_BYTES } else { 5242880 }
+$LogMaxBytes = 5242880
 try {
+    # Inside the try on purpose: $ErrorActionPreference is 'Stop', so a
+    # non-numeric override would throw on the cast and abort the whole shim
+    # before it ever execs node - a logging knob must never cost a start.
+    if ($env:TRACE_MCP_LOG_MAX_BYTES) { $LogMaxBytes = [int64]$env:TRACE_MCP_LOG_MAX_BYTES }
     $existing = Get-Item -LiteralPath $LogPath -ErrorAction SilentlyContinue
     if ($existing -and $existing.Length -gt $LogMaxBytes) {
         Move-Item -LiteralPath $LogPath -Destination "$LogPath.1" -Force -ErrorAction SilentlyContinue

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -30,6 +30,13 @@ PKG_ROOTS_FILE="$TRACE_HOME/pkg-roots"
 # costs one stat and bounds the file at 2 x LOG_MAX_BYTES across both
 # generations. Without it launcher.log only ever grew — 9.7 MB observed.
 LOG_MAX_BYTES=${TRACE_MCP_LOG_MAX_BYTES:-5242880}
+# The override is user input. `[ x -gt y ]` on a non-numeric operand prints
+# "integer expression expected" straight to the MCP client's stderr, which is
+# exactly the leak TRA-797 closed elsewhere — bound it here, as the shim
+# already does for NODE_MIN_MAJOR below.
+case "$LOG_MAX_BYTES" in
+  ''|*[!0-9]*) LOG_MAX_BYTES=5242880 ;;
+esac
 rotate_log() {
   [ -f "$LOG" ] || return 0
   # stat is not portable between GNU and BSD, and the two disagree in a way a

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.6.4
+# trace-mcp-launcher v0.6.5
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -32,8 +32,18 @@ PKG_ROOTS_FILE="$TRACE_HOME/pkg-roots"
 LOG_MAX_BYTES=${TRACE_MCP_LOG_MAX_BYTES:-5242880}
 rotate_log() {
   [ -f "$LOG" ] || return 0
-  # stat is not portable between GNU and BSD; try both, give up quietly.
-  size=$(stat -f %z "$LOG" 2>/dev/null || stat -c %s "$LOG" 2>/dev/null || echo 0)
+  # stat is not portable between GNU and BSD, and the two disagree in a way a
+  # single `a || b` substitution cannot survive: GNU reads `-f %z FILE` as a
+  # request for the filesystem holding `%z`, prints a multi-line report for
+  # FILE on *stdout* and exits 1 — so the fallback runs but its number is
+  # captured appended to that report, and the numeric guard below then rejects
+  # the lot. That is why this never rotated on Linux (TRA-707). Try each form
+  # separately and check for a plain number after each; BSD rejects `-c` on
+  # stderr only, so nothing leaks either way.
+  size=$(stat -c %s "$LOG" 2>/dev/null) || size=''
+  case "$size" in
+    ''|*[!0-9]*) size=$(stat -f %z "$LOG" 2>/dev/null) || size='' ;;
+  esac
   case "$size" in
     ''|*[!0-9]*) return 0 ;;
   esac

--- a/hooks/trace-mcp-reindex.sh
+++ b/hooks/trace-mcp-reindex.sh
@@ -125,7 +125,19 @@ write_stat() {
   # keep their fd alive; data loss is acceptable for telemetry.
   if [[ -f "$STATS_FILE" ]]; then
     local size
-    size=$(stat -f%z "$STATS_FILE" 2>/dev/null || stat -c%s "$STATS_FILE" 2>/dev/null || echo 0)
+    # Same GNU/BSD split as rotate_log in trace-mcp-launcher.sh (TRA-707): GNU
+    # stat reads `-f%z FILE` as a filesystem query, prints a report on stdout
+    # and exits 1, so a single `a || b` substitution captures that report with
+    # the fallback's number stuck on the end. Here it was worse than a missed
+    # rotation — `[[ x -gt y ]]` on that string prints a bash syntax error to
+    # stderr. Try each form separately and require a plain number.
+    size=$(stat -c%s "$STATS_FILE" 2>/dev/null) || size=''
+    case "$size" in
+      ''|*[!0-9]*) size=$(stat -f%z "$STATS_FILE" 2>/dev/null) || size='' ;;
+    esac
+    case "$size" in
+      ''|*[!0-9]*) size=0 ;;
+    esac
     if [[ "$size" -gt "$STATS_MAX_BYTES" ]]; then
       : > "$STATS_FILE" 2>/dev/null || true
     fi

--- a/ops/machine-state.md
+++ b/ops/machine-state.md
@@ -76,9 +76,26 @@ it, which is why that file doubles as the checklist for this one.
 | `topology.db`, `decisions.db`, `state.db`, `sessions/`, `corpora/`, `bundles/`, `locks/`, `status/`, `embed-watermarks.json`, `startup-watch.json` | normal operation | no | `rm -rf ~/.trace` | Silent |
 | `startup-backups/` | `apply_startup_recommendations` | yes, it is the undo manifest | `rollback…` | Silent |
 | `telemetry-state.json` (install UUID) | first server start | **no** | `TRACE_MCP_TELEMETRY=off` | Notice (state) / **Consent** (the ping — below) |
-| `daemon.log`, `postinstall.log`, `launcher.log` | daemon / install | no | `rm` | Silent |
+| `daemon.log`, `postinstall.log`, `launcher.log`, `update.log` | daemon / install / update | no | `rm` | Silent |
 | `daemon.disabled` sentinel | `daemon stop` | yes | `daemon start` | Silent |
 | `~/.trace-mcp` → `~/.trace` rename | first run after TRA-611 | no | — (compat symlink kept) | Notice |
+
+
+**Log ceilings.** Every log under `~/.trace` is size-bounded and keeps exactly one
+previous generation (`<name>.1`), so the pair can never exceed twice the ceiling.
+The writers are independent — the daemon cannot rotate a file the bash /
+PowerShell shim appends to — so each states its own limit:
+
+| Log | Ceiling | Set in |
+|---|---|---|
+| `daemon.log` | 20 MB, checked every 60 s by the running daemon | `src/daemon/lifecycle.ts` |
+| `launcher.log` | 5 MB, override with `TRACE_MCP_LOG_MAX_BYTES` | `hooks/trace-mcp-launcher.sh`, `.ps1` |
+| `update.log` | 2 MB | `packages/app/src/main/update-log.ts` |
+| `run.log` (opt-in `logging.file`) | `logging.max_size_mb`, default 10 MB | `src/logger.ts` |
+
+Rotation is best-effort everywhere: a rotation failure is swallowed rather than
+allowed to abort an MCP start or an update. `postinstall.log` is unbounded, and
+stays that way — it gains a few lines per `npm install`, not per run.
 
 ### B. Leaves the machine
 

--- a/ops/machine-state.md
+++ b/ops/machine-state.md
@@ -91,7 +91,13 @@ PowerShell shim appends to — so each states its own limit:
 | `daemon.log` | 20 MB, checked every 60 s by the running daemon | `src/daemon/lifecycle.ts` |
 | `launcher.log` | 5 MB, override with `TRACE_MCP_LOG_MAX_BYTES` | `hooks/trace-mcp-launcher.sh`, `.ps1` |
 | `update.log` | 2 MB | `packages/app/src/main/update-log.ts` |
-| `run.log` (opt-in `logging.file`) | `logging.max_size_mb`, default 10 MB | `src/logger.ts` |
+
+`logging.max_size_mb` (default 10 MB) governs none of these three. It caps the
+opt-in `logging.file` transport in `src/logger.ts`, whose `logging.path` still
+defaults to **`~/.trace-mcp/run.log`** — the pre-TRA-611 directory. That path is
+expanded with a plain `~` substitution, not the rename-aware `getLauncherDir()`
+the three logs above use, so on a migrated machine it writes outside `~/.trace`.
+Off by default, so nothing is written there unless a user opts in.
 
 Rotation is best-effort everywhere: a rotation failure is swallowed rather than
 allowed to abort an MCP start or an update. `postinstall.log` is unbounded, and

--- a/packages/app/src/main/__tests__/update-log.test.ts
+++ b/packages/app/src/main/__tests__/update-log.test.ts
@@ -1,0 +1,71 @@
+/**
+ * update.log has a ceiling (TRA-707). Without one it only ever grew: each entry
+ * carries a full stdout/stderr capture, so a handful of failing updates move it
+ * by megabytes and nothing ever trims it.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { appendUpdateLog, UPDATE_LOG_MAX_BYTES, updateLogPath } from '../update-log';
+
+let traceHome: string;
+let logPath: string;
+
+beforeEach(() => {
+  traceHome = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-update-log-'));
+  vi.stubEnv('TRACE_HOME', traceHome);
+  logPath = updateLogPath();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  fs.rmSync(traceHome, { recursive: true, force: true });
+});
+
+describe('appendUpdateLog', () => {
+  it('appends while under the ceiling', () => {
+    appendUpdateLog({ event: 'one' });
+    appendUpdateLog({ event: 'two' });
+
+    const lines = fs.readFileSync(logPath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[1]).event).toBe('two');
+    expect(fs.existsSync(`${logPath}.1`)).toBe(false);
+  });
+
+  it('rotates once past the ceiling instead of growing forever', () => {
+    fs.writeFileSync(logPath, 'x'.repeat(UPDATE_LOG_MAX_BYTES + 1));
+
+    appendUpdateLog({ event: 'after-rotation' });
+
+    // Oversized content moved aside; the live log restarts from the new entry.
+    expect(fs.statSync(`${logPath}.1`).size).toBe(UPDATE_LOG_MAX_BYTES + 1);
+    const live = fs.readFileSync(logPath, 'utf-8').trim();
+    expect(live.split('\n')).toHaveLength(1);
+    expect(JSON.parse(live).event).toBe('after-rotation');
+  });
+
+  it('keeps one generation — a second rotation discards the older one', () => {
+    fs.writeFileSync(logPath, 'first'.padEnd(UPDATE_LOG_MAX_BYTES + 1, 'x'));
+    appendUpdateLog({ event: 'gen-2' });
+    fs.appendFileSync(logPath, 'y'.repeat(UPDATE_LOG_MAX_BYTES));
+    appendUpdateLog({ event: 'gen-3' });
+
+    expect(fs.readFileSync(`${logPath}.1`, 'utf-8')).toContain('gen-2');
+    expect(fs.readFileSync(`${logPath}.1`, 'utf-8')).not.toContain('first');
+    expect(fs.readFileSync(logPath, 'utf-8')).toContain('gen-3');
+  });
+
+  it('never throws when the log cannot be written', () => {
+    // A file where the directory has to be — mkdir and append both fail.
+    fs.rmSync(traceHome, { recursive: true, force: true });
+    fs.writeFileSync(traceHome, 'not a directory');
+
+    expect(() => appendUpdateLog({ event: 'doomed' })).not.toThrow();
+
+    fs.rmSync(traceHome, { force: true });
+    fs.mkdirSync(traceHome);
+  });
+});

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -7,6 +7,7 @@ import { resolveAutoUpdaterExport } from './autoupdater-interop';
 import { t } from './i18n';
 import { registerAppMenu } from './menu';
 import { getLauncherDir } from './trace-home';
+import { appendUpdateLog, updateLogPath } from './update-log';
 import { ACCESSORY_APP, createTray, restoreAppearance, showMenuWindow } from './tray';
 import { updateChannelFor } from './update-channel';
 import { detectMcpClients } from '../shared/mcp-detector';
@@ -1042,44 +1043,6 @@ function parseNpmRenamePaths(stderr: string): { src?: string; dest?: string } {
   const src = stderr.match(/^npm (?:error|ERR!) path (.+)$/m)?.[1]?.trim();
   const dest = stderr.match(/^npm (?:error|ERR!) dest (.+)$/m)?.[1]?.trim();
   return { src, dest };
-}
-
-// Update flow uses <CLI state dir>/update.log for full audit trail — every
-// `apply-update` attempt records command, exit code, full stdout/stderr. The
-// renderer only sees a short summary, so the log is the place to look when a
-// user reports "Update failed".
-//
-// Resolved per call, not once at import: the CLI can rename ~/.trace-mcp to
-// ~/.trace (TRA-611) while this app is running, and a cached path would keep
-// recreating the directory the rename just removed.
-function updateLogPath(): string {
-  return path.join(getLauncherDir(), 'update.log');
-}
-
-// TRA-702: update.log had no rotation and only ever grew. Every entry carries
-// a full stdout/stderr capture, so a few failing updates move it by megabytes.
-// One generation is enough for the "user reports 'Update failed'" case this log
-// exists to serve — nobody reads the run before last.
-const UPDATE_LOG_MAX_BYTES = 2 * 1024 * 1024;
-
-function appendUpdateLog(entry: Record<string, unknown>): void {
-  try {
-    const target = updateLogPath();
-    fs.mkdirSync(path.dirname(target), { recursive: true });
-    try {
-      if (fs.statSync(target).size > UPDATE_LOG_MAX_BYTES) {
-        fs.renameSync(target, `${target}.1`);
-      }
-    } catch {
-      /* no log yet, or rotation raced another writer — append regardless */
-    }
-    fs.appendFileSync(
-      target,
-      JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n',
-    );
-  } catch {
-    /* logging must never break the update */
-  }
 }
 
 function readVersionFromRoot(npmRoot: string | null): string | undefined {

--- a/packages/app/src/main/update-log.ts
+++ b/packages/app/src/main/update-log.ts
@@ -1,0 +1,48 @@
+/**
+ * The update audit log: `<CLI state dir>/update.log`.
+ *
+ * Every `apply-update` attempt records command, exit code, full stdout/stderr.
+ * The renderer only sees a short summary, so this log is the place to look when
+ * a user reports "Update failed".
+ *
+ * Lives in its own module rather than in index.ts so the rotation ceiling can be
+ * tested without booting the Electron main process (TRA-707).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { getLauncherDir } from './trace-home';
+
+// TRA-702: update.log had no rotation and only ever grew. Every entry carries
+// a full stdout/stderr capture, so a few failing updates move it by megabytes.
+// One generation is enough for the "user reports 'Update failed'" case this log
+// exists to serve — nobody reads the run before last.
+export const UPDATE_LOG_MAX_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Resolved per call, not once at import: the CLI can rename ~/.trace-mcp to
+ * ~/.trace (TRA-611) while this app is running, and a cached path would keep
+ * recreating the directory the rename just removed.
+ */
+export function updateLogPath(): string {
+  return path.join(getLauncherDir(), 'update.log');
+}
+
+export function appendUpdateLog(entry: Record<string, unknown>): void {
+  try {
+    const target = updateLogPath();
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    try {
+      if (fs.statSync(target).size > UPDATE_LOG_MAX_BYTES) {
+        fs.renameSync(target, `${target}.1`);
+      }
+    } catch {
+      /* no log yet, or rotation raced another writer — append regardless */
+    }
+    fs.appendFileSync(
+      target,
+      JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n',
+    );
+  } catch {
+    /* logging must never break the update */
+  }
+}

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -112,4 +112,4 @@ export const MIRROR_HOOK_VERSION = '0.3.0';
 // 0.6.0 (TRA-755): the resolved node is version-gated against engines.node. An
 // older one used to exec fine and die on a SyntaxError the client could only
 // report as "failed to connect" — and get pinned into launcher.env on the way.
-export const LAUNCHER_VERSION = '0.6.4';
+export const LAUNCHER_VERSION = '0.6.5';

--- a/tests/init/launcher-integration-windows.test.ts
+++ b/tests/init/launcher-integration-windows.test.ts
@@ -292,6 +292,7 @@ Write-Output "EXIT:$LASTEXITCODE"`;
     const q = (p: string) => p.replace(/'/g, "''");
     const script = `$env:TRACE_MCP_HOME = '${q(traceHome)}'
 $env:USERPROFILE = '${q(home)}'
+$env:NPM_CONFIG_PREFIX = ''
 $env:TRACE_MCP_LOG_MAX_BYTES = '1024'
 & powershell.exe -NoProfile -NonInteractive -File '${q(ps1)}' serve
 Write-Output "EXIT:$LASTEXITCODE"`;
@@ -315,6 +316,7 @@ Write-Output "EXIT:$LASTEXITCODE"`;
     const q = (p: string) => p.replace(/'/g, "''");
     const script = `$env:TRACE_MCP_HOME = '${q(traceHome)}'
 $env:USERPROFILE = '${q(home)}'
+$env:NPM_CONFIG_PREFIX = ''
 $env:TRACE_MCP_LOG_MAX_BYTES = '1048576'
 & powershell.exe -NoProfile -NonInteractive -File '${q(ps1)}' serve
 Write-Output "EXIT:$LASTEXITCODE"`;

--- a/tests/init/launcher-integration-windows.test.ts
+++ b/tests/init/launcher-integration-windows.test.ts
@@ -276,4 +276,54 @@ Write-Output "EXIT:$LASTEXITCODE"`;
     const log = fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8');
     expect(log).toMatch(/ERROR: config node=.*runtime shim whose target is gone/);
   });
+
+  // TRA-707: launcher.log takes a line on every MCP start and nothing else
+  // trims it. The ps1 rotates it itself - the daemon's own rotation cannot
+  // reach a file written from PowerShell. Driven through powershell.exe
+  // directly, like the tests above: the cmd shim does not spawn on the runner.
+  it('rotates launcher.log once it is past the ceiling', () => {
+    const { home, traceHome, nodeExe, cli } = setupFakeHome();
+    writeConfig(traceHome, nodeExe, cli);
+    const logPath = path.join(traceHome, 'launcher.log');
+    const oversize = 'old entry\r\n'.repeat(200);
+    fs.writeFileSync(logPath, oversize);
+
+    const ps1 = path.join(HOOKS_DIR, 'trace-mcp-launcher.ps1');
+    const q = (p: string) => p.replace(/'/g, "''");
+    const script = `$env:TRACE_MCP_HOME = '${q(traceHome)}'
+$env:USERPROFILE = '${q(home)}'
+$env:TRACE_MCP_LOG_MAX_BYTES = '1024'
+& powershell.exe -NoProfile -NonInteractive -File '${q(ps1)}' serve
+Write-Output "EXIT:$LASTEXITCODE"`;
+    spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], {
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+
+    // Oversized content moved aside; the live log restarts from this run.
+    expect(fs.readFileSync(`${logPath}.1`, 'utf-8')).toBe(oversize);
+    expect(fs.readFileSync(logPath, 'utf-8')).not.toContain('old entry');
+  });
+
+  it('keeps appending to launcher.log while under the ceiling', () => {
+    const { home, traceHome, nodeExe, cli } = setupFakeHome();
+    writeConfig(traceHome, nodeExe, cli);
+    const logPath = path.join(traceHome, 'launcher.log');
+    fs.writeFileSync(logPath, 'old entry\r\n');
+
+    const ps1 = path.join(HOOKS_DIR, 'trace-mcp-launcher.ps1');
+    const q = (p: string) => p.replace(/'/g, "''");
+    const script = `$env:TRACE_MCP_HOME = '${q(traceHome)}'
+$env:USERPROFILE = '${q(home)}'
+$env:TRACE_MCP_LOG_MAX_BYTES = '1048576'
+& powershell.exe -NoProfile -NonInteractive -File '${q(ps1)}' serve
+Write-Output "EXIT:$LASTEXITCODE"`;
+    spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], {
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+
+    expect(fs.existsSync(`${logPath}.1`)).toBe(false);
+    expect(fs.readFileSync(logPath, 'utf-8')).toContain('old entry');
+  });
 });

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1025,6 +1025,11 @@ describe.skipIf(process.platform === 'win32')('app runtime shim with a dangling 
   // TRA-707: launcher.log takes a line on every MCP start and nothing else
   // trims it — 9.7 MB observed in the field. The shim rotates it itself; the
   // daemon's own rotation cannot reach a file written from bash.
+  //
+  // This has to run on both CI runners, not one: the size probe is the part
+  // that broke, and GNU and BSD `stat` disagree about the flags it uses. The
+  // first cut of this test passed on macOS while the Linux job caught the shim
+  // silently never rotating at all.
   it('rotates launcher.log once it is past the ceiling', () => {
     const { home, traceHome, node, cli } = setupFakeHome();
     writeConfig(traceHome, node, cli);

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1021,4 +1021,43 @@ describe.skipIf(process.platform === 'win32')('app runtime shim with a dangling 
     expect(status).toBe(0);
     expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
   });
+
+  // TRA-707: launcher.log takes a line on every MCP start and nothing else
+  // trims it — 9.7 MB observed in the field. The shim rotates it itself; the
+  // daemon's own rotation cannot reach a file written from bash.
+  it('rotates launcher.log once it is past the ceiling', () => {
+    const { home, traceHome, node, cli } = setupFakeHome();
+    writeConfig(traceHome, node, cli);
+    const logPath = path.join(traceHome, 'launcher.log');
+    const oversize = 'old entry\n'.repeat(200);
+    fs.writeFileSync(logPath, oversize);
+
+    const { status } = runLauncher(
+      { HOME: home, TRACE_MCP_HOME: traceHome, TRACE_MCP_LOG_MAX_BYTES: '1024' },
+      ['serve'],
+    );
+
+    expect(status).toBe(0);
+    // Oversized content moved aside, live log restarted from this run's lines.
+    expect(fs.readFileSync(`${logPath}.1`, 'utf-8')).toBe(oversize);
+    const live = fs.readFileSync(logPath, 'utf-8');
+    expect(live).not.toContain('old entry');
+    expect(live).toMatch(/exec\(config\)/);
+  });
+
+  it('keeps appending while under the ceiling', () => {
+    const { home, traceHome, node, cli } = setupFakeHome();
+    writeConfig(traceHome, node, cli);
+    const logPath = path.join(traceHome, 'launcher.log');
+    fs.writeFileSync(logPath, 'old entry\n');
+
+    const { status } = runLauncher(
+      { HOME: home, TRACE_MCP_HOME: traceHome, TRACE_MCP_LOG_MAX_BYTES: '1048576' },
+      ['serve'],
+    );
+
+    expect(status).toBe(0);
+    expect(fs.existsSync(`${logPath}.1`)).toBe(false);
+    expect(fs.readFileSync(logPath, 'utf-8')).toContain('old entry');
+  });
 });

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1065,4 +1065,26 @@ describe.skipIf(process.platform === 'win32')('app runtime shim with a dangling 
     expect(fs.existsSync(`${logPath}.1`)).toBe(false);
     expect(fs.readFileSync(logPath, 'utf-8')).toContain('old entry');
   });
+
+  // The ceiling override is user input, and `[ x -gt y ]` on a non-numeric
+  // operand prints "integer expression expected" straight to the client's
+  // stderr — the leak TRA-797 closed elsewhere in this shim. A logging knob
+  // must never cost a start, nor corrupt the MCP stderr channel.
+  it('falls back to the default ceiling when the override is not a number', () => {
+    const { home, traceHome, node, cli } = setupFakeHome();
+    writeConfig(traceHome, node, cli);
+    const logPath = path.join(traceHome, 'launcher.log');
+    fs.writeFileSync(logPath, 'old entry\n');
+
+    const { status, stdout, stderr } = runLauncher(
+      { HOME: home, TRACE_MCP_HOME: traceHome, TRACE_MCP_LOG_MAX_BYTES: 'not-a-number' },
+      ['serve'],
+    );
+
+    expect(status).toBe(0);
+    expect(stderr).toBe('');
+    expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+    // Default 5 MB applies, so a one-line log is nowhere near it.
+    expect(fs.existsSync(`${logPath}.1`)).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes TRA-707.

## What was actually missing

The rotation itself already shipped: TRA-702 bounded `launcher.log` (5 MB, in both the bash and PowerShell shims) and `update.log` (2 MB), and `daemon.log` has had a 20 MB copytruncate ceiling since #209. Of the three, only `daemon.log` had a test. A ceiling nothing exercises is a ceiling that quietly stops holding — which is how `launcher.log` reached 9.7 MB to begin with.

So this PR closes the acceptance criterion rather than re-implementing the fix: **each log has a stated ceiling, and a test that a log past the ceiling is rotated rather than appended to indefinitely.**

## Changes

**`launcher.log` — two tests per shim.** They drive the real shim with `TRACE_MCP_LOG_MAX_BYTES`, so the rotation path is executed, not asserted about:
- past the ceiling → oversized content lands in `launcher.log.1`, the live file restarts from this run's lines;
- under the ceiling → no `.1`, the old content is still there.

The bash pair runs on macOS/Linux CI. The PowerShell pair goes in the win32-only suite and is driven through `powershell.exe` directly, matching the existing tests there (the `.cmd` shim does not spawn on the GitHub runner).

**`update.log` — extracted to test it.** `appendUpdateLog` / `updateLogPath` moved out of the 3k-line Electron main entry into `packages/app/src/main/update-log.ts`. Behavior is unchanged and `index.ts` imports the same two names; the point is that the ceiling can now be tested without booting Electron. Four tests: appends under the ceiling, rotates past it, keeps exactly one generation, never throws when the log is unwritable.

**`ops/machine-state.md`** now states each log's ceiling and where it is set — including that `run.log` (opt-in `logging.file`) is the thing `logging.max_size_mb` actually governs, not `daemon.log`.

## One deliberate non-change

`postinstall.log` is also unbounded and stays that way. It gains a few lines per `npm install`, not per run — it did not appear in the field sizes that opened this issue. Documented as deliberate so the next sweep does not re-open it.

## Test evidence

- `pnpm test` (root): 924 files, 10251 passed, 5 files / 28 tests skipped.
- `pnpm test` (packages/app): 71 files, 714 passed — includes the 4 new `update-log` tests.
- `pnpm typecheck` clean in both packages; `pnpm biome ci` clean on the touched files; `pnpm build` succeeds.

A first full-suite run had 3 timeouts (`locate-app.test.ts` and one other) that passed in isolation and on rerun — the known worker-contention flake class that gave the launcher tests their 30 s budget, unrelated to this change.

No MCP tool signature, on-disk schema, or query-cost change.

---

## Update: the test found a live bug

The first push had the Linux `test` job fail on the new `rotates launcher.log once it is past the ceiling` — while macOS passed. That difference *is* the finding.

`rotate_log`'s size probe in `hooks/trace-mcp-launcher.sh` was:

```sh
size=$(stat -f %z "$LOG" 2>/dev/null || stat -c %s "$LOG" 2>/dev/null || echo 0)
```

BSD `stat` answers the first form. GNU `stat` reads `-f %z FILE` as a request for the filesystem holding a file named `%z`: it prints a multi-line filesystem report for FILE **on stdout** and exits 1. The fallback then runs, but command substitution captures both, so `$size` ends up as that report with a number stuck on the end. The numeric guard rejects it and `rotate_log` returns without rotating.

So since TRA-702, `launcher.log` has been bounded on macOS and unbounded on Linux — silently. That is where the 9.7 MB in this issue came from.

Verified both directions locally by putting GNU `stat` on the shim's pinned PATH: the old shim leaves an over-ceiling log in place and appends to it (4000 → 4108 bytes, no `.1`); the new one rotates (`.1` created, live log back to 108 bytes).

`LAUNCHER_VERSION` goes 0.6.4 → 0.6.5 in all three shim headers and `src/init/types.ts` — shim install is version-gated, so without the bump an already-installed shim is never rewritten and the fix reaches no existing machine.

Full suite green again locally (926 files / 10253 tests) and all CI checks pass, including the Linux `test` job that caught this.

## Update 2: three same-class defects one file away

The second review pass approved the fix and flagged three more instances of the same contract being broken — rotation must never abort a start or leak to the client's stderr. All fixed in `90d418c9`:

- **`hooks/trace-mcp-reindex.sh:128`** carried the identical `stat -f%z || stat -c%s` substitution. Consequence there is worse than a missed rotation: the captured filesystem report reaches `[[ x -gt y ]]`, which prints a bash syntax error to stderr on every reindex on Linux.
- **`LOG_MAX_BYTES`** is user input and went unvalidated into `[ -gt ]`, printing `integer expression expected` to the MCP client's stderr — the exact leak TRA-797 closed elsewhere in this same shim, which already bounds `NODE_MIN_MAJOR` this way. Now bounded and covered: with the guard removed the new test fails with that literal stderr line.
- **`.ps1`** read its override with an `[int64]` cast placed *outside* the try/catch, under `$ErrorActionPreference = 'Stop'` — a non-numeric value would throw and abort the shim before it ever exec'd node. Moved inside.

Final state: 926 files / 10254 tests green locally, all 23 CI checks pass.
