### PR TITLE
fix(indexer): normalize backslash paths in indexFiles/deleteFiles on Windows (TRA-1045)

### DIFF
--- a/src/indexer/pipeline.ts
+++ b/src/indexer/pipeline.ts
@@ -547,7 +547,11 @@ export class IndexingPipeline {
     if (filePaths.length === 0) return;
     this.store.db.transaction(() => {
       for (const fp of filePaths) {
-        const relPath = path.isAbsolute(fp) ? path.relative(this.rootPath, fp) : fp;
+        const rel = path.isAbsolute(fp) ? path.relative(this.rootPath, fp) : fp;
+        // Store paths are always posix-separated (collectFiles() via
+        // fast-glob) — an unconverted backslash on Windows misses the row
+        // entirely, silently no-op'ing the delete (TRA-1045).
+        const relPath = rel.split(path.sep).join('/');
         const file = this.store.getFile(relPath);
         if (file) {
           this.store.deleteFile(file.id);
@@ -603,7 +607,11 @@ export class IndexingPipeline {
         logger.debug({ file: rel }, 'Git-ignored path skipped in indexFiles');
         continue;
       }
-      relPaths.push(rel);
+      // Store paths are always posix-separated (collectFiles() via
+      // fast-glob) — pushing `rel` instead of `relPosix` inserted a phantom
+      // duplicate file row on Windows instead of matching the existing one,
+      // breaking every downstream mtime/existing-row lookup (TRA-1045).
+      relPaths.push(relPosix);
     }
     return relPaths;
   }


### PR DESCRIPTION
## Summary

Fixes the 5 Windows-only failures in `tests/integration/csharp-import-resolution-e2e.test.ts` blocking the 3.23.0 release train (TRA-1045).

Root cause is not in the C# resolver — it's a path-separator bug in the pipeline's incremental entry points, `indexFiles()` / `deleteFiles()`:

- `filterIndexablePaths()` already computed a posix-normalized `relPosix` for its exclude/gitignore checks, but pushed the un-normalized, native-separator `rel` into the returned batch.
- `deleteFiles()` never normalized at all.

On Windows, callers that pass absolute paths (a file watcher, or these tests via `path.join`) get a backslash-separated relative path out of `path.relative()`. That string never matches the forward-slash paths `collectFiles()` (fast-glob) stores for every existing file row. The mismatched lookup:
- on edit, misses the existing row and inserts a **phantom duplicate file**, instead of updating the real one — the real row's stale type declaration and its incoming edge are never revisited;
- on delete, silently no-ops — the row and its edge survive.

Both leave stale `imports` edges behind that the incremental C# resolver's `changedFileIds`-driven revalidation can never revisit, since it never touches the real (correctly-pathed) row.

Confirmed against the CI log for the failing job: one of the five failures shows the giveaway directly — `expected Set{ 'src\Two.cs' } to deeply equal Set{}` — a literal backslash in a stored path where every other path in the suite uses `/`.

## Fix

Normalize to the same `rel.split(path.sep).join('/')` idiom already used (and proven) two lines above in `filterIndexablePaths()`, and push/store *that*, in both `filterIndexablePaths()` and `deleteFiles()`.

## Test plan

- [x] `pnpm run test --run tests/integration/csharp-import-resolution-e2e.test.ts` — 11/11 pass (unchanged on macOS/Linux, where `path.sep === '/'` makes this a no-op — the bug is Windows-only by construction)
- [x] Full local suite: `pnpm run test` — 943 files / 10513 tests passed, 0 failures
- [x] `pnpm run build` — clean
- [x] `biome check src/indexer/pipeline.ts` — clean
- [ ] `cross-platform-test (windows-latest)` on this PR — added the `cross-platform` label so it runs here rather than only at the next release PR

I could not reproduce the Windows-only path mismatch with a local regression test: simulating it requires `path.sep === '\\'`, and mocking `node:path` globally to force win32 semantics breaks every other real-fs call in the same test process (they hit a real posix filesystem). The authoritative check is this PR's own `cross-platform-test (windows-latest)` job.
