### PR TITLE
fix(postinstall): stop the daemon only when a new binary was installed (TRA-1015)

### DIFF
--- a/scripts/postinstall-app.mjs
+++ b/scripts/postinstall-app.mjs
@@ -42,6 +42,7 @@ import http from 'node:http';
 import https from 'node:https';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { getAppDistRepo } from './app-dist-repo.mjs';
 import {
@@ -99,8 +100,22 @@ if (process.env.TRACE_MCP_NO_AUTO_UPDATE === '1') process.exit(0);
  *   stdio session or Electron tray poll will ensureDaemon() back up.
  * Manually-spawned dev daemons (no pidfile, no launchd) are not touched —
  *   the developer will restart them as needed.
+ *
+ * Skipped entirely when this package was not installed into a `node_modules`
+ * tree — a source checkout (`pnpm install` in a clone, `npm link`) links its
+ * bin into the checkout's own `node_modules/.bin`, so there is no new binary
+ * for the launchd daemon to respawn with and the stop is pure downtime. Field
+ * measurement on the maintainer's machine: 118 of 155 daemon stops over 48h
+ * came from this hook, and 68 shutdowns landed within two minutes of the
+ * daemon's own start (TRA-1015).
  */
+function installedIntoNodeModules() {
+  const pkgDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  return path.basename(path.dirname(pkgDir)) === 'node_modules';
+}
+
 function stopRunningDaemon() {
+  if (!installedIntoNodeModules()) return;
   try {
     logDaemonStopAttribution(
       path.join(traceHomeDir(), 'daemon.log'),

--- a/tests/scripts/postinstall-app.test.ts
+++ b/tests/scripts/postinstall-app.test.ts
@@ -601,3 +601,63 @@ describe.skipIf(process.platform !== 'darwin')('postinstall-app.mjs bundle swap'
     expect(fs.existsSync(path.join(fx.installDir, '.trace-mcp-pending-version'))).toBe(false);
   });
 });
+
+/* TRA-1015: the hook stopped the running daemon on every install, including a
+   `pnpm install` inside a source checkout — which links its bin into the
+   checkout's own node_modules/.bin and therefore gives the launchd daemon no
+   new binary to respawn with. On the maintainer's machine that accounted for
+   118 of 155 daemon stops in 48h, with 68 shutdowns landing inside two minutes
+   of the daemon's own start. */
+describe('postinstall-app.mjs daemon stop', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-daemon-stop-'));
+    fs.mkdirSync(path.join(tmp, '.trace'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  /** Run a copy of the script from `scriptPath` and return what it appended to daemon.log. */
+  function runAndReadLog(scriptPath: string): Promise<string> {
+    const child = spawn(process.execPath, [scriptPath], {
+      env: {
+        ...process.env,
+        TRACE_HOME: path.join(tmp, '.trace'),
+        // Never touch the real launchd daemon or the real /Applications.
+        TRACE_MCP_LAUNCHCTL_BIN: '/usr/bin/true',
+        TRACE_MCP_APP_DIRS: path.join(tmp, 'Applications'),
+        TRACE_MCP_MDFIND_BIN: '/usr/bin/false',
+        TRACE_MCP_PGREP_BIN: '/usr/bin/false',
+        TRACE_MCP_PS_BIN: '/usr/bin/false',
+        TRACE_MCP_NO_AUTO_UPDATE: '',
+      },
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    return new Promise((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', () => {
+        const log = path.join(tmp, '.trace', 'daemon.log');
+        resolve(fs.existsSync(log) ? fs.readFileSync(log, 'utf-8') : '');
+      });
+    });
+  }
+
+  it('stops the daemon when installed into a node_modules tree', async () => {
+    const pkg = path.join(tmp, 'node_modules', 'trace-mcp');
+    fs.mkdirSync(pkg, { recursive: true });
+    fs.cpSync(path.join(REPO_ROOT, 'scripts'), path.join(pkg, 'scripts'), { recursive: true });
+
+    const log = await runAndReadLog(path.join(pkg, 'scripts', 'postinstall-app.mjs'));
+
+    expect(log).toContain('Daemon stop requested');
+  });
+
+  it('leaves the daemon alone when run from a source checkout', async () => {
+    const log = await runAndReadLog(SCRIPT_PATH);
+
+    expect(log).not.toContain('Daemon stop requested');
+  });
+});


### PR DESCRIPTION
## What

`scripts/postinstall-app.mjs` stopped the running daemon on **every** install. A source checkout (`pnpm install` in a clone, `npm link`) links its bin into that checkout's own `node_modules/.bin` — the launchd daemon keeps running the globally installed CLI, so there is no new binary to respawn with and the stop is pure downtime.

The hook now stops the daemon only when the package was installed into a `node_modules` tree (global prefix, project `node_modules`, pnpm's `.pnpm/<pkg>/node_modules/<pkg>` — all match). The real upgrade path (`npm i -g trace-mcp@latest`, the app's self-update re-running the postinstall) is unchanged.

## Evidence

From `~/.trace-mcp/daemon.log` + `daemon.log.1` on the maintainer's machine, 2026-09-04 16:02 → 2026-09-06 15:53 (48h, 120 launchd runs):

| | count |
|---|---|
| `Daemon shutting down` (all `reason: SIGTERM`) | 155 |
| …attributed to `postinstall-app: respawn with new binary` | **118** |
| …attributed to an explicit CLI `daemon restart`/`stop` | 23 |
| shutdowns with uptime < 120s | **68** |
| median uptime at shutdown | 170s |

This reproduced live during the run: `pnpm install` in this checkout killed the daemon serving every registered project on the machine.

## Test

`tests/scripts/postinstall-app.test.ts` — the script is executed twice, once from a copy under `<tmp>/node_modules/trace-mcp/` and once from the checkout, asserting the attribution record in `daemon.log` appears only in the first. Verified to fail without the guard (second case logs the stop).

Full suite: 10378 passed / 28 skipped, `pnpm run build` clean, `tsc --noEmit` clean, biome clean.

Closes part of TRA-1015.

Agent: Lead Engineer (trace-mcp autopilot)
