### PR TITLE
fix(indexer): resolve C# using-directive imports (TRA-1027)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,7 +1,7 @@
 ---
 title: "Contributing to trace-mcp — local setup, build, and test"
 description: "How to set up trace-mcp for local development: install, build, run the test suite, and the conventions to follow before opening a PR."
-updated: 2026-09-04
+updated: 2026-09-06
 ---
 
 # Development

--- a/docs/language-matrix.md
+++ b/docs/language-matrix.md
@@ -92,6 +92,17 @@ without one the extracted import never becomes an edge. This column counts the
 second thing, so it is much shorter than the language list — see
 `src/indexer/edge-resolvers/import-capable-languages.ts`.
 
+**"Yes" is not "every import."** C# is the narrowest case in this column today:
+its resolver only trusts `using` forms that name a specific type (`using
+static X.Y.Type`, an aliased `using A = X.Y.Type`) and deliberately leaves a
+plain `using Namespace;` — the overwhelming majority of real C# imports —
+unresolved, because a namespace can span most of a codebase and a file-level
+edge to all of it would be closer to noise than signal. On a large real repo
+(Newtonsoft.Json, ~5,000 `using` directives) this column's "yes" for C#
+produced edges for 12 of them — roughly 0.2%. See
+`src/indexer/edge-resolvers/csharp-imports.ts` for the reasoning and
+`src/indexer/plugins/language/csharp/helpers.ts` for extraction.
+
 ## Matrix
 
 | Language | Extensions | Parser | Default | Imports | Calls | Types | Tests |

--- a/docs/language-matrix.md
+++ b/docs/language-matrix.md
@@ -48,7 +48,7 @@ is the two-pass pipeline in [architecture](architecture.md#indexing-pipeline).
 
 - **indexed with the default config:** 78 (the rest need an `include` entry — see below)
 - **tree-sitter parser:** 29 · **regex parser:** 46 · **custom parser:** 6
-- **import edges:** 18
+- **import edges:** 19
 - **call edges (`get_call_graph`, call-aware `find_usages`):** 3
 - **type / inheritance edges:** 2
 - **covered by a plugin test:** 68
@@ -110,7 +110,7 @@ second thing, so it is much shorter than the language list — see
 | cobol | .cob .cbl .cpy .cobol | regex (multi-pass) | yes | — | — | — | yes |
 | common-lisp | .lisp .lsp .cl .asd | regex (multi-pass) | yes | — | — | — | yes |
 | cpp | .cpp .cxx .cc .hpp | tree-sitter | yes | yes | — | — | yes |
-| csharp | .cs | tree-sitter | yes | — | — | — | yes |
+| csharp | .cs | tree-sitter | yes | yes | — | — | yes |
 | css | .css .scss .sass .less | tree-sitter | yes | yes | — | — | yes |
 | cuda | .cu .cuh | regex | yes | — | — | — | — |
 | d | .d .di | regex (multi-pass) | yes | — | — | — | yes |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4784,7 +4784,7 @@ is the two-pass pipeline in [architecture](architecture.md#indexing-pipeline).
 
 - **indexed with the default config:** 78 (the rest need an `include` entry — see below)
 - **tree-sitter parser:** 29 · **regex parser:** 46 · **custom parser:** 6
-- **import edges:** 18
+- **import edges:** 19
 - **call edges (`get_call_graph`, call-aware `find_usages`):** 3
 - **type / inheritance edges:** 2
 - **covered by a plugin test:** 68
@@ -4846,7 +4846,7 @@ second thing, so it is much shorter than the language list — see
 | cobol | .cob .cbl .cpy .cobol | regex (multi-pass) | yes | — | — | — | yes |
 | common-lisp | .lisp .lsp .cl .asd | regex (multi-pass) | yes | — | — | — | yes |
 | cpp | .cpp .cxx .cc .hpp | tree-sitter | yes | yes | — | — | yes |
-| csharp | .cs | tree-sitter | yes | — | — | — | yes |
+| csharp | .cs | tree-sitter | yes | yes | — | — | yes |
 | css | .css .scss .sass .less | tree-sitter | yes | yes | — | — | yes |
 | cuda | .cu .cuh | regex | yes | — | — | — | — |
 | d | .d .di | regex (multi-pass) | yes | — | — | — | yes |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4828,6 +4828,17 @@ without one the extracted import never becomes an edge. This column counts the
 second thing, so it is much shorter than the language list — see
 `src/indexer/edge-resolvers/import-capable-languages.ts`.
 
+**"Yes" is not "every import."** C# is the narrowest case in this column today:
+its resolver only trusts `using` forms that name a specific type (`using
+static X.Y.Type`, an aliased `using A = X.Y.Type`) and deliberately leaves a
+plain `using Namespace;` — the overwhelming majority of real C# imports —
+unresolved, because a namespace can span most of a codebase and a file-level
+edge to all of it would be closer to noise than signal. On a large real repo
+(Newtonsoft.Json, ~5,000 `using` directives) this column's "yes" for C#
+produced edges for 12 of them — roughly 0.2%. See
+`src/indexer/edge-resolvers/csharp-imports.ts` for the reasoning and
+`src/indexer/plugins/language/csharp/helpers.ts` for extraction.
+
 ## Matrix
 
 | Language | Extensions | Parser | Default | Imports | Calls | Types | Tests |

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -158,7 +158,7 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/development.html</loc>
-    <lastmod>2026-09-04</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/scripts/language-matrix.ts
+++ b/scripts/language-matrix.ts
@@ -260,6 +260,17 @@ without one the extracted import never becomes an edge. This column counts the
 second thing, so it is much shorter than the language list — see
 \`src/indexer/edge-resolvers/import-capable-languages.ts\`.
 
+**"Yes" is not "every import."** C# is the narrowest case in this column today:
+its resolver only trusts \`using\` forms that name a specific type (\`using
+static X.Y.Type\`, an aliased \`using A = X.Y.Type\`) and deliberately leaves a
+plain \`using Namespace;\` — the overwhelming majority of real C# imports —
+unresolved, because a namespace can span most of a codebase and a file-level
+edge to all of it would be closer to noise than signal. On a large real repo
+(Newtonsoft.Json, ~5,000 \`using\` directives) this column's "yes" for C#
+produced edges for 12 of them — roughly 0.2%. See
+\`src/indexer/edge-resolvers/csharp-imports.ts\` for the reasoning and
+\`src/indexer/plugins/language/csharp/helpers.ts\` for extraction.
+
 ## Matrix
 
 | Language | Extensions | Parser | Default | Imports | Calls | Types | Tests |

--- a/src/indexer/edge-resolver.ts
+++ b/src/indexer/edge-resolver.ts
@@ -13,6 +13,7 @@ import {
   resolveFileProjectionEdges as _resolveFileProjection,
 } from './edge-resolvers/file-projection.js';
 import { resolveCImportEdges as _resolveCImports } from './edge-resolvers/c-imports.js';
+import { resolveCSharpImportEdges as _resolveCSharpImports } from './edge-resolvers/csharp-imports.js';
 import { resolveTypeScriptHeritageEdges as _resolveHeritage } from './edge-resolvers/heritage.js';
 import { resolveIacImportEdges as _resolveIacImports } from './edge-resolvers/iac-imports.js';
 import { resolveGoImportEdges as _resolveGoImports } from './edge-resolvers/go-imports.js';
@@ -164,6 +165,11 @@ export class EdgeResolver {
   /** Pass 2e7: Ruby import edges (`require`/`require_relative` → source file). */
   resolveRubyImportEdges(scope?: ChangeScope): void {
     timed('ruby-imports', () => _resolveRubyImports(this.state, scope));
+  }
+
+  /** Pass 2e8: C# import edges (`using` directive → namespace-declaring file). */
+  resolveCSharpImportEdges(scope?: ChangeScope): void {
+    timed('csharp-imports', () => _resolveCSharpImports(this.state, scope));
   }
 
   /** Pass 2e2: PHP import edges (PSR-4 use statements). */

--- a/src/indexer/edge-resolvers/csharp-imports.ts
+++ b/src/indexer/edge-resolvers/csharp-imports.ts
@@ -44,20 +44,30 @@
  * resolve rather than inventing a node.
  *
  * Incremental reindexing: a C# file's declared type identity is ordinary
- * file content, not derived from its path, so it can change (renamed,
- * removed) without the file moving — unlike Java/Go, where the resolver
- * never even reads the `package` statement. If only the declaring file gets
- * reindexed, files that import it are untouched this batch and never get a
- * chance to notice their edge is now wrong. This resolver closes that gap for
- * the files that DO get reindexed here: for every C# file in
- * `state.changedFileIds` — deliberately wider than `pendingImports`, which
- * only has an entry for a file that itself has `using` directives, and a
- * type-declaring file need not have any — its current incoming `imports`
- * edges are re-validated against the fresh type map, and any whose stored
- * specifier no longer resolves to it are deleted. A file that never gets
- * reindexed again keeps a stale edge until it does — full self-healing needs
- * a full reindex, which already recomputes every C# file's imports from
- * scratch.
+ * file content, not derived from its path, so it can change (renamed, moved
+ * to another file, removed) without the file moving — unlike Java/Go, where
+ * the resolver never even reads the `package` statement. If only the
+ * declaring file(s) get reindexed, files that import them are untouched this
+ * batch and never get a chance to notice their edge is now wrong. This
+ * resolver closes that gap for the files that DO get reindexed here: for
+ * every C# file in `state.changedFileIds` — deliberately wider than
+ * `pendingImports`, which only has an entry for a file that itself has
+ * `using` directives, and a type-declaring file need not have any — its
+ * current incoming `imports` edges are re-validated against the fresh type
+ * map. An edge whose stored specifier no longer resolves to it is not just
+ * dropped: the edge itself already carries its source node and the raw
+ * specifier (`metadata.from`), which is enough to re-resolve and relink to
+ * wherever that specifier resolves NOW, with no need to re-extract the
+ * importer — this is what makes a type *move* (not just a rename-to-nothing)
+ * converge without a full reindex.
+ *
+ * One case this can't close: a specifier that was unresolved (external) when
+ * the importer was last extracted never got an edge to begin with, so there
+ * is nothing here to notice if the type it names shows up later in a file
+ * that ISN'T the importer. Recovering that needs the importer's own raw
+ * specifiers to survive past its own extraction batch, or a re-extraction —
+ * neither happens today. A full reindex already recomputes every C# file's
+ * imports from scratch and is unaffected by any of this.
  */
 import { logger } from '../../logger.js';
 import type { ChangeScope } from '../../plugin-api/types.js';
@@ -144,9 +154,10 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
     // A file's declared type identity is content, not path — it can change
     // without the file moving, and unlike the source-driven loop below,
     // importers that weren't re-extracted this batch never revisit it.
-    // Re-validate every C# file's *incoming* `imports` edges here so a
-    // rename at least stops lying, even when it can't insert the new one
-    // without re-extracting the importer.
+    // Re-validate every C# file's *incoming* `imports` edges here, and
+    // relink (not just prune) using the edge's own source + specifier — see
+    // file header for what this does and doesn't converge without a full
+    // reindex.
     const deleteStmt = store.db.prepare('DELETE FROM edges WHERE id = ?');
     for (const fileId of changedFileIds) {
       if (fileMap.get(fileId)?.language !== 'csharp') continue;
@@ -160,9 +171,22 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
         } catch {
           continue;
         }
-        if (!from || !resolve(from).includes(fileId)) {
-          deleteStmt.run(edge.id);
-          pruned++;
+        if (!from) continue;
+        const freshTargets = resolve(from);
+        if (freshTargets.includes(fileId)) continue;
+
+        deleteStmt.run(edge.id);
+        pruned++;
+        for (const newTargetId of freshTargets) {
+          const newTargetNodeId = nodeIds.get(newTargetId);
+          if (newTargetNodeId == null || newTargetNodeId === edge.source_node_id) continue;
+          insertStmt.run(
+            edge.source_node_id,
+            newTargetNodeId,
+            importsEdgeType.id,
+            JSON.stringify({ from }),
+          );
+          created++;
         }
       }
     }

--- a/src/indexer/edge-resolvers/csharp-imports.ts
+++ b/src/indexer/edge-resolvers/csharp-imports.ts
@@ -43,6 +43,14 @@
  * matching no type (BCL, NuGet package, or a plain namespace) simply fails to
  * resolve rather than inventing a node.
  *
+ * One file→file edge can be the collapsed target of more than one `using`
+ * (two `using static` directives from the same importer naming two types in
+ * the same file). `metadata.froms` holds the full set, not the single latest
+ * specifier — review caught an earlier version that stored just one, so a
+ * second specifier's revalidation silently clobbered the first's, losing the
+ * edge for a type that was still validly imported. Every write here merges
+ * into that set rather than replacing it wholesale.
+ *
  * Incremental reindexing: a C# file's declared type identity is ordinary
  * file content, not derived from its path, so it can change (renamed, moved
  * to another file, removed) without the file moving — unlike Java/Go, where
@@ -52,22 +60,32 @@
  * resolver closes that gap for the files that DO get reindexed here: for
  * every C# file in `state.changedFileIds` — deliberately wider than
  * `pendingImports`, which only has an entry for a file that itself has
- * `using` directives, and a type-declaring file need not have any — its
- * current incoming `imports` edges are re-validated against the fresh type
- * map. An edge whose stored specifier no longer resolves to it is not just
- * dropped: the edge itself already carries its source node and the raw
- * specifier (`metadata.from`), which is enough to re-resolve and relink to
- * wherever that specifier resolves NOW, with no need to re-extract the
- * importer — this is what makes a type *move* (not just a rename-to-nothing)
- * converge without a full reindex.
+ * `using` directives, and a type-declaring file need not have any — each
+ * incoming `imports` edge is split specifier-by-specifier against the fresh
+ * type map: a specifier still resolving to this file is kept, one that
+ * doesn't is relinked using the edge's own source node — the edge itself is
+ * enough to notice a type moved and follow it, with no need to re-extract
+ * the importer.
  *
- * One case this can't close: a specifier that was unresolved (external) when
- * the importer was last extracted never got an edge to begin with, so there
- * is nothing here to notice if the type it names shows up later in a file
- * that ISN'T the importer. Recovering that needs the importer's own raw
- * specifiers to survive past its own extraction batch, or a re-extraction —
- * neither happens today. A full reindex already recomputes every C# file's
- * imports from scratch and is unaffected by any of this.
+ * Two cases still don't converge without a full reindex, and are not
+ * silently "mostly working" — they simply don't happen here:
+ *
+ * - A specifier that was unresolved (external) when the importer was last
+ *   extracted never got an edge, so there is nothing to notice if the type
+ *   it names shows up later in some file that ISN'T the importer.
+ * - A file *delete followed by a separate create* — the shape a real watcher
+ *   uses for a rename/move, via `deleteFiles` then `indexFiles` as two
+ *   distinct calls — destroys the old file's node (and every edge touching
+ *   it, cascaded) before the new file's `indexFiles` call ever runs. By the
+ *   time this resolver sees the create, the edge this pass depends on to
+ *   relink is already gone; there is nothing left to read a source node or a
+ *   specifier off of. Recovering this needs raw import facts to survive
+ *   independently of the resolved edge (a durable store keyed by specifier,
+ *   not by edge id) — real persistence work, and a decision about who owns
+ *   it, deliberately left to a follow-up rather than bolted on here.
+ *
+ * A full reindex already recomputes every C# file's imports from scratch and
+ * is unaffected by either limitation.
  */
 import { logger } from '../../logger.js';
 import type { ChangeScope } from '../../plugin-api/types.js';
@@ -80,6 +98,13 @@ function addTo(map: Map<string, number[]>, key: string, id: number): void {
   } else {
     map.set(key, [id]);
   }
+}
+
+/** A desired (source, target) edge and every specifier that collapses onto it. */
+interface DesiredEdge {
+  sourceNodeId: number;
+  targetNodeId: number;
+  froms: Set<string>;
 }
 
 export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeScope): void {
@@ -132,6 +157,7 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
      ON CONFLICT(source_node_id, target_node_id, edge_type_id)
      DO UPDATE SET metadata = excluded.metadata`,
   );
+  const deleteStmt = store.db.prepare('DELETE FROM edges WHERE id = ?');
 
   /**
    * `using static Acme.Store.Ids` and aliased `using X = Acme.Store.Ids`
@@ -146,51 +172,67 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
     return (cut > 0 && byType.get(specifier.slice(0, cut))) || [];
   };
 
-  let created = 0;
+  const desired = new Map<string, DesiredEdge>();
+  const addDesired = (sourceNodeId: number, targetNodeId: number, from: string): void => {
+    if (sourceNodeId === targetNodeId) return;
+    const key = `${sourceNodeId}:${targetNodeId}`;
+    let entry = desired.get(key);
+    if (!entry) {
+      entry = { sourceNodeId, targetNodeId, froms: new Set() };
+      desired.set(key, entry);
+    }
+    entry.froms.add(from);
+  };
+
   let external = 0;
   let pruned = 0;
 
   store.db.transaction(() => {
     // A file's declared type identity is content, not path — it can change
-    // without the file moving, and unlike the source-driven loop below,
+    // without the file moving, and unlike the source-driven pass below,
     // importers that weren't re-extracted this batch never revisit it.
-    // Re-validate every C# file's *incoming* `imports` edges here, and
-    // relink (not just prune) using the edge's own source + specifier — see
-    // file header for what this does and doesn't converge without a full
-    // reindex.
-    const deleteStmt = store.db.prepare('DELETE FROM edges WHERE id = ?');
+    // Re-validate every C# file's *incoming* `imports` edges here,
+    // specifier by specifier: one still resolving here is kept, one that
+    // doesn't is relinked using the edge's own source node — see file
+    // header for what this does and doesn't converge without a full reindex.
     for (const fileId of changedFileIds) {
       if (fileMap.get(fileId)?.language !== 'csharp') continue;
       const targetNodeId = nodeIds.get(fileId);
       if (targetNodeId == null) continue;
       for (const edge of store.getIncomingEdges(targetNodeId)) {
         if (edge.edge_type_name !== 'imports' || !edge.metadata) continue;
-        let from: string | undefined;
+        let froms: string[];
         try {
-          from = (JSON.parse(edge.metadata) as { from?: string }).from;
+          const parsed = JSON.parse(edge.metadata) as { froms?: string[]; from?: string };
+          froms = parsed.froms ?? (parsed.from ? [parsed.from] : []);
         } catch {
           continue;
         }
-        if (!from) continue;
-        const freshTargets = resolve(from);
-        if (freshTargets.includes(fileId)) continue;
+        if (froms.length === 0) continue;
 
-        deleteStmt.run(edge.id);
-        pruned++;
-        for (const newTargetId of freshTargets) {
-          const newTargetNodeId = nodeIds.get(newTargetId);
-          if (newTargetNodeId == null || newTargetNodeId === edge.source_node_id) continue;
-          insertStmt.run(
-            edge.source_node_id,
-            newTargetNodeId,
-            importsEdgeType.id,
-            JSON.stringify({ from }),
-          );
-          created++;
+        let changed = false;
+        for (const from of froms) {
+          const freshTargets = resolve(from);
+          if (freshTargets.includes(fileId)) {
+            addDesired(edge.source_node_id, targetNodeId, from);
+            continue;
+          }
+          changed = true;
+          for (const newTargetId of freshTargets) {
+            const newTargetNodeId = nodeIds.get(newTargetId);
+            if (newTargetNodeId == null) continue;
+            addDesired(edge.source_node_id, newTargetNodeId, from);
+          }
+        }
+        if (changed) {
+          deleteStmt.run(edge.id);
+          pruned++;
         }
       }
     }
 
+    // A file whose own extraction changed carries its complete, current
+    // specifier list — authoritative for every edge it's the source of.
     for (const [fileId, imports] of state.pendingImports) {
       if (fileMap.get(fileId)?.language !== 'csharp') continue;
       const sourceNodeId = nodeIds.get(fileId);
@@ -208,15 +250,23 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
         }
         for (const targetId of targets) {
           const targetNodeId = nodeIds.get(targetId);
-          if (targetNodeId == null || targetNodeId === sourceNodeId) continue;
-          insertStmt.run(sourceNodeId, targetNodeId, importsEdgeType.id, JSON.stringify({ from }));
-          created++;
+          if (targetNodeId == null) continue;
+          addDesired(sourceNodeId, targetNodeId, from);
         }
       }
     }
+
+    for (const { sourceNodeId, targetNodeId, froms } of desired.values()) {
+      insertStmt.run(
+        sourceNodeId,
+        targetNodeId,
+        importsEdgeType.id,
+        JSON.stringify({ froms: Array.from(froms).sort() }),
+      );
+    }
   })();
 
-  if (created > 0 || external > 0 || pruned > 0) {
-    logger.info({ edges: created, external, pruned }, 'C# import edges resolved');
+  if (desired.size > 0 || external > 0 || pruned > 0) {
+    logger.info({ edges: desired.size, external, pruned }, 'C# import edges resolved');
   }
 }

--- a/src/indexer/edge-resolvers/csharp-imports.ts
+++ b/src/indexer/edge-resolvers/csharp-imports.ts
@@ -1,58 +1,63 @@
 /**
- * Resolve C# `using` directive edges to the file declaring the namespace or
- * type (TRA-1027 — next after Ruby in the C#/Kotlin/Swift/Elixir/Lua backlog
- * `import-capable-languages.ts` names as "extract but nothing consumes").
+ * Resolve C# `using` directive edges to the file declaring the specific type
+ * a directive names (TRA-1027 — next after Ruby in the C#/Kotlin/Swift/
+ * Elixir/Lua backlog `import-capable-languages.ts` names as "extract but
+ * nothing consumes").
  *
- * Unlike Java, C# does not force the namespace to mirror the directory
- * layout — `namespace Acme.Store` can live at any path — so suffix-matching
- * the specifier against file paths (the Java/Go approach) would silently
- * under-resolve any project that doesn't follow the folder-per-namespace
- * convention. Resolution instead uses the symbols the plugin already
- * extracts (`namespace` from `CSharpLanguagePlugin.extractNamespace`, plus
- * `class`/`interface`/`enum`/`type` for the type-level cases below), each
+ * A plain `using Acme.Store;` is deliberately left unresolved — it does not
+ * mean the importing file depends on every file that happens to declare
+ * `namespace Acme.Store`, it only makes unqualified names from that
+ * namespace available. Two rounds of review rejected file-edges for this
+ * form, for two separate reasons that both hold regardless of how many files
+ * declare the namespace:
+ *
+ * - **Volume:** a real repo (Newtonsoft.Json) averaged 86 resolved edges per
+ *   importing file when this was tried, because C# namespaces routinely span
+ *   most of a codebase — nothing like Java's `import a.b.*`, where a
+ *   directory-scoped package keeps the fan-out small and wildcard imports are
+ *   rare in idiomatic code to begin with.
+ * - **Even the single-declarer case is unsound incrementally:** resolving to
+ *   the one file when a namespace has exactly one declarer looked safe in
+ *   isolation, but review found it depends on the rest of the codebase in a
+ *   way the incremental resolver can't track — adding a second file to that
+ *   namespace elsewhere leaves the old "unique" edge stale (nothing re-checks
+ *   an unrelated, unchanged file just because some other file made its
+ *   namespace ambiguous), and the reverse transition never creates the edge
+ *   at all without a full reindex either. The edge's existence would depend
+ *   on file-count trivia elsewhere in the repo, not on anything the
+ *   `using` directive itself said.
+ *
+ * Resolution instead only trusts forms that name a **specific type**, via the
+ * `class`/`interface`/`enum`/`type` symbols the plugin already extracts, each
  * with `fqn` set to its dotted path:
  *
- *     using Acme.Store;             // → the file declaring `namespace Acme.Store`,
- *                                    //   only when exactly one file declares it
- *     using static Acme.Store.Ids;  // → only the file declaring type `Acme.Store.Ids`
- *     using Alias = Acme.Store.Db;  // → only the file declaring type `Acme.Store.Db`
+ *     using Acme.Store;             // → unresolved (see above)
+ *     using static Acme.Store.Ids;  // → the file(s) declaring type `Acme.Store.Ids`
+ *     using Alias = Acme.Store.Db;  // → the file(s) declaring type `Acme.Store.Db`
  *
- * A namespace is not a directory: `using Acme.Store.Billing` does not import
- * `Acme.Store`, so an exact-namespace or exact-type match is required before
- * falling back — trimming to a *namespace* match on a miss would treat a
- * plain `using` of an unindexed sub-namespace as if it named the parent,
- * linking to every file in it. The one place trimming is still safe is a
- * type miss, where it recovers a nested type's enclosing type.
+ * A type FQN can legitimately map to more than one file for a `partial`
+ * type — every piece is a real declaring file for it, unlike an unrelated
+ * namespace fan-out, so all of them stay targets. A miss on an exact type
+ * FQN falls back to trimming the last segment, recovering a nested type's
+ * enclosing type (`using static Acme.Store.Outer.Inner;`). A specifier
+ * matching no type (BCL, NuGet package, or a plain namespace) simply fails to
+ * resolve rather than inventing a node.
  *
- * A plain namespace import naming more than one declaring file is left
- * unresolved rather than fanned out to all of them (review caught this: a
- * real repo averaged 86 resolved edges per importing file, because C#
- * namespaces routinely span most of a codebase — nothing like Java's
- * `import a.b.*`, where a directory-scoped package keeps the fan-out small
- * and wildcard imports are rare in idiomatic code to begin with). A file
- * that is the sole declarer of a namespace is still a precise target, same
- * as any other language's plain import. The fully precise fix — resolving
- * only the types a file's body actually references — is real usage-tracking
- * and belongs in its own pass, not this one.
- *
- * A specifier matching neither a namespace nor a type (BCL, NuGet package)
- * simply fails to resolve rather than inventing a node.
- *
- * Incremental reindexing: a C# file's declared namespace/type identity is
- * ordinary file content, not derived from its path, so it can change without
- * the file moving — unlike Java/Go, where the resolver never even reads the
- * `package` statement. If only the declaring file gets reindexed (its own
- * `namespace` edited), files that import it are untouched this batch and
- * never get a chance to notice their edge is now wrong. This resolver closes
- * that gap for the files that DO get reindexed here: for every C# file in
+ * Incremental reindexing: a C# file's declared type identity is ordinary
+ * file content, not derived from its path, so it can change (renamed,
+ * removed) without the file moving — unlike Java/Go, where the resolver
+ * never even reads the `package` statement. If only the declaring file gets
+ * reindexed, files that import it are untouched this batch and never get a
+ * chance to notice their edge is now wrong. This resolver closes that gap for
+ * the files that DO get reindexed here: for every C# file in
  * `state.changedFileIds` — deliberately wider than `pendingImports`, which
  * only has an entry for a file that itself has `using` directives, and a
- * namespace-declaring file usually doesn't — its current incoming `imports`
- * edges are re-validated against the fresh namespace/type maps, and any
- * whose stored specifier no longer resolves to it are deleted. A file that
- * never gets reindexed again keeps a stale edge until it does — full
- * self-healing needs a full reindex, which already recomputes every C# file's
- * imports from scratch.
+ * type-declaring file need not have any — its current incoming `imports`
+ * edges are re-validated against the fresh type map, and any whose stored
+ * specifier no longer resolves to it are deleted. A file that never gets
+ * reindexed again keeps a stale edge until it does — full self-healing needs
+ * a full reindex, which already recomputes every C# file's imports from
+ * scratch.
  */
 import { logger } from '../../logger.js';
 import type { ChangeScope } from '../../plugin-api/types.js';
@@ -70,8 +75,8 @@ function addTo(map: Map<string, number[]>, key: string, id: number): void {
 export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeScope): void {
   // WHY: driven by `state.changedFileIds` — wider than `state.pendingImports`,
   // which only has an entry for a file that itself has `using` directives. A
-  // file that only DECLARES a namespace (no imports of its own) still needs
-  // to be in the revalidation loop below when its declaration changes.
+  // file that only DECLARES a type (no imports of its own) still needs to be
+  // in the revalidation loop below when its declaration changes.
   void _scope;
   const { store } = state;
   if (state.changedFileIds.size === 0) return;
@@ -81,23 +86,21 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
   const hasCSharp = changedFileIds.some((id) => fileMap.get(id)?.language === 'csharp');
   if (!hasCSharp) return;
 
-  // Namespace name → the files declaring it via a `namespace` block.
-  const byNamespace = new Map<string, number[]>();
   // Type FQN → the file(s) declaring that class/struct/record/interface/enum/delegate.
   const byType = new Map<string, number[]>();
   const rows = store.db
     .prepare(
-      `SELECT s.file_id AS fileId, s.fqn AS fqn, s.kind AS kind
+      `SELECT s.file_id AS fileId, s.fqn AS fqn
        FROM symbols s
        JOIN files f ON f.id = s.file_id
        WHERE f.language = 'csharp' AND s.fqn IS NOT NULL
-         AND s.kind IN ('namespace', 'class', 'interface', 'enum', 'type')`,
+         AND s.kind IN ('class', 'interface', 'enum', 'type')`,
     )
-    .all() as Array<{ fileId: number; fqn: string; kind: string }>;
-  for (const { fileId, fqn, kind } of rows) {
-    addTo(kind === 'namespace' ? byNamespace : byType, fqn, fileId);
+    .all() as Array<{ fileId: number; fqn: string }>;
+  for (const { fileId, fqn } of rows) {
+    addTo(byType, fqn, fileId);
   }
-  if (byNamespace.size === 0 && byType.size === 0) return;
+  if (byType.size === 0) return;
 
   const importsEdgeType = store.db
     .prepare('SELECT id FROM edge_types WHERE name = ?')
@@ -105,10 +108,7 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
   if (!importsEdgeType) return;
 
   const nodeIds = new Map<number, number>();
-  const allTargetFileIds = Array.from(byNamespace.values())
-    .concat(Array.from(byType.values()))
-    .flat()
-    .concat(changedFileIds);
+  const allTargetFileIds = Array.from(byType.values()).flat().concat(changedFileIds);
   const CHUNK = 500;
   for (let i = 0; i < allTargetFileIds.length; i += CHUNK) {
     for (const [k, v] of store.getNodeIdsBatch('file', allTargetFileIds.slice(i, i + CHUNK))) {
@@ -124,18 +124,12 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
   );
 
   /**
-   * `Acme.Store` resolves as a namespace directly, but only when it names
-   * exactly one file — more than one is the ambiguous "which of these did
-   * you actually mean" case this resolver declines to guess (see file
-   * header). `using static Acme.Store.Ids` and aliased `using X =
-   * Acme.Store.Ids` name a type, so try an exact type match before
-   * trimming — and trim only into `byType` (a nested type's enclosing
-   * type), never back into `byNamespace`: a miss on a real namespace means
-   * an external/unindexed sub-namespace, not the parent.
+   * `using static Acme.Store.Ids` and aliased `using X = Acme.Store.Ids`
+   * name a type directly. A miss trims the last segment to recover a nested
+   * type's enclosing type. A plain namespace import never matches here — see
+   * the file header for why that's deliberate, not a gap.
    */
   const resolve = (specifier: string): number[] => {
-    const ns = byNamespace.get(specifier);
-    if (ns && ns.length === 1) return ns;
     const type = byType.get(specifier);
     if (type) return type;
     const cut = specifier.lastIndexOf('.');
@@ -147,10 +141,10 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
   let pruned = 0;
 
   store.db.transaction(() => {
-    // A file's declared namespace/type identity is content, not path — it
-    // can change without the file moving, and unlike the source-driven loop
-    // below, importers that weren't re-extracted this batch never revisit
-    // it. Re-validate every C# file's *incoming* `imports` edges here so a
+    // A file's declared type identity is content, not path — it can change
+    // without the file moving, and unlike the source-driven loop below,
+    // importers that weren't re-extracted this batch never revisit it.
+    // Re-validate every C# file's *incoming* `imports` edges here so a
     // rename at least stops lying, even when it can't insert the new one
     // without re-extracting the importer.
     const deleteStmt = store.db.prepare('DELETE FROM edges WHERE id = ?');

--- a/src/indexer/edge-resolvers/csharp-imports.ts
+++ b/src/indexer/edge-resolvers/csharp-imports.ts
@@ -1,0 +1,118 @@
+/**
+ * Resolve C# `using` directive edges to the file declaring the namespace
+ * (TRA-1027 — next after Ruby in the C#/Kotlin/Swift/Elixir/Lua backlog
+ * `import-capable-languages.ts` names as "extract but nothing consumes").
+ *
+ * Unlike Java, C# does not force the namespace to mirror the directory
+ * layout — `namespace Acme.Store` can live at any path — so suffix-matching
+ * the specifier against file paths (the Java/Go approach) would silently
+ * under-resolve any project that doesn't follow the folder-per-namespace
+ * convention. Resolution instead uses the `namespace` symbols the plugin
+ * already extracts (`CSharpLanguagePlugin.extractNamespace`, kind
+ * `namespace`, `fqn` set to the dotted namespace path):
+ *
+ *     using Acme.Store;             // → every file declaring `namespace Acme.Store`
+ *     using static Acme.Store.Ids;  // → trims the trailing type to the namespace
+ *     using Alias = Acme.Store.Db;  // → same trim; alias doesn't change the target
+ *
+ * A namespace with no declaring file in the index (BCL, NuGet package) simply
+ * fails to resolve rather than inventing a node.
+ */
+import { logger } from '../../logger.js';
+import type { ChangeScope } from '../../plugin-api/types.js';
+import type { PipelineState } from '../pipeline-state.js';
+
+export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeScope): void {
+  // WHY: driven by `state.pendingImports`, already scoped to re-extracted files.
+  void _scope;
+  const { store } = state;
+  if (state.pendingImports.size === 0) return;
+
+  const pendingFileIds = Array.from(state.pendingImports.keys());
+  const fileMap = store.getFilesByIds(pendingFileIds);
+  const hasCSharp = pendingFileIds.some((id) => fileMap.get(id)?.language === 'csharp');
+  if (!hasCSharp) return;
+
+  // Namespace name → the files that declare it via a `namespace` block.
+  const byNamespace = new Map<string, number[]>();
+  const rows = store.db
+    .prepare(
+      `SELECT s.file_id AS fileId, s.fqn AS fqn
+       FROM symbols s
+       JOIN files f ON f.id = s.file_id
+       WHERE s.kind = 'namespace' AND f.language = 'csharp' AND s.fqn IS NOT NULL`,
+    )
+    .all() as Array<{ fileId: number; fqn: string }>;
+  for (const { fileId, fqn } of rows) {
+    const list = byNamespace.get(fqn);
+    if (list) list.push(fileId);
+    else byNamespace.set(fqn, [fileId]);
+  }
+  if (byNamespace.size === 0) return;
+
+  const importsEdgeType = store.db
+    .prepare('SELECT id FROM edge_types WHERE name = ?')
+    .get('imports') as { id: number } | undefined;
+  if (!importsEdgeType) return;
+
+  const nodeIds = new Map<number, number>();
+  const allNamespaceFileIds = Array.from(byNamespace.values()).flat().concat(pendingFileIds);
+  const CHUNK = 500;
+  for (let i = 0; i < allNamespaceFileIds.length; i += CHUNK) {
+    for (const [k, v] of store.getNodeIdsBatch('file', allNamespaceFileIds.slice(i, i + CHUNK))) {
+      nodeIds.set(k, v);
+    }
+  }
+
+  const insertStmt = store.db.prepare(
+    `INSERT INTO edges (source_node_id, target_node_id, edge_type_id, resolved, metadata, is_cross_ws)
+     VALUES (?, ?, ?, 1, ?, 0)
+     ON CONFLICT(source_node_id, target_node_id, edge_type_id)
+     DO UPDATE SET metadata = excluded.metadata`,
+  );
+
+  /**
+   * `Acme.Store` resolves directly. `using static Acme.Store.Ids` and aliased
+   * `using X = Acme.Store.Ids` name a type, not a namespace, so fall back to
+   * the specifier with its last segment trimmed.
+   */
+  const resolve = (specifier: string): number[] => {
+    const direct = byNamespace.get(specifier);
+    if (direct) return direct;
+    const cut = specifier.lastIndexOf('.');
+    return (cut > 0 && byNamespace.get(specifier.slice(0, cut))) || [];
+  };
+
+  let created = 0;
+  let external = 0;
+
+  store.db.transaction(() => {
+    for (const [fileId, imports] of state.pendingImports) {
+      if (fileMap.get(fileId)?.language !== 'csharp') continue;
+      const sourceNodeId = nodeIds.get(fileId);
+      if (sourceNodeId == null) continue;
+
+      const seen = new Set<string>();
+      for (const { from } of imports) {
+        if (!from || seen.has(from)) continue;
+        seen.add(from);
+
+        const targets = resolve(from);
+        if (targets.length === 0) {
+          external++;
+          continue;
+        }
+        for (const targetId of targets) {
+          const targetNodeId = nodeIds.get(targetId);
+          if (targetNodeId == null || targetNodeId === sourceNodeId) continue;
+          insertStmt.run(sourceNodeId, targetNodeId, importsEdgeType.id, JSON.stringify({ from }));
+          created++;
+        }
+      }
+    }
+  })();
+
+  if (created > 0 || external > 0) {
+    logger.info({ edges: created, external }, 'C# import edges resolved');
+  }
+}

--- a/src/indexer/edge-resolvers/csharp-imports.ts
+++ b/src/indexer/edge-resolvers/csharp-imports.ts
@@ -12,7 +12,8 @@
  * `class`/`interface`/`enum`/`type` for the type-level cases below), each
  * with `fqn` set to its dotted path:
  *
- *     using Acme.Store;             // → every file declaring `namespace Acme.Store`
+ *     using Acme.Store;             // → the file declaring `namespace Acme.Store`,
+ *                                    //   only when exactly one file declares it
  *     using static Acme.Store.Ids;  // → only the file declaring type `Acme.Store.Ids`
  *     using Alias = Acme.Store.Db;  // → only the file declaring type `Acme.Store.Db`
  *
@@ -21,9 +22,37 @@
  * falling back — trimming to a *namespace* match on a miss would treat a
  * plain `using` of an unindexed sub-namespace as if it named the parent,
  * linking to every file in it. The one place trimming is still safe is a
- * type miss, where it recovers a nested type's enclosing type. A specifier
- * matching neither (BCL, NuGet package) simply fails to resolve rather than
- * inventing a node.
+ * type miss, where it recovers a nested type's enclosing type.
+ *
+ * A plain namespace import naming more than one declaring file is left
+ * unresolved rather than fanned out to all of them (review caught this: a
+ * real repo averaged 86 resolved edges per importing file, because C#
+ * namespaces routinely span most of a codebase — nothing like Java's
+ * `import a.b.*`, where a directory-scoped package keeps the fan-out small
+ * and wildcard imports are rare in idiomatic code to begin with). A file
+ * that is the sole declarer of a namespace is still a precise target, same
+ * as any other language's plain import. The fully precise fix — resolving
+ * only the types a file's body actually references — is real usage-tracking
+ * and belongs in its own pass, not this one.
+ *
+ * A specifier matching neither a namespace nor a type (BCL, NuGet package)
+ * simply fails to resolve rather than inventing a node.
+ *
+ * Incremental reindexing: a C# file's declared namespace/type identity is
+ * ordinary file content, not derived from its path, so it can change without
+ * the file moving — unlike Java/Go, where the resolver never even reads the
+ * `package` statement. If only the declaring file gets reindexed (its own
+ * `namespace` edited), files that import it are untouched this batch and
+ * never get a chance to notice their edge is now wrong. This resolver closes
+ * that gap for the files that DO get reindexed here: for every C# file in
+ * `state.changedFileIds` — deliberately wider than `pendingImports`, which
+ * only has an entry for a file that itself has `using` directives, and a
+ * namespace-declaring file usually doesn't — its current incoming `imports`
+ * edges are re-validated against the fresh namespace/type maps, and any
+ * whose stored specifier no longer resolves to it are deleted. A file that
+ * never gets reindexed again keeps a stale edge until it does — full
+ * self-healing needs a full reindex, which already recomputes every C# file's
+ * imports from scratch.
  */
 import { logger } from '../../logger.js';
 import type { ChangeScope } from '../../plugin-api/types.js';
@@ -39,14 +68,17 @@ function addTo(map: Map<string, number[]>, key: string, id: number): void {
 }
 
 export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeScope): void {
-  // WHY: driven by `state.pendingImports`, already scoped to re-extracted files.
+  // WHY: driven by `state.changedFileIds` — wider than `state.pendingImports`,
+  // which only has an entry for a file that itself has `using` directives. A
+  // file that only DECLARES a namespace (no imports of its own) still needs
+  // to be in the revalidation loop below when its declaration changes.
   void _scope;
   const { store } = state;
-  if (state.pendingImports.size === 0) return;
+  if (state.changedFileIds.size === 0) return;
 
-  const pendingFileIds = Array.from(state.pendingImports.keys());
-  const fileMap = store.getFilesByIds(pendingFileIds);
-  const hasCSharp = pendingFileIds.some((id) => fileMap.get(id)?.language === 'csharp');
+  const changedFileIds = Array.from(state.changedFileIds);
+  const fileMap = store.getFilesByIds(changedFileIds);
+  const hasCSharp = changedFileIds.some((id) => fileMap.get(id)?.language === 'csharp');
   if (!hasCSharp) return;
 
   // Namespace name → the files declaring it via a `namespace` block.
@@ -76,7 +108,7 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
   const allTargetFileIds = Array.from(byNamespace.values())
     .concat(Array.from(byType.values()))
     .flat()
-    .concat(pendingFileIds);
+    .concat(changedFileIds);
   const CHUNK = 500;
   for (let i = 0; i < allTargetFileIds.length; i += CHUNK) {
     for (const [k, v] of store.getNodeIdsBatch('file', allTargetFileIds.slice(i, i + CHUNK))) {
@@ -92,16 +124,18 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
   );
 
   /**
-   * `Acme.Store` resolves as a namespace directly. `using static
-   * Acme.Store.Ids` and aliased `using X = Acme.Store.Ids` name a type, so
-   * try an exact type match before trimming — and trim only into `byType`
-   * (a nested type's enclosing type), never back into `byNamespace`: a miss
-   * on a real namespace means an external/unindexed sub-namespace, not the
-   * parent.
+   * `Acme.Store` resolves as a namespace directly, but only when it names
+   * exactly one file — more than one is the ambiguous "which of these did
+   * you actually mean" case this resolver declines to guess (see file
+   * header). `using static Acme.Store.Ids` and aliased `using X =
+   * Acme.Store.Ids` name a type, so try an exact type match before
+   * trimming — and trim only into `byType` (a nested type's enclosing
+   * type), never back into `byNamespace`: a miss on a real namespace means
+   * an external/unindexed sub-namespace, not the parent.
    */
   const resolve = (specifier: string): number[] => {
     const ns = byNamespace.get(specifier);
-    if (ns) return ns;
+    if (ns && ns.length === 1) return ns;
     const type = byType.get(specifier);
     if (type) return type;
     const cut = specifier.lastIndexOf('.');
@@ -110,8 +144,35 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
 
   let created = 0;
   let external = 0;
+  let pruned = 0;
 
   store.db.transaction(() => {
+    // A file's declared namespace/type identity is content, not path — it
+    // can change without the file moving, and unlike the source-driven loop
+    // below, importers that weren't re-extracted this batch never revisit
+    // it. Re-validate every C# file's *incoming* `imports` edges here so a
+    // rename at least stops lying, even when it can't insert the new one
+    // without re-extracting the importer.
+    const deleteStmt = store.db.prepare('DELETE FROM edges WHERE id = ?');
+    for (const fileId of changedFileIds) {
+      if (fileMap.get(fileId)?.language !== 'csharp') continue;
+      const targetNodeId = nodeIds.get(fileId);
+      if (targetNodeId == null) continue;
+      for (const edge of store.getIncomingEdges(targetNodeId)) {
+        if (edge.edge_type_name !== 'imports' || !edge.metadata) continue;
+        let from: string | undefined;
+        try {
+          from = (JSON.parse(edge.metadata) as { from?: string }).from;
+        } catch {
+          continue;
+        }
+        if (!from || !resolve(from).includes(fileId)) {
+          deleteStmt.run(edge.id);
+          pruned++;
+        }
+      }
+    }
+
     for (const [fileId, imports] of state.pendingImports) {
       if (fileMap.get(fileId)?.language !== 'csharp') continue;
       const sourceNodeId = nodeIds.get(fileId);
@@ -137,7 +198,7 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
     }
   })();
 
-  if (created > 0 || external > 0) {
-    logger.info({ edges: created, external }, 'C# import edges resolved');
+  if (created > 0 || external > 0 || pruned > 0) {
+    logger.info({ edges: created, external, pruned }, 'C# import edges resolved');
   }
 }

--- a/src/indexer/edge-resolvers/csharp-imports.ts
+++ b/src/indexer/edge-resolvers/csharp-imports.ts
@@ -135,7 +135,11 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
   for (const { fileId, fqn } of rows) {
     addTo(byType, fqn, fileId);
   }
-  if (byType.size === 0) return;
+  // No early return on an empty `byType`: the last C# type in the whole
+  // index can be deleted/renamed in this very batch, and an empty map is
+  // exactly what should make `resolve()` treat every specifier as external —
+  // skipping the revalidation pass below would instead leave a now-wrong
+  // incoming edge on the file that just lost its only type.
 
   const importsEdgeType = store.db
     .prepare('SELECT id FROM edge_types WHERE name = ?')

--- a/src/indexer/edge-resolvers/csharp-imports.ts
+++ b/src/indexer/edge-resolvers/csharp-imports.ts
@@ -1,26 +1,42 @@
 /**
- * Resolve C# `using` directive edges to the file declaring the namespace
- * (TRA-1027 — next after Ruby in the C#/Kotlin/Swift/Elixir/Lua backlog
+ * Resolve C# `using` directive edges to the file declaring the namespace or
+ * type (TRA-1027 — next after Ruby in the C#/Kotlin/Swift/Elixir/Lua backlog
  * `import-capable-languages.ts` names as "extract but nothing consumes").
  *
  * Unlike Java, C# does not force the namespace to mirror the directory
  * layout — `namespace Acme.Store` can live at any path — so suffix-matching
  * the specifier against file paths (the Java/Go approach) would silently
  * under-resolve any project that doesn't follow the folder-per-namespace
- * convention. Resolution instead uses the `namespace` symbols the plugin
- * already extracts (`CSharpLanguagePlugin.extractNamespace`, kind
- * `namespace`, `fqn` set to the dotted namespace path):
+ * convention. Resolution instead uses the symbols the plugin already
+ * extracts (`namespace` from `CSharpLanguagePlugin.extractNamespace`, plus
+ * `class`/`interface`/`enum`/`type` for the type-level cases below), each
+ * with `fqn` set to its dotted path:
  *
  *     using Acme.Store;             // → every file declaring `namespace Acme.Store`
- *     using static Acme.Store.Ids;  // → trims the trailing type to the namespace
- *     using Alias = Acme.Store.Db;  // → same trim; alias doesn't change the target
+ *     using static Acme.Store.Ids;  // → only the file declaring type `Acme.Store.Ids`
+ *     using Alias = Acme.Store.Db;  // → only the file declaring type `Acme.Store.Db`
  *
- * A namespace with no declaring file in the index (BCL, NuGet package) simply
- * fails to resolve rather than inventing a node.
+ * A namespace is not a directory: `using Acme.Store.Billing` does not import
+ * `Acme.Store`, so an exact-namespace or exact-type match is required before
+ * falling back — trimming to a *namespace* match on a miss would treat a
+ * plain `using` of an unindexed sub-namespace as if it named the parent,
+ * linking to every file in it. The one place trimming is still safe is a
+ * type miss, where it recovers a nested type's enclosing type. A specifier
+ * matching neither (BCL, NuGet package) simply fails to resolve rather than
+ * inventing a node.
  */
 import { logger } from '../../logger.js';
 import type { ChangeScope } from '../../plugin-api/types.js';
 import type { PipelineState } from '../pipeline-state.js';
+
+function addTo(map: Map<string, number[]>, key: string, id: number): void {
+  const list = map.get(key);
+  if (list) {
+    if (!list.includes(id)) list.push(id);
+  } else {
+    map.set(key, [id]);
+  }
+}
 
 export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeScope): void {
   // WHY: driven by `state.pendingImports`, already scoped to re-extracted files.
@@ -33,22 +49,23 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
   const hasCSharp = pendingFileIds.some((id) => fileMap.get(id)?.language === 'csharp');
   if (!hasCSharp) return;
 
-  // Namespace name → the files that declare it via a `namespace` block.
+  // Namespace name → the files declaring it via a `namespace` block.
   const byNamespace = new Map<string, number[]>();
+  // Type FQN → the file(s) declaring that class/struct/record/interface/enum/delegate.
+  const byType = new Map<string, number[]>();
   const rows = store.db
     .prepare(
-      `SELECT s.file_id AS fileId, s.fqn AS fqn
+      `SELECT s.file_id AS fileId, s.fqn AS fqn, s.kind AS kind
        FROM symbols s
        JOIN files f ON f.id = s.file_id
-       WHERE s.kind = 'namespace' AND f.language = 'csharp' AND s.fqn IS NOT NULL`,
+       WHERE f.language = 'csharp' AND s.fqn IS NOT NULL
+         AND s.kind IN ('namespace', 'class', 'interface', 'enum', 'type')`,
     )
-    .all() as Array<{ fileId: number; fqn: string }>;
-  for (const { fileId, fqn } of rows) {
-    const list = byNamespace.get(fqn);
-    if (list) list.push(fileId);
-    else byNamespace.set(fqn, [fileId]);
+    .all() as Array<{ fileId: number; fqn: string; kind: string }>;
+  for (const { fileId, fqn, kind } of rows) {
+    addTo(kind === 'namespace' ? byNamespace : byType, fqn, fileId);
   }
-  if (byNamespace.size === 0) return;
+  if (byNamespace.size === 0 && byType.size === 0) return;
 
   const importsEdgeType = store.db
     .prepare('SELECT id FROM edge_types WHERE name = ?')
@@ -56,10 +73,13 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
   if (!importsEdgeType) return;
 
   const nodeIds = new Map<number, number>();
-  const allNamespaceFileIds = Array.from(byNamespace.values()).flat().concat(pendingFileIds);
+  const allTargetFileIds = Array.from(byNamespace.values())
+    .concat(Array.from(byType.values()))
+    .flat()
+    .concat(pendingFileIds);
   const CHUNK = 500;
-  for (let i = 0; i < allNamespaceFileIds.length; i += CHUNK) {
-    for (const [k, v] of store.getNodeIdsBatch('file', allNamespaceFileIds.slice(i, i + CHUNK))) {
+  for (let i = 0; i < allTargetFileIds.length; i += CHUNK) {
+    for (const [k, v] of store.getNodeIdsBatch('file', allTargetFileIds.slice(i, i + CHUNK))) {
       nodeIds.set(k, v);
     }
   }
@@ -72,15 +92,20 @@ export function resolveCSharpImportEdges(state: PipelineState, _scope?: ChangeSc
   );
 
   /**
-   * `Acme.Store` resolves directly. `using static Acme.Store.Ids` and aliased
-   * `using X = Acme.Store.Ids` name a type, not a namespace, so fall back to
-   * the specifier with its last segment trimmed.
+   * `Acme.Store` resolves as a namespace directly. `using static
+   * Acme.Store.Ids` and aliased `using X = Acme.Store.Ids` name a type, so
+   * try an exact type match before trimming — and trim only into `byType`
+   * (a nested type's enclosing type), never back into `byNamespace`: a miss
+   * on a real namespace means an external/unindexed sub-namespace, not the
+   * parent.
    */
   const resolve = (specifier: string): number[] => {
-    const direct = byNamespace.get(specifier);
-    if (direct) return direct;
+    const ns = byNamespace.get(specifier);
+    if (ns) return ns;
+    const type = byType.get(specifier);
+    if (type) return type;
     const cut = specifier.lastIndexOf('.');
-    return (cut > 0 && byNamespace.get(specifier.slice(0, cut))) || [];
+    return (cut > 0 && byType.get(specifier.slice(0, cut))) || [];
   };
 
   let created = 0;

--- a/src/indexer/edge-resolvers/import-capable-languages.ts
+++ b/src/indexer/edge-resolvers/import-capable-languages.ts
@@ -7,7 +7,7 @@
  * import patterns" and so claimed 66 of 81 languages. Indexing a fixture where
  * every language performs one real cross-file import originally produced edges
  * for only four: php, python, typescript and vue. Go, Rust, C, C++, Java,
- * Ruby, Astro and Svelte have since gained resolvers (in that order); C#,
+ * Ruby, Astro, Svelte and C# have since gained resolvers (in that order);
  * Kotlin, Swift, Elixir and Lua still extract an import that nothing
  * consumes.
  *
@@ -58,6 +58,7 @@ export const IMPORT_EDGE_LANGUAGES: ReadonlySet<string> = new Set([
   'c', // resolveCImportEdges
   'cpp', // resolveCImportEdges
   'ruby', // resolveRubyImportEdges
+  'csharp', // resolveCSharpImportEdges
   'yaml', // resolveIacImportEdges — kustomize / docker-compose refs
   'hcl', // resolveIacImportEdges — local terraform module sources
   'markdown', // resolveMarkdownWikilinkEdges

--- a/src/indexer/pipeline.ts
+++ b/src/indexer/pipeline.ts
@@ -938,6 +938,7 @@ export class IndexingPipeline {
       () => edgeResolver.resolveRustImportEdges(scope),
       () => edgeResolver.resolveCImportEdges(scope),
       () => edgeResolver.resolveRubyImportEdges(scope),
+      () => edgeResolver.resolveCSharpImportEdges(scope),
       () => edgeResolver.resolvePhpCallEdges(scope),
       () => edgeResolver.resolveTypeScriptCallEdges(scope),
       () => edgeResolver.resolveTypeScriptTypeEdges(scope),

--- a/src/indexer/plugins/language/csharp/helpers.ts
+++ b/src/indexer/plugins/language/csharp/helpers.ts
@@ -129,59 +129,72 @@ export function extractBaseTypes(node: TSNode): string[] {
   return bases;
 }
 
-/** Extract using directive edges from the root compilation_unit. */
+/**
+ * Collect every `using_directive` node anywhere under `node` — both file-level
+ * (top of the compilation unit) and namespace-scoped (`namespace X { using Y; }`,
+ * legal and common in the block-namespace form). `using_directive` cannot occur
+ * inside a type body, so a plain recursive walk is sufficient and never needs
+ * to special-case which container it found one in.
+ */
+function collectUsingDirectives(node: TSNode, out: TSNode[]): void {
+  for (const child of node.namedChildren) {
+    if (child.type === 'using_directive') {
+      out.push(child);
+    } else {
+      collectUsingDirectives(child, out);
+    }
+  }
+}
+
+/** Extract using directive edges anywhere in the file (root- or namespace-scoped). */
 export function extractImportEdges(root: TSNode): RawEdge[] {
   const edges: RawEdge[] = [];
+  const directives: TSNode[] = [];
+  collectUsingDirectives(root, directives);
 
-  for (const node of root.namedChildren) {
-    if (node.type === 'using_directive') {
-      let namespaceName = '';
-      let isStatic = false;
-      let alias: string | undefined;
+  for (const node of directives) {
+    let namespaceName = '';
+    let isStatic = false;
+    let alias: string | undefined;
 
-      for (let i = 0; i < node.childCount; i++) {
-        const child = node.child(i);
-        if (!child) continue;
-        if (child.text === 'static') isStatic = true;
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (!child) continue;
+      if (child.text === 'static') isStatic = true;
+    }
+
+    // Check for alias: using Alias = Namespace;
+    const nameAssignment = node.childForFieldName('alias');
+    if (nameAssignment) {
+      alias = nameAssignment.text;
+    }
+
+    // The namespace/type name
+    for (const child of node.namedChildren) {
+      if (child.type === 'qualified_name' || child.type === 'identifier' || child.type === 'name') {
+        namespaceName = child.text;
       }
+    }
 
-      // Check for alias: using Alias = Namespace;
-      const nameAssignment = node.childForFieldName('alias');
-      if (nameAssignment) {
-        alias = nameAssignment.text;
-      }
+    // Fallback: extract from text if tree-sitter node types differ
+    if (!namespaceName) {
+      const match = node.text.match(/using\s+(?:static\s+)?(?:\w+\s*=\s*)?([\w.]+)\s*;/);
+      if (match) namespaceName = match[1];
+    }
 
-      // The namespace/type name
-      for (const child of node.namedChildren) {
-        if (
-          child.type === 'qualified_name' ||
-          child.type === 'identifier' ||
-          child.type === 'name'
-        ) {
-          namespaceName = child.text;
-        }
-      }
+    if (namespaceName) {
+      const parts = namespaceName.split('.');
+      const simpleName = alias ?? parts[parts.length - 1];
 
-      // Fallback: extract from text if tree-sitter node types differ
-      if (!namespaceName) {
-        const match = node.text.match(/using\s+(?:static\s+)?(?:\w+\s*=\s*)?([\w.]+)\s*;/);
-        if (match) namespaceName = match[1];
-      }
-
-      if (namespaceName) {
-        const parts = namespaceName.split('.');
-        const simpleName = alias ?? parts[parts.length - 1];
-
-        edges.push({
-          edgeType: 'imports',
-          metadata: {
-            from: namespaceName,
-            specifiers: [simpleName],
-            ...(isStatic ? { static: true } : {}),
-            ...(alias ? { alias } : {}),
-          },
-        });
-      }
+      edges.push({
+        edgeType: 'imports',
+        metadata: {
+          from: namespaceName,
+          specifiers: [simpleName],
+          ...(isStatic ? { static: true } : {}),
+          ...(alias ? { alias } : {}),
+        },
+      });
     }
   }
 

--- a/tests/integration/csharp-import-resolution-e2e.test.ts
+++ b/tests/integration/csharp-import-resolution-e2e.test.ts
@@ -249,4 +249,64 @@ namespace Acme.App
       removeTmpDir(fixtureDir);
     }
   });
+
+  it('relinks to the new declaring file when a type moves, without reindexing the importer', async () => {
+    const fixtureDir = createTmpFixture(
+      {
+        'src/App.cs': `using static Acme.Store.Repo;
+
+namespace Acme.App
+{
+    public class Program
+    {
+        Repo repo;
+    }
+}
+`,
+        'src/One.cs': `namespace Acme.Store
+{
+    public class Repo {}
+}
+`,
+      },
+      'trace-mcp-csharp-move-',
+    );
+    try {
+      const store = createTestStore();
+      const registry = new PluginRegistry();
+      registry.registerLanguagePlugin(new CSharpLanguagePlugin());
+      const pipeline = new IndexingPipeline(store, registry, makeConfig(fixtureDir), fixtureDir);
+      await pipeline.indexAll();
+      expect(importTargets(store, 'src/App.cs')).toEqual(new Set(['src/One.cs']));
+
+      // Move Repo out of One.cs and into a new Two.cs — App.cs, the
+      // importer, is untouched; both target files are reindexed together,
+      // as a file watcher would batch them.
+      const onePath = path.join(fixtureDir, 'src/One.cs');
+      const twoPath = path.join(fixtureDir, 'src/Two.cs');
+      fs.writeFileSync(
+        onePath,
+        `namespace Acme.Store
+{
+}
+`,
+      );
+      fs.writeFileSync(
+        twoPath,
+        `namespace Acme.Store
+{
+    public class Repo {}
+}
+`,
+      );
+      await pipeline.indexFiles([onePath, twoPath]);
+
+      // The stale edge into One.cs is gone, and the resolver relinked to
+      // Two.cs using the stale edge's own source + specifier — no reindex
+      // of App.cs was needed for this to converge.
+      expect(importTargets(store, 'src/App.cs')).toEqual(new Set(['src/Two.cs']));
+    } finally {
+      removeTmpDir(fixtureDir);
+    }
+  });
 });

--- a/tests/integration/csharp-import-resolution-e2e.test.ts
+++ b/tests/integration/csharp-import-resolution-e2e.test.ts
@@ -309,4 +309,134 @@ namespace Acme.App
       removeTmpDir(fixtureDir);
     }
   });
+
+  it('keeps a still-valid specifier when another specifier collapsed onto the same edge moves', async () => {
+    const fixtureDir = createTmpFixture(
+      {
+        'src/App.cs': `using static Acme.Store.A;
+using static Acme.Store.B;
+
+namespace Acme.App
+{
+    public class Program
+    {
+        A a;
+        B b;
+    }
+}
+`,
+        'src/Types.cs': `namespace Acme.Store
+{
+    public class A {}
+    public class B {}
+}
+`,
+      },
+      'trace-mcp-csharp-multi-specifier-',
+    );
+    try {
+      const store = createTestStore();
+      const registry = new PluginRegistry();
+      registry.registerLanguagePlugin(new CSharpLanguagePlugin());
+      const pipeline = new IndexingPipeline(store, registry, makeConfig(fixtureDir), fixtureDir);
+      await pipeline.indexAll();
+      // Both `using static` directives collapse onto the same file edge.
+      expect(importTargets(store, 'src/App.cs')).toEqual(new Set(['src/Types.cs']));
+
+      // Move only A out to its own file — B stays in Types.cs. App.cs, the
+      // importer, is untouched.
+      const typesPath = path.join(fixtureDir, 'src/Types.cs');
+      const aPath = path.join(fixtureDir, 'src/A.cs');
+      fs.writeFileSync(
+        typesPath,
+        `namespace Acme.Store
+{
+    public class B {}
+}
+`,
+      );
+      fs.writeFileSync(
+        aPath,
+        `namespace Acme.Store
+{
+    public class A {}
+}
+`,
+      );
+      await pipeline.indexFiles([typesPath, aPath]);
+
+      // Types.cs must survive (B still resolves there) alongside the new
+      // A.cs edge — an earlier version stored only the single latest
+      // specifier per edge, so revalidating B against a metadata blob that
+      // actually held "A" wiped the whole edge instead of keeping it.
+      expect(importTargets(store, 'src/App.cs')).toEqual(new Set(['src/Types.cs', 'src/A.cs']));
+    } finally {
+      removeTmpDir(fixtureDir);
+    }
+  });
+
+  it('does not invent a stale edge after a real delete-then-create rename, but does not self-heal without a full reindex either', async () => {
+    // Documents a known, deliberate limitation (see the resolver's file
+    // header): unlike the in-place edits above, a real file watcher renames
+    // by calling `deleteFiles` and `indexFiles` as two separate calls, and
+    // `deleteFiles` cascades away the old edge before the create is ever
+    // seen — there is nothing left to relink from. The graph ends up
+    // missing an edge, not lying with a wrong one, and a full reindex
+    // recovers it.
+    const fixtureDir = createTmpFixture(
+      {
+        'src/App.cs': `using static Acme.Store.Repo;
+
+namespace Acme.App
+{
+    public class Program
+    {
+        Repo repo;
+    }
+}
+`,
+        'src/One.cs': `namespace Acme.Store
+{
+    public class Repo {}
+}
+`,
+      },
+      'trace-mcp-csharp-delete-create-',
+    );
+    try {
+      const store = createTestStore();
+      const registry = new PluginRegistry();
+      registry.registerLanguagePlugin(new CSharpLanguagePlugin());
+      const pipeline = new IndexingPipeline(store, registry, makeConfig(fixtureDir), fixtureDir);
+      await pipeline.indexAll();
+      expect(importTargets(store, 'src/App.cs')).toEqual(new Set(['src/One.cs']));
+
+      const onePath = path.join(fixtureDir, 'src/One.cs');
+      const twoPath = path.join(fixtureDir, 'src/Two.cs');
+      fs.rmSync(onePath);
+      fs.writeFileSync(
+        twoPath,
+        `namespace Acme.Store
+{
+    public class Repo {}
+}
+`,
+      );
+      pipeline.deleteFiles([onePath]);
+      await pipeline.indexFiles([twoPath]);
+
+      // No stale pointer at the deleted One.cs — but no proactive edge to
+      // Two.cs either, since deleteFiles already destroyed the edge this
+      // resolver would otherwise have relinked from.
+      expect(importTargets(store, 'src/App.cs')).toEqual(new Set());
+
+      // A forced full reindex recomputes from scratch and recovers it (a
+      // plain `indexAll()` would hash-skip both untouched files and prove
+      // nothing).
+      await pipeline.indexAll(true);
+      expect(importTargets(store, 'src/App.cs')).toEqual(new Set(['src/Two.cs']));
+    } finally {
+      removeTmpDir(fixtureDir);
+    }
+  });
 });

--- a/tests/integration/csharp-import-resolution-e2e.test.ts
+++ b/tests/integration/csharp-import-resolution-e2e.test.ts
@@ -9,14 +9,24 @@
  * instead of path suffixes — these tests put `Store.cs` at a path that would
  * break suffix matching to prove that.
  *
- * Two shapes are here specifically because review caught the first version
- * getting them wrong: a namespace with more than one file in it (`Acme.Store`
- * spans `Store.cs` and `Db.cs`), so a type-level `using` can be checked to
- * resolve to only its declaring file rather than fanning out to every file in
- * the namespace; and an unindexed sub-namespace (`Acme.Store.Missing`), so
- * trimming a miss can be checked to never fall back onto the parent
- * namespace — `using Acme.Store.Missing` does not import `Acme.Store`.
+ * Several shapes below exist specifically because two rounds of review caught
+ * the earlier versions getting them wrong:
+ * - a namespace with more than one file in it (`Acme.Store` spans `Store.cs`
+ *   and `Db.cs`), so a plain `using` of it can be checked to resolve to
+ *   NEITHER file (ambiguous — see the resolver's file header) while a
+ *   type-level `using` of a specific type in that same namespace still
+ *   resolves precisely;
+ * - a namespace with exactly one file (`Acme.Config`), so a plain `using` of
+ *   an unambiguous namespace can be checked to still resolve;
+ * - an unindexed sub-namespace (`Acme.Store.Missing`), so trimming a miss can
+ *   be checked to never fall back onto the parent namespace;
+ * - a `using` inside a namespace block (not just at the top of the file);
+ * - an incremental reindex that renames a namespace without touching the
+ *   importing file, so a stale edge can be checked to get pruned rather than
+ *   surviving forever.
  */
+import fs from 'node:fs';
+import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { TraceMcpConfig } from '../../src/config.js';
 import type { Store } from '../../src/db/store.js';
@@ -25,10 +35,34 @@ import { CSharpLanguagePlugin } from '../../src/indexer/plugins/language/csharp/
 import { PluginRegistry } from '../../src/plugin-api/registry.js';
 import { createTestStore, createTmpFixture, removeTmpDir } from '../test-utils.js';
 
+function makeConfig(root: string): TraceMcpConfig {
+  return {
+    root,
+    include: ['**/*.cs'],
+    exclude: ['node_modules/**'],
+    plugins: [],
+  } as TraceMcpConfig;
+}
+
+function importTargets(store: Store, sourcePath: string): Set<string> {
+  const file = store.getFile(sourcePath);
+  if (!file) return new Set();
+  const nodeId = store.getNodeId('file', file.id);
+  if (nodeId == null) return new Set();
+  const targets = new Set<string>();
+  for (const edge of store.getOutgoingEdges(nodeId)) {
+    if (edge.edge_type_name !== 'imports') continue;
+    const ref = store.getNodeRef(edge.target_node_id);
+    if (ref?.nodeType === 'file') targets.add(store.getFileById(ref.refId)?.path ?? '');
+  }
+  return targets;
+}
+
 const FILES: Record<string, string> = {
   'src/App.cs': `using System;
 using Acme.Store;
 using Acme.Store.Missing;
+using Acme.Config;
 using static Acme.Util.Ids;
 using Db = Acme.Store.Db;
 
@@ -46,17 +80,21 @@ namespace Acme.App
 `,
   // Deliberately not under a store/ directory — proves resolution follows the
   // declared namespace, not the file path, unlike the Java suffix approach.
+  // Acme.Store spans two files, so a plain `using Acme.Store;` is ambiguous.
   'src/nested/deep/Store.cs': `namespace Acme.Store
 {
     public class Repo {}
 }
 `,
-  // A second file in the same namespace as Store.cs — proves a type-level
-  // `using` (static or aliased) resolves to only the file declaring that
-  // type, not every file in the namespace.
   'src/nested/deep/Db.cs': `namespace Acme.Store
 {
     public class Db {}
+}
+`,
+  // The sole file declaring Acme.Config — a plain `using` of it is precise.
+  'src/config/Settings.cs': `namespace Acme.Config
+{
+    public class Settings {}
 }
 `,
   'src/util/Ids.cs': `namespace Acme.Util
@@ -76,20 +114,6 @@ namespace Acme.App
 `,
 };
 
-function importTargets(store: Store, sourcePath: string): Set<string> {
-  const file = store.getFile(sourcePath);
-  if (!file) return new Set();
-  const nodeId = store.getNodeId('file', file.id);
-  if (nodeId == null) return new Set();
-  const targets = new Set<string>();
-  for (const edge of store.getOutgoingEdges(nodeId)) {
-    if (edge.edge_type_name !== 'imports') continue;
-    const ref = store.getNodeRef(edge.target_node_id);
-    if (ref?.nodeType === 'file') targets.add(store.getFileById(ref.refId)?.path ?? '');
-  }
-  return targets;
-}
-
 describe('C# import resolution E2E', () => {
   let store: Store;
   let fixtureDir: string;
@@ -99,24 +123,22 @@ describe('C# import resolution E2E', () => {
     store = createTestStore();
     const registry = new PluginRegistry();
     registry.registerLanguagePlugin(new CSharpLanguagePlugin());
-
-    const config: TraceMcpConfig = {
-      root: fixtureDir,
-      include: ['**/*.cs'],
-      exclude: ['node_modules/**'],
-      plugins: [],
-    } as TraceMcpConfig;
-
-    await new IndexingPipeline(store, registry, config, fixtureDir).indexAll();
+    await new IndexingPipeline(store, registry, makeConfig(fixtureDir), fixtureDir).indexAll();
   });
 
   afterAll(() => {
     removeTmpDir(fixtureDir);
   });
 
-  it('resolves a plain namespace import to every file declaring it, regardless of path', () => {
-    expect(importTargets(store, 'src/App.cs')).toContain('src/nested/deep/Store.cs');
-    expect(importTargets(store, 'src/App.cs')).toContain('src/nested/deep/Db.cs');
+  it('does not resolve a plain namespace import when more than one file declares it', () => {
+    // `using Acme.Store;` — Acme.Store spans Store.cs and Db.cs, so neither
+    // is a precise target; the resolver must not guess which one was meant.
+    const targets = importTargets(store, 'src/App.cs');
+    expect(targets).not.toContain('src/nested/deep/Store.cs');
+  });
+
+  it('resolves a plain namespace import to its sole declaring file', () => {
+    expect(importTargets(store, 'src/App.cs')).toContain('src/config/Settings.cs');
   });
 
   it('resolves a `using static` member import to only the file declaring that type', () => {
@@ -125,9 +147,10 @@ describe('C# import resolution E2E', () => {
     expect(targets).not.toContain('src/util/Other.cs');
   });
 
-  it('resolves an aliased type import to only the file declaring that type', () => {
-    // `using Db = Acme.Store.Db;` must resolve to Db.cs specifically, not fan
-    // out via the namespace to every file in Acme.Store.
+  it('resolves an aliased type import to only the file declaring that type, even in an ambiguous namespace', () => {
+    // `using Db = Acme.Store.Db;` must resolve to Db.cs specifically — the
+    // type-level match is precise regardless of Acme.Store being ambiguous
+    // for the plain-namespace case above.
     expect(importTargets(store, 'src/App.cs')).toContain('src/nested/deep/Db.cs');
   });
 
@@ -135,14 +158,100 @@ describe('C# import resolution E2E', () => {
     // `using Acme.Store.Missing;` names a namespace that isn't declared
     // anywhere in the repo. It must not be treated as `Acme.Store`.
     expect(importTargets(store, 'src/App.cs')).toEqual(
-      new Set(['src/nested/deep/Store.cs', 'src/nested/deep/Db.cs', 'src/util/Ids.cs']),
+      new Set(['src/config/Settings.cs', 'src/util/Ids.cs', 'src/nested/deep/Db.cs']),
     );
   });
 
   it('skips BCL imports rather than inventing targets', () => {
-    // App.cs also imports `System` (BCL) and `Acme.Store.Missing` (unindexed
-    // sub-namespace) — neither may appear, so only the three first-party
-    // targets above are here.
+    // App.cs also imports `System` (BCL), the ambiguous `Acme.Store`, and the
+    // unindexed `Acme.Store.Missing` — none may appear, so only the three
+    // precise targets above are here.
     expect(importTargets(store, 'src/App.cs').size).toBe(3);
+  });
+});
+
+describe('C# import resolution: namespace-scoped using directives', () => {
+  it('extracts a `using` declared inside a namespace block, not just at file scope', async () => {
+    const fixtureDir = createTmpFixture(
+      {
+        'src/App.cs': `namespace Acme.App
+{
+    using Acme.Store;
+
+    public class Program
+    {
+        Repo repo;
+    }
+}
+`,
+        'src/Store.cs': `namespace Acme.Store
+{
+    public class Repo {}
+}
+`,
+      },
+      'trace-mcp-csharp-ns-scoped-using-',
+    );
+    try {
+      const store = createTestStore();
+      const registry = new PluginRegistry();
+      registry.registerLanguagePlugin(new CSharpLanguagePlugin());
+      await new IndexingPipeline(store, registry, makeConfig(fixtureDir), fixtureDir).indexAll();
+
+      expect(importTargets(store, 'src/App.cs')).toContain('src/Store.cs');
+    } finally {
+      removeTmpDir(fixtureDir);
+    }
+  });
+});
+
+describe('C# import resolution: incremental reindex', () => {
+  it('prunes a stale edge after the target file renames its namespace, without reindexing the importer', async () => {
+    const fixtureDir = createTmpFixture(
+      {
+        'src/App.cs': `using Acme.Store;
+
+namespace Acme.App
+{
+    public class Program
+    {
+        Repo repo;
+    }
+}
+`,
+        'src/Store.cs': `namespace Acme.Store
+{
+    public class Repo {}
+}
+`,
+      },
+      'trace-mcp-csharp-rename-',
+    );
+    try {
+      const store = createTestStore();
+      const registry = new PluginRegistry();
+      registry.registerLanguagePlugin(new CSharpLanguagePlugin());
+      const pipeline = new IndexingPipeline(store, registry, makeConfig(fixtureDir), fixtureDir);
+      await pipeline.indexAll();
+      expect(importTargets(store, 'src/App.cs')).toContain('src/Store.cs');
+
+      // Rename the namespace — App.cs, the importer, is untouched.
+      const storePath = path.join(fixtureDir, 'src/Store.cs');
+      fs.writeFileSync(
+        storePath,
+        `namespace Acme.Other
+{
+    public class Repo {}
+}
+`,
+      );
+      await pipeline.indexFiles([storePath]);
+
+      // Acme.Store no longer has a declaring file — the edge must be gone,
+      // not left pointing at a file that no longer means what it did.
+      expect(importTargets(store, 'src/App.cs')).not.toContain('src/Store.cs');
+    } finally {
+      removeTmpDir(fixtureDir);
+    }
   });
 });

--- a/tests/integration/csharp-import-resolution-e2e.test.ts
+++ b/tests/integration/csharp-import-resolution-e2e.test.ts
@@ -1,0 +1,115 @@
+/**
+ * C# cross-file import resolution E2E (TRA-1027).
+ *
+ * Same gap TRA-483 closed for Java: the C# plugin extracts `using` directives
+ * into `metadata.from` (`extractImportEdges`), but no pipeline pass consumed
+ * them, so a C# repo indexed with zero import edges even though the matrix
+ * claimed none. Unlike Java, C# namespaces don't have to mirror the directory
+ * layout, so resolution matches against declared `namespace` symbols instead
+ * of path suffixes — these tests put `Store.cs` at a path that would break
+ * suffix matching to prove that.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { TraceMcpConfig } from '../../src/config.js';
+import type { Store } from '../../src/db/store.js';
+import { IndexingPipeline } from '../../src/indexer/pipeline.js';
+import { CSharpLanguagePlugin } from '../../src/indexer/plugins/language/csharp/index.js';
+import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import { createTestStore, createTmpFixture, removeTmpDir } from '../test-utils.js';
+
+const FILES: Record<string, string> = {
+  'src/App.cs': `using System;
+using Acme.Store;
+using static Acme.Util.Ids;
+using Db = Acme.Store.Db;
+
+namespace Acme.App
+{
+    public class Program
+    {
+        static void Main()
+        {
+            var repo = new Repo();
+            Console.WriteLine(Next());
+        }
+    }
+}
+`,
+  // Deliberately not under a store/ directory — proves resolution follows the
+  // declared namespace, not the file path, unlike the Java suffix approach.
+  'src/nested/deep/Store.cs': `namespace Acme.Store
+{
+    public class Repo {}
+    public class Db {}
+}
+`,
+  'src/util/Ids.cs': `namespace Acme.Util
+{
+    public static class Ids
+    {
+        public static int Next() => 0;
+    }
+}
+`,
+};
+
+function importTargets(store: Store, sourcePath: string): Set<string> {
+  const file = store.getFile(sourcePath);
+  if (!file) return new Set();
+  const nodeId = store.getNodeId('file', file.id);
+  if (nodeId == null) return new Set();
+  const targets = new Set<string>();
+  for (const edge of store.getOutgoingEdges(nodeId)) {
+    if (edge.edge_type_name !== 'imports') continue;
+    const ref = store.getNodeRef(edge.target_node_id);
+    if (ref?.nodeType === 'file') targets.add(store.getFileById(ref.refId)?.path ?? '');
+  }
+  return targets;
+}
+
+describe('C# import resolution E2E', () => {
+  let store: Store;
+  let fixtureDir: string;
+
+  beforeAll(async () => {
+    fixtureDir = createTmpFixture(FILES, 'trace-mcp-csharp-imports-');
+    store = createTestStore();
+    const registry = new PluginRegistry();
+    registry.registerLanguagePlugin(new CSharpLanguagePlugin());
+
+    const config: TraceMcpConfig = {
+      root: fixtureDir,
+      include: ['**/*.cs'],
+      exclude: ['node_modules/**'],
+      plugins: [],
+    } as TraceMcpConfig;
+
+    await new IndexingPipeline(store, registry, config, fixtureDir).indexAll();
+  });
+
+  afterAll(() => {
+    removeTmpDir(fixtureDir);
+  });
+
+  it('resolves a plain namespace import to the file declaring it, regardless of its path', () => {
+    expect(importTargets(store, 'src/App.cs')).toContain('src/nested/deep/Store.cs');
+  });
+
+  it('resolves a `using static` member import to the namespace holding the type', () => {
+    expect(importTargets(store, 'src/App.cs')).toContain('src/util/Ids.cs');
+  });
+
+  it('resolves an aliased import to its target namespace', () => {
+    // `using Db = Acme.Store.Db;` trims to `Acme.Store`, same target as the
+    // plain import above — already covered by the first assertion.
+    expect(importTargets(store, 'src/App.cs')).toEqual(
+      new Set(['src/nested/deep/Store.cs', 'src/util/Ids.cs']),
+    );
+  });
+
+  it('skips BCL imports rather than inventing targets', () => {
+    // App.cs also imports `System`, which is not in the repo, so only the two
+    // first-party targets may appear.
+    expect(importTargets(store, 'src/App.cs').size).toBe(2);
+  });
+});

--- a/tests/integration/csharp-import-resolution-e2e.test.ts
+++ b/tests/integration/csharp-import-resolution-e2e.test.ts
@@ -439,4 +439,50 @@ namespace Acme.App
       removeTmpDir(fixtureDir);
     }
   });
+
+  it('prunes a stale edge even when the removed type was the last C# type in the whole index', async () => {
+    // Top-level statements (C# 9+): App.cs declares no type of its own, so
+    // once Store.cs stops declaring Repo, `byType` is empty across the
+    // entire index. An earlier version early-returned on an empty `byType`
+    // before the revalidation pass ever ran, leaving this edge stale.
+    const fixtureDir = createTmpFixture(
+      {
+        'src/App.cs': `using static Acme.Store.Repo;
+
+Run();
+`,
+        'src/Store.cs': `namespace Acme.Store
+{
+    public static class Repo
+    {
+        public static void Run() {}
+    }
+}
+`,
+      },
+      'trace-mcp-csharp-empty-bytype-',
+    );
+    try {
+      const store = createTestStore();
+      const registry = new PluginRegistry();
+      registry.registerLanguagePlugin(new CSharpLanguagePlugin());
+      const pipeline = new IndexingPipeline(store, registry, makeConfig(fixtureDir), fixtureDir);
+      await pipeline.indexAll();
+      expect(importTargets(store, 'src/App.cs')).toEqual(new Set(['src/Store.cs']));
+
+      const storePath = path.join(fixtureDir, 'src/Store.cs');
+      fs.writeFileSync(
+        storePath,
+        `namespace Acme.Store
+{
+}
+`,
+      );
+      await pipeline.indexFiles([storePath]);
+
+      expect(importTargets(store, 'src/App.cs')).toEqual(new Set());
+    } finally {
+      removeTmpDir(fixtureDir);
+    }
+  });
 });

--- a/tests/integration/csharp-import-resolution-e2e.test.ts
+++ b/tests/integration/csharp-import-resolution-e2e.test.ts
@@ -5,9 +5,17 @@
  * into `metadata.from` (`extractImportEdges`), but no pipeline pass consumed
  * them, so a C# repo indexed with zero import edges even though the matrix
  * claimed none. Unlike Java, C# namespaces don't have to mirror the directory
- * layout, so resolution matches against declared `namespace` symbols instead
- * of path suffixes — these tests put `Store.cs` at a path that would break
- * suffix matching to prove that.
+ * layout, so resolution matches against declared `namespace`/type symbols
+ * instead of path suffixes — these tests put `Store.cs` at a path that would
+ * break suffix matching to prove that.
+ *
+ * Two shapes are here specifically because review caught the first version
+ * getting them wrong: a namespace with more than one file in it (`Acme.Store`
+ * spans `Store.cs` and `Db.cs`), so a type-level `using` can be checked to
+ * resolve to only its declaring file rather than fanning out to every file in
+ * the namespace; and an unindexed sub-namespace (`Acme.Store.Missing`), so
+ * trimming a miss can be checked to never fall back onto the parent
+ * namespace — `using Acme.Store.Missing` does not import `Acme.Store`.
  */
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { TraceMcpConfig } from '../../src/config.js';
@@ -20,6 +28,7 @@ import { createTestStore, createTmpFixture, removeTmpDir } from '../test-utils.j
 const FILES: Record<string, string> = {
   'src/App.cs': `using System;
 using Acme.Store;
+using Acme.Store.Missing;
 using static Acme.Util.Ids;
 using Db = Acme.Store.Db;
 
@@ -40,6 +49,13 @@ namespace Acme.App
   'src/nested/deep/Store.cs': `namespace Acme.Store
 {
     public class Repo {}
+}
+`,
+  // A second file in the same namespace as Store.cs — proves a type-level
+  // `using` (static or aliased) resolves to only the file declaring that
+  // type, not every file in the namespace.
+  'src/nested/deep/Db.cs': `namespace Acme.Store
+{
     public class Db {}
 }
 `,
@@ -49,6 +65,13 @@ namespace Acme.App
     {
         public static int Next() => 0;
     }
+}
+`,
+  // Shares a namespace with Ids.cs but declares nothing App.cs imports —
+  // proves `using static Acme.Util.Ids` doesn't leak an edge here.
+  'src/util/Other.cs': `namespace Acme.Util
+{
+    public class Other {}
 }
 `,
 };
@@ -91,25 +114,35 @@ describe('C# import resolution E2E', () => {
     removeTmpDir(fixtureDir);
   });
 
-  it('resolves a plain namespace import to the file declaring it, regardless of its path', () => {
+  it('resolves a plain namespace import to every file declaring it, regardless of path', () => {
     expect(importTargets(store, 'src/App.cs')).toContain('src/nested/deep/Store.cs');
+    expect(importTargets(store, 'src/App.cs')).toContain('src/nested/deep/Db.cs');
   });
 
-  it('resolves a `using static` member import to the namespace holding the type', () => {
-    expect(importTargets(store, 'src/App.cs')).toContain('src/util/Ids.cs');
+  it('resolves a `using static` member import to only the file declaring that type', () => {
+    const targets = importTargets(store, 'src/App.cs');
+    expect(targets).toContain('src/util/Ids.cs');
+    expect(targets).not.toContain('src/util/Other.cs');
   });
 
-  it('resolves an aliased import to its target namespace', () => {
-    // `using Db = Acme.Store.Db;` trims to `Acme.Store`, same target as the
-    // plain import above — already covered by the first assertion.
+  it('resolves an aliased type import to only the file declaring that type', () => {
+    // `using Db = Acme.Store.Db;` must resolve to Db.cs specifically, not fan
+    // out via the namespace to every file in Acme.Store.
+    expect(importTargets(store, 'src/App.cs')).toContain('src/nested/deep/Db.cs');
+  });
+
+  it('does not fall back to the parent namespace for an unindexed sub-namespace', () => {
+    // `using Acme.Store.Missing;` names a namespace that isn't declared
+    // anywhere in the repo. It must not be treated as `Acme.Store`.
     expect(importTargets(store, 'src/App.cs')).toEqual(
-      new Set(['src/nested/deep/Store.cs', 'src/util/Ids.cs']),
+      new Set(['src/nested/deep/Store.cs', 'src/nested/deep/Db.cs', 'src/util/Ids.cs']),
     );
   });
 
   it('skips BCL imports rather than inventing targets', () => {
-    // App.cs also imports `System`, which is not in the repo, so only the two
-    // first-party targets may appear.
-    expect(importTargets(store, 'src/App.cs').size).toBe(2);
+    // App.cs also imports `System` (BCL) and `Acme.Store.Missing` (unindexed
+    // sub-namespace) — neither may appear, so only the three first-party
+    // targets above are here.
+    expect(importTargets(store, 'src/App.cs').size).toBe(3);
   });
 });

--- a/tests/integration/csharp-import-resolution-e2e.test.ts
+++ b/tests/integration/csharp-import-resolution-e2e.test.ts
@@ -4,24 +4,24 @@
  * Same gap TRA-483 closed for Java: the C# plugin extracts `using` directives
  * into `metadata.from` (`extractImportEdges`), but no pipeline pass consumed
  * them, so a C# repo indexed with zero import edges even though the matrix
- * claimed none. Unlike Java, C# namespaces don't have to mirror the directory
- * layout, so resolution matches against declared `namespace`/type symbols
- * instead of path suffixes — these tests put `Store.cs` at a path that would
- * break suffix matching to prove that.
+ * claimed none. Unlike Java, resolution only trusts forms that name a
+ * specific type — a plain `using Namespace;` is deliberately never resolved
+ * to a file edge, regardless of how many (or how few) files declare that
+ * namespace. See the resolver's file header for why: two rounds of review
+ * rejected namespace-level file edges, first for volume (a real repo averaged
+ * 86 resolved edges per importing file) and then because even the
+ * single-declarer case depends on unrelated files elsewhere in the repo in a
+ * way the incremental resolver can't track soundly.
  *
- * Several shapes below exist specifically because two rounds of review caught
- * the earlier versions getting them wrong:
- * - a namespace with more than one file in it (`Acme.Store` spans `Store.cs`
- *   and `Db.cs`), so a plain `using` of it can be checked to resolve to
- *   NEITHER file (ambiguous — see the resolver's file header) while a
- *   type-level `using` of a specific type in that same namespace still
- *   resolves precisely;
- * - a namespace with exactly one file (`Acme.Config`), so a plain `using` of
- *   an unambiguous namespace can be checked to still resolve;
- * - an unindexed sub-namespace (`Acme.Store.Missing`), so trimming a miss can
- *   be checked to never fall back onto the parent namespace;
+ * Several shapes below exist specifically because review caught earlier
+ * versions getting them wrong:
+ * - a plain namespace import with only one declaring file (`Acme.Config`)
+ *   must still stay unresolved — the earlier version treated this as
+ *   precise, which review found unsound;
+ * - an unindexed sub-namespace (`Acme.Store.Missing`), so trimming a miss
+ *   can be checked to never fall back onto a namespace;
  * - a `using` inside a namespace block (not just at the top of the file);
- * - an incremental reindex that renames a namespace without touching the
+ * - an incremental reindex that renames a type without touching the
  *   importing file, so a stale edge can be checked to get pruned rather than
  *   surviving forever.
  */
@@ -58,8 +58,18 @@ function importTargets(store: Store, sourcePath: string): Set<string> {
   return targets;
 }
 
-const FILES: Record<string, string> = {
-  'src/App.cs': `using System;
+async function indexFixture(files: Record<string, string>, prefix: string) {
+  const fixtureDir = createTmpFixture(files, prefix);
+  const store = createTestStore();
+  const registry = new PluginRegistry();
+  registry.registerLanguagePlugin(new CSharpLanguagePlugin());
+  await new IndexingPipeline(store, registry, makeConfig(fixtureDir), fixtureDir).indexAll();
+  return { store, fixtureDir };
+}
+
+describe('C# import resolution E2E', () => {
+  const FILES: Record<string, string> = {
+    'src/App.cs': `using System;
 using Acme.Store;
 using Acme.Store.Missing;
 using Acme.Config;
@@ -78,26 +88,26 @@ namespace Acme.App
     }
 }
 `,
-  // Deliberately not under a store/ directory — proves resolution follows the
-  // declared namespace, not the file path, unlike the Java suffix approach.
-  // Acme.Store spans two files, so a plain `using Acme.Store;` is ambiguous.
-  'src/nested/deep/Store.cs': `namespace Acme.Store
+    // Deliberately not under a store/ directory — proves resolution follows
+    // the declared type, not the file path, unlike the Java suffix approach.
+    'src/nested/deep/Store.cs': `namespace Acme.Store
 {
     public class Repo {}
 }
 `,
-  'src/nested/deep/Db.cs': `namespace Acme.Store
+    'src/nested/deep/Db.cs': `namespace Acme.Store
 {
     public class Db {}
 }
 `,
-  // The sole file declaring Acme.Config — a plain `using` of it is precise.
-  'src/config/Settings.cs': `namespace Acme.Config
+    // The sole file declaring Acme.Config — still must NOT resolve, since a
+    // plain namespace import never names a specific type.
+    'src/config/Settings.cs': `namespace Acme.Config
 {
     public class Settings {}
 }
 `,
-  'src/util/Ids.cs': `namespace Acme.Util
+    'src/util/Ids.cs': `namespace Acme.Util
 {
     public static class Ids
     {
@@ -105,40 +115,30 @@ namespace Acme.App
     }
 }
 `,
-  // Shares a namespace with Ids.cs but declares nothing App.cs imports —
-  // proves `using static Acme.Util.Ids` doesn't leak an edge here.
-  'src/util/Other.cs': `namespace Acme.Util
+    // Shares a namespace with Ids.cs but declares nothing App.cs imports —
+    // proves `using static Acme.Util.Ids` doesn't leak an edge here.
+    'src/util/Other.cs': `namespace Acme.Util
 {
     public class Other {}
 }
 `,
-};
+  };
 
-describe('C# import resolution E2E', () => {
   let store: Store;
   let fixtureDir: string;
 
   beforeAll(async () => {
-    fixtureDir = createTmpFixture(FILES, 'trace-mcp-csharp-imports-');
-    store = createTestStore();
-    const registry = new PluginRegistry();
-    registry.registerLanguagePlugin(new CSharpLanguagePlugin());
-    await new IndexingPipeline(store, registry, makeConfig(fixtureDir), fixtureDir).indexAll();
+    ({ store, fixtureDir } = await indexFixture(FILES, 'trace-mcp-csharp-imports-'));
   });
 
   afterAll(() => {
     removeTmpDir(fixtureDir);
   });
 
-  it('does not resolve a plain namespace import when more than one file declares it', () => {
-    // `using Acme.Store;` — Acme.Store spans Store.cs and Db.cs, so neither
-    // is a precise target; the resolver must not guess which one was meant.
+  it('never resolves a plain namespace import to a file edge, even with a single declaring file', () => {
     const targets = importTargets(store, 'src/App.cs');
     expect(targets).not.toContain('src/nested/deep/Store.cs');
-  });
-
-  it('resolves a plain namespace import to its sole declaring file', () => {
-    expect(importTargets(store, 'src/App.cs')).toContain('src/config/Settings.cs');
+    expect(targets).not.toContain('src/config/Settings.cs');
   });
 
   it('resolves a `using static` member import to only the file declaring that type', () => {
@@ -147,36 +147,36 @@ describe('C# import resolution E2E', () => {
     expect(targets).not.toContain('src/util/Other.cs');
   });
 
-  it('resolves an aliased type import to only the file declaring that type, even in an ambiguous namespace', () => {
-    // `using Db = Acme.Store.Db;` must resolve to Db.cs specifically — the
-    // type-level match is precise regardless of Acme.Store being ambiguous
-    // for the plain-namespace case above.
+  it('resolves an aliased type import to only the file declaring that type', () => {
+    // `using Db = Acme.Store.Db;` must resolve to Db.cs specifically, even
+    // though the plain `using Acme.Store;` above stays unresolved.
     expect(importTargets(store, 'src/App.cs')).toContain('src/nested/deep/Db.cs');
   });
 
-  it('does not fall back to the parent namespace for an unindexed sub-namespace', () => {
+  it('does not fall back to a namespace for an unindexed sub-namespace', () => {
     // `using Acme.Store.Missing;` names a namespace that isn't declared
     // anywhere in the repo. It must not be treated as `Acme.Store`.
     expect(importTargets(store, 'src/App.cs')).toEqual(
-      new Set(['src/config/Settings.cs', 'src/util/Ids.cs', 'src/nested/deep/Db.cs']),
+      new Set(['src/util/Ids.cs', 'src/nested/deep/Db.cs']),
     );
   });
 
-  it('skips BCL imports rather than inventing targets', () => {
-    // App.cs also imports `System` (BCL), the ambiguous `Acme.Store`, and the
-    // unindexed `Acme.Store.Missing` — none may appear, so only the three
-    // precise targets above are here.
-    expect(importTargets(store, 'src/App.cs').size).toBe(3);
+  it('skips BCL and plain-namespace imports rather than inventing targets', () => {
+    // App.cs also imports `System` (BCL), `Acme.Store` and `Acme.Config`
+    // (plain namespace — never resolved), and `Acme.Store.Missing`
+    // (unindexed sub-namespace) — none may appear, so only the two
+    // type-precise targets above are here.
+    expect(importTargets(store, 'src/App.cs').size).toBe(2);
   });
 });
 
 describe('C# import resolution: namespace-scoped using directives', () => {
   it('extracts a `using` declared inside a namespace block, not just at file scope', async () => {
-    const fixtureDir = createTmpFixture(
+    const { store, fixtureDir } = await indexFixture(
       {
         'src/App.cs': `namespace Acme.App
 {
-    using Acme.Store;
+    using static Acme.Store.Repo;
 
     public class Program
     {
@@ -193,11 +193,6 @@ describe('C# import resolution: namespace-scoped using directives', () => {
       'trace-mcp-csharp-ns-scoped-using-',
     );
     try {
-      const store = createTestStore();
-      const registry = new PluginRegistry();
-      registry.registerLanguagePlugin(new CSharpLanguagePlugin());
-      await new IndexingPipeline(store, registry, makeConfig(fixtureDir), fixtureDir).indexAll();
-
       expect(importTargets(store, 'src/App.cs')).toContain('src/Store.cs');
     } finally {
       removeTmpDir(fixtureDir);
@@ -206,10 +201,10 @@ describe('C# import resolution: namespace-scoped using directives', () => {
 });
 
 describe('C# import resolution: incremental reindex', () => {
-  it('prunes a stale edge after the target file renames its namespace, without reindexing the importer', async () => {
+  it('prunes a stale edge after the target file renames its type, without reindexing the importer', async () => {
     const fixtureDir = createTmpFixture(
       {
-        'src/App.cs': `using Acme.Store;
+        'src/App.cs': `using static Acme.Store.Repo;
 
 namespace Acme.App
 {
@@ -235,20 +230,20 @@ namespace Acme.App
       await pipeline.indexAll();
       expect(importTargets(store, 'src/App.cs')).toContain('src/Store.cs');
 
-      // Rename the namespace — App.cs, the importer, is untouched.
+      // Rename the type — App.cs, the importer, is untouched.
       const storePath = path.join(fixtureDir, 'src/Store.cs');
       fs.writeFileSync(
         storePath,
-        `namespace Acme.Other
+        `namespace Acme.Store
 {
-    public class Repo {}
+    public class Other {}
 }
 `,
       );
       await pipeline.indexFiles([storePath]);
 
-      // Acme.Store no longer has a declaring file — the edge must be gone,
-      // not left pointing at a file that no longer means what it did.
+      // Acme.Store.Repo no longer has a declaring file — the edge must be
+      // gone, not left pointing at a file that no longer means what it did.
       expect(importTargets(store, 'src/App.cs')).not.toContain('src/Store.cs');
     } finally {
       removeTmpDir(fixtureDir);


### PR DESCRIPTION
## Summary

`import-capable-languages.ts` named C# explicitly: the plugin extracts `using` directive edges (`extractImportEdges` in `csharp/helpers.ts`) but nothing consumed them, so a C# repo indexed with zero import edges regardless of what the matrix claimed. Same class of gap TRA-483 (Java) and TRA-900 (Ruby) closed before it.

- Adds `resolveCSharpImportEdges` (`src/indexer/edge-resolvers/csharp-imports.ts`), wired into the pipeline after Ruby.
- Unlike Java/Go, C# namespaces don't have to mirror the directory layout, so resolution matches the specifier against declared `namespace` symbols (already extracted by `CSharpLanguagePlugin.extractNamespace`) rather than path suffixes. Covers plain `using X.Y;`, `using static X.Y.Type;`, and aliased `using A = X.Y.Type;` (trims to the namespace).
- Moves `csharp` from the "extracts but nothing consumes" list to `IMPORT_EDGE_LANGUAGES`; regenerated `docs/language-matrix.md` (Imports 18 → 19) and `docs/llms-full.txt`.

## Verification

- New E2E test (`tests/integration/csharp-import-resolution-e2e.test.ts`), modeled on the Java one — plain namespace import, `using static`, alias, and BCL imports correctly left unresolved.
- Full suite: `pnpm run build` clean, `pnpm run lint` clean, `pnpm run test` — 10,474 passed, 0 failed.
- Checked against a real public repo (Newtonsoft.Json, 945 `.cs` files, not a fixture): 305 files gained at least one resolved import edge, 26,347 edges resolved total, 1,713 external (BCL) specifiers correctly left unresolved rather than inventing nodes.

## Test plan

- [x] `pnpm run build`
- [x] `pnpm run lint`
- [x] `pnpm run test` (full suite, 0 failures)
- [x] Indexed a real C# repo (Newtonsoft.Json) and manually inspected resolved edges