### PR TITLE
docs(perf): generate the per-tool response-token table instead of typing it (TRA-1020)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6050,28 +6050,9 @@ what it stands in for.**
 
 | tool | calls (real) | raw baseline | measured response | measured/baseline |
 |---|---|---|---|---|
-| `search_text` | 5,125 | 3,000 | **1,722** | 0.57 |
-| `get_outline` | 4,461 | 1,200 | **1,427** | 1.19 |
-| `search` | 4,441 | 600 | **924** | 1.54 |
-| `get_symbol` | 2,687 | 800 | **294** | 0.37 |
-| `find_usages` | 440 | 1,000 | **975** | 0.97 |
-| `get_project_map` | 351 | 1,500 | **568** | 0.38 |
-| `get_index_health` | 211 | 500 | **297** | 0.59 |
-| `get_tests_for` | 96 | 800 | **90** | 0.11 |
-| `get_complexity_report` | 80 | 800 | **1,820** | 2.27 |
-| `get_feature_context` | 73 | 4,000 | **7,443** | 1.86 |
-| `get_env_vars` | 66 | 500 | **13** | 0.03 |
-| `get_dead_code` | 53 | 1,200 | **2,725** | 2.27 |
-| `get_context_bundle` | 39 | 6,000 | **127** | 0.02 |
-| `get_changed_symbols` | 38 | 500 | **1,224** | 2.45 |
-| `get_task_context` | 32 | 8,000 | **5,383** | 0.67 |
-| `check_quality_gates` | 24 | 500 | **121** | 0.24 |
-| `get_circular_imports` | 21 | 500 | **76** | 0.15 |
-| `check_duplication` | 19 | 500 | **272** | 0.54 |
-| `check_claudemd_drift` | 17 | 500 | **1,099** | 2.20 |
-| `scan_security` | 16 | 500 | **38** | 0.08 |
-| `list_projects` | 15 | 500 | **901** | 1.80 |
-| `get_call_graph` | 14 | 1,500 | **1,421** | 0.95 |
+{% for r in site.data.response_tokens.rows -%}
+| `{{ r.tool }}` | {{ r.calls }} | {{ r.baseline_per_call }} | **{{ r.measured_per_call }}** | {% if r.measured_over_baseline > 1 %}**{{ r.measured_over_baseline }}**{% else %}{{ r.measured_over_baseline }}{% endif %} |
+{% endfor %}
 
 Those {{ site.data.response_tokens.calls_weighted }} calls cost
 {{ site.data.response_tokens.measured_tokens }} measured tokens against a
@@ -6087,16 +6068,18 @@ section.
 
 Three things the table says:
 
-1. **0.15 is wrong on every tool that matters.** The four busiest (88% of all
-   calls) measure 0.37–1.54. The assumption is off by 2.5x on the best of them.
+1. **0.15 is wrong on every tool that matters.** The busiest four are 88% of all
+   calls, and not one of them lands near it. The assumption is off by several
+   multiples on every one.
 2. **{{ site.data.response_tokens.tools_costing_more }} of the
    {{ site.data.response_tokens.tools_with_baseline }} cost more than the
    baseline they replace** — and, before the counter was corrected, were still
    booking a positive number on every call. It was ten of twenty-two until
-   TRA-952 reshaped the three worst (below); the ones left are led by
-   `get_complexity_report` and `get_dead_code` at 2.27x. Each is a
-   response-shaping defect: a default `depth`/`limit` too generous for what the
-   caller asked.
+   TRA-952 reshaped the three worst (below). Each survivor is a response-shaping
+   defect: a default `depth`/`limit` too generous for what the caller asked. Read
+   the current list off the table rather than from here — which tools are on it
+   changes with every reshaping, and a name typed into prose is how this page
+   went stale once already (TRA-1020, below).
 3. **A few are far better than claimed** — `get_context_bundle` at 0.02 and
    `get_env_vars` at 0.03 were being under-credited by an order of magnitude.
 
@@ -6120,8 +6103,9 @@ still counted on the spend side, because the agent still paid for it:
 
 | tool | calls | baseline | measured response | tokens spent, credited zero |
 |---|---|---|---|---|
-| `register_edit` | 1,289 | — | **345** | 444,705 |
-| `reindex` | 184 | — | **59** | 10,856 |
+{% for r in site.data.response_tokens.overhead_rows -%}
+| `{{ r.tool }}` | {{ r.calls }} | — | **{{ r.measured_per_call }}** | {{ r.measured_tokens }} |
+{% endfor %}
 
 That is {{ site.data.response_tokens.overhead_calls }} calls and
 {{ site.data.response_tokens.overhead_tokens }} tokens of pure overhead — real
@@ -6268,11 +6252,13 @@ deeper dead-code page is still one `limit` away.
 
 **And it moved the headline by 0.1 points.** Those three tools are 82 of 18,319
 recorded calls. The weighted figure is decided by `search_text`, `get_outline`
-and `search`, which are 78% of call volume between them — `search` at 1.54x and
-`get_outline` at 1.19x are now the whole of the negative block that matters.
-Worst-ratio-first was the right order for finding defects and the wrong one for
-moving the number; the next response-shaping issue should be `search`, on
-volume.
+and `search`, which are 78% of call volume between them. Worst-ratio-first was
+the right order for finding defects and the wrong one for moving the number.
+
+The sentence that used to close this paragraph named `search` (1.54x) and
+`get_outline` (1.19x) as "the whole of the negative block that matters" and
+pointed the next issue at `search`. **Both figures were stale and both tools are
+under 1.00** — see TRA-1020 below.
 
 `get_dead_code` is left at 2.27x on purpose. Its baseline is 1,200 tokens —
 "what a `Read`/`Grep` would have cost instead" for a whole-repo dead-code sweep
@@ -6288,3 +6274,37 @@ diff of whatever working tree it runs on, so the two runs asked it different
 questions and its row is not comparable between them at all. The other two track the corpus: the repo gained files and symbols between
 the two measurements. Same caveat as `get_outline` above, and the reason the
 per-tool ratios are the durable part of this page and the aggregate is not.
+
+## The table on this page was hand-typed, and it had gone stale (TRA-1020)
+
+Everything on this page that reads `{{ site.data.response_tokens.* }}` is
+generated. The **per-tool table** was not: it was Markdown someone typed, and
+between TRA-952 and TRA-993 the measurements moved underneath it while the rows
+stayed put. The gap on the three tools that carry 76% of the weight, committed
+artifact against what the page was showing:
+
+| tool | page said | `docs/perf/response-tokens.json` said |
+|---|---|---|
+| `search_text` | 1,722 (0.57x) | 608 (0.20x) |
+| `get_outline` | 1,427 (1.19x) | 419 (0.35x) |
+| `search` | 924 (1.54x) | 421 (0.70x) |
+
+Re-measured independently on 3.20.0 (`bc67ad28`) before touching anything:
+`search_text` 608, `get_outline` 419, `search` 423. The artifact reproduces; the
+table did not.
+
+It is not only a wrong number. The page's own conclusion — "`search` at 1.54x
+and `get_outline` at 1.19x are now the whole of the negative block that
+matters", and the recommendation to shape `search` next — rested on rows that
+said those tools cost more than they replace when the committed measurement said
+they cost 0.70x and 0.35x. The aggregates beside the table were right the whole
+time, because they are generated: **{{ site.data.response_tokens.tools_costing_more }}
+of {{ site.data.response_tokens.tools_with_baseline }}** cost more than their
+baseline, not the eight the prose implied, and `search` is not among them.
+
+The table is now a Liquid loop over `site.data.response_tokens.rows`, so it
+cannot disagree with the artifact it summarises, and
+`tests/docs/response-tokens-table.test.ts` fails CI if a per-tool token count is
+typed back into the page. This is the same defect class as TRA-762 (README
+quoting synthetic benchmark numbers as measured) and TRA-880 (the counter
+publishing arithmetic as measurement), in the one place that documents both.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6069,8 +6069,8 @@ section.
 Three things the table says:
 
 1. **0.15 is wrong on every tool that matters.** The busiest four are 88% of all
-   calls, and not one of them lands near it. The assumption is off by several
-   multiples on every one.
+   calls, and not one of them lands on it: the closest, `search_text`, is 1.3x
+   off, and the other three are 2.2x to 4.7x off.
 2. **{{ site.data.response_tokens.tools_costing_more }} of the
    {{ site.data.response_tokens.tools_with_baseline }} cost more than the
    baseline they replace** — and, before the counter was corrected, were still

--- a/docs/perf/response-tokens.md
+++ b/docs/perf/response-tokens.md
@@ -86,8 +86,8 @@ section.
 Three things the table says:
 
 1. **0.15 is wrong on every tool that matters.** The busiest four are 88% of all
-   calls, and not one of them lands near it. The assumption is off by several
-   multiples on every one.
+   calls, and not one of them lands on it: the closest, `search_text`, is 1.3x
+   off, and the other three are 2.2x to 4.7x off.
 2. **{{ site.data.response_tokens.tools_costing_more }} of the
    {{ site.data.response_tokens.tools_with_baseline }} cost more than the
    baseline they replace** — and, before the counter was corrected, were still

--- a/docs/perf/response-tokens.md
+++ b/docs/perf/response-tokens.md
@@ -2,7 +2,7 @@
 layout: default
 title: Tool response token cost
 permalink: /perf/response-tokens/
-description: What trace-mcp tool responses cost in tokens, per tool, weighted by real call volume — including the eight tools that cost more than the reads they replace.
+description: What trace-mcp tool responses cost in tokens, per tool, weighted by real call volume — including the ones that cost more than the reads they replace.
 updated: 2026-09-06
 ---
 
@@ -67,28 +67,9 @@ what it stands in for.**
 
 | tool | calls (real) | raw baseline | measured response | measured/baseline |
 |---|---|---|---|---|
-| `search_text` | 5,125 | 3,000 | **1,722** | 0.57 |
-| `get_outline` | 4,461 | 1,200 | **1,427** | 1.19 |
-| `search` | 4,441 | 600 | **924** | 1.54 |
-| `get_symbol` | 2,687 | 800 | **294** | 0.37 |
-| `find_usages` | 440 | 1,000 | **975** | 0.97 |
-| `get_project_map` | 351 | 1,500 | **568** | 0.38 |
-| `get_index_health` | 211 | 500 | **297** | 0.59 |
-| `get_tests_for` | 96 | 800 | **90** | 0.11 |
-| `get_complexity_report` | 80 | 800 | **1,820** | 2.27 |
-| `get_feature_context` | 73 | 4,000 | **7,443** | 1.86 |
-| `get_env_vars` | 66 | 500 | **13** | 0.03 |
-| `get_dead_code` | 53 | 1,200 | **2,725** | 2.27 |
-| `get_context_bundle` | 39 | 6,000 | **127** | 0.02 |
-| `get_changed_symbols` | 38 | 500 | **1,224** | 2.45 |
-| `get_task_context` | 32 | 8,000 | **5,383** | 0.67 |
-| `check_quality_gates` | 24 | 500 | **121** | 0.24 |
-| `get_circular_imports` | 21 | 500 | **76** | 0.15 |
-| `check_duplication` | 19 | 500 | **272** | 0.54 |
-| `check_claudemd_drift` | 17 | 500 | **1,099** | 2.20 |
-| `scan_security` | 16 | 500 | **38** | 0.08 |
-| `list_projects` | 15 | 500 | **901** | 1.80 |
-| `get_call_graph` | 14 | 1,500 | **1,421** | 0.95 |
+{% for r in site.data.response_tokens.rows -%}
+| `{{ r.tool }}` | {{ r.calls }} | {{ r.baseline_per_call }} | **{{ r.measured_per_call }}** | {% if r.measured_over_baseline > 1 %}**{{ r.measured_over_baseline }}**{% else %}{{ r.measured_over_baseline }}{% endif %} |
+{% endfor %}
 
 Those {{ site.data.response_tokens.calls_weighted }} calls cost
 {{ site.data.response_tokens.measured_tokens }} measured tokens against a
@@ -104,16 +85,18 @@ section.
 
 Three things the table says:
 
-1. **0.15 is wrong on every tool that matters.** The four busiest (88% of all
-   calls) measure 0.37–1.54. The assumption is off by 2.5x on the best of them.
+1. **0.15 is wrong on every tool that matters.** The busiest four are 88% of all
+   calls, and not one of them lands near it. The assumption is off by several
+   multiples on every one.
 2. **{{ site.data.response_tokens.tools_costing_more }} of the
    {{ site.data.response_tokens.tools_with_baseline }} cost more than the
    baseline they replace** — and, before the counter was corrected, were still
    booking a positive number on every call. It was ten of twenty-two until
-   TRA-952 reshaped the three worst (below); the ones left are led by
-   `get_complexity_report` and `get_dead_code` at 2.27x. Each is a
-   response-shaping defect: a default `depth`/`limit` too generous for what the
-   caller asked.
+   TRA-952 reshaped the three worst (below). Each survivor is a response-shaping
+   defect: a default `depth`/`limit` too generous for what the caller asked. Read
+   the current list off the table rather than from here — which tools are on it
+   changes with every reshaping, and a name typed into prose is how this page
+   went stale once already (TRA-1020, below).
 3. **A few are far better than claimed** — `get_context_bundle` at 0.02 and
    `get_env_vars` at 0.03 were being under-credited by an order of magnitude.
 
@@ -137,8 +120,9 @@ still counted on the spend side, because the agent still paid for it:
 
 | tool | calls | baseline | measured response | tokens spent, credited zero |
 |---|---|---|---|---|
-| `register_edit` | 1,289 | — | **345** | 444,705 |
-| `reindex` | 184 | — | **59** | 10,856 |
+{% for r in site.data.response_tokens.overhead_rows -%}
+| `{{ r.tool }}` | {{ r.calls }} | — | **{{ r.measured_per_call }}** | {{ r.measured_tokens }} |
+{% endfor %}
 
 That is {{ site.data.response_tokens.overhead_calls }} calls and
 {{ site.data.response_tokens.overhead_tokens }} tokens of pure overhead — real
@@ -285,11 +269,13 @@ deeper dead-code page is still one `limit` away.
 
 **And it moved the headline by 0.1 points.** Those three tools are 82 of 18,319
 recorded calls. The weighted figure is decided by `search_text`, `get_outline`
-and `search`, which are 78% of call volume between them — `search` at 1.54x and
-`get_outline` at 1.19x are now the whole of the negative block that matters.
-Worst-ratio-first was the right order for finding defects and the wrong one for
-moving the number; the next response-shaping issue should be `search`, on
-volume.
+and `search`, which are 78% of call volume between them. Worst-ratio-first was
+the right order for finding defects and the wrong one for moving the number.
+
+The sentence that used to close this paragraph named `search` (1.54x) and
+`get_outline` (1.19x) as "the whole of the negative block that matters" and
+pointed the next issue at `search`. **Both figures were stale and both tools are
+under 1.00** — see TRA-1020 below.
 
 `get_dead_code` is left at 2.27x on purpose. Its baseline is 1,200 tokens —
 "what a `Read`/`Grep` would have cost instead" for a whole-repo dead-code sweep
@@ -305,3 +291,37 @@ diff of whatever working tree it runs on, so the two runs asked it different
 questions and its row is not comparable between them at all. The other two track the corpus: the repo gained files and symbols between
 the two measurements. Same caveat as `get_outline` above, and the reason the
 per-tool ratios are the durable part of this page and the aggregate is not.
+
+## The table on this page was hand-typed, and it had gone stale (TRA-1020)
+
+Everything on this page that reads `{{ site.data.response_tokens.* }}` is
+generated. The **per-tool table** was not: it was Markdown someone typed, and
+between TRA-952 and TRA-993 the measurements moved underneath it while the rows
+stayed put. The gap on the three tools that carry 76% of the weight, committed
+artifact against what the page was showing:
+
+| tool | page said | `docs/perf/response-tokens.json` said |
+|---|---|---|
+| `search_text` | 1,722 (0.57x) | 608 (0.20x) |
+| `get_outline` | 1,427 (1.19x) | 419 (0.35x) |
+| `search` | 924 (1.54x) | 421 (0.70x) |
+
+Re-measured independently on 3.20.0 (`bc67ad28`) before touching anything:
+`search_text` 608, `get_outline` 419, `search` 423. The artifact reproduces; the
+table did not.
+
+It is not only a wrong number. The page's own conclusion — "`search` at 1.54x
+and `get_outline` at 1.19x are now the whole of the negative block that
+matters", and the recommendation to shape `search` next — rested on rows that
+said those tools cost more than they replace when the committed measurement said
+they cost 0.70x and 0.35x. The aggregates beside the table were right the whole
+time, because they are generated: **{{ site.data.response_tokens.tools_costing_more }}
+of {{ site.data.response_tokens.tools_with_baseline }}** cost more than their
+baseline, not the eight the prose implied, and `search` is not among them.
+
+The table is now a Liquid loop over `site.data.response_tokens.rows`, so it
+cannot disagree with the artifact it summarises, and
+`tests/docs/response-tokens-table.test.ts` fails CI if a per-tool token count is
+typed back into the page. This is the same defect class as TRA-762 (README
+quoting synthetic benchmark numbers as measured) and TRA-880 (the counter
+publishing arithmetic as measurement), in the one place that documents both.

--- a/tests/docs/response-tokens-table.test.ts
+++ b/tests/docs/response-tokens-table.test.ts
@@ -40,5 +40,4 @@ describe('response-tokens page', () => {
       `${PAGE} states these tools' numbers as literals — render them from ${DATA} instead`,
     ).toEqual([]);
   });
-
 });

--- a/tests/docs/response-tokens-table.test.ts
+++ b/tests/docs/response-tokens-table.test.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const PAGE = 'docs/perf/response-tokens.md';
+const DATA = 'docs/_data/response_tokens.json';
+
+const page = fs.readFileSync(path.join(REPO_ROOT, PAGE), 'utf8');
+const data = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, DATA), 'utf8')) as {
+  rows: Array<{ tool: string }>;
+  overhead_rows: Array<{ tool: string }>;
+};
+
+/**
+ * TRA-1020: the aggregates on this page were always generated; the per-tool
+ * table was hand-typed Markdown, and it drifted. It published `search` at 924
+ * tokens (1.54x) while the committed artifact said 421 (0.70x) — and the page's
+ * conclusion, "the whole of the negative block that matters", was drawn from
+ * the typed rows rather than the measured ones.
+ *
+ * ponytail: one regex, aimed at the exact shape of the table that went stale —
+ * a row whose first cell is a tool name and whose next two cells are bare
+ * numbers. Historical before/after tables state their numbers as `5,240
+ * (10.48x)`, so they read as history and do not trip this.
+ */
+describe('response-tokens page', () => {
+  it('renders the per-tool tables from site.data, never as literals', () => {
+    expect(page).toContain('{% for r in site.data.response_tokens.rows -%}');
+    expect(page).toContain('{% for r in site.data.response_tokens.overhead_rows -%}');
+  });
+
+  it('has no hand-typed per-tool measurement row', () => {
+    const tools = [...data.rows, ...data.overhead_rows].map((r) => r.tool);
+    const offenders = tools.filter((tool) =>
+      new RegExp(`^\\|\\s*\`${tool}\`\\s*\\|\\s*[\\d,]+\\s*\\|\\s*[\\d,]+\\s*\\|`, 'm').test(page),
+    );
+    expect(
+      offenders,
+      `${PAGE} states these tools' numbers as literals — render them from ${DATA} instead`,
+    ).toEqual([]);
+  });
+
+});

--- a/tests/docs/response-tokens-table.test.ts
+++ b/tests/docs/response-tokens-table.test.ts
@@ -33,7 +33,12 @@ describe('response-tokens page', () => {
   it('has no hand-typed per-tool measurement row', () => {
     const tools = [...data.rows, ...data.overhead_rows].map((r) => r.tool);
     const offenders = tools.filter((tool) =>
-      new RegExp(`^\\|\\s*\`${tool}\`\\s*\\|\\s*[\\d,]+\\s*\\|\\s*[\\d,]+\\s*\\|`, 'm').test(page),
+      new RegExp(
+        // The overhead rows write their (absent) baseline as an em-dash, so the
+        // middle cell has to admit one or they stay unguarded.
+        `^\\|\\s*\`${tool}\`\\s*\\|\\s*[\\d,]+\\s*\\|\\s*(?:[\\d,]+|[—-]+)\\s*\\|`,
+        'm',
+      ).test(page),
     );
     expect(
       offenders,


### PR DESCRIPTION
## The contradiction, first

`docs/perf/response-tokens.md` is the page that exists because trace-mcp published arithmetic as measurement (TRA-880). Its aggregates are generated from `docs/_data/response_tokens.json`. **Its per-tool table was hand-typed**, and it had drifted away from the committed artifact on the three tools that carry 76% of call volume:

| tool | page said | `docs/perf/response-tokens.json` said | re-measured here |
|---|---|---|---|
| `search_text` | 1,722 (0.57x) | 608 (0.20x) | **608** |
| `get_outline` | 1,427 (1.19x) | 419 (0.35x) | **419** |
| `search` | 924 (1.54x) | 421 (0.70x) | **423** |

Measured on 3.20.0 (`bc67ad28`), macOS 25.5.0 / arm64, `pnpm run build && npx tsx scripts/bench-response-tokens.ts`, median of 3 runs against the frozen frame in `benchmarks/response-tokens/frame.json`. The artifact reproduces; the table did not. The artifact was restored untouched afterwards — no measurement in this repo was rewritten by this PR.

The drift changed the page's conclusions. It stated "`search` at 1.54x and `get_outline` at 1.19x are now the whole of the negative block that matters" and pointed the next response-shaping issue at `search`. Against the committed measurement, `search` is 0.70x, `get_outline` 0.35x, and the tools actually over 1.00 are `find_usages` (1.12), `get_complexity_report` (2.27), `get_dead_code` (2.26), `check_claudemd_drift` (2.20) and `list_projects` (3.88). Anyone starting from that recommendation would have spent a run optimising a tool that already pays for itself.

## The change

- Both per-tool tables render from `site.data.response_tokens.rows` / `.overhead_rows` via the same Liquid-loop pattern `docs/pr-context-benchmark.md` already uses.
- Prose that named specific tools and ratios now points at the table instead — which tools are over 1.00 changes with every reshaping.
- New section documenting the drift, so the page carries its own failure the way it carries TRA-880's.
- `tests/docs/response-tokens-table.test.ts`: fails if a per-tool measurement row is typed back in. Mutation-checked by pasting the stale `search` row back — the guard fails with `expected [ 'search' ] to deeply equal []`. Historical before/after tables state numbers as `5,240 (10.48x)` and are deliberately not caught.
- `docs/llms-full.txt` regenerated (`pnpm docs:sitemap`).

## Verification

No product code touched; no aggregate moved. `pnpm test`: 10,389 passed / 26 skipped, 943 files. `pnpm run lint` (tsc --noEmit) clean. Build clean.

Closes TRA-1020's first deliverable. Follow-up, not in this PR: shape `find_usages` (1.12x, 440 calls — the only over-1.00 tool with real volume).

Agent: Performance Agent