### PR TITLE
fix(app): disambiguate identically-named projects in Recent/Quick Open (TRA-1058)

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -129,6 +129,7 @@ const BASE = 'http://127.0.0.1:3741';
 import { daemonFetch } from './daemon-fetch';
 import {
   addRecentProject,
+  disambiguateProjectLabels,
   getRecentProjects,
   removeRecentProject,
 } from './recent-projects.js';
@@ -178,6 +179,8 @@ function RecentProjects() {
     setRecent(getRecentProjects());
   };
 
+  const recentLabels = disambiguateProjectLabels(recent);
+
   return (
     <>
       {ctx && (
@@ -214,11 +217,25 @@ function RecentProjects() {
           </MenuItem>
         </Menu>
       )}
-      {recent.map((root) => (
+      {recent.map((root, i) => {
+        const label = recentLabels[i] ?? root;
+        const sep = label.lastIndexOf(' / ');
+        const name = sep === -1 ? label : label.slice(sep + 3);
+        const dir = sep === -1 ? null : label.slice(0, sep);
+        return (
         <SidebarRow
           key={root}
           icon="folder"
-          label={root.split(/[/\\]/).filter(Boolean).pop() ?? root}
+          label={
+            dir ? (
+              <span className="ws-sb-path">
+                <span className="name">{name}</span>
+                <span className="dir">{dir}</span>
+              </span>
+            ) : (
+              name
+            )
+          }
           title={root}
           onClick={() => openProject(root)}
           onContextMenu={(e) => {
@@ -246,7 +263,8 @@ function RecentProjects() {
             </span>
           }
         />
-      ))}
+        );
+      })}
     </>
   );
 }
@@ -1174,10 +1192,12 @@ function AppTabView({
       icon: section.icon,
       run: () => selectSection(i + 1),
     }));
-    for (const projectRoot of getRecentProjects()) {
+    const recentRoots = getRecentProjects();
+    const recentLabels = disambiguateProjectLabels(recentRoots);
+    recentRoots.forEach((projectRoot, i) => {
       items.push({
         id: `project:${projectRoot}`,
-        label: projectRoot.split(/[/\\]/).filter(Boolean).pop() ?? projectRoot,
+        label: recentLabels[i] ?? projectRoot,
         detail: projectRoot,
         group: t('quickOpenGroupRecent'),
         icon: 'folder',
@@ -1186,7 +1206,7 @@ function AppTabView({
           window.electronAPI?.openProjectTab(projectRoot);
         },
       });
-    }
+    });
     for (const filePath of quickFiles) {
       const display = root && filePath.startsWith(root)
         ? filePath.slice(root.length).replace(/^[/\\]/, '')

--- a/packages/app/src/renderer/__tests__/recent-projects.test.ts
+++ b/packages/app/src/renderer/__tests__/recent-projects.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { disambiguateProjectLabels } from '../recent-projects';
+
+describe('disambiguateProjectLabels', () => {
+  it('leaves unique basenames alone', () => {
+    expect(disambiguateProjectLabels(['/a/foo', '/b/bar'])).toEqual(['foo', 'bar']);
+  });
+
+  it('grows collisions by one parent segment at a time (TRA-1058)', () => {
+    expect(
+      disambiguateProjectLabels([
+        '/x/tra-1049-f6ea6628d239/workdir',
+        '/x/task-30782d5e62d2/workdir',
+        '/x/unique/workdir-only',
+      ]),
+    ).toEqual([
+      'tra-1049-f6ea6628d239 / workdir',
+      'task-30782d5e62d2 / workdir',
+      'workdir-only',
+    ]);
+  });
+
+  it('keeps growing until distinct, even past one extra segment', () => {
+    expect(disambiguateProjectLabels(['/a/x/workdir', '/b/x/workdir'])).toEqual([
+      'a / x / workdir',
+      'b / x / workdir',
+    ]);
+  });
+
+  it('gives up once parent segments are exhausted (still ambiguous, no crash)', () => {
+    expect(disambiguateProjectLabels(['/workdir', '/workdir'])).toEqual(['workdir', 'workdir']);
+  });
+});

--- a/packages/app/src/renderer/recent-projects.ts
+++ b/packages/app/src/renderer/recent-projects.ts
@@ -25,3 +25,35 @@ export function removeRecentProject(root: string): void {
   const recent = getRecentProjects().filter((r) => r !== root);
   localStorage.setItem(RECENT_KEY, JSON.stringify(recent));
 }
+
+/**
+ * Disambiguates project roots that share a basename (TRA-1058) — a project
+ * name is only the last path segment, and two different checkouts (or two
+ * agent workdirs) regularly share one, e.g. multiple `.../<task-id>/workdir`.
+ * Grows each colliding label one more parent segment at a time, the way
+ * Finder and IDE tabs do, until every label in the set is unique.
+ * Returns one label per input root, in order, `parent / … / name` joined.
+ */
+export function disambiguateProjectLabels(roots: string[]): string[] {
+  const segsOf = (r: string) => r.split(/[/\\]/).filter(Boolean);
+  const allSegs = roots.map(segsOf);
+  const labelSegs = allSegs.map((segs) => segs.slice(-1));
+
+  for (;;) {
+    const joined = labelSegs.map((segs) => segs.join(' / '));
+    const counts = new Map<string, number>();
+    for (const s of joined) counts.set(s, (counts.get(s) ?? 0) + 1);
+
+    let grew = false;
+    joined.forEach((s, i) => {
+      if ((counts.get(s) ?? 0) <= 1) return;
+      const segs = allSegs[i];
+      if (labelSegs[i].length >= segs.length) return; // out of parent segments
+      labelSegs[i] = segs.slice(-(labelSegs[i].length + 1));
+      grew = true;
+    });
+    if (!grew) break;
+  }
+
+  return labelSegs.map((segs) => segs.join(' / '));
+}

--- a/packages/app/src/renderer/tabs/GraphExplorerGPU.tsx
+++ b/packages/app/src/renderer/tabs/GraphExplorerGPU.tsx
@@ -3691,6 +3691,21 @@ export const GraphExplorerGPU = forwardRef<GraphExplorerGPUHandle, Props>(functi
           background: var(--fill-quaternary);
           outline: none;
         }
+        /* Search results are content (file matches), not chrome — over the
+           canvas's own dark labels-on-light-tiles, any transparency turns the
+           list into a double exposure (TRA-1058 #4). Opaque, same recipe as
+           .ws-ctx-menu. z-index above the Filter popover (60): the two aren't
+           mutually exclusive, and a buried "Select all N matches" is worse
+           than a buried filter panel the user just opened and can re-open. */
+        .cosmos-gpu-search-results {
+          position: absolute;
+          z-index: 65;
+          background: var(--surface-raised);
+          border: 0.5px solid var(--separator);
+          box-shadow: var(--shadow-panel);
+          backdrop-filter: none;
+          -webkit-backdrop-filter: none;
+        }
         /* Legend — bottom-left, opposite the stats readout so neither moves
            when the other grows. */
         .cosmos-gpu-legend {
@@ -3958,7 +3973,7 @@ export const GraphExplorerGPU = forwardRef<GraphExplorerGPUHandle, Props>(functi
           </div>
           {searchMatches.length > 0 && (
             <ul
-              className="viz-glass absolute z-40 mt-1.5 w-80 max-h-80 overflow-y-auto"
+              className="cosmos-gpu-search-results mt-1.5 w-80 max-h-80 overflow-y-auto"
               style={{ borderRadius: 'var(--radius-popover)', padding: 'var(--space-4)' }}
             >
               {searchTotal > 1 && (

--- a/packages/app/src/renderer/tabs/__tests__/graph-search-results.test.ts
+++ b/packages/app/src/renderer/tabs/__tests__/graph-search-results.test.ts
@@ -1,0 +1,39 @@
+/* TRA-1058 #4 — the Graph search-results dropdown ("Select all N matches" +
+   file matches) used `.viz-glass`, the canvas's translucent overlay material.
+   Over the graph's own dark labels-on-light-tiles, that turned the list into
+   a double exposure — readable neither as graph nor as list. It also sat at
+   z-40 while the Filter popover sits at z-60, so opening Filter while search
+   results were showing buried "Select all N matches" and the first row under
+   the filter panel. Read the same way graph-overlays.test.ts does: the source
+   file's inline <style> block, since rendering needs a live WebGL context. */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const src = readFileSync(fileURLToPath(new URL('../GraphExplorerGPU.tsx', import.meta.url)), 'utf8');
+
+function rule(selector: string): string {
+  const m = src.match(new RegExp(`\\.${selector}\\s*\\{([^{}]*)\\}`));
+  if (!m) throw new Error(`no rule found for .${selector}`);
+  return m[1];
+}
+
+describe('graph search-results dropdown', () => {
+  it('is not the canvas glass material', () => {
+    expect(src).toMatch(/cosmos-gpu-search-results[^"]*"\s*\n\s*style=\{\{ borderRadius: 'var\(--radius-popover\)'/);
+    expect(src).not.toMatch(/viz-glass absolute z-40/);
+  });
+
+  it('renders opaque, no blur', () => {
+    const body = rule('cosmos-gpu-search-results');
+    expect(body).toMatch(/background:\s*var\(--surface-raised\)/);
+    expect(body).not.toMatch(/backdrop-filter:\s*blur/);
+  });
+
+  it('stacks above the Filter popover', () => {
+    const resultsZ = Number(rule('cosmos-gpu-search-results').match(/z-index:\s*(\d+)/)?.[1]);
+    const popoverZ = Number(rule('cosmos-gpu-popover').match(/z-index:\s*(\d+)/)?.[1]);
+    expect(resultsZ).toBeGreaterThan(popoverZ);
+  });
+});

--- a/packages/app/src/renderer/workspace/Workspace.tsx
+++ b/packages/app/src/renderer/workspace/Workspace.tsx
@@ -25,7 +25,7 @@ import { useTranslation } from 'react-i18next';
 import { t } from '../i18n';
 import { formatNumber } from '../i18n/format';
 import { Button, EmptyState } from '../lattice/ui';
-import { addRecentProject, removeRecentProject } from '../recent-projects';
+import { addRecentProject, disambiguateProjectLabels, removeRecentProject } from '../recent-projects';
 import { useUsefulPaint } from '../perf';
 import { DaemonDownPane } from '../components/DaemonDownPane';
 import { AddProjectControl } from './AddProjectControl';
@@ -243,6 +243,15 @@ export function Workspace() {
     [filtered, sortKey, sortDir],
   );
   const kpis = useMemo(() => deriveKpis(data.projects), [data.projects]);
+  // Same fix as the sidebar's Recent list (TRA-1058): `project.name` is a bare
+  // basename, and two roots that share a folder name (agent workdirs are the
+  // common case) render as identical, unselectable-by-eye rows. Keyed by root
+  // so it works whether or not the dashboard sent a name at all.
+  const labelByRoot = useMemo(() => {
+    const roots = visible.map((p) => p.root);
+    const labels = disambiguateProjectLabels(roots);
+    return new Map(roots.map((r, i) => [r, labels[i]]));
+  }, [visible]);
 
   // ── Selection ────────────────────────────────────────────────────────
   const getId = useCallback((p: { root: string }) => p.root, []);
@@ -346,6 +355,7 @@ export function Workspace() {
 
   const viewProps = {
     projects: visible,
+    labelByRoot,
     selected: selection.selected,
     canMutate: data.connected,
     onSelectChange: selection.set,

--- a/packages/app/src/renderer/workspace/WorkspaceCompactView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceCompactView.tsx
@@ -17,6 +17,8 @@ import { type ProjectViewModel, statusLabel, statusToDot } from './types';
 
 export interface WorkspaceCompactViewProps {
   projects: ProjectViewModel[];
+  /** Disambiguated display label per root — see Workspace.tsx (TRA-1058). */
+  labelByRoot: Map<string, string>;
   selected: Set<string>;
   onSelectChange: (root: string, selected: boolean) => void;
   onOpen: (root: string) => void;
@@ -31,14 +33,9 @@ export interface WorkspaceCompactViewProps {
 /** Matches the table so switching views does not change row rhythm. */
 export const COMPACT_ROW_H = 46;
 
-function basename(root: string): string {
-  const trimmed = root.replace(/\/+$/, '');
-  const idx = trimmed.lastIndexOf('/');
-  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
-}
-
 interface RowProps {
   project: ProjectViewModel;
+  label: string;
   selected: boolean;
   cursored: boolean;
   canMutate: boolean;
@@ -54,6 +51,7 @@ interface RowProps {
 
 function CompactRow({
   project,
+  label,
   selected,
   cursored,
   canMutate,
@@ -93,7 +91,7 @@ function CompactRow({
         <Checkbox
           checked={selected}
           onChange={(next) => onSelectChange(project.root, next)}
-          aria-label={t('selectProject', { name: project.name || basename(project.root) })}
+          aria-label={t('selectProject', { name: label })}
         />
       </span>
       <StatusDot tone={dotTone} pulse={dotTone === 'green'} />
@@ -104,9 +102,9 @@ function CompactRow({
           <div
             className="text-[13px] font-medium truncate"
             style={{ color: 'var(--label)' }}
-            title={project.name}
+            title={label}
           >
-            {project.name || basename(project.root)}
+            {label}
           </div>
           <div className="text-[11px] shrink-0" style={{ color: 'var(--label-secondary)' }}>
             {statusLabel(project.displayStatus)}
@@ -143,6 +141,7 @@ function CompactRow({
 
 export function WorkspaceCompactView({
   projects,
+  labelByRoot,
   selected,
   canMutate,
   onSelectChange,
@@ -203,6 +202,7 @@ export function WorkspaceCompactView({
         <CompactRow
           key={p.root}
           project={p}
+          label={labelByRoot.get(p.root) ?? p.name}
           selected={selected.has(p.root)}
           cursored={i === cursor}
           canMutate={canMutate}

--- a/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
@@ -38,6 +38,8 @@ import {
 
 export interface WorkspaceTableViewProps {
   projects: ProjectViewModel[];
+  /** Disambiguated display label per root — see Workspace.tsx (TRA-1058). */
+  labelByRoot: Map<string, string>;
   sortKey: SortKey;
   sortDir: SortDir;
   onSort: (key: SortKey) => void;
@@ -183,6 +185,7 @@ function SelectAllCheckbox({
 
 interface RowProps {
   project: ProjectViewModel;
+  label: string;
   selected: boolean;
   cursored: boolean;
   canMutate: boolean;
@@ -198,6 +201,7 @@ interface RowProps {
 
 function Row({
   project,
+  label,
   selected,
   cursored,
   canMutate,
@@ -243,7 +247,7 @@ function Row({
         <Checkbox
           checked={selected}
           onChange={(next) => onSelectChange(project.root, next)}
-          aria-label={t('selectProject', { name: project.name })}
+          aria-label={t('selectProject', { name: label })}
         />
       </td>
 
@@ -251,8 +255,8 @@ function Row({
         className="px-3 max-w-[240px]"
         style={{ color: 'var(--label)', ...stickyCell('left', SELECT_COL_W, bg) }}
       >
-        <div className="truncate font-medium" title={project.name}>
-          {project.name}
+        <div className="truncate font-medium" title={label}>
+          {label}
         </div>
         {/* Head-truncated: sibling checkouts differ in the tail, not the head. */}
         <ProjectPath root={project.root} className="text-[11px] text-[var(--label-secondary)]" />
@@ -364,6 +368,7 @@ function Row({
 
 export function WorkspaceTableView({
   projects,
+  labelByRoot,
   sortKey,
   sortDir,
   onSort,
@@ -543,6 +548,7 @@ export function WorkspaceTableView({
             <Row
               key={p.root}
               project={p}
+              label={labelByRoot.get(p.root) ?? p.name}
               selected={selected.has(p.root)}
               cursored={start + i === cursor}
               canMutate={canMutate}

--- a/packages/app/src/renderer/workspace/__tests__/Workspace.duplicateNames.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/Workspace.duplicateNames.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * TRA-1058 follow-up: the sidebar's Recent list and Quick Open were fixed to
+ * disambiguate roots that share a basename, but the projects list (Table and
+ * Compact — the screen the bug was actually filed against) still rendered
+ * bare `project.name`, so two roots named `workdir` were indistinguishable.
+ */
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Workspace } from '../Workspace';
+import type { ProjectViewModel } from '../types';
+
+const projects: ProjectViewModel[] = [
+  '/x/tra-1049-f6ea6628d239/workdir',
+  '/x/task-30782d5e62d2/workdir',
+  '/y/unique',
+].map((root) => ({
+  root,
+  name: root.split('/').filter(Boolean).pop() ?? root,
+  displayStatus: 'ok',
+  lastIndexed: null,
+  hasMetrics: false,
+  inDaemon: true,
+}));
+
+vi.mock('../useWorkspaceProjects', () => ({
+  useWorkspaceProjects: () => ({
+    projects,
+    loading: false,
+    metricsLoading: false,
+    refreshing: false,
+    error: null,
+    errorKind: null,
+    daemonState: 'ok',
+    connected: true,
+    restarting: false,
+    addProject: async () => {},
+    removeProject: async () => {},
+    reindexProject: async () => {},
+    reindexMany: async () => {},
+    removeMany: async () => {},
+    refresh: async () => {},
+    restartDaemon: async () => {},
+  }),
+}));
+
+/** Row labels in DOM order, read off the per-row select checkboxes. */
+function renderedLabels(container: HTMLElement): string[] {
+  return [...container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')]
+    .map((c) => c.getAttribute('aria-label') ?? '')
+    .filter((l) => l.startsWith('Select ') && l !== 'Select all projects')
+    .map((l) => l.slice('Select '.length));
+}
+
+describe('Workspace duplicate project names', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('disambiguates same-basename rows in table view', () => {
+    localStorage.setItem('trace-mcp.workspace.view', 'table');
+    const { container } = render(<Workspace />);
+    const labels = renderedLabels(container);
+    expect(new Set(labels).size).toBe(labels.length);
+    expect(labels).toContain('tra-1049-f6ea6628d239 / workdir');
+    expect(labels).toContain('task-30782d5e62d2 / workdir');
+    expect(labels).toContain('unique');
+  });
+
+  it('disambiguates same-basename rows in compact view', () => {
+    localStorage.setItem('trace-mcp.workspace.view', 'compact');
+    const { container } = render(<Workspace />);
+    const labels = renderedLabels(container);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+});

--- a/packages/app/src/renderer/workspace/__tests__/WorkspaceTableView.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/WorkspaceTableView.test.tsx
@@ -31,6 +31,7 @@ function renderTable() {
   const { container } = render(
     <WorkspaceTableView
       projects={[PROJECT]}
+      labelByRoot={new Map([[PROJECT.root, PROJECT.name]])}
       sortKey="name"
       sortDir="asc"
       onSort={() => {}}


### PR DESCRIPTION
## Summary
- Fixes the #1-priority finding from Lead Engineer's QA pass (TRA-1058, comment https://multica.ai): recent-project rows and the Quick Open recent group render only the basename, so two roots that share a folder name (e.g. multiple agent `.../workdir` checkouts) are indistinguishable — reported as 7 of 43 rows non-unique, 5 in a row named `workdir`.
- Adds `disambiguateProjectLabels()` (`recent-projects.ts`): grows each colliding label one parent path segment at a time until the set is unique, the way Finder and IDE tabs disambiguate duplicate names.
- Wires it into the sidebar's `RecentProjects` list (reusing the existing `.ws-sb-path .name/.dir` styling already used for file rows) and into the Quick Open recent-project group.

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 724/724 passing (new `recent-projects.test.ts` covers unique names, one-level collisions, multi-level collisions, and the "still ambiguous, no crash" exhausted case)