### PR TITLE
fix(quality): reject stale spans in get_changed_symbols/compare_branches

### DIFF
--- a/scripts/bench-pr-context.ts
+++ b/scripts/bench-pr-context.ts
@@ -388,7 +388,7 @@ async function runOne(entry: PrEntry): Promise<PrResult | null> {
   const indexMs = Date.now() - t0;
 
   try {
-    const changed = getChangedSymbols(store, dir, {
+    const changed = await getChangedSymbols(store, dir, {
       since: entry.base_sha,
       until: head,
     });

--- a/src/tools/quality/changed-symbols.ts
+++ b/src/tools/quality/changed-symbols.ts
@@ -7,6 +7,7 @@
 import { execFileSync } from 'node:child_process';
 import type { Store } from '../../db/store.js';
 import { err, ok, type TraceMcpResult } from '../../errors.js';
+import { contentHash, initContentHasher } from '../../util/hash.js';
 import { findUnsafeRef, isSafeGitRef, safeGitEnv } from '../../utils/git-env.js';
 
 type ChangeKind = 'added' | 'modified' | 'removed' | 'renamed';
@@ -28,6 +29,13 @@ interface ChangedSymbolsResult {
   changedFiles: number;
   changedSymbols: ChangedSymbolEntry[];
   summary: { added: number; modified: number; removed: number; renamed: number };
+  /**
+   * Files whose indexed content_hash no longer matches the git blob at the
+   * ref we joined against — the index was built on a different tree, so
+   * their symbols were excluded rather than joined against stale spans.
+   * Reindex these files and retry for full coverage.
+   */
+  staleFiles: string[];
 }
 
 interface ChangedSymbolsOptions {
@@ -158,14 +166,54 @@ function detectBaseBranch(
 }
 
 /**
+ * Fetch a file's raw bytes as they existed in a specific git tree. Returns
+ * null if the ref/path pair doesn't resolve (e.g. the path never existed at
+ * that ref).
+ */
+function getBlobBytes(rootPath: string, ref: string, filePath: string): Buffer | null {
+  try {
+    return execFileSync('git', ['show', `${ref}:${filePath}`], {
+      cwd: rootPath,
+      maxBuffer: 20 * 1024 * 1024,
+      timeout: 15_000,
+      env: safeGitEnv(),
+      stdio: 'pipe',
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when the indexed row's content_hash still matches the blob at `ref`.
+ * This is the guard against joining diff hunks onto spans from a stale
+ * index: without it, an edit that shifts line numbers (e.g. inserting lines
+ * above a function) silently resolves to whatever symbol used to occupy
+ * that span. A row with no recorded content_hash (legacy index, predates
+ * the hashing column) can't be verified either way — treated as fresh so
+ * old indexes don't regress into blanket staleness.
+ */
+function isFileFresh(
+  rootPath: string,
+  ref: string,
+  filePath: string,
+  storedHash: string | null,
+): boolean {
+  if (!storedHash) return true;
+  const blob = getBlobBytes(rootPath, ref, filePath);
+  if (!blob) return false;
+  return contentHash(blob) === storedHash;
+}
+
+/**
  * Parse git diff to find changed symbols.
  * Single git diff call → parse hunks → batch SQL per file.
  */
-export function getChangedSymbols(
+export async function getChangedSymbols(
   store: Store,
   rootPath: string,
   opts: ChangedSymbolsOptions,
-): TraceMcpResult<ChangedSymbolsResult> {
+): Promise<TraceMcpResult<ChangedSymbolsResult>> {
   const until = opts.until ?? 'HEAD';
 
   // Reject hostile ref strings before they hit any subprocess. The previous
@@ -221,6 +269,7 @@ export function getChangedSymbols(
       changedFiles: 0,
       changedSymbols: [],
       summary: { added: 0, modified: 0, removed: 0, renamed: 0 },
+      staleFiles: [],
     });
   }
 
@@ -272,6 +321,7 @@ export function getChangedSymbols(
   // Map hunks to symbols — batch per file (no N+1)
   const changedSymbols: ChangedSymbolEntry[] = [];
   const seenSymbols = new Set<string>();
+  const staleFiles = new Set<string>();
 
   // Group hunks by file
   const hunksByFile = new Map<string, DiffHunk[]>();
@@ -281,10 +331,17 @@ export function getChangedSymbols(
     hunksByFile.set(hunk.file, arr);
   }
 
+  await initContentHasher();
+
   // Process each file — single SQL per file for symbols in range
   for (const [filePath, fileHunks] of hunksByFile) {
     const file = store.getFile(filePath);
     if (!file) continue;
+
+    if (!isFileFresh(rootPath, until, filePath, file.content_hash)) {
+      staleFiles.add(filePath);
+      continue;
+    }
 
     // Batch-fetch all symbols for this file
     const symbols = store.getSymbolsByFile(file.id);
@@ -321,6 +378,13 @@ export function getChangedSymbols(
     if (status === 'A' || status === 'D') {
       const file = store.getFile(filePath);
       if (!file) continue;
+      // Added files must match the blob at `until`; deleted files no longer
+      // exist there, so verify against the tree they were last seen in.
+      const ref = status === 'A' ? until : since;
+      if (!isFileFresh(rootPath, ref, filePath, file.content_hash)) {
+        staleFiles.add(filePath);
+        continue;
+      }
       const symbols = store.getSymbolsByFile(file.id);
       const changeKind = status === 'A' ? 'added' : 'removed';
       for (const sym of symbols) {
@@ -365,6 +429,7 @@ export function getChangedSymbols(
     changedFiles: fileStatuses.size,
     changedSymbols,
     summary,
+    staleFiles: [...staleFiles],
   });
 }
 
@@ -405,11 +470,11 @@ interface BranchComparisonResult extends ChangedSymbolsResult {
  * Compare two branches at the symbol level.
  * Resolves merge-base automatically, then delegates to getChangedSymbols.
  */
-export function compareBranches(
+export async function compareBranches(
   store: Store,
   rootPath: string,
   opts: BranchComparisonOptions,
-): TraceMcpResult<BranchComparisonResult> {
+): Promise<TraceMcpResult<BranchComparisonResult>> {
   const branch = opts.branch;
 
   const unsafe = findUnsafeRef({
@@ -466,7 +531,7 @@ export function compareBranches(
   }
 
   // Delegate to getChangedSymbols
-  const result = getChangedSymbols(store, rootPath, {
+  const result = await getChangedSymbols(store, rootPath, {
     since: mergeBase,
     until: branch,
     includeBlastRadius: opts.includeBlastRadius ?? true,

--- a/src/tools/register/quality.ts
+++ b/src/tools/register/quality.ts
@@ -144,7 +144,7 @@ export function registerQualityTools(server: McpServer, ctx: ServerContext): voi
       output_format: OutputFormatSchema,
     },
     async ({ since, until, include_blast_radius, max_blast_depth, output_format }) => {
-      const result = getChangedSymbols(store, projectRoot, {
+      const result = await getChangedSymbols(store, projectRoot, {
         since,
         until,
         includeBlastRadius: include_blast_radius,
@@ -187,7 +187,7 @@ export function registerQualityTools(server: McpServer, ctx: ServerContext): voi
         ),
     },
     async ({ branch, base, include_blast_radius, max_blast_depth, group_by }) => {
-      const result = compareBranches(store, projectRoot, {
+      const result = await compareBranches(store, projectRoot, {
         branch,
         base,
         includeBlastRadius: include_blast_radius,

--- a/tests/tools/behavioural/compare-branches.behavioural.test.ts
+++ b/tests/tools/behavioural/compare-branches.behavioural.test.ts
@@ -9,9 +9,10 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Store } from '../../../src/db/store.js';
 import { compareBranches } from '../../../src/tools/quality/changed-symbols.js';
+import { contentHash, initContentHasher } from '../../../src/util/hash.js';
 import { createTestStore } from '../../test-utils.js';
 
 vi.mock('node:child_process', () => ({
@@ -25,6 +26,8 @@ interface GitMock {
   commitCount?: string;
   nameStatus?: string;
   unified?: string;
+  /** Blob content returned for `git show <ref>:<path>`, keyed by path. */
+  show?: Record<string, string>;
 }
 
 function mockGit(g: GitMock): void {
@@ -32,14 +35,36 @@ function mockGit(g: GitMock): void {
     const a = (args ?? []) as string[];
     if (a[0] === 'merge-base') return g.mergeBase ?? 'mb-sha';
     if (a[0] === 'rev-list') return g.commitCount ?? '3';
+    if (a[0] === 'show') {
+      const spec = a[1] ?? '';
+      const path = spec.slice(spec.indexOf(':') + 1);
+      if (!g.show || !(path in g.show)) throw new Error(`no blob mocked for "${spec}"`);
+      return Buffer.from(g.show[path]);
+    }
     if (a[0] === 'diff' && a.includes('--name-status')) return g.nameStatus ?? '';
     if (a[0] === 'diff' && a.includes('--unified=0')) return g.unified ?? '';
     return '';
   }) as never);
 }
 
+// Real file contents, hashed for real, so the freshness check sees a match.
+const PAYMENTS_CONTENT = 'export function charge() {}\nexport function refund() {}\n';
+const EMAIL_CONTENT = 'export function sendEmail() {}\n';
+const API_CONTENT = 'export function route() {}\n';
+
+let PAYMENTS_HASH: string;
+let EMAIL_HASH: string;
+let API_HASH: string;
+
+beforeAll(async () => {
+  await initContentHasher();
+  PAYMENTS_HASH = contentHash(Buffer.from(PAYMENTS_CONTENT));
+  EMAIL_HASH = contentHash(Buffer.from(EMAIL_CONTENT));
+  API_HASH = contentHash(Buffer.from(API_CONTENT));
+});
+
 function seedStore(store: Store): void {
-  const f1 = store.insertFile('src/payments.ts', 'typescript', 'h-pay', 600);
+  const f1 = store.insertFile('src/payments.ts', 'typescript', PAYMENTS_HASH, 600);
   store.insertSymbol(f1, {
     symbolId: 'src/payments.ts::charge#function',
     name: 'charge',
@@ -61,7 +86,7 @@ function seedStore(store: Store): void {
     signature: 'function refund()',
   });
 
-  const f2 = store.insertFile('src/email.ts', 'typescript', 'h-em', 200);
+  const f2 = store.insertFile('src/email.ts', 'typescript', EMAIL_HASH, 200);
   store.insertSymbol(f2, {
     symbolId: 'src/email.ts::sendEmail#function',
     name: 'sendEmail',
@@ -74,7 +99,7 @@ function seedStore(store: Store): void {
   });
 
   // Added (whole-file-added) src/api.ts — touched by diff name-status A
-  const f3 = store.insertFile('src/api.ts', 'typescript', 'h-api', 100);
+  const f3 = store.insertFile('src/api.ts', 'typescript', API_HASH, 100);
   store.insertSymbol(f3, {
     symbolId: 'src/api.ts::route#function',
     name: 'route',
@@ -95,6 +120,11 @@ const ADDS_AND_MODS_DIFF = {
     '+++ b/src/payments.ts\n@@ -5,3 +5,5 @@\n' +
     '+++ b/src/payments.ts\n@@ -20,3 +20,5 @@\n' +
     '+++ b/src/email.ts\n@@ -1,3 +1,5 @@\n',
+  show: {
+    'src/payments.ts': PAYMENTS_CONTENT,
+    'src/email.ts': EMAIL_CONTENT,
+    'src/api.ts': API_CONTENT,
+  },
 };
 
 describe('compareBranches() — behavioural contract', () => {
@@ -106,10 +136,10 @@ describe('compareBranches() — behavioural contract', () => {
     seedStore(store);
   });
 
-  it('returns { branch, base, mergeBase, commitCount, changedSymbols, summary }', () => {
+  it('returns { branch, base, mergeBase, commitCount, changedSymbols, summary }', async () => {
     mockGit(ADDS_AND_MODS_DIFF);
 
-    const result = compareBranches(store, '/proj', { branch: 'feat-x', base: 'main' });
+    const result = await compareBranches(store, '/proj', { branch: 'feat-x', base: 'main' });
     expect(result.isOk()).toBe(true);
     if (result.isErr()) return;
 
@@ -124,12 +154,13 @@ describe('compareBranches() — behavioural contract', () => {
       removed: expect.any(Number),
       renamed: expect.any(Number),
     });
+    expect(result.value.staleFiles).toEqual([]);
   });
 
-  it('group_by="category" buckets symbols by changeKind', () => {
+  it('group_by="category" buckets symbols by changeKind', async () => {
     mockGit(ADDS_AND_MODS_DIFF);
 
-    const result = compareBranches(store, '/proj', {
+    const result = await compareBranches(store, '/proj', {
       branch: 'feat-x',
       base: 'main',
       groupBy: 'category',
@@ -146,10 +177,10 @@ describe('compareBranches() — behavioural contract', () => {
     expect(keys.length).toBeGreaterThan(0);
   });
 
-  it('group_by="file" buckets symbols by their source file', () => {
+  it('group_by="file" buckets symbols by their source file', async () => {
     mockGit(ADDS_AND_MODS_DIFF);
 
-    const result = compareBranches(store, '/proj', {
+    const result = await compareBranches(store, '/proj', {
       branch: 'feat-x',
       base: 'main',
       groupBy: 'file',
@@ -164,10 +195,10 @@ describe('compareBranches() — behavioural contract', () => {
     }
   });
 
-  it('group_by="risk" produces low/medium/high buckets keyed by blastRadius', () => {
+  it('group_by="risk" produces low/medium/high buckets keyed by blastRadius', async () => {
     mockGit(ADDS_AND_MODS_DIFF);
 
-    const result = compareBranches(store, '/proj', {
+    const result = await compareBranches(store, '/proj', {
       branch: 'feat-x',
       base: 'main',
       groupBy: 'risk',
@@ -181,10 +212,10 @@ describe('compareBranches() — behavioural contract', () => {
     }
   });
 
-  it('includeBlastRadius=true + maxBlastDepth is propagated to per-symbol blastRadius', () => {
+  it('includeBlastRadius=true + maxBlastDepth is propagated to per-symbol blastRadius', async () => {
     mockGit(ADDS_AND_MODS_DIFF);
 
-    const result = compareBranches(store, '/proj', {
+    const result = await compareBranches(store, '/proj', {
       branch: 'feat-x',
       base: 'main',
       includeBlastRadius: true,
@@ -198,5 +229,32 @@ describe('compareBranches() — behavioural contract', () => {
       expect(typeof s.blastRadius).toBe('number');
     }
     expect(Array.isArray(result.value.riskAssessment)).toBe(true);
+  });
+
+  // --- Freshness gate (TRA-1075) ---
+  // compareBranches accepts an arbitrary `branch` argument and joins the diff
+  // against whatever the index happened to hold at last reindex — the branch
+  // never has to have been checked out. The content_hash gate is what makes
+  // that safe: a divergent file is excluded and reported, not silently joined.
+
+  it('excludes stale files from the diff and reports them in staleFiles, without failing the whole comparison', async () => {
+    mockGit({
+      ...ADDS_AND_MODS_DIFF,
+      show: {
+        ...ADDS_AND_MODS_DIFF.show,
+        // src/payments.ts drifted from what the index recorded — e.g. the
+        // index was built against a different checkout of `feat-x`.
+        'src/payments.ts': 'export function charge(extra) {}\n',
+      },
+    });
+
+    const result = await compareBranches(store, '/proj', { branch: 'feat-x', base: 'main' });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) return;
+
+    expect(result.value.staleFiles).toEqual(['src/payments.ts']);
+    expect(result.value.changedSymbols.some((s) => s.file === 'src/payments.ts')).toBe(false);
+    // The rest of the comparison still resolves normally.
+    expect(result.value.changedSymbols.some((s) => s.file === 'src/email.ts')).toBe(true);
   });
 });

--- a/tests/tools/behavioural/get-changed-symbols.behavioural.test.ts
+++ b/tests/tools/behavioural/get-changed-symbols.behavioural.test.ts
@@ -7,13 +7,15 @@
  *
  * Complements the existing injection-only suite
  * (tests/tools/changed-symbols-injection.test.ts) — this file covers the
- * happy-path shape, filter semantics, and change-type classification.
+ * happy-path shape, filter semantics, change-type classification, and the
+ * content_hash freshness gate (TRA-1075).
  */
 
 import { execFileSync } from 'node:child_process';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Store } from '../../../src/db/store.js';
 import { getChangedSymbols } from '../../../src/tools/quality/changed-symbols.js';
+import { contentHash, initContentHasher } from '../../../src/util/hash.js';
 import { createTestStore } from '../../test-utils.js';
 
 vi.mock('node:child_process', () => ({
@@ -35,6 +37,8 @@ interface GitMock {
   upstream?: string;
   /** Base-branch names that fail merge-base (simulates "branch doesn't exist"). */
   mergeBaseFailsFor?: string[];
+  /** Blob content returned for `git show <ref>:<path>`, keyed by path. */
+  show?: Record<string, string>;
 }
 
 function mockGit(g: GitMock): void {
@@ -54,15 +58,40 @@ function mockGit(g: GitMock): void {
         throw new Error(`unknown revision: ${candidate}`);
       return g.mergeBase ?? 'abc1234';
     }
+    if (a[0] === 'show') {
+      // args[1] is "<ref>:<path>" — match by path only, mock ignores the ref.
+      const spec = a[1] ?? '';
+      const path = spec.slice(spec.indexOf(':') + 1);
+      if (!g.show || !(path in g.show)) throw new Error(`no blob mocked for "${spec}"`);
+      return Buffer.from(g.show[path]);
+    }
     if (a[0] === 'diff' && a.includes('--name-status')) return g.nameStatus ?? '';
     if (a[0] === 'diff' && a.includes('--unified=0')) return g.unified ?? '';
     return '';
   }) as never);
 }
 
+// Real file contents, hashed for real via the same xxh64 hasher the indexer
+// uses — so the freshness check in getChangedSymbols sees a genuine match
+// unless a test deliberately mocks a different `show` blob.
+const LOGIN_CONTENT = 'export function login() {}\nexport function logout() {}\n';
+const SSO_CONTENT = 'export function ssoEntry() {}\n';
+const OLD_CONTENT = 'export function oldFn() {}\n';
+
+let LOGIN_HASH: string;
+let SSO_HASH: string;
+let OLD_HASH: string;
+
+beforeAll(async () => {
+  await initContentHasher();
+  LOGIN_HASH = contentHash(Buffer.from(LOGIN_CONTENT));
+  SSO_HASH = contentHash(Buffer.from(SSO_CONTENT));
+  OLD_HASH = contentHash(Buffer.from(OLD_CONTENT));
+});
+
 function seedFiles(store: Store): void {
   // Modified file with two symbols
-  const modFile = store.insertFile('src/auth/login.ts', 'typescript', 'h-mod', 500);
+  const modFile = store.insertFile('src/auth/login.ts', 'typescript', LOGIN_HASH, 500);
   store.insertSymbol(modFile, {
     symbolId: 'src/auth/login.ts::login#function',
     name: 'login',
@@ -85,7 +114,7 @@ function seedFiles(store: Store): void {
   });
 
   // Added file
-  const addFile = store.insertFile('src/auth/sso.ts', 'typescript', 'h-add', 300);
+  const addFile = store.insertFile('src/auth/sso.ts', 'typescript', SSO_HASH, 300);
   store.insertSymbol(addFile, {
     symbolId: 'src/auth/sso.ts::ssoEntry#function',
     name: 'ssoEntry',
@@ -98,7 +127,7 @@ function seedFiles(store: Store): void {
   });
 
   // Removed file
-  const delFile = store.insertFile('src/legacy/old.ts', 'typescript', 'h-del', 200);
+  const delFile = store.insertFile('src/legacy/old.ts', 'typescript', OLD_HASH, 200);
   store.insertSymbol(delFile, {
     symbolId: 'src/legacy/old.ts::oldFn#function',
     name: 'oldFn',
@@ -120,14 +149,19 @@ describe('getChangedSymbols() — behavioural contract', () => {
     seedFiles(store);
   });
 
-  it('classifies adds/modifies/removes from git diff into changeKind', () => {
+  it('classifies adds/modifies/removes from git diff into changeKind', async () => {
     mockGit({
       nameStatus: 'A\tsrc/auth/sso.ts\nM\tsrc/auth/login.ts\nD\tsrc/legacy/old.ts',
       unified:
         '+++ b/src/auth/sso.ts\n@@ -0,0 +1,10 @@\n' + '+++ b/src/auth/login.ts\n@@ -5,3 +5,5 @@\n',
+      show: {
+        'src/auth/sso.ts': SSO_CONTENT,
+        'src/auth/login.ts': LOGIN_CONTENT,
+        'src/legacy/old.ts': OLD_CONTENT,
+      },
     });
 
-    const result = getChangedSymbols(store, '/proj', { since: 'main', until: 'HEAD' });
+    const result = await getChangedSymbols(store, '/proj', { since: 'main', until: 'HEAD' });
     expect(result.isOk()).toBe(true);
     if (result.isErr()) return;
 
@@ -141,15 +175,17 @@ describe('getChangedSymbols() — behavioural contract', () => {
     expect(summary.added).toBeGreaterThanOrEqual(1);
     expect(summary.modified).toBeGreaterThanOrEqual(1);
     expect(summary.removed).toBeGreaterThanOrEqual(1);
+    expect(result.value.staleFiles).toEqual([]);
   });
 
-  it('result envelope carries since/until/changedFiles/changedSymbols/summary', () => {
+  it('result envelope carries since/until/changedFiles/changedSymbols/summary/staleFiles', async () => {
     mockGit({
       nameStatus: 'M\tsrc/auth/login.ts',
       unified: '+++ b/src/auth/login.ts\n@@ -5,3 +5,5 @@\n',
+      show: { 'src/auth/login.ts': LOGIN_CONTENT },
     });
 
-    const result = getChangedSymbols(store, '/proj', { since: 'main', until: 'HEAD' });
+    const result = await getChangedSymbols(store, '/proj', { since: 'main', until: 'HEAD' });
     expect(result.isOk()).toBe(true);
     if (result.isErr()) return;
 
@@ -157,6 +193,7 @@ describe('getChangedSymbols() — behavioural contract', () => {
     expect(result.value.until).toBe('HEAD');
     expect(typeof result.value.changedFiles).toBe('number');
     expect(Array.isArray(result.value.changedSymbols)).toBe(true);
+    expect(Array.isArray(result.value.staleFiles)).toBe(true);
     expect(result.value.summary).toMatchObject({
       added: expect.any(Number),
       modified: expect.any(Number),
@@ -174,13 +211,14 @@ describe('getChangedSymbols() — behavioural contract', () => {
     }
   });
 
-  it('includeBlastRadius=true populates blastRadius on each changed symbol', () => {
+  it('includeBlastRadius=true populates blastRadius on each changed symbol', async () => {
     mockGit({
       nameStatus: 'M\tsrc/auth/login.ts',
       unified: '+++ b/src/auth/login.ts\n@@ -5,3 +5,5 @@\n',
+      show: { 'src/auth/login.ts': LOGIN_CONTENT },
     });
 
-    const result = getChangedSymbols(store, '/proj', {
+    const result = await getChangedSymbols(store, '/proj', {
       since: 'main',
       until: 'HEAD',
       includeBlastRadius: true,
@@ -195,26 +233,28 @@ describe('getChangedSymbols() — behavioural contract', () => {
     }
   });
 
-  it('empty diff (since == until) yields zero changed symbols + zero summary', () => {
+  it('empty diff (since == until) yields zero changed symbols + zero summary', async () => {
     mockGit({ nameStatus: '', unified: '' });
 
-    const result = getChangedSymbols(store, '/proj', { since: 'HEAD', until: 'HEAD' });
+    const result = await getChangedSymbols(store, '/proj', { since: 'HEAD', until: 'HEAD' });
     expect(result.isOk()).toBe(true);
     if (result.isErr()) return;
 
     expect(result.value.changedSymbols).toEqual([]);
     expect(result.value.changedFiles).toBe(0);
+    expect(result.value.staleFiles).toEqual([]);
     expect(result.value.summary).toEqual({ added: 0, modified: 0, removed: 0, renamed: 0 });
   });
 
-  it('auto-detects base branch when "since" is omitted (calls git merge-base)', () => {
+  it('auto-detects base branch when "since" is omitted (calls git merge-base)', async () => {
     mockGit({
       mergeBase: 'merge-base-sha',
       nameStatus: 'M\tsrc/auth/login.ts',
       unified: '+++ b/src/auth/login.ts\n@@ -5,3 +5,5 @@\n',
+      show: { 'src/auth/login.ts': LOGIN_CONTENT },
     });
 
-    const result = getChangedSymbols(store, '/proj', { until: 'HEAD' });
+    const result = await getChangedSymbols(store, '/proj', { until: 'HEAD' });
     expect(result.isOk()).toBe(true);
     if (result.isErr()) return;
 
@@ -227,15 +267,16 @@ describe('getChangedSymbols() — behavioural contract', () => {
     expect(result.value.since).toBe('merge-base-sha');
   });
 
-  it('falls back to origin/HEAD when default branch is neither main nor master', () => {
+  it('falls back to origin/HEAD when default branch is neither main nor master', async () => {
     mockGit({
       originHead: 'origin/trunk',
       mergeBase: 'trunk-merge-base',
       nameStatus: 'M\tsrc/auth/login.ts',
       unified: '+++ b/src/auth/login.ts\n@@ -5,3 +5,5 @@\n',
+      show: { 'src/auth/login.ts': LOGIN_CONTENT },
     });
 
-    const result = getChangedSymbols(store, '/proj', { until: 'HEAD' });
+    const result = await getChangedSymbols(store, '/proj', { until: 'HEAD' });
     expect(result.isOk()).toBe(true);
     if (result.isErr()) return;
 
@@ -244,16 +285,17 @@ describe('getChangedSymbols() — behavioural contract', () => {
     expect((mergeBaseCall?.[1] as string[])[1]).toBe('origin/trunk');
   });
 
-  it('falls back to the upstream branch when origin/HEAD is unset', () => {
+  it('falls back to the upstream branch when origin/HEAD is unset', async () => {
     mockGit({
       // no originHead → symbolic-ref throws
       upstream: 'origin/develop',
       mergeBase: 'develop-merge-base',
       nameStatus: 'M\tsrc/auth/login.ts',
       unified: '+++ b/src/auth/login.ts\n@@ -5,3 +5,5 @@\n',
+      show: { 'src/auth/login.ts': LOGIN_CONTENT },
     });
 
-    const result = getChangedSymbols(store, '/proj', { until: 'HEAD' });
+    const result = await getChangedSymbols(store, '/proj', { until: 'HEAD' });
     expect(result.isOk()).toBe(true);
     if (result.isErr()) return;
 
@@ -262,30 +304,31 @@ describe('getChangedSymbols() — behavioural contract', () => {
     expect((mergeBaseCall?.[1] as string[])[1]).toBe('origin/develop');
   });
 
-  it('still falls back to main/master when origin/HEAD and upstream are both unset', () => {
+  it('still falls back to main/master when origin/HEAD and upstream are both unset', async () => {
     mockGit({
       // no originHead, no upstream → both probes throw
       mergeBaseFailsFor: ['main'],
       mergeBase: 'master-merge-base',
       nameStatus: 'M\tsrc/auth/login.ts',
       unified: '+++ b/src/auth/login.ts\n@@ -5,3 +5,5 @@\n',
+      show: { 'src/auth/login.ts': LOGIN_CONTENT },
     });
 
-    const result = getChangedSymbols(store, '/proj', { until: 'HEAD' });
+    const result = await getChangedSymbols(store, '/proj', { until: 'HEAD' });
     expect(result.isOk()).toBe(true);
     if (result.isErr()) return;
 
     expect(result.value.since).toBe('master-merge-base');
   });
 
-  it('an explicit defaultBaseBranch config is tried exclusively (no main/master fallback)', () => {
+  it('an explicit defaultBaseBranch config is tried exclusively (no main/master fallback)', async () => {
     mockGit({
       mergeBaseFailsFor: ['release'],
       nameStatus: '',
       unified: '',
     });
 
-    const result = getChangedSymbols(store, '/proj', {
+    const result = await getChangedSymbols(store, '/proj', {
       until: 'HEAD',
       defaultBaseBranch: 'release',
     });
@@ -293,5 +336,58 @@ describe('getChangedSymbols() — behavioural contract', () => {
     if (!result.isErr()) return;
     expect(result.error.message).toContain('"release"');
     expect(result.error.message).not.toContain('"main"');
+  });
+
+  // --- Freshness gate (TRA-1075) ---
+  // The bug this test class catches: an indexed symbol's line_start/line_end
+  // reflect the tree at the last reindex, not necessarily the tree at
+  // `until`. Without a content_hash check, a diff hunk silently resolves to
+  // whatever symbol used to occupy that line range.
+
+  it('excludes a modified file from changedSymbols and reports it in staleFiles when its blob no longer matches the indexed content_hash', async () => {
+    mockGit({
+      nameStatus: 'M\tsrc/auth/login.ts',
+      unified: '+++ b/src/auth/login.ts\n@@ -5,3 +5,5 @@\n',
+      // Blob at `until` no longer matches LOGIN_HASH recorded at index time —
+      // e.g. 20 lines were inserted above `login()` since the last reindex.
+      show: { 'src/auth/login.ts': 'totally different content now\n' },
+    });
+
+    const result = await getChangedSymbols(store, '/proj', { since: 'main', until: 'HEAD' });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) return;
+
+    expect(result.value.staleFiles).toEqual(['src/auth/login.ts']);
+    expect(result.value.changedSymbols.some((s) => s.file === 'src/auth/login.ts')).toBe(false);
+  });
+
+  it('excludes an added file whose blob at "until" cannot be resolved (git show fails)', async () => {
+    mockGit({
+      nameStatus: 'A\tsrc/auth/sso.ts',
+      unified: '+++ b/src/auth/sso.ts\n@@ -0,0 +1,10 @@\n',
+      show: {}, // no blob mocked → git show throws → treated as stale, not dropped silently
+    });
+
+    const result = await getChangedSymbols(store, '/proj', { since: 'main', until: 'HEAD' });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) return;
+
+    expect(result.value.staleFiles).toEqual(['src/auth/sso.ts']);
+    expect(result.value.changedSymbols).toEqual([]);
+  });
+
+  it('still joins a fresh file normally when content_hash matches the blob at "until"', async () => {
+    mockGit({
+      nameStatus: 'M\tsrc/auth/login.ts',
+      unified: '+++ b/src/auth/login.ts\n@@ -5,3 +5,5 @@\n',
+      show: { 'src/auth/login.ts': LOGIN_CONTENT },
+    });
+
+    const result = await getChangedSymbols(store, '/proj', { since: 'main', until: 'HEAD' });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) return;
+
+    expect(result.value.staleFiles).toEqual([]);
+    expect(result.value.changedSymbols.some((s) => s.file === 'src/auth/login.ts')).toBe(true);
   });
 });

--- a/tests/tools/branch-comparison.test.ts
+++ b/tests/tools/branch-comparison.test.ts
@@ -4,14 +4,16 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { Store } from '../../src/db/store.js';
 import { compareBranches } from '../../src/tools/quality/changed-symbols.js';
+import { contentHash, initContentHasher } from '../../src/util/hash.js';
 import { createTestStore, createTmpDir, removeTmpDir } from '../test-utils.js';
 
 describe('compareBranches', () => {
   let store: Store;
   let repoDir: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     store = createTestStore();
+    await initContentHasher();
 
     // Create a temporary git repo with two branches
     repoDir = createTmpDir('branch-compare-');
@@ -48,50 +50,25 @@ describe('compareBranches', () => {
     run('git add -A');
     run('git commit -m "initial"');
 
-    // Index the base file
-    const fileId = store.insertFile('src/auth.ts', 'typescript', 'h1', 200);
-    store.insertSymbol(fileId, {
-      symbolId: 'src/auth.ts::login#function',
-      name: 'login',
-      kind: 'function',
-      fqn: 'login',
-      byteStart: 0,
-      byteEnd: 60,
-      lineStart: 1,
-      lineEnd: 3,
-    });
-    store.insertSymbol(fileId, {
-      symbolId: 'src/auth.ts::logout#function',
-      name: 'logout',
-      kind: 'function',
-      fqn: 'logout',
-      byteStart: 62,
-      byteEnd: 100,
-      lineStart: 5,
-      lineEnd: 7,
-    });
-
     // Create feature branch with changes
     run('git checkout -b feature/auth-upgrade');
 
     // Modify login function
-    fs.writeFileSync(
-      path.join(repoDir, 'src/auth.ts'),
-      [
-        'export function login(email: string, password: string) {',
-        '  const user = findUser(email);',
-        '  return verify(password, user.hash);',
-        '}',
-        '',
-        'export function logout() {',
-        '  clearSession();',
-        '}',
-        '',
-        'export function register(email: string) {',
-        '  return createUser(email);',
-        '}',
-      ].join('\n'),
-    );
+    const upgradedAuthContent = [
+      'export function login(email: string, password: string) {',
+      '  const user = findUser(email);',
+      '  return verify(password, user.hash);',
+      '}',
+      '',
+      'export function logout() {',
+      '  clearSession();',
+      '}',
+      '',
+      'export function register(email: string) {',
+      '  return createUser(email);',
+      '}',
+    ].join('\n');
+    fs.writeFileSync(path.join(repoDir, 'src/auth.ts'), upgradedAuthContent);
 
     // Add a new file
     fs.writeFileSync(
@@ -103,14 +80,56 @@ describe('compareBranches', () => {
 
     run('git add -A');
     run('git commit -m "upgrade auth"');
+
+    // Index the tree as it stands on the feature branch — the tip we're
+    // about to diff against (`until`). content_hash must match that blob for
+    // the freshness gate in getChangedSymbols/compareBranches to join it;
+    // using the pre-upgrade content here would reproduce the exact stale-span
+    // bug (TRA-1075) this gate exists to catch.
+    const fileId = store.insertFile(
+      'src/auth.ts',
+      'typescript',
+      contentHash(Buffer.from(upgradedAuthContent)),
+      200,
+    );
+    store.insertSymbol(fileId, {
+      symbolId: 'src/auth.ts::login#function',
+      name: 'login',
+      kind: 'function',
+      fqn: 'login',
+      byteStart: 0,
+      byteEnd: 60,
+      lineStart: 1,
+      lineEnd: 4,
+    });
+    store.insertSymbol(fileId, {
+      symbolId: 'src/auth.ts::logout#function',
+      name: 'logout',
+      kind: 'function',
+      fqn: 'logout',
+      byteStart: 62,
+      byteEnd: 100,
+      lineStart: 6,
+      lineEnd: 8,
+    });
+    store.insertSymbol(fileId, {
+      symbolId: 'src/auth.ts::register#function',
+      name: 'register',
+      kind: 'function',
+      fqn: 'register',
+      byteStart: 102,
+      byteEnd: 140,
+      lineStart: 10,
+      lineEnd: 12,
+    });
   });
 
   afterEach(() => {
     removeTmpDir(repoDir);
   });
 
-  it('resolves merge-base and returns branch comparison', () => {
-    const result = compareBranches(store, repoDir, {
+  it('resolves merge-base and returns branch comparison', async () => {
+    const result = await compareBranches(store, repoDir, {
       branch: 'feature/auth-upgrade',
       base: 'main',
       includeBlastRadius: false,
@@ -123,10 +142,11 @@ describe('compareBranches', () => {
     expect(data.mergeBase).toBeTruthy();
     expect(data.commitCount).toBe(1);
     expect(data.changedFiles).toBeGreaterThan(0);
+    expect(data.staleFiles).toEqual([]);
   });
 
-  it('groups by category by default', () => {
-    const result = compareBranches(store, repoDir, {
+  it('groups by category by default', async () => {
+    const result = await compareBranches(store, repoDir, {
       branch: 'feature/auth-upgrade',
       base: 'main',
       includeBlastRadius: false,
@@ -142,8 +162,8 @@ describe('compareBranches', () => {
     }
   });
 
-  it('groups by file when requested', () => {
-    const result = compareBranches(store, repoDir, {
+  it('groups by file when requested', async () => {
+    const result = await compareBranches(store, repoDir, {
       branch: 'feature/auth-upgrade',
       base: 'main',
       includeBlastRadius: false,
@@ -158,8 +178,8 @@ describe('compareBranches', () => {
     }
   });
 
-  it('includes risk assessment with blast radius', () => {
-    const result = compareBranches(store, repoDir, {
+  it('includes risk assessment with blast radius', async () => {
+    const result = await compareBranches(store, repoDir, {
       branch: 'feature/auth-upgrade',
       base: 'main',
       includeBlastRadius: true,
@@ -171,8 +191,8 @@ describe('compareBranches', () => {
     expect(Array.isArray(data.riskAssessment)).toBe(true);
   });
 
-  it('returns error for non-existent branch', () => {
-    const result = compareBranches(store, repoDir, {
+  it('returns error for non-existent branch', async () => {
+    const result = await compareBranches(store, repoDir, {
       branch: 'nonexistent-branch',
       base: 'main',
     });
@@ -180,8 +200,8 @@ describe('compareBranches', () => {
     expect(result.isErr()).toBe(true);
   });
 
-  it('includes summary counts', () => {
-    const result = compareBranches(store, repoDir, {
+  it('includes summary counts', async () => {
+    const result = await compareBranches(store, repoDir, {
       branch: 'feature/auth-upgrade',
       base: 'main',
       includeBlastRadius: false,
@@ -193,5 +213,54 @@ describe('compareBranches', () => {
     expect(typeof data.summary.added).toBe('number');
     expect(typeof data.summary.modified).toBe('number');
     expect(typeof data.summary.removed).toBe('number');
+  });
+
+  // --- Freshness gate (TRA-1075) ---
+  it('excludes the file and reports staleFiles when the index was built against a different tree', async () => {
+    // Simulate the exact bug: index recorded spans for the *pre-upgrade*
+    // main content, but we diff against the feature branch tip. The blob at
+    // `until` no longer matches content_hash, so auth.ts must be excluded
+    // rather than joined against spans that shifted (login moved from lines
+    // 1-3 to 1-4, logout from 5-7 to 6-8).
+    const staleFileId = store.insertFile(
+      'src/stale.ts',
+      'typescript',
+      contentHash(Buffer.from('this content never existed in the repo')),
+      50,
+    );
+    store.insertSymbol(staleFileId, {
+      symbolId: 'src/stale.ts::whatever#function',
+      name: 'whatever',
+      kind: 'function',
+      fqn: 'whatever',
+      byteStart: 0,
+      byteEnd: 20,
+      lineStart: 1,
+      lineEnd: 1,
+    });
+    fs.writeFileSync(path.join(repoDir, 'src/stale.ts'), 'export function whatever() {}\n');
+    execSync('git add -A && git commit -m "add stale.ts"', {
+      cwd: repoDir,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: 'Test',
+        GIT_AUTHOR_EMAIL: 'test@test.com',
+        GIT_COMMITTER_NAME: 'Test',
+        GIT_COMMITTER_EMAIL: 'test@test.com',
+      },
+    });
+
+    const result = await compareBranches(store, repoDir, {
+      branch: 'feature/auth-upgrade',
+      base: 'main',
+      includeBlastRadius: false,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const data = result._unsafeUnwrap();
+    expect(data.staleFiles).toContain('src/stale.ts');
+    expect(data.changedSymbols.some((s) => s.file === 'src/stale.ts')).toBe(false);
+    // auth.ts was indexed with a matching hash — still resolves normally.
+    expect(data.changedSymbols.some((s) => s.file === 'src/auth.ts')).toBe(true);
   });
 });

--- a/tests/tools/changed-symbols-injection.test.ts
+++ b/tests/tools/changed-symbols-injection.test.ts
@@ -16,8 +16,8 @@ describe('changed-symbols ref validation', () => {
   const store = new Store(db);
   const cwd = process.cwd();
 
-  it('compareBranches rejects a branch starting with a dash', () => {
-    const result = compareBranches(store, cwd, { branch: '-c=core.sshCommand=evil' });
+  it('compareBranches rejects a branch starting with a dash', async () => {
+    const result = await compareBranches(store, cwd, { branch: '-c=core.sshCommand=evil' });
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.code).toBe('VALIDATION_ERROR');
@@ -25,25 +25,28 @@ describe('changed-symbols ref validation', () => {
     }
   });
 
-  it('compareBranches rejects shell metacharacters in the branch', () => {
+  it('compareBranches rejects shell metacharacters in the branch', async () => {
     for (const ref of ['main; rm -rf /', 'main && id', 'main`whoami`', 'main | nc x.y']) {
-      const result = compareBranches(store, cwd, { branch: ref });
+      const result = await compareBranches(store, cwd, { branch: ref });
       expect(result.isErr()).toBe(true);
     }
   });
 
-  it('compareBranches rejects a hostile base ref', () => {
-    const result = compareBranches(store, cwd, { branch: 'main', base: '--upload-pack=evil' });
+  it('compareBranches rejects a hostile base ref', async () => {
+    const result = await compareBranches(store, cwd, {
+      branch: 'main',
+      base: '--upload-pack=evil',
+    });
     expect(result.isErr()).toBe(true);
   });
 
-  it('getChangedSymbols rejects a hostile since ref', () => {
-    const result = getChangedSymbols(store, cwd, { since: '-x; rm -rf /' });
+  it('getChangedSymbols rejects a hostile since ref', async () => {
+    const result = await getChangedSymbols(store, cwd, { since: '-x; rm -rf /' });
     expect(result.isErr()).toBe(true);
   });
 
-  it('getChangedSymbols rejects a hostile until ref', () => {
-    const result = getChangedSymbols(store, cwd, { since: 'main', until: 'HEAD; id' });
+  it('getChangedSymbols rejects a hostile until ref', async () => {
+    const result = await getChangedSymbols(store, cwd, { since: 'main', until: 'HEAD; id' });
     expect(result.isErr()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

`getChangedSymbols` joined git diff hunks onto whatever `line_start`/`line_end` the index happened to have, with no check that the index was built from the same tree as `until` (or `since` for deleted files). An edit that shifts line numbers — e.g. inserting lines above a function — silently resolved to whatever symbol used to occupy that span, with no error and no log. `compareBranches` made this worse since its `branch` argument is caller-supplied and never has to be checked out for the call to succeed.

Both functions now verify each file's `content_hash` against the git blob at the ref being joined against (`until` for added/modified/renamed files, `since` for deleted files) before joining its symbols. A mismatch excludes the file from `changedSymbols` and reports it in a new `staleFiles` field instead of silently dropping or misattributing it.

Reported by the `sosalejandro/atlas` maintainer, who hit the same defect independently in two unrelated features ([atlas#105](https://github.com/sosalejandro/atlas/issues/105#issuecomment-5561457832)). Fixes TRA-1075.

## Test plan

- [x] `pnpm run build` (tsup + type-check)
- [x] `pnpm run lint` (`tsc --noEmit`)
- [x] `pnpm run test --run` — full suite, 946 files / 10543 tests passed, 27 pre-existing skips
- [x] New tests reproduce the reported bug directly: a file whose blob no longer matches the indexed `content_hash` is excluded from `changedSymbols` and listed in `staleFiles`, for both `get_changed_symbols` (mocked git) and `compare_branches` (mocked git + a real temp git repo in `branch-comparison.test.ts`)