### PR TITLE
feat(guard): nudge long sessions into the StateEngine loop (TRA-763)

### DIFF
--- a/docs/SKILL_STATE.md
+++ b/docs/SKILL_STATE.md
@@ -82,6 +82,21 @@ long sessions, and the one short session in the set lost. Until the crossover is
 located, paying schema tokens for these seven tools in every session — most of
 which are short — is not justified by anything measured.
 
+### The hint that closes the gap (TRA-763)
+
+Off the default preset also means unreachable: an agent cannot ask for tools it
+cannot see, so the sessions the measurement says would profit never enter the
+loop. The guard hook counts guarded tool calls and, on the 30th, emits a single
+advisory `additionalContext` naming the `load_tools` call above. It fires once
+per session, never blocks, and stays silent when the MCP channel is dead, when
+`TRACE_MCP_PRESET` is already `state`/`full`, or when `state.db` has been
+written since the session started. `TRACE_MCP_STATE_HINT_TURNS` moves the
+threshold; `0` turns the hint off.
+
+Turn 30 is where TRA-724 put the profitable regime, not a round number: over 669
+real sessions past that mark, 667 came out ahead on billed tokens (+33.2% at
+50–99 turns, +68.7% at 200+), while sessions under ~28 turns lost 5.6–8.4%.
+
 ## MCP Prompt: `state`
 
 The tools do not start the loop on their own — an agent has to be told to run

--- a/hooks/trace-mcp-guard.cmd
+++ b/hooks/trace-mcp-guard.cmd
@@ -391,6 +391,10 @@ REM crosses the threshold; silent otherwise. One shot per session.
 set "STATE_HINT_FIRED=0"
 set "STATE_TURNS=30"
 if defined TRACE_MCP_STATE_HINT_TURNS set "STATE_TURNS=%TRACE_MCP_STATE_HINT_TURNS%"
+REM Garbage in the knob falls back to the default, same as the POSIX guard -
+REM `set /a` would otherwise read it as 0 and silently disable the hint.
+echo !STATE_TURNS!| findstr /r "^-*[0-9][0-9]*$" >nul 2>&1
+if errorlevel 1 set "STATE_TURNS=30"
 set /a STATE_TURNS=STATE_TURNS+0 >nul 2>&1
 if !STATE_TURNS! LEQ 0 goto :eof
 if /i "%TRACE_MCP_PRESET%"=="state" goto :eof

--- a/hooks/trace-mcp-guard.cmd
+++ b/hooks/trace-mcp-guard.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-guard v0.15.0
+REM trace-mcp-guard v0.16.0
 REM trace-mcp PreToolUse guard (Windows)
 REM Blocks Read/Grep/Glob/Bash on source code files + Agent(Explore) subagents - redirects to trace-mcp tools.
 REM Allows: non-code files, Read before Edit, safe Bash commands (git, npm, build, test).
@@ -48,6 +48,14 @@ if "%TOOL_NAME%"=="" goto :allow
 REM Extract session id once — needed by .md doc-tour helper and the code-file branch.
 set "SESSION_ID=default"
 for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "try { (Get-Content '%TMPINPUT%' -Raw | ConvertFrom-Json).session_id } catch { 'default' }"`) do set "SESSION_ID=%%i"
+
+REM StateEngine discovery hint (TRA-763) - parity with trace-mcp-guard.sh.
+REM TRA-724 put the break-even for the trace_state_* loop at turns 25-28; from
+REM turn 30 on, 667 of 669 real sessions came out ahead on billed tokens. The
+REM seven schemas stay off the default `minimal` preset, which leaves the
+REM feature unreachable in exactly those long sessions - so nudge once.
+call :state_hint
+if "%STATE_HINT_FIRED%"=="1" goto :cleanup
 
 REM --- Read ---
 if /i not "%TOOL_NAME%"=="Read" goto :check_grep
@@ -375,6 +383,36 @@ if !NAV_LAST! EQU 0 (
 set /a NAV_COUNT=NAV_COUNT+1 >nul 2>&1
 > "!NAV_DIR!\.nav-streak" echo !NAV_COUNT! !NAV_NOW!
 if !NAV_COUNT! LSS !NAV_MIN! set "NAV_BELOW=1"
+goto :eof
+
+:state_hint
+REM Sets STATE_HINT_FIRED=1 (and prints the advisory JSON) on the call that
+REM crosses the threshold; silent otherwise. One shot per session.
+set "STATE_HINT_FIRED=0"
+set "STATE_TURNS=30"
+if defined TRACE_MCP_STATE_HINT_TURNS set "STATE_TURNS=%TRACE_MCP_STATE_HINT_TURNS%"
+set /a STATE_TURNS=STATE_TURNS+0 >nul 2>&1
+if !STATE_TURNS! LEQ 0 goto :eof
+if /i "%TRACE_MCP_PRESET%"=="state" goto :eof
+if /i "%TRACE_MCP_PRESET%"=="full" goto :eof
+set "STATE_DIR=%TEMP%\trace-mcp-reads-%SESSION_ID%"
+if not exist "!STATE_DIR!" mkdir "!STATE_DIR!" >nul 2>&1
+if exist "!STATE_DIR!\.state-hint-emitted" goto :eof
+set "STATE_COUNT=0"
+if exist "!STATE_DIR!\.session-turn-count" (
+    for /f "usebackq tokens=1" %%a in ("!STATE_DIR!\.session-turn-count") do set "STATE_COUNT=%%a"
+)
+set /a STATE_COUNT=STATE_COUNT+1 >nul 2>&1
+> "!STATE_DIR!\.session-turn-count" echo !STATE_COUNT!
+if !STATE_COUNT! LSS !STATE_TURNS! goto :eof
+> "!STATE_DIR!\.state-hint-emitted" echo 1
+set "STATE_HINT_FIRED=1"
+echo {
+echo   "hookSpecificOutput": {
+echo     "hookEventName": "PreToolUse",
+echo     "additionalContext": "[trace-mcp] This session has passed !STATE_COUNT! tool calls. Past ~30 turns the ReAct transcript is the dominant prompt cost; carrying a compact state block instead measured 67%% lower billed prompt tokens on real sessions of this length. To switch: load_tools({ tools: [\"trace_state_init\", \"trace_state_patch\", \"trace_state_get\", \"trace_state_add_dead_end\"] }), then trace_state_init with the goal and plan steps, and patch it per step instead of restating progress. Ignore this if the task is nearly done."
+echo   }
+echo }
 goto :eof
 
 :is_env_example

--- a/hooks/trace-mcp-guard.sh
+++ b/hooks/trace-mcp-guard.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
-# trace-mcp-guard v0.16
+# trace-mcp-guard v0.17
 # REQUIRES: trace-mcp >= 1.32.7   (status JSON sentinel introduced in this version)
+#
+# v0.17 changes (TRA-763 — StateEngine discovery hint):
+#   - Counts guarded tool calls per session and, on the 30th (default,
+#     TRACE_MCP_STATE_HINT_TURNS), emits one advisory additionalContext
+#     pointing at load_tools + trace_state_init. TRA-724 measured the
+#     break-even for that loop at turns 25-28; the seven schemas are kept off
+#     the default `minimal` preset for the short sessions that lose, which
+#     left the feature unreachable in the long ones that win.
+#   - Silent when the channel is dead, when TRACE_MCP_PRESET already
+#     advertises the tools, when state.db has been written since the session
+#     started, and after the one shot. Never blocks.
 #
 # v0.16 changes (TRA-869 — sentinels moved out of $TMPDIR):
 #   - The heartbeat, status, consultation-marker and bypass paths are read from
@@ -683,6 +694,53 @@ maybe_auto_degrade() {
 if any_consultation_markers; then
   rm -f "$DENY_AGGREGATE_FILE" 2>/dev/null || true
 fi
+
+
+# ─── StateEngine discovery hint (TRA-763) ──────────────────────────
+# TRA-724 put the break-even for the trace_state_* loop at turns 25-28: below
+# it the state block costs more than the history it replaces (median -5.6% to
+# -8.4% billed), from turn 30 on 667 of 669 real sessions came out ahead
+# (+33.2% billed at 50-99 turns, +68.7% at 200+). The seven schemas (838
+# tokens) are therefore kept off the default `minimal` preset — which leaves
+# the feature unreachable in exactly the sessions it pays off in. This counts
+# guarded tool calls and, once past the threshold, points the agent at
+# load_tools. Once per session, advisory only, never blocks.
+STATE_HINT_TURNS=${TRACE_MCP_STATE_HINT_TURNS:-30}
+STATE_HINT_FILE="$READS_DIR/.state-hint-emitted"
+STATE_SESSION_START="$READS_DIR/.session-start"
+STATE_TURN_COUNTER="$READS_DIR/.session-turn-count"
+
+state_hint_if_due() {
+  (( STATE_HINT_TURNS <= 0 )) && return 0        # 0 or negative disables the hint
+  (( HEARTBEAT_DEAD == 1 )) && return 0          # no live channel to enable it on
+  [[ -f "$STATE_HINT_FILE" ]] && return 0        # one shot per session
+  case "${TRACE_MCP_PRESET:-}" in state|full) return 0 ;; esac  # already advertised
+
+  local count=0
+  [[ -f "$STATE_TURN_COUNTER" ]] && count=$(cat "$STATE_TURN_COUNTER" 2>/dev/null || echo 0)
+  [[ "$count" =~ ^[0-9]+$ ]] || count=0
+  count=$((count + 1))
+  (( count == 1 )) && touch "$STATE_SESSION_START" 2>/dev/null
+  true
+  echo "$count" > "$STATE_TURN_COUNTER" 2>/dev/null || true
+  (( count < STATE_HINT_TURNS )) && return 0
+
+  # ponytail: "state is already in use" is inferred from state.db having been
+  # written since this session started, not from watching the calls — the
+  # guard's matcher is Read|Grep|Glob|Bash|Agent, so trace_state_* calls never
+  # reach this hook. A concurrent session writing state.db swallows one soft
+  # hint; a marker written by the server is the upgrade if that ever matters.
+  if [[ -f "$STATE_SESSION_START" ]] && \
+     [[ -n "$(find "$TRACE_STATE_HOME/state.db" -newer "$STATE_SESSION_START" 2>/dev/null)" ]]; then
+    touch "$STATE_HINT_FILE" 2>/dev/null || true
+    return 0
+  fi
+
+  touch "$STATE_HINT_FILE" 2>/dev/null || true
+  allow_with_context "[trace-mcp] This session has passed ${count} tool calls. Past ~30 turns the ReAct transcript is the dominant prompt cost; carrying a compact state block instead measured 67% lower billed prompt tokens on real sessions of this length. To switch: load_tools({ tools: [\\\"trace_state_init\\\", \\\"trace_state_patch\\\", \\\"trace_state_get\\\", \\\"trace_state_add_dead_end\\\"] }), then trace_state_init with the goal and plan steps, and patch it per step instead of restating progress. Ignore this if the task is nearly done."
+}
+
+state_hint_if_due || true
 
 # ─── Read ──────────────────────────────────────────────────────────
 if [[ "$TOOL_NAME" == "Read" ]]; then

--- a/hooks/trace-mcp-guard.sh
+++ b/hooks/trace-mcp-guard.sh
@@ -706,6 +706,11 @@ fi
 # guarded tool calls and, once past the threshold, points the agent at
 # load_tools. Once per session, advisory only, never blocks.
 STATE_HINT_TURNS=${TRACE_MCP_STATE_HINT_TURNS:-30}
+# A non-numeric value here is not a bad hint, it is a dead guard: under
+# `set -u` bash reads the string inside (( )) as a variable name and aborts
+# the hook with no JSON on stdout, which fails open for every remaining
+# guarded call in the session. Fall back to the default instead.
+[[ "$STATE_HINT_TURNS" =~ ^-?[0-9]+$ ]] || STATE_HINT_TURNS=30
 STATE_HINT_FILE="$READS_DIR/.state-hint-emitted"
 STATE_SESSION_START="$READS_DIR/.session-start"
 STATE_TURN_COUNTER="$READS_DIR/.session-turn-count"

--- a/tests/hooks/guard.test.ts
+++ b/tests/hooks/guard.test.ts
@@ -1601,6 +1601,21 @@ describe.skipIf(process.platform === 'win32')('guard StateEngine hint (TRA-763)'
     }
   });
 
+  it('falls back to the default threshold when the knob is not a number', () => {
+    // Under `set -u` a non-numeric value inside (( )) aborts the hook with no
+    // JSON on stdout, which fails open for every remaining guarded call in the
+    // session — a typo in the knob must not disable the guard.
+    for (let i = 0; i < 3; i++) {
+      expect(call({ TRACE_MCP_STATE_HINT_TURNS: 'not-a-number' }).context).toBeUndefined();
+    }
+    // The default (30) is in force, so the guard is still routing: a
+    // navigational call is still denied.
+    const nav = runGuard('Grep', { pattern: 'foo', glob: '*.ts' }, sessionId, projectDir, {
+      TRACE_MCP_STATE_HINT_TURNS: 'not-a-number',
+    });
+    expect(nav.allowed).toBe(false);
+  });
+
   it('is disabled by setting the threshold to zero', () => {
     for (let i = 0; i < 5; i++) {
       expect(call({ TRACE_MCP_STATE_HINT_TURNS: '0' }).context).toBeUndefined();

--- a/tests/hooks/guard.test.ts
+++ b/tests/hooks/guard.test.ts
@@ -1544,3 +1544,66 @@ describe.skipIf(process.platform === 'win32')('navigation streak gate (TRA-711)'
     expect(decision.reason ?? '').toMatch(/Agent\(Explore\)/);
   });
 });
+
+/**
+ * StateEngine discovery hint (TRA-763). The trace_state_* tools are off the
+ * default `minimal` preset because TRA-724 measured them losing below ~turn
+ * 28 — which also makes them unreachable in the long sessions where the same
+ * measurement puts them 33-69% ahead. The guard closes that gap with one
+ * advisory nudge, so what matters is that it fires exactly once and only past
+ * the threshold.
+ */
+describe.skipIf(process.platform === 'win32')('guard StateEngine hint (TRA-763)', () => {
+  const projectDir = path.join(TMP_BASE, `trace-mcp-state-hint-${Date.now()}`);
+  let sessionId: string;
+
+  beforeEach(() => {
+    fs.mkdirSync(projectDir, { recursive: true });
+    sessionId = `vitest-state-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    setHeartbeatAlive(projectDir);
+  });
+
+  afterEach(() => {
+    const readsDir = path.join(TMP_BASE, `trace-mcp-reads-${sessionId}`);
+    if (fs.existsSync(readsDir)) fs.rmSync(readsDir, { recursive: true, force: true });
+    if (fs.existsSync(projectDir)) {
+      const real = fs.realpathSync(projectDir);
+      fs.rmSync(path.join(TMP_BASE, `trace-mcp-alive-${projectHash(real)}`), { force: true });
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  /** One ordinary, non-navigational Bash call — silent unless the hint fires. */
+  function call(extraEnv: Record<string, string> = {}): HookDecision {
+    return runGuard('Bash', { command: 'echo hi' }, sessionId, projectDir, {
+      TRACE_MCP_STATE_HINT_TURNS: '3',
+      ...extraEnv,
+    });
+  }
+
+  it('stays silent below the threshold and nudges once at it', () => {
+    expect(call().context).toBeUndefined();
+    expect(call().context).toBeUndefined();
+
+    const hinted = call();
+    expect(hinted.allowed).toBe(true);
+    expect(hinted.context ?? '').toMatch(/load_tools/);
+    expect(hinted.context ?? '').toMatch(/trace_state_init/);
+
+    // One shot: the next calls are silent again.
+    expect(call().context).toBeUndefined();
+    expect(call().context).toBeUndefined();
+  });
+
+  it('says nothing when the session already advertises the state tools', () => {
+    for (let i = 0; i < 5; i++) {
+      expect(call({ TRACE_MCP_PRESET: 'state' }).context).toBeUndefined();
+    }
+  });
+
+  it('is disabled by setting the threshold to zero', () => {
+    for (let i = 0; i < 5; i++) {
+      expect(call({ TRACE_MCP_STATE_HINT_TURNS: '0' }).context).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
Closes TRA-763.

## The gap

`trace_state_*` is measured and shipped, and unreachable. TRA-724 put the break-even for the state loop at turns 25–28, so the seven schemas (838 tokens) stay off the default `minimal` preset — correct for the short sessions that lose. The side effect is that the long sessions that win never see the tools either: an agent cannot ask for what is not in `tools/list`.

## The change

Both guards (`trace-mcp-guard.sh`, `trace-mcp-guard.cmd`) count guarded tool calls per session and, on the 30th, emit one advisory `additionalContext` naming the `load_tools` + `trace_state_init` call. Turn 30 is where TRA-724 measured the profitable regime: 667 of 669 real sessions past it came out ahead on billed tokens (+33.2% at 50–99 turns, +68.7% at 200+), while sessions under ~28 turns lost 5.6–8.4%.

Silent when: the MCP channel is dead (nothing to enable), `TRACE_MCP_PRESET` is already `state`/`full`, `state.db` has been written since the session started, or the hint already fired. `TRACE_MCP_STATE_HINT_TURNS=0` disables it. Never blocks — advisory only, in both enforcement tiers.

## Contract and cost

No MCP tool signature changes, no preset changes, no DB schema changes. Default `minimal` still advertises the same tools, so the schema cost of a session that never reaches turn 30 is unchanged — that is the invariant the first test pins.

## Tests

`tests/hooks/guard.test.ts` — three cases: silent below the threshold and one nudge at it (then silent again), silent when the preset already advertises the tools, silent at threshold `0`. Full suite: 10364 passed, `pnpm typecheck` and `biome ci` clean.

## Deliberately not in this PR

TRA-763 also proposed removing `noindex` from `docs/SKILL_STATE.md`, adding it to `docs_nav.yml`, and a README section. Those are public-surface moves, and `ops/positioning.md` embargoes the Phase-4 A/B numbers until one arm of that harness can fail (Pass@1 was 100% in both). The reachability defect is what this closes; the page stays `noindex` and the doc gains a section describing the hint.