### PR TITLE
fix(launcher): name control-plane tmp files so the orphan sweeper collects them (TRA-982)

### DIFF
--- a/packages/app/src/main/__tests__/daemon-install.test.ts
+++ b/packages/app/src/main/__tests__/daemon-install.test.ts
@@ -5,7 +5,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import net from 'node:net';
 import {
   compareVersions,
@@ -504,5 +504,67 @@ describe('a live but unanswering daemon', () => {
     const result = await run(port, { healthTimeoutMs: 200 });
     expect(result.state.phase).toBe('failed');
     expect((result.state as { message: string }).message).toContain('nothing is listening');
+  });
+});
+
+/**
+ * TRA-982: every control-plane file this module writes lands in the state home
+ * or its `bin` directory, both of which the server sweeps for orphaned atomic
+ * -write tmps (SWEPT_STATE_DIRS in src/utils/atomic-write.ts). That sweeper
+ * matches `.tmp.<pid>.<12 hex>`; `writeIfChanged` emitted `.tmp.<pid>.<epoch
+ * ms>` — 13 decimal digits — so an app killed mid-install left a permanent
+ * file beside the shim that nothing collects.
+ *
+ * The regex is duplicated rather than imported: packages/app is its own package
+ * with its own test setup and does not import from the server's src.
+ */
+const ORPHAN_TMP_PATTERN = /^\.?.+\.tmp\.\d+\.[0-9a-f]{12}$/;
+
+describe.runIf(process.platform === 'darwin')('control-plane tmp files are sweepable', () => {
+  let home: string;
+  let resources: string;
+  let launchAgent: string;
+  const previousHome = process.env.TRACE_MCP_HOME;
+
+  beforeEach(() => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-install-tmp-'));
+    home = path.join(tmp, 'home');
+    resources = path.join(tmp, 'Resources');
+    launchAgent = path.join(tmp, 'com.trace-mcp.server.plist');
+    fs.mkdirSync(path.join(resources, 'server', 'dist'), { recursive: true });
+    fs.mkdirSync(path.join(resources, 'server', 'hooks'), { recursive: true });
+    fs.writeFileSync(path.join(resources, 'server', 'dist', 'cli.js'), '');
+    fs.writeFileSync(path.join(resources, 'server', 'hooks', 'trace-mcp-launcher.sh'), '#!/bin/bash\n');
+    process.env.TRACE_MCP_HOME = home;
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env.TRACE_MCP_HOME;
+    else process.env.TRACE_MCP_HOME = previousHome;
+  });
+
+  it('names every tmp so the orphan sweeper collects it after a crash', async () => {
+    const tmpNames: string[] = [];
+    const realRename = fs.renameSync;
+    const spy = vi.spyOn(fs, 'renameSync').mockImplementation((from, to) => {
+      tmpNames.push(path.basename(from as string));
+      return realRename(from as string, to as string);
+    });
+
+    await ensureDaemonInstalled({
+      appVersion: '3.7.0',
+      execPath: '/Applications/trace-mcp.app/Contents/MacOS/trace-mcp',
+      resourcesPath: resources,
+      launchAgentPath: launchAgent,
+      runLaunchctl: () => ({ ok: true, stderr: '' }),
+      probeHealth: async () => true,
+      log: () => {},
+    });
+    spy.mockRestore();
+
+    expect(tmpNames.length).toBeGreaterThan(0);
+    for (const name of tmpNames) {
+      expect(name).toMatch(ORPHAN_TMP_PATTERN);
+    }
   });
 });

--- a/packages/app/src/main/daemon-install.ts
+++ b/packages/app/src/main/daemon-install.ts
@@ -29,6 +29,7 @@ import {
   type ExecFileException,
   type ExecFileOptions,
 } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import http from 'node:http';
 import net from 'node:net';
@@ -149,7 +150,11 @@ function writeIfChanged(filePath: string, content: string, mode: number): boolea
     /* missing or unreadable — write it */
   }
   ensureDir(path.dirname(filePath));
-  const tmp = `${filePath}.tmp.${process.pid}.${Date.now()}`;
+  // `.tmp.<pid>.<12 hex>`, not an epoch: that is the shape the server's orphan
+  // sweeper matches, and it sweeps both the state home and its `bin` dir. An
+  // app killed between the write and the rename used to leak a file here that
+  // nothing would ever collect (TRA-982).
+  const tmp = `${filePath}.tmp.${process.pid}.${randomBytes(6).toString('hex')}`;
   fs.writeFileSync(tmp, content, { mode });
   fs.renameSync(tmp, filePath);
   if (!IS_WINDOWS) fs.chmodSync(filePath, mode);

--- a/src/init/launcher.ts
+++ b/src/init/launcher.ts
@@ -13,6 +13,7 @@
  * symlink to the above — see installLegacyBinCompat().
  */
 
+import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -290,7 +291,12 @@ export function legacyCompatCmdBody(currentLauncher: string): string {
  * old one and swap it in with a single rename.
  */
 function writeLegacyCompat(legacyPath: string, current: string): void {
-  const tmp = `${legacyPath}.tmp.${process.pid}`;
+  // `.tmp.<pid>.<12 hex>`: the shape sweepOrphanTmpFiles collects
+  // (src/utils/atomic-write.ts), and `bin` is one of the dirs it sweeps. A
+  // process killed between the symlink and the rename leaks this file, and
+  // without the hex suffix the pattern never matched it — so it sat next to the
+  // launcher forever (TRA-982).
+  const tmp = `${legacyPath}.tmp.${process.pid}.${randomBytes(6).toString('hex')}`;
   try {
     if (IS_WINDOWS) {
       fs.writeFileSync(tmp, legacyCompatCmdBody(current), { mode: 0o755 });

--- a/tests/init/launcher-legacy-compat.test.ts
+++ b/tests/init/launcher-legacy-compat.test.ts
@@ -11,6 +11,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getLauncherPath, installLauncher, legacyCompatCmdBody } from '../../src/init/launcher.js';
 import { LAUNCHER_VERSION } from '../../src/init/types.js';
+import { sweepOrphanTmpFiles } from '../../src/utils/atomic-write.js';
 
 const STALE_SHIM = '#!/bin/bash\n# trace-mcp-launcher v0.3.0\nexit 127\n';
 
@@ -186,6 +187,55 @@ describe.skipIf(process.platform === 'win32')('legacy bin compat', () => {
       expect(fs.lstatSync(getLauncherPath()).isSymbolicLink()).toBe(false);
     } finally {
       delete process.env.TRACE_MCP_HOME;
+    }
+  });
+});
+
+/**
+ * TRA-982: `bin` is in SWEPT_STATE_DIRS (src/utils/atomic-write.ts) precisely so
+ * a write interrupted next to the shim gets collected. The sweeper matches
+ * `.tmp.<pid>.<12 hex>` — the trailing hex is what keeps it from eating a user
+ * file that merely has ".tmp." in its name — and this writer emitted
+ * `.tmp.<pid>` with no suffix at all, so a process killed between the symlink
+ * and the rename left a file in the launcher's own bin directory that nothing
+ * would ever collect.
+ */
+describe.skipIf(process.platform === 'win32')('legacy compat tmp is sweepable', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-legacy-tmp-'));
+    vi.spyOn(os, 'homedir').mockReturnValue(home);
+    delete process.env.TRACE_MCP_HOME;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('names its tmp so the orphan sweeper collects it after a crash', () => {
+    const legacyPath = path.join(home, '.trace-mcp', 'bin', 'trace-mcp');
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    fs.writeFileSync(legacyPath, STALE_SHIM, { mode: 0o755 });
+
+    const tmpNames: string[] = [];
+    const realSymlink = fs.symlinkSync;
+    vi.spyOn(fs, 'symlinkSync').mockImplementation((target, p, type) => {
+      tmpNames.push(path.basename(p as string));
+      return realSymlink(target, p as string, type);
+    });
+
+    installLauncher({ force: true });
+
+    expect(tmpNames.length).toBeGreaterThan(0);
+    for (const name of tmpNames) {
+      // Must survive a full sweep pass, not just look right.
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-sweep-'));
+      fs.writeFileSync(path.join(dir, name), '');
+      fs.utimesSync(path.join(dir, name), new Date(0), new Date(0));
+      expect(sweepOrphanTmpFiles(dir).map((f) => path.basename(f))).toEqual([name]);
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## What

Two writers put files into the trace-mcp state home (and its `bin/` directory) with an atomic write, but named their tmp file in a shape the orphan sweeper cannot match — so a process killed between the write and the rename leaked a file that nothing would ever collect.

`sweepOrphanTmpFiles` matches `^\.?.+\.tmp\.\d+\.[0-9a-f]{12}$` and `bin` is in `SWEPT_STATE_DIRS` precisely so leftovers next to the launcher shim get cleaned up. The trailing hex is deliberate — it keeps the sweeper from eating a user file that merely has `.tmp.` in its name.

| Writer | Emitted | Swept? |
|---|---|---|
| `atomicWriteString` (`src/utils/atomic-write.ts`) | `.tmp.<pid>.<12 hex>` | yes |
| `acquireLock` (`src/utils/pid-lock.ts`) | `.tmp.<pid>.<12 hex>` | yes |
| `writeLegacyCompat` (`src/init/launcher.ts`) | `.tmp.<pid>` | **no** |
| `writeIfChanged` (`packages/app/src/main/daemon-install.ts`) | `.tmp.<pid>.<epoch ms>` (13 decimal digits) | **no** |

Both now use `randomBytes(6).toString('hex')`.

## How it was found

TRA-982 autopilot run. `claude mcp list` shows trace-mcp connected and `launcher.log` has zero `ERROR` lines in the last 24h, so the run moved on to the untested failure scenarios the issue lists. Item 5 (state hygiene — "остаются осиротевшие `.tmp.*` от прерванных атомарных записей") led to auditing every tmp-name producer against the sweeper's pattern.

## Tests

Both tests capture the tmp path the writer actually hands to `renameSync`/`symlinkSync`, so they pin the producer rather than restating the regex:

- `tests/init/launcher-legacy-compat.test.ts` — writes a leftover with the captured name into a temp dir, ages it, and asserts a real `sweepOrphanTmpFiles` pass collects it.
- `packages/app/src/main/__tests__/daemon-install.test.ts` — asserts every tmp name a full `ensureDaemonInstalled` produces matches the sweeper's pattern. (The regex is duplicated there rather than imported: `packages/app` is its own package with its own test setup and does not import from the server's `src`.)

Both fail on `main` (`trace-mcp.tmp.48403`, `node-runtime.tmp.48599.1788660433641`) and pass with the fix.

Full suite: `927 files / 10275 tests passed`, `pnpm typecheck`, `pnpm biome:ci`, `pnpm build` all clean. The `packages/app` suite has 44 pre-existing file-level failures (react/jsx-runtime resolution) — identical counts with and without this change; it adds one passing test (233 → 234).

## Not in this PR

The run also reproduced the TRA-965 dangling-`node-runtime`-shim outage against the copy installed on this machine (launcher v0.6.3: `exit 126`, all ~170 tools lost, no `ERROR` line). The fix is already on `main` as launcher v0.6.5 and recovers correctly — it is simply unreleased (repo 3.19.0 vs 3.18.0 installed everywhere). Release timing, not a code defect.

Closes TRA-982.
