### PR TITLE
test(launcher): cover concurrent client starts on the probe+heal path (TRA-1029)

### DIFF
--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -44,6 +44,32 @@ function runLauncher(env: Record<string, string>, args: string[] = ['serve']): R
   return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
 }
 
+/** Concurrent counterpart to {@link runLauncher} — spawnSync cannot overlap. */
+function runLauncherAsync(
+  env: Record<string, string>,
+  args: string[] = ['serve'],
+): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(LAUNCHER_SRC, args, {
+      env: { ...env, PATH: '/usr/bin:/bin' },
+      timeout: LAUNCHER_TIMEOUT_MS,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => {
+      stdout += d;
+    });
+    child.stderr.on('data', (d) => {
+      stderr += d;
+    });
+    child.on('error', reject);
+    child.on('close', (status, signal) => {
+      assertNotKilled({ signal }, args);
+      resolve({ status, stdout, stderr });
+    });
+  });
+}
+
 function fakeNodeBody(version: string, marker = 'NODE_ARGS'): string {
   return `#!/bin/bash\nif [ "\${1:-}" = "-v" ]; then echo "v${version}"; exit 0; fi\necho "${marker}:$*"\n`;
 }
@@ -72,6 +98,25 @@ function writeConfig(traceHome: string, node: string, cli: string) {
       '\n',
     ),
   );
+}
+
+// Plants an nvm-layout tree under the fake HOME holding node + the package,
+// so the probe has a prefix to find that is NOT the configured node's.
+function plantNvmPackage(home: string, cliBody = '// fake cli\n'): string {
+  const version = 'v22.22.2';
+  const prefix = path.join(home, '.nvm', 'versions', 'node', version);
+  fs.mkdirSync(path.join(prefix, 'bin'), { recursive: true });
+  fs.writeFileSync(path.join(prefix, 'bin', 'node'), '#!/bin/bash\nexit 1\n', { mode: 0o755 });
+  fs.mkdirSync(path.join(home, '.nvm', 'alias'), { recursive: true });
+  fs.writeFileSync(path.join(home, '.nvm', 'alias', 'default'), `${version}\n`);
+  const pkgDir = path.join(prefix, 'lib', 'node_modules', 'trace-mcp', 'dist');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  const cli = path.join(pkgDir, 'cli.js');
+  fs.writeFileSync(cli, cliBody);
+  // The launcher normalises probed paths through realpath; on macOS the
+  // temp dir lives behind the /var → /private/var symlink, so compare
+  // against the resolved form.
+  return fs.realpathSync(cli);
 }
 
 beforeAll(() => {
@@ -176,25 +221,6 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
   // package in a different npm prefix lost the MCP server outright (3576 fatal
   // launcher errors in the field).
   describe('cli.js resolves independently of the selected node', () => {
-    // Plants an nvm-layout tree under the fake HOME holding node + the package,
-    // so the probe has a prefix to find that is NOT the configured node's.
-    function plantNvmPackage(home: string, cliBody = '// fake cli\n'): string {
-      const version = 'v22.22.2';
-      const prefix = path.join(home, '.nvm', 'versions', 'node', version);
-      fs.mkdirSync(path.join(prefix, 'bin'), { recursive: true });
-      fs.writeFileSync(path.join(prefix, 'bin', 'node'), '#!/bin/bash\nexit 1\n', { mode: 0o755 });
-      fs.mkdirSync(path.join(home, '.nvm', 'alias'), { recursive: true });
-      fs.writeFileSync(path.join(home, '.nvm', 'alias', 'default'), `${version}\n`);
-      const pkgDir = path.join(prefix, 'lib', 'node_modules', 'trace-mcp', 'dist');
-      fs.mkdirSync(pkgDir, { recursive: true });
-      const cli = path.join(pkgDir, 'cli.js');
-      fs.writeFileSync(cli, cliBody);
-      // The launcher normalises probed paths through realpath; on macOS the
-      // temp dir lives behind the /var → /private/var symlink, so compare
-      // against the resolved form.
-      return fs.realpathSync(cli);
-    }
-
     it('finds the package in another prefix when the configured node has none', () => {
       const { home, traceHome, node } = setupFakeHome();
       const otherCli = plantNvmPackage(home);
@@ -1066,6 +1092,47 @@ describe.skipIf(process.platform === 'win32')('app runtime shim with a dangling 
   // that broke, and GNU and BSD `stat` disagree about the flags it uses. The
   // first cut of this test passed on macOS while the Linux job caught the shim
   // silently never rotating at all.
+  // TRA-1029: several MCP clients routinely start at the same moment — a
+  // Claude Code window, a Codex run and the desktop app all exec this shim
+  // within the same second, and after an npm upgrade every one of them takes
+  // the probe+heal path at once. Nothing covered that overlap; every other
+  // test here runs the shim alone.
+  //
+  // What this pins is the state the racers leave behind, not the ordering
+  // between them. A torn config is deliberately *not* asserted on: the shim
+  // self-heals from any unparseable launcher.env (see the stale/unreadable
+  // config tests above), so a half-written one costs a probe, never a start —
+  // rewriting the heal to a non-atomic truncate still passes this test. The
+  // invariant that does bite is the tmp file: each heal writes
+  // `launcher.env.tmp.<pid>.<hex>` and renames it away, and a heal that leaks
+  // one instead leaves a pile of them in the state home under contention,
+  // exactly the orphan accumulation TRA-797 gave the sweeper a pattern for.
+  it('concurrent starts all reach the server and leave a readable config', async () => {
+    const { home, traceHome, node } = setupFakeHome();
+    const probedCli = plantNvmPackage(home);
+    // cli.js is gone from the configured pair, so every one of these probes
+    // and then heals — the contended path, not the fast one.
+    writeConfig(traceHome, node, path.join(home, 'gone', 'cli.js'));
+
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => runLauncherAsync({ HOME: home, TRACE_MCP_HOME: traceHome })),
+    );
+
+    for (const { status, stdout } of results) {
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${probedCli} serve`);
+    }
+    // No half-written config, and nothing left in the state home for the
+    // orphan sweeper to find.
+    const cfg = fs.readFileSync(path.join(traceHome, 'launcher.env'), 'utf-8');
+    expect(cfg).toContain(`TRACE_MCP_CLI="${probedCli}"`);
+    expect(fs.readdirSync(traceHome).filter((f) => f.includes('.tmp.'))).toEqual([]);
+    // And the config those racers left still drives a plain fast-path start.
+    expect(runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }).stdout.trim()).toBe(
+      `NODE_ARGS:${probedCli} serve`,
+    );
+  });
+
   it('rotates launcher.log once it is past the ceiling', () => {
     const { home, traceHome, node, cli } = setupFakeHome();
     writeConfig(traceHome, node, cli);

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -64,8 +64,15 @@ function runLauncherAsync(
     });
     child.on('error', reject);
     child.on('close', (status, signal) => {
-      assertNotKilled({ signal }, args);
-      resolve({ status, stdout, stderr });
+      // assertNotKilled throws, and a throw inside an EventEmitter handler
+      // escapes the promise chain as an unhandled exception instead of
+      // rejecting it — the timeout would surface as a hung test, not a failure.
+      try {
+        assertNotKilled({ signal }, args);
+        resolve({ status, stdout, stderr });
+      } catch (err) {
+        reject(err);
+      }
     });
   });
 }
@@ -1084,14 +1091,6 @@ describe.skipIf(process.platform === 'win32')('app runtime shim with a dangling 
     expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
   });
 
-  // TRA-707: launcher.log takes a line on every MCP start and nothing else
-  // trims it — 9.7 MB observed in the field. The shim rotates it itself; the
-  // daemon's own rotation cannot reach a file written from bash.
-  //
-  // This has to run on both CI runners, not one: the size probe is the part
-  // that broke, and GNU and BSD `stat` disagree about the flags it uses. The
-  // first cut of this test passed on macOS while the Linux job caught the shim
-  // silently never rotating at all.
   // TRA-1029: several MCP clients routinely start at the same moment — a
   // Claude Code window, a Codex run and the desktop app all exec this shim
   // within the same second, and after an npm upgrade every one of them takes
@@ -1133,6 +1132,14 @@ describe.skipIf(process.platform === 'win32')('app runtime shim with a dangling 
     );
   });
 
+  // TRA-707: launcher.log takes a line on every MCP start and nothing else
+  // trims it — 9.7 MB observed in the field. The shim rotates it itself; the
+  // daemon's own rotation cannot reach a file written from bash.
+  //
+  // This has to run on both CI runners, not one: the size probe is the part
+  // that broke, and GNU and BSD `stat` disagree about the flags it uses. The
+  // first cut of this test passed on macOS while the Linux job caught the shim
+  // silently never rotating at all.
   it('rotates launcher.log once it is past the ceiling', () => {
     const { home, traceHome, node, cli } = setupFakeHome();
     writeConfig(traceHome, node, cli);


### PR DESCRIPTION
## What this is

An MCP Connection Reliability autopilot run (TRA-1029) that came back green on every measurement, so per the issue's "«всё зелёно» — не финальный ответ" rule I went after a failure scenario that had no coverage: **several clients starting at once**.

## Measurements first

- `claude mcp list` → `trace-mcp: ✔ Connected`.
- `~/.trace-mcp/launcher.log`: **0 `ERROR` lines in the last 24h** (0 in the whole retained log).
- node prefixes: two hold the package (Hermes bundled + Herd nvm v22.22.2); `launcher.env` pins the Herd pair and both halves exist.
- No orphan `.tmp.*` in the state home.
- `.config.json` 65 KB / 47 project sections, 17 dead. All 17 are claimed by `registry.json` inside its 7-day `sweepMissingRoots` grace, so `pruneProjectConfigSections` correctly keeps them — this is TRA-992 residue written before 3.20.0 was installed at 16:24 today, and it drains on its own by 2026-09-13. Not a leak, no change needed.

## The gap

All 58 existing launcher integration cases run the shim **alone**. But a Claude Code window, a Codex run and the desktop app routinely exec it within the same second, and after `npm i -g trace-mcp` every one of them takes the probe+heal path at once — each heal rewriting `launcher.env`.

I reproduced that first as a standalone harness (30 concurrent launchers against a fake node/cli fixture): all exited 0, all exec'd the right `cli.js`, config intact, zero orphan tmp files. Then I also threw 12 malformed `launcher.env` shapes at it — CRLF, empty, binary, unquoted, `=` in the path, garbage/huge `NODE_MAJOR`, 500 KB single line, 200k lines, and a *directory* where the config should be. Every one self-heals to exit 0 with a clean stderr; the directory case additionally logs the actionable `ERROR` TRA-829 added. **No defect reproduced.**

This PR turns the concurrency half into a permanent test, since a passing manual probe evaporates.

## What the test actually asserts

Honest scoping, because the first draft overclaimed. A **torn config is deliberately not asserted on**: the shim self-heals from any unparseable `launcher.env`, so tearing costs a probe, never a start. I verified this — rewriting `heal_config` to a non-atomic `> "$CONFIG"` truncate **still passes**, so an atomicity claim here would be fake coverage.

The invariant that does bite is the **tmp file**. Mutating the heal to leak its tmp instead of renaming it (`cp -f` in place of `mv -f`) fails the test with 7 orphans left in the state home — exactly the accumulation TRA-797 gave the sweeper a pattern for, and one of the state-hygiene items TRA-1029 calls out.

So the test pins: every concurrent starter reaches the server, nothing is left for the orphan sweeper, and the config the racers leave still drives a fast-path start.

## Test evidence

- `tests/init/launcher-integration.test.ts` — **59 passed** (58 existing + 1 new).
- Mutation-checked both directions: leak-tmp mutant → fails; non-atomic-truncate mutant → passes (documented in the test comment as the reason no tearing assertion exists).
- Full suite: **940 files, 10469 passed, 0 failed**.
- `tsc --noEmit` clean, `biome ci` clean.

## Risk

Test-only. No change to the shim, to any MCP tool signature, or to on-disk schema. `plantNvmPackage` moves from a `describe` block to module scope so both suites can use it — same body, no behaviour change.
