### PR TITLE
docs(benchmarks): what share of a subscription can trace-mcp actually save

### DIFF
--- a/benchmarks/wallet-share.md
+++ b/benchmarks/wallet-share.md
@@ -1,6 +1,6 @@
 # What share of a subscription can trace-mcp actually save?
 
-Every saving figure this project publishes — 90.6% on PR-review context, 67.4%
+Every saving figure this project publishes — 70.5% on PR-review context, 67.4%
 on mixed workloads — is a share of **tool output**. A subscription is billed on
 the **whole prompt**, re-sent on every request. Those are not the same
 denominator, and the ratio between them decides whether "cut your tool output by
@@ -82,8 +82,9 @@ is the load-bearing part of this file.
 
 1. **No subscription-multiplier claim.** 40–50% "off your plan" has the same
    provenance problem as the 40–50% we retired in #915: nobody measured it.
-2. **The task-level numbers stay.** 90.6% on PR-review context is measured,
-   external and reproducible. It answers "how much context does this step cost",
+2. **The task-level numbers stay.** 70.5% on PR-review context is measured,
+   external and reproducible, and it comes with comprehension parity on the same
+   60 PRs (TRA-1090: 65.0% naive vs 66.7% trace). It answers "how much context does this step cost",
    which is a real question — just not the wallet question.
 3. **The biggest lever is our own surface, not our responses.** At 66.7% fixed
    and 1.6% ours, a kilotoken removed from the tool list outweighs a kilotoken

--- a/benchmarks/wallet-share.md
+++ b/benchmarks/wallet-share.md
@@ -1,0 +1,101 @@
+# What share of a subscription can trace-mcp actually save?
+
+Every saving figure this project publishes — 90.6% on PR-review context, 67.4%
+on mixed workloads — is a share of **tool output**. A subscription is billed on
+the **whole prompt**, re-sent on every request. Those are not the same
+denominator, and the ratio between them decides whether "cut your tool output by
+two thirds" means "double your plan" or "buy back one task in eight".
+
+This file measures that ratio on real transcripts, and then checks it against a
+controlled experiment that never touches transcripts at all.
+
+Measured 2026-09-07, corpus 2026-05-28…2026-09-06, macOS, Claude Code, Sonnet
+list prices with the 1-hour cache TTL the corpus actually uses.
+Reproduce: `node scripts/bench-wallet-share.mjs ~/.claude/projects`.
+
+## Answer
+
+**Roughly 10–12%, and the ceiling is structural.** Two thirds of what a session
+bills is the fixed prompt surface — system prompt, tool definitions, injected
+skill and tool listings — re-billed on every request. Tool output of every kind,
+ours and native, is about 15% of billed input. Compressing 15% by two thirds
+cannot produce a 2x plan no matter how good the compression gets.
+
+Do not write "double your subscription limits". The honest wallet sentence is
+"about 12% cheaper per task"; the honest headline stays the task-level one.
+
+## Method
+
+2,907 sessions, 120,969 API requests, $10,371 of billed input and $1,027 of
+output at list price. For each request the real billed input is split across the
+classes present in its context, in proportion to token mass; the part the prompt
+bills beyond the reconstructed message mass is the fixed surface. That residual
+is an upper bound — it absorbs every estimation error — so the tool-output
+shares are a lower bound. Chars-per-token is calibrated per class against
+`gpt-tokenizer` o200k (3.16 for assistant text through 4.39 for thinking) on a
+15% block sample; images count 1,500.
+
+## Where the money goes
+
+| class | % of billed input | % of input + output |
+|---|---:|---:|
+| system prompt + tool definitions | 51.6% | 46.9% |
+| injected tool / skill / agent listings | 15.1% | 13.7% |
+| tool-call arguments | 7.2% | 6.6% |
+| `Bash` output | 7.1% | 6.5% |
+| `Read` output | 5.0% | 4.5% |
+| injected hook output | 2.6% | 2.3% |
+| injected files + CLAUDE.md | 2.6% | 2.3% |
+| user text | 1.9% | 1.7% |
+| other MCP servers' output | 1.7% | 1.5% |
+| **trace-mcp tool output** | **1.6%** | **1.4%** |
+| reminders, assistant text, thinking, other tools | 3.6% | 3.2% |
+| output tokens | — | 9.0% |
+
+The fixed surface is **66.7%** of billed input. Everything any tool-output
+compression can ever touch — ours, native, other servers — is **15.4%**.
+
+The first request of a session carries a median **59,040**-token prompt before
+the conversation starts (p10 28.5k, p90 80.8k). That is what gets re-billed,
+turn after turn.
+
+## Counterfactual on the same corpus
+
+Repricing every recorded trace-mcp call at its `docs/_data/response_tokens.json`
+baseline — what a `Read`/`Grep` would have cost instead — adds **$387** to a
+$10,371 bill. The tool surface that made those calls possible costs more than
+that on any preset above `minimal` (`full` is 42–45k tokens, `standard` 16.3k,
+`minimal` 8.6k, per `benchmarks/name-token-savings.md`). On this corpus, where
+trace-mcp carries 1.55% of the context, the server does not pay for its own tool
+list. That is a statement about this corpus's usage mix, not about the product —
+see the next section for the controlled version.
+
+## The controlled experiment agrees
+
+`benchmarks/crawl-detector-three-arm.md` (TRA-773) ran 99 live runs, bare agent
+vs trace-mcp, and measured end-to-end cost: **0.888x on light questions, 0.883x
+on crawls**. That is ~11–12% cheaper per task, net of our own tool list, arrived
+at without touching a transcript. Two independent methods landing at ~10–12%
+is the load-bearing part of this file.
+
+## What this changes
+
+1. **No subscription-multiplier claim.** 40–50% "off your plan" has the same
+   provenance problem as the 40–50% we retired in #915: nobody measured it.
+2. **The task-level numbers stay.** 90.6% on PR-review context is measured,
+   external and reproducible. It answers "how much context does this step cost",
+   which is a real question — just not the wallet question.
+3. **The biggest lever is our own surface, not our responses.** At 66.7% fixed
+   and 1.6% ours, a kilotoken removed from the tool list outweighs a kilotoken
+   removed from a response many times over. Tool consolidation and lean presets
+   are worth more than further response compression.
+4. **Turns, then tokens.** With a fixed per-turn surface this large, cutting the
+   number of turns a task takes beats cutting the tokens each turn returns.
+
+## What this does not answer
+
+One machine, one user, one heavy configuration (many MCP servers, plugins and
+skills — which is exactly what inflates the fixed surface). A vanilla install
+has a smaller prompt, so tool output would be a larger share there and the
+ceiling would sit higher. The direction of that bias is known; its size is not
+measured. The 0.883x arm is the number that does not depend on this corpus.

--- a/scripts/bench-wallet-share.mjs
+++ b/scripts/bench-wallet-share.mjs
@@ -22,85 +22,235 @@
 // lives in `attachment` records, not in message.content.
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-const root=process.argv[2]; const files=[];
-(function walk(d){for(const e of readdirSync(d,{withFileTypes:true})){const p=join(d,e.name); if(e.isDirectory())walk(p); else if(e.name.endsWith('.jsonl'))files.push(p);}})(root);
-const rt=JSON.parse(readFileSync('docs/_data/response_tokens.json','utf8'));
-const ratio={}; for(const r of rt.rows) ratio[r.tool]= r.measured_per_call>0 ? r.baseline_per_call/r.measured_per_call : 1;
-const CH={native_read:3.39,other_mcp:3.23,trace:3.70,other_tool:3.65,task:3.65,tool_use_args:3.27,assistant_text:3.16,thinking:4.39,user_text:4.13};
-const IMG=1500; const NATIVE=new Set(['Read','Bash','Grep','Glob','NotebookRead','LS']);
-const cls=n=>!n?'other_tool':n.startsWith('mcp__trace-mcp__')?'trace':NATIVE.has(n)?'native_read':n.startsWith('mcp__')?'other_mcp':n==='Task'?'task':'other_tool';
-const KEYS=Object.keys(CH);
-let billedIn=0,billedOut=0,reqs=0,sysTok=0,sysCost=0;
-const cost={}, callTok={}, calls={};
-for(const f of files){
-  let raw; try{raw=readFileSync(f,'utf8')}catch{continue}
-  const recs=[]; for(const l of raw.split('\n')){if(!l)continue; try{recs.push(JSON.parse(l))}catch{}}
-  const byUuid=new Map(); for(const d of recs) if(d.uuid) byUuid.set(d.uuid,d);
-  const tn=new Map(); for(const d of recs){const c=d.message?.content; if(Array.isArray(c))for(const b of c)if(b.type==='tool_use')tn.set(b.id,b.name);}
-  const own=new Map();
-  for(const d of recs){
-    const c=d.message?.content; const v={}; const blocks=Array.isArray(c)?c:typeof c==='string'?[{type:'text',text:c}]:[];
-    const put=(k,t)=>{v[k]=(v[k]||0)+t;};
-    for(const b of blocks){
-      if(b.type==='tool_result'){ const name=tn.get(b.tool_use_id); const g=cls(name);
-        const key = g==='trace' ? 'trace:'+name.replace('mcp__trace-mcp__','') : g==='native_read' ? 'native:'+name : g;
-        let t=0;
-        if(Array.isArray(b.content)){ for(const x of b.content){ if(x.type==='image') t+=IMG; else if(x.type==='text') t+=(x.text||'').length/CH[g]; } }
-        else t=String(b.content??'').length/CH[g];
-        put(key,t); if(g==='trace'){calls[key]=(calls[key]||0)+1;}
-      }
-      else if(b.type==='text'){const k=d.type==='user'?'user_text':'assistant_text'; put(k,(b.text||'').length/CH[k]);}
-      else if(b.type==='thinking') put('thinking',(b.thinking||'').length/CH.thinking);
-      else if(b.type==='tool_use') put('tool_use_args',JSON.stringify(b.input??'').length/CH.tool_use_args);
+const root = process.argv[2];
+const files = [];
+(function walk(d) {
+  for (const e of readdirSync(d, { withFileTypes: true })) {
+    const p = join(d, e.name);
+    if (e.isDirectory()) walk(p);
+    else if (e.name.endsWith('.jsonl')) files.push(p);
+  }
+})(root);
+const rt = JSON.parse(readFileSync('docs/_data/response_tokens.json', 'utf8'));
+const ratio = {};
+for (const r of rt.rows)
+  ratio[r.tool] = r.measured_per_call > 0 ? r.baseline_per_call / r.measured_per_call : 1;
+const CH = {
+  native_read: 3.39,
+  other_mcp: 3.23,
+  trace: 3.7,
+  other_tool: 3.65,
+  task: 3.65,
+  tool_use_args: 3.27,
+  assistant_text: 3.16,
+  thinking: 4.39,
+  user_text: 4.13,
+};
+const IMG = 1500;
+const NATIVE = new Set(['Read', 'Bash', 'Grep', 'Glob', 'NotebookRead', 'LS']);
+const cls = (n) =>
+  !n
+    ? 'other_tool'
+    : n.startsWith('mcp__trace-mcp__')
+      ? 'trace'
+      : NATIVE.has(n)
+        ? 'native_read'
+        : n.startsWith('mcp__')
+          ? 'other_mcp'
+          : n === 'Task'
+            ? 'task'
+            : 'other_tool';
+const KEYS = Object.keys(CH);
+let billedIn = 0,
+  billedOut = 0,
+  reqs = 0,
+  sysTok = 0,
+  sysCost = 0;
+const cost = {},
+  callTok = {},
+  calls = {};
+for (const f of files) {
+  let raw;
+  try {
+    raw = readFileSync(f, 'utf8');
+  } catch {
+    continue;
+  }
+  const recs = [];
+  for (const l of raw.split('\n')) {
+    if (!l) continue;
+    try {
+      recs.push(JSON.parse(l));
+    } catch {}
+  }
+  const byUuid = new Map();
+  for (const d of recs) if (d.uuid) byUuid.set(d.uuid, d);
+  const tn = new Map();
+  for (const d of recs) {
+    const c = d.message?.content;
+    if (Array.isArray(c)) for (const b of c) if (b.type === 'tool_use') tn.set(b.id, b.name);
+  }
+  const own = new Map();
+  for (const d of recs) {
+    const c = d.message?.content;
+    const v = {};
+    const blocks = Array.isArray(c) ? c : typeof c === 'string' ? [{ type: 'text', text: c }] : [];
+    const put = (k, t) => {
+      v[k] = (v[k] || 0) + t;
+    };
+    for (const b of blocks) {
+      if (b.type === 'tool_result') {
+        const name = tn.get(b.tool_use_id);
+        const g = cls(name);
+        const key =
+          g === 'trace'
+            ? 'trace:' + name.replace('mcp__trace-mcp__', '')
+            : g === 'native_read'
+              ? 'native:' + name
+              : g;
+        let t = 0;
+        if (Array.isArray(b.content)) {
+          for (const x of b.content) {
+            if (x.type === 'image') t += IMG;
+            else if (x.type === 'text') t += (x.text || '').length / CH[g];
+          }
+        } else t = String(b.content ?? '').length / CH[g];
+        put(key, t);
+        if (g === 'trace') {
+          calls[key] = (calls[key] || 0) + 1;
+        }
+      } else if (b.type === 'text') {
+        const k = d.type === 'user' ? 'user_text' : 'assistant_text';
+        put(k, (b.text || '').length / CH[k]);
+      } else if (b.type === 'thinking') put('thinking', (b.thinking || '').length / CH.thinking);
+      else if (b.type === 'tool_use')
+        put('tool_use_args', JSON.stringify(b.input ?? '').length / CH.tool_use_args);
     }
-    if(d.attachment){ const t=d.attachment.type||'?'; const s=JSON.stringify(d.attachment).length/3.6;
-      const g = (t==='skill_listing'||t==='deferred_tools_delta'||t==='mcp_instructions_delta'||t==='agent_listing_delta'||t==='mcp_dropped_tools_delta') ? 'inj:tool_and_skill_listings'
-        : (t==='nested_memory'||t==='file'||t==='edited_text_file'||t==='compact_file_reference') ? 'inj:files_and_memory'
-        : t.startsWith('hook') ? 'inj:hooks' : 'inj:reminders_other';
-      put(g,s); }
-    own.set(d,v);
+    if (d.attachment) {
+      const t = d.attachment.type || '?';
+      const s = JSON.stringify(d.attachment).length / 3.6;
+      const g =
+        t === 'skill_listing' ||
+        t === 'deferred_tools_delta' ||
+        t === 'mcp_instructions_delta' ||
+        t === 'agent_listing_delta' ||
+        t === 'mcp_dropped_tools_delta'
+          ? 'inj:tool_and_skill_listings'
+          : t === 'nested_memory' ||
+              t === 'file' ||
+              t === 'edited_text_file' ||
+              t === 'compact_file_reference'
+            ? 'inj:files_and_memory'
+            : t.startsWith('hook')
+              ? 'inj:hooks'
+              : 'inj:reminders_other';
+      put(g, s);
+    }
+    own.set(d, v);
   }
-  const cum=new Map();
-  const cumOf=(d,depth=0)=>{ if(!d||depth>10000) return {};
-    if(cum.has(d))return cum.get(d); const p=cumOf(byUuid.get(d.parentUuid),depth+1); const o=own.get(d)||{};
-    const v={...p}; for(const k in o) v[k]=(v[k]||0)+o[k]; cum.set(d,v); return v; };
-  const seen=new Set();
-  for(const d of recs){
-    if(d.type!=='assistant'||!d.requestId||seen.has(d.requestId))continue;
-    const u=d.message?.usage; if(!u||typeof u.cache_read_input_tokens!=='number')continue;
-    seen.add(d.requestId); reqs++;
-    const prefix=(u.input_tokens||0)+(u.cache_creation_input_tokens||0)+(u.cache_read_input_tokens||0);
-    const c$=((u.input_tokens||0)+2*(u.cache_creation_input_tokens||0)+0.1*(u.cache_read_input_tokens||0))*3/1e6;
-    billedIn+=c$; billedOut+=(u.output_tokens||0)*15/1e6;
-    const c=cumOf(byUuid.get(d.parentUuid)); let msg=0; for(const k in c) msg+=c[k];
-    const sys=Math.max(0,prefix-msg); const tot=msg+sys; if(tot<=0)continue;
-    for(const k in c){ cost[k]=(cost[k]||0)+c$*c[k]/tot; callTok[k]=(callTok[k]||0)+c[k]; }
-    sysCost+=c$*sys/tot; sysTok+=sys;
+  const cum = new Map();
+  const cumOf = (d, depth = 0) => {
+    if (!d || depth > 10000) return {};
+    if (cum.has(d)) return cum.get(d);
+    const p = cumOf(byUuid.get(d.parentUuid), depth + 1);
+    const o = own.get(d) || {};
+    const v = { ...p };
+    for (const k in o) v[k] = (v[k] || 0) + o[k];
+    cum.set(d, v);
+    return v;
+  };
+  const seen = new Set();
+  for (const d of recs) {
+    if (d.type !== 'assistant' || !d.requestId || seen.has(d.requestId)) continue;
+    const u = d.message?.usage;
+    if (!u || typeof u.cache_read_input_tokens !== 'number') continue;
+    seen.add(d.requestId);
+    reqs++;
+    const prefix =
+      (u.input_tokens || 0) +
+      (u.cache_creation_input_tokens || 0) +
+      (u.cache_read_input_tokens || 0);
+    const c$ =
+      (((u.input_tokens || 0) +
+        2 * (u.cache_creation_input_tokens || 0) +
+        0.1 * (u.cache_read_input_tokens || 0)) *
+        3) /
+      1e6;
+    billedIn += c$;
+    billedOut += ((u.output_tokens || 0) * 15) / 1e6;
+    const c = cumOf(byUuid.get(d.parentUuid));
+    let msg = 0;
+    for (const k in c) msg += c[k];
+    const sys = Math.max(0, prefix - msg);
+    const tot = msg + sys;
+    if (tot <= 0) continue;
+    for (const k in c) {
+      cost[k] = (cost[k] || 0) + (c$ * c[k]) / tot;
+      callTok[k] = (callTok[k] || 0) + c[k];
+    }
+    sysCost += (c$ * sys) / tot;
+    sysTok += sys;
   }
 }
-const traceCost=Object.entries(cost).filter(([k])=>k.startsWith('trace:')).reduce((a,[,v])=>a+v,0);
-const total=Object.values(cost).reduce((a,b)=>a+b,0)+sysCost;
+const traceCost = Object.entries(cost)
+  .filter(([k]) => k.startsWith('trace:'))
+  .reduce((a, [, v]) => a + v, 0);
+const total = Object.values(cost).reduce((a, b) => a + b, 0) + sysCost;
 console.log(`requests ${reqs} billedInput $${billedIn.toFixed(0)} output $${billedOut.toFixed(0)}`);
-console.log(`avg system+tooldefs prefix per request: ${(sysTok/reqs).toFixed(0)} tokens, cost $${sysCost.toFixed(0)} (${(sysCost/total*100).toFixed(1)}% of input)`);
-console.log(`trace tool results: cost $${traceCost.toFixed(2)} (${(traceCost/total*100).toFixed(2)}% of input)`);
-const grouped={};
-for(const [k,v] of Object.entries(cost)) grouped[k.startsWith('trace:')?'trace_mcp_results':k]=(grouped[k.startsWith('trace:')?'trace_mcp_results':k]||0)+v;
-grouped['system_prompt_and_tool_defs']=sysCost;
+console.log(
+  `avg system+tooldefs prefix per request: ${(sysTok / reqs).toFixed(0)} tokens, cost $${sysCost.toFixed(0)} (${((sysCost / total) * 100).toFixed(1)}% of input)`,
+);
+console.log(
+  `trace tool results: cost $${traceCost.toFixed(2)} (${((traceCost / total) * 100).toFixed(2)}% of input)`,
+);
+const grouped = {};
+for (const [k, v] of Object.entries(cost))
+  grouped[k.startsWith('trace:') ? 'trace_mcp_results' : k] =
+    (grouped[k.startsWith('trace:') ? 'trace_mcp_results' : k] || 0) + v;
+grouped['system_prompt_and_tool_defs'] = sysCost;
 console.log('\nclass                            cost$   %input  %in+out');
-for(const [k,v] of Object.entries(grouped).sort((a,b)=>b[1]-a[1]))
-  console.log(' ',k.padEnd(30), v.toFixed(0).padStart(6), ((v/total)*100).toFixed(1).padStart(6)+'%', ((v/(total+billedOut))*100).toFixed(1).padStart(7)+'%');
-console.log(' ','output'.padEnd(30), billedOut.toFixed(0).padStart(6),'      -',((billedOut/(total+billedOut))*100).toFixed(1).padStart(7)+'%');
+for (const [k, v] of Object.entries(grouped).sort((a, b) => b[1] - a[1]))
+  console.log(
+    ' ',
+    k.padEnd(30),
+    v.toFixed(0).padStart(6),
+    ((v / total) * 100).toFixed(1).padStart(6) + '%',
+    ((v / (total + billedOut)) * 100).toFixed(1).padStart(7) + '%',
+  );
+console.log(
+  ' ',
+  'output'.padEnd(30),
+  billedOut.toFixed(0).padStart(6),
+  '      -',
+  ((billedOut / (total + billedOut)) * 100).toFixed(1).padStart(7) + '%',
+);
 console.log('\nper trace tool: calls, attributed $, baseline/measured ratio');
-let cfExtra=0, unknown=0;
-for(const [k,v] of Object.entries(cost).filter(([k])=>k.startsWith('trace:')).sort((a,b)=>b[1]-a[1])){
-  const t=k.slice(6); const r=ratio[t]; if(r===undefined) unknown+=v;
-  const rr=r??1; cfExtra+=v*(rr-1);
-  console.log('  ',t.padEnd(28), String(calls[k]||0).padStart(5), v.toFixed(2).padStart(7), (r!==undefined?rr.toFixed(2):'n/a').padStart(6));
+let cfExtra = 0,
+  unknown = 0;
+for (const [k, v] of Object.entries(cost)
+  .filter(([k]) => k.startsWith('trace:'))
+  .sort((a, b) => b[1] - a[1])) {
+  const t = k.slice(6);
+  const r = ratio[t];
+  if (r === undefined) unknown += v;
+  const rr = r ?? 1;
+  cfExtra += v * (rr - 1);
+  console.log(
+    '  ',
+    t.padEnd(28),
+    String(calls[k] || 0).padStart(5),
+    v.toFixed(2).padStart(7),
+    (r !== undefined ? rr.toFixed(2) : 'n/a').padStart(6),
+  );
 }
-console.log(`\ncounterfactual extra if those calls were file reads instead: +$${cfExtra.toFixed(0)} (unpriced tools $${unknown.toFixed(2)})`);
-for(const DEF of [45000,25000,12000]){
-  const share=Math.min(1,DEF/(sysTok/reqs));
-  const defCost=sysCost*share;
-  const without=total - traceCost - defCost + traceCost + cfExtra;
-  console.log(`tool-defs ${DEF} tok -> defs cost $${defCost.toFixed(0)}; without trace-mcp input would be $${without.toFixed(0)} vs $${total.toFixed(0)}  => saving ${(100*(without-total)/without).toFixed(1)}% of input, ${(100*(without-total)/(without+billedOut)).toFixed(1)}% of input+output`);
+console.log(
+  `\ncounterfactual extra if those calls were file reads instead: +$${cfExtra.toFixed(0)} (unpriced tools $${unknown.toFixed(2)})`,
+);
+for (const DEF of [45000, 25000, 12000]) {
+  const share = Math.min(1, DEF / (sysTok / reqs));
+  const defCost = sysCost * share;
+  const without = total - traceCost - defCost + traceCost + cfExtra;
+  console.log(
+    `tool-defs ${DEF} tok -> defs cost $${defCost.toFixed(0)}; without trace-mcp input would be $${without.toFixed(0)} vs $${total.toFixed(0)}  => saving ${((100 * (without - total)) / without).toFixed(1)}% of input, ${((100 * (without - total)) / (without + billedOut)).toFixed(1)}% of input+output`,
+  );
 }

--- a/scripts/bench-wallet-share.mjs
+++ b/scripts/bench-wallet-share.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// Where does the money in a Claude Code session actually go? (TRA-wallet-share)
+//
+//   node scripts/bench-wallet-share.mjs ~/.claude/projects
+//
+// Every published trace-mcp saving is a share of TOOL OUTPUT. A subscription is
+// billed on the whole prompt, re-sent on every request. This script measures the
+// gap between those two things on real transcripts, so no one has to guess it.
+//
+// Method: for each API request take its REAL billed input
+// (input + 2x cache_creation + 0.1x cache_read, the $3/M Sonnet mix) and split it
+// across the classes actually present in that request's context, in proportion to
+// their token mass. Message mass is estimated from characters with a per-class
+// chars/token ratio calibrated against gpt-tokenizer o200k on a 15% sample.
+// Whatever the prompt bills beyond the message mass is the fixed surface: system
+// prompt plus tool definitions. That residual is an UPPER bound (it absorbs every
+// estimation error), so the tool-output shares below are a LOWER bound.
+//
+// Two things are easy to get wrong, both inflate the residual by an order of
+// magnitude: one API request is logged as several records (dedupe by requestId),
+// and injected context (skill listings, tool-list deltas, CLAUDE.md, hook output)
+// lives in `attachment` records, not in message.content.
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+const root=process.argv[2]; const files=[];
+(function walk(d){for(const e of readdirSync(d,{withFileTypes:true})){const p=join(d,e.name); if(e.isDirectory())walk(p); else if(e.name.endsWith('.jsonl'))files.push(p);}})(root);
+const rt=JSON.parse(readFileSync('docs/_data/response_tokens.json','utf8'));
+const ratio={}; for(const r of rt.rows) ratio[r.tool]= r.measured_per_call>0 ? r.baseline_per_call/r.measured_per_call : 1;
+const CH={native_read:3.39,other_mcp:3.23,trace:3.70,other_tool:3.65,task:3.65,tool_use_args:3.27,assistant_text:3.16,thinking:4.39,user_text:4.13};
+const IMG=1500; const NATIVE=new Set(['Read','Bash','Grep','Glob','NotebookRead','LS']);
+const cls=n=>!n?'other_tool':n.startsWith('mcp__trace-mcp__')?'trace':NATIVE.has(n)?'native_read':n.startsWith('mcp__')?'other_mcp':n==='Task'?'task':'other_tool';
+const KEYS=Object.keys(CH);
+let billedIn=0,billedOut=0,reqs=0,sysTok=0,sysCost=0;
+const cost={}, callTok={}, calls={};
+for(const f of files){
+  let raw; try{raw=readFileSync(f,'utf8')}catch{continue}
+  const recs=[]; for(const l of raw.split('\n')){if(!l)continue; try{recs.push(JSON.parse(l))}catch{}}
+  const byUuid=new Map(); for(const d of recs) if(d.uuid) byUuid.set(d.uuid,d);
+  const tn=new Map(); for(const d of recs){const c=d.message?.content; if(Array.isArray(c))for(const b of c)if(b.type==='tool_use')tn.set(b.id,b.name);}
+  const own=new Map();
+  for(const d of recs){
+    const c=d.message?.content; const v={}; const blocks=Array.isArray(c)?c:typeof c==='string'?[{type:'text',text:c}]:[];
+    const put=(k,t)=>{v[k]=(v[k]||0)+t;};
+    for(const b of blocks){
+      if(b.type==='tool_result'){ const name=tn.get(b.tool_use_id); const g=cls(name);
+        const key = g==='trace' ? 'trace:'+name.replace('mcp__trace-mcp__','') : g==='native_read' ? 'native:'+name : g;
+        let t=0;
+        if(Array.isArray(b.content)){ for(const x of b.content){ if(x.type==='image') t+=IMG; else if(x.type==='text') t+=(x.text||'').length/CH[g]; } }
+        else t=String(b.content??'').length/CH[g];
+        put(key,t); if(g==='trace'){calls[key]=(calls[key]||0)+1;}
+      }
+      else if(b.type==='text'){const k=d.type==='user'?'user_text':'assistant_text'; put(k,(b.text||'').length/CH[k]);}
+      else if(b.type==='thinking') put('thinking',(b.thinking||'').length/CH.thinking);
+      else if(b.type==='tool_use') put('tool_use_args',JSON.stringify(b.input??'').length/CH.tool_use_args);
+    }
+    if(d.attachment){ const t=d.attachment.type||'?'; const s=JSON.stringify(d.attachment).length/3.6;
+      const g = (t==='skill_listing'||t==='deferred_tools_delta'||t==='mcp_instructions_delta'||t==='agent_listing_delta'||t==='mcp_dropped_tools_delta') ? 'inj:tool_and_skill_listings'
+        : (t==='nested_memory'||t==='file'||t==='edited_text_file'||t==='compact_file_reference') ? 'inj:files_and_memory'
+        : t.startsWith('hook') ? 'inj:hooks' : 'inj:reminders_other';
+      put(g,s); }
+    own.set(d,v);
+  }
+  const cum=new Map();
+  const cumOf=(d,depth=0)=>{ if(!d||depth>10000) return {};
+    if(cum.has(d))return cum.get(d); const p=cumOf(byUuid.get(d.parentUuid),depth+1); const o=own.get(d)||{};
+    const v={...p}; for(const k in o) v[k]=(v[k]||0)+o[k]; cum.set(d,v); return v; };
+  const seen=new Set();
+  for(const d of recs){
+    if(d.type!=='assistant'||!d.requestId||seen.has(d.requestId))continue;
+    const u=d.message?.usage; if(!u||typeof u.cache_read_input_tokens!=='number')continue;
+    seen.add(d.requestId); reqs++;
+    const prefix=(u.input_tokens||0)+(u.cache_creation_input_tokens||0)+(u.cache_read_input_tokens||0);
+    const c$=((u.input_tokens||0)+2*(u.cache_creation_input_tokens||0)+0.1*(u.cache_read_input_tokens||0))*3/1e6;
+    billedIn+=c$; billedOut+=(u.output_tokens||0)*15/1e6;
+    const c=cumOf(byUuid.get(d.parentUuid)); let msg=0; for(const k in c) msg+=c[k];
+    const sys=Math.max(0,prefix-msg); const tot=msg+sys; if(tot<=0)continue;
+    for(const k in c){ cost[k]=(cost[k]||0)+c$*c[k]/tot; callTok[k]=(callTok[k]||0)+c[k]; }
+    sysCost+=c$*sys/tot; sysTok+=sys;
+  }
+}
+const traceCost=Object.entries(cost).filter(([k])=>k.startsWith('trace:')).reduce((a,[,v])=>a+v,0);
+const total=Object.values(cost).reduce((a,b)=>a+b,0)+sysCost;
+console.log(`requests ${reqs} billedInput $${billedIn.toFixed(0)} output $${billedOut.toFixed(0)}`);
+console.log(`avg system+tooldefs prefix per request: ${(sysTok/reqs).toFixed(0)} tokens, cost $${sysCost.toFixed(0)} (${(sysCost/total*100).toFixed(1)}% of input)`);
+console.log(`trace tool results: cost $${traceCost.toFixed(2)} (${(traceCost/total*100).toFixed(2)}% of input)`);
+const grouped={};
+for(const [k,v] of Object.entries(cost)) grouped[k.startsWith('trace:')?'trace_mcp_results':k]=(grouped[k.startsWith('trace:')?'trace_mcp_results':k]||0)+v;
+grouped['system_prompt_and_tool_defs']=sysCost;
+console.log('\nclass                            cost$   %input  %in+out');
+for(const [k,v] of Object.entries(grouped).sort((a,b)=>b[1]-a[1]))
+  console.log(' ',k.padEnd(30), v.toFixed(0).padStart(6), ((v/total)*100).toFixed(1).padStart(6)+'%', ((v/(total+billedOut))*100).toFixed(1).padStart(7)+'%');
+console.log(' ','output'.padEnd(30), billedOut.toFixed(0).padStart(6),'      -',((billedOut/(total+billedOut))*100).toFixed(1).padStart(7)+'%');
+console.log('\nper trace tool: calls, attributed $, baseline/measured ratio');
+let cfExtra=0, unknown=0;
+for(const [k,v] of Object.entries(cost).filter(([k])=>k.startsWith('trace:')).sort((a,b)=>b[1]-a[1])){
+  const t=k.slice(6); const r=ratio[t]; if(r===undefined) unknown+=v;
+  const rr=r??1; cfExtra+=v*(rr-1);
+  console.log('  ',t.padEnd(28), String(calls[k]||0).padStart(5), v.toFixed(2).padStart(7), (r!==undefined?rr.toFixed(2):'n/a').padStart(6));
+}
+console.log(`\ncounterfactual extra if those calls were file reads instead: +$${cfExtra.toFixed(0)} (unpriced tools $${unknown.toFixed(2)})`);
+for(const DEF of [45000,25000,12000]){
+  const share=Math.min(1,DEF/(sysTok/reqs));
+  const defCost=sysCost*share;
+  const without=total - traceCost - defCost + traceCost + cfExtra;
+  console.log(`tool-defs ${DEF} tok -> defs cost $${defCost.toFixed(0)}; without trace-mcp input would be $${without.toFixed(0)} vs $${total.toFixed(0)}  => saving ${(100*(without-total)/without).toFixed(1)}% of input, ${(100*(without-total)/(without+billedOut)).toFixed(1)}% of input+output`);
+}


### PR DESCRIPTION
Nikolai asked whether the headline should be a wallet claim ("double your subscription limits") instead of the task-level 90.6%. It cannot be, and this measures why.

**Method.** For each of 120,969 API requests across 2,907 real sessions, split the *real* billed input (input + 2x cache_creation + 0.1x cache_read) across the classes present in that request's context. Message mass is chars with a per-class chars/token ratio calibrated against gpt-tokenizer o200k; the residual over message mass is the fixed surface, and it is an upper bound, so the tool-output shares are a lower bound.

**Result.** Fixed prompt surface (system prompt + tool definitions + injected listings) is 66.7% of billed input. All tool output of every origin is 15.4%. trace-mcp's own output is 1.6%. Compressing 15% by two thirds cannot double a plan.

**Cross-check.** TRA-773's live 99-run A/B measured 0.888x / 0.883x end-to-end — ~11-12% cheaper per task, arrived at without touching a transcript. Two independent methods at ~10-12%.

Docs-only: adds `benchmarks/wallet-share.md` and the script that reproduces it. No code, no tool-contract change.