### PR TITLE
docs(seo): link tools-reference to MCP tracing; record the TRA-1025 re-derivation

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -156,7 +156,9 @@ Decisions auto-enrich code intelligence: `get_change_impact` shows `linked_decis
 
 ## Session Analytics
 
-See [Analytics](analytics.md) for full documentation.
+See [Analytics](analytics.md) for full documentation. Those tools read session
+logs after the fact; for a live span per tool call exported to your own Jaeger
+or Langfuse, see [MCP tracing](telemetry.md).
 
 | Tool | What it does |
 |---|---|

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -8,7 +8,7 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/tools-reference.html</loc>
-    <lastmod>2026-09-04</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -1,7 +1,7 @@
 ---
 title: "MCP Tools Reference — code-intelligence tools by task and framework"
 description: "The trace-mcp MCP tools you reach for most, grouped by task: navigation, refactoring, impact analysis, security and framework-aware queries."
-updated: 2026-09-04
+updated: 2026-09-06
 ---
 
 # Tools reference
@@ -170,7 +170,9 @@ Decisions auto-enrich code intelligence: `get_change_impact` shows `linked_decis
 
 ## Session Analytics
 
-See [Analytics](analytics.md) for full documentation.
+See [Analytics](analytics.md) for full documentation. Those tools read session
+logs after the fact; for a live span per tool call exported to your own Jaeger
+or Langfuse, see [MCP tracing](telemetry.md).
 
 | Tool | What it does |
 |---|---|

--- a/ops/index-coverage.md
+++ b/ops/index-coverage.md
@@ -276,6 +276,35 @@ the homepage onto `/telemetry.html` and the average position should improve on
 13.7. Perceived-authority fixes take a recrawl; Request Indexing for
 `/telemetry.html` is queued with TRA-633's batch of Nikolai-clicks.
 
+### Re-derived independently as TRA-1025, same day — read this before filing a third
+
+TRA-1025 arrived 2026-09-06 from the same GSC window with the same conclusion
+and a remedy that was already merged in #990 hours earlier. Two corrections it
+adds, and one it gets wrong:
+
+**A fourth page carries the query.** Its breakdown lists `/tools-reference.html`
+at 2 impressions, position 92 — not in the table above. It was the only one of
+the four with no in-body link to `/telemetry.html`; added in the same change as
+this note. The homepage anchor rows (`/#capabilities`, `/#install`, `/#problem`,
+`/#product`, 28 impressions each) are the same homepage impressions counted
+per in-page anchor, not extra pages.
+
+**"Remove the tracing wording from the homepage" has no target.** The string
+`tracing` appears exactly once in `docs/index.html` (line 2705) and it is the
+outbound anchor to `/telemetry.html` that #990 added. There is nothing to
+de-optimize; the homepage wins this query on domain/entity match
+(`trace-mcp` ≈ `mcp tracing`) plus host crowding, not on copy. Any future
+proposal to strip words from the homepage for this query should be rejected on
+this line unless it names a specific string that exists.
+
+**CTR 0 is not evidence here, and both issues leaned on it.** 51 impressions at
+position 8.3 has an expected yield of roughly one click. Zero is inside the
+noise floor of that sample — it does not demonstrate that the served result was
+wrong for the searcher. The load-bearing fact is the *page split* (the profile
+page taking 1 impression against the homepage's 51), not the CTR. Same trap as
+the `/vs/` inference two sections down: a number too small to distinguish a
+result from nothing.
+
 ## Reading 2026-09-06 (TRA-995): sitemap is the only discovery channel that has produced an index entry
 
 URL Inspection over all 28 sitemap URLs: 13 submitted-and-indexed, 10 unknown


### PR DESCRIPTION
Closes TRA-1025 — which re-derives TRA-974 (merged in #990 a few hours earlier) from the same GSC window. Two of its three asks were already shipped or have no target; this PR lands the one that did.

## What changed

**`docs/tools-reference.md`** — one contextual in-body link to `telemetry.md` with the anchor "MCP tracing", in the Session Analytics section. TRA-1025's page breakdown surfaced a fourth page carrying the `mcp tracing` query that #990's table missed: `/tools-reference.html`, 2 impressions at position 92. It was the only one of the four indexed pages taking the query with no in-body link to the profile page (#990 covered the homepage, `configuration.html` and `analytics.html`).

**`ops/index-coverage.md`** — appended to the TRA-974 section so the next run doesn't file this a third time:

- The fourth page, and that the `/#capabilities`, `/#install`, `/#problem`, `/#product` rows in TRA-1025's table are the same homepage impressions counted per in-page anchor, not extra pages.
- **"Remove the tracing wording from the homepage" has no target.** The string `tracing` appears exactly once in `docs/index.html` (line 2705) and it is the outbound anchor to `/telemetry.html` that #990 added. The homepage wins this query on domain/entity match (`trace-mcp` ≈ `mcp tracing`) plus host crowding, not on copy.
- **CTR 0 is not evidence here**, and both issues leaned on it. 51 impressions at position 8.3 has an expected yield of ~1 click; zero is inside the noise floor. The load-bearing fact is the page split (1 impression to the profile page against the homepage's 51), not the CTR — same trap as the `/vs/` inference the file already corrects two sections down.

`docs/llms-full.txt` and `docs/sitemap.xml` are regenerated by `pnpm docs:sitemap`, not hand-edited.

## Test evidence

`pnpm exec vitest run tests/docs` — 20 files, 266 passed / 4 skipped, including `internal-links`, `readme-claims` and the sitemap `lastmod` guards.

No source, tool-signature or schema changes; token cost unaffected.