### PR TITLE
fix(daemon): lazy-load idle-unloaded projects over HTTP, reconcile status periodically (TRA-1052, TRA-1067)

### DIFF
--- a/packages/app/src/renderer/daemon-fetch.ts
+++ b/packages/app/src/renderer/daemon-fetch.ts
@@ -51,3 +51,27 @@ export function daemonFetch(
   // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request -- BASE is the app's own local daemon (127.0.0.1), not a remote endpoint.
   return fetch(url, { ...init, signal: init.signal ?? AbortSignal.timeout(timeoutMs) });
 }
+
+/**
+ * `daemonFetch` for a project-scoped read that may 503 while the daemon
+ * lazily reloads an idle-unloaded project (TRA-1052 — see cli.ts's
+ * `resolveProjectForRest`). Retries on 503, honouring `Retry-After`, so the
+ * caller's existing `loading` state carries the wait instead of it having to
+ * special-case "the project is still coming up" as a failure. Gives up after
+ * `maxWaitMs` and returns the last 503 as-is — the caller's normal
+ * `!res.ok` failure path takes it from there.
+ */
+export async function daemonFetchProject(
+  url: string,
+  init: RequestInit = {},
+  maxWaitMs = 30_000,
+): Promise<Response> {
+  const deadline = Date.now() + maxWaitMs;
+  for (;;) {
+    const res = await daemonFetch(url, init);
+    if (res.status !== 503) return res;
+    const retryAfterSec = Number(res.headers.get('Retry-After')) || 2;
+    if (Date.now() + retryAfterSec * 1000 > deadline) return res;
+    await new Promise((r) => setTimeout(r, retryAfterSec * 1000));
+  }
+}

--- a/packages/app/src/renderer/hooks/__tests__/daemon-status-reconciliation.test.tsx
+++ b/packages/app/src/renderer/hooks/__tests__/daemon-status-reconciliation.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * @vitest-environment jsdom
+ */
+/* TRA-1067 / TRA-1052 cluster. Two failure modes shared one root cause: the
+ * project list rendered whatever the LAST event said, and nothing ever asked
+ * the daemon again unless a fresh mount or an SSE reconnect happened to do it.
+ *
+ * 1. The initial indexAll() chain has no dedicated "done" event (unlike
+ *    reindex_completed/embed_completed) — its own last progress tick,
+ *    `indexing_progress` with `phase: 'completed'`, WAS the terminal signal,
+ *    but the handler treated every indexing_progress tick as "still
+ *    indexing". A finished project stayed rendered as "Indexing" forever.
+ * 2. Even a genuinely lost/misordered terminal event (dropped by a flaky SSE
+ *    reconnect, a daemon restart, whatever) had no way to self-correct: fetch
+ *    ran once on mount and once on SSE `onopen`, never again.
+ *
+ * This file locks down the fix for both: the completed-tick branch, and the
+ * periodic poll that converges the UI on the daemon's own answer even when no
+ * event ever arrives to say so.
+ */
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PROJECT_STATUS_POLL_INTERVAL_MS, useDaemon } from '../useDaemon.js';
+
+const ROOT = '/Users/nikolai/PhpstormProjects/assetfeed';
+
+class FakeEventSource {
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  static instances: FakeEventSource[] = [];
+  constructor(readonly url: string) {
+    FakeEventSource.instances.push(this);
+  }
+  close() {}
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+}
+
+function jsonResponse(body: unknown) {
+  return { ok: true, statusText: 'OK', json: async () => body };
+}
+
+beforeEach(() => {
+  FakeEventSource.instances = [];
+  vi.stubGlobal('EventSource', FakeEventSource);
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => 'visible',
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('project status: indexing_progress completion tick', () => {
+  it('a "completed" progress tick lands on ready, not a stuck "indexing"', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ projects: [{ root: ROOT, status: 'indexing' }] })),
+    );
+    const { result } = renderHook(() => useDaemon());
+    await act(async () => {});
+
+    const es = FakeEventSource.instances[0];
+    act(() => {
+      es.emit({ type: 'indexing_progress', project: ROOT, phase: 'completed', processed: 43, total: 43 });
+    });
+
+    const project = result.current.projects.find((p) => p.root === ROOT);
+    expect(project?.status).toBe('ready');
+    expect(project?.progress).toBeUndefined();
+  });
+
+  it('current >= total also counts as done even without phase: "completed"', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ projects: [{ root: ROOT, status: 'indexing' }] })),
+    );
+    const { result } = renderHook(() => useDaemon());
+    await act(async () => {});
+
+    const es = FakeEventSource.instances[0];
+    act(() => {
+      es.emit({ type: 'indexing_progress', project: ROOT, phase: 'embedding', processed: 10, total: 10 });
+    });
+
+    expect(result.current.projects.find((p) => p.root === ROOT)?.status).toBe('ready');
+  });
+
+  it('a mid-run tick still reports "indexing" with progress', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ projects: [{ root: ROOT, status: 'indexing' }] })),
+    );
+    const { result } = renderHook(() => useDaemon());
+    await act(async () => {});
+
+    const es = FakeEventSource.instances[0];
+    act(() => {
+      es.emit({ type: 'indexing_progress', project: ROOT, phase: 'running', processed: 5, total: 43 });
+    });
+
+    const project = result.current.projects.find((p) => p.root === ROOT);
+    expect(project?.status).toBe('indexing');
+    expect(project?.progress).toEqual({ phase: 'running', current: 5, total: 43, percent: 12 });
+  });
+});
+
+describe('project status: periodic reconciliation with the daemon (TRA-1067 acceptance test)', () => {
+  it('converges on the daemon-reported status even when the terminal event is dropped', async () => {
+    vi.useFakeTimers();
+    // The daemon's own truth changes between polls — simulating the real
+    // failure: an SSE event was lost, so the UI's only way to learn the
+    // project finished is the next `/api/projects` poll answering 'ready'.
+    let daemonStatus = 'indexing';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ projects: [{ root: ROOT, status: daemonStatus }] })),
+    );
+
+    const { result } = renderHook(() => useDaemon());
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+    expect(result.current.projects.find((p) => p.root === ROOT)?.status).toBe('indexing');
+
+    // The daemon finished. No SSE event announces it — the completion event
+    // is simply never delivered (the exact scenario a dropped/misordered SSE
+    // message produces).
+    daemonStatus = 'ready';
+
+    // Nothing short of the periodic poll should change this — advancing by
+    // less than the interval must NOT flip the status yet.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PROJECT_STATUS_POLL_INTERVAL_MS - 1000);
+    });
+    expect(result.current.projects.find((p) => p.root === ROOT)?.status).toBe('indexing');
+
+    // Crossing the poll interval reconciles state with the daemon's answer —
+    // this is the safety net a dropped event can no longer defeat.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    expect(result.current.projects.find((p) => p.root === ROOT)?.status).toBe('ready');
+  });
+
+  it('does not poll while the window is hidden', async () => {
+    vi.useFakeTimers();
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    let daemonStatus = 'indexing';
+    const fetchMock = vi.fn(async () => jsonResponse({ projects: [{ root: ROOT, status: daemonStatus }] }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderHook(() => useDaemon());
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+    const callsAfterMount = fetchMock.mock.calls.length;
+
+    daemonStatus = 'ready';
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PROJECT_STATUS_POLL_INTERVAL_MS * 3);
+    });
+
+    // Only the mount-time fetches (projects/clients/settings) — no
+    // hidden-window polling burning cycles against a daemon the user isn't
+    // even looking at (mirrors the SSE visibility gate, TRA-526).
+    expect(fetchMock.mock.calls.length).toBe(callsAfterMount);
+  });
+});

--- a/packages/app/src/renderer/hooks/useDaemon.ts
+++ b/packages/app/src/renderer/hooks/useDaemon.ts
@@ -139,6 +139,11 @@ type SSEEvent =
    ../daemon-fetch (TRA-264, TRA-934). */
 export { DAEMON_FETCH_TIMEOUT_MS };
 
+/** How often `/api/projects` is re-polled while the window is visible, on top
+ *  of the mount + SSE-reconnect fetches — see the reconciliation effect below
+ *  (TRA-1067). */
+export const PROJECT_STATUS_POLL_INTERVAL_MS = 15_000;
+
 // ── Hook ───────────────────────────────────────────────────────────────
 
 export function useDaemon() {
@@ -248,19 +253,28 @@ export function useDaemon() {
       } else if (event.type === 'indexing_progress') {
         const total = event.total || 1;
         const current = event.processed ?? event.current ?? 0;
+        // The initial indexAll() chain has no dedicated "done" event of its
+        // own (unlike reindex_completed/embed_completed) — its last progress
+        // tick, `phase: 'completed'` at `current === total`, IS the terminal
+        // signal. Unconditionally setting status:'indexing' here meant that
+        // tick landed the row in "Indexing · completed 100%" and nothing
+        // after it ever moved the status to 'ready' (TRA-1067).
+        const done = event.phase === 'completed' || current >= total;
         setProjects((prev) =>
           prev.map((p) =>
             p.root === event.project
-              ? {
-                  ...p,
-                  status: 'indexing',
-                  progress: {
-                    phase: event.phase,
-                    current,
-                    total,
-                    percent: Math.round((current / total) * 100),
-                  },
-                }
+              ? done
+                ? { ...p, status: 'ready', progress: undefined }
+                : {
+                    ...p,
+                    status: 'indexing',
+                    progress: {
+                      phase: event.phase,
+                      current,
+                      total,
+                      percent: Math.round((current / total) * 100),
+                    },
+                  }
               : p,
           ),
         );
@@ -373,6 +387,20 @@ export function useDaemon() {
       eventSourceRef.current = null;
     };
   }, [visible, fetchProjects, fetchClients]);
+
+  /* Periodic reconciliation (TRA-1067). Mount + SSE `onopen` alone leave a
+     permanent gap: if any terminal event (indexing_progress's completed tick,
+     indexing_done, reindex_completed…) is ever dropped, misordered, or racing
+     a reconnect, nothing else ever asks the daemon again — `/api/projects` is
+     the daemon's own answer and it stays un-consulted until the window
+     reloads. This is the safety net under every event-driven status update
+     above: whatever an event gets wrong, the next poll corrects within one
+     interval. Gated on `visible` for the same reason SSE is (TRA-526). */
+  useEffect(() => {
+    if (!visible) return;
+    const id = setInterval(() => void fetchProjects(), PROJECT_STATUS_POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [visible, fetchProjects]);
 
   // Actions
   const addProject = useCallback(async (root: string) => {

--- a/packages/app/src/renderer/tabs/AskTab.tsx
+++ b/packages/app/src/renderer/tabs/AskTab.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { relativeTime } from '../i18n/format';
-import { daemonFetch } from '../daemon-fetch';
+import { daemonFetch, daemonFetchProject } from '../daemon-fetch';
 import { Icon } from '../lattice/icons';
 import { useUsefulPaint } from '../perf';
 import {
@@ -171,8 +171,19 @@ export function AskTab({ root }: { root: string }) {
     let cancelled = false;
     (async () => {
       try {
-        const r = await daemonFetch(`${BASE}/api/ask/provider?project=${encodeURIComponent(root)}`);
-        if (cancelled || !r.ok) return;
+        const r = await daemonFetchProject(
+          `${BASE}/api/ask/provider?project=${encodeURIComponent(root)}`,
+        );
+        if (cancelled) return;
+        // A failed response (project genuinely gone, or still 503 after
+        // daemonFetchProject's retry budget) is still an ANSWER — the panel
+        // must not stay on "Connecting…" forever waiting for one that already
+        // arrived (TRA-1052). `provider` stays null, which the toolbar and the
+        // no-provider CTA below already render correctly.
+        if (!r.ok) {
+          setProviderReady(true);
+          return;
+        }
         const d = await r.json();
         if (!cancelled) {
           setProvider(d.provider ?? null);

--- a/packages/app/src/renderer/tabs/GraphExplorerGPU.tsx
+++ b/packages/app/src/renderer/tabs/GraphExplorerGPU.tsx
@@ -18,7 +18,7 @@ import {
 import { t } from '../i18n';
 import { formatNumber } from '../i18n/format';
 import { FloatingLayer } from '../lattice/FloatingLayer';
-import { daemonFetch } from '../daemon-fetch';
+import { daemonFetchProject } from '../daemon-fetch';
 import { Icon } from '../lattice/icons';
 import { useUsefulPaint } from '../perf';
 import {
@@ -1710,7 +1710,7 @@ export const GraphExplorerGPU = forwardRef<GraphExplorerGPUHandle, Props>(functi
     let lastErr: Error | null = null;
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
       try {
-        const resp = await daemonFetch(`${BASE}/api/projects/graph?${params}`);
+        const resp = await daemonFetchProject(`${BASE}/api/projects/graph?${params}`);
         if (resp.status === 429) {
           const delay = 400 * 2 ** attempt;
           await new Promise((r) => setTimeout(r, delay));

--- a/packages/app/src/renderer/tabs/ProjectOverview.tsx
+++ b/packages/app/src/renderer/tabs/ProjectOverview.tsx
@@ -28,7 +28,7 @@ import { useDaemon } from '../hooks/useDaemon';
 import { deriveDaemonState } from '../workspace/useWorkspaceProjects';
 import { t } from '../i18n';
 import { formatDate, formatList, formatNumber, relativeTime } from '../i18n/format';
-import { daemonFetch } from '../daemon-fetch';
+import { daemonFetch, daemonFetchProject } from '../daemon-fetch';
 import { loadSnapshot, saveSnapshot } from '../snapshot';
 import { Icon } from '../lattice/icons';
 import { useUsefulPaint } from '../perf';
@@ -316,7 +316,9 @@ export function ProjectOverview({
   const fetchStats = useCallback(async () => {
     setStatsLoad('loading');
     try {
-      const res = await daemonFetch(`${BASE}/api/projects/stats?project=${encodeURIComponent(root)}`);
+      const res = await daemonFetchProject(
+        `${BASE}/api/projects/stats?project=${encodeURIComponent(root)}`,
+      );
       if (!res.ok) throw new Error(String(res.status));
       const fresh = (await res.json()) as ProjectStats;
       setStats(fresh);
@@ -360,7 +362,7 @@ export function ProjectOverview({
       setSmellsLoad('loading');
       try {
         const params = new URLSearchParams({ project: root, category, limit: '500' });
-        const res = await daemonFetch(`${BASE}/api/projects/smells?${params}`);
+        const res = await daemonFetchProject(`${BASE}/api/projects/smells?${params}`);
         if (!res.ok) throw new Error(String(res.status));
         setSmells(await res.json());
         setSmellsLoad('ready');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -767,6 +767,130 @@ program
       subscribeToProjectProgress(p.root);
     }
 
+    // ── Lazy HTTP project loading (TRA-1052) ──────────────────────────────
+    // The MCP path (createSessionTransport's caller, above) has always been
+    // able to auto-register/reload a project on first connect. The REST API
+    // never had an equivalent: every `/api/projects/*` read 404'd the moment
+    // `projectManager.getProject()` came back empty, which is the daemon's
+    // resident-in-memory set — a strict subset of what's registered on disk
+    // (idle-unloaded projects, or ones dropped from memory by a daemon
+    // restart, stay registered but aren't in that set). On a real workspace
+    // with 40+ registered projects and a handful resident, that made most of
+    // the project list open broken (404 banners, a raw "Project not found:
+    // <path>" string on Graph, Ask stuck on "Connecting…").
+    //
+    // One in-flight load per root, shared across concurrent requests for the
+    // same project — without this, N tabs/fetches racing a cold project would
+    // each fire their own addProject() (redundant DB opens/watcher starts).
+    const projectLoadPromises = new Map<string, Promise<void>>();
+
+    type ProjectResolution =
+      | { ok: true; managed: ManagedProject }
+      | {
+          ok: false;
+          status: 404 | 503;
+          reason: 'not_registered' | 'folder_missing' | 'loading' | 'indexing';
+          message: string;
+          retryAfterSec?: number;
+        };
+
+    /**
+     * Resolve a REST request's `?project=` to a resident `ManagedProject`,
+     * kicking off a background reload when it's registered but currently
+     * unloaded — mirrors the MCP auto-register path. Never throws; callers
+     * turn a non-ok result into a response via `writeProjectResolutionError`.
+     *
+     * `requireReady`: for routes that need a fully-indexed project (Ask),
+     * a resident-but-still-indexing project also answers "not ready yet"
+     * rather than racing a half-built index.
+     */
+    function resolveProjectForRest(
+      root: string,
+      opts?: { requireReady?: boolean },
+    ): ProjectResolution {
+      const managed = projectManager.getProject(root);
+      if (managed) {
+        if (opts?.requireReady && managed.status !== 'ready') {
+          return {
+            ok: false,
+            status: 503,
+            reason: 'indexing',
+            message: `"${path.basename(root)}" is still indexing — try again in a few seconds.`,
+            retryAfterSec: 3,
+          };
+        }
+        return { ok: true, managed };
+      }
+
+      const registryEntry = getProject(root);
+      if (!registryEntry) {
+        return {
+          ok: false,
+          status: 404,
+          reason: 'not_registered',
+          message: `"${path.basename(root)}" isn't registered with this daemon. Add it from the app's project list.`,
+        };
+      }
+      if (!fs.existsSync(root)) {
+        return {
+          ok: false,
+          status: 404,
+          reason: 'folder_missing',
+          message: `"${path.basename(root)}"'s folder no longer exists on disk. Remove it from the project list.`,
+        };
+      }
+
+      // Registered but idle-unloaded (or dropped by a daemon restart) — kick
+      // off (or join) a reload. `addProject()` itself is idempotent (returns
+      // the existing entry if one raced in first), but starting it twice from
+      // here would still pay setup cost twice, hence the shared promise map.
+      if (!projectLoadPromises.has(root)) {
+        const promise = projectManager
+          .addProject(root)
+          .then(() => {
+            subscribeToProjectProgress(root);
+            broadcastEvent({ type: 'project_status', project: root, status: 'indexing' });
+          })
+          .catch((err) => {
+            logger.warn(
+              { err: String(err), projectRoot: root },
+              'Lazy reload for REST request failed',
+            );
+          })
+          .finally(() => {
+            projectLoadPromises.delete(root);
+          });
+        projectLoadPromises.set(root, promise);
+      }
+      return {
+        ok: false,
+        status: 503,
+        reason: 'loading',
+        message: `Loading "${path.basename(root)}"…`,
+        retryAfterSec: 5,
+      };
+    }
+
+    /** Write a non-ok `ProjectResolution` as the HTTP response. */
+    function writeProjectResolutionError(
+      res: http.ServerResponse,
+      resolution: Extract<ProjectResolution, { ok: false }>,
+      contentType: 'json' | 'text' = 'json',
+    ): void {
+      const headers: Record<string, string> = {
+        'Content-Type': contentType === 'json' ? 'application/json' : 'text/plain',
+      };
+      if (resolution.retryAfterSec != null) {
+        headers['Retry-After'] = String(resolution.retryAfterSec);
+      }
+      res.writeHead(resolution.status, headers);
+      res.end(
+        contentType === 'json'
+          ? JSON.stringify({ error: resolution.message, reason: resolution.reason })
+          : resolution.message,
+      );
+    }
+
     // Shared project-level resources (TopologyStore, DecisionStore) — avoids per-session SQLite overhead
     const { ProjectResourcePool } = await import('./daemon/resource-pool.js');
     const resourcePool = new ProjectResourcePool();
@@ -1367,12 +1491,12 @@ program
           res.end(JSON.stringify({ error: 'Missing ?project= query param' }));
           return;
         }
-        const managed = projectManager.getProject(projectRoot);
-        if (!managed) {
-          res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: `Project not found: ${projectRoot}` }));
+        const resolution = resolveProjectForRest(projectRoot);
+        if (!resolution.ok) {
+          writeProjectResolutionError(res, resolution);
           return;
         }
+        const managed = resolution.managed;
         try {
           const db = managed.store.db;
           let sql: string;
@@ -1434,12 +1558,12 @@ program
           res.end(JSON.stringify({ error: 'Missing ?project= or ?id= query param' }));
           return;
         }
-        const managed = projectManager.getProject(projectRoot);
-        if (!managed) {
-          res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: `Project not found: ${projectRoot}` }));
+        const resolution = resolveProjectForRest(projectRoot);
+        if (!resolution.ok) {
+          writeProjectResolutionError(res, resolution);
           return;
         }
+        const managed = resolution.managed;
         try {
           const db = managed.store.db;
           const symbol = db
@@ -1499,12 +1623,12 @@ program
           res.end(JSON.stringify({ error: 'Missing ?project= query param' }));
           return;
         }
-        const managed = projectManager.getProject(projectRoot);
-        if (!managed) {
-          res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: `Project not found: ${projectRoot}` }));
+        const resolution = resolveProjectForRest(projectRoot);
+        if (!resolution.ok) {
+          writeProjectResolutionError(res, resolution);
           return;
         }
+        const managed = resolution.managed;
         try {
           const scope = url.searchParams.get('scope') ?? 'project';
           const depth = parseInt(url.searchParams.get('depth') ?? '2', 10);
@@ -1570,12 +1694,12 @@ program
           res.end('Missing ?project= query param');
           return;
         }
-        const managed = projectManager.getProject(projectRoot);
-        if (!managed) {
-          res.writeHead(404, { 'Content-Type': 'text/plain' });
-          res.end(`Project not found: ${projectRoot}`);
+        const resolution = resolveProjectForRest(projectRoot);
+        if (!resolution.ok) {
+          writeProjectResolutionError(res, resolution, 'text');
           return;
         }
+        const managed = resolution.managed;
         try {
           const scope = url.searchParams.get('scope') ?? 'project';
           const depth = parseInt(url.searchParams.get('depth') ?? '2', 10);
@@ -1661,12 +1785,12 @@ program
           res.end(JSON.stringify({ error: 'Missing ?project= query param' }));
           return;
         }
-        const managed = projectManager.getProject(projectRoot);
-        if (!managed) {
-          res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: `Project not found: ${projectRoot}` }));
+        const resolution = resolveProjectForRest(projectRoot);
+        if (!resolution.ok) {
+          writeProjectResolutionError(res, resolution);
           return;
         }
+        const managed = resolution.managed;
         try {
           const db = managed.store.db;
           const totalSymbols =
@@ -1727,12 +1851,12 @@ program
           res.end(JSON.stringify({ error: 'Missing ?project= query param' }));
           return;
         }
-        const managed = projectManager.getProject(projectRoot);
-        if (!managed) {
-          res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: `Project not found: ${projectRoot}` }));
+        const resolution = resolveProjectForRest(projectRoot);
+        if (!resolution.ok) {
+          writeProjectResolutionError(res, resolution);
           return;
         }
+        const managed = resolution.managed;
         try {
           const db = managed.store.db;
           const files =
@@ -1767,12 +1891,12 @@ program
           res.end(JSON.stringify({ error: 'Missing ?project= query param' }));
           return;
         }
-        const managed = projectManager.getProject(projectRoot);
-        if (!managed) {
-          res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: `Project not found: ${projectRoot}` }));
+        const resolution = resolveProjectForRest(projectRoot);
+        if (!resolution.ok) {
+          writeProjectResolutionError(res, resolution);
           return;
         }
+        const managed = resolution.managed;
         const categoryParam = url.searchParams.get('category');
         const categories = categoryParam
           ? categoryParam
@@ -1887,12 +2011,12 @@ program
           res.end(JSON.stringify({ error: 'Missing ?project= query param' }));
           return;
         }
-        const managed = projectManager.getProject(projectRoot);
-        if (!managed) {
-          res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: `Project not found: ${projectRoot}` }));
+        const resolution = resolveProjectForRest(projectRoot);
+        if (!resolution.ok) {
+          writeProjectResolutionError(res, resolution);
           return;
         }
+        const managed = resolution.managed;
         try {
           const db = managed.store.db;
           let sql: string;
@@ -2201,11 +2325,33 @@ program
 
       // REST API: list projects
       if (req.method === 'GET' && url.pathname === '/api/projects') {
-        const projects = projectManager.listProjects().map((p) => ({
-          root: p.root,
-          status: p.status,
-          error: p.error,
-        }));
+        // Resident (in-memory) projects are a strict subset of what's
+        // registered on disk — idle-unloaded projects and ones a daemon
+        // restart hasn't reloaded yet stay registered but aren't resident.
+        // Reporting only the resident set here made the app's CTA read the
+        // *daemon's memory pressure* instead of the project's actual state:
+        // an already-indexed, merely-unloaded project showed "+ Index
+        // project" instead of "Reindex" (TRA-1052). A registered entry was
+        // indexed at least once to get registered, so 'ready' is the correct
+        // last-known status until a resident reload (via
+        // resolveProjectForRest, above) says otherwise over SSE.
+        const resident = new Map(projectManager.listProjects().map((p) => [p.root, p]));
+        const projects: { root: string; status: string; error?: string }[] = listProjects().map(
+          (entry) => {
+            const managed = resident.get(entry.root);
+            return managed
+              ? { root: managed.root, status: managed.status, error: managed.error }
+              : { root: entry.root, status: 'ready' };
+          },
+        );
+        // Resident projects the registry doesn't know about (read-mostly
+        // subprojects served with `persist: false` — see addProject()) still
+        // need to appear so their live status reaches the UI.
+        for (const managed of resident.values()) {
+          if (!projects.some((p) => p.root === managed.root)) {
+            projects.push({ root: managed.root, status: managed.status, error: managed.error });
+          }
+        }
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ projects }));
         return;
@@ -2219,12 +2365,16 @@ program
           res.end(JSON.stringify({ error: 'Missing ?project= query param' }));
           return;
         }
-        const managed = projectManager.getProject(projectRoot);
-        if (!managed) {
-          res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: `Project not found: ${projectRoot}` }));
+        // A registered-but-idle-unloaded project answers "Reindex" from the
+        // app's CTA (its last known status is 'ready') — resolving it here
+        // lazily reloads it instead of 404ing; the reload's own indexAll()
+        // covers the user's intent even though it isn't a forced rebuild.
+        const resolution = resolveProjectForRest(projectRoot);
+        if (!resolution.ok) {
+          writeProjectResolutionError(res, resolution);
           return;
         }
+        const managed = resolution.managed;
         // R09 v2: lifecycle events around the reindex call.
         // started is fire-and-forget; completed/errored fire on the
         // async settlement of the pipeline promise.
@@ -2649,12 +2799,12 @@ program
           res.end(JSON.stringify({ error: 'Missing ?project= parameter' }));
           return;
         }
-        const managed = projectManager.getProject(projectRoot);
-        if (!managed || managed.status !== 'ready') {
-          res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Project not found or not ready' }));
+        const resolution = resolveProjectForRest(projectRoot, { requireReady: true });
+        if (!resolution.ok) {
+          writeProjectResolutionError(res, resolution);
           return;
         }
+        const managed = resolution.managed;
         try {
           const { resolveProvider } = await import('./ai/ask-shared.js');
           // Reload config from disk so we pick up settings changed via the UI
@@ -2682,12 +2832,12 @@ program
           res.end(JSON.stringify({ error: 'Missing ?project= parameter' }));
           return;
         }
-        const managed = projectManager.getProject(projectRoot);
-        if (!managed || managed.status !== 'ready') {
-          res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Project not found or not ready' }));
+        const resolution = resolveProjectForRest(projectRoot, { requireReady: true });
+        if (!resolution.ok) {
+          writeProjectResolutionError(res, resolution);
           return;
         }
+        const managed = resolution.managed;
 
         let body: {
           messages?: { role: string; content: string }[];


### PR DESCRIPTION
## Summary

Cluster fix for TRA-1052 / TRA-1053 / TRA-1067 (this PR covers the two issues assigned to me — TRA-1052 and TRA-1067; TRA-1053's `/api/dashboard/projects` cold-start latency is a separate assignee's fix). Reproduces on a real workspace with 40+ registered projects and only a handful resident — a fixture with every project already loaded never shows this class of bug.

**Root cause (TRA-1052):** every `/api/projects/*` REST route 404'd the instant `projectManager.getProject()` came back empty. That set is the daemon's *resident-in-memory* projects, a strict subset of what's *registered* on disk — idle-unloaded projects (the common case on a large workspace) stay registered but aren't resident. The MCP path has always been able to auto-register/reload a project on first connect; the REST API never had an equivalent.

**Root cause (TRA-1067):** the initial `indexAll()` chain has no dedicated "done" SSE event (unlike `reindex_completed`/`embed_completed`) — its own last `indexing_progress` tick, `phase: 'completed'`, IS the terminal signal. The frontend handler treated every tick as "still indexing", so a finished project stayed rendered as "Indexing · completed 100%" forever.

## Changes

- **`src/cli.ts`** — new `resolveProjectForRest()`, mirroring the MCP auto-register path: a REST read against a registered-but-idle-unloaded project now kicks off a background reload and answers `503 + Retry-After` instead of `404`, with a human-readable reason instead of a raw absolute path (`Project not found: /Users/...`). Applied to every project-scoped route that depends on daemon memory (symbols, symbol/edges, graph, graph/html, graph-stats, stats, smells, files, reindex, ask/provider, ask). `GET /api/projects` now lists every *registered* project (status `'ready'` when idle-unloaded, since registration implies it was indexed at least once), not just the resident subset — this is what the header CTA reads, so it stops offering "+ Index project" for an already-indexed, merely-unloaded project.
- **`packages/app/.../daemon-fetch.ts`** — `daemonFetchProject()`: retries a `503` honoring `Retry-After`, so Overview/Graph/Ask's existing `loading` UI state carries the wait instead of the caller having to special-case "still loading" as a failure.
- **`packages/app/.../tabs/AskTab.tsx`** — fixed a real bug found while wiring this up: the provider probe left `providerReady` false forever on any non-ok response, which is the literal "Ask stuck on Connecting…" symptom reported in TRA-1052 (independent of the 404 — a genuine failure after retries would have hung the same way).
- **`packages/app/.../hooks/useDaemon.ts`** — `indexing_progress` now treats `phase === 'completed'` (or `current >= total`) as terminal → `ready`, not `indexing`. Added a periodic `/api/projects` poll (on top of mount + SSE reconnect) so status converges with the daemon even if a terminal event is ever dropped or misordered — the safety net the cluster's acceptance criteria asked for.

## Test plan

- [x] New test `daemon-status-reconciliation.test.tsx`: completion-tick fix (3 cases) + the acceptance-criterion scenario — a dropped terminal event, converging via the periodic poll, and a check that hidden windows don't poll.
- [x] Full local suites green: root `pnpm test` — 946 files / 10543 tests passed, 3 pre-existing skips; `packages/app` — 72 files / 725 tests passed.
- [x] `pnpm run typecheck` clean in both packages; `biome check` clean on touched root files.