### PR TITLE
perf(daemon): serve first requests from the index snapshot before daemon handshake (TRA-948)

### DIFF
--- a/src/daemon/router/__tests__/snapshot-backend.test.ts
+++ b/src/daemon/router/__tests__/snapshot-backend.test.ts
@@ -1,0 +1,105 @@
+/**
+ * TRA-948: SnapshotBackend opens the daemon's canonical index DB directly,
+ * readonly, with no seed copy — unlike LocalBackend, which derives an owned
+ * session temp DB it deletes on stop(). These tests guard the property that
+ * makes the fast path safe: the shared file is never mutated or deleted.
+ */
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TraceMcpConfigSchema } from '../../../config.js';
+import { initializeDatabase } from '../../../db/schema.js';
+import { SnapshotBackend } from '../snapshot-backend.js';
+
+let tmpDir: string;
+let dbPath: string;
+let backend: SnapshotBackend | null = null;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'trace-mcp-snapshot-backend-'));
+  dbPath = join(tmpDir, 'shared.db');
+  // Pre-create the index DB the way the daemon would — the backend must
+  // never run DDL/migrations on it itself.
+  initializeDatabase(dbPath).close();
+});
+
+afterEach(async () => {
+  await backend?.stop();
+  backend = null;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Drives one request/response round trip over the backend's in-memory transport. */
+function sendAndWait(b: SnapshotBackend, msg: JSONRPCMessage): Promise<Record<string, unknown>> {
+  return new Promise((resolve) => {
+    b.onmessage = (m) => resolve(m as unknown as Record<string, unknown>);
+    void b.send(msg);
+  });
+}
+
+describe('SnapshotBackend (TRA-948)', () => {
+  it('answers initialize and get_project_map from the snapshot without mutating it', async () => {
+    backend = new SnapshotBackend({
+      projectRoot: tmpDir,
+      config: TraceMcpConfigSchema.parse({}),
+      sharedDbPath: dbPath,
+    });
+    await backend.start();
+
+    const init = await sendAndWait(backend, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test', version: '0' },
+      },
+    } as unknown as JSONRPCMessage);
+    expect(init.error).toBeUndefined();
+    expect((init.result as { serverInfo?: { name?: string } })?.serverInfo?.name).toBe('trace');
+
+    const call = await sendAndWait(backend, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'get_project_map', arguments: {} },
+    } as unknown as JSONRPCMessage);
+    expect(call.error).toBeUndefined();
+    expect(call.result).toBeTruthy();
+  });
+
+  it('rejects start() when the shared DB does not exist (safe-fallback contract)', async () => {
+    backend = new SnapshotBackend({
+      projectRoot: tmpDir,
+      config: TraceMcpConfigSchema.parse({}),
+      sharedDbPath: join(tmpDir, 'never-created.db'),
+    });
+    await expect(backend.start()).rejects.toThrow();
+  });
+
+  it('leaves the shared DB file on disk and reusable after stop() — never deletes or locks it', async () => {
+    backend = new SnapshotBackend({
+      projectRoot: tmpDir,
+      config: TraceMcpConfigSchema.parse({}),
+      sharedDbPath: dbPath,
+    });
+    await backend.start();
+    await backend.stop();
+    backend = null;
+
+    expect(existsSync(dbPath)).toBe(true);
+
+    // A second backend can still open the same file — proves the first
+    // instance's readonly connection didn't leave it locked or corrupted.
+    const second = new SnapshotBackend({
+      projectRoot: tmpDir,
+      config: TraceMcpConfigSchema.parse({}),
+      sharedDbPath: dbPath,
+    });
+    await expect(second.start()).resolves.toBeUndefined();
+    await second.stop();
+  });
+});

--- a/src/daemon/router/session.ts
+++ b/src/daemon/router/session.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
 import type { Readable, Writable } from 'node:stream';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
@@ -19,6 +20,7 @@ import {
 import { LocalBackend } from './local-backend.js';
 import { MessageRouter } from './message-router.js';
 import { ProxyBackend } from './proxy-backend.js';
+import { SnapshotBackend } from './snapshot-backend.js';
 import type { Backend } from './types.js';
 
 declare const PKG_VERSION_INJECTED: string;
@@ -119,7 +121,7 @@ export class StdioSession {
   private shuttingDown = false;
   private bootstrapped = false;
   /** Tracks the mode we *intend* to have — may differ briefly from router.getActiveKind() during swap. */
-  private desiredMode: 'proxy' | 'local' | 'dormant' = 'dormant';
+  private desiredMode: 'proxy' | 'local' | 'snapshot' | 'dormant' = 'dormant';
   /** Guards against concurrent wakeUp() calls when multiple stdin messages arrive in the dormant window. */
   private wakePromise: Promise<void> | null = null;
   /**
@@ -208,39 +210,119 @@ export class StdioSession {
       logger.warn({ err: String(err) }, 'StdioSession: stdio transport error');
     };
 
+    // Instant path (TRA-948): if the daemon has already indexed this project,
+    // its snapshot is sitting on disk — serve the client's first requests
+    // from it directly instead of blocking stdio on the daemon /health check,
+    // HTTP session registration, and SSE handshake (measured 2.7-3.6s cold,
+    // TRA-931). The real backend is negotiated off the critical path below
+    // and takes over via MessageRouter.swap() the moment it's ready.
+    const snapshot = this.buildSnapshotBackend();
+    if (snapshot) {
+      try {
+        await snapshot.start();
+        this.router.setInitialBackend(snapshot);
+        this.desiredMode = 'snapshot';
+        await this.finishBootstrap();
+        void this.settleRealBackend();
+        return;
+      } catch (err) {
+        logger.warn(
+          { err: String(err) },
+          'StdioSession: snapshot backend failed to start, falling back to full bootstrap',
+        );
+        try {
+          await snapshot.stop();
+        } catch {
+          /* best-effort */
+        }
+      }
+    }
+
+    const { backend: initialBackend, daemonActive } = await this.selectAndStartBackend();
+    this.router.setInitialBackend(initialBackend);
+    this.desiredMode = initialBackend.kind;
+    this.watcher.onStableChange((nowActive) => {
+      void this.onDaemonStateChange(nowActive);
+    });
+    this.resetIdleTimer();
+    await this.finishBootstrap();
+
+    // Now that the client can be answered, try to bring a daemon up. Success
+    // is picked up by the watcher, which swaps this session onto a proxy
+    // backend; failure just leaves us in local mode.
+    if (!daemonActive && this.opts.autoSpawnDaemon !== false) {
+      void this.backgroundAutoSpawn();
+    }
+  }
+
+  /**
+   * Poll the daemon and start whichever backend its state implies. This is
+   * the slow path: `watcher.start()` blocks on a real `/health` round trip,
+   * and a proxy backend blocks on HTTP session registration + SSE handshake.
+   */
+  private async selectAndStartBackend(): Promise<{ backend: Backend; daemonActive: boolean }> {
     await this.watcher.start();
     const daemonActive = this.watcher.getCurrentState();
 
     // Pick a backend from the daemon state we already know. Spawning a daemon
     // is an optimization and must never gate the handshake (TRA-704) — it runs
-    // in the background below, and the watcher swaps us onto it when it lands.
-    let initialBackend: Backend = daemonActive
-      ? this.buildProxyBackend()
-      : this.buildLocalBackend();
+    // in the background, and the watcher swaps us onto it when it lands.
+    let backend: Backend = daemonActive ? this.buildProxyBackend() : this.buildLocalBackend();
     try {
-      await initialBackend.start();
+      await backend.start();
     } catch (err) {
-      if (initialBackend.kind === 'local') throw err;
+      if (backend.kind === 'local') throw err;
       // Daemon answered /health but wouldn't take the session — serve this
       // session in-process rather than failing the whole connection.
       logger.warn(
         { err: String(err) },
         'StdioSession: proxy backend failed to start, falling back to local mode',
       );
-      initialBackend = this.buildLocalBackend();
-      await initialBackend.start();
+      backend = this.buildLocalBackend();
+      await backend.start();
     }
-    this.router.setInitialBackend(initialBackend);
-    this.desiredMode = initialBackend.kind;
+    return { backend, daemonActive };
+  }
 
-    // Subscribe to stable daemon state changes.
+  /**
+   * Runs after the snapshot backend has already answered the client's first
+   * requests and stdio is live: negotiate the real backend the same way the
+   * no-snapshot path does, then hand off via `swapTo()` — which drains
+   * in-flight requests, replays the cached `initialize` into the new backend
+   * (seeded via `cachedInitialize`, see buildProxyBackend), and stops (closes)
+   * the snapshot's readonly connection. Mirrors onDaemonStateChange: the
+   * candidate backend is handed to `swapTo` *unstarted* — `router.swap()`
+   * starts it — instead of pre-starting it here and starting it again.
+   */
+  private async settleRealBackend(): Promise<void> {
+    await this.watcher.start();
+    const daemonActive = this.watcher.getCurrentState();
+    await this.swapTo(
+      daemonActive ? this.buildProxyBackend() : this.buildLocalBackend(),
+      'snapshot-settled',
+    );
+    // Daemon answered /health but wouldn't take the session — swapTo() already
+    // logged and cleaned up the failed attempt; retry once in-process rather
+    // than leaving the session stuck on the read-only snapshot forever.
+    if (daemonActive && this.router.getActiveKind() !== 'proxy') {
+      await this.swapTo(this.buildLocalBackend(), 'snapshot-settled-fallback');
+    }
     this.watcher.onStableChange((nowActive) => {
       void this.onDaemonStateChange(nowActive);
     });
-
-    // Install idle timer (non-lethal).
     this.resetIdleTimer();
+    if (!daemonActive && this.opts.autoSpawnDaemon !== false) {
+      void this.backgroundAutoSpawn();
+    }
+  }
 
+  /**
+   * Everything after a backend is active: release the early-init stdout
+   * guard, start the stdio transport, the version-drift probe, the handshake
+   * watchdog, and the bootstrap log line. Runs exactly once per session,
+   * regardless of which path picked the first backend.
+   */
+  private async finishBootstrap(): Promise<void> {
     // Release the early-init stdout guard now that the MCP transport owns
     // the stream. Anything that writes to stdout from this point on is
     // expected to be a JSON-RPC frame.
@@ -282,13 +364,6 @@ export class StdioSession {
       },
       'StdioSession bootstrapped',
     );
-
-    // Now that the client can be answered, try to bring a daemon up. Success
-    // is picked up by the watcher, which swaps this session onto a proxy
-    // backend; failure just leaves us in local mode.
-    if (!daemonActive && this.opts.autoSpawnDaemon !== false) {
-      void this.backgroundAutoSpawn();
-    }
   }
 
   /**
@@ -549,6 +624,16 @@ export class StdioSession {
     return new LocalBackend({
       projectRoot: this.opts.projectRoot,
       indexRoot: this.opts.indexRoot,
+      config: this.opts.config,
+      sharedDbPath: this.opts.sharedDbPath,
+    });
+  }
+
+  /** Null when there's nothing on disk yet to read instantly (safe fallback, TRA-948). */
+  private buildSnapshotBackend(): SnapshotBackend | null {
+    if (!fs.existsSync(this.opts.sharedDbPath)) return null;
+    return new SnapshotBackend({
+      projectRoot: this.opts.projectRoot,
       config: this.opts.config,
       sharedDbPath: this.opts.sharedDbPath,
     });

--- a/src/daemon/router/snapshot-backend.ts
+++ b/src/daemon/router/snapshot-backend.ts
@@ -1,0 +1,155 @@
+import fs from 'node:fs';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import Database from 'better-sqlite3';
+import type { TraceMcpConfig } from '../../config.js';
+import { Store } from '../../db/store.js';
+import { DECISIONS_DB_PATH, TOPOLOGY_DB_PATH } from '../../global.js';
+import { logger } from '../../logger.js';
+import { DecisionStore } from '../../memory/decision-store.js';
+import { PluginRegistry } from '../../plugin-api/registry.js';
+import { ProgressState } from '../../progress.js';
+import { createServer, type ServerHandle } from '../../server/server.js';
+import type { ProjectRelay } from '../../server/types.js';
+import { TopologyStore } from '../../topology/topology-db.js';
+import { createLightweightProjectRelay } from '../project-relay.js';
+import type { Backend } from './types.js';
+
+export interface SnapshotBackendOptions {
+  projectRoot: string;
+  config: TraceMcpConfig;
+  /** The daemon's canonical index DB — opened directly, readonly, never copied. */
+  sharedDbPath: string;
+}
+
+/**
+ * Instant, read-only view of the daemon's on-disk index (TRA-948). StdioSession
+ * uses this to answer a client's first requests — `initialize`, `get_project_map`,
+ * `get_outline`, `search` — without waiting on the daemon's /health check, HTTP
+ * session registration, and SSE handshake (measured 2.7-3.6s cold, TRA-931).
+ * That negotiation runs in parallel and the session swaps onto its result via
+ * MessageRouter.swap() the moment it's ready.
+ *
+ * Opens `sharedDbPath` directly with no seed copy and no schema/migration pass
+ * (unlike LocalBackend's owned session DB) — this file belongs to the daemon,
+ * so start() is dominated by SQLite's open cost, not a page-by-page backup.
+ */
+export class SnapshotBackend implements Backend {
+  readonly kind = 'snapshot' as const;
+
+  onmessage?: (msg: JSONRPCMessage) => void;
+  onerror?: (err: Error) => void;
+
+  private readonly opts: SnapshotBackendOptions;
+  private db: Database.Database | null = null;
+  private handle: ServerHandle | null = null;
+  private clientTransport: InMemoryTransport | null = null;
+  private topoStore: TopologyStore | null = null;
+  private decisionStore: DecisionStore | null = null;
+  private readonly projectRelay: ProjectRelay = createLightweightProjectRelay();
+
+  constructor(opts: SnapshotBackendOptions) {
+    this.opts = opts;
+  }
+
+  /** Cheap pre-check so a caller can skip building this backend entirely. */
+  static canOpen(sharedDbPath: string): boolean {
+    return fs.existsSync(sharedDbPath);
+  }
+
+  async start(): Promise<void> {
+    const { sharedDbPath, projectRoot, config } = this.opts;
+    // Readonly, no DDL/migrations — the daemon owns this file's schema.
+    this.db = new Database(sharedDbPath, { readonly: true, fileMustExist: true });
+    const store = new Store(this.db);
+    const registry = PluginRegistry.createWithDefaults();
+    const progress = new ProgressState(this.db);
+
+    // Readonly shared stores — mirrors LocalBackend's read-only fallback wiring.
+    try {
+      if (config.topology?.enabled && fs.existsSync(TOPOLOGY_DB_PATH)) {
+        this.topoStore = new TopologyStore(TOPOLOGY_DB_PATH, { readonly: true });
+      }
+    } catch {
+      /* noop */
+    }
+    try {
+      if (fs.existsSync(DECISIONS_DB_PATH)) {
+        this.decisionStore = new DecisionStore(DECISIONS_DB_PATH, { readonly: true });
+      }
+    } catch {
+      /* noop */
+    }
+
+    this.handle = createServer(store, registry, config, projectRoot, progress, {
+      topoStore: this.topoStore,
+      decisionStore: this.decisionStore,
+      projectRelay: this.projectRelay,
+      // The real backend (proxy or local) reports this session's usage a
+      // moment later — counting this transient snapshot too would double
+      // every session that has one (TRA-951 precedent).
+      skipUsagePing: true,
+    });
+
+    const [client, server] = InMemoryTransport.createLinkedPair();
+    this.clientTransport = client;
+    client.onmessage = (msg) => {
+      this.onmessage?.(msg);
+    };
+    client.onerror = (err) => {
+      logger.warn({ err: String(err) }, 'SnapshotBackend: in-memory client error');
+      this.onerror?.(err instanceof Error ? err : new Error(String(err)));
+    };
+
+    await this.handle.server.connect(server);
+    await client.start();
+
+    logger.info({ sharedDbPath, projectRoot }, 'SnapshotBackend started');
+  }
+
+  async stop(): Promise<void> {
+    if (this.clientTransport) this.clientTransport.onmessage = undefined;
+    try {
+      await this.clientTransport?.close();
+    } catch {
+      /* best-effort */
+    }
+    this.clientTransport = null;
+    try {
+      this.projectRelay.dispose();
+    } catch {
+      /* best-effort */
+    }
+    try {
+      this.handle?.dispose();
+    } catch {
+      /* best-effort */
+    }
+    this.handle = null;
+    try {
+      this.topoStore?.close();
+    } catch {
+      /* best-effort */
+    }
+    this.topoStore = null;
+    try {
+      this.decisionStore?.close();
+    } catch {
+      /* best-effort */
+    }
+    this.decisionStore = null;
+    // Readonly connection onto a file we don't own — closing it never
+    // touches the file on disk, unlike LocalBackend's owned session DB.
+    try {
+      this.db?.close();
+    } catch {
+      /* best-effort */
+    }
+    this.db = null;
+  }
+
+  async send(msg: JSONRPCMessage): Promise<void> {
+    if (!this.clientTransport) throw new Error('SnapshotBackend not started');
+    await this.clientTransport.send(msg);
+  }
+}

--- a/src/daemon/router/types.ts
+++ b/src/daemon/router/types.ts
@@ -2,9 +2,11 @@ import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 
 /**
  * A backend is what processes MCP messages behind the MessageRouter.
- * Two implementations:
+ * Three implementations:
  *   - ProxyBackend: forwards to a running daemon via HTTP/SSE
  *   - LocalBackend: runs a full in-process McpServer + indexer
+ *   - SnapshotBackend: instant read-only view of the daemon's on-disk index,
+ *     used only until one of the above is ready (TRA-948)
  *
  * Router owns a single StdioServerTransport and swaps backends beneath it
  * so the MCP client never sees a disconnect.
@@ -28,7 +30,7 @@ export interface Backend {
   backgroundDispose?: Promise<void>;
 }
 
-export type BackendKind = 'proxy' | 'local';
+export type BackendKind = 'proxy' | 'local' | 'snapshot';
 
 export type Mode = 'proxy' | 'local' | 'idle' | 'transitioning';
 

--- a/tests/daemon/session-snapshot-fast-path.test.ts
+++ b/tests/daemon/session-snapshot-fast-path.test.ts
@@ -1,0 +1,221 @@
+import net from 'node:net';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * TRA-948: when the daemon has already indexed this project, its snapshot
+ * sits on disk. StdioSession must answer the client's first requests from it
+ * directly instead of blocking stdio on the daemon's /health check — here
+ * simulated by a daemon that accepts the TCP connection and never answers,
+ * the same worst case TRA-704's tests use, which costs 500ms today via the
+ * `/health` fetch's own AbortSignal.timeout(500). The real backend (unreachable
+ * daemon, so LocalBackend — mocked here, matching the TRA-704 test style) is
+ * negotiated in the background and swapped in afterwards.
+ */
+
+/** Stands in for the real indexer-backed local backend the swap settles onto. */
+const localBackendStarts = vi.fn();
+vi.mock('../../src/daemon/router/local-backend.js', () => ({
+  LocalBackend: class {
+    readonly kind = 'local' as const;
+    onmessage?: (msg: JSONRPCMessage) => void;
+    async start(): Promise<void> {
+      localBackendStarts();
+    }
+    async stop(): Promise<void> {}
+    async send(msg: JSONRPCMessage): Promise<void> {
+      const id = (msg as { id?: string | number }).id;
+      if (id === undefined) return;
+      this.onmessage?.({
+        jsonrpc: '2.0',
+        id,
+        result: { protocolVersion: '2024-11-05', capabilities: {}, serverInfo: { name: 'x' } },
+      } as unknown as JSONRPCMessage);
+    }
+  },
+}));
+
+const { TraceMcpConfigSchema } = await import('../../src/config.js');
+const { initializeDatabase } = await import('../../src/db/schema.js');
+const { StdioSession } = await import('../../src/daemon/router/session.js');
+
+/** A socket that accepts and never replies — worst case for a /health probe. */
+async function startBlackHoleServer(): Promise<{ port: number; close: () => Promise<void> }> {
+  const sockets = new Set<net.Socket>();
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as net.AddressInfo).port;
+  return {
+    port,
+    close: () =>
+      new Promise<void>((resolve) => {
+        for (const socket of sockets) socket.destroy();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+let tmpDir: string;
+let dbPath: string;
+let blackHole: { port: number; close: () => Promise<void> };
+let session: InstanceType<typeof StdioSession> | null = null;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'trace-mcp-snapshot-session-'));
+  dbPath = join(tmpDir, 'shared.db');
+  // Pre-create the index DB the way the daemon would (TRA-948 requirement 1:
+  // StdioSession must find it already sitting on disk at boot).
+  initializeDatabase(dbPath).close();
+  blackHole = await startBlackHoleServer();
+});
+
+afterEach(async () => {
+  await session?.shutdown('test');
+  session = null;
+  await blackHole.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+describe('StdioSession snapshot fast path (TRA-948)', () => {
+  it('answers initialize and a read tool call from the snapshot before the daemon /health timeout elapses, then hands off to the real backend', async () => {
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    session = new StdioSession({
+      projectRoot: tmpDir,
+      indexRoot: tmpDir,
+      config: TraceMcpConfigSchema.parse({}),
+      sharedDbPath: dbPath,
+      daemonPort: blackHole.port,
+      idleTimeoutMs: 0,
+      daemonStabilityMs: 60_000,
+      autoSpawnDaemon: false,
+      handshakeTimeoutMs: 0,
+      stdin,
+      stdout,
+    });
+
+    const frames: Array<Record<string, unknown>> = [];
+    stdout.on('data', (chunk: Buffer) => {
+      for (const line of chunk.toString('utf8').split('\n')) {
+        if (line.trim()) frames.push(JSON.parse(line));
+      }
+    });
+    const waitForId = (id: number): Promise<Record<string, unknown>> =>
+      new Promise((resolve) => {
+        const existing = frames.find((f) => f.id === id && (f.result || f.error));
+        if (existing) {
+          resolve(existing);
+          return;
+        }
+        const t = setInterval(() => {
+          const f = frames.find((fr) => fr.id === id && (fr.result || fr.error));
+          if (f) {
+            clearInterval(t);
+            resolve(f);
+          }
+        }, 5);
+      });
+
+    const started = Date.now();
+    await session.bootstrap();
+
+    const initializeParams = {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test-client', version: '0.0.0' },
+    };
+    stdin.write(
+      `${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: initializeParams })}\n`,
+    );
+    stdin.write(
+      `${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'get_project_map', arguments: {} },
+      })}\n`,
+    );
+
+    const initResponse = await Promise.race([
+      waitForId(1),
+      new Promise<never>((_, reject) => {
+        const t = setTimeout(() => reject(new Error('no initialize response within 400ms')), 400);
+        t.unref?.();
+      }),
+    ]);
+    const initMs = Date.now() - started;
+
+    // The daemon's /health fetch alone is bounded to 500ms
+    // (getDaemonHealth's AbortSignal.timeout) before the *old* flow could
+    // even pick a backend — the snapshot must beat that comfortably.
+    expect(initMs).toBeLessThan(400);
+    expect(initResponse.error).toBeUndefined();
+    expect((initResponse.result as { serverInfo?: { name?: string } })?.serverInfo?.name).toBe(
+      'trace',
+    );
+
+    const mapResponse = await waitForId(2);
+    expect(mapResponse.error).toBeUndefined();
+    expect(mapResponse.result).toBeTruthy();
+
+    // Let the background daemon negotiation finish and swap onto the (mocked)
+    // real backend — proves the handover in settleRealBackend() actually runs.
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(resolve, 700);
+      t.unref?.();
+    });
+    expect(localBackendStarts).toHaveBeenCalledTimes(1);
+
+    // Exactly one response per id — no late duplicate from the snapshot
+    // racing the real backend during handover.
+    expect(frames.filter((f) => f.id === 1 && (f.result || f.error))).toHaveLength(1);
+    expect(frames.filter((f) => f.id === 2 && (f.result || f.error))).toHaveLength(1);
+  });
+
+  it('leaves the shared DB file untouched after the session shuts down', async () => {
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    session = new StdioSession({
+      projectRoot: tmpDir,
+      indexRoot: tmpDir,
+      config: TraceMcpConfigSchema.parse({}),
+      sharedDbPath: dbPath,
+      daemonPort: blackHole.port,
+      idleTimeoutMs: 0,
+      daemonStabilityMs: 60_000,
+      autoSpawnDaemon: false,
+      handshakeTimeoutMs: 0,
+      stdin,
+      stdout,
+    });
+    await session.bootstrap();
+    stdin.write(
+      `${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '0.0.0' },
+        },
+      })}\n`,
+    );
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(resolve, 700);
+      t.unref?.();
+    });
+    await session.shutdown('test');
+    session = null;
+
+    expect(existsSync(dbPath)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `SnapshotBackend`: opens the daemon's canonical index DB (`sharedDbPath`) directly — readonly, no seed copy, no DDL/migrations — and serves a full MCP surface from it.
- `StdioSession.bootstrap()` now uses it as the initial backend whenever that DB file already exists on disk, so `stdio.start()` (and thus `initialize` / first tool calls) no longer waits on `watcher.start()`'s daemon `/health` check or `ProxyBackend.start()`'s HTTP registration + SSE handshake (measured 2.7–3.6s cold, TRA-931).
- The real backend (proxy or local) is negotiated off the critical path in the new `settleRealBackend()` and handed off via the existing `MessageRouter.swap()` — draining in-flight requests, replaying the cached `initialize` into the new backend, and closing the snapshot's readonly connection. Candidate backends are passed to `swapTo()` unstarted (matching the existing `onDaemonStateChange`/`fallbackToLocal` convention), so `router.swap()` is the only thing that starts them.
- No shared DB yet (fresh project, never indexed) → `buildSnapshotBackend()` returns `null` and `bootstrap()` falls through to the exact pre-existing flow, unchanged.

## Test plan
- New: `src/daemon/router/__tests__/snapshot-backend.test.ts` — `SnapshotBackend` answers `initialize`/`tools/call get_project_map` from a prebuilt DB; rejects `start()` when the file doesn't exist; never mutates or locks the shared file (`stop()` leaves it openable by a second instance).
- New: `tests/daemon/session-snapshot-fast-path.test.ts` — full `StdioSession` bootstrap against a real snapshot DB and a black-hole "daemon" (accepts TCP, never answers — the same worst case TRA-704's tests use): `initialize` + a `get_project_map` tool call both answer in well under the daemon's 500ms `/health` timeout, then the session hands off to the (mocked) real backend exactly once; the shared DB file survives session shutdown.
- Existing `tests/daemon/session-cold-start-handshake.test.ts` (TRA-704, uses a nonexistent `sharedDbPath`) passes unchanged — confirms the no-snapshot fallback path is behavior-preserving.
- `pnpm run build`, `pnpm run lint` (`tsc --noEmit`), `pnpm run format:check` (biome) all clean.
- `pnpm run test` (full suite): 928 test files / 10,256 tests passed, 24 skipped (pre-existing), exit 0.