### PR TITLE
fix(analysis): make community labels unique across communities

### DIFF
--- a/src/tools/analysis/communities.ts
+++ b/src/tools/analysis/communities.ts
@@ -272,6 +272,60 @@ function autoLabel(files: string[]): string {
   return bestSegment;
 }
 
+/** Most frequent directory path of a file set, as segments. Ties break lexicographically. */
+function dominantDir(files: string[]): string[] {
+  const dirs = new Map<string, number>();
+  for (const file of files) {
+    const cut = file.lastIndexOf('/');
+    if (cut <= 0) continue;
+    const dir = file.slice(0, cut);
+    dirs.set(dir, (dirs.get(dir) ?? 0) + 1);
+  }
+  let best = '';
+  let bestCount = 0;
+  for (const [dir, count] of dirs) {
+    if (count > bestCount || (count === bestCount && dir < best)) {
+      bestCount = count;
+      best = dir;
+    }
+  }
+  return best === '' ? [] : best.split('/');
+}
+
+/**
+ * Assign a unique label to each community, shortest-first.
+ *
+ * `autoLabel()` alone collides whenever two unrelated communities share their
+ * most common path segment (`indexer`, `packages`, …) — the on-canvas cluster
+ * label and the graph legend then can't tell them apart (TRA-1078). So each
+ * community offers a ladder of candidates — the bare segment, then growing
+ * tails of its dominant directory — and the first free one wins. Callers pass
+ * groups in priority order (largest community first), so the biggest cluster
+ * keeps the short name.
+ */
+export function labelCommunities(fileGroups: string[][]): string[] {
+  const used = new Set<string>();
+  return fileGroups.map((files) => {
+    const base = autoLabel(files);
+    const dir = dominantDir(files);
+    const candidates = [base];
+    for (let k = 1; k <= dir.length; k++) {
+      const tail = dir.slice(dir.length - k).join('/');
+      if (!candidates.includes(tail)) candidates.push(tail);
+    }
+
+    let label = candidates.find((c) => !used.has(c));
+    if (label === undefined) {
+      const longest = candidates[candidates.length - 1];
+      let n = 2;
+      while (used.has(`${longest} (${n})`)) n++;
+      label = `${longest} (${n})`;
+    }
+    used.add(label);
+    return label;
+  });
+}
+
 // ─── Two-phase cohesion pass ──────────────────────────────
 
 /**
@@ -436,11 +490,9 @@ export async function detectCommunities(
     const cohesion =
       internal + external > 0 ? Math.round((internal / (internal + external)) * 100) / 100 : 0;
 
-    const label = autoLabel(files);
-
     communities.push({
       id: commId,
-      label,
+      label: '', // assigned below, once all communities are known (needs cross-community uniqueness)
       fileCount: files.length,
       cohesion,
       internalEdges: internal,
@@ -451,6 +503,12 @@ export async function detectCommunities(
 
   // Sort by file count descending
   communities.sort((a, b) => b.fileCount - a.fileCount);
+
+  // Label after sorting so the biggest community wins the short name on a collision.
+  const labels = labelCommunities(communities.map((c) => communityFiles.get(c.id) ?? []));
+  communities.forEach((c, i) => {
+    c.label = labels[i];
+  });
 
   // Persist to DB (single transaction)
   store.db.transaction(() => {

--- a/tests/tools/communities.test.ts
+++ b/tests/tools/communities.test.ts
@@ -6,6 +6,7 @@ import {
   detectCommunities,
   getCommunities,
   getCommunityDetail,
+  labelCommunities,
 } from '../../src/tools/analysis/communities.js';
 
 describe('Community Detection', () => {
@@ -228,5 +229,30 @@ describe('Community Detection', () => {
       // pass the hub's edges typically collapse this into one.
       expect(result.communities.length).toBeGreaterThanOrEqual(2);
     });
+  });
+});
+
+describe('labelCommunities', () => {
+  it('keeps distinct labels as-is', () => {
+    expect(
+      labelCommunities([
+        ['src/auth/a.ts', 'src/auth/b.ts'],
+        ['src/payments/c.ts', 'src/payments/d.ts'],
+      ]),
+    ).toEqual(['auth', 'payments']);
+  });
+
+  it('extends colliding labels with their dominant directory (TRA-1078)', () => {
+    const labels = labelCommunities([
+      ['src/indexer/a.ts', 'src/indexer/b.ts'],
+      ['core/indexer/c.ts', 'core/indexer/d.ts', 'misc/indexer/e.ts'],
+      ['tools/indexer/f.ts', 'tools/indexer/g.ts', 'other/indexer/h.ts'],
+    ]);
+    expect(labels).toEqual(['indexer', 'core/indexer', 'tools/indexer']);
+  });
+
+  it('falls back to numeric suffixes when the paths are identical', () => {
+    const labels = labelCommunities([['src/api/a.ts'], ['src/api/b.ts'], ['src/api/c.ts']]);
+    expect(labels).toEqual(['api', 'src/api', 'src/api (2)']);
   });
 });


### PR DESCRIPTION
Fixes TRA-1078.

## Problem

`autoLabel()` picked each community's single most-frequent path segment with no check against what the other communities in the same run picked. Two unrelated communities whose dominant segment is `indexer` (or `src`, `app`, `packages`) both got the same label — the Graph tab printed `src/indexer` 12 times on canvas and the legend showed two `src` rows with different counts. Neither the label nor the legend could identify which cluster was which.

## Fix

Labeling moved from a per-community call to one pass over the whole set, `labelCommunities()`, run after the file-count sort so the biggest cluster keeps the short name:

- each community offers a ladder of candidates — the bare `autoLabel()` segment, then growing tails of its dominant directory (`indexer` → `core/indexer` → `packages/core/indexer`);
- it takes the first candidate no other community has claimed;
- `label (2)` suffixing only kicks in when two communities have genuinely identical paths.

Shape borrowed from `disambiguateProjectLabels()` (PR #1050), ported to work over communities instead of path strings.

No client change: `GraphExplorerGPU.tsx` already renders `data.communities[].label` as-is, and both the on-canvas label and the legend read that same field. No MCP tool signature or DB schema change — `communities.label` is still one string column, just now guaranteed unique within a run.

## Tests

Three cases added to `tests/tools/communities.test.ts` against the exported `labelCommunities()`: distinct labels pass through untouched; colliding labels extend to `core/indexer` / `tools/indexer` with the first (largest) keeping `indexer`; identical paths fall back to `src/api (2)`.

`pnpm test` green (944 files / 10 544 tests), `pnpm lint` and `pnpm build` clean.
