### PR TITLE
fix(launcher): verify the configured node still runs on every start (TRA-1040)

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.6.7 (Windows)
+REM trace-mcp-launcher v0.6.8 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.6.7 (Windows)
+# trace-mcp-launcher v0.6.8 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.
@@ -60,19 +60,9 @@ if ($env:TRACE_MCP_NODE_MIN_MAJOR) {
     }
 }
 
-# A cached major is usable only if it parses into a real integer. Digits alone
-# are not enough - an overflowing numeric string would throw on the cast.
-function Get-BoundedMajor {
-    param([string]$Value)
-    $parsed = 0
-    if ([int]::TryParse($Value, [ref]$parsed) -and $parsed -ge 0) { return $parsed }
-    return $null
-}
-
 # --- 1. Parse config safely (no Invoke-Expression, whitelist keys) ---
 $NodePath = ''
 $CliPath  = ''
-$NodeMajor = ''
 $UsingOverride = $false
 $UsingNodeOverride = $false
 
@@ -104,10 +94,8 @@ if ($configLines.Count -gt 0) {
         switch ($key) {
             'TRACE_MCP_NODE' { $NodePath = $val }
             'TRACE_MCP_CLI'  { $CliPath  = $val }
-            # Major version of TRACE_MCP_NODE, verified when the pair was
-            # recorded. Cached so the fast path never has to run node -v.
-            'TRACE_MCP_NODE_MAJOR' { $NodeMajor = $val }
-            # TRACE_MCP_VERSION ignored (informational only)
+            # TRACE_MCP_NODE_MAJOR and TRACE_MCP_VERSION ignored
+            # (informational only; older configs may still carry them)
         }
     }
 }
@@ -180,7 +168,7 @@ function Test-CliFile {
 
 # Persist a probed (or freshly verified) pair so the next start takes the fast path.
 function Save-LauncherConfig {
-    param([string]$NodeExe, [string]$Cli, [string]$Major = '')
+    param([string]$NodeExe, [string]$Cli)
     # The parser strips exactly one pair of quotes and never expands; a literal
     # quote in a path would corrupt the file, so skip rather than mangle.
     if ($NodeExe.Contains('"') -or $Cli.Contains('"')) { return }
@@ -207,8 +195,6 @@ function Save-LauncherConfig {
             # wrong version is worse than none. `trace-mcp init` restores it.
             ('TRACE_MCP_CLI="{0}"' -f ($Cli -replace '\\', '/'))
         )
-        # Cache the verified major so the fast path stays a pure file check.
-        if ($Major -match '^\d+$') { $lines += ('TRACE_MCP_NODE_MAJOR="{0}"' -f $Major) }
         # `.tmp.<pid>.<12 hex>` is the shape sweepOrphanTmpFiles collects
         # (src/utils/atomic-write.ts) - its pattern requires the trailing hex.
         # The catch below only runs for a caught failure; a process killed
@@ -238,9 +224,8 @@ function Get-NodeMajor {
 
 # --- 3. Fast path: config is good -> exec directly ---
 #
-# A config recorded before the version gate existed carries no verified major.
-# Check it once here, then cache it, so the check costs nothing from the next
-# start on - and an already-poisoned config heals itself instead of failing
+# "Good" means the recorded pair still exists AND the recorded node still runs;
+# a config that stopped describing reality heals itself here instead of failing
 # forever.
 # Only the NODE override exempts a run from the gate. Sharing one flag with
 # TRACE_MCP_CLI_OVERRIDE would let a CLI-only debugging override carry the
@@ -248,24 +233,28 @@ function Get-NodeMajor {
 if (-not $UsingNodeOverride -and (Test-NodeBinary $NodePath) -and -not (Test-RuntimeShim $NodePath)) {
     Write-LauncherLog "ERROR: config node=$NodePath is an app runtime shim whose target is gone (app updated, moved or removed) - reprobing"
     $NodePath = ''
-    $NodeMajor = ''
 }
 
+# The version gate is also the liveness gate, and it runs on EVERY start.
+#
+# It used to be skipped whenever the config carried a cached
+# TRACE_MCP_NODE_MAJOR. But the question the fast path needs answered is not
+# "which major is this" but "does this binary still run at all", and a file
+# check cannot answer it: a node broken in place - a runtime uninstalled from
+# under its own shim, an arch mismatch after a machine migration - still passes
+# Test-NodeBinary, so the launcher started it, the start succeeded from its own
+# side, and nothing was logged and nothing healed. The client lost every tool
+# for the rest of the session and each later start repeated it (TRA-1040).
+# TRACE_MCP_NODE_MAJOR is no longer read or written.
 if (-not $UsingNodeOverride -and (Test-NodeBinary $NodePath)) {
-    $cached = Get-BoundedMajor $NodeMajor
-    if ($null -eq $cached) {
-        $probed = Get-NodeMajor $NodePath
-        $cached = if ($null -eq $probed) { 0 } else { $probed }
-        $NodeMajor = "$cached"
-        # Cache only a pair we are actually going to use - never write back a
-        # node we are about to reject, and never an override: $CliPath may be a
-        # throwaway debug path, and baking it in would outlive the session.
-        if (-not $UsingOverride -and $cached -ge $NodeMinMajor -and (Test-CliFile $CliPath)) {
-            Save-LauncherConfig $NodePath $CliPath $NodeMajor
+    $probed = Get-NodeMajor $NodePath
+    $verified = if ($null -eq $probed) { 0 } else { $probed }
+    if ($verified -lt $NodeMinMajor) {
+        if ($verified -eq 0) {
+            Write-LauncherLog "ERROR: config node=$NodePath exists but cannot run (broken install, moved runtime or arch mismatch) - reprobing"
+        } else {
+            Write-LauncherLog "config node=$NodePath is node $verified, need >= $NodeMinMajor - reprobing"
         }
-    }
-    if ($cached -lt $NodeMinMajor) {
-        Write-LauncherLog "config node=$NodePath is node $cached, need >= $NodeMinMajor - reprobing"
         $NodePath = ''
     }
 }
@@ -450,9 +439,7 @@ if (-not (Test-NodeBinary $NodePath)) {
         }
         Die 'node binary not found - install Node.js (nodejs.org / nvs / nvm-windows / volta) or set TRACE_MCP_NODE_OVERRIDE'
     }
-    $probedMajor = Get-NodeMajor $NodePath
-    $NodeMajor = if ($null -eq $probedMajor) { '' } else { "$probedMajor" }
-    Write-LauncherLog "probe: node=$NodePath (v$NodeMajor)"
+    Write-LauncherLog "probe: node=$NodePath"
     $Healed = $true
 }
 
@@ -466,7 +453,7 @@ if (-not (Test-CliFile $CliPath)) {
 }
 
 # Overrides are a debugging escape hatch; never bake them into the config.
-if ($Healed -and -not $UsingOverride) { Save-LauncherConfig $NodePath $CliPath $NodeMajor }
+if ($Healed -and -not $UsingOverride) { Save-LauncherConfig $NodePath $CliPath }
 
 Write-LauncherLog "exec(probe) node=$NodePath cli=$CliPath argc=$($args.Count)"
 & $NodePath $CliPath @args

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.6.7
+# trace-mcp-launcher v0.6.8
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -93,7 +93,6 @@ esac
 # --- 1. Parse config safely (no `source` — RCE-safe, whitelist keys) ---
 NODE_PATH=""
 CLI_PATH=""
-NODE_MAJOR=""
 
 # `-f` as well as `-r`: `-r` is true for a directory too, and reading one is
 # an error, not an empty config (TRA-797).
@@ -118,10 +117,8 @@ if [ -f "$CONFIG" ] && [ -r "$CONFIG" ]; then
     case "$key" in
       TRACE_MCP_NODE) NODE_PATH="$value" ;;
       TRACE_MCP_CLI)  CLI_PATH="$value" ;;
-      # Major version of TRACE_MCP_NODE, verified when the pair was recorded.
-      # Cached so the fast path never has to spawn node just to check it.
-      TRACE_MCP_NODE_MAJOR) NODE_MAJOR="$value" ;;
-      # TRACE_MCP_VERSION exists but is informational only
+      # TRACE_MCP_NODE_MAJOR and TRACE_MCP_VERSION may appear in configs
+      # written by older versions; both are informational only.
     esac
   done < "$CONFIG"
 fi
@@ -183,10 +180,9 @@ node_major() {
 #
 #  1. The basename. RUNTIME_SHIM_NAME in daemon-install.ts is always
 #     `node-runtime`, so anything else — every real node binary — is answered
-#     without opening the file at all. The fast path must stay fork-free: the
-#     cached TRACE_MCP_NODE_MAJOR exists precisely so a normal start spawns no
-#     process, and a `head | grep` pair on every start would have quietly
-#     undone that (review of #982).
+#     without opening the file at all. Still worth having now that the fast
+#     path verifies the node for real (TRA-1040): probing a shim means starting
+#     Electron, and two builtin string tests are far cheaper than that.
 #  2. The marker, matched anywhere in the header rather than on a fixed line:
 #     the shim has gained comment lines before and may again, and a
 #     line-number match would silently stop recognising it.
@@ -541,7 +537,7 @@ probe_cli() {
 # Persist a freshly probed pair so the next start takes the fast path, and so
 # a client that never reaches `trace-mcp init` still stops paying for the probe.
 heal_config() {
-  local node="$1" cli="$2" major="${3:-}" tmp old_umask
+  local node="$1" cli="$2" tmp old_umask
   # The shim strips exactly one pair of quotes and never expands; a literal
   # quote in a path would corrupt the file, so skip rather than mangle.
   case "$node$cli" in *'"'*) return 0 ;; esac
@@ -580,11 +576,6 @@ heal_config() {
     printf '# Rewritten by the launcher after a successful probe.\n'
     printf 'TRACE_MCP_NODE="%s"\n' "$node"
     printf 'TRACE_MCP_CLI="%s"\n' "$cli"
-    # Cache the verified major so the fast path stays a pure stat check.
-    case "$major" in
-      ''|*[!0-9]*) ;;
-      *) printf 'TRACE_MCP_NODE_MAJOR="%s"\n' "$major" ;;
-    esac
     # TRACE_MCP_VERSION is deliberately dropped: the probed cli.js may be a
     # different build than the one the stale config described, and a wrong
     # version is worse than none. `trace-mcp init` restores it.
@@ -649,10 +640,9 @@ resolve_exec_target() {
 
 # --- 3. Fast path: config is good → exec directly ---
 #
-# A config recorded before the version gate existed carries no verified major.
-# Check it once here (one `node -v`), then cache it, so the check costs nothing
-# from the next start on — and an already-poisoned config heals itself instead
-# of failing forever.
+# "Good" means the recorded pair still exists AND the recorded node still runs;
+# a config that stopped describing reality heals itself here instead of failing
+# forever.
 # Only the NODE override exempts a run from the gate. Sharing one flag with
 # TRACE_MCP_CLI_OVERRIDE would let a CLI-only debugging override carry the
 # configured node past the check — the exact failure this gate exists to stop.
@@ -660,22 +650,35 @@ if [ "$USING_NODE_OVERRIDE" = 0 ] && [ -n "$NODE_PATH" ] && [ -x "$NODE_PATH" ];
   if ! node_runtime_shim_ok "$NODE_PATH"; then
     log "ERROR: config node=$NODE_PATH is an app runtime shim whose target is gone (app updated, moved or removed) — reprobing"
     NODE_PATH=""
-    NODE_MAJOR=""
   fi
 fi
 
+# The version gate is also the liveness gate, and it runs on EVERY start.
+#
+# It used to be skipped whenever launcher.env carried a cached
+# TRACE_MCP_NODE_MAJOR, on the theory that a node's major never changes. True —
+# but the question the fast path actually needs answered is not "which major is
+# this" but "does this binary still run at all", and `[ -x ]` cannot answer it.
+# A node broken in place — a Homebrew dylib bump, an arch mismatch after a
+# machine migration, a code signature macOS stopped honouring — is still +x, so
+# the shim exec'd it, the exec succeeded from its own side, and nothing was
+# logged and nothing healed. The client lost all ~170 tools for the session and
+# every later start repeated it, with a working node and cli.js on the same disk
+# (TRA-1040, reproduced). TRA-965 closed one instance of this — a `node-runtime`
+# shim with a dead target — by name; this closes the class.
+#
+# The cost is one `node -v` per client start (~12 ms measured), which is the
+# price of the pair being real rather than merely recorded, on a path that is
+# about to load a whole Node process anyway. TRACE_MCP_NODE_MAJOR is no longer
+# read or written; older configs still carrying it are simply ignored.
 if [ "$USING_NODE_OVERRIDE" = 0 ] && [ -n "$NODE_PATH" ] && [ -x "$NODE_PATH" ]; then
-  if ! is_bounded_major "$NODE_MAJOR"; then
-    NODE_MAJOR=$(node_major "$NODE_PATH") || NODE_MAJOR=0
-    # Cache only a pair we are actually going to use — never write back a
-    # node we are about to reject, and never an override: CLI_PATH may be a
-    # throwaway debug path, and baking it in would outlive the debug session.
-    if [ "$USING_OVERRIDE" = 0 ] && [ "$NODE_MAJOR" -ge "$NODE_MIN_MAJOR" ] && [ -n "$CLI_PATH" ] && [ -f "$CLI_PATH" ]; then
-      heal_config "$NODE_PATH" "$CLI_PATH" "$NODE_MAJOR"
+  VERIFIED_MAJOR=$(node_major "$NODE_PATH") || VERIFIED_MAJOR=0
+  if [ "$VERIFIED_MAJOR" -lt "$NODE_MIN_MAJOR" ]; then
+    if [ "$VERIFIED_MAJOR" = 0 ]; then
+      log "ERROR: config node=$NODE_PATH exists but cannot run (broken install, moved runtime or arch mismatch) — reprobing"
+    else
+      log "config node=$NODE_PATH is node $VERIFIED_MAJOR, need >= $NODE_MIN_MAJOR — reprobing"
     fi
-  fi
-  if [ "$NODE_MAJOR" -lt "$NODE_MIN_MAJOR" ]; then
-    log "config node=$NODE_PATH is node $NODE_MAJOR, need >= $NODE_MIN_MAJOR — reprobing"
     NODE_PATH=""
   fi
 fi
@@ -698,8 +701,7 @@ if [ -z "$NODE_PATH" ] || [ ! -x "$NODE_PATH" ]; then
     fi
     die "node binary not found — install Node.js (brew install node / nvm / volta) or set TRACE_MCP_NODE_OVERRIDE"
   fi
-  NODE_MAJOR=$(node_major "$NODE_PATH") || NODE_MAJOR=""
-  log "probe: node=$NODE_PATH (v$NODE_MAJOR)"
+  log "probe: node=$NODE_PATH"
   HEALED=1
 fi
 
@@ -712,7 +714,7 @@ fi
 
 # Overrides are a debugging escape hatch; never bake them into the config.
 if [ "$HEALED" = 1 ] && [ "$USING_OVERRIDE" = 0 ]; then
-  heal_config "$NODE_PATH" "$CLI_PATH" "$NODE_MAJOR"
+  heal_config "$NODE_PATH" "$CLI_PATH"
 fi
 
 EXEC_TARGET=$(resolve_exec_target "$CLI_PATH" "$@")

--- a/src/init/launcher.ts
+++ b/src/init/launcher.ts
@@ -152,13 +152,6 @@ export interface LauncherConfig {
   node: string;
   cli: string;
   version: string;
-  /**
-   * Major version of `node`. The shim refuses to exec a node older than
-   * `engines.node`, and reads this instead of spawning `node -v` on every
-   * start. Omitted only by configs written before the check existed — the
-   * shim fills those in itself on the next run.
-   */
-  nodeMajor?: string;
 }
 
 /**
@@ -172,7 +165,6 @@ export function writeLauncherConfig(cfg: LauncherConfig): void {
     `TRACE_MCP_NODE=${quoteEnvValue(cfg.node)}`,
     `TRACE_MCP_CLI=${quoteEnvValue(cfg.cli)}`,
     `TRACE_MCP_VERSION=${quoteEnvValue(cfg.version)}`,
-    ...(cfg.nodeMajor ? [`TRACE_MCP_NODE_MAJOR=${quoteEnvValue(cfg.nodeMajor)}`] : []),
     '',
   ];
   atomicWriteString(getLauncherConfigPath(), lines.join('\n'), {
@@ -203,7 +195,6 @@ export function readLauncherConfig(): Partial<LauncherConfig> {
     if (key === 'TRACE_MCP_NODE') result.node = value;
     else if (key === 'TRACE_MCP_CLI') result.cli = value;
     else if (key === 'TRACE_MCP_VERSION') result.version = value;
-    else if (key === 'TRACE_MCP_NODE_MAJOR') result.nodeMajor = value;
   }
   return result;
 }
@@ -648,17 +639,11 @@ export function setupLauncher(
       node: process.execPath,
       cli: resolveCurrentCliPath(),
       version: opts.pkgVersion,
-      // We are running on the node we are recording, so its major is known
-      // without spawning anything.
-      nodeMajor: process.versions.node.split('.')[0],
     };
     recordPkgRoot(cfg.cli);
     const existing = readLauncherConfig();
     const unchanged =
-      existing.node === cfg.node &&
-      existing.cli === cfg.cli &&
-      existing.version === cfg.version &&
-      existing.nodeMajor === cfg.nodeMajor;
+      existing.node === cfg.node && existing.cli === cfg.cli && existing.version === cfg.version;
     if (unchanged && !opts.force) {
       steps.push({
         target: getLauncherConfigPath(),

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -112,4 +112,4 @@ export const MIRROR_HOOK_VERSION = '0.3.0';
 // 0.6.0 (TRA-755): the resolved node is version-gated against engines.node. An
 // older one used to exec fine and die on a SyntaxError the client could only
 // report as "failed to connect" — and get pinned into launcher.env on the way.
-export const LAUNCHER_VERSION = '0.6.7';
+export const LAUNCHER_VERSION = '0.6.8';

--- a/tests/init/launcher-integration-windows.test.ts
+++ b/tests/init/launcher-integration-windows.test.ts
@@ -214,8 +214,8 @@ try {
       [
         `TRACE_MCP_NODE="${shim.replace(/\\/g, '\\\\')}"`,
         `TRACE_MCP_CLI="${cli.replace(/\\/g, '\\\\')}"`,
-        // Cached, so nothing on the fast path would have run `node -v` and
-        // noticed - the exact shape the app writes.
+        // The shape the app used to write. The launcher no longer reads it,
+        // but the fixture keeps it so the parser stays exercised on it.
         'TRACE_MCP_NODE_MAJOR="24"',
         '',
       ].join('\r\n'),
@@ -275,6 +275,41 @@ Write-Output "EXIT:$LASTEXITCODE"`;
 
     const log = fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8');
     expect(log).toMatch(/ERROR: config node=.*runtime shim whose target is gone/);
+  });
+
+  // TRA-1040: the cached major used to stand in for "this node still works",
+  // so a node broken in place - a runtime uninstalled from under its own path,
+  // an arch mismatch after a machine migration - was started anyway. Nothing
+  // failed on the launcher's own side, so nothing was logged and nothing
+  // healed, and every later start repeated it.
+  it('reprobes when the configured node exists but no longer runs', () => {
+    const { home, traceHome, cli } = setupFakeHome();
+    const dead = path.join(home, 'dead-node.cmd');
+    fs.writeFileSync(dead, '@echo off\r\nexit /b 1\r\n');
+    fs.writeFileSync(
+      path.join(traceHome, 'launcher.env'),
+      [
+        `TRACE_MCP_NODE="${dead.replace(/\\/g, '\\\\')}"`,
+        `TRACE_MCP_CLI="${cli.replace(/\\/g, '\\\\')}"`,
+        'TRACE_MCP_NODE_MAJOR="24"',
+        '',
+      ].join('\r\n'),
+    );
+
+    const ps1 = path.join(HOOKS_DIR, 'trace-mcp-launcher.ps1');
+    const q = (p: string) => p.replace(/'/g, "''");
+    const script = `$env:TRACE_MCP_HOME = '${q(traceHome)}'
+$env:USERPROFILE = '${q(home)}'
+$env:NPM_CONFIG_PREFIX = ''
+& powershell.exe -NoProfile -NonInteractive -File '${q(ps1)}' serve
+Write-Output "EXIT:$LASTEXITCODE"`;
+    spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], {
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+
+    const log = fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8');
+    expect(log).toMatch(/ERROR: config node=.*cannot run/);
   });
 
   // TRA-707: launcher.log takes a line on every MCP start and nothing else

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -648,21 +648,68 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
         expect(cfg).toContain(`TRACE_MCP_CLI="${cli}"`);
       });
 
-      it('caches the verified major so the next start spawns nothing extra', () => {
-        const { home, traceHome, node, cli } = setupFakeHome();
-        writeConfig(traceHome, node, cli); // legacy config: no recorded major
-
-        runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
-
-        expect(fs.readFileSync(path.join(traceHome, 'launcher.env'), 'utf-8')).toContain(
-          'TRACE_MCP_NODE_MAJOR="22"',
+      // TRA-1040: the cached major used to stand in for "this node still works",
+      // so the fast path exec'd a binary that no longer runs — a Node broken by
+      // a Homebrew dylib bump, an arch mismatch after a machine migration, an
+      // invalidated code signature. The exec succeeds from the shim's side, so
+      // nothing was logged and nothing healed: the client lost every tool for
+      // the rest of the session, and every later start repeated it, with a
+      // working node and cli.js sitting on the same disk.
+      it('reprobes when the configured node exists but no longer runs', () => {
+        const { home, traceHome, cli } = setupFakeHome();
+        const dead = path.join(home, 'dead-node');
+        // +x, but dies on exec the way a missing dylib makes a real node die.
+        fs.writeFileSync(dead, '#!/bin/bash\necho "dyld: Library not loaded" >&2\nexit 1\n', {
+          mode: 0o755,
+        });
+        fs.writeFileSync(
+          path.join(traceHome, 'launcher.env'),
+          [`TRACE_MCP_NODE="${dead}"`, `TRACE_MCP_CLI="${cli}"`, ''].join('\n'),
         );
-        // Second start takes the fast path on the cached value alone.
-        const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, [
-          'serve',
-        ]);
+        const good = plantNvm(home, '99.0.0');
+
+        const { status, stdout } = runLauncher(
+          { HOME: home, TRACE_MCP_HOME: traceHome, ...ABOVE_ANY_REAL },
+          ['serve'],
+        );
+
+        // Only the node is replaced — the configured cli.js is still on disk,
+        // and any working node runs any cli.js.
         expect(status).toBe(0);
         expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+        const cfg = fs.readFileSync(path.join(traceHome, 'launcher.env'), 'utf-8');
+        expect(cfg).toContain(`TRACE_MCP_NODE="${good.node}"`);
+        expect(cfg).not.toContain(dead);
+      });
+
+      // Same binary, but with the major a previous start recorded: the cached
+      // value must not buy it a pass.
+      it('does not let a cached major vouch for a node that stopped running', () => {
+        const { home, traceHome, cli } = setupFakeHome();
+        const dead = path.join(home, 'dead-node');
+        fs.writeFileSync(dead, '#!/bin/bash\nexit 1\n', { mode: 0o755 });
+        fs.writeFileSync(
+          path.join(traceHome, 'launcher.env'),
+          [
+            `TRACE_MCP_NODE="${dead}"`,
+            `TRACE_MCP_CLI="${cli}"`,
+            'TRACE_MCP_NODE_MAJOR="99"',
+            '',
+          ].join('\n'),
+        );
+        const good = plantNvm(home, '99.0.0');
+
+        const { status, stdout } = runLauncher(
+          { HOME: home, TRACE_MCP_HOME: traceHome, ...ABOVE_ANY_REAL },
+          ['serve'],
+        );
+
+        expect(status).toBe(0);
+        expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+        expect(fs.readFileSync(path.join(traceHome, 'launcher.env'), 'utf-8')).toContain(
+          `TRACE_MCP_NODE="${good.node}"`,
+        );
+        expect(fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8')).toContain('ERROR');
       });
     });
 


### PR DESCRIPTION
## The failure

The launcher's fast path used a cached `TRACE_MCP_NODE_MAJOR` as proof that the node recorded in `launcher.env` was usable, so it only ever asked *which major is this*, never *does this binary still run*. `[ -x ]` cannot answer the second one.

A node broken in place is still executable: a Homebrew dylib bump under an older node, an arch mismatch after a Migration Assistant move, a code signature macOS stopped honouring. The shim exec'd it, the exec succeeded from the shim's own side, so **nothing was logged and nothing healed** — the MCP client lost all ~170 tools for the rest of the session, and every later start repeated it, with a working node and `cli.js` sitting on the same disk.

TRA-965 closed one instance of this by name (a `node-runtime` shim with a dead target). This closes the class.

## Reproduced first

Sandbox with a dead `node` + a healthy node and `cli.js` reachable via `pkg-roots`, driven through the real shim:

```
=== run 1 ===  dyld[1]: Library not loaded: libicui18n.dylib   exit=1
=== run 2 ===  dyld[1]: Library not loaded: libicui18n.dylib   exit=1
launcher.log:  exec(config) node=.../prefix/bin/node ...   (twice, no ERROR)
config after:  unchanged
```

After the fix, on the first start:

```
=== run 1 ===  SERVER OK   exit=0
launcher.log:  ERROR: config node=... exists but cannot run (broken install, moved runtime or arch mismatch) — reprobing
               probe: node=/Users/.../bin/node
config after:  rewritten onto the working node
```

## The change

- The version gate is now also a liveness gate and runs on **every** start: one `node -v` on the configured node, ERROR-logged when it cannot run, then a reprobe that heals `launcher.env` — so recovery is permanent, not per-start.
- `TRACE_MCP_NODE_MAJOR` is no longer read or written by either launcher or by `trace-mcp init`. Configs written by older versions still carrying the key are simply ignored.
- Same fix applied to `trace-mcp-launcher.ps1` for parity; launcher version bumped to `0.6.8`.

`node_runtime_shim_ok` stays: probing a `node-runtime` shim means starting Electron, and two builtin string tests are far cheaper than that.

## The tradeoff, stated

This spends one `node -v` (~12 ms measured on this machine) per MCP client launch — the cost the cached major existed to avoid (review of #982). It buys the pair being *real* rather than merely *recorded*, on a path that is about to load a whole Node process anyway. A permanently silent loss of every tool is not worth 12 ms.

## Tests

- `reprobes when the configured node exists but no longer runs` — recovers onto a working node, rewrites the config.
- `does not let a cached major vouch for a node that stopped running` — the regression itself; fails on `main` (exit 1, dead node exec'd).
- Windows counterpart added to `launcher-integration-windows.test.ts`.

Full suite green: 10497 passed, 27 skipped. Build and biome clean.

Closes TRA-1040.

Agent: Lead Engineer
