### PR TITLE
test(scale): run the real tools against a 150k-symbol index (TRA-977)

### DIFF
--- a/ops/index-scale-testing.md
+++ b/ops/index-scale-testing.md
@@ -1,0 +1,100 @@
+# Index-scale testing: the ceiling we test to, and why that number
+
+A defect that only exists above a size threshold is invisible to a corpus below
+it. This file records where our threshold sits, so the next run does not
+re-derive it — and so that a fixture shrunk in a refactor is a visible change
+rather than a silent loss of coverage.
+
+## The threshold that matters
+
+`Math.min(...xs)` and `arr.push(...xs)` pass every element as a separate
+argument. V8 throws `RangeError: Maximum call stack size exceeded` past its
+argument limit — **~65 000 to ~125 000, depending on remaining stack depth**.
+Not a fixed number: the same array can pass on one machine and throw on
+another, and can pass in a shallow call and throw in a deep one.
+
+Practical consequence: a fixture at 70k proves nothing. A fixture has to clear
+the *upper* end of that range to be evidence.
+
+## Where we were (2026-09-06, before this change)
+
+| Corpus | Symbols | What it exercised |
+|--------|--------:|-------------------|
+| `tests/perf/stress.test.ts` | **50 000** (10 000 files x 5) | `searchFts`, store batch methods |
+| everything else | < 1 000 | tools, end to end |
+
+So the largest thing CI ran was **50 000 symbols** — an order below the
+threshold — and even that only reached the DB layer, never a tool handler. The
+size the defect needs and the surface it lives on were both outside CI.
+
+That is how GitHub [#957](https://github.com/nikolai-vysotskyi/trace-mcp/issues/957)
+reached a user: `search` returned the bare string "Maximum call stack size
+exceeded" for every query against a 152 734-symbol index, deterministically,
+while `search_text` on the same index worked. Reported by `msalem89` with a
+3/3 repro; cause and the first fix are Nikolai's, in the thread.
+
+## Where we are now
+
+| Corpus | Symbols | Nodes ranked | Cost |
+|--------|--------:|-------------:|------|
+| `tests/perf/scale-rangeerror.test.ts` | **150 000** | 165 000 | ~4 s |
+
+150 000 is chosen to sit above the upper end of the V8 range and to match the
+size actually reported from the field, not to be round.
+
+The fixture is **generated, never vendored** — `tests/perf/large-index.ts`,
+which is the seeder `stress.test.ts` has always used, extended with
+symbol-level edges. That extension is not cosmetic: PageRank ranks only nodes
+that appear in a resolved edge, so a file-only edge set caps `pagerankMap` at
+the file count and cannot reproduce the failure at all.
+
+## What the audit found
+
+Reviewing "who expands or sorts the un-truncated set" turned up something the
+original diagnosis had backwards, and it is worth writing down because the same
+reasoning error will recur.
+
+`searchFts` applies `LIMIT ?` **in SQL**. Every `ftsResults` array in the
+codebase is therefore bounded by the caller's `limit` (~70-120 rows), not by
+the index. Those spreads were never the crash — they cannot reach 65k.
+
+The array that does scale with the index is `pagerankMap`, one entry per graph
+node, spread as `Math.max(...pagerankMap.values(), 0.001)` in three places:
+
+- `src/tools/navigation/navigation.ts` — `search()` and the fusion path
+- `src/tools/navigation/context.ts` — `get_feature_context`
+
+All three still crashed after the FTS fix landed, and the scale test above
+reproduces each of them by name. `src/tools/navigation/task-context.ts` had
+already been written as a manual loop and was the one correct precedent in the
+tree.
+
+Lesson for the next audit: **"bounded by the index" is a claim about where the
+array comes from, and it has to be checked at the query, not inferred from the
+variable name.** Two of us read `ftsResults` and assumed unbounded.
+
+## The gate
+
+`tests/ci/no-spread-into-call.test.ts` fails CI on any
+`Math.min(...` / `Math.max(...` in `src/**`. The rule is **total, with no
+allowlist**, because `minMax()` from `src/util/minmax.ts` is a drop-in for
+every form and reducing a small array costs nothing — an allowlist would be
+the only part of this that needs maintaining, and the entries would outlive
+their reasons. All 26 call sites in `src/` were converted in the same change.
+
+The behavioural test and the static gate are not redundant. The gate reaches
+every line, including code no test calls — which is where both of #957's
+instances lived. The behavioural test catches the forms the regex cannot see.
+
+## Known and deliberately not gated
+
+`arr.push(...xs)` throws the same `RangeError` on the same threshold and has
+~40 call sites in `src/`, most of them bounded by a file or a query limit.
+There is **no static gate on it**: unlike `Math.max`, the safe rewrite is not
+a drop-in, and a rule with 35 exemptions is an allowlist wearing a rule's
+clothes. The scale test covers the paths it exercises; the ones it does not
+are the standing risk. Revisit if a field report names one — do not
+pre-emptively rewrite 40 sites on a guess.
+
+Also out of scope: sorting an un-truncated result set. That is a latency
+problem, not a `RangeError`, and `stress.test.ts` already has time budgets.

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -30,6 +30,7 @@ import type {
   MetricResult,
   MetricRollup,
 } from './types.js';
+import { minMax } from '../util/minmax.js';
 
 export interface RunOptions {
   /** Path to the SQLite index for the project the dataset targets. */
@@ -167,8 +168,8 @@ export class BenchmarkRunner {
       rollups.push({
         metric,
         mean: sum / filtered.length,
-        min: Math.min(...filtered),
-        max: Math.max(...filtered),
+        min: minMax(filtered).min,
+        max: minMax(filtered).max,
         n: filtered.length,
       });
     }

--- a/src/init/md-block.ts
+++ b/src/init/md-block.ts
@@ -12,6 +12,7 @@
 import fs from 'node:fs';
 import { readIfExists } from '../utils/safe-fs.js';
 import type { InitStepResult } from './types.js';
+import { minMax } from '../util/minmax.js';
 
 export const START_MARKER = '<!-- trace:start -->';
 export const LEGACY_START_MARKER = '<!-- trace-mcp:start -->';
@@ -159,7 +160,7 @@ function removeOrphanedEndMarkers(content: string): string {
       const startIdxes = [START_MARKER, LEGACY_START_MARKER]
         .map((m) => result.indexOf(m))
         .filter((idx) => idx !== -1);
-      const startIdx = startIdxes.length > 0 ? Math.min(...startIdxes) : -1;
+      const startIdx = startIdxes.length > 0 ? minMax(startIdxes).min : -1;
       const endIdx = result.indexOf(endMarker);
       if (endIdx !== -1 && (startIdx === -1 || endIdx < startIdx)) {
         result = result.slice(0, endIdx) + result.slice(endIdx + endMarker.length);

--- a/src/runtime/embedding-drift.ts
+++ b/src/runtime/embedding-drift.ts
@@ -19,6 +19,7 @@ import type { EmbeddingService } from '../ai/interfaces.js';
 import { ensureGlobalDirs, TRACE_MCP_HOME } from '../global.js';
 import { logger } from '../logger.js';
 import { atomicWriteJson } from '../utils/atomic-write.js';
+import { minMax } from '../util/minmax.js';
 
 export const CANARY_PATH = path.join(TRACE_MCP_HOME, 'embedding-canary.json');
 
@@ -135,7 +136,7 @@ export async function checkEmbeddingDrift(
     perString.push({ text: CANARY_STRINGS[i] ?? '', distance: cosineDistance(a, b) });
   }
   const distances = perString.map((p) => p.distance);
-  const max = Math.max(...distances);
+  const max = minMax(distances).max;
   const mean = distances.reduce((acc, d) => acc + d, 0) / (distances.length || 1);
   const drifted = max >= threshold;
 

--- a/src/subproject/subproject-search.ts
+++ b/src/subproject/subproject-search.ts
@@ -8,6 +8,7 @@ import Database from 'better-sqlite3';
 import { searchFts } from '../db/fts.js';
 import { logger } from '../logger.js';
 import type { TopologyStore } from '../topology/topology-db.js';
+import { minMax } from '../util/minmax.js';
 
 export interface SubprojectSearchItem {
   repo: string;
@@ -49,8 +50,8 @@ function searchRepoDb(
   });
   if (ftsResults.length === 0) return [];
 
-  const minRank = Math.min(...ftsResults.map((r) => r.rank));
-  const maxRank = Math.max(...ftsResults.map((r) => r.rank));
+  const minRank = minMax(ftsResults.map((r) => r.rank)).min;
+  const maxRank = minMax(ftsResults.map((r) => r.rank)).max;
   const rankSpread = maxRank - minRank || 1;
 
   const symbolIds = ftsResults.map((r) => r.symbolId);

--- a/src/tools/analysis/ast-clones.ts
+++ b/src/tools/analysis/ast-clones.ts
@@ -18,6 +18,7 @@ import type { Tree } from 'web-tree-sitter';
 import type { Store } from '../../db/store.js';
 import { ok, type TraceMcpResult } from '../../errors.js';
 import { getParser, type TSNode } from '../../parser/tree-sitter.js';
+import { minMax } from '../../util/minmax.js';
 
 /** Parsed tree-sitter syntax tree — owns a WASM heap that must be `delete()`d. */
 type TSTree = Tree;
@@ -364,7 +365,7 @@ export async function detectAstClones(
     // LOC sanity filter: a Type-2 clone group should have members of roughly
     // the same size. Drop any member whose LOC differs from the smallest by
     // more than 2x — they slipped in via a hash collision, not real cloning.
-    const minMemberLoc = Math.min(...members.map((m) => Math.max(1, m.loc)));
+    const minMemberLoc = minMax(members.map((m) => Math.max(1, m.loc))).min;
     const sized = members.filter((m) => Math.max(1, m.loc) <= minMemberLoc * 2);
     if (sized.length < 2) continue;
 
@@ -385,7 +386,7 @@ export async function detectAstClones(
     groups.push({
       hash,
       size: sized.length,
-      loc: Math.max(...sized.map((m) => m.loc)),
+      loc: minMax(sized.map((m) => m.loc)).max,
       symbols: sized.map((m) => ({
         symbol_id: m.symbol_id,
         name: m.name,

--- a/src/tools/analysis/communities.ts
+++ b/src/tools/analysis/communities.ts
@@ -10,6 +10,7 @@
 import type { Store } from '../../db/store.js';
 import { ok, type TraceMcpResult } from '../../errors.js';
 import { maybeYield } from '../../utils/event-loop.js';
+import { minMax } from '../../util/minmax.js';
 
 interface Community {
   id: number;
@@ -349,7 +350,7 @@ async function refineLowCohesionCommunities(
 
     // Vary the seed so we do not just reproduce the parent partition.
     const subAssignments = await leidenDetect(subGraph, resolution, 20, seed ^ commId ^ 0x9e3779b1);
-    const numSub = Math.max(...subAssignments) + 1;
+    const numSub = minMax(subAssignments).max + 1;
     if (numSub <= 1) continue; // nothing learned — keep original
 
     // First sub-cluster keeps the parent id, the rest get fresh ids beyond
@@ -400,7 +401,7 @@ export async function detectCommunities(
   // CLAUDE.md or barrel file could merge unrelated subsystems into one
   // useless community. Same bug pattern applies here.
   await refineLowCohesionCommunities(graph, assignments, resolution, seed);
-  const _numCommunities = Math.max(...assignments) + 1;
+  const _numCommunities = minMax(assignments).max + 1;
 
   // Group files by community
   const communityFiles = new Map<number, string[]>();

--- a/src/tools/analysis/complexity-trend.ts
+++ b/src/tools/analysis/complexity-trend.ts
@@ -11,6 +11,7 @@ import { logger } from '../../logger.js';
 import { isSafeGitRef, safeGitEnv } from '../../utils/git-env.js';
 import { isGitRepo } from '../git/git-analysis.js';
 import { computeCyclomatic, computeMaxNesting } from './complexity.js';
+import { minMax } from '../../util/minmax.js';
 
 // ════════════════════════════════════════════════════════════════════════
 // TYPES
@@ -152,7 +153,7 @@ function computeSnapshot(content: string, commitHash: string, date: string): Com
     maxNesting = Math.max(maxNesting, computeMaxNesting(block));
   }
 
-  const maxCc = Math.max(...complexities);
+  const maxCc = minMax(complexities).max;
   const avgCc =
     Math.round((complexities.reduce((a, b) => a + b, 0) / complexities.length) * 100) / 100;
 
@@ -193,12 +194,12 @@ export function getComplexityTrend(
 
   let currentSnapshot: ComplexitySnapshot;
   if (currentSymbols.length > 0) {
-    const maxCc = Math.max(...currentSymbols.map((s) => s.cyclomatic));
+    const maxCc = minMax(currentSymbols.map((s) => s.cyclomatic)).max;
     const avgCc =
       Math.round(
         (currentSymbols.reduce((sum, s) => sum + s.cyclomatic, 0) / currentSymbols.length) * 100,
       ) / 100;
-    const maxNest = Math.max(...currentSymbols.map((s) => s.max_nesting));
+    const maxNest = minMax(currentSymbols.map((s) => s.max_nesting)).max;
     currentSnapshot = {
       date: new Date().toISOString().split('T')[0],
       commit: 'HEAD',

--- a/src/tools/analysis/visualize-subproject.ts
+++ b/src/tools/analysis/visualize-subproject.ts
@@ -10,6 +10,7 @@ import path from 'node:path';
 import { err, ok, type TraceMcpResult, validationError } from '../../errors.js';
 import type { TopologyStore } from '../../topology/topology-db.js';
 import { writeTmpFileSync } from '../../utils/safe-fs.js';
+import { minMax } from '../../util/minmax.js';
 
 // ════════════════════════════════════════════════════════════════════════
 // TYPES
@@ -307,10 +308,10 @@ simulation.on('tick', () => {
     const el = d3.select(this);
     const xs = grp.nodes.map(n => n.x);
     const ys = grp.nodes.map(n => n.y);
-    const minX = Math.min(...xs) - PAD;
-    const minY = Math.min(...ys) - PAD - 16;
-    const maxX = Math.max(...xs) + PAD;
-    const maxY = Math.max(...ys) + PAD;
+    const minX = minMax(xs).min - PAD;
+    const minY = minMax(ys).min - PAD - 16;
+    const maxX = minMax(xs).max + PAD;
+    const maxY = minMax(ys).max + PAD;
     el.select('rect').attr('x', minX).attr('y', minY).attr('width', maxX - minX).attr('height', maxY - minY);
     el.select('text').attr('x', minX + 10).attr('y', minY + 14);
   });

--- a/src/tools/navigation/context.ts
+++ b/src/tools/navigation/context.ts
@@ -8,6 +8,7 @@ import { assembleContext, type ContextItem } from '../../scoring/assembly.js';
 import { computeRecency, getTypeBonus, hybridScore } from '../../scoring/hybrid.js';
 import { computePageRank } from '../../scoring/pagerank.js';
 import { readByteRange } from '../../utils/source-reader.js';
+import { minMax } from '../../util/minmax.js';
 
 interface FeatureContextResult {
   description: string;
@@ -205,11 +206,11 @@ export function getFeatureContext(
 
   // Build PageRank map
   const pagerankMap = computePageRank(store.db);
-  const maxPr = Math.max(...pagerankMap.values(), 0.001);
+  const maxPr = Math.max(minMax(pagerankMap.values()).max, 0.001);
 
   // Normalize FTS ranks
-  const minRank = Math.min(...ftsResults.map((r) => r.rank));
-  const maxRank = Math.max(...ftsResults.map((r) => r.rank));
+  const minRank = minMax(ftsResults.map((r) => r.rank)).min;
+  const maxRank = minMax(ftsResults.map((r) => r.rank)).max;
   const rankSpread = maxRank - minRank || 1;
 
   const now = new Date();

--- a/src/tools/navigation/navigation.ts
+++ b/src/tools/navigation/navigation.ts
@@ -30,6 +30,7 @@ import {
   signalFusion,
 } from '../../scoring/signal-fusion.js';
 import { readSymbolSource } from '../../utils/source-reader.js';
+import { minMax } from '../../util/minmax.js';
 
 // ─── get_symbol ─────────────────────────────────────────────
 
@@ -418,8 +419,8 @@ export async function search(
     const ftsResults = searchFts(store.db, query, fetchLimit, 0, ftsFilters);
     if (ftsResults.length === 0) return { items: [], total: 0, search_mode: 'fts' };
     // BM25 ranks are negative: lower = better match
-    const minRank = Math.min(...ftsResults.map((r) => r.rank));
-    const maxRank = Math.max(...ftsResults.map((r) => r.rank));
+    const minRank = minMax(ftsResults.map((r) => r.rank)).min;
+    const maxRank = minMax(ftsResults.map((r) => r.rank)).max;
     const rankSpread = maxRank - minRank || 1;
     candidates = ftsResults.map((r) => ({
       symbolIdStr: r.symbolIdStr,
@@ -430,7 +431,7 @@ export async function search(
 
   // Build PageRank map
   const pagerankMap = computePageRank(store.db);
-  const maxPr = Math.max(...pagerankMap.values(), 0.001);
+  const maxPr = Math.max(minMax(pagerankMap.values()).max, 0.001);
   const now = new Date();
   const scored: SearchResultItem[] = [];
 
@@ -743,7 +744,7 @@ async function runFusionSearch(
   }
 
   // Structural channel: sort all valid candidates by PageRank descending
-  const maxPr = Math.max(...pagerankMap.values(), 0.001);
+  const maxPr = Math.max(minMax(pagerankMap.values()).max, 0.001);
   const structuralItems = validCandidates
     .map((c) => ({
       id: c.id,

--- a/src/tools/navigation/task-context.ts
+++ b/src/tools/navigation/task-context.ts
@@ -18,6 +18,7 @@ import { computePageRank } from '../../scoring/pagerank.js';
 import { assembleStructuredContext } from '../../scoring/structured-assembly.js';
 import { readByteRange } from '../../utils/source-reader.js';
 import { tokenizeDescription } from './context.js';
+import { minMax } from '../../util/minmax.js';
 
 // ═══════════════════════════════════════════════════════════════════
 // TYPES
@@ -295,8 +296,8 @@ export async function getTaskContext(
     }
 
     // Normalize ranks to scores (0-1)
-    const minRank = Math.min(...ftsRows.map((r) => r.rank));
-    const maxRank = Math.max(...ftsRows.map((r) => r.rank));
+    const minRank = minMax(ftsRows.map((r) => r.rank)).min;
+    const maxRank = minMax(ftsRows.map((r) => r.rank)).max;
     const spread = maxRank - minRank || 1;
 
     seeds = ftsRows.slice(0, seedLimit).map((r) => ({

--- a/src/tools/quality/antipatterns.ts
+++ b/src/tools/quality/antipatterns.ts
@@ -14,6 +14,7 @@ import {
   classifyNumericConfidence,
   type Methodology,
 } from '../shared/confidence.js';
+import { minMax } from '../../util/minmax.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1365,8 +1366,8 @@ function maxIndentDepth(body: string): number {
     return n;
   });
 
-  const base = Math.min(...indents);
-  const maxIndent = Math.max(...indents);
+  const base = minMax(indents).min;
+  const maxIndent = minMax(indents).max;
   const depthLevels = Math.floor((maxIndent - base) / 2); // assume 2-space step minimum
   return depthLevels;
 }

--- a/src/util/minmax.ts
+++ b/src/util/minmax.ts
@@ -9,10 +9,13 @@
  * one — the small index takes the on-the-fly fallback and never reaches the
  * ranking code.
  *
- * Any array whose length is bounded by the index rather than by a `limit` has
- * to be reduced, not spread.
+ * Any collection whose length is bounded by the index rather than by a `limit`
+ * has to be reduced, not spread. `search()` and `get_feature_context` spread
+ * `pagerankMap.values()` — one entry per graph node — which is why this takes
+ * an `Iterable` and not just an array: reducing the iterator directly avoids
+ * materialising a second 150k-element copy just to measure it.
  */
-export function minMax(values: readonly number[]): { min: number; max: number } {
+export function minMax(values: Iterable<number>): { min: number; max: number } {
   let min = Number.POSITIVE_INFINITY;
   let max = Number.NEGATIVE_INFINITY;
   for (const v of values) {

--- a/tests/ci/no-spread-into-call.test.ts
+++ b/tests/ci/no-spread-into-call.test.ts
@@ -1,0 +1,45 @@
+/**
+ * The gate for the defect class in #957: `Math.min(...xs)` / `Math.max(...xs)`
+ * pass every element as a separate argument and throw `RangeError` once the
+ * collection passes V8's argument limit (~65k-125k, stack-dependent).
+ *
+ * `scale-rangeerror.test.ts` catches this behaviourally, but only on the code
+ * paths it happens to call. This catches it on every line of `src/`, including
+ * the ones no test reaches — which is where both of #957's instances lived.
+ *
+ * The rule is total on purpose: `minMax()` is a drop-in for every spread form,
+ * so there is no legitimate exception and therefore no allowlist to rot. A
+ * bounded array reduced instead of spread costs nothing.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const SPREAD_INTO_MATH = /Math\.(?:min|max)\(\s*\.\.\./;
+
+describe('no spread into Math.min/Math.max in src/', () => {
+  it('every min/max over a collection reduces instead of spreading', () => {
+    const files = (readdirSync('src', { recursive: true }) as string[])
+      .filter((f) => f.endsWith('.ts') && !f.includes('__tests__'))
+      .map((f) => `src/${f}`);
+    expect(files.length).toBeGreaterThan(100); // the glob itself must not silently match nothing
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        const code = line.trim();
+        if (code.startsWith('*') || code.startsWith('//')) return; // prose, incl. this rule's own docs
+        if (SPREAD_INTO_MATH.test(code)) offenders.push(`${file}:${i + 1}  ${code}`);
+      });
+    }
+
+    expect(
+      offenders,
+      `Spreading a collection into Math.min/Math.max throws RangeError past V8's\n` +
+        `argument limit (#957). Use minMax() from src/util/minmax.ts:\n\n` +
+        `  Math.max(...xs)        ->  minMax(xs).max\n` +
+        `  Math.max(...xs, 0.001) ->  Math.max(minMax(xs).max, 0.001)\n\n` +
+        offenders.join('\n'),
+    ).toEqual([]);
+  });
+});

--- a/tests/perf/large-index.ts
+++ b/tests/perf/large-index.ts
@@ -1,0 +1,153 @@
+/**
+ * Synthetic large-index fixture — generated, never vendored.
+ *
+ * Exists because a whole class of defect is invisible below a size threshold
+ * our corpora never reached. `Math.min(...xs)` / `arr.push(...xs)` throw
+ * `RangeError: Maximum call stack size exceeded` once the spread array passes
+ * V8's argument limit (~65k–125k, stack-dependent). Reported from the field as
+ * GitHub #957: every `search` against a 152 734-symbol index failed, while the
+ * same query on a ~100-file repo worked.
+ *
+ * Before this file the largest corpus CI ran was 50 000 symbols
+ * (`stress.test.ts`, 10 000 files x 5) — an order below the threshold, and it
+ * only exercised `searchFts` and store methods, never a tool. So the size the
+ * defect needs and the surface it lives on were both outside CI.
+ *
+ * `seedLargeIndex` is the same seeder `stress.test.ts` has always used, moved
+ * here and extended with symbol-level edges: PageRank only ranks nodes that
+ * appear in a resolved edge, so a file-only edge set caps `pagerankMap` at the
+ * file count and cannot reproduce the failure.
+ */
+import { createTestStore } from '../test-utils.js';
+
+const KINDS = [
+  'class',
+  'function',
+  'method',
+  'interface',
+  'variable',
+  'type',
+  'constant',
+  'property',
+] as const;
+const PREFIXES = [
+  'User',
+  'Auth',
+  'Payment',
+  'Order',
+  'Product',
+  'Cart',
+  'Invoice',
+  'Config',
+  'Logger',
+  'Metric',
+];
+const LANGS = ['typescript', 'python', 'go', 'rust', 'java', 'csharp', 'ruby', 'kotlin'];
+
+export interface SeedOptions {
+  workspaces?: string[];
+  crossWsEdges?: number;
+  /**
+   * Also chain every symbol node into the edge table. PageRank ranks only
+   * nodes reachable through a resolved edge, so this is what makes
+   * `pagerankMap` scale with the symbol count rather than the file count.
+   */
+  symbolEdges?: boolean;
+}
+
+export function seedLargeIndex(fileCount: number, symbolsPerFile: number, opts?: SeedOptions) {
+  const store = createTestStore();
+  const db = store.db;
+
+  const insertFile = db.prepare(
+    `INSERT INTO files (path, language, content_hash, byte_length, indexed_at, workspace)
+     VALUES (?, ?, ?, ?, datetime('now'), ?)`,
+  );
+  const insertSymbol = db.prepare(
+    `INSERT INTO symbols (file_id, symbol_id, name, kind, fqn, byte_start, byte_end, line_start, line_end, metadata)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  const insertNode = db.prepare(`INSERT OR IGNORE INTO nodes (node_type, ref_id) VALUES (?, ?)`);
+  const insertEdge = db.prepare(
+    `INSERT OR IGNORE INTO edges (source_node_id, target_node_id, edge_type_id, resolved, is_cross_ws)
+     VALUES (?, ?, ?, 1, ?)`,
+  );
+
+  const edgeType = db.prepare("SELECT id FROM edge_types WHERE name = 'imports'").get() as {
+    id: number;
+  };
+  const workspaces = opts?.workspaces ?? [null as any];
+  const fileIds: number[] = [];
+  const symbolNodeIds: number[] = [];
+
+  db.transaction(() => {
+    for (let i = 0; i < fileCount; i++) {
+      const ws = workspaces[i % workspaces.length];
+      const lang = LANGS[i % LANGS.length]!;
+      const filePath = ws
+        ? `packages/${ws}/src/module${Math.floor(i / 10)}/file${i}.ts`
+        : `src/modules/module${Math.floor(i / 10)}/file${i}.ts`;
+
+      const result = insertFile.run(filePath, lang, `hash_${i}`, 500 + (i % 5000), ws ?? null);
+      const fileId = Number(result.lastInsertRowid);
+      insertNode.run('file', fileId);
+      fileIds.push(fileId);
+
+      for (let j = 0; j < symbolsPerFile; j++) {
+        const prefix = PREFIXES[j % PREFIXES.length]!;
+        const kind = KINDS[j % KINDS.length]!;
+        const name = `${prefix}${kind.charAt(0).toUpperCase() + kind.slice(1)}${i}_${j}`;
+        const symbolId = `${filePath}::${name}#${kind}`;
+        const fqn = ws
+          ? `${ws}.module${Math.floor(i / 10)}.${name}`
+          : `module${Math.floor(i / 10)}.${name}`;
+        const meta = j % 3 === 0 ? JSON.stringify({ exported: 1 }) : null;
+
+        const symResult = insertSymbol.run(
+          fileId,
+          symbolId,
+          name,
+          kind,
+          fqn,
+          j * 100,
+          (j + 1) * 100,
+          j * 5 + 1,
+          (j + 1) * 5,
+          meta,
+        );
+        const nodeResult = insertNode.run('symbol', Number(symResult.lastInsertRowid));
+        if (opts?.symbolEdges) symbolNodeIds.push(Number(nodeResult.lastInsertRowid));
+      }
+    }
+
+    // Add import edges between consecutive files
+    for (let i = 0; i < fileIds.length - 1; i++) {
+      const srcNode = store.getNodeId('file', fileIds[i]!);
+      const tgtNode = store.getNodeId('file', fileIds[i + 1]!);
+      if (srcNode && tgtNode) {
+        const isCrossWs =
+          workspaces.length > 1 && i % workspaces.length === workspaces.length - 1 ? 1 : 0;
+        insertEdge.run(srcNode, tgtNode, edgeType.id, isCrossWs);
+      }
+    }
+
+    // Chain the symbol nodes so PageRank has to rank all of them.
+    for (let i = 0; i < symbolNodeIds.length - 1; i++) {
+      insertEdge.run(symbolNodeIds[i]!, symbolNodeIds[i + 1]!, edgeType.id, 0);
+    }
+
+    // Additional cross-workspace edges
+    if (opts?.crossWsEdges) {
+      const step = Math.max(1, Math.floor(fileIds.length / opts.crossWsEdges));
+      for (let i = 0; i < opts.crossWsEdges && i * step + step < fileIds.length; i++) {
+        const srcNode = store.getNodeId('file', fileIds[i * step]!);
+        const tgtNode = store.getNodeId('file', fileIds[i * step + step]!);
+        if (srcNode && tgtNode) {
+          insertEdge.run(srcNode, tgtNode, edgeType.id, 1);
+        }
+      }
+    }
+  })();
+
+  return { db, store };
+}

--- a/tests/perf/scale-rangeerror.test.ts
+++ b/tests/perf/scale-rangeerror.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Above V8's argument limit — the size band where a whole defect class lives.
+ *
+ * GitHub #957: `search` returned the bare string "Maximum call stack size
+ * exceeded" for every query against a 152 734-symbol index, deterministically,
+ * while `search_text` on the same index worked and the same query on a
+ * ~100-file repo worked. Cause: `Math.min(...xs)` passes every element as a
+ * separate argument, and V8 throws `RangeError` past ~65k-125k of them.
+ *
+ * The unit test in `src/util/__tests__/minmax.test.ts` covers the helper. This
+ * file covers the class: real tool entry points, against an index big enough
+ * for the ceiling to be reachable. Nothing smaller can catch the next one,
+ * because the next one will also be a different array in a different function.
+ *
+ * Sized at 150 000 symbols to sit above the *upper* end of the V8 range rather
+ * than the lower one — a fixture at 70k passes on a machine with a deeper
+ * stack and gives a green CI for a crash the user still gets.
+ */
+import { describe, expect, it } from 'vitest';
+import { getFeatureContext } from '../../src/tools/navigation/context.js';
+import { search } from '../../src/tools/navigation/navigation.js';
+import { runFlatSearch } from '../../src/tools/navigation/search-dispatcher.js';
+import { seedLargeIndex } from './large-index.js';
+
+const FILES = 15_000;
+const SYMBOLS_PER_FILE = 10; // 150 000 symbols, 165 000 graph nodes
+
+describe('tools above V8 argument limit (#957)', () => {
+  const { store } = seedLargeIndex(FILES, SYMBOLS_PER_FILE, { symbolEdges: true });
+
+  it('builds an index past the threshold the defect class needs', () => {
+    const symbols = store.db.prepare('SELECT COUNT(*) c FROM symbols').get() as { c: number };
+    expect(symbols.c).toBe(FILES * SYMBOLS_PER_FILE);
+    // The guard on the guard: if a future refactor shrinks this fixture back
+    // under the ceiling, every assertion below passes for the wrong reason.
+    expect(symbols.c).toBeGreaterThan(125_000);
+  });
+
+  it('search() ranks a 150k-symbol index without spreading it into a call', async () => {
+    const result = await search(store, 'module0', undefined, 20, 0);
+    expect(result.items.length).toBeGreaterThan(0);
+  });
+
+  it('runFlatSearch() survives the same index', async () => {
+    const result = await runFlatSearch(store, 'module0', {}, 20, 0);
+    expect(result.items.length).toBeGreaterThan(0);
+  });
+
+  it('get_feature_context survives the same index', () => {
+    const result = getFeatureContext(store, '/repo', 'module0 user authentication', 4000);
+    expect(result).toBeDefined();
+  });
+});

--- a/tests/perf/stress.test.ts
+++ b/tests/perf/stress.test.ts
@@ -1,128 +1,13 @@
 /**
  * Stress tests — verify the system handles large codebases without
  * exploding in memory or time. These use in-memory SQLite.
+ *
+ * The seeder lives in `large-index.ts`; `scale-rangeerror.test.ts` uses the
+ * same one at the size where V8's argument limit starts to bite.
  */
 import { describe, expect, it } from 'vitest';
 import { searchFts } from '../../src/db/fts.js';
-import { createTestStore } from '../test-utils.js';
-
-const KINDS = [
-  'class',
-  'function',
-  'method',
-  'interface',
-  'variable',
-  'type',
-  'constant',
-  'property',
-] as const;
-const PREFIXES = [
-  'User',
-  'Auth',
-  'Payment',
-  'Order',
-  'Product',
-  'Cart',
-  'Invoice',
-  'Config',
-  'Logger',
-  'Metric',
-];
-const LANGS = ['typescript', 'python', 'go', 'rust', 'java', 'csharp', 'ruby', 'kotlin'];
-
-function seedDatabase(
-  fileCount: number,
-  symbolsPerFile: number,
-  opts?: { workspaces?: string[]; crossWsEdges?: number },
-) {
-  const store = createTestStore();
-  const db = store.db;
-
-  const insertFile = db.prepare(
-    `INSERT INTO files (path, language, content_hash, byte_length, indexed_at, workspace)
-     VALUES (?, ?, ?, ?, datetime('now'), ?)`,
-  );
-  const insertSymbol = db.prepare(
-    `INSERT INTO symbols (file_id, symbol_id, name, kind, fqn, byte_start, byte_end, line_start, line_end, metadata)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  );
-  const insertNode = db.prepare(`INSERT OR IGNORE INTO nodes (node_type, ref_id) VALUES (?, ?)`);
-  const insertEdge = db.prepare(
-    `INSERT OR IGNORE INTO edges (source_node_id, target_node_id, edge_type_id, resolved, is_cross_ws)
-     VALUES (?, ?, ?, 1, ?)`,
-  );
-
-  const edgeType = db.prepare("SELECT id FROM edge_types WHERE name = 'imports'").get() as {
-    id: number;
-  };
-  const workspaces = opts?.workspaces ?? [null as any];
-  const fileIds: number[] = [];
-
-  db.transaction(() => {
-    for (let i = 0; i < fileCount; i++) {
-      const ws = workspaces[i % workspaces.length];
-      const lang = LANGS[i % LANGS.length]!;
-      const filePath = ws
-        ? `packages/${ws}/src/module${Math.floor(i / 10)}/file${i}.ts`
-        : `src/modules/module${Math.floor(i / 10)}/file${i}.ts`;
-
-      const result = insertFile.run(filePath, lang, `hash_${i}`, 500 + (i % 5000), ws ?? null);
-      const fileId = Number(result.lastInsertRowid);
-      insertNode.run('file', fileId);
-      fileIds.push(fileId);
-
-      for (let j = 0; j < symbolsPerFile; j++) {
-        const prefix = PREFIXES[j % PREFIXES.length]!;
-        const kind = KINDS[j % KINDS.length]!;
-        const name = `${prefix}${kind.charAt(0).toUpperCase() + kind.slice(1)}${i}_${j}`;
-        const symbolId = `${filePath}::${name}#${kind}`;
-        const fqn = ws
-          ? `${ws}.module${Math.floor(i / 10)}.${name}`
-          : `module${Math.floor(i / 10)}.${name}`;
-        const meta = j % 3 === 0 ? JSON.stringify({ exported: 1 }) : null;
-
-        const symResult = insertSymbol.run(
-          fileId,
-          symbolId,
-          name,
-          kind,
-          fqn,
-          j * 100,
-          (j + 1) * 100,
-          j * 5 + 1,
-          (j + 1) * 5,
-          meta,
-        );
-        insertNode.run('symbol', Number(symResult.lastInsertRowid));
-      }
-    }
-
-    // Add import edges between consecutive files
-    for (let i = 0; i < fileIds.length - 1; i++) {
-      const srcNode = store.getNodeId('file', fileIds[i]!);
-      const tgtNode = store.getNodeId('file', fileIds[i + 1]!);
-      if (srcNode && tgtNode) {
-        const isCrossWs =
-          workspaces.length > 1 && i % workspaces.length === workspaces.length - 1 ? 1 : 0;
-        insertEdge.run(srcNode, tgtNode, edgeType.id, isCrossWs);
-      }
-    }
-
-    // Additional cross-workspace edges
-    if (opts?.crossWsEdges) {
-      const step = Math.max(1, Math.floor(fileIds.length / opts.crossWsEdges));
-      for (let i = 0; i < opts.crossWsEdges && i * step + step < fileIds.length; i++) {
-        const srcNode = store.getNodeId('file', fileIds[i * step]!);
-        const tgtNode = store.getNodeId('file', fileIds[i * step + step]!);
-        if (srcNode && tgtNode) {
-          insertEdge.run(srcNode, tgtNode, edgeType.id, 1);
-        }
-      }
-    }
-  })();
-
-  return { db, store };
-}
+import { seedLargeIndex as seedDatabase } from './large-index.js';
 
 describe('Stress: 10K files', () => {
   it('seeds and queries 10,000 files with ~50K symbols', () => {


### PR DESCRIPTION
Closes TRA-977. Builds on #976 (contains its commit; will be a clean diff once that merges).

## What this is

#976 fixed two `Math.min(...)` call sites. This covers the **class**: a defect that only exists above ~65k elements, against a corpus that never reached it.

## The number the issue asked for

Largest corpus CI ran: **50 000 symbols** (`tests/perf/stress.test.ts`, 10 000 files × 5) — an order below V8's argument limit, and it only exercised `searchFts` and store methods, never a tool handler.

## The audit turned the diagnosis around

`searchFts` applies `LIMIT ?` **in SQL**. Every `ftsResults` array is therefore bounded by the caller's `limit` (~70–120 rows) and cannot reach 65k. Those spreads were never the crash.

The array that scales with the index is `pagerankMap` — one entry per graph node — spread as `Math.max(...pagerankMap.values(), 0.001)` in three places (`search()`, the fusion path, `get_feature_context`). **All three still threw on a 150k index after #976's fix.** The new test reproduces each by name:

```
RangeError: Maximum call stack size exceeded
 ❯ search src/tools/navigation/navigation.ts:433:22
 ❯ getFeatureContext src/tools/navigation/context.ts:208:22
```

`task-context.ts` had already been written as a manual loop — the one correct precedent in the tree.

## What landed

| | |
|---|---|
| `tests/perf/large-index.ts` | The `stress.test.ts` seeder, extracted, plus symbol-level edges. Generated, never vendored. PageRank ranks only nodes in a resolved edge, so a file-only edge set caps `pagerankMap` at the file count and cannot reproduce the failure at all. |
| `tests/perf/scale-rangeerror.test.ts` | 150 000 symbols / 165 000 nodes, real tool entry points, **~4 s**. Sized above the *upper* end of the V8 range — a 70k fixture passes on a deeper stack and greens a crash the user still gets. |
| `tests/ci/no-spread-into-call.test.ts` | Total ban on `Math.min/max(...)` in `src/**`, **no allowlist** — `minMax()` is a drop-in for every form, so there is no legitimate exception and nothing to maintain. Verified to fail on reintroduction. |
| 26 call sites | Converted to `minMax()`. `minMax` widened to `Iterable<number>` so `pagerankMap.values()` reduces without materialising a second 150k copy. |
| `ops/index-scale-testing.md` | The threshold, the audit, and what is deliberately **not** gated. |

## Deliberately not gated

`arr.push(...xs)` throws the same `RangeError`, ~40 sites, most bounded. The safe rewrite is not a drop-in, and a rule with 35 exemptions is an allowlist wearing a rule's clothes. The scale test covers the paths it exercises; recorded as standing risk. Revisit on a field report, not on a guess.

## Test evidence

`pnpm test` — 925 files / 10 248 passed. One unrelated pre-existing flake (`tests/ai/onnx.test.ts`, cold model import under full-suite contention; passes in isolation). `pnpm typecheck` clean, `biome check` clean.

Original report and repro: @msalem89 in #957. Cause and the first fix: Nikolai, in that thread.