### PR TITLE
ci: run cross-platform tests on any PR touching shipped code (TRA-1048)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,10 @@ name: CI
 #     ├── test-shard 4/4   ~30-60s
 #     └── impact-report    ~30s     (PR only; reuses dist)
 #   app-typecheck (parallel, path-filtered) ~30-60s when triggered, skipped otherwise
-#   cross-platform-test (matrix mac+windows) — only on release-please PR, nightly,
-#                                              workflow_dispatch, or "cross-platform" label
+#   cross-platform-test (matrix mac+windows) — on any PR touching shipped code
+#                                              (see the `platform` filter), plus
+#                                              release PRs, nightly, dispatch,
+#                                              and the "cross-platform" label
 #
 # Strategy:
 #   1. ONE install + ONE build on ubuntu, fan-out the dist/ via artifact.
@@ -90,55 +92,32 @@ jobs:
             vscode:
               - 'packages/vscode-extension/**'
               - '.github/workflows/ci.yml'
-            # Path/OS-sensitive code. TRA-236: the dangerous-root guard shipped
-            # a Windows-shaped hole because cross-platform-test only ran on
-            # release PRs — nothing exercised these files on Windows until the
-            # release was already cut.
-            # TRA-326: the registry/global/db-holder files do raw fs work
-            # (mtime caching, holder files, pid liveness) whose semantics differ
-            # on Windows — #477 broke master there while showing all-green here.
-            # TRA-375: same hole, third time. The import rewriter behind
-            # `apply_move` does path arithmetic on `path.relative` output, so
-            # its separator handling is Windows-shaped by construction — #527
-            # was all-green here and broke the release PR on Windows.
-            # TRA-567: fourth Windows-shaped hole, and the first one that came
-            # from a dependency rather than our code — a better-sqlite3 bump
-            # made pnpm compile it from source, which only fails on Windows.
-            # Any lockfile change can move a native binding, so dep bumps now
-            # pay the cross-platform run instead of the release job doing it.
+            # Cross-platform (mac+windows) gate. Anything we ship, or test what
+            # we ship with, can be Windows-shaped: seven releases in a row were
+            # blocked by a path/fs/spawn bug that was fully green on ubuntu
+            # (TRA-236, 326, 375, 567, 638, 755, 1045).
+            #
+            # This used to be an allowlist of the exact files each of those
+            # incidents happened to touch — i.e. a list of yesterday's bugs. It
+            # was extended six times and missed the seventh anyway: #1041 broke
+            # on src/indexer/pipeline.ts, which nothing had ever put on a
+            # Windows runner. TRA-1048 replaced it with "code that ships, or
+            # tests it". That costs ~6 min of extra wall clock on those PRs;
+            # GitHub runners are free on a public repo, and a release train
+            # blocked on a Windows-only bisect costs far more than that.
+            #
+            # Deliberately NOT a required status check: it is skipped on
+            # docs-only PRs, and a required check that can be skipped is an
+            # unsatisfiable gate (see TRA-255/257 under `core` below).
             platform:
-              - 'pnpm-lock.yaml'
-              - 'package.json'
-              - 'tests/db/native-prebuild.test.ts'
-              - 'src/tools/refactoring/**'
-              - 'tests/refactoring/**'
-              - 'src/dangerous-root.ts'
-              - 'src/project-setup.ts'
-              - 'src/topology/**'
-              - 'src/registry.ts'
-              - 'src/global.ts'
-              - 'src/db-holders.ts'
-              - 'tests/project-setup/dangerous-root.test.ts'
-              - 'tests/topology/**'
-              - 'tests/registry.test.ts'
-            # TRA-638: fifth Windows-shaped hole. The app's main process spawns
-            # the CLI, and on Windows the launcher it resolves is a `.cmd` that
-            # execFile cannot launch — three MCP-client IPCs were dead there for
-            # months. The app's own test job is ubuntu-only, so the regression
-            # test lives in tests/app/ and this filter is what puts it on a
-            # Windows runner.
-              - 'packages/app/src/main/daemon-install.ts'
-              - 'packages/app/src/main/daemon-lifecycle.ts'
-              - 'packages/app/src/main/trace-home.ts'
-              - 'tests/app/**'
-            # TRA-755: sixth. The launcher has a separate PowerShell backend,
-            # and nothing here ever put it on a Windows runner — a syntax error
-            # in it breaks the MCP connection for every Windows install at once,
-            # and its two end-to-end tests are skipped for a runner issue. The
-            # shim files are the most Windows-shaped code we ship.
+              - 'src/**'
+              - 'tests/**'
               - 'hooks/**'
-              - 'src/init/launcher.ts'
-              - 'tests/init/**'
+              - 'scripts/**'
+              - 'packages/app/src/main/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/ci.yml'
             core:
               - 'src/**'
               - 'scripts/**'
@@ -778,11 +757,11 @@ jobs:
   # Cross-platform test — macOS + Windows.
   #
   # Trigger logic (any one fires it):
-  #   1. release-please PR branch     — full validation before publishing.
-  #   2. nightly schedule (04:00 UTC) — catch OS regressions overnight.
-  #   3. workflow_dispatch            — manual ad-hoc verification.
-  #   4. PR labeled "cross-platform"  — opt-in per PR when needed.
-  #   5. PR touching path/OS-sensitive code — see the `platform` filter above.
+  #   1. PR touching shipped code     — the common case; see `platform` above.
+  #   2. release-please PR branch     — full validation before publishing.
+  #   3. nightly schedule (04:00 UTC) — catch OS regressions overnight.
+  #   4. workflow_dispatch            — manual ad-hoc verification.
+  #   5. PR labeled "cross-platform"  — opt-in for a PR the filter misses.
   #
   # Ubuntu coverage already happens in the `test` job above; this matrix is
   # mac+windows only. Each runner does its own install+build+test (the
@@ -811,10 +790,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Deliberately still pnpm/action-setup, not .github/actions/setup-pnpm:
-      # this job only runs on release-please PRs, nightly, dispatch, or an
-      # opt-in label, so the redundant download isn't the everyday cost that
-      # TRA-790 targeted, and mac/windows are exactly the runners where an
-      # unverified change to pnpm activation is riskiest to land blind.
+      # mac/windows are exactly the runners where an unverified change to pnpm
+      # activation is riskiest to land blind, and the redundant download is
+      # seconds against an 8-minute job (TRA-790 targeted the ubuntu shards).
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/tests/ci/cross-platform-filter.test.ts
+++ b/tests/ci/cross-platform-filter.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import YAML from 'yaml';
+
+// The `platform` filter decides whether a PR is tested on macOS and Windows.
+// For six incidents it was an allowlist of the files that had already broken
+// (TRA-236, 326, 375, 567, 638, 755) and it missed the seventh anyway — #1041
+// broke on `src/indexer/pipeline.ts`, which no entry covered. TRA-1048 widened
+// it to whole trees; this test is what stops it from being narrowed back to a
+// list of yesterday's bugs.
+const CI = join(import.meta.dirname, '../../.github/workflows/ci.yml');
+
+function platformFilter(): string[] {
+  const doc = YAML.parse(readFileSync(CI, 'utf8'));
+  const step = doc.jobs.changes.steps.find((s: { id?: string }) => s.id === 'filter');
+  return YAML.parse(step.with.filters).platform;
+}
+
+describe('cross-platform path filter', () => {
+  // Whole trees, not individual files: every shipped source and test file must
+  // be covered by construction.
+  it.each(['src/**', 'tests/**', 'hooks/**', 'scripts/**', 'package.json', 'pnpm-lock.yaml'])(
+    'covers %s',
+    (pattern) => {
+      expect(platformFilter()).toContain(pattern);
+    },
+  );
+
+  it('fires the mac+windows matrix off that filter', () => {
+    const doc = YAML.parse(readFileSync(CI, 'utf8'));
+    const job = doc.jobs['cross-platform-test'];
+    expect(job.needs).toContain('changes');
+    expect(job.if).toContain("needs.changes.outputs.platform == 'true'");
+    expect(job.strategy.matrix.os).toEqual(['macos-latest', 'windows-latest']);
+  });
+});


### PR DESCRIPTION
## Decision

TRA-1048 asked for a call between two options: run `cross-platform-test` on every PR touching indexer/parser paths, or auto-apply a `cross-platform` label from a path filter.

**Option 1, broadened.** Option 2 is the same detection with a worse blast radius: labelling a PR needs `pull-requests: write` on a workflow that runs in the context of PR content, which is exactly the shape our `pr-comment.yml` was deliberately built to avoid. It also adds a workflow to maintain for a signal we already compute in the `changes` job.

The premise in the issue was slightly stale: path-filtered triggering already existed (`needs.changes.outputs.platform == 'true'`, item 5 in the job's trigger list) — only the file header comment still said "release PR, nightly, dispatch, or label". The real gap is the shape of the filter, not its absence.

## What changed

The `platform` filter was an allowlist of the exact files each past Windows-only incident happened to touch. It was extended six times — TRA-236, 326, 375, 567, 638, 755 — and missed the seventh anyway: #1041 broke on `src/indexer/pipeline.ts`, which no entry covered. An allowlist of yesterday's bugs cannot catch tomorrow's.

Replaced with whole trees:

```yaml
platform:
  - 'src/**'
  - 'tests/**'
  - 'hooks/**'
  - 'scripts/**'
  - 'packages/app/src/main/**'
  - 'package.json'
  - 'pnpm-lock.yaml'
  - '.github/workflows/ci.yml'
```

Strict superset of the 20 entries it replaces — net −58/+36 lines, since six incident-specific comment blocks collapse into one rationale.

Docs-only, website-only and vscode-extension-only PRs still skip the matrix.

## Cost

Measured on the last release-please run (34051315637): `cross-platform-test` is 5 min on macOS, 8 min on Windows; the rest of CI is ~3 min. So a PR touching `src/**` goes from ~4 min to ~10 min wall clock. Runner minutes are free on a public repo, so the only cost is merge latency — against seven blocked release trains, each needing a Windows bisect after the fact, that trade is not close.

`cross-platform-test` stays a non-required check on purpose: it is skipped on docs-only PRs, and a required check that can be skipped is an unsatisfiable branch-protection gate (the TRA-255/257 problem already documented in this file).

## Tests

`tests/ci/cross-platform-filter.test.ts` — asserts the filter covers whole trees and that the mac+windows matrix is still wired to it. Verified failing by narrowing `src/**` back to a single file, then restored.

Full suite: 944 files / 10523 tests passed.

Fixes TRA-1048.
