### PR TITLE
fix(registry): classify <tmp>/multica-task-<id> checkouts as ephemeral (TRA-992)

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -588,6 +588,25 @@ const EPHEMERAL_WORKDIR_PATTERN =
   /[/\\]multica_workspaces[^/\\]*[/\\][^/\\]+[/\\][^/\\]+[/\\]workdir([/\\]|$)/i;
 
 /**
+ * Dead end, so the next run does not re-walk it (TRA-992). The same runtime has
+ * a second one-shot layout the pattern above does not see — a task given a
+ * scratch directory instead of a workspace checkout lands in
+ * `<tmp>/multica-task-<run-id>/...` — and 17 of the 37 rows in the reported
+ * registry.json were exactly that: dead within the hour, each pinning a
+ * `.config.json` section for the full 7-day `sweepMissingRoots` grace.
+ *
+ * Adding `/[/\\]multica-task-\d+[/\\]/` here does fix that, and it must not be
+ * done: on a machine whose agent runtime exports `TMPDIR` as its own task
+ * directory — which is how the leak arises in the first place — `os.tmpdir()`
+ * IS a `multica-task-<id>` path, so the rule reclassifies every fixture the
+ * test suite builds under it. Seven registry tests fail locally and pass in CI,
+ * which is worse than the leak: the leak is bounded and self-healing, since the
+ * grace period expires and `pruneProjectConfigSections` then drops the sections
+ * it was holding. Anchoring the shape at the temp root instead does not help —
+ * `os.tmpdir()` is the task directory, not its parent.
+ */
+
+/**
  * True when `root` is a one-shot agent-run checkout (see
  * {@link EPHEMERAL_WORKDIR_PATTERN}). Such roots are never persisted to
  * registry.json — see the `_ephemeralEntries` note above.

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -588,31 +588,34 @@ const EPHEMERAL_WORKDIR_PATTERN =
   /[/\\]multica_workspaces[^/\\]*[/\\][^/\\]+[/\\][^/\\]+[/\\]workdir([/\\]|$)/i;
 
 /**
- * Dead end, so the next run does not re-walk it (TRA-992). The same runtime has
- * a second one-shot layout the pattern above does not see — a task given a
- * scratch directory instead of a workspace checkout lands in
- * `<tmp>/multica-task-<run-id>/...` — and 17 of the 37 rows in the reported
- * registry.json were exactly that: dead within the hour, each pinning a
- * `.config.json` section for the full 7-day `sweepMissingRoots` grace.
+ * The same runtime's other one-shot layout: a task given a scratch directory
+ * instead of a workspace checkout lands in `<tmp>/multica-task-<run-id>/...`.
+ * `EPHEMERAL_WORKDIR_PATTERN` above never matched those, so each was persisted
+ * like a real project — 17 of the 37 rows in the reported registry.json, all
+ * dead within the hour, each pinning a `.config.json` section for the full
+ * 7-day `sweepMissingRoots` grace (TRA-992).
  *
- * Adding `/[/\\]multica-task-\d+[/\\]/` here does fix that, and it must not be
- * done: on a machine whose agent runtime exports `TMPDIR` as its own task
- * directory — which is how the leak arises in the first place — `os.tmpdir()`
- * IS a `multica-task-<id>` path, so the rule reclassifies every fixture the
- * test suite builds under it. Seven registry tests fail locally and pass in CI,
- * which is worse than the leak: the leak is bounded and self-healing, since the
- * grace period expires and `pruneProjectConfigSections` then drops the sections
- * it was holding. Anchoring the shape at the temp root instead does not help —
- * `os.tmpdir()` is the task directory, not its parent.
+ * The container is matched, not the leaf: a run drops several roots under it
+ * (its own scratch dirs, benchmark fixtures) and none outlive the run. The
+ * numeric run id keeps this off a user directory that merely says
+ * "multica-task".
+ *
+ * Note for tests: such a runtime also exports TMPDIR as its own task
+ * directory, so `os.tmpdir()` itself can match this. A fixture that must stay
+ * persistent has to be built outside it — see `tmpRootOutsideTaskDir` in
+ * tests/test-utils.ts.
  */
+const EPHEMERAL_TASK_DIR_PATTERN = /[/\\]multica-task-\d+[/\\]/i;
 
 /**
- * True when `root` is a one-shot agent-run checkout (see
- * {@link EPHEMERAL_WORKDIR_PATTERN}). Such roots are never persisted to
+ * True when `root` is a one-shot agent-run checkout, in either layout the
+ * runtime uses (see {@link EPHEMERAL_WORKDIR_PATTERN} and
+ * {@link EPHEMERAL_TASK_DIR_PATTERN}). Such roots are never persisted to
  * registry.json — see the `_ephemeralEntries` note above.
  */
 export function isEphemeralProjectRoot(root: string): boolean {
-  return EPHEMERAL_WORKDIR_PATTERN.test(path.resolve(root));
+  const abs = path.resolve(root);
+  return EPHEMERAL_WORKDIR_PATTERN.test(abs) || EPHEMERAL_TASK_DIR_PATTERN.test(abs);
 }
 
 export interface EphemeralProjectCandidate {
@@ -638,7 +641,7 @@ export function findEphemeralProjects(minAgeHours = 24): EphemeralProjectCandida
   const now = Date.now();
   const out: EphemeralProjectCandidate[] = [];
   for (const entry of listProjects()) {
-    if (!EPHEMERAL_WORKDIR_PATTERN.test(entry.root)) continue;
+    if (!isEphemeralProjectRoot(entry.root)) continue;
     const addedMs = Date.parse(entry.addedAt);
     if (Number.isNaN(addedMs)) continue;
     const ageHours = (now - addedMs) / (60 * 60 * 1000);

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -49,6 +49,18 @@ function makeEphemeralWorkdir(): string {
 }
 
 /**
+ * The runtime's other one-shot layout: `<tmp>/multica-task-<run-id>/<scratch>`
+ * (TRA-992). No `multica_workspaces` segment anywhere in it.
+ */
+function makeEphemeralTaskDir(): string {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-task-'));
+  const dir = path.join(base, 'multica-task-3265850447', 'tmpl06qk62l');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), '{}');
+  return dir;
+}
+
+/**
  * Write a registry row for an ephemeral workdir the way versions before
  * TRA-396 did. `registerProject` no longer persists these at all, but field
  * registries are full of them and `findEphemeralProjects` is what drains them.
@@ -347,6 +359,37 @@ describe('ephemeral workdirs are never persisted', () => {
     // an empty one is what keeps a foreground metrics call off the queue.
     expect(Object.keys(registryProjects())).toHaveLength(0);
     expect(listProjects()).toEqual([]);
+  });
+
+  // TRA-992: the tmp-dir layout was invisible to the ephemeral check, so these
+  // rows were persisted, then sat out the full 7-day `sweepMissingRoots` grace
+  // — 17 of 37 rows on the reported machine, each pinning a `.config.json`
+  // section that `pruneProjectConfigSections` will not touch while a registry
+  // entry claims it.
+  it('keeps a one-shot task scratch dir out of registry.json', () => {
+    const dir = makeEphemeralTaskDir();
+    registerProject(dir);
+
+    expect(registryProjects()).toEqual({});
+    // Still resolvable for the run that registered it, like the other layout.
+    expect(getProject(dir)?.root).toBe(dir);
+  });
+
+  it('still persists an ordinary project fixture built under the temp root', () => {
+    const repo = makeTmpRepo();
+    registerProject(repo);
+
+    expect(Object.keys(registryProjects())).toEqual([repo]);
+  });
+
+  it('leaves a directory that merely says "multica-task" alone', () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-real-'));
+    const dir = path.join(base, 'multica-task-notes');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'package.json'), '{}');
+    registerProject(dir);
+
+    expect(Object.keys(registryProjects())).toEqual([dir]);
   });
 
   it('still persists a workdir-shaped root registered as an explicit multi-root', () => {

--- a/tests/setup/isolate-home.ts
+++ b/tests/setup/isolate-home.ts
@@ -27,9 +27,49 @@
  * actual index (eval-cli-smoke validates the built CLI against the self-index)
  * can opt back in for a spawned subprocess.
  */
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
+
+/**
+ * Step the temp root out of a one-shot agent-run scratch directory (TRA-992).
+ *
+ * The Multica runtime exports TMPDIR as its own `multica-task-<run-id>`
+ * directory, and `isEphemeralProjectRoot` classifies anything under such a path
+ * as a throwaway checkout that is never persisted to registry.json. That is
+ * correct in production and wrong for the suite: ~200 tests build their
+ * "ordinary persistent project" fixture with `mkdtempSync(join(tmpdir(), ...))`,
+ * so on that one runtime every one of them silently became an ephemeral root —
+ * 36 failures across 14 files that pass everywhere else. Retargeting TMPDIR once
+ * here fixes all of them, and keeps future fixtures from inheriting the trap. A
+ * test that wants the ephemeral shape still builds the path explicitly.
+ *
+ * `os.tmpdir()` re-reads TMPDIR on every call on POSIX, so this must run before
+ * any test module calls it — which is what a setupFile guarantees.
+ */
+function escapeTaskScopedTmpdir(): void {
+  let dir = tmpdir();
+  let changed = false;
+  while (/^multica-task-\d+$/i.test(basename(dir))) {
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+    changed = true;
+  }
+  if (changed) {
+    // Resolve symlinks: on macOS the walk lands on `/tmp`, which is a symlink
+    // to `/private/tmp`. `find "$TMPDIR" -maxdepth 1` in hooks/*.sh does not
+    // descend a symlink argument, so an unresolved value silently disables the
+    // hooks' own GC — and the test that asserts it.
+    dir = realpathSync(dir);
+    process.env.TMPDIR = dir;
+    // Windows and some libs read these instead; keep them in step.
+    if (process.env.TEMP) process.env.TEMP = dir;
+    if (process.env.TMP) process.env.TMP = dir;
+  }
+}
+
+escapeTaskScopedTmpdir();
 
 if (!process.env.TRACE_MCP_DATA_DIR) {
   // Preserve a pointer to the real home before we redirect it. When the override


### PR DESCRIPTION
Auditing MCP connection reliability (TRA-992) turned up 17 of 37 `registry.json` rows on the reported machine that were dead one-shot agent checkouts under `<tmp>/multica-task-<run-id>/...`. `EPHEMERAL_WORKDIR_PATTERN` only knows the `multica_workspaces/.../workdir` layout, so the runtime's other one — a task given a scratch directory instead of a workspace checkout — was persisted like a real project. Each row then sat out the full 7-day `sweepMissingRoots` grace, pinning a `.config.json` section that `pruneProjectConfigSections` will not touch while a registry entry claims it, and holding an index DB.

## The change

- `isEphemeralProjectRoot` also matches `EPHEMERAL_TASK_DIR_PATTERN` (`/[/\\]multica-task-\d+[/\\]/`). The container is matched, not the leaf: a run drops several roots under it and none outlive the run. The numeric run id keeps this off a directory that merely says "multica-task".
- `findEphemeralProjects` now goes through `isEphemeralProjectRoot` instead of testing one pattern directly, so the drain path sees both layouts.
- `tests/setup/isolate-home.ts` steps `TMPDIR` out of a task-scoped temp root.

That last part is the reason the first draft of this PR was a comment saying the fix could not be done. The runtime that produces these roots also exports `TMPDIR` as its own `multica-task-<id>` directory, so `os.tmpdir()` itself matches the new pattern and ~200 fixtures built with `mkdtempSync(join(tmpdir(), ...))` — all standing for ordinary persistent projects — were reclassified: 36 failures across 14 files that pass everywhere else. @Code Reviewer pushed back on calling that a dead end and was right; retargeting `TMPDIR` once in the setup file fixes all 14 and keeps future fixtures out of the trap. The value is `realpathSync`d because `find "$TMPDIR" -maxdepth 1` in `hooks/*.sh` does not descend a symlink argument, and the macOS walk lands on `/tmp`.

## Tests

New in `tests/registry.test.ts`, covering both directions the reviewer asked for:
- a one-shot task scratch dir stays out of `registry.json` and is still resolvable for the run that registered it;
- an ordinary fixture built under the temp root still persists;
- a directory merely named `multica-task-notes` still persists.

`pnpm test` — 933 files, 10335 passed, 28 skipped. `tsc --noEmit` and biome clean.