### PR TITLE
perf(graph): stop the per-file symbol N+1 in the daemon's graph build (TRA-651)

### DIFF
--- a/docs/perf/daemon-serving-memory.md
+++ b/docs/perf/daemon-serving-memory.md
@@ -1,0 +1,130 @@
+---
+layout: default
+title: Daemon memory while serving one project
+permalink: /perf/daemon-serving-memory/
+description: Internal working document. What the trace-mcp daemon's resident memory does while a client drives it.
+noindex: true
+---
+
+# Daemon memory while serving one project
+
+TRA-651. Measured 2026-09-06 on darwin 25.5.0 / arm64, daemon v3.18.0 at `3e749a02`,
+throwaway `TRACE_MCP_DATA_DIR`, private port, **one** registered project: this repo at the
+pinned perf-fixture commit `fc47c10f44eb` — 1 817 files / 9 705 symbols. Reproduce with
+
+```
+pnpm run build
+node scripts/perf/daemon-serving-rss.mjs --drive-seconds 120 --idle-seconds 120
+node scripts/perf/daemon-query-alloc.mjs --calls 200
+```
+
+Raw runs: `docs/perf/tra651-before.json`, `docs/perf/tra651-after.json`.
+
+## The reported number does not survive a settled measurement
+
+TRA-651 filed "727 MB RSS **idle** while serving a single project". Sampling the same
+fixture on the same harness, at one-second resolution and with `heapUsed` alongside RSS:
+
+| Daemon state | RSS | `heapUsed` |
+|---|---|---|
+| Fresh, nothing registered | 166 MB | — |
+| First seconds after the index finishes | 700–720 MB | 200 MB |
+| **Median over the next 60 s, untouched** | **399 MB** | **91 MB** |
+| Median while a client drives it | 856 MB | ~300 MB |
+| Peak while driven | 894 MB | 428 MB |
+| 20 s after the client stops | 416 MB | 88 MB |
+
+727 MB is a real reading, but it is a reading taken inside the post-index window, not an
+idle steady state. The settled idle figure is ~400 MB of RSS over 91 MB of live heap, and
+it is reached about twenty seconds after the last request. Everything above that line is
+garbage V8 has not collected yet plus pages the process has not handed back — in one run
+RSS fell from 419 MB to 85 MB at t=80 s with `heapUsed` unchanged at 88 MB, which is the
+macOS page-retention effect TRA-278 documented and not a change in what is live.
+
+So there is no per-project leak to find here. What is real is the cost of *serving*: the
+daemon transiently doubles, and it does so on the same thread that answers `/health`.
+
+## Where the serving cost comes from
+
+`scripts/perf/daemon-query-alloc.mjs` drives one endpoint at a time, 200 calls each:
+
+| Endpoint | ms/call | response | RSS growth over 200 calls |
+|---|---|---|---|
+| `/api/projects/graph` | **544** | **1 268 KB** | +99 MB |
+| `/api/projects/smells` | **426** | 118 KB | **+293 MB** |
+| `/api/projects/graph-stats` | 8.5 | 2.2 KB | +1 MB |
+| `/api/projects/files` | 3.2 | 2.1 KB | +4 MB |
+| `/api/projects/stats` | 0.8 | 0.1 KB | ~0 |
+| `/health` | 0.14 | 0.2 KB | 0 |
+
+`/api/projects/graph` rebuilds the whole project graph from SQLite on every request — the
+app refetches it on any scope/granularity/filter change, and the result for identical
+parameters is byte-identical every time. 544 ms of that is synchronous `better-sqlite3`
+work on the process that also serves `/health`, which is the starvation shape from
+TRA-941.
+
+Profiling `buildGraphData` directly (12 consecutive whole-project builds,
+`node --cpu-prof`) put the time in two places, both of them work that did not need to
+happen:
+
+1. **`getSymbolsByFileIds` was a per-file loop** — 424 ms of self time. Despite the plural
+   name it called the single-file statement once per file, so 1 507 statements to fetch
+   9 705 symbol rows, `SELECT *` each, for a file-level graph that reads nothing but `id`
+   and `file_id`. Every signature and metadata blob in the project was loaded and dropped.
+2. **`getEdgesForNodesBatch` copied every row and re-parsed its SQL per chunk** — 442 ms
+   self time plus 136 ms in `prepare`. `{ ...row, pivot_node_id }` allocated a second
+   object for every edge in the project on every build, and each of the ~22 chunks
+   prepared the same statement text again.
+
+## What changed
+
+- `getSymbolsByFileIds` is one chunked `IN` query per 900 files (`symbol-repository.ts`).
+- New `getSymbolFileRefsByFileIds` selects only `(id, file_id)`; the file-level graph path
+  in `visualize.ts` uses it.
+- `getEdgesForNodesBatch` annotates `pivot_node_id` on the row instead of spreading into a
+  copy, and caches the chunk statement by placeholder count (`graph-repository.ts`).
+
+Nothing was cached at the response level and no result was memoized — this is the same
+answer computed with fewer round trips and fewer allocations.
+
+### Before → after
+
+Whole-project `buildGraphData`, in-process, 12 consecutive builds, output byte-identical
+(1 507 nodes / 5 070 edges / 922 738 bytes in both):
+
+| | before | after |
+|---|---|---|
+| Median build | 152 ms | **85 ms** (−44%) |
+| Top profile frame | `getSymbolsByFileIds` 424 ms | `getEdgesForNodesBatch` 290 ms |
+| `prepare` | 136 ms | 36 ms |
+| GC | 264 ms | 67 ms |
+| RSS after 12 builds | 415 MB | **307 MB** |
+
+End-to-end on the daemon, 120 s of the app's query mix against the fixture:
+
+| | before | after |
+|---|---|---|
+| Queries served in 120 s | 1 492 | **2 150** (+44%) |
+| Idle RSS after index (60 s median) | 399 MB | 404 MB |
+| Idle `heapUsed` after index | 91 MB | 91 MB |
+| Serving median RSS | 856 MB | 841 MB |
+| Serving peak RSS | 894 MB | 865 MB |
+
+**Resident memory while serving barely moved.** That is the honest result: 44% more work
+per second for the same footprint, because the daemon's RSS under load is set by GC pacing
+against a large young generation, not by how much each request allocates. The reason to
+take the change is the latency and the throughput; the RSS number is unchanged and should
+not be quoted as a memory win.
+
+## Still open
+
+- **`/api/projects/smells` at 426 ms and +293 MB per 200 calls** is the larger remaining
+  allocator on the read path and was not touched here.
+- **Seven handlers in `src/cli.ts` open `new TopologyStore(TOPOLOGY_DB_PATH)` per request**
+  (lines 1548, 1621, 2032, 2096, 2140, 2186) while `ProjectResourcePool` exists to hold
+  exactly one daemon-wide instance (TRA-938). Measured at 0.42 ms per open/close, so this
+  is an fd-churn concern rather than a latency one — but it is the same file-descriptor
+  exhaustion shape TRA-938 fixed elsewhere.
+- **The regression guard is a query count, not a timing.** `tests/perf/graph-build-query-count.test.ts`
+  asserts a whole-project graph build issues fewer statements than it has files. It fails
+  on the pre-fix code (128 queries for 120 files) and is machine-independent.

--- a/docs/perf/tra651-after.json
+++ b/docs/perf/tra651-after.json
@@ -1,0 +1,2018 @@
+{
+  "tra": "TRA-651",
+  "at": "2026-09-06T00:34:26.106Z",
+  "version": "3.18.0",
+  "commit": "3e749a02",
+  "fixture": {
+    "root": "/Users/nikolai/.trace-mcp/perf-fixture/fc47c10f44eb",
+    "files": 1817,
+    "symbols": 9705,
+    "index_seconds": 4.2
+  },
+  "registered": [
+    {
+      "root": "/Users/nikolai/.trace-mcp/perf-fixture/fc47c10f44eb",
+      "status": "ready"
+    }
+  ],
+  "searches": 2150,
+  "baseline_rss_mb": 167,
+  "idle_after_index_mb": 404,
+  "idle_after_index_heap_mb": 91,
+  "serving_median_mb": 841,
+  "serving_peak_mb": 865,
+  "serving_peak_heap_mb": 420,
+  "idle_after_drive_mb": 86,
+  "idle_after_drive_heap_mb": 89,
+  "idle_after_drive_min_mb": 81,
+  "procs_peak": 1,
+  "procs_idle_end": 1,
+  "debug_memory_at_peak": {
+    "process": {
+      "rss": 891895808,
+      "heapUsed": 287862432,
+      "heapTotal": 323534848,
+      "external": 37764315,
+      "arrayBuffers": 381857
+    },
+    "uptime_seconds": 185.872788375,
+    "caches": {
+      "clients": 0,
+      "sseConnections": 0,
+      "rateBuckets": 0,
+      "lastProgressEmittedAt": 1,
+      "progressUnsubscribers": 1,
+      "projectSessions": 0,
+      "sessionTransports": 0,
+      "sessionHandles": 0,
+      "sessionClients": 0,
+      "registered_projects": 1,
+      "recent_reindex_total_entries": 0,
+      "project_stats_cache_entries": 0
+    }
+  },
+  "debug_memory_after_idle": {
+    "process": {
+      "rss": 104562688,
+      "heapUsed": 93190800,
+      "heapTotal": 97501184,
+      "external": 37764315,
+      "arrayBuffers": 381857
+    },
+    "uptime_seconds": 309.300807666,
+    "caches": {
+      "clients": 0,
+      "sseConnections": 0,
+      "rateBuckets": 0,
+      "lastProgressEmittedAt": 1,
+      "progressUnsubscribers": 1,
+      "projectSessions": 0,
+      "sessionTransports": 0,
+      "sessionHandles": 0,
+      "sessionClients": 0,
+      "registered_projects": 1,
+      "recent_reindex_total_entries": 0,
+      "project_stats_cache_entries": 0
+    }
+  },
+  "series": {
+    "idleA": [
+      {
+        "t": 0,
+        "rss_mb": 712,
+        "heap_mb": 201,
+        "cpu_pct": 104.5,
+        "procs": 1
+      },
+      {
+        "t": 1,
+        "rss_mb": 712,
+        "heap_mb": 201,
+        "cpu_pct": 1.6,
+        "procs": 1
+      },
+      {
+        "t": 2,
+        "rss_mb": 712,
+        "heap_mb": 201,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 3,
+        "rss_mb": 712,
+        "heap_mb": 201,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 4,
+        "rss_mb": 628,
+        "heap_mb": 201,
+        "cpu_pct": 3.9,
+        "procs": 1
+      },
+      {
+        "t": 5,
+        "rss_mb": 575,
+        "heap_mb": 90,
+        "cpu_pct": 0.6,
+        "procs": 1
+      },
+      {
+        "t": 6,
+        "rss_mb": 576,
+        "heap_mb": 90,
+        "cpu_pct": 0.1,
+        "procs": 1
+      },
+      {
+        "t": 7,
+        "rss_mb": 576,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 8,
+        "rss_mb": 533,
+        "heap_mb": 90,
+        "cpu_pct": 2.2,
+        "procs": 1
+      },
+      {
+        "t": 9,
+        "rss_mb": 533,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 10,
+        "rss_mb": 533,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 11,
+        "rss_mb": 533,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 12,
+        "rss_mb": 533,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 13,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 11.8,
+        "procs": 1
+      },
+      {
+        "t": 14,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 15,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 16,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 17,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 18,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 19,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 20,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 21,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 22,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 23,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 24,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 25,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 26,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 27,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 28,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 29,
+        "rss_mb": 404,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 30,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 31,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 32,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 33,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 34,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 35,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 36,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 37,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 38,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 39,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 40,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 41,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 42,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 43,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 44,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 45,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 46,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 47,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 48,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 49,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 50,
+        "rss_mb": 404,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 51,
+        "rss_mb": 405,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 52,
+        "rss_mb": 405,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 53,
+        "rss_mb": 405,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 54,
+        "rss_mb": 405,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 55,
+        "rss_mb": 405,
+        "heap_mb": 91,
+        "cpu_pct": 0.1,
+        "procs": 1
+      },
+      {
+        "t": 56,
+        "rss_mb": 405,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 57,
+        "rss_mb": 405,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 58,
+        "rss_mb": 405,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 59,
+        "rss_mb": 405,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      }
+    ],
+    "drive": [
+      {
+        "rss_mb": 481,
+        "heap_mb": 130,
+        "cpu_pct": 40.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 745,
+        "heap_mb": 387,
+        "cpu_pct": 114.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 771,
+        "heap_mb": 415,
+        "cpu_pct": 107.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 847,
+        "heap_mb": 314,
+        "cpu_pct": 106.5,
+        "procs": 1
+      },
+      {
+        "rss_mb": 851,
+        "heap_mb": 333,
+        "cpu_pct": 106.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 853,
+        "heap_mb": 379,
+        "cpu_pct": 105.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 846,
+        "heap_mb": 315,
+        "cpu_pct": 107.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 851,
+        "heap_mb": 347,
+        "cpu_pct": 106.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 844,
+        "heap_mb": 293,
+        "cpu_pct": 113.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 844,
+        "heap_mb": 277,
+        "cpu_pct": 109.5,
+        "procs": 1
+      },
+      {
+        "rss_mb": 839,
+        "heap_mb": 231,
+        "cpu_pct": 115.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 844,
+        "heap_mb": 276,
+        "cpu_pct": 114.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 842,
+        "heap_mb": 259,
+        "cpu_pct": 111.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 845,
+        "heap_mb": 310,
+        "cpu_pct": 108.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 836,
+        "heap_mb": 190,
+        "cpu_pct": 108.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 835,
+        "heap_mb": 192,
+        "cpu_pct": 118.5,
+        "procs": 1
+      },
+      {
+        "rss_mb": 833,
+        "heap_mb": 164,
+        "cpu_pct": 116.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 839,
+        "heap_mb": 221,
+        "cpu_pct": 115,
+        "procs": 1
+      },
+      {
+        "rss_mb": 841,
+        "heap_mb": 232,
+        "cpu_pct": 113.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 843,
+        "heap_mb": 278,
+        "cpu_pct": 112.5,
+        "procs": 1
+      },
+      {
+        "rss_mb": 845,
+        "heap_mb": 285,
+        "cpu_pct": 110.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 857,
+        "heap_mb": 88,
+        "cpu_pct": 109.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 834,
+        "heap_mb": 161,
+        "cpu_pct": 116.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 838,
+        "heap_mb": 228,
+        "cpu_pct": 103.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 842,
+        "heap_mb": 255,
+        "cpu_pct": 111.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 850,
+        "heap_mb": 325,
+        "cpu_pct": 110.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 826,
+        "heap_mb": 93,
+        "cpu_pct": 111.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 833,
+        "heap_mb": 164,
+        "cpu_pct": 124,
+        "procs": 1
+      },
+      {
+        "rss_mb": 833,
+        "heap_mb": 159,
+        "cpu_pct": 121.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 838,
+        "heap_mb": 221,
+        "cpu_pct": 117,
+        "procs": 1
+      },
+      {
+        "rss_mb": 841,
+        "heap_mb": 233,
+        "cpu_pct": 114.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 844,
+        "heap_mb": 281,
+        "cpu_pct": 111.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 846,
+        "heap_mb": 288,
+        "cpu_pct": 111.2,
+        "procs": 1
+      },
+      {
+        "rss_mb": 844,
+        "heap_mb": 261,
+        "cpu_pct": 113,
+        "procs": 1
+      },
+      {
+        "rss_mb": 846,
+        "heap_mb": 311,
+        "cpu_pct": 110.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 847,
+        "heap_mb": 306,
+        "cpu_pct": 110.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 845,
+        "heap_mb": 284,
+        "cpu_pct": 109,
+        "procs": 1
+      },
+      {
+        "rss_mb": 849,
+        "heap_mb": 318,
+        "cpu_pct": 109.5,
+        "procs": 1
+      },
+      {
+        "rss_mb": 853,
+        "heap_mb": 380,
+        "cpu_pct": 107.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 852,
+        "heap_mb": 88,
+        "cpu_pct": 108.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 834,
+        "heap_mb": 161,
+        "cpu_pct": 120.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 838,
+        "heap_mb": 220,
+        "cpu_pct": 113.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 829,
+        "heap_mb": 132,
+        "cpu_pct": 115.2,
+        "procs": 1
+      },
+      {
+        "rss_mb": 841,
+        "heap_mb": 249,
+        "cpu_pct": 111.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 835,
+        "heap_mb": 196,
+        "cpu_pct": 115.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 841,
+        "heap_mb": 246,
+        "cpu_pct": 113.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 841,
+        "heap_mb": 250,
+        "cpu_pct": 113.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 839,
+        "heap_mb": 250,
+        "cpu_pct": 114,
+        "procs": 1
+      },
+      {
+        "rss_mb": 848,
+        "heap_mb": 324,
+        "cpu_pct": 110.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 848,
+        "heap_mb": 314,
+        "cpu_pct": 108.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 857,
+        "heap_mb": 88,
+        "cpu_pct": 110.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 833,
+        "heap_mb": 160,
+        "cpu_pct": 119.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 831,
+        "heap_mb": 130,
+        "cpu_pct": 116.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 836,
+        "heap_mb": 191,
+        "cpu_pct": 114.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 838,
+        "heap_mb": 204,
+        "cpu_pct": 118.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 841,
+        "heap_mb": 250,
+        "cpu_pct": 114.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 839,
+        "heap_mb": 250,
+        "cpu_pct": 113.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 848,
+        "heap_mb": 313,
+        "cpu_pct": 109.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 857,
+        "heap_mb": 88,
+        "cpu_pct": 107.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 834,
+        "heap_mb": 161,
+        "cpu_pct": 118.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 838,
+        "heap_mb": 219,
+        "cpu_pct": 112.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 830,
+        "heap_mb": 135,
+        "cpu_pct": 112.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 857,
+        "heap_mb": 408,
+        "cpu_pct": 106.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 829,
+        "heap_mb": 132,
+        "cpu_pct": 120.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 828,
+        "heap_mb": 133,
+        "cpu_pct": 120.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 836,
+        "heap_mb": 192,
+        "cpu_pct": 121.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 838,
+        "heap_mb": 204,
+        "cpu_pct": 117.5,
+        "procs": 1
+      },
+      {
+        "rss_mb": 841,
+        "heap_mb": 250,
+        "cpu_pct": 112.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 844,
+        "heap_mb": 260,
+        "cpu_pct": 112.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 848,
+        "heap_mb": 313,
+        "cpu_pct": 108.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 827,
+        "heap_mb": 112,
+        "cpu_pct": 110.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 832,
+        "heap_mb": 169,
+        "cpu_pct": 117.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 837,
+        "heap_mb": 213,
+        "cpu_pct": 116,
+        "procs": 1
+      },
+      {
+        "rss_mb": 838,
+        "heap_mb": 220,
+        "cpu_pct": 117.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 836,
+        "heap_mb": 199,
+        "cpu_pct": 117.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 839,
+        "heap_mb": 234,
+        "cpu_pct": 112.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 844,
+        "heap_mb": 281,
+        "cpu_pct": 111,
+        "procs": 1
+      },
+      {
+        "rss_mb": 847,
+        "heap_mb": 289,
+        "cpu_pct": 109.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 851,
+        "heap_mb": 356,
+        "cpu_pct": 109.5,
+        "procs": 1
+      },
+      {
+        "rss_mb": 854,
+        "heap_mb": 364,
+        "cpu_pct": 107.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 850,
+        "heap_mb": 338,
+        "cpu_pct": 109,
+        "procs": 1
+      },
+      {
+        "rss_mb": 854,
+        "heap_mb": 88,
+        "cpu_pct": 108,
+        "procs": 1
+      },
+      {
+        "rss_mb": 835,
+        "heap_mb": 160,
+        "cpu_pct": 125,
+        "procs": 1
+      },
+      {
+        "rss_mb": 836,
+        "heap_mb": 192,
+        "cpu_pct": 124.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 831,
+        "heap_mb": 145,
+        "cpu_pct": 122.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 855,
+        "heap_mb": 379,
+        "cpu_pct": 79.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 840,
+        "heap_mb": 222,
+        "cpu_pct": 87.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 834,
+        "heap_mb": 120,
+        "cpu_pct": 65.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 848,
+        "heap_mb": 252,
+        "cpu_pct": 37,
+        "procs": 1
+      },
+      {
+        "rss_mb": 864,
+        "heap_mb": 88,
+        "cpu_pct": 45.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 845,
+        "heap_mb": 228,
+        "cpu_pct": 39.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 855,
+        "heap_mb": 313,
+        "cpu_pct": 33.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 832,
+        "heap_mb": 113,
+        "cpu_pct": 40.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 838,
+        "heap_mb": 171,
+        "cpu_pct": 25.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 848,
+        "heap_mb": 273,
+        "cpu_pct": 27.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 855,
+        "heap_mb": 359,
+        "cpu_pct": 35.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 833,
+        "heap_mb": 119,
+        "cpu_pct": 43,
+        "procs": 1
+      },
+      {
+        "rss_mb": 845,
+        "heap_mb": 231,
+        "cpu_pct": 49.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 865,
+        "heap_mb": 420,
+        "cpu_pct": 84.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 852,
+        "heap_mb": 285,
+        "cpu_pct": 107.5,
+        "procs": 1
+      },
+      {
+        "rss_mb": 845,
+        "heap_mb": 226,
+        "cpu_pct": 111.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 851,
+        "heap_mb": 274,
+        "cpu_pct": 115.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 851,
+        "heap_mb": 293,
+        "cpu_pct": 110.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 851,
+        "heap_mb": 261,
+        "cpu_pct": 113.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 849,
+        "heap_mb": 253,
+        "cpu_pct": 110.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 842,
+        "heap_mb": 203,
+        "cpu_pct": 114.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 839,
+        "heap_mb": 175,
+        "cpu_pct": 120.2,
+        "procs": 1
+      },
+      {
+        "rss_mb": 835,
+        "heap_mb": 118,
+        "cpu_pct": 126.2,
+        "procs": 1
+      },
+      {
+        "rss_mb": 833,
+        "heap_mb": 102,
+        "cpu_pct": 109.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 837,
+        "heap_mb": 147,
+        "cpu_pct": 125.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 831,
+        "heap_mb": 107,
+        "cpu_pct": 110.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 832,
+        "heap_mb": 107,
+        "cpu_pct": 107.7,
+        "procs": 1
+      }
+    ],
+    "idleB": [
+      {
+        "t": 0,
+        "rss_mb": 851,
+        "heap_mb": 275,
+        "cpu_pct": 109.9,
+        "procs": 1
+      },
+      {
+        "t": 1,
+        "rss_mb": 851,
+        "heap_mb": 275,
+        "cpu_pct": 2.2,
+        "procs": 1
+      },
+      {
+        "t": 2,
+        "rss_mb": 851,
+        "heap_mb": 275,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 3,
+        "rss_mb": 851,
+        "heap_mb": 275,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 4,
+        "rss_mb": 851,
+        "heap_mb": 275,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 5,
+        "rss_mb": 851,
+        "heap_mb": 275,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 6,
+        "rss_mb": 851,
+        "heap_mb": 275,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 7,
+        "rss_mb": 851,
+        "heap_mb": 275,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 8,
+        "rss_mb": 851,
+        "heap_mb": 275,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 9,
+        "rss_mb": 851,
+        "heap_mb": 275,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 10,
+        "rss_mb": 851,
+        "heap_mb": 275,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 11,
+        "rss_mb": 419,
+        "heap_mb": 275,
+        "cpu_pct": 17.1,
+        "procs": 1
+      },
+      {
+        "t": 12,
+        "rss_mb": 419,
+        "heap_mb": 275,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 13,
+        "rss_mb": 419,
+        "heap_mb": 275,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 14,
+        "rss_mb": 419,
+        "heap_mb": 275,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 15,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 16,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0.1,
+        "procs": 1
+      },
+      {
+        "t": 17,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 18,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 19,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 20,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 21,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 22,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 23,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 24,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 25,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 26,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 27,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 28,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 29,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 30,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 31,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 32,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 33,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 34,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 35,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 36,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 37,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 38,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 39,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 40,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 41,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 42,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 43,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 44,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 45,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 46,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 47,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 48,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 49,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 50,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 51,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 52,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 53,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 54,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 55,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 56,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 57,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 58,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 59,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 60,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 61,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 62,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 63,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 64,
+        "rss_mb": 419,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 65,
+        "rss_mb": 398,
+        "heap_mb": 89,
+        "cpu_pct": 0.1,
+        "procs": 1
+      },
+      {
+        "t": 66,
+        "rss_mb": 289,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 67,
+        "rss_mb": 289,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 68,
+        "rss_mb": 290,
+        "heap_mb": 89,
+        "cpu_pct": 0.1,
+        "procs": 1
+      },
+      {
+        "t": 69,
+        "rss_mb": 290,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 70,
+        "rss_mb": 290,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 71,
+        "rss_mb": 290,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 72,
+        "rss_mb": 290,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 73,
+        "rss_mb": 290,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 74,
+        "rss_mb": 83,
+        "heap_mb": 89,
+        "cpu_pct": 0.2,
+        "procs": 1
+      },
+      {
+        "t": 75,
+        "rss_mb": 81,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 76,
+        "rss_mb": 85,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 77,
+        "rss_mb": 85,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 78,
+        "rss_mb": 85,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 79,
+        "rss_mb": 85,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 80,
+        "rss_mb": 85,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 81,
+        "rss_mb": 85,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 82,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 83,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 84,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 85,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 86,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 87,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 88,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 89,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 90,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 91,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 92,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 93,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 94,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 95,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 96,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 97,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 98,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 99,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 100,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 101,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 102,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 103,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 104,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 105,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 106,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 107,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 108,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 109,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 110,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 111,
+        "rss_mb": 86,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 112,
+        "rss_mb": 91,
+        "heap_mb": 89,
+        "cpu_pct": 0.2,
+        "procs": 1
+      },
+      {
+        "t": 113,
+        "rss_mb": 91,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 114,
+        "rss_mb": 91,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 115,
+        "rss_mb": 100,
+        "heap_mb": 89,
+        "cpu_pct": 0.1,
+        "procs": 1
+      },
+      {
+        "t": 116,
+        "rss_mb": 100,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 117,
+        "rss_mb": 100,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 118,
+        "rss_mb": 100,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 119,
+        "rss_mb": 100,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      }
+    ]
+  }
+}

--- a/docs/perf/tra651-before.json
+++ b/docs/perf/tra651-before.json
@@ -1,0 +1,2006 @@
+{
+  "tra": "TRA-651",
+  "at": "2026-09-06T00:29:02.264Z",
+  "version": "3.18.0",
+  "commit": "3e749a02",
+  "fixture": {
+    "root": "/Users/nikolai/.trace-mcp/perf-fixture/fc47c10f44eb",
+    "files": 1817,
+    "symbols": 9705,
+    "index_seconds": 4.1
+  },
+  "registered": [
+    {
+      "root": "/Users/nikolai/.trace-mcp/perf-fixture/fc47c10f44eb",
+      "status": "ready"
+    }
+  ],
+  "searches": 1492,
+  "baseline_rss_mb": 166,
+  "idle_after_index_mb": 399,
+  "idle_after_index_heap_mb": 91,
+  "serving_median_mb": 856,
+  "serving_peak_mb": 894,
+  "serving_peak_heap_mb": 428,
+  "idle_after_drive_mb": 416,
+  "idle_after_drive_heap_mb": 89,
+  "idle_after_drive_min_mb": 309,
+  "procs_peak": 1,
+  "procs_idle_end": 1,
+  "debug_memory_at_peak": {
+    "process": {
+      "rss": 909803520,
+      "heapUsed": 430773368,
+      "heapTotal": 474251264,
+      "external": 37772507,
+      "arrayBuffers": 390049
+    },
+    "uptime_seconds": 186.27999375,
+    "caches": {
+      "clients": 0,
+      "sseConnections": 0,
+      "rateBuckets": 0,
+      "lastProgressEmittedAt": 1,
+      "progressUnsubscribers": 1,
+      "projectSessions": 0,
+      "sessionTransports": 0,
+      "sessionHandles": 0,
+      "sessionClients": 0,
+      "registered_projects": 1,
+      "recent_reindex_total_entries": 0,
+      "project_stats_cache_entries": 0
+    }
+  },
+  "debug_memory_after_idle": {
+    "process": {
+      "rss": 323567616,
+      "heapUsed": 93163648,
+      "heapTotal": 97239040,
+      "external": 37764315,
+      "arrayBuffers": 381857
+    },
+    "uptime_seconds": 308.682045459,
+    "caches": {
+      "clients": 0,
+      "sseConnections": 0,
+      "rateBuckets": 0,
+      "lastProgressEmittedAt": 1,
+      "progressUnsubscribers": 1,
+      "projectSessions": 0,
+      "sessionTransports": 0,
+      "sessionHandles": 0,
+      "sessionClients": 0,
+      "registered_projects": 1,
+      "recent_reindex_total_entries": 0,
+      "project_stats_cache_entries": 0
+    }
+  },
+  "series": {
+    "idleA": [
+      {
+        "t": 0,
+        "rss_mb": 709,
+        "heap_mb": 201,
+        "cpu_pct": 14.9,
+        "procs": 1
+      },
+      {
+        "t": 1,
+        "rss_mb": 709,
+        "heap_mb": 201,
+        "cpu_pct": 0.3,
+        "procs": 1
+      },
+      {
+        "t": 2,
+        "rss_mb": 709,
+        "heap_mb": 201,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 3,
+        "rss_mb": 709,
+        "heap_mb": 201,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 4,
+        "rss_mb": 709,
+        "heap_mb": 201,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 5,
+        "rss_mb": 659,
+        "heap_mb": 201,
+        "cpu_pct": 2.3,
+        "procs": 1
+      },
+      {
+        "t": 6,
+        "rss_mb": 622,
+        "heap_mb": 201,
+        "cpu_pct": 2.1,
+        "procs": 1
+      },
+      {
+        "t": 7,
+        "rss_mb": 617,
+        "heap_mb": 201,
+        "cpu_pct": 0.1,
+        "procs": 1
+      },
+      {
+        "t": 8,
+        "rss_mb": 617,
+        "heap_mb": 201,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 9,
+        "rss_mb": 617,
+        "heap_mb": 201,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 10,
+        "rss_mb": 617,
+        "heap_mb": 201,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 11,
+        "rss_mb": 617,
+        "heap_mb": 201,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 12,
+        "rss_mb": 529,
+        "heap_mb": 201,
+        "cpu_pct": 1.9,
+        "procs": 1
+      },
+      {
+        "t": 13,
+        "rss_mb": 398,
+        "heap_mb": 201,
+        "cpu_pct": 6.5,
+        "procs": 1
+      },
+      {
+        "t": 14,
+        "rss_mb": 398,
+        "heap_mb": 201,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 15,
+        "rss_mb": 398,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 16,
+        "rss_mb": 398,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 17,
+        "rss_mb": 398,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 18,
+        "rss_mb": 398,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 19,
+        "rss_mb": 398,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 20,
+        "rss_mb": 398,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 21,
+        "rss_mb": 398,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 22,
+        "rss_mb": 398,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 23,
+        "rss_mb": 398,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 24,
+        "rss_mb": 398,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 25,
+        "rss_mb": 398,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 26,
+        "rss_mb": 398,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 27,
+        "rss_mb": 398,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 28,
+        "rss_mb": 399,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 29,
+        "rss_mb": 399,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 30,
+        "rss_mb": 399,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 31,
+        "rss_mb": 399,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 32,
+        "rss_mb": 399,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 33,
+        "rss_mb": 399,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 34,
+        "rss_mb": 399,
+        "heap_mb": 90,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 35,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 36,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 37,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 38,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 39,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 40,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 41,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 42,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 43,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 44,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 45,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0.1,
+        "procs": 1
+      },
+      {
+        "t": 46,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 47,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 48,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 49,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 50,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 51,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 52,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 53,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 54,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 55,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 56,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 57,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 58,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 59,
+        "rss_mb": 399,
+        "heap_mb": 91,
+        "cpu_pct": 0,
+        "procs": 1
+      }
+    ],
+    "drive": [
+      {
+        "rss_mb": 499,
+        "heap_mb": 140,
+        "cpu_pct": 47.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 677,
+        "heap_mb": 303,
+        "cpu_pct": 108,
+        "procs": 1
+      },
+      {
+        "rss_mb": 836,
+        "heap_mb": 111,
+        "cpu_pct": 112.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 865,
+        "heap_mb": 424,
+        "cpu_pct": 109.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 859,
+        "heap_mb": 277,
+        "cpu_pct": 99.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 846,
+        "heap_mb": 194,
+        "cpu_pct": 117.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 843,
+        "heap_mb": 145,
+        "cpu_pct": 124.5,
+        "procs": 1
+      },
+      {
+        "rss_mb": 865,
+        "heap_mb": 330,
+        "cpu_pct": 108.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 863,
+        "heap_mb": 333,
+        "cpu_pct": 109.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 863,
+        "heap_mb": 347,
+        "cpu_pct": 102.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 858,
+        "heap_mb": 261,
+        "cpu_pct": 111.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 854,
+        "heap_mb": 228,
+        "cpu_pct": 113.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 849,
+        "heap_mb": 192,
+        "cpu_pct": 115.2,
+        "procs": 1
+      },
+      {
+        "rss_mb": 846,
+        "heap_mb": 159,
+        "cpu_pct": 117.2,
+        "procs": 1
+      },
+      {
+        "rss_mb": 856,
+        "heap_mb": 293,
+        "cpu_pct": 112.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 854,
+        "heap_mb": 227,
+        "cpu_pct": 115.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 851,
+        "heap_mb": 219,
+        "cpu_pct": 118.2,
+        "procs": 1
+      },
+      {
+        "rss_mb": 859,
+        "heap_mb": 341,
+        "cpu_pct": 110.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 857,
+        "heap_mb": 308,
+        "cpu_pct": 104.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 861,
+        "heap_mb": 356,
+        "cpu_pct": 110.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 842,
+        "heap_mb": 132,
+        "cpu_pct": 124.5,
+        "procs": 1
+      },
+      {
+        "rss_mb": 842,
+        "heap_mb": 132,
+        "cpu_pct": 120.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 842,
+        "heap_mb": 132,
+        "cpu_pct": 119,
+        "procs": 1
+      },
+      {
+        "rss_mb": 866,
+        "heap_mb": 88,
+        "cpu_pct": 107.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 841,
+        "heap_mb": 127,
+        "cpu_pct": 110,
+        "procs": 1
+      },
+      {
+        "rss_mb": 867,
+        "heap_mb": 394,
+        "cpu_pct": 104.2,
+        "procs": 1
+      },
+      {
+        "rss_mb": 855,
+        "heap_mb": 258,
+        "cpu_pct": 106,
+        "procs": 1
+      },
+      {
+        "rss_mb": 845,
+        "heap_mb": 148,
+        "cpu_pct": 115.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 872,
+        "heap_mb": 394,
+        "cpu_pct": 104.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 855,
+        "heap_mb": 254,
+        "cpu_pct": 93.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 844,
+        "heap_mb": 125,
+        "cpu_pct": 99.2,
+        "procs": 1
+      },
+      {
+        "rss_mb": 860,
+        "heap_mb": 269,
+        "cpu_pct": 58.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 848,
+        "heap_mb": 171,
+        "cpu_pct": 71.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 860,
+        "heap_mb": 283,
+        "cpu_pct": 52.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 843,
+        "heap_mb": 112,
+        "cpu_pct": 77.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 857,
+        "heap_mb": 252,
+        "cpu_pct": 61.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 879,
+        "heap_mb": 423,
+        "cpu_pct": 75.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 861,
+        "heap_mb": 281,
+        "cpu_pct": 73.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 877,
+        "heap_mb": 428,
+        "cpu_pct": 61.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 852,
+        "heap_mb": 189,
+        "cpu_pct": 52.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 872,
+        "heap_mb": 369,
+        "cpu_pct": 81.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 850,
+        "heap_mb": 185,
+        "cpu_pct": 63.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 867,
+        "heap_mb": 321,
+        "cpu_pct": 51.2,
+        "procs": 1
+      },
+      {
+        "rss_mb": 843,
+        "heap_mb": 116,
+        "cpu_pct": 62.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 863,
+        "heap_mb": 287,
+        "cpu_pct": 62.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 846,
+        "heap_mb": 124,
+        "cpu_pct": 99.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 864,
+        "heap_mb": 326,
+        "cpu_pct": 89.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 868,
+        "heap_mb": 336,
+        "cpu_pct": 111.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 842,
+        "heap_mb": 92,
+        "cpu_pct": 111.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 851,
+        "heap_mb": 189,
+        "cpu_pct": 121.2,
+        "procs": 1
+      },
+      {
+        "rss_mb": 851,
+        "heap_mb": 175,
+        "cpu_pct": 123.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 847,
+        "heap_mb": 143,
+        "cpu_pct": 109.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 850,
+        "heap_mb": 198,
+        "cpu_pct": 115.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 844,
+        "heap_mb": 126,
+        "cpu_pct": 113,
+        "procs": 1
+      },
+      {
+        "rss_mb": 854,
+        "heap_mb": 128,
+        "cpu_pct": 120.5,
+        "procs": 1
+      },
+      {
+        "rss_mb": 855,
+        "heap_mb": 132,
+        "cpu_pct": 118.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 860,
+        "heap_mb": 169,
+        "cpu_pct": 123.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 894,
+        "heap_mb": 88,
+        "cpu_pct": 106.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 876,
+        "heap_mb": 304,
+        "cpu_pct": 77,
+        "procs": 1
+      },
+      {
+        "rss_mb": 871,
+        "heap_mb": 314,
+        "cpu_pct": 107.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 872,
+        "heap_mb": 341,
+        "cpu_pct": 113.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 880,
+        "heap_mb": 401,
+        "cpu_pct": 110.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 878,
+        "heap_mb": 386,
+        "cpu_pct": 100.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 877,
+        "heap_mb": 322,
+        "cpu_pct": 100,
+        "procs": 1
+      },
+      {
+        "rss_mb": 856,
+        "heap_mb": 138,
+        "cpu_pct": 117.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 856,
+        "heap_mb": 151,
+        "cpu_pct": 125.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 886,
+        "heap_mb": 401,
+        "cpu_pct": 107.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 869,
+        "heap_mb": 269,
+        "cpu_pct": 109.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 854,
+        "heap_mb": 125,
+        "cpu_pct": 121.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 881,
+        "heap_mb": 368,
+        "cpu_pct": 105.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 860,
+        "heap_mb": 180,
+        "cpu_pct": 96.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 881,
+        "heap_mb": 351,
+        "cpu_pct": 78.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 861,
+        "heap_mb": 210,
+        "cpu_pct": 99.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 838,
+        "heap_mb": 149,
+        "cpu_pct": 85.2,
+        "procs": 1
+      },
+      {
+        "rss_mb": 856,
+        "heap_mb": 351,
+        "cpu_pct": 85.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 839,
+        "heap_mb": 155,
+        "cpu_pct": 58.2,
+        "procs": 1
+      },
+      {
+        "rss_mb": 857,
+        "heap_mb": 292,
+        "cpu_pct": 70.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 834,
+        "heap_mb": 137,
+        "cpu_pct": 56.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 848,
+        "heap_mb": 239,
+        "cpu_pct": 34.4,
+        "procs": 1
+      },
+      {
+        "rss_mb": 839,
+        "heap_mb": 168,
+        "cpu_pct": 73.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 855,
+        "heap_mb": 303,
+        "cpu_pct": 55.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 870,
+        "heap_mb": 405,
+        "cpu_pct": 32.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 844,
+        "heap_mb": 245,
+        "cpu_pct": 47.8,
+        "procs": 1
+      },
+      {
+        "rss_mb": 848,
+        "heap_mb": 281,
+        "cpu_pct": 51,
+        "procs": 1
+      },
+      {
+        "rss_mb": 835,
+        "heap_mb": 130,
+        "cpu_pct": 42.5,
+        "procs": 1
+      },
+      {
+        "rss_mb": 850,
+        "heap_mb": 255,
+        "cpu_pct": 44.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 864,
+        "heap_mb": 358,
+        "cpu_pct": 41.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 844,
+        "heap_mb": 217,
+        "cpu_pct": 91.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 864,
+        "heap_mb": 394,
+        "cpu_pct": 82.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 861,
+        "heap_mb": 367,
+        "cpu_pct": 109,
+        "procs": 1
+      },
+      {
+        "rss_mb": 849,
+        "heap_mb": 265,
+        "cpu_pct": 113,
+        "procs": 1
+      },
+      {
+        "rss_mb": 853,
+        "heap_mb": 342,
+        "cpu_pct": 110.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 855,
+        "heap_mb": 373,
+        "cpu_pct": 111.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 858,
+        "heap_mb": 373,
+        "cpu_pct": 113.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 858,
+        "heap_mb": 349,
+        "cpu_pct": 108.5,
+        "procs": 1
+      },
+      {
+        "rss_mb": 858,
+        "heap_mb": 296,
+        "cpu_pct": 111.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 858,
+        "heap_mb": 386,
+        "cpu_pct": 111,
+        "procs": 1
+      },
+      {
+        "rss_mb": 861,
+        "heap_mb": 406,
+        "cpu_pct": 108.7,
+        "procs": 1
+      },
+      {
+        "rss_mb": 849,
+        "heap_mb": 281,
+        "cpu_pct": 92.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 847,
+        "heap_mb": 251,
+        "cpu_pct": 111.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 857,
+        "heap_mb": 311,
+        "cpu_pct": 109.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 860,
+        "heap_mb": 374,
+        "cpu_pct": 108.1,
+        "procs": 1
+      },
+      {
+        "rss_mb": 858,
+        "heap_mb": 378,
+        "cpu_pct": 110.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 862,
+        "heap_mb": 370,
+        "cpu_pct": 107.3,
+        "procs": 1
+      },
+      {
+        "rss_mb": 857,
+        "heap_mb": 347,
+        "cpu_pct": 109.5,
+        "procs": 1
+      },
+      {
+        "rss_mb": 862,
+        "heap_mb": 342,
+        "cpu_pct": 108.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 839,
+        "heap_mb": 156,
+        "cpu_pct": 119.9,
+        "procs": 1
+      },
+      {
+        "rss_mb": 843,
+        "heap_mb": 202,
+        "cpu_pct": 116.6,
+        "procs": 1
+      },
+      {
+        "rss_mb": 838,
+        "heap_mb": 148,
+        "cpu_pct": 122,
+        "procs": 1
+      },
+      {
+        "rss_mb": 841,
+        "heap_mb": 206,
+        "cpu_pct": 106.5,
+        "procs": 1
+      }
+    ],
+    "idleB": [
+      {
+        "t": 0,
+        "rss_mb": 868,
+        "heap_mb": 411,
+        "cpu_pct": 106.7,
+        "procs": 1
+      },
+      {
+        "t": 1,
+        "rss_mb": 868,
+        "heap_mb": 411,
+        "cpu_pct": 3.2,
+        "procs": 1
+      },
+      {
+        "t": 2,
+        "rss_mb": 868,
+        "heap_mb": 411,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 3,
+        "rss_mb": 868,
+        "heap_mb": 411,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 4,
+        "rss_mb": 868,
+        "heap_mb": 411,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 5,
+        "rss_mb": 868,
+        "heap_mb": 411,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 6,
+        "rss_mb": 868,
+        "heap_mb": 411,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 7,
+        "rss_mb": 484,
+        "heap_mb": 411,
+        "cpu_pct": 12.3,
+        "procs": 1
+      },
+      {
+        "t": 8,
+        "rss_mb": 415,
+        "heap_mb": 411,
+        "cpu_pct": 2.3,
+        "procs": 1
+      },
+      {
+        "t": 9,
+        "rss_mb": 415,
+        "heap_mb": 411,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 10,
+        "rss_mb": 415,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 11,
+        "rss_mb": 415,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 12,
+        "rss_mb": 415,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 13,
+        "rss_mb": 415,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 14,
+        "rss_mb": 415,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 15,
+        "rss_mb": 415,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 16,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 17,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 18,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 19,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 20,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 21,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 22,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 23,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 24,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 25,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 26,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 27,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 28,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 29,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 30,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 31,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 32,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 33,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 34,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 35,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 36,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 37,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 38,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 39,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 40,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 41,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0.1,
+        "procs": 1
+      },
+      {
+        "t": 42,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 43,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 44,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 45,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 46,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 47,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 48,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 49,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 50,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 51,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 52,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 53,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 54,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 55,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 56,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 57,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 58,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 59,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 60,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 61,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 62,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 63,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 64,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 65,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 66,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 67,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 68,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 69,
+        "rss_mb": 416,
+        "heap_mb": 88,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 70,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 71,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 72,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 73,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 74,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 75,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 76,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 77,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 78,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 79,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 80,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0.1,
+        "procs": 1
+      },
+      {
+        "t": 81,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 82,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 83,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 84,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 85,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 86,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 87,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 88,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 89,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 90,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 91,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 92,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 93,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 94,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 95,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 96,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 97,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 98,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 99,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 100,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 101,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 102,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 103,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 104,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 105,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 106,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 107,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 108,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 109,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 110,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 111,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 112,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0.1,
+        "procs": 1
+      },
+      {
+        "t": 113,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 114,
+        "rss_mb": 416,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 115,
+        "rss_mb": 309,
+        "heap_mb": 89,
+        "cpu_pct": 0.1,
+        "procs": 1
+      },
+      {
+        "t": 116,
+        "rss_mb": 309,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 117,
+        "rss_mb": 309,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 118,
+        "rss_mb": 309,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      },
+      {
+        "t": 119,
+        "rss_mb": 309,
+        "heap_mb": 89,
+        "cpu_pct": 0,
+        "procs": 1
+      }
+    ]
+  }
+}

--- a/scripts/perf/daemon-query-alloc.mjs
+++ b/scripts/perf/daemon-query-alloc.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * TRA-651 — per-endpoint allocation on the daemon's read path.
+ *
+ * `daemon-serving-rss.mjs` shows the daemon's RSS going from 400 MB idle to
+ * 850 MB while a client drives it, with the V8 heap tracking it (91 MB → 412
+ * MB) and collapsing back the moment queries stop. That is transient garbage,
+ * not retention — so the useful question is which endpoint produces it and how
+ * much per call. This drives one endpoint at a time and reports heap growth
+ * per request.
+ *
+ *   node scripts/perf/daemon-query-alloc.mjs [--port 37421] [--calls 200]
+ */
+import { execFileSync, spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { procStats, round } from '../../packages/app/scripts/perf-lib.mjs';
+
+const args = process.argv.slice(2);
+const flag = (n, d) => {
+  const i = args.indexOf(`--${n}`);
+  return i >= 0 && args[i + 1] ? args[i + 1] : d;
+};
+const PORT = Number(flag('port', 37421));
+const CALLS = Number(flag('calls', 200));
+const DAEMON = `http://127.0.0.1:${PORT}`;
+const repoRoot = path.resolve(import.meta.dirname, '..', '..');
+const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'tra651q-'));
+const ENV = { ...process.env, TRACE_MCP_DATA_DIR: DATA_DIR, TRACE_MCP_HOME: DATA_DIR };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const log = (s) => process.stderr.write(`${s}\n`);
+
+async function req(pathname, method = 'GET', body) {
+  const res = await fetch(DAEMON + pathname, {
+    method,
+    headers: body ? { 'content-type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(60_000),
+  });
+  const text = await res.text();
+  return { ok: res.ok, status: res.status, bytes: Buffer.byteLength(text) };
+}
+
+async function mem() {
+  const r = await fetch(`${DAEMON}/debug/memory`);
+  return (await r.json()).process;
+}
+
+async function main() {
+  const pin = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, 'packages/app/scripts/perf-fixture.json'), 'utf8'),
+  );
+  const root = path.join(os.homedir(), '.trace-mcp', 'perf-fixture', pin.commit.slice(0, 12));
+  const cli = path.join(repoRoot, 'dist', 'cli.js');
+  const child = spawn(process.execPath, [cli, 'serve-http', '--port', String(PORT)], {
+    stdio: 'ignore',
+    cwd: DATA_DIR,
+    env: ENV,
+  });
+  try {
+    for (let i = 0; i < 240; i++) {
+      try {
+        if ((await fetch(`${DAEMON}/health`, { signal: AbortSignal.timeout(2000) })).ok) break;
+      } catch {
+        /* not up */
+      }
+      await sleep(500);
+    }
+    await req('/api/projects', 'POST', { root });
+    for (let i = 0; i < 300; i++) {
+      const l = await (await fetch(`${DAEMON}/api/projects`)).json();
+      if (l.projects?.[0]?.status === 'ready') break;
+      await sleep(2000);
+    }
+    const p = encodeURIComponent(root);
+    const cases = {
+      symbols: (q) => `/api/projects/symbols?project=${p}&q=${q}&limit=50`,
+      graph: (q) => `/api/projects/graph?project=${p}&q=${q}&limit=100`,
+      'graph-stats': () => `/api/projects/graph-stats?project=${p}`,
+      stats: () => `/api/projects/stats?project=${p}`,
+      files: () => `/api/projects/files?project=${p}`,
+      smells: () => `/api/projects/smells?project=${p}`,
+      health: () => '/health',
+    };
+    const out = {};
+    for (const [name, mk] of Object.entries(cases)) {
+      await sleep(4000); // let the previous case's garbage go
+      const before = await mem();
+      let bytes = 0;
+      const t0 = Date.now();
+      for (let i = 0; i < CALLS; i++) {
+        const r = await req(mk(pin.queries[i % pin.queries.length]));
+        bytes += r.bytes;
+      }
+      const ms = Date.now() - t0;
+      const after = await mem();
+      out[name] = {
+        calls: CALLS,
+        ms_per_call: round(ms / CALLS, 2),
+        response_kb_per_call: round(bytes / CALLS / 1024, 1),
+        heap_growth_mb: round((after.heapUsed - before.heapUsed) / 1048576, 1),
+        rss_growth_mb: round((after.rss - before.rss) / 1048576, 1),
+        rss_mb: round(after.rss / 1048576, 0),
+        tree_rss_mb: round(procStats(child.pid).rss_mb, 0),
+      };
+      log(`${name}: ${JSON.stringify(out[name])}`);
+    }
+    process.stdout.write(
+      `${JSON.stringify({ tra: 'TRA-651', calls: CALLS, cases: out }, null, 2)}\n`,
+    );
+  } finally {
+    child.kill('SIGKILL');
+    fs.rmSync(DATA_DIR, { recursive: true, force: true });
+  }
+}
+main().catch((e) => {
+  process.stderr.write(`${e?.stack ?? e}\n`);
+  process.exit(1);
+});

--- a/scripts/perf/daemon-serving-rss.mjs
+++ b/scripts/perf/daemon-serving-rss.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+/**
+ * TRA-651 — daemon RSS while serving exactly one project.
+ *
+ * The number in TRA-651 (727 MB idle / 1014 MB peak) came out of the full
+ * Electron workload harness, where the app is only the load generator. This
+ * script is the daemon half of that on its own: same pinned fixture, same
+ * REST endpoints the app's Overview/Graph/Activity views hit, no renderer.
+ * That makes a run ~12 minutes instead of ~45 and attributes every byte to
+ * `serve-http`.
+ *
+ *   node scripts/perf/daemon-serving-rss.mjs [--port 37413] [--drive-seconds 180]
+ *                                            [--idle-seconds 480] [--searches 5720]
+ *
+ * Phases, each sampled once a second across the whole daemon process tree:
+ *   index   — register the fixture, wait until served
+ *   idleA   — 60 s untouched, immediately post-index   → `idle_after_index_mb`
+ *   drive   — the app's query mix                      → `serving_peak_mb`
+ *   idleB   — untouched again, long enough to cross the extract-pool
+ *             idle-release window (TRA-811, 5 min)     → `idle_after_drive_mb`
+ *
+ * Prints JSON on stdout. Every number is a reading; nothing here is modelled.
+ */
+import { execFileSync, spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { median, procStats, round } from '../../packages/app/scripts/perf-lib.mjs';
+
+const args = process.argv.slice(2);
+const flag = (name, dflt) => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
+};
+const PORT = Number(flag('port', 37413));
+const DRIVE_SECONDS = Number(flag('drive-seconds', 180));
+const IDLE_SECONDS = Number(flag('idle-seconds', 480));
+const SEARCHES = Number(flag('searches', 5720));
+const DAEMON = `http://127.0.0.1:${PORT}`;
+const repoRoot = path.resolve(import.meta.dirname, '..', '..');
+
+// Throwaway data dir: an empty registry, so "one project" is literally true.
+const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'tra651-'));
+const ENV = {
+  ...process.env,
+  TRACE_MCP_DATA_DIR: DATA_DIR,
+  TRACE_MCP_HOME: DATA_DIR,
+  TRACE_MCP_AUTO_UPDATE: '0',
+  TRACE_MCP_NO_UPDATE_CHECK: '1',
+};
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const log = (s) => process.stderr.write(`${s}\n`);
+
+function fixture() {
+  const pin = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, 'packages/app/scripts/perf-fixture.json'), 'utf8'),
+  );
+  const dir = path.join(os.homedir(), '.trace-mcp', 'perf-fixture', pin.commit.slice(0, 12));
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(path.dirname(dir), { recursive: true });
+    execFileSync('git', ['worktree', 'add', '--detach', dir, pin.commit], {
+      cwd: repoRoot,
+      stdio: 'inherit',
+    });
+  }
+  return { dir, queries: pin.queries };
+}
+
+async function req(method, pathname, body) {
+  const res = await fetch(DAEMON + pathname, {
+    method,
+    headers: body ? { 'content-type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!res.ok) throw new Error(`${method} ${pathname} -> ${res.status}`);
+  return res.json().catch(() => ({}));
+}
+
+async function waitHealthy(deadline) {
+  while (Date.now() < deadline) {
+    try {
+      if ((await fetch(`${DAEMON}/health`, { signal: AbortSignal.timeout(2000) })).ok) return;
+    } catch {
+      /* not up yet */
+    }
+    await sleep(500);
+  }
+  throw new Error(`daemon never came up on ${PORT}`);
+}
+
+/** heapUsed alongside RSS — the gap between them is the whole question here. */
+async function heapMb() {
+  const m = await req('GET', '/debug/memory').catch(() => null);
+  return m ? round(m.process.heapUsed / 1048576, 0) : null;
+}
+
+/**
+ * Sample the tree once a second for `seconds`, without driving anything.
+ * Returns the raw series so the caller can take its own median/peak.
+ */
+async function sampleIdle(pid, seconds, label) {
+  const series = [];
+  for (let i = 0; i < seconds; i++) {
+    const s = procStats(pid);
+    // /debug/memory is a `process.memoryUsage()` read on an otherwise idle
+    // daemon — cheap enough to poll at the sample rate, and without it there
+    // is no way to tell retained bytes from bytes V8 has not handed back.
+    const heap = i % 5 === 0 ? await heapMb() : (series.at(-1)?.heap_mb ?? null);
+    series.push({
+      t: i,
+      rss_mb: round(s.rss_mb, 0),
+      heap_mb: heap,
+      cpu_pct: round(s.cpu),
+      procs: s.procs,
+    });
+    if (i % 60 === 0) {
+      log(`  ${label} t=${i}s rss=${round(s.rss_mb, 0)}MB heap=${heap}MB procs=${s.procs}`);
+    }
+    await sleep(1000);
+  }
+  return series;
+}
+
+async function main() {
+  const { dir: root, queries } = fixture();
+  const cli = path.join(repoRoot, 'dist', 'cli.js');
+  if (!fs.existsSync(cli)) throw new Error(`missing ${cli} — pnpm run build first`);
+
+  log(`data dir ${DATA_DIR}`);
+  // cwd is deliberately the throwaway data dir, not the repo: a daemon started
+  // inside a checkout picks that checkout up as a project of its own, and then
+  // "exactly one project" is no longer true.
+  const child = spawn(process.execPath, [cli, 'serve-http', '--port', String(PORT)], {
+    stdio: 'ignore',
+    cwd: DATA_DIR,
+    env: ENV,
+  });
+  const pid = child.pid;
+  try {
+    await waitHealthy(Date.now() + 120_000);
+    const baseline = round(procStats(pid).rss_mb, 0);
+    log(`daemon up, pid ${pid}, baseline ${baseline}MB`);
+
+    // ── index ────────────────────────────────────────────────────────────
+    const t0 = Date.now();
+    const added = await req('POST', '/api/projects', { root });
+    if (added.status === 'using_parent') throw new Error(`fixture rerouted to ${added.project}`);
+    // Wait for `status === 'ready'`, not for `files > 0`: the first symbols
+    // land within seconds and a `files > 0` gate measures a daemon that is
+    // still mid-index, which is a different state entirely.
+    let stats = null;
+    const deadline = Date.now() + 10 * 60_000;
+    while (Date.now() < deadline) {
+      const list = await req('GET', '/api/projects').catch(() => null);
+      const me = list?.projects?.find((x) => x.root === root);
+      if (me?.error) throw new Error(`fixture failed to index: ${me.error}`);
+      if (me?.status === 'ready') {
+        stats = await req('GET', `/api/projects/stats?project=${encodeURIComponent(root)}`);
+        if (stats?.files > 0) break;
+      }
+      await sleep(2000);
+    }
+    if (!stats?.files) throw new Error('fixture never got indexed');
+    const registered = (await req('GET', '/api/projects')).projects;
+    const indexSeconds = round((Date.now() - t0) / 1000);
+    log(`indexed ${stats.files} files / ${stats.symbols} symbols in ${indexSeconds}s`);
+
+    // ── idleA ────────────────────────────────────────────────────────────
+    const idleA = await sampleIdle(pid, 60, 'idleA');
+
+    // ── drive ────────────────────────────────────────────────────────────
+    const p = encodeURIComponent(root);
+    const views = [
+      `/api/projects/stats?project=${p}`,
+      `/api/projects/graph-stats?project=${p}`,
+      `/api/projects/smells?project=${p}`,
+      `/api/projects/coverage?project=${p}`,
+      `/api/projects/files?project=${p}`,
+    ];
+    const drive = [];
+    let searches = 0;
+    let sampled = 0;
+    const driveEnd = Date.now() + DRIVE_SECONDS * 1000;
+    while (Date.now() < driveEnd && searches < SEARCHES) {
+      const q = queries[searches % queries.length];
+      await Promise.all([
+        req('GET', `/api/projects/symbols?project=${p}&q=${q}&limit=50`).catch(() => null),
+        req('GET', `/api/projects/graph?project=${p}&q=${q}&limit=100`).catch(() => null),
+      ]);
+      searches += 2;
+      if (searches % 40 === 0) {
+        await req('GET', views[(searches / 40) % views.length]).catch(() => null);
+      }
+      const now = Date.now();
+      if (now - sampled >= 1000) {
+        sampled = now;
+        const s = procStats(pid);
+        drive.push({
+          rss_mb: round(s.rss_mb, 0),
+          heap_mb: await heapMb(),
+          cpu_pct: round(s.cpu),
+          procs: s.procs,
+        });
+      }
+    }
+    log(`drove ${searches} queries; peak ${Math.max(...drive.map((d) => d.rss_mb))}MB`);
+    const memAtPeak = await req('GET', '/debug/memory').catch(() => null);
+
+    // ── idleB ────────────────────────────────────────────────────────────
+    const idleB = await sampleIdle(pid, IDLE_SECONDS, 'idleB');
+    const memAfterIdle = await req('GET', '/debug/memory').catch(() => null);
+
+    const out = {
+      tra: 'TRA-651',
+      at: new Date().toISOString(),
+      version: JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')).version,
+      commit: execFileSync('git', ['rev-parse', '--short', 'HEAD'], { cwd: repoRoot })
+        .toString()
+        .trim(),
+      fixture: { root, files: stats.files, symbols: stats.symbols, index_seconds: indexSeconds },
+      registered,
+      searches,
+      baseline_rss_mb: baseline,
+      idle_after_index_mb: median(idleA.map((s) => s.rss_mb)),
+      idle_after_index_heap_mb: median(idleA.map((s) => s.heap_mb).filter((h) => h != null)),
+      serving_median_mb: median(drive.map((s) => s.rss_mb)),
+      serving_peak_mb: Math.max(...drive.map((s) => s.rss_mb)),
+      serving_peak_heap_mb: Math.max(...drive.map((s) => s.heap_mb ?? 0)),
+      idle_after_drive_mb: median(idleB.slice(-60).map((s) => s.rss_mb)),
+      idle_after_drive_heap_mb: median(
+        idleB
+          .slice(-60)
+          .map((s) => s.heap_mb)
+          .filter((h) => h != null),
+      ),
+      idle_after_drive_min_mb: Math.min(...idleB.map((s) => s.rss_mb)),
+      procs_peak: Math.max(...drive.map((s) => s.procs)),
+      procs_idle_end: idleB.at(-1)?.procs ?? null,
+      debug_memory_at_peak: memAtPeak,
+      debug_memory_after_idle: memAfterIdle,
+      series: { idleA, drive, idleB },
+    };
+    process.stdout.write(`${JSON.stringify(out, null, 2)}\n`);
+  } finally {
+    child.kill('SIGKILL');
+    fs.rmSync(DATA_DIR, { recursive: true, force: true });
+  }
+}
+
+main().catch((e) => {
+  process.stderr.write(`${e?.stack ?? e}\n`);
+  process.exit(1);
+});

--- a/src/db/repositories/graph-repository.ts
+++ b/src/db/repositories/graph-repository.ts
@@ -231,25 +231,47 @@ export class GraphRepository {
     const CHUNK = 450;
     for (let i = 0; i < nodeIds.length; i += CHUNK) {
       const chunk = nodeIds.slice(i, i + CHUNK);
-      const placeholders = chunk.map(() => '?').join(',');
-      const rows = this.db
-        .prepare(
-          `SELECT e.*, et.name AS edge_type_name
-           FROM edges e
-           JOIN edge_types et ON e.edge_type_id = et.id
-          WHERE e.source_node_id IN (${placeholders})
-             OR e.target_node_id IN (${placeholders})`,
-        )
-        .all(...chunk, ...chunk) as (EdgeRow & { edge_type_name: string })[];
+      const rows = this.edgesForNodesStmt(chunk.length).all(...chunk, ...chunk) as (EdgeRow & {
+        edge_type_name: string;
+        pivot_node_id?: number;
+      })[];
 
+      // Annotate in place. TRA-651: `{ ...row, pivot_node_id }` allocated a
+      // second object for every edge in the project on every graph build —
+      // the rows are freshly minted by better-sqlite3 and owned by nobody
+      // else, so there is nothing to protect by copying.
       for (const row of rows) {
-        results.push({
-          ...row,
-          pivot_node_id: nodeSet.has(row.source_node_id) ? row.source_node_id : row.target_node_id,
-        });
+        row.pivot_node_id = nodeSet.has(row.source_node_id)
+          ? row.source_node_id
+          : row.target_node_id;
+        results.push(row as EdgeRow & { edge_type_name: string; pivot_node_id: number });
       }
     }
     return results;
+  }
+
+  /**
+   * The chunked edge query, prepared once per placeholder count. TRA-651:
+   * a full-project graph build issues ~22 of these and every one re-parsed
+   * identical SQL — `prepare` was 136 ms of a 130 ms/build hot path across
+   * the profiled run. Only the full-size chunk repeats, so the map holds one
+   * entry in practice and is bounded by the distinct chunk sizes a caller
+   * happens to produce.
+   */
+  private edgesForNodesCache = new Map<number, Database.Statement>();
+  private edgesForNodesStmt(n: number): Database.Statement {
+    const cached = this.edgesForNodesCache.get(n);
+    if (cached) return cached;
+    const placeholders = new Array(n).fill('?').join(',');
+    const stmt = this.db.prepare(
+      `SELECT e.*, et.name AS edge_type_name
+         FROM edges e
+         JOIN edge_types et ON e.edge_type_id = et.id
+        WHERE e.source_node_id IN (${placeholders})
+           OR e.target_node_id IN (${placeholders})`,
+    );
+    this.edgesForNodesCache.set(n, stmt);
+    return stmt;
   }
 
   getEdgeTypes(): EdgeTypeRow[] {

--- a/src/db/repositories/symbol-repository.ts
+++ b/src/db/repositories/symbol-repository.ts
@@ -281,6 +281,56 @@ export class SymbolRepository {
     return this.db.prepare(base).all() as (SymbolRow & { file_path: string })[];
   }
 
+  /**
+   * All symbols for a set of files, in one chunked query per 900 files
+   * instead of one query per file. TRA-651: the file-granularity graph build
+   * called the per-file statement 1 507 times for a 1 817-file project —
+   * 424 ms of the 150 ms/build was `prepare` + statement dispatch overhead,
+   * not row work. Ordering is (file_id, byte_start) so a caller that grouped
+   * by file still sees each file's symbols in source order.
+   */
+  getSymbolsByFileIds(fileIds: number[]): SymbolRow[] {
+    if (fileIds.length === 0) return [];
+    const out: SymbolRow[] = [];
+    const CHUNK = 900;
+    for (let i = 0; i < fileIds.length; i += CHUNK) {
+      const chunk = fileIds.slice(i, i + CHUNK);
+      const placeholders = chunk.map(() => '?').join(',');
+      const rows = this.db
+        .prepare(
+          `SELECT * FROM symbols WHERE file_id IN (${placeholders}) ORDER BY file_id, byte_start`,
+        )
+        .all(...chunk) as SymbolRow[];
+      // push(...rows) spreads through Function.apply and blows the stack at a
+      // few hundred thousand symbols; a loop costs nothing and has no ceiling.
+      for (const row of rows) out.push(row);
+    }
+    return out;
+  }
+
+  /**
+   * The (id, file_id) pairs only. TRA-651: the file-level graph needs nothing
+   * else from a symbol — it maps symbol ids to node ids and collapses the
+   * resulting symbol→symbol edges back to files. Selecting `*` there loaded
+   * every signature and metadata blob for every symbol in the project and
+   * threw them away, which was the bulk of the ~45 MB of garbage each graph
+   * request produced.
+   */
+  getSymbolFileRefsByFileIds(fileIds: number[]): { id: number; file_id: number }[] {
+    if (fileIds.length === 0) return [];
+    const out: { id: number; file_id: number }[] = [];
+    const CHUNK = 900;
+    for (let i = 0; i < fileIds.length; i += CHUNK) {
+      const chunk = fileIds.slice(i, i + CHUNK);
+      const placeholders = chunk.map(() => '?').join(',');
+      const rows = this.db
+        .prepare(`SELECT id, file_id FROM symbols WHERE file_id IN (${placeholders})`)
+        .all(...chunk) as { id: number; file_id: number }[];
+      for (const row of rows) out.push(row);
+    }
+    return out;
+  }
+
   getSymbolsByIds(ids: number[]): Map<number, SymbolRow> {
     const map = new Map<number, SymbolRow>();
     if (ids.length === 0) return map;

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -152,12 +152,12 @@ export class Store {
   }
 
   getSymbolsByFileIds(fileIds: number[]): SymbolRow[] {
-    if (fileIds.length === 0) return [];
-    const results: SymbolRow[] = [];
-    for (const fid of fileIds) {
-      results.push(...this.symbols.getSymbolsByFile(fid));
-    }
-    return results;
+    return this.symbols.getSymbolsByFileIds(fileIds);
+  }
+
+  /** (id, file_id) pairs for a set of files — see the repository method. */
+  getSymbolFileRefsByFileIds(fileIds: number[]): { id: number; file_id: number }[] {
+    return this.symbols.getSymbolFileRefsByFileIds(fileIds);
   }
 
   getSymbolBySymbolId(symbolId: string): SymbolRow | undefined {

--- a/src/tools/analysis/visualize.ts
+++ b/src/tools/analysis/visualize.ts
@@ -370,8 +370,9 @@ function buildFileGraph(
   const fileIdSet = new Set(seedFiles.map((f) => f.id));
   const _fileByIdMap = new Map(seedFiles.map((f) => [f.id, f]));
 
-  // Get symbol→nodeId mapping for seed files
-  const allSymbols = store.getSymbolsByFileIds([...fileIdSet]);
+  // Get symbol→nodeId mapping for seed files. Only (id, file_id) is used
+  // below — this is a file-level graph, symbol rows never reach the payload.
+  const allSymbols = store.getSymbolFileRefsByFileIds([...fileIdSet]);
   const symRefIds = allSymbols.map((s) => s.id);
   const symNodeMap = store.getNodeIdsBatch('symbol', symRefIds); // refId → nodeId
   const symbolNodeIds = [...symNodeMap.values()];

--- a/tests/perf/graph-build-query-count.test.ts
+++ b/tests/perf/graph-build-query-count.test.ts
@@ -1,0 +1,100 @@
+/**
+ * TRA-651 regression guard for the daemon's graph read path.
+ *
+ * `/api/projects/graph` rebuilds a whole-project graph per request on the same
+ * thread that answers `/health`. What made that expensive was not the SQL but
+ * the number of round trips: `getSymbolsByFileIds` ran one prepared statement
+ * per file, so a 1 817-file project issued ~1 800 statements to fetch symbols
+ * nobody read past `id`/`file_id`, and the chunked edge query re-parsed
+ * identical SQL on every chunk.
+ *
+ * A timing assertion here would be machine-dependent and would rot. Statement
+ * count would not: it is the thing that regressed and it is exact. The ceiling
+ * is deliberately generous — this catches "the N+1 came back", not a drift of
+ * a few queries.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Store } from '../../src/db/store.js';
+import { buildGraphData } from '../../src/tools/analysis/visualize.js';
+import { createTestStore } from '../test-utils.js';
+
+/** Files × symbols-per-file, enough to make a per-file loop obvious. */
+const FILES = 120;
+const SYMBOLS_PER_FILE = 4;
+
+function seed(store: Store): void {
+  const fileIds: number[] = [];
+  for (let f = 0; f < FILES; f++) {
+    const id = store.insertFile(`src/mod${f}.ts`, 'typescript', `h${f}`, 500);
+    fileIds.push(id);
+    for (let s = 0; s < SYMBOLS_PER_FILE; s++) {
+      store.insertSymbol(id, {
+        symbolId: `src/mod${f}.ts::fn${s}#function`,
+        name: `fn${s}`,
+        kind: 'function',
+        fqn: `mod${f}.fn${s}`,
+        byteStart: s * 50,
+        byteEnd: s * 50 + 40,
+        lineStart: s * 5 + 1,
+        lineEnd: s * 5 + 4,
+      });
+    }
+  }
+  // A chain of imports so the graph has edges to walk, not just isolated nodes.
+  for (let f = 1; f < FILES; f++) {
+    store.insertEdge(
+      store.createNode('file', fileIds[f]),
+      store.createNode('file', fileIds[f - 1]),
+      'imports',
+    );
+  }
+}
+
+/**
+ * Count statement *executions* for the duration of `fn`, not `prepare` calls:
+ * the N+1 this guards against ran a statement the repository had prepared once
+ * in its constructor, so a prepare counter never saw it.
+ */
+function countQueries(store: Store, fn: () => void): number {
+  // biome-ignore lint/suspicious/noExplicitAny: reaching the raw handle is the point of the probe
+  const db = (store as any).db as { prepare: (sql: string) => { all: unknown } };
+  const proto = Object.getPrototypeOf(db.prepare('SELECT 1')) as {
+    all: (...a: unknown[]) => unknown;
+  };
+  const original = proto.all;
+  let calls = 0;
+  proto.all = function patched(this: unknown, ...a: unknown[]) {
+    calls++;
+    return original.apply(this, a);
+  };
+  try {
+    fn();
+  } finally {
+    proto.all = original;
+  }
+  return calls;
+}
+
+describe('TRA-651: whole-project graph build does not scale queries with file count', () => {
+  it('issues far fewer statements than it has files', () => {
+    const store = createTestStore();
+    seed(store);
+
+    let nodes = 0;
+    const queries = countQueries(store, () => {
+      const g = buildGraphData(store, {
+        scope: 'project',
+        depth: 2,
+        granularity: 'file',
+        hideIsolated: false,
+      } as never);
+      nodes = g.nodes.length;
+    });
+
+    expect(nodes).toBeGreaterThan(0);
+    // Before the fix this sat above FILES (one symbol query per file) and grew
+    // linearly with the project. A batched build is a small fixed number of
+    // statements per chunk, independent of FILES.
+    expect(queries).toBeLessThan(FILES / 2);
+  });
+});


### PR DESCRIPTION
Closes TRA-651.

## The reported number does not survive a settled measurement

TRA-651 filed *"serve-http holds 727 MB RSS **idle** while serving a single 1817-file project"*. Re-measured on v3.18.0 with the same pinned fixture (`fc47c10f44eb`, 1 817 files / 9 705 symbols), fresh `TRACE_MCP_DATA_DIR`, private port, exactly one registered project — sampled once a second with `heapUsed` alongside RSS:

| Daemon state | RSS | `heapUsed` |
|---|---|---|
| Fresh, nothing registered | 166 MB | — |
| First seconds after the index finishes | 700–720 MB | 200 MB |
| **Median over the next 60 s, untouched** | **399 MB** | **91 MB** |
| Median while a client drives it | 856 MB | ~300 MB |
| Peak while driven | 894 MB | 428 MB |
| 20 s after the client stops | 416 MB | 88 MB |

727 MB is a real reading, but it was taken inside the post-index window, not at idle. The settled idle figure is ~400 MB RSS over 91 MB of live heap, reached about twenty seconds after the last request. In one run RSS fell from 419 MB to 85 MB at t=80 s with `heapUsed` unchanged at 88 MB — the macOS page-retention effect TRA-278 documented, not a change in what is live. **There is no per-project leak to find here.**

What is real is the cost of *serving*, and it lands on the thread that answers `/health`.

## Where the serving cost comes from

`scripts/perf/daemon-query-alloc.mjs`, 200 calls per endpoint:

| Endpoint | ms/call | response | RSS growth / 200 calls |
|---|---|---|---|
| `/api/projects/graph` | **544** | **1 268 KB** | +99 MB |
| `/api/projects/smells` | **426** | 118 KB | **+293 MB** |
| `/api/projects/graph-stats` | 8.5 | 2.2 KB | +1 MB |
| `/api/projects/files` | 3.2 | 2.1 KB | +4 MB |
| `/health` | 0.14 | 0.2 KB | 0 |

`node --cpu-prof` over 12 whole-project `buildGraphData` calls put the time in two places, both work that did not need to happen:

1. **`getSymbolsByFileIds` was a per-file loop** despite the plural name — 424 ms self time. 1 507 statements to fetch 9 705 `SELECT *` symbol rows for a *file-level* graph that reads nothing but `id` and `file_id`; every signature and metadata blob in the project loaded and dropped.
2. **`getEdgesForNodesBatch` copied every row and re-parsed its SQL per chunk** — 442 ms self plus 136 ms in `prepare`. `{ ...row, pivot_node_id }` allocated a second object for every edge in the project on every build.

## The change

- `getSymbolsByFileIds` → one chunked `IN` query per 900 files.
- New `getSymbolFileRefsByFileIds` selects only `(id, file_id)`; the file-level graph path uses it.
- `getEdgesForNodesBatch` annotates `pivot_node_id` in place instead of spreading into a copy, and caches its chunk statement by placeholder count.

Nothing is cached at the response level and no result is memoized — same answer, fewer round trips and fewer allocations. Output is byte-identical before and after: 1 507 nodes / 5 070 edges / 922 738 bytes.

## Before → after

In-process, 12 consecutive whole-project builds:

| | before | after |
|---|---|---|
| Median build | 152 ms | **85 ms** (−44%) |
| `prepare` | 136 ms | 36 ms |
| GC | 264 ms | 67 ms |
| RSS after 12 builds | 415 MB | **307 MB** |

End-to-end on the daemon, 120 s of the app's query mix (`scripts/perf/daemon-serving-rss.mjs`, raw runs in `docs/perf/tra651-{before,after}.json`):

| | before | after |
|---|---|---|
| Queries served in 120 s | 1 492 | **2 150** (+44%) |
| Idle RSS after index | 399 MB | 404 MB |
| Idle `heapUsed` after index | 91 MB | 91 MB |
| Serving median RSS | 856 MB | 841 MB |
| Serving peak RSS | 894 MB | 865 MB |

**Resident memory while serving barely moved, and this PR is not claiming it did.** The daemon's RSS under load is set by GC pacing against a large young generation, not by how much each request allocates. The reason to take this change is the 44% latency and throughput win; the RSS number is flat and should not be quoted as a memory result.

## Guard

`tests/perf/graph-build-query-count.test.ts` asserts a whole-project graph build issues fewer statements than it has files. It counts statement *executions*, not `prepare` calls — the first version of this test counted prepares and passed on the broken code, because the N+1 reused a statement prepared in the repository constructor. Verified to fail on the pre-fix tree (128 queries for 120 files) and pass after. Machine-independent, no timing assertion to rot.

## Not fixed here

- `/api/projects/smells` at 426 ms and +293 MB per 200 calls is the larger remaining allocator on this path.
- Seven handlers in `src/cli.ts` open `new TopologyStore(TOPOLOGY_DB_PATH)` per request while `ProjectResourcePool` exists to hold one daemon-wide instance (TRA-938). 0.42 ms per open/close, so this is fd churn rather than latency — but it is the same descriptor-exhaustion shape TRA-938 fixed elsewhere.

Full write-up: `docs/perf/daemon-serving-memory.md`. Local: 10 252 tests pass, typecheck and `biome ci` clean.
