### PR TITLE
fix(launcher): recover node and cli.js from the app bundle (TRA-996)

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.6.5 (Windows)
+REM trace-mcp-launcher v0.6.6 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.6.5 (Windows)
+# trace-mcp-launcher v0.6.6 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -286,7 +286,13 @@ node_from_pkg_roots() {
 app_bundle() {
   local line path=''
   [ -f "$APP_LOCATION_FILE" ] && [ -r "$APP_LOCATION_FILE" ] || return 1
-  while IFS= read -r line; do
+  # `|| [ -n "${line:-}" ]` — the same guard the config parser and pkg_roots
+  # use, for the same reason: `read` reports failure on a final line with no
+  # trailing newline, so a plain loop silently drops it. Today the writer emits
+  # `appPath` first and pretty-printed, so only a closing brace would be lost —
+  # but that is an accident of key order, not something this parser checks
+  # (review of #1011).
+  while IFS= read -r line || [ -n "${line:-}" ]; do
     case "$line" in
       *'"appPath"'*)
         path="${line#*\"appPath\"}"

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.6.5
+# trace-mcp-launcher v0.6.6
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -24,6 +24,10 @@ CONFIG="$TRACE_HOME/launcher.env"
 LOG="$TRACE_HOME/launcher.log"
 # One global node_modules root per line, appended by each install.
 PKG_ROOTS_FILE="$TRACE_HOME/pkg-roots"
+# Where the desktop app last saw itself, written by the app on every launch
+# (packages/app/src/main/install-path.ts). The only pointer to an app-only
+# install that survives the app being moved.
+APP_LOCATION_FILE="$TRACE_HOME/app-location.json"
 
 # Rotate once per invocation, before the first append (TRA-702). The shim runs
 # once per MCP client launch and writes a couple of lines, so a size check here
@@ -153,7 +157,10 @@ is_bounded_major() {
 # Major version of a node binary, or non-zero if it will not run at all.
 node_major() {
   local v
-  v=$("$1" -v 2>/dev/null) || return 1
+  # `ELECTRON_RUN_AS_NODE` is meaningless to a real node binary and is what
+  # makes the app's own binary answer `-v` as the Node it embeds, so one form
+  # covers both kinds of candidate.
+  v=$(ELECTRON_RUN_AS_NODE=1 "$1" -v 2>/dev/null) || return 1
   v="${v#v}"
   v="${v%%.*}"
   is_bounded_major "$v" || return 1
@@ -273,6 +280,70 @@ node_from_pkg_roots() {
   return 0
 }
 
+# Absolute path of the desktop app bundle, per the location file the app
+# rewrites on every launch. Parsed with builtins — the shim never spawns a
+# JSON tool, and the value is an opaque path, never evaluated.
+app_bundle() {
+  local line path=''
+  [ -f "$APP_LOCATION_FILE" ] && [ -r "$APP_LOCATION_FILE" ] || return 1
+  while IFS= read -r line; do
+    case "$line" in
+      *'"appPath"'*)
+        path="${line#*\"appPath\"}"
+        path="${path#*:}"
+        path="${path#"${path%%[![:space:]]*}"}"   # ltrim
+        path="${path#\"}"
+        path="${path%%\"*}"
+        ;;
+    esac
+  done < "$APP_LOCATION_FILE"
+  case "$path" in
+    /*) [ -d "$path" ] && echo "$path" && return 0 ;;
+  esac
+  return 1
+}
+
+# node and cli.js from inside the app bundle (TRA-996).
+#
+# A DMG install carries its own Node and its own cli.js and needs neither npm
+# nor a system node — that is the whole point of `bin/node-runtime`. But every
+# recovery path in this shim searched npm prefixes only, so the moment
+# launcher.env stopped describing reality the machine had no second source:
+# `probe_node` found nothing and the client lost all ~170 tools until someone
+# re-launched the app. Reproduced two ways on an app-only sandbox: dragging
+# trace-mcp.app to another folder (TRA-965's shim check fires, then dies at the
+# probe), and deleting launcher.env. Both now recover without the app running.
+#
+# Bundle layout is macOS-only, matching daemon-install.ts, which is the only
+# platform that ships an .app. `Contents/MacOS/*` rather than a hardcoded
+# binary name: a bundle has exactly one main executable and the app is free to
+# rename it.
+# ponytail: glob the one binary instead of parsing Info.plist — CFBundleExecutable
+# if a bundle ever ships a second executable there.
+node_from_app_bundle() {
+  local app c
+  app=$(app_bundle) || return 1
+  for c in "$app"/Contents/MacOS/*; do
+    [ -f "$c" ] && [ -x "$c" ] && normalise_path "$c" && return 0
+  done
+  return 1
+}
+
+cli_from_app_bundle() {
+  local app cli
+  app=$(app_bundle) || return 1
+  cli="$app/Contents/Resources/server/dist/cli.js"
+  [ -f "$cli" ] && normalise_path "$cli"
+}
+
+# True when $1 is the app's own binary, which only runs as Node with this set.
+is_app_runtime() {
+  case "$1" in
+    *.app/Contents/MacOS/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Every node worth trying, one per line, most-likely-first.
 node_candidates() {
   local n fnm_dir candidate
@@ -298,6 +369,11 @@ node_candidates() {
 
   # 4f. Last resort: prefixes that only pkg_roots knows about.
   node_from_pkg_roots
+
+  # 4g. The Node embedded in the desktop app. Last, because a real node needs
+  # no `ELECTRON_RUN_AS_NODE` dance — but on a DMG-only machine it is the only
+  # one there is.
+  node_from_app_bundle
 
   return 0
 }
@@ -449,6 +525,10 @@ probe_cli() {
     done
   done <<< "$roots"
 
+  # No npm prefix holds us: this is an app-only install (TRA-996). The bundle
+  # ships the same dist/cli.js, so serve that rather than ending the session.
+  cli_from_app_bundle && return 0
+
   return 1
 }
 
@@ -548,6 +628,7 @@ fi
 if [ -n "$NODE_PATH" ] && [ -x "$NODE_PATH" ] && [ -n "$CLI_PATH" ] && [ -f "$CLI_PATH" ]; then
   log "exec(config) node=$NODE_PATH cli=$CLI_PATH argc=$#"
   PATH="$CLIENT_PATH"
+  is_app_runtime "$NODE_PATH" && export ELECTRON_RUN_AS_NODE=1
   exec "$NODE_PATH" "$CLI_PATH" "$@"
 fi
 
@@ -580,4 +661,7 @@ fi
 
 log "exec(probe) node=$NODE_PATH cli=$CLI_PATH argc=$#"
 PATH="$CLIENT_PATH"
+# Set only for the app's own binary, never globally: the server spawns git and
+# LSP children, and an inherited ELECTRON_RUN_AS_NODE would follow them.
+is_app_runtime "$NODE_PATH" && export ELECTRON_RUN_AS_NODE=1
 exec "$NODE_PATH" "$CLI_PATH" "$@"

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -112,4 +112,4 @@ export const MIRROR_HOOK_VERSION = '0.3.0';
 // 0.6.0 (TRA-755): the resolved node is version-gated against engines.node. An
 // older one used to exec fine and die on a SyntaxError the client could only
 // report as "failed to connect" — and get pinned into launcher.env on the way.
-export const LAUNCHER_VERSION = '0.6.5';
+export const LAUNCHER_VERSION = '0.6.6';

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -902,15 +902,19 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
 // exited 126. The client lost all ~170 tools for the session, and the daily
 // "zero ERROR lines in launcher.log" health check read clean, because from the
 // shim's own side the exec had succeeded.
-describe.skipIf(process.platform === 'win32')('app runtime shim with a dangling target', () => {
-  /** The real generator, so the launcher's marker can never drift from it. */
-  function plantRuntimeShim(dir: string, execPath: string): string {
-    fs.mkdirSync(dir, { recursive: true });
-    const shim = path.join(dir, 'node-runtime');
-    fs.writeFileSync(shim, runtimeShimContent(execPath), { mode: 0o755 });
-    return shim;
-  }
+/**
+ * The real generator, so the launcher's marker can never drift from it. Module
+ * scope because two suites plant this shim: the dangling-target one below and
+ * the app-only recovery one at the end of the file.
+ */
+function plantRuntimeShim(dir: string, execPath: string): string {
+  fs.mkdirSync(dir, { recursive: true });
+  const shim = path.join(dir, 'node-runtime');
+  fs.writeFileSync(shim, runtimeShimContent(execPath), { mode: 0o755 });
+  return shim;
+}
 
+describe.skipIf(process.platform === 'win32')('app runtime shim with a dangling target', () => {
   function plantFallbackPrefix(home: string, traceHome: string): { cli: string } {
     const prefix = path.join(home, 'fallback-prefix');
     fs.mkdirSync(path.join(prefix, 'bin'), { recursive: true });
@@ -1087,4 +1091,137 @@ describe.skipIf(process.platform === 'win32')('app runtime shim with a dangling 
     // Default 5 MB applies, so a one-line log is nowhere near it.
     expect(fs.existsSync(`${logPath}.1`)).toBe(false);
   });
+});
+
+// TRA-996: the mirror image of the dangling-shim outage above, on the other
+// half of the pair. A DMG install carries its own Node and its own cli.js and
+// needs neither npm nor a system node — but every recovery path in the shim
+// searched npm prefixes only. So the moment launcher.env stopped describing
+// reality (the app was dragged to another folder, the file was lost), an
+// app-only machine had no second source: the probe found nothing and the
+// client lost all ~170 tools until someone re-launched the app. Both failures
+// were reproduced against a sandboxed app-only install before the fix.
+describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)', () => {
+  /** A minimal trace-mcp.app: one main binary, one bundled dist/cli.js. */
+  function plantAppBundle(root: string, marker = 'APP_NODE'): { app: string; cli: string } {
+    const app = path.join(root, 'trace-mcp.app');
+    const macos = path.join(app, 'Contents', 'MacOS');
+    const dist = path.join(app, 'Contents', 'Resources', 'server', 'dist');
+    fs.mkdirSync(macos, { recursive: true });
+    fs.mkdirSync(dist, { recursive: true });
+    // Echoes ELECTRON_RUN_AS_NODE so the tests can prove the shim exports it —
+    // without it the Electron binary is an app, not a Node runtime, and the
+    // exec would open a window instead of serving MCP.
+    fs.writeFileSync(
+      path.join(macos, 'trace-mcp'),
+      `#!/bin/bash\nif [ "\${1:-}" = "-v" ]; then echo "v24.0.0"; exit 0; fi\necho "${marker}:\${ELECTRON_RUN_AS_NODE:-unset}:$*"\n`,
+      { mode: 0o755 },
+    );
+    const cli = path.join(dist, 'cli.js');
+    fs.writeFileSync(cli, '// bundled cli\n');
+    return { app, cli: fs.realpathSync(cli) };
+  }
+
+  function writeAppLocation(traceHome: string, appPath: string): void {
+    fs.writeFileSync(
+      path.join(traceHome, 'app-location.json'),
+      `${JSON.stringify({ appPath, bundleId: 'com.trace-mcp.app', version: '3.8.0' }, null, 2)}\n`,
+    );
+  }
+
+  it('finds the bundled cli.js when no npm prefix holds the package', () => {
+    const { home, traceHome, node } = setupFakeHome();
+    const { app, cli } = plantAppBundle(home);
+    writeAppLocation(traceHome, app);
+    // Node is fine; only the cli.js pointer went stale — the shape left behind
+    // when the app moves but a system node is present.
+    writeConfig(traceHome, node, path.join(home, 'gone.app', 'cli.js'));
+
+    const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+  });
+
+  it('does not reach for the bundle while the configured cli.js still exists', () => {
+    const { home, traceHome, node, cli } = setupFakeHome();
+    const { app } = plantAppBundle(home);
+    writeAppLocation(traceHome, app);
+    writeConfig(traceHome, node, cli);
+
+    const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+  });
+
+  it('ignores an app-location file naming a bundle that is gone', () => {
+    const { home, traceHome, node } = setupFakeHome();
+    writeAppLocation(traceHome, path.join(home, 'never-installed.app'));
+    writeConfig(traceHome, node, path.join(home, 'gone.js'));
+
+    const { status, stderr } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+    expect(status).toBe(127);
+    expect(stderr).toContain('trace-mcp package not found');
+  });
+
+  // The node half needs the machine to have no standard node, or the probe
+  // rightly prefers it — same guard the pkg-roots node suite uses.
+  describe.skipIf(fs.existsSync('/opt/homebrew/bin/node') || fs.existsSync('/usr/local/bin/node'))(
+    'node resolves from the bundle',
+    () => {
+      it('recovers a moved app end to end, with no node and no npm anywhere', () => {
+        const { home, traceHome } = setupFakeHome();
+        // The stale pair: a runtime shim pointing into the app's OLD location,
+        // and a launcher.env carrying the cached major, so nothing on the fast
+        // path would spawn `node -v` and notice.
+        const shim = plantRuntimeShim(
+          path.join(traceHome, 'bin'),
+          path.join(home, 'Downloads', 'trace-mcp.app', 'Contents', 'MacOS', 'trace-mcp'),
+        );
+        const { app, cli } = plantAppBundle(path.join(home, 'Applications'));
+        fs.mkdirSync(path.join(home, 'Applications'), { recursive: true });
+        writeAppLocation(traceHome, app);
+        fs.writeFileSync(
+          path.join(traceHome, 'launcher.env'),
+          [
+            `TRACE_MCP_NODE="${shim}"`,
+            `TRACE_MCP_CLI="${path.join(home, 'Downloads', 'trace-mcp.app', 'cli.js')}"`,
+            'TRACE_MCP_NODE_MAJOR="24"',
+            '',
+          ].join('\n'),
+        );
+
+        const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, [
+          'serve',
+        ]);
+
+        expect(status).toBe(0);
+        // `1`, not `unset`: the app binary is only a Node runtime with this set.
+        expect(stdout.trim()).toBe(`APP_NODE:1:${cli} serve`);
+      });
+
+      it('prefers a real node over the app binary', () => {
+        const { home, traceHome } = setupFakeHome();
+        const nvmBin = path.join(home, '.nvm', 'versions', 'node', 'v22.22.2', 'bin');
+        fs.mkdirSync(nvmBin, { recursive: true });
+        fs.writeFileSync(path.join(nvmBin, 'node'), fakeNodeBody('22.22.2', 'NVM_NODE'), {
+          mode: 0o755,
+        });
+        fs.mkdirSync(path.join(home, '.nvm', 'alias'), { recursive: true });
+        fs.writeFileSync(path.join(home, '.nvm', 'alias', 'default'), 'v22.22.2\n');
+        const { app, cli } = plantAppBundle(home);
+        writeAppLocation(traceHome, app);
+        writeConfig(traceHome, '/nonexistent/node', '/nonexistent/cli.js');
+
+        const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, [
+          'serve',
+        ]);
+
+        expect(status).toBe(0);
+        expect(stdout.trim()).toBe(`NVM_NODE:${cli} serve`);
+      });
+    },
+  );
 });

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1155,6 +1155,25 @@ describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)'
     expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
   });
 
+  // Review of #1011: `read` reports failure on a final line with no trailing
+  // newline, so a plain `while read` loop drops it. The writer happens to emit
+  // `appPath` first today, which is key order, not a parser invariant — a
+  // minified or hand-edited file puts it on the only line there is.
+  it('reads an app-location file with no trailing newline', () => {
+    const { home, traceHome, node } = setupFakeHome();
+    const { app, cli } = plantAppBundle(home);
+    fs.writeFileSync(
+      path.join(traceHome, 'app-location.json'),
+      JSON.stringify({ appPath: app }), // one line, no newline at the end
+    );
+    writeConfig(traceHome, node, path.join(home, 'gone.app', 'cli.js'));
+
+    const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+  });
+
   it('ignores an app-location file naming a bundle that is gone', () => {
     const { home, traceHome, node } = setupFakeHome();
     writeAppLocation(traceHome, path.join(home, 'never-installed.app'));


### PR DESCRIPTION
On an app-only install (DMG, no `npm i -g trace-mcp`) the launcher had exactly one source for node and cli.js — `launcher.env` — and no way to recover when it stopped describing reality. Every fallback in the shim searches npm prefixes, and a DMG machine has none. So the client got `exit 127` and lost all ~170 tools until someone re-launched the app, with a working install sitting on disk the whole time.

This is the mirror image of TRA-965: that one fixed the *detection* (a dangling `node-runtime` shim is now spotted before it is exec'd); this fixes the *recovery* that detection falls through to.

## Reproduced

Sandboxed app-only install (app bundle + `node-runtime` + `launcher.env`, no npm global, no system node), against the shipped v0.6.5 shim. Both cases died with `exit 127 — node binary not found`:

1. **App moved.** Dragging `trace-mcp.app` to another folder — the standard "move to Applications" action. TRA-965's check correctly fires and clears the node, then `probe_node` finds nothing.
2. **`launcher.env` lost or corrupted.** Same dead end from the other direction.

Both now exit 0 and serve from the bundle.

## Fix

The app already records where it is, in `~/.trace-mcp/app-location.json`, and rewrites it on every launch. The shim now reads it as a last-resort source:

- `node_from_app_bundle` — appended **last** to `node_candidates`, after every real node, since a real node needs no `ELECTRON_RUN_AS_NODE` dance.
- `cli_from_app_bundle` — tried in `probe_cli` after the npm roots and the swap-window backups.
- `ELECTRON_RUN_AS_NODE=1` is exported at the exec sites **only** when the resolved node is inside a `.app` — never globally, or it would follow the server's git and LSP children.
- `node_major` sets it per-invocation so one probe form covers both kinds of candidate; it is meaningless to a real node binary.

Parsing is shell builtins only — the fast path must stay fork-free, and the value is an opaque path that is never evaluated (same trust model as `launcher.env` and `pkg-roots`).

macOS-only, matching `daemon-install.ts`: it is the only platform that ships an `.app`. The Windows shims get the version-header bump only.

## Tests

Five new cases in `tests/init/launcher-integration.test.ts`, covering both halves of the pair and, as importantly, what must *not* change:

- bundled cli.js found when no npm prefix holds the package
- the bundle is **not** consulted while the configured cli.js still exists
- an `app-location.json` naming a gone bundle still exits 127, loudly
- a moved app recovers end to end with no node and no npm anywhere, and the binary receives `ELECTRON_RUN_AS_NODE=1`
- a real node still beats the app binary

Full suite: `Test Files 937 passed | 3 skipped · Tests 10368 passed | 26 skipped`. Lint, typecheck, biome and build green.

## Note on the version bump

`LAUNCHER_VERSION` 0.6.5 → 0.6.6 is what makes `trace-mcp init` replace an already-installed shim, so the fix reaches existing installs.

Closes TRA-996.
