### PR TITLE
ci: cache pnpm activation via corepack instead of re-downloading per job

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,37 @@
+name: Setup pnpm (corepack, cached)
+description: >-
+  Activates the pnpm version pinned in package.json's "packageManager" field
+  via Node's built-in corepack, and caches corepack's download directory so
+  the pnpm tarball is fetched from the npm registry at most once per pnpm
+  version bump instead of once per job. Requires actions/setup-node (Node
+  >=22) to have already run.
+runs:
+  using: composite
+  steps:
+    # Job-wide (not just this step) via $GITHUB_ENV, so every later `pnpm`
+    # invocation in the calling job reads from the same cached directory
+    # instead of corepack's default per-user location.
+    - name: Point corepack's download cache at a cacheable path
+      shell: bash
+      run: echo "COREPACK_HOME=${{ runner.temp }}/corepack-home" >> "$GITHUB_ENV"
+
+    - name: Enable corepack
+      shell: bash
+      run: corepack enable
+
+    - name: Resolve pinned pnpm version
+      id: pnpm-version
+      shell: bash
+      run: echo "value=$(node -p "require('./package.json').packageManager")" >> "$GITHUB_OUTPUT"
+
+    # Keyed on the pnpm version string, not on the lockfile or package.json
+    # hash — a dependency bump shouldn't bust this, only a pnpm upgrade should.
+    - name: Cache pnpm download
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.temp }}/corepack-home
+        key: corepack-${{ runner.os }}-${{ steps.pnpm-version.outputs.value }}
+
+    - name: Activate pinned pnpm version
+      shell: bash
+      run: corepack prepare --activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,16 +329,18 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # No cache: 'pnpm' here: install below is conditional on the
+      # node_modules cache below missing, so a warm node_modules cache with a
+      # cold pnpm-store cache would skip install entirely and leave the store
+      # directory never created — actions/cache's post-job save then hard-
+      # errors on a path that doesn't exist. node_modules caching already
+      # covers the common case; a lockfile bump pays a plain (uncached-store)
+      # install instead.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
 
       - uses: ./.github/actions/setup-pnpm
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '22'
-          cache: 'pnpm'
 
       - id: keys
         name: Compute cache key
@@ -686,17 +688,18 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # No cache: 'pnpm' here: "Install app dependencies" below is
+      # conditional on the node_modules cache below missing, so a warm
+      # node_modules cache with a cold pnpm-store cache would skip install
+      # entirely and leave the store directory never created —
+      # actions/cache's post-job save then hard-errors on a path that
+      # doesn't exist. node_modules caching already covers the common case;
+      # a lockfile bump pays a plain (uncached-store) install instead.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
 
       - uses: ./.github/actions/setup-pnpm
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-          cache-dependency-path: packages/app/pnpm-lock.yaml
 
       - name: Restore app node_modules cache
         id: app-nm-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,18 +179,26 @@ jobs:
   # ───────────────────────────────────────────────────────────────────────────
   biome:
     runs-on: ubuntu-latest
-    # Every job that runs pnpm/action-setup pays for its self-installer, which
-    # has been measured between 84s and 6m28s depending on npm registry health.
-    # A budget that only fits the fast case turns a slow registry into a red
-    # gate — 12 is the floor already used by the report jobs below.
+    # pnpm setup used to pay for pnpm/action-setup's self-installer on every
+    # job (measured 84s-6m28s depending on npm registry health). It's now
+    # activated via corepack with its download cached (.github/actions/
+    # setup-pnpm) — a cache hit after the first job/run. 12 stays as the
+    # floor for a cold cache and for the report jobs below.
     timeout-minutes: 12
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
 
+      - uses: ./.github/actions/setup-pnpm
+
+      # Second call: cache: 'pnpm' shells out to `pnpm store path`, so pnpm
+      # must already be on PATH — which the setup-pnpm step above just put
+      # there. This call is a near-instant tool-cache hit for Node itself.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
@@ -229,13 +237,15 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
       # No `cache: 'pnpm'` here on purpose: this job never installs, so the
       # pnpm store never exists and the post-job cache save fails the run.
+      # (setup-pnpm's own corepack-download cache is unaffected — it's
+      # populated by activation alone, not by `pnpm install`.)
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
+
+      - uses: ./.github/actions/setup-pnpm
 
       # Audits the lockfile; no install needed.
       #
@@ -307,10 +317,10 @@ jobs:
     if: needs.changes.outputs.core == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     # Safety cap. Cold cache build is ~90s; warm ~30s. 6 min absorbs npm/registry slowdowns.
-    # Every job that runs pnpm/action-setup pays for its self-installer, which
-    # has been measured between 84s and 6m28s depending on npm registry health.
-    # A budget that only fits the fast case turns a slow registry into a red
-    # gate — 12 is the floor already used by the report jobs below.
+    # pnpm setup no longer pays a per-job self-installer download (see
+    # .github/actions/setup-pnpm) — corepack's own cache makes this a hit
+    # after the first job/run. 12 stays as the floor for a cold cache and
+    # for the report jobs below.
     timeout-minutes: 12
     permissions:
       contents: read
@@ -319,7 +329,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+
+      - uses: ./.github/actions/setup-pnpm
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -412,12 +426,12 @@ jobs:
           # stale-lastmod guard could never fail where it matters.
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           # No pnpm cache here — we're downloading the prebuilt node_modules.
+
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -485,8 +499,8 @@ jobs:
         with:
           fetch-depth: 0 # Needed for git diff base..head.
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
+      # No pnpm setup: these steps only run `node dist/cli.js` against the
+      # downloaded artifact below, never `pnpm`.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
@@ -555,8 +569,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
+      # No pnpm setup: these steps only run `node dist/cli.js` against the
+      # downloaded artifact below, never `pnpm`.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
@@ -623,8 +637,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
+      # No pnpm setup: these steps only run `node dist/cli.js` against the
+      # downloaded artifact below, never `pnpm`.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
@@ -662,17 +676,21 @@ jobs:
     needs: changes
     if: needs.changes.outputs.app == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
-    # Every job that runs pnpm/action-setup pays for its self-installer, which
-    # has been measured between 84s and 6m28s depending on npm registry health.
-    # A budget that only fits the fast case turns a slow registry into a red
-    # gate — 12 is the floor already used by the report jobs below.
+    # pnpm setup no longer pays a per-job self-installer download (see
+    # .github/actions/setup-pnpm) — corepack's own cache makes this a hit
+    # after the first job/run. 12 stays as the floor for a cold cache and
+    # for the report jobs below.
     timeout-minutes: 12
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+
+      - uses: ./.github/actions/setup-pnpm
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -719,17 +737,21 @@ jobs:
     needs: changes
     if: needs.changes.outputs.vscode == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
-    # Every job that runs pnpm/action-setup pays for its self-installer, which
-    # has been measured between 84s and 6m28s depending on npm registry health.
-    # A budget that only fits the fast case turns a slow registry into a red
-    # gate — 12 is the floor already used by the report jobs below.
+    # pnpm setup no longer pays a per-job self-installer download (see
+    # .github/actions/setup-pnpm) — corepack's own cache makes this a hit
+    # after the first job/run. 12 stays as the floor for a cold cache and
+    # for the report jobs below.
     timeout-minutes: 12
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+
+      - uses: ./.github/actions/setup-pnpm
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -785,6 +807,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Deliberately still pnpm/action-setup, not .github/actions/setup-pnpm:
+      # this job only runs on release-please PRs, nightly, dispatch, or an
+      # opt-in label, so the redundant download isn't the everyday cost that
+      # TRA-790 targeted, and mac/windows are exactly the runners where an
+      # unverified change to pnpm activation is riskiest to land blind.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0


### PR DESCRIPTION
## Summary

- `pnpm/action-setup`'s self-installer downloads pnpm from the npm registry on every job that needs it (measured 84s-6m28s depending on registry health) — root cause of the TRA-785 outage where a slow registry cancelled `audit` mid-setup and blocked master for ~4h.
- Replaces it with a local composite action (`.github/actions/setup-pnpm`) that activates the pinned pnpm version via Node 22's built-in corepack, caching corepack's download directory keyed on the pnpm version string (not the lockfile, so dependency bumps don't bust it).
- `impact-report`, `quality-gates-report`, `security-scan-report` never actually invoked `pnpm` (they only run `node dist/cli.js` against the prebuilt artifact) — pnpm setup is removed there entirely instead of replaced.
- `cross-platform-test` (macOS/Windows, rarely triggered) is deliberately left on `pnpm/action-setup` — not the everyday cost this targets, and the riskiest runners to change blind.
- No change to any job's commands, to the `audit` gate semantics from #853, or to the `timeout-minutes` ceilings from #850.

Closes TRA-790.

## Local verification

Confirmed the mechanism directly (Node v22.22.3, corepack 0.34.6):
```
$ export COREPACK_HOME=/tmp/corepack-test-home; rm -rf "$COREPACK_HOME"
$ corepack enable
$ time corepack prepare --activate      # cold: 1.6s (network fetch)
$ time corepack prepare --activate      # warm: 0.046s (cache hit, no fetch)
$ pnpm --version
10.33.0
```

## Test plan

- [x] `yaml.safe_load` on both changed/added files
- [x] Local corepack cold→warm cache round-trip (above)
- [ ] Push to this branch shows the pnpm setup step as a cache hit on jobs after the first — CI timings below once this run completes
- [ ] Second-model review (red-zone: `.github/workflows/**`)