### PR TITLE
fix(analysis): label communities in the Graph tab, not detect_communities

### DIFF
--- a/src/tools/analysis/visualize.ts
+++ b/src/tools/analysis/visualize.ts
@@ -18,6 +18,7 @@ import { logger } from '../../logger.js';
 import type { TopologyStore } from '../../topology/topology-db.js';
 import { writeTmpFileSync } from '../../utils/safe-fs.js';
 import { computeBottlenecksForVizGraph } from './bottlenecks.js';
+import { labelCommunities } from './communities.js';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -839,8 +840,11 @@ function finalize(
   }
 
   // Build community list with meaningful labels — group nodes by community,
-  // then derive a human-readable name from the dominant path prefix (e.g.
-  // "src/indexer" for a cluster of files under src/indexer/*).
+  // then label via the same cross-community-unique ladder as the MCP
+  // detect_communities/get_communities tools (TRA-1078: this file used to
+  // have its own single-segment labeler with no uniqueness pass, which is
+  // what the Graph tab actually renders — labelCommunities() is now the only
+  // implementation for both paths).
   const byCommunity = new Map<number, VizNode[]>();
   for (const n of vizNodes) {
     const arr = byCommunity.get(n.community);
@@ -860,50 +864,23 @@ function finalize(
     '#9c755f',
     '#bab0ac',
   ];
+  // labelCommunities() picks in priority order — largest community first
+  // keeps the short label — so sort before labeling, then map back by id.
+  const orderedIds = [...communitySet].sort(
+    (a, b) => (byCommunity.get(b)?.length ?? 0) - (byCommunity.get(a)?.length ?? 0),
+  );
+  const fileGroups = orderedIds.map((id) =>
+    (byCommunity.get(id) ?? []).map((n) => n.id.split('::')[0]),
+  );
+  const labels = labelCommunities(fileGroups);
+  const labelById = new Map(orderedIds.map((id, i) => [id, labels[i]]));
   const communities: VizCommunity[] = [...communitySet].map((id) => ({
     id,
-    label: deriveCommunityLabel(byCommunity.get(id) ?? [], id),
+    label: labelById.get(id) ?? `group-${id}`,
     color: COLORS[id % COLORS.length],
   }));
 
   return { nodes: vizNodes, edges: dedupedEdges, communities };
-}
-
-/**
- * Derive a human-readable label for a community from the dominant file-path
- * prefix of its members. Tries 2-level prefixes first (e.g. "src/indexer"),
- * falls back to 1-level ("src") if nothing is dominant, then to "group-N".
- *
- * For symbol-granularity graphs the node id carries a "::" suffix — we strip
- * it so the prefix reflects the file location, not the FQN.
- */
-function deriveCommunityLabel(nodes: VizNode[], communityId: number): string {
-  if (nodes.length === 0) return `group-${communityId}`;
-  const prefixCounts = new Map<string, number>();
-  for (const n of nodes) {
-    const filePath = n.id.split('::')[0];
-    const parts = filePath.split('/').filter(Boolean);
-    if (parts.length === 0) continue;
-    const key2 = parts.slice(0, 2).join('/');
-    const key1 = parts[0];
-    // Count both — the winner of key2 is used if dominant enough, else key1.
-    prefixCounts.set(key2, (prefixCounts.get(key2) ?? 0) + 1);
-    if (key1 !== key2) prefixCounts.set(key1, (prefixCounts.get(key1) ?? 0) + 1);
-  }
-  // Pick the longest prefix that covers at least 50% of the community.
-  let best = '';
-  let bestScore = 0;
-  const threshold = Math.ceil(nodes.length * 0.5);
-  for (const [prefix, count] of prefixCounts) {
-    if (count < threshold) continue;
-    // Prefer longer (deeper) prefix; tie-break by higher count.
-    const score = prefix.split('/').length * 1000 + count;
-    if (score > bestScore) {
-      bestScore = score;
-      best = prefix;
-    }
-  }
-  return best || `group-${communityId}`;
 }
 
 // ── HTML Template ──────────────────────────────────────────────────────

--- a/tests/tools/visualize.test.ts
+++ b/tests/tools/visualize.test.ts
@@ -353,3 +353,44 @@ describe('buildGraphData subproject filtering', () => {
     expect(result.nodes.every((n) => n.repo !== 'trace-mcp')).toBe(true);
   });
 });
+
+describe('buildGraphData community labels (TRA-1078)', () => {
+  it('assigns unique labels across communities that collide on their dominant segment', () => {
+    // Regression for the Graph tab (not detect_communities/get_communities):
+    // three disconnected clusters that all share "indexer" as their most
+    // frequent path segment used to render two "src" legend rows and repeat
+    // "indexer" across unrelated clusters.
+    const store = createTestStore();
+
+    const cluster = (files: string[]) => {
+      const nodeIds = files.map(
+        (f, i) => store.getNodeId('file', store.insertFile(f, 'typescript', `h-${f}-${i}`, 10))!,
+      );
+      for (let i = 1; i < nodeIds.length; i++) {
+        store.insertEdge(nodeIds[0], nodeIds[i], 'imports');
+      }
+    };
+
+    cluster(['src/indexer/a.ts', 'src/indexer/b.ts']);
+    cluster(['core/indexer/c.ts', 'core/indexer/d.ts', 'misc/indexer/e.ts']);
+    cluster([
+      'tools/indexer/f.ts',
+      'tools/indexer/g.ts',
+      'other/indexer/h.ts',
+      'other/indexer/i.ts',
+    ]);
+
+    const result = buildGraphData(store, { scope: 'project' });
+
+    const labels = result.communities.map((c) => c.label);
+    expect(new Set(labels).size).toBe(labels.length); // no legend duplicates
+
+    const labelForFile = (file: string) => {
+      const node = result.nodes.find((n) => n.id === file);
+      return result.communities.find((c) => c.id === node?.community)?.label;
+    };
+    expect(labelForFile('tools/indexer/f.ts')).toBe('indexer'); // largest cluster keeps the short name
+    expect(labelForFile('core/indexer/c.ts')).toBe('core/indexer');
+    expect(labelForFile('src/indexer/a.ts')).toBe('src/indexer');
+  });
+});


### PR DESCRIPTION
## Summary

TRA-1078's original fix (#1052, already merged) fixed the wrong function.
The Graph tab (`/api/projects/graph` → `buildGraphData()` in
`src/tools/analysis/visualize.ts`) never calls `autoLabel()` /
`labelCommunities()` from `src/tools/analysis/communities.ts` (used by the
`detect_communities`/`get_communities` MCP tools) — it has its own
`deriveCommunityLabel()`, with the identical no-cross-community-uniqueness
defect. #1052 left that function untouched, so the Graph tab still renders
colliding labels ("src" twice in the legend, `src/indexer` repeated across
unrelated clusters).

- Removed `deriveCommunityLabel()` and switched `finalize()` (the shared
  tail of every `buildGraphData()` path — single project, subproject merge,
  file graph, symbol graph) to call the exported `labelCommunities()` from
  `communities.ts`, so there is exactly one label-uniqueness implementation
  for both surfaces.
- `labelCommunities()` expects its input groups in priority order (largest
  first keeps the short name), so `finalize()` now sorts communities by
  size before labeling and maps labels back by community id.

## Test plan

- [x] New test in `tests/tools/visualize.test.ts` (`buildGraphData community labels (TRA-1078)`) builds three disconnected file clusters that all share `indexer` as their dominant path segment and asserts `buildGraphData()` — not `labelCommunities()` directly — returns unique labels with no duplicate legend entries, exactly what the Graph tab renders.
- [x] `npx vitest run` — 944 files / 10545 tests passed, 29 skipped (no regressions)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` (tsup) — clean
- [x] `npx biome check` on changed files — clean