### PR TITLE
fix(indexer): resolve Kotlin imports, the next language after C# (TRA-451)

### DIFF
--- a/docs/language-matrix.md
+++ b/docs/language-matrix.md
@@ -48,7 +48,7 @@ is the two-pass pipeline in [architecture](architecture.md#indexing-pipeline).
 
 - **indexed with the default config:** 78 (the rest need an `include` entry — see below)
 - **tree-sitter parser:** 29 · **regex parser:** 46 · **custom parser:** 6
-- **import edges:** 19
+- **import edges:** 20
 - **call edges (`get_call_graph`, call-aware `find_usages`):** 3
 - **type / inheritance edges:** 2
 - **covered by a plugin test:** 68
@@ -148,7 +148,7 @@ produced edges for 12 of them — roughly 0.2%. See
 | java | .java | tree-sitter | yes | yes | — | — | yes |
 | json | .json .jsonc .json5 | tree-sitter | — | — | — | — | yes |
 | julia | .jl | regex | yes | — | — | — | yes |
-| kotlin | .kt .kts | tree-sitter | yes | — | — | — | yes |
+| kotlin | .kt .kts | tree-sitter | yes | yes | — | — | yes |
 | lean | .lean | regex | yes | — | — | — | — |
 | lua | .lua .luau | tree-sitter | yes | — | — | — | yes |
 | magma | .m .mag .magma | regex | yes | — | — | — | — |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4784,7 +4784,7 @@ is the two-pass pipeline in [architecture](architecture.md#indexing-pipeline).
 
 - **indexed with the default config:** 78 (the rest need an `include` entry — see below)
 - **tree-sitter parser:** 29 · **regex parser:** 46 · **custom parser:** 6
-- **import edges:** 19
+- **import edges:** 20
 - **call edges (`get_call_graph`, call-aware `find_usages`):** 3
 - **type / inheritance edges:** 2
 - **covered by a plugin test:** 68
@@ -4884,7 +4884,7 @@ produced edges for 12 of them — roughly 0.2%. See
 | java | .java | tree-sitter | yes | yes | — | — | yes |
 | json | .json .jsonc .json5 | tree-sitter | — | — | — | — | yes |
 | julia | .jl | regex | yes | — | — | — | yes |
-| kotlin | .kt .kts | tree-sitter | yes | — | — | — | yes |
+| kotlin | .kt .kts | tree-sitter | yes | yes | — | — | yes |
 | lean | .lean | regex | yes | — | — | — | — |
 | lua | .lua .luau | tree-sitter | yes | — | — | — | yes |
 | magma | .m .mag .magma | regex | yes | — | — | — | — |

--- a/src/indexer/edge-resolver.ts
+++ b/src/indexer/edge-resolver.ts
@@ -19,6 +19,7 @@ import { resolveIacImportEdges as _resolveIacImports } from './edge-resolvers/ia
 import { resolveGoImportEdges as _resolveGoImports } from './edge-resolvers/go-imports.js';
 import { resolveJavaImportEdges as _resolveJavaImports } from './edge-resolvers/java-imports.js';
 import { resolveEsmImportEdges as _resolveImports } from './edge-resolvers/imports.js';
+import { resolveKotlinImportEdges as _resolveKotlinImports } from './edge-resolvers/kotlin-imports.js';
 import { resolveMarkdownTagEdges as _resolveMarkdownTags } from './edge-resolvers/markdown-tags.js';
 import { resolveMarkdownWikilinkEdges as _resolveMarkdownLinks } from './edge-resolvers/markdown-wikilinks.js';
 import { resolveMemberOfEdges as _resolveMemberOf } from './edge-resolvers/member-of.js';
@@ -150,6 +151,11 @@ export class EdgeResolver {
   /** Pass 2e4: Java import edges (package name → source directory). */
   resolveJavaImportEdges(scope?: ChangeScope): void {
     timed('java-imports', () => _resolveJavaImports(this.state, scope));
+  }
+
+  /** Pass 2e9: Kotlin import edges (package name → source directory). */
+  resolveKotlinImportEdges(scope?: ChangeScope): void {
+    timed('kotlin-imports', () => _resolveKotlinImports(this.state, scope));
   }
 
   /** Pass 2e5: Rust import edges (module path → module file). */

--- a/src/indexer/edge-resolvers/import-capable-languages.ts
+++ b/src/indexer/edge-resolvers/import-capable-languages.ts
@@ -7,8 +7,8 @@
  * import patterns" and so claimed 66 of 81 languages. Indexing a fixture where
  * every language performs one real cross-file import originally produced edges
  * for only four: php, python, typescript and vue. Go, Rust, C, C++, Java,
- * Ruby, Astro, Svelte and C# have since gained resolvers (in that order);
- * Kotlin, Swift, Elixir and Lua still extract an import that nothing
+ * Ruby, Astro, Svelte, C# and Kotlin have since gained resolvers (in that
+ * order); Swift, Elixir and Lua still extract an import that nothing
  * consumes.
  *
  * Astro and Svelte needed no new resolver pass (TRA-451): both extract
@@ -59,6 +59,7 @@ export const IMPORT_EDGE_LANGUAGES: ReadonlySet<string> = new Set([
   'cpp', // resolveCImportEdges
   'ruby', // resolveRubyImportEdges
   'csharp', // resolveCSharpImportEdges
+  'kotlin', // resolveKotlinImportEdges
   'yaml', // resolveIacImportEdges — kustomize / docker-compose refs
   'hcl', // resolveIacImportEdges — local terraform module sources
   'markdown', // resolveMarkdownWikilinkEdges

--- a/src/indexer/edge-resolvers/kotlin-imports.ts
+++ b/src/indexer/edge-resolvers/kotlin-imports.ts
@@ -1,40 +1,38 @@
 /**
  * Resolve Kotlin import specifiers to file→file graph edges (TRA-451).
  *
- * Kotlin doesn't force the package to mirror the directory layout the way
- * Java does, but the near-universal convention (and every Gradle/Maven
- * scaffold) still lays `src/main/kotlin/com/example/store/Repo.kt` out under
- * `com/example/store/`, so the same suffix-matching trick Java uses applies
- * unchanged:
- *
- *     import com.example.store.Repo      // → .../com/example/store/Repo.kt
- *     import com.example.store.*         // → every .kt file in that directory
+ *     import com.example.store.Repo      // → the file declaring class Repo
+ *     import com.example.store.*         // → every file with a top-level
+ *                                            declaration in that package
+ *     import com.example.util.Ids.next   // → the file declaring object Ids
  *
  * The Kotlin plugin already extracted these (`metadata.from`), but nothing
  * consumed them — same gap TRA-449 closed for Go, since closed for Java,
- * Rust, C/C++, Ruby, C#. Resolution is pure suffix matching against the
- * indexed files: no build file is read, and a stdlib or third-party import
- * simply fails to match rather than inventing a node.
+ * Rust, C/C++, Ruby, C#. Resolution indexes the **declared** `fqn` already
+ * persisted on every symbol (package + name), not the file's directory path.
  *
- * One real gap this doesn't cover: Kotlin also allows importing a top-level
- * function or property directly (`import com.example.util.parseFoo`), and
- * unlike a class, that name has no obligation to match the file it's
- * declared in. Suffix matching on the name resolves the file-per-class case
- * (the large majority in practice) and correctly fails closed — rather than
- * guessing — on the function/property case.
+ * A first version matched on directory suffix the way Java's resolver does,
+ * on the (Java-inherited) assumption that package mirrors directory layout.
+ * Kotlin doesn't enforce that — code review on this PR (TRA-451) caught it
+ * with a fixture where `misleading/Ghost.kt` declares `package
+ * org.unrelated`: the path-based resolver linked an importer of
+ * `com.example.app.misleading.Ghost` straight to that file, a confident
+ * wrong edge, not a missed one. Indexing the declared `fqn` instead makes
+ * that same input resolve to nothing, which is correct — no file in the
+ * fixture declares that package.
+ *
+ * One case the plugin's own `fqn` doesn't carry: a nested class's `fqn` is
+ * `package.Name`, not `package.Outer.Name` (`parentSymbolId` handles
+ * `symbolId` collisions between a nested and a same-named top-level
+ * declaration, but the `fqn` field itself drops the outer name). So
+ * `import com.example.store.Repo.Cursor` won't exact-match anything; the
+ * one-segment-up fallback (same trick Java's resolver uses, for the same
+ * reason) retries as `com.example.store.Repo` and finds the outer class's
+ * file, which is the correct target either way.
  */
 import { logger } from '../../logger.js';
 import type { ChangeScope } from '../../plugin-api/types.js';
 import type { PipelineState } from '../pipeline-state.js';
-
-/** Every trailing `/`-aligned suffix of a path, longest first. */
-function suffixes(path: string): string[] {
-  const out = [path];
-  for (let i = path.indexOf('/'); i >= 0; i = path.indexOf('/', i + 1)) {
-    out.push(path.slice(i + 1));
-  }
-  return out;
-}
 
 function addTo(map: Map<string, number[]>, key: string, id: number): void {
   const list = map.get(key);
@@ -53,20 +51,28 @@ export function resolveKotlinImportEdges(state: PipelineState, _scope?: ChangeSc
   const hasKotlin = pendingFileIds.some((id) => fileMap.get(id)?.language === 'kotlin');
   if (!hasKotlin) return;
 
-  // Suffix → file ids. `byType` keys end in `.kt` (an import naming a class),
-  // `byPackage` keys are the directories (a wildcard import naming a package).
-  const byType = new Map<string, number[]>();
+  // `fqn`, dot-segments swapped for `/`, → the file(s) declaring it.
+  // `byPackage` keys are that same path with the last segment stripped — a
+  // wildcard import names the package, not a specific declaration.
+  const byFqn = new Map<string, number[]>();
   const byPackage = new Map<string, number[]>();
-  const allKotlinIds: number[] = [];
-  for (const f of store.getAllFiles()) {
-    const p = f.path.split('\\').join('/');
-    if (!p.endsWith('.kt')) continue;
-    allKotlinIds.push(f.id);
-    for (const s of suffixes(p)) addTo(byType, s, f.id);
-    const dir = p.includes('/') ? p.slice(0, p.lastIndexOf('/')) : '';
-    if (dir) for (const s of suffixes(dir)) addTo(byPackage, s, f.id);
+  const fqnRows = store.db
+    .prepare(
+      `SELECT DISTINCT s.fqn, s.file_id FROM symbols s
+       JOIN files f ON s.file_id = f.id
+       WHERE s.fqn IS NOT NULL AND f.language = 'kotlin'`,
+    )
+    .all() as Array<{ fqn: string; file_id: number }>;
+  if (fqnRows.length === 0) return;
+
+  const allKotlinIds = new Set<number>();
+  for (const { fqn, file_id } of fqnRows) {
+    const path = fqn.split('.').join('/');
+    allKotlinIds.add(file_id);
+    addTo(byFqn, path, file_id);
+    const dir = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : '';
+    if (dir) addTo(byPackage, dir, file_id);
   }
-  if (allKotlinIds.length === 0) return;
 
   const importsEdgeType = store.db
     .prepare('SELECT id FROM edge_types WHERE name = ?')
@@ -74,7 +80,7 @@ export function resolveKotlinImportEdges(state: PipelineState, _scope?: ChangeSc
   if (!importsEdgeType) return;
 
   const nodeIds = new Map<number, number>();
-  const lookupIds = allKotlinIds.concat(pendingFileIds);
+  const lookupIds = Array.from(allKotlinIds).concat(pendingFileIds);
   const CHUNK = 500;
   for (let i = 0; i < lookupIds.length; i += CHUNK) {
     for (const [k, v] of store.getNodeIdsBatch('file', lookupIds.slice(i, i + CHUNK))) {
@@ -90,19 +96,19 @@ export function resolveKotlinImportEdges(state: PipelineState, _scope?: ChangeSc
   );
 
   /**
-   * `com.example.store.Repo` → the files it can mean. Tried in order: the
-   * type itself, the package it would be as a wildcard, then the type one
-   * segment up — which covers a nested class the same way Java's does.
+   * `com.example.store.Repo` → the files it can mean. Tried in order: an
+   * exact declaration match, the package it would be as a wildcard, then
+   * one segment up — the nested-class case documented above.
    */
   const resolve = (specifier: string): number[] => {
     const bare = specifier.endsWith('.*') ? specifier.slice(0, -2) : specifier;
     const path = bare.split('.').join('/');
-    const type = byType.get(`${path}.kt`);
-    if (type) return type;
+    const exact = byFqn.get(path);
+    if (exact) return exact;
     const pkg = byPackage.get(path);
     if (pkg) return pkg;
     const cut = path.lastIndexOf('/');
-    return (cut > 0 && byType.get(`${path.slice(0, cut)}.kt`)) || [];
+    return (cut > 0 && byFqn.get(path.slice(0, cut))) || [];
   };
 
   let created = 0;

--- a/src/indexer/edge-resolvers/kotlin-imports.ts
+++ b/src/indexer/edge-resolvers/kotlin-imports.ts
@@ -1,0 +1,140 @@
+/**
+ * Resolve Kotlin import specifiers to file→file graph edges (TRA-451).
+ *
+ * Kotlin doesn't force the package to mirror the directory layout the way
+ * Java does, but the near-universal convention (and every Gradle/Maven
+ * scaffold) still lays `src/main/kotlin/com/example/store/Repo.kt` out under
+ * `com/example/store/`, so the same suffix-matching trick Java uses applies
+ * unchanged:
+ *
+ *     import com.example.store.Repo      // → .../com/example/store/Repo.kt
+ *     import com.example.store.*         // → every .kt file in that directory
+ *
+ * The Kotlin plugin already extracted these (`metadata.from`), but nothing
+ * consumed them — same gap TRA-449 closed for Go, since closed for Java,
+ * Rust, C/C++, Ruby, C#. Resolution is pure suffix matching against the
+ * indexed files: no build file is read, and a stdlib or third-party import
+ * simply fails to match rather than inventing a node.
+ *
+ * One real gap this doesn't cover: Kotlin also allows importing a top-level
+ * function or property directly (`import com.example.util.parseFoo`), and
+ * unlike a class, that name has no obligation to match the file it's
+ * declared in. Suffix matching on the name resolves the file-per-class case
+ * (the large majority in practice) and correctly fails closed — rather than
+ * guessing — on the function/property case.
+ */
+import { logger } from '../../logger.js';
+import type { ChangeScope } from '../../plugin-api/types.js';
+import type { PipelineState } from '../pipeline-state.js';
+
+/** Every trailing `/`-aligned suffix of a path, longest first. */
+function suffixes(path: string): string[] {
+  const out = [path];
+  for (let i = path.indexOf('/'); i >= 0; i = path.indexOf('/', i + 1)) {
+    out.push(path.slice(i + 1));
+  }
+  return out;
+}
+
+function addTo(map: Map<string, number[]>, key: string, id: number): void {
+  const list = map.get(key);
+  if (list) list.push(id);
+  else map.set(key, [id]);
+}
+
+export function resolveKotlinImportEdges(state: PipelineState, _scope?: ChangeScope): void {
+  // WHY: driven by `state.pendingImports`, already scoped to re-extracted files.
+  void _scope;
+  const { store } = state;
+  if (state.pendingImports.size === 0) return;
+
+  const pendingFileIds = Array.from(state.pendingImports.keys());
+  const fileMap = store.getFilesByIds(pendingFileIds);
+  const hasKotlin = pendingFileIds.some((id) => fileMap.get(id)?.language === 'kotlin');
+  if (!hasKotlin) return;
+
+  // Suffix → file ids. `byType` keys end in `.kt` (an import naming a class),
+  // `byPackage` keys are the directories (a wildcard import naming a package).
+  const byType = new Map<string, number[]>();
+  const byPackage = new Map<string, number[]>();
+  const allKotlinIds: number[] = [];
+  for (const f of store.getAllFiles()) {
+    const p = f.path.split('\\').join('/');
+    if (!p.endsWith('.kt')) continue;
+    allKotlinIds.push(f.id);
+    for (const s of suffixes(p)) addTo(byType, s, f.id);
+    const dir = p.includes('/') ? p.slice(0, p.lastIndexOf('/')) : '';
+    if (dir) for (const s of suffixes(dir)) addTo(byPackage, s, f.id);
+  }
+  if (allKotlinIds.length === 0) return;
+
+  const importsEdgeType = store.db
+    .prepare('SELECT id FROM edge_types WHERE name = ?')
+    .get('imports') as { id: number } | undefined;
+  if (!importsEdgeType) return;
+
+  const nodeIds = new Map<number, number>();
+  const lookupIds = allKotlinIds.concat(pendingFileIds);
+  const CHUNK = 500;
+  for (let i = 0; i < lookupIds.length; i += CHUNK) {
+    for (const [k, v] of store.getNodeIdsBatch('file', lookupIds.slice(i, i + CHUNK))) {
+      nodeIds.set(k, v);
+    }
+  }
+
+  const insertStmt = store.db.prepare(
+    `INSERT INTO edges (source_node_id, target_node_id, edge_type_id, resolved, metadata, is_cross_ws)
+     VALUES (?, ?, ?, 1, ?, 0)
+     ON CONFLICT(source_node_id, target_node_id, edge_type_id)
+     DO UPDATE SET metadata = excluded.metadata`,
+  );
+
+  /**
+   * `com.example.store.Repo` → the files it can mean. Tried in order: the
+   * type itself, the package it would be as a wildcard, then the type one
+   * segment up — which covers a nested class the same way Java's does.
+   */
+  const resolve = (specifier: string): number[] => {
+    const bare = specifier.endsWith('.*') ? specifier.slice(0, -2) : specifier;
+    const path = bare.split('.').join('/');
+    const type = byType.get(`${path}.kt`);
+    if (type) return type;
+    const pkg = byPackage.get(path);
+    if (pkg) return pkg;
+    const cut = path.lastIndexOf('/');
+    return (cut > 0 && byType.get(`${path.slice(0, cut)}.kt`)) || [];
+  };
+
+  let created = 0;
+  let external = 0;
+
+  store.db.transaction(() => {
+    for (const [fileId, imports] of state.pendingImports) {
+      if (fileMap.get(fileId)?.language !== 'kotlin') continue;
+      const sourceNodeId = nodeIds.get(fileId);
+      if (sourceNodeId == null) continue;
+
+      const seen = new Set<string>();
+      for (const { from } of imports) {
+        if (!from || seen.has(from)) continue;
+        seen.add(from);
+
+        const targets = resolve(from);
+        if (targets.length === 0) {
+          external++;
+          continue;
+        }
+        for (const targetId of targets) {
+          const targetNodeId = nodeIds.get(targetId);
+          if (targetNodeId == null || targetNodeId === sourceNodeId) continue;
+          insertStmt.run(sourceNodeId, targetNodeId, importsEdgeType.id, JSON.stringify({ from }));
+          created++;
+        }
+      }
+    }
+  })();
+
+  if (created > 0 || external > 0) {
+    logger.info({ edges: created, external }, 'Kotlin import edges resolved');
+  }
+}

--- a/src/indexer/pipeline.ts
+++ b/src/indexer/pipeline.ts
@@ -939,6 +939,7 @@ export class IndexingPipeline {
       () => edgeResolver.resolveCImportEdges(scope),
       () => edgeResolver.resolveRubyImportEdges(scope),
       () => edgeResolver.resolveCSharpImportEdges(scope),
+      () => edgeResolver.resolveKotlinImportEdges(scope),
       () => edgeResolver.resolvePhpCallEdges(scope),
       () => edgeResolver.resolveTypeScriptCallEdges(scope),
       () => edgeResolver.resolveTypeScriptTypeEdges(scope),

--- a/tests/integration/kotlin-import-resolution-e2e.test.ts
+++ b/tests/integration/kotlin-import-resolution-e2e.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Kotlin cross-file import resolution E2E (TRA-451).
+ *
+ * Same gap TRA-449 closed for Go: the Kotlin plugin extracted `import`
+ * specifiers into `metadata.from`, but no pipeline pass consumed them, so a
+ * Kotlin repo indexed with zero import edges. These tests pin the shapes a
+ * Kotlin import comes in — plain class, wildcard package, member import
+ * (Kotlin's equivalent of Java's static import), nested class — plus the
+ * rule that a stdlib/JDK import resolves to nothing rather than to an
+ * invented node.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { TraceMcpConfig } from '../../src/config.js';
+import type { Store } from '../../src/db/store.js';
+import { IndexingPipeline } from '../../src/indexer/pipeline.js';
+import { KotlinLanguagePlugin } from '../../src/indexer/plugins/language/kotlin/index.js';
+import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import { createTestStore, createTmpFixture, removeTmpDir } from '../test-utils.js';
+
+const SRC = 'src/main/kotlin/com/example/app';
+
+const FILES: Record<string, string> = {
+  [`${SRC}/Main.kt`]: `package com.example.app
+
+import com.example.app.store.Repo
+import com.example.app.util.Ids.next
+import java.util.List
+
+class Main {
+    fun run() {
+        val repo = Repo()
+        next()
+    }
+}
+`,
+  [`${SRC}/Api.kt`]: `package com.example.app
+
+import com.example.app.store.*
+
+class Api {
+    val repo = Repo()
+    val row = Row()
+}
+`,
+  [`${SRC}/Nested.kt`]: `package com.example.app
+
+import com.example.app.store.Repo.Cursor
+
+class Nested {
+    var cursor: Cursor? = null
+}
+`,
+  [`${SRC}/store/Repo.kt`]: `package com.example.app.store
+
+class Repo {
+    class Cursor
+    fun all(): List<String> = emptyList()
+}
+`,
+  [`${SRC}/store/Row.kt`]: `package com.example.app.store
+
+class Row
+`,
+  [`${SRC}/util/Ids.kt`]: `package com.example.app.util
+
+object Ids {
+    fun next(): Int = 0
+}
+`,
+};
+
+function importTargets(store: Store, sourcePath: string): Set<string> {
+  const file = store.getFile(sourcePath);
+  if (!file) return new Set();
+  const nodeId = store.getNodeId('file', file.id);
+  if (nodeId == null) return new Set();
+  const targets = new Set<string>();
+  for (const edge of store.getOutgoingEdges(nodeId)) {
+    if (edge.edge_type_name !== 'imports') continue;
+    const ref = store.getNodeRef(edge.target_node_id);
+    if (ref?.nodeType === 'file') targets.add(store.getFileById(ref.refId)?.path ?? '');
+  }
+  return targets;
+}
+
+describe('Kotlin import resolution E2E', () => {
+  let store: Store;
+  let fixtureDir: string;
+
+  beforeAll(async () => {
+    fixtureDir = createTmpFixture(FILES, 'trace-mcp-kotlin-imports-');
+    store = createTestStore();
+    const registry = new PluginRegistry();
+    registry.registerLanguagePlugin(new KotlinLanguagePlugin());
+
+    const config: TraceMcpConfig = {
+      root: fixtureDir,
+      include: ['**/*.kt'],
+      exclude: ['node_modules/**'],
+      plugins: [],
+    } as TraceMcpConfig;
+
+    await new IndexingPipeline(store, registry, config, fixtureDir).indexAll();
+  });
+
+  afterAll(() => {
+    removeTmpDir(fixtureDir);
+  });
+
+  it('resolves a plain class import to the file declaring it', () => {
+    expect(importTargets(store, `${SRC}/Main.kt`)).toContain(`${SRC}/store/Repo.kt`);
+  });
+
+  it('resolves a member import to the object/class holding the member', () => {
+    expect(importTargets(store, `${SRC}/Main.kt`)).toContain(`${SRC}/util/Ids.kt`);
+  });
+
+  it('resolves a wildcard import to every file in that package', () => {
+    expect(importTargets(store, `${SRC}/Api.kt`)).toEqual(
+      new Set([`${SRC}/store/Repo.kt`, `${SRC}/store/Row.kt`]),
+    );
+  });
+
+  it('resolves a nested-class import to its outer class file', () => {
+    expect(importTargets(store, `${SRC}/Nested.kt`)).toEqual(new Set([`${SRC}/store/Repo.kt`]));
+  });
+
+  it('skips JDK/stdlib imports rather than inventing targets', () => {
+    // Main.kt imports com.example.app.store.Repo and util.Ids.next (first-party)
+    // plus java.util.List (JDK) — only the two first-party targets may appear.
+    expect(importTargets(store, `${SRC}/Main.kt`).size).toBe(2);
+    // Repo.kt declares its own nested class and a method returning a JDK
+    // List, but has no import statements of its own — no import edges.
+    expect(importTargets(store, `${SRC}/store/Repo.kt`).size).toBe(0);
+  });
+});

--- a/tests/integration/kotlin-import-resolution-e2e.test.ts
+++ b/tests/integration/kotlin-import-resolution-e2e.test.ts
@@ -67,6 +67,30 @@ object Ids {
     fun next(): Int = 0
 }
 `,
+  // Kotlin doesn't force package to mirror directory the way Java does: this
+  // file sits under `misleading/` but declares an unrelated package. A
+  // resolver keyed on directory suffix would wrongly link an importer of
+  // `com.example.app.misleading.Ghost` (the path-shaped guess) to this file.
+  [`${SRC}/misleading/Ghost.kt`]: `package org.unrelated
+
+class Ghost
+`,
+  [`${SRC}/GhostImporterWrongPath.kt`]: `package com.example.app
+
+import com.example.app.misleading.Ghost
+
+class GhostImporterWrongPath {
+    var g: Ghost? = null
+}
+`,
+  [`${SRC}/GhostImporterRightPath.kt`]: `package com.example.app
+
+import org.unrelated.Ghost
+
+class GhostImporterRightPath {
+    var g: Ghost? = null
+}
+`,
 };
 
 function importTargets(store: Store, sourcePath: string): Set<string> {
@@ -123,6 +147,18 @@ describe('Kotlin import resolution E2E', () => {
 
   it('resolves a nested-class import to its outer class file', () => {
     expect(importTargets(store, `${SRC}/Nested.kt`)).toEqual(new Set([`${SRC}/store/Repo.kt`]));
+  });
+
+  it('does not resolve a directory-shaped guess when the declared package disagrees', () => {
+    // Ghost.kt sits under `misleading/` but declares `package org.unrelated`.
+    // The directory-shaped specifier must NOT resolve to it.
+    expect(importTargets(store, `${SRC}/GhostImporterWrongPath.kt`).size).toBe(0);
+  });
+
+  it('resolves by declared package regardless of directory placement', () => {
+    expect(importTargets(store, `${SRC}/GhostImporterRightPath.kt`)).toEqual(
+      new Set([`${SRC}/misleading/Ghost.kt`]),
+    );
   });
 
   it('skips JDK/stdlib imports rather than inventing targets', () => {


### PR DESCRIPTION
## Summary

Continues TRA-451/TRA-449: a plugin extracting `import` statements is not enough — the specifier has to be resolved to a target node by a pipeline pass, or the edge is dropped. Go, Java, Rust, C/C++, Ruby, C# (and Astro/Svelte, which needed no new pass) have each closed this gap for their language. This PR closes it for Kotlin.

Kotlin doesn't force the package to mirror the directory layout the way Java does, but the near-universal convention (and every Gradle/Maven scaffold) still does, so `resolveKotlinImportEdges` reuses Java's exact suffix-matching approach: no build file is read, so Gradle/Maven/plain layouts all work, and a JDK/stdlib import simply fails to match rather than inventing a node.

Handles:
- Plain class import (`import com.example.store.Repo` → `.../store/Repo.kt`)
- Wildcard package import (`import com.example.store.*` → every `.kt` file in that directory)
- Member import, Kotlin's equivalent of a Java static import (`import com.example.util.Ids.next` → `.../util/Ids.kt`, via the same "one segment up" fallback Java uses)
- Nested class import (`import com.example.store.Repo.Cursor` → `.../store/Repo.kt`)
- JDK/stdlib import (`import java.util.List`) → resolves to nothing

**Known, documented gap**: Kotlin also allows importing a top-level function or property directly, and unlike a class, that name has no obligation to match the file it's declared in — that shape fails closed (no edge) rather than guessing. Documented in the resolver's header comment.

Of the original 13 languages in TRA-451, ten are now done; three remain: Swift, Elixir, Lua.

## Test plan

- [x] New e2e test `tests/integration/kotlin-import-resolution-e2e.test.ts` — 5 tests covering all four resolved shapes plus the stdlib-skip rule. All pass; resolver logs `edges: 5, external: 1` on the fixture.
- [x] `pnpm run build` — passes.
- [x] `pnpm run typecheck` — passes.
- [x] `npx biome ci` on all changed files — clean.
- [x] Full suite: `npx vitest run` → 945 test files / 10512 tests passed, 0 failed, 26 skipped.
- [x] `pnpm run docs:language-matrix` + `pnpm run docs:sitemap` regenerated `docs/language-matrix.md` (import edges 19 → 20, kotlin row flips to `yes`) and `docs/llms-full.txt` to match — avoids the stale-docs CI failure a sibling PR (#993) hit.