### PR TITLE
test(launcher): a read-only state home must not cost the session (TRA-1016)

### DIFF
--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -246,6 +246,14 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
         // Nothing may leak onto the client's stderr — a healthy server that
         // looks broken in the client log is the TRA-797 failure mode.
         expect(stderr).toBe('');
+        // A read-only *directory* still allows truncating a 0644 file already
+        // inside it, so the chmod above does not by itself catch a heal that
+        // dropped the tmp-then-rename and writes $CONFIG in place (review of
+        // #1021). Pin the config as untouched: on this run the heal cannot
+        // land, so the stale path it named must still be there.
+        expect(fs.readFileSync(path.join(traceHome, 'launcher.env'), 'utf-8')).toContain(
+          path.join(home, 'gone', 'cli.js'),
+        );
       } finally {
         fs.chmodSync(traceHome, 0o755);
       }

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -227,6 +227,30 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
       );
     });
 
+    it('still starts the server when the state home is read-only', () => {
+      // A full disk or a root-owned ~/.trace makes every write in the shim
+      // fail: the log append, the rotation, the heal. None of them is the
+      // point of the run — losing all ~170 tools because the log could not be
+      // written would be. Verified on a real chmod 555 home, not asserted from
+      // reading the `|| true`s.
+      const { home, traceHome, node } = setupFakeHome();
+      const otherCli = plantNvmPackage(home);
+      writeConfig(traceHome, node, path.join(home, 'gone', 'cli.js'));
+      fs.chmodSync(traceHome, 0o555);
+      try {
+        const { status, stdout, stderr } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, [
+          'serve',
+        ]);
+        expect(status).toBe(0);
+        expect(stdout.trim()).toBe(`NODE_ARGS:${otherCli} serve`);
+        // Nothing may leak onto the client's stderr — a healthy server that
+        // looks broken in the client log is the TRA-797 failure mode.
+        expect(stderr).toBe('');
+      } finally {
+        fs.chmodSync(traceHome, 0o755);
+      }
+    });
+
     it('does not persist env overrides into launcher.env', () => {
       const { home, traceHome, node, cli } = setupFakeHome();
       // No config at all — overrides carry the run.


### PR DESCRIPTION
## What

One regression test: the launcher shim must still start the server when `~/.trace` is read-only.

## Why

TRA-1016 is the MCP-connection-reliability autopilot. This run's measurements came back clean (details in the issue), so per the autopilot brief I exercised failure scenarios that had never been checked. A read-only / full state home was one of them.

The shim writes to `~/.trace` on every single start — the `launcher.log` append, the rotation `mv`, and the `launcher.env` heal after a probe. On a full disk or a root-owned state home all three fail. All three are already guarded (`2>/dev/null`, `|| true`), and the shim does exec correctly today — verified against a real `chmod 555` home. Nothing pinned that behaviour, though, and the two ways it can regress are both session-fatal:

- dropping a guard makes a disk-full machine lose all ~170 tools;
- dropping the `2>/dev/null` in `heal_config` prints `Permission denied` onto the MCP client's stderr on every start — a healthy server that looks broken in the client's log, which is exactly what TRA-797 closed.

## Test evidence

- `pnpm vitest run tests/init/launcher-integration.test.ts` — 58 passed.
- Full suite: `Test Files 937 passed | 5 skipped (942) · Tests 10386 passed | 28 skipped (10414)`.
- `pnpm lint`, `pnpm typecheck`, `pnpm format:check` clean.
- Mutation-checked: removing the `2>/dev/null` before `> "$tmp"` in `heal_config` makes this test fail.

## Not included

I also wrote a concurrent-clients test (12 shims probing and healing the same stale `launcher.env` at once). It passed against a shim deliberately broken two different ways — a shared tmp filename, and an in-place `> "$CONFIG"` write — so the race window is too narrow to assert on deterministically. A test that cannot fail is worse than no test, so it is not in this PR. The scenario itself was verified by hand at 25 concurrent clients: all exit 0, clean stderr, config converged, no orphan tmp.

Tests only — no source change, no MCP tool-contract or schema change.
