### PR TITLE
fix(app): contract-test daemon wire responses; fix pagerank/hotspot/search/get_symbol field drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "biome:ci": "biome ci",
     "serve": "tsx src/cli.ts serve",
     "count:tools": "node scripts/count-advertised-tools.mjs",
+    "record:wire-fixtures": "tsx scripts/record-wire-fixtures.ts",
     "replay:check": "tsx scripts/replay-eval.ts",
     "replay:update-baseline": "tsx scripts/replay-eval.ts --update-baseline",
     "bench:state-replay": "tsx scripts/state-trace-replay.ts",

--- a/packages/app/src/renderer/tabs/__tests__/insights-runtime.wire.test.ts
+++ b/packages/app/src/renderer/tabs/__tests__/insights-runtime.wire.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ */
+/* Contract tests for the Insights report flatteners, run against *recorded*
+ * daemon wire responses (tests/fixtures/wire/*.json) rather than hand-built
+ * mock objects.
+ *
+ * TRA-1068: five production bugs were a mapping reading a field name the
+ * daemon never sends, and each one degraded silently into "0 rows" — the
+ * exact same shape a genuinely empty project produces. A mock built by the
+ * same person who wrote the mapping reproduces their assumption, not the
+ * wire; only a real captured response can catch that class of bug. These
+ * fixtures were captured from a live `serve-http` daemon indexing this repo
+ * (see the tool responses quoted in TRA-1062/TRA-1064). To refresh: start a
+ * daemon on a scratch project, call the tool, and copy `content[0].text`
+ * (JSON.parse'd) into the matching fixture file.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  flattenDriftRows,
+  flattenPagerankRows,
+  flattenRiskHotspotRows,
+} from '../insights-runtime.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const wireDir = path.resolve(here, '../../../../../../tests/fixtures/wire');
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(readFileSync(path.join(wireDir, name), 'utf-8'));
+}
+
+describe('flattenPagerankRows — real get_pagerank wire shape', () => {
+  it('reads the `{ data: [...] }` envelope the tool-gate layer actually sends', () => {
+    const payload = loadFixture('get_pagerank.json');
+    const { rows } = flattenPagerankRows(payload);
+    expect(rows.length).toBe(6);
+    expect(rows[0].primary).toBe('src/errors.ts');
+    // Real score 0.039362 — not "?", not undefined.
+    expect(rows[0].badge).toBe('0.039');
+  });
+
+  it('throws instead of silently emptying on a shape it does not recognise', () => {
+    expect(() => flattenPagerankRows({ unexpected_field: 'x' })).toThrow();
+  });
+
+  it('treats a null/undefined payload as the real empty state', () => {
+    expect(flattenPagerankRows(null)).toEqual({ rows: [] });
+    expect(flattenPagerankRows(undefined)).toEqual({ rows: [] });
+  });
+});
+
+describe('flattenRiskHotspotRows — real get_risk_hotspots wire shape', () => {
+  it('reads `max_cyclomatic` and `assessment`, the fields the tool actually returns', () => {
+    const payload = loadFixture('get_risk_hotspots.json');
+    const { rows } = flattenRiskHotspotRows(payload);
+    expect(rows.length).toBe(6);
+    const first = rows[0];
+    expect(first.primary).toBe('src/daemon/project-manager.ts');
+    // Real max_cyclomatic is 175 — the old code read `.complexity` (undefined)
+    // and printed "?" here.
+    expect(first.secondary).toContain('175');
+    // Real assessment is "high" — the old code showed `confidence_level`
+    // ("medium") in this slot instead.
+    expect(first.secondary).toContain('high');
+    expect(first.secondary).not.toContain('medium');
+  });
+
+  it('treats the tool\'s own "no hotspots" shape as a real empty result, not a parse failure', () => {
+    // Verbatim shape from src/tools/git/git-analysis.ts's zero-results branch:
+    // no `hotspots` key at all, just a message + methodology notes.
+    const payload = { message: 'No hotspots found (no complex files with git churn)' };
+    expect(flattenRiskHotspotRows(payload)).toEqual({ rows: [] });
+  });
+
+  it('throws instead of silently emptying on a shape it does not recognise', () => {
+    expect(() => flattenRiskHotspotRows({ unexpected_field: 'x' })).toThrow();
+  });
+});
+
+describe('flattenDriftRows — real check_claudemd_drift wire shape', () => {
+  it('throws instead of silently emptying when `issues` is missing', () => {
+    expect(() => flattenDriftRows({ files_scanned: 3 })).toThrow();
+  });
+
+  it('treats a null/undefined payload as the real empty state', () => {
+    expect(flattenDriftRows(null)).toEqual({ rows: [] });
+  });
+});

--- a/packages/app/src/renderer/tabs/__tests__/notebook-runtime.wire.test.ts
+++ b/packages/app/src/renderer/tabs/__tests__/notebook-runtime.wire.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Contract test for the Notebook `get_symbol` cell's argument shaping
+ * (TRA-1064): the cell's field key must match the argument name the daemon's
+ * `get_symbol` tool actually reads (`symbol_id`), not `fqn` — nearly every
+ * symbol's `fqn` column is NULL, so sending the id under the wrong key
+ * produced NOT_FOUND on a perfectly valid id. This drives the real
+ * request-building code in defaultNotebookClient (not a mock of it) through
+ * a fake daemon that answers exactly like the real one recorded in
+ * tests/fixtures/wire/*.json — success for `symbol_id`, NOT_FOUND for `fqn`.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TOOL_BY_NAME, defaultNotebookClient } from '../notebook-runtime.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const wireDir = path.resolve(here, '../../../../../../tests/fixtures/wire');
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(readFileSync(path.join(wireDir, name), 'utf-8'));
+}
+
+const root = '/some/project';
+const SESSION_ID = 'test-session';
+
+/** Fakes the initialize -> notifications/initialized -> tools/call dance,
+ * routing the tools/call response by the arguments actually sent — same
+ * branching the real daemon does based on which argument key it receives. */
+function stubDaemon(respond: (args: Record<string, unknown>) => unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      if (body.method === 'initialize') {
+        return {
+          ok: true,
+          headers: new Headers({ 'mcp-session-id': SESSION_ID }),
+          text: async () => '',
+        } as unknown as Response;
+      }
+      if (body.method === 'notifications/initialized') {
+        return { ok: true, text: async () => '' } as unknown as Response;
+      }
+      const args = (body.params?.arguments ?? {}) as Record<string, unknown>;
+      const result = respond(args);
+      return {
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: body.id,
+          result: { content: [{ type: 'text', text: JSON.stringify(result) }] },
+        }),
+      } as unknown as Response;
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('Notebook get_symbol cell — argument key (TRA-1064)', () => {
+  it('is defined to send `symbol_id`, not `fqn`', () => {
+    expect(TOOL_BY_NAME.get_symbol.fields.map((f) => f.key)).toEqual(['symbol_id']);
+  });
+
+  it("resolves a real symbol_id against the daemon's actual get_symbol contract", async () => {
+    const success = loadFixture('get_symbol.json');
+    const notFound = loadFixture('get_symbol_wrong_arg_not_found.json');
+    stubDaemon((args) => (args.symbol_id ? success : notFound));
+
+    // Build args the way the UI does: one entry per field, keyed by field.key.
+    const field = TOOL_BY_NAME.get_symbol.fields[0];
+    const args = { [field.key]: 'src/daemon/project-manager.ts::ProjectManager#class' };
+
+    const result = await defaultNotebookClient.callTool('get_symbol', args, root);
+    expect(result).toEqual(success);
+  });
+
+  it('reproduces the recorded NOT_FOUND when the id is sent under `fqn` instead', async () => {
+    const success = loadFixture('get_symbol.json');
+    const notFound = loadFixture('get_symbol_wrong_arg_not_found.json');
+    stubDaemon((args) => (args.symbol_id ? success : notFound));
+
+    // The client doesn't unwrap MCP's `isError` into a thrown JS error (a
+    // separate, pre-existing gap — Notebook.tsx renders whatever resolves),
+    // so this resolves to the recorded NOT_FOUND payload rather than throwing.
+    const result = await defaultNotebookClient.callTool(
+      'get_symbol',
+      { fqn: 'src/daemon/project-manager.ts::ProjectManager#class' },
+      root,
+    );
+    expect(result).toEqual(notFound);
+  });
+});

--- a/packages/app/src/renderer/tabs/insights-runtime.ts
+++ b/packages/app/src/renderer/tabs/insights-runtime.ts
@@ -159,9 +159,12 @@ export function buildLoadToolsCall(reportId: ReportId, id: number = 2): JsonRpcC
 
 // ── Result shaping ───────────────────────────────────────────────────
 // Each MCP tool returns a slightly different payload. The renderer needs
-// a uniform shape, so we flatten here. Defensive — if the payload is
-// missing or malformed we return an empty rows array rather than throwing,
-// because the renderer surfaces "0 rows" as the empty state.
+// a uniform shape, so we flatten here. A missing/`null` payload (the daemon
+// truly has nothing to say) flattens to zero rows — that's the real empty
+// state. A payload that IS present but doesn't match any shape we know
+// throws instead (TRA-1068): five bugs in production were a mapping
+// silently returning [] on a field-name mismatch and the renderer drawing
+// "nothing to report" over what was actually broken parsing.
 
 function shortFile(file: string): string {
   // Strip a leading project root if it leaked through (the tool usually
@@ -169,7 +172,13 @@ function shortFile(file: string): string {
   return file.replace(/^.*?\/(?=src\/|packages\/|tests\/|plans\/|docs\/)/, '');
 }
 
+/** Nullish payload = genuinely nothing to report; anything else must resolve to a real shape. */
+function unrecognizedShape(): never {
+  throw new Error(t('insights:errorUnrecognizedShape'));
+}
+
 export function flattenDriftRows(payload: unknown): InsightRows {
+  if (payload === null || payload === undefined) return { rows: [] };
   const p = payload as {
     issues?: Array<{
       file?: string;
@@ -180,8 +189,8 @@ export function flattenDriftRows(payload: unknown): InsightRows {
       fix?: string;
     }>;
   };
-  const issues = Array.isArray(p?.issues) ? p.issues : [];
-  const rows = issues.map((it) => {
+  if (!Array.isArray(p.issues)) return unrecognizedShape();
+  const rows = p.issues.map((it) => {
     const location = it.line ? `${shortFile(it.file ?? '?')}:${it.line}` : shortFile(it.file ?? '?');
     return {
       primary: t('insights:rowIssue', {
@@ -196,14 +205,25 @@ export function flattenDriftRows(payload: unknown): InsightRows {
 }
 
 export function flattenPagerankRows(payload: unknown): InsightRows {
-  // Tool returns a bare array; the JSON-RPC content unwrap in the client
-  // produces either an array directly or an envelope { items: [...] }.
-  const arr = Array.isArray(payload)
-    ? payload
-    : Array.isArray((payload as { items?: unknown[] })?.items)
-      ? (payload as { items: Array<{ file?: string; score?: number }> }).items
-      : [];
-  const rows = (arr as Array<{ file?: string; score?: number }>).map((it) => ({
+  if (payload === null || payload === undefined) return { rows: [] };
+  // get_pagerank's own code returns a bare array, but the tool-gate layer
+  // (src/server/tool-gate-helpers.ts:rewriteResponseJson) wraps any
+  // non-object top-level result as `{ data: [...] }` when it attaches hints
+  // or budget metadata — which happens on effectively every call. `items` is
+  // kept as a second envelope for tools that wrap that way natively.
+  let arr: Array<{ file?: string; score?: number }>;
+  if (Array.isArray(payload)) {
+    arr = payload;
+  } else if (typeof payload === 'object') {
+    const obj = payload as { data?: unknown; items?: unknown };
+    if (Array.isArray(obj.data)) arr = obj.data as Array<{ file?: string; score?: number }>;
+    else if (Array.isArray(obj.items)) arr = obj.items as Array<{ file?: string; score?: number }>;
+    else if (Object.keys(obj).length === 0) arr = [];
+    else return unrecognizedShape();
+  } else {
+    return unrecognizedShape();
+  }
+  const rows = arr.map((it) => ({
     primary: shortFile(it.file ?? '?'),
     secondary:
       typeof it.score === 'number'
@@ -215,26 +235,32 @@ export function flattenPagerankRows(payload: unknown): InsightRows {
 }
 
 export function flattenRiskHotspotRows(payload: unknown): InsightRows {
+  if (payload === null || payload === undefined) return { rows: [] };
+  if (typeof payload !== 'object') return unrecognizedShape();
   const p = payload as {
     hotspots?: Array<{
       file?: string;
       score?: number;
-      complexity?: number;
+      max_cyclomatic?: number;
       commits?: number;
-      confidence_level?: string;
+      assessment?: string;
     }>;
+    // get_risk_hotspots' own "nothing found" shape (src/tools/register/git.ts)
+    // has no `hotspots` key at all — a real empty result, not a parse miss.
+    message?: string;
   };
-  const hotspots = Array.isArray(p?.hotspots) ? p.hotspots : [];
+  let hotspots: NonNullable<typeof p.hotspots>;
+  if (Array.isArray(p.hotspots)) hotspots = p.hotspots;
+  else if (typeof p.message === 'string') hotspots = [];
+  else if (Object.keys(p).length === 0) hotspots = [];
+  else return unrecognizedShape();
   const rows = hotspots.map((it) => ({
     primary: shortFile(it.file ?? '?'),
-    secondary: t(
-      it.confidence_level ? 'insights:rowHotspotConfidence' : 'insights:rowHotspot',
-      {
-        complexity: it.complexity ?? '?',
-        commits: it.commits ?? '?',
-        confidence: it.confidence_level,
-      },
-    ),
+    secondary: t(it.assessment ? 'insights:rowHotspotConfidence' : 'insights:rowHotspot', {
+      complexity: it.max_cyclomatic ?? '?',
+      commits: it.commits ?? '?',
+      confidence: it.assessment,
+    }),
     badge: typeof it.score === 'number' ? it.score.toFixed(1) : undefined,
   }));
   return { rows };

--- a/packages/app/src/renderer/tabs/insights-runtime.ts
+++ b/packages/app/src/renderer/tabs/insights-runtime.ts
@@ -189,7 +189,10 @@ export function flattenDriftRows(payload: unknown): InsightRows {
       fix?: string;
     }>;
   };
-  if (!Array.isArray(p.issues)) return unrecognizedShape();
+  if (!Array.isArray(p.issues)) {
+    if (Object.keys(p).length === 0) return { rows: [] };
+    return unrecognizedShape();
+  }
   const rows = p.issues.map((it) => {
     const location = it.line ? `${shortFile(it.file ?? '?')}:${it.line}` : shortFile(it.file ?? '?');
     return {

--- a/packages/app/src/renderer/tabs/notebook-runtime.ts
+++ b/packages/app/src/renderer/tabs/notebook-runtime.ts
@@ -83,10 +83,10 @@ export const NOTEBOOK_TOOLS: ToolDef[] = [
     descriptionKey: 'notebook:symbolDescription',
     fields: [
       {
-        key: 'fqn',
-        labelKey: 'notebook:fqnLabel',
-        placeholderKey: 'notebook:fqnPlaceholder',
-        missingKey: 'notebook:fqnMissing',
+        key: 'symbol_id',
+        labelKey: 'notebook:symbolIdLabel',
+        placeholderKey: 'notebook:symbolIdPlaceholder',
+        missingKey: 'notebook:symbolIdMissing',
         required: true,
       },
     ],

--- a/packages/app/src/shared/i18n/catalog/de/insights.ts
+++ b/packages/app/src/shared/i18n/catalog/de/insights.ts
@@ -10,6 +10,8 @@ export const insights = {
   errorNoSession: 'Der Daemon hat eine Sitzung gestartet, sie aber nicht benannt.',
   errorHttp: 'Die Berichtsanfrage ist fehlgeschlagen (HTTP {{status}}). {{detail}}',
   errorToolFailed: 'Der Bericht wurde nicht ausgeführt.',
+  errorUnrecognizedShape:
+    'Der Bericht wurde ausgeführt, aber die Antwort entsprach nicht der erwarteten Form — das sieht nach einem Fehler aus, nicht nach einem leeren Projekt.',
 
   reportDriftTitle: 'CLAUDE.md-Abweichungen',
   reportDriftDescription: 'Veraltete Pfade und tote Symbolverweise in Agenten-Konfigurationsdateien.',

--- a/packages/app/src/shared/i18n/catalog/en/insights.ts
+++ b/packages/app/src/shared/i18n/catalog/en/insights.ts
@@ -19,6 +19,11 @@ export const insights = {
   errorNoSession: 'The daemon started a session but did not name it.',
   errorHttp: 'The report request failed (HTTP {{status}}). {{detail}}',
   errorToolFailed: 'The report did not run.',
+  /* TRA-1068: the daemon answered with real data, but this report's parser
+     did not recognise the response shape (a field-name mismatch, not an
+     empty project). Showing "Nothing to report" here would assert something
+     false about the user's data, so it surfaces as an error instead. */
+  errorUnrecognizedShape: "The report ran, but its response didn't match the shape this report expects — this looks like a bug, not an empty project.",
 
   reportDriftTitle: 'CLAUDE.md drift',
   reportDriftDescription: 'Stale paths and dead symbol references in agent config files.',

--- a/packages/app/src/shared/i18n/catalog/es/insights.ts
+++ b/packages/app/src/shared/i18n/catalog/es/insights.ts
@@ -10,6 +10,8 @@ export const insights = {
   errorNoSession: 'El daemon inició una sesión pero no la identificó.',
   errorHttp: 'La petición del informe falló (HTTP {{status}}). {{detail}}',
   errorToolFailed: 'El informe no llegó a ejecutarse.',
+  errorUnrecognizedShape:
+    'El informe se ejecutó, pero su respuesta no coincidió con la forma esperada — esto parece un error, no un proyecto vacío.',
 
   reportDriftTitle: 'Desvío de CLAUDE.md',
   reportDriftDescription:

--- a/packages/app/src/shared/i18n/catalog/fr/insights.ts
+++ b/packages/app/src/shared/i18n/catalog/fr/insights.ts
@@ -10,6 +10,8 @@ export const insights = {
   errorNoSession: 'Le démon a ouvert une session mais ne l’a pas nommée.',
   errorHttp: 'La demande de rapport a échoué (HTTP {{status}}). {{detail}}',
   errorToolFailed: 'Le rapport n’a pas été exécuté.',
+  errorUnrecognizedShape:
+    'Le rapport s’est exécuté, mais sa réponse ne correspondait pas à la forme attendue — cela ressemble à un bug, pas à un projet vide.',
 
   reportDriftTitle: 'Dérive de CLAUDE.md',
   reportDriftDescription:

--- a/packages/app/src/shared/i18n/catalog/hi/insights.ts
+++ b/packages/app/src/shared/i18n/catalog/hi/insights.ts
@@ -10,6 +10,8 @@ export const insights = {
   errorNoSession: 'डेमन ने सेशन शुरू किया पर उसका नाम नहीं दिया।',
   errorHttp: 'रिपोर्ट की रिक्वेस्ट विफल रही (HTTP {{status}})। {{detail}}',
   errorToolFailed: 'रिपोर्ट नहीं चली।',
+  errorUnrecognizedShape:
+    'रिपोर्ट चली, लेकिन उसका जवाब अपेक्षित रूप से मेल नहीं खाया — यह खाली प्रोजेक्ट नहीं, बग जैसा लगता है।',
 
   reportDriftTitle: 'CLAUDE.md drift',
   reportDriftDescription: 'एजेंट कॉन्फ़िग फ़ाइलों में पुराने पाथ और मृत सिंबल संदर्भ।',

--- a/packages/app/src/shared/i18n/catalog/ja/insights.ts
+++ b/packages/app/src/shared/i18n/catalog/ja/insights.ts
@@ -10,6 +10,8 @@ export const insights = {
   errorNoSession: 'デーモンはセッションを開始しましたが、名前を返しませんでした。',
   errorHttp: 'レポートのリクエストが失敗しました（HTTP {{status}}）。{{detail}}',
   errorToolFailed: 'レポートは実行されませんでした。',
+  errorUnrecognizedShape:
+    'レポートは実行されましたが、レスポンスが想定される形式と一致しませんでした — これは空のプロジェクトではなく、不具合のように見えます。',
 
   reportDriftTitle: 'CLAUDE.md のずれ',
   reportDriftDescription: 'エージェント設定ファイル内の古いパスと存在しないシンボル参照。',

--- a/packages/app/src/shared/i18n/catalog/ko/insights.ts
+++ b/packages/app/src/shared/i18n/catalog/ko/insights.ts
@@ -10,6 +10,8 @@ export const insights = {
   errorNoSession: '데몬이 세션을 시작했지만 이름을 반환하지 않았습니다.',
   errorHttp: '리포트 요청이 실패했습니다 (HTTP {{status}}). {{detail}}',
   errorToolFailed: '리포트가 실행되지 않았습니다.',
+  errorUnrecognizedShape:
+    '리포트는 실행되었지만 응답이 예상한 형식과 일치하지 않았습니다 — 빈 프로젝트가 아니라 버그로 보입니다.',
 
   reportDriftTitle: 'CLAUDE.md 불일치',
   reportDriftDescription: '에이전트 설정 파일의 오래된 경로와 사라진 심볼 참조.',

--- a/packages/app/src/shared/i18n/catalog/pt-BR/insights.ts
+++ b/packages/app/src/shared/i18n/catalog/pt-BR/insights.ts
@@ -10,6 +10,8 @@ export const insights = {
   errorNoSession: 'O daemon abriu uma sessão, mas não a identificou.',
   errorHttp: 'A requisição do relatório falhou (HTTP {{status}}). {{detail}}',
   errorToolFailed: 'O relatório não foi executado.',
+  errorUnrecognizedShape:
+    'O relatório rodou, mas a resposta não correspondeu ao formato esperado — isso parece um bug, não um projeto vazio.',
 
   reportDriftTitle: 'Desvio do CLAUDE.md',
   reportDriftDescription:

--- a/packages/app/src/shared/i18n/catalog/ru/insights.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/insights.ts
@@ -13,6 +13,8 @@ export const insights = {
   errorNoSession: 'Служба начала сеанс, но не сообщила его идентификатор.',
   errorHttp: 'Запрос отчёта не прошёл (HTTP {{status}}). {{detail}}',
   errorToolFailed: 'Отчёт не выполнился.',
+  errorUnrecognizedShape:
+    'Отчёт выполнился, но его ответ не совпал с ожидаемой формой — это похоже на баг, а не на пустой проект.',
 
   reportDriftTitle: 'Расхождения в CLAUDE.md',
   reportDriftDescription:

--- a/packages/app/src/shared/i18n/catalog/zh/insights.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/insights.ts
@@ -10,6 +10,7 @@ export const insights = {
   errorNoSession: '守护进程创建了会话，但没有返回会话名。',
   errorHttp: '报告请求失败（HTTP {{status}}）。{{detail}}',
   errorToolFailed: '报告没有运行。',
+  errorUnrecognizedShape: '报告已运行，但其响应与预期格式不匹配——这看起来像是一个错误，而不是空项目。',
 
   reportDriftTitle: 'CLAUDE.md 偏移',
   reportDriftDescription: '智能体配置文件中失效的路径和不存在的符号引用。',

--- a/scripts/record-wire-fixtures.ts
+++ b/scripts/record-wire-fixtures.ts
@@ -1,0 +1,182 @@
+#!/usr/bin/env tsx
+/**
+ * TRA-1068 — refresh tests/fixtures/wire/*.json from a real daemon.
+ *
+ * Five production bugs (TRA-1062, TRA-1064) were a client parsing a field
+ * name the daemon never sends. The contract tests in
+ * packages/app/src/renderer/tabs/__tests__/*.wire.test.ts and
+ * tests/api/symbols-search-query.test.ts catch that class of bug ONLY if the
+ * fixtures they run against are the real wire shape, not a hand-typed guess.
+ * This script is that capture step, so refreshing it costs one command
+ * instead of a manual curl session against a live daemon.
+ *
+ * It spawns a real `serve-http` daemon (in-process registration would skip
+ * the tool-gate layer in src/server/tool-gate-helpers.ts, which wraps a
+ * bare-array tool result as `{ data: [...] }` on effectively every call —
+ * that wrapping IS part of the contract these fixtures pin), points it at
+ * this repo's own checkout, and drives the exact JSON-RPC / REST sequence
+ * the renderer uses.
+ *
+ * Usage:
+ *   npx tsx scripts/record-wire-fixtures.ts [--project <root>] [--port <port>]
+ *
+ * Default --project is this repo's own checkout (dogfooding the same corpus
+ * TRA-1062/TRA-1064 were found against).
+ */
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const FIXTURES_DIR = path.join(REPO_ROOT, 'tests/fixtures/wire');
+
+function parseArgs(argv: string[]): { project: string; port: number } {
+  let project = REPO_ROOT;
+  let port = 3799;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--project') project = path.resolve(argv[++i]);
+    else if (argv[i] === '--port') port = Number(argv[++i]);
+  }
+  return { project, port };
+}
+
+async function waitForReady(base: string, project: string, timeoutMs = 120_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${base}/health`);
+      if (res.ok) {
+        const body = (await res.json()) as { projects: Array<{ root: string; status: string }> };
+        const p = body.projects.find((x) => x.root === project);
+        if (p?.status === 'ready') return;
+      }
+    } catch {
+      /* daemon not listening yet */
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  throw new Error(`daemon did not become ready for ${project} within ${timeoutMs}ms`);
+}
+
+async function openSession(base: string, project: string): Promise<string> {
+  const res = await fetch(`${base}/mcp?project=${encodeURIComponent(project)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'record-wire-fixtures', version: '0.1.0' },
+      },
+    }),
+  });
+  const sessionId = res.headers.get('mcp-session-id');
+  if (!sessionId) throw new Error('initialize did not return mcp-session-id');
+  await res.text();
+  await fetch(`${base}/mcp?project=${encodeURIComponent(project)}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      'mcp-session-id': sessionId,
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} }),
+  }).then((r) => r.text());
+  return sessionId;
+}
+
+async function callTool(
+  base: string,
+  project: string,
+  sessionId: string,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const res = await fetch(`${base}/mcp?project=${encodeURIComponent(project)}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      'mcp-session-id': sessionId,
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    }),
+  });
+  const raw = await res.text();
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('data:')) continue;
+    const parsed = JSON.parse(trimmed.slice(5).trim());
+    return JSON.parse(parsed.result.content[0].text);
+  }
+  throw new Error(`no data frame in tools/call response for ${name}: ${raw.slice(0, 300)}`);
+}
+
+function writeFixture(name: string, value: unknown): void {
+  fs.writeFileSync(path.join(FIXTURES_DIR, name), `${JSON.stringify(value, null, 2)}\n`);
+  console.log(`wrote tests/fixtures/wire/${name}`);
+}
+
+async function main(): Promise<void> {
+  const { project, port } = parseArgs(process.argv.slice(2));
+  const base = `http://127.0.0.1:${port}`;
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-record-fixtures-'));
+
+  console.log(`spawning serve-http on :${port} for ${project} ...`);
+  const daemon = spawn('npx', ['tsx', 'src/cli.ts', 'serve-http', '--port', String(port)], {
+    cwd: project,
+    env: { ...process.env, TRACE_MCP_DATA_DIR: dataDir },
+    stdio: 'ignore',
+  });
+
+  try {
+    await waitForReady(base, project);
+    const sessionId = await openSession(base, project);
+    await callTool(base, project, sessionId, 'load_tools', {
+      tools: ['get_pagerank', 'get_risk_hotspots', 'get_symbol'],
+    });
+
+    writeFixture(
+      'get_pagerank.json',
+      await callTool(base, project, sessionId, 'get_pagerank', { limit: 6 }),
+    );
+    writeFixture(
+      'get_risk_hotspots.json',
+      await callTool(base, project, sessionId, 'get_risk_hotspots', { limit: 6 }),
+    );
+
+    // Pick a real symbol so get_symbol.json and the NOT_FOUND fixture below
+    // both exercise the same id — cap source length so the fixture stays small.
+    const searchRes = await fetch(
+      `${base}/api/projects/symbols?${new URLSearchParams({ project, q: 'ProjectManager', limit: '5' })}`,
+    );
+    writeFixture('symbols_search.json', await searchRes.json());
+    const symbolId = 'src/daemon/project-manager.ts::ProjectManager#class';
+
+    writeFixture(
+      'get_symbol.json',
+      await callTool(base, project, sessionId, 'get_symbol', { symbol_id: symbolId, max_lines: 1 }),
+    );
+    writeFixture(
+      'get_symbol_wrong_arg_not_found.json',
+      await callTool(base, project, sessionId, 'get_symbol', { fqn: symbolId }),
+    );
+  } finally {
+    daemon.kill();
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/api/symbols-search-query.ts
+++ b/src/api/symbols-search-query.ts
@@ -1,0 +1,37 @@
+/**
+ * SQL builder for `GET /api/projects/symbols` (cli.ts). Pure and side-effect
+ * free so a contract test can run the exact query the route uses against a
+ * real Store, instead of re-typing the SQL string a second time and hoping
+ * it stays in lockstep (TRA-1068 was exactly that kind of drift: the route
+ * filtered on `s.fqn`, which is NULL for the overwhelming majority of
+ * symbols — `s.name` is where the indexer actually puts the searchable name).
+ */
+export function buildSymbolsSearchQuery(
+  query: string,
+  kind: string,
+  limit: number,
+  isolated: boolean,
+): { sql: string; params: unknown[] } {
+  const params: unknown[] = [];
+  let sql = isolated
+    ? `SELECT s.id, s.name, s.fqn, s.kind, f.path as file_path, s.line_start, s.line_end
+       FROM symbols s
+       JOIN files f ON f.id = s.file_id
+       LEFT JOIN nodes n ON n.ref_id = s.id AND n.node_type = 'symbol'
+       LEFT JOIN edges e_out ON e_out.source_node_id = n.id
+       LEFT JOIN edges e_in ON e_in.target_node_id = n.id
+       WHERE e_out.id IS NULL AND e_in.id IS NULL`
+    : `SELECT s.id, s.name, s.fqn, s.kind, f.path as file_path, s.line_start, s.line_end
+       FROM symbols s JOIN files f ON f.id = s.file_id WHERE 1=1`;
+  if (query) {
+    sql += ` AND (s.name LIKE ? OR s.fqn LIKE ?)`;
+    params.push(`%${query}%`, `%${query}%`);
+  }
+  if (kind) {
+    sql += ` AND s.kind = ?`;
+    params.push(kind);
+  }
+  sql += ` ORDER BY s.name LIMIT ?`;
+  params.push(limit);
+  return { sql, params };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -145,6 +145,7 @@ import { handleDashboardRequest } from './api/dashboard-routes.js';
 import { handleJournalStatsRequest, type JournalStatsContext } from './api/journal-stats-routes.js';
 import { handleMemoryRequest } from './api/memory-routes.js';
 import { handleProjectStatsRequest } from './api/project-stats-routes.js';
+import { buildSymbolsSearchQuery } from './api/symbols-search-query.js';
 import { buildMemoryReport } from './daemon/memory-report.js';
 import { buildJournalEvent, buildJournalSnapshot } from './server/journal-broadcast.js';
 import { createServer } from './server/server.js';
@@ -1375,43 +1376,7 @@ program
         }
         try {
           const db = managed.store.db;
-          let sql: string;
-          let params: unknown[];
-
-          if (isolated) {
-            sql = `SELECT s.id, s.fqn, s.kind, f.path as file_path, s.line_start, s.line_end
-                   FROM symbols s
-                   JOIN files f ON f.id = s.file_id
-                   LEFT JOIN nodes n ON n.ref_id = s.id AND n.node_type = 'symbol'
-                   LEFT JOIN edges e_out ON e_out.source_node_id = n.id
-                   LEFT JOIN edges e_in ON e_in.target_node_id = n.id
-                   WHERE e_out.id IS NULL AND e_in.id IS NULL`;
-            params = [];
-            if (query) {
-              sql += ` AND s.fqn LIKE ?`;
-              params.push(`%${query}%`);
-            }
-            if (kind) {
-              sql += ` AND s.kind = ?`;
-              params.push(kind);
-            }
-            sql += ` LIMIT ?`;
-            params.push(limit);
-          } else {
-            sql = `SELECT s.id, s.fqn, s.kind, f.path as file_path, s.line_start, s.line_end
-                   FROM symbols s JOIN files f ON f.id = s.file_id WHERE 1=1`;
-            params = [];
-            if (query) {
-              sql += ` AND s.fqn LIKE ?`;
-              params.push(`%${query}%`);
-            }
-            if (kind) {
-              sql += ` AND s.kind = ?`;
-              params.push(kind);
-            }
-            sql += ` ORDER BY s.fqn LIMIT ?`;
-            params.push(limit);
-          }
+          const { sql, params } = buildSymbolsSearchQuery(query, kind, limit, isolated);
 
           const symbols = db.prepare(sql).all(...params);
           res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/src/tools/register/git.ts
+++ b/src/tools/register/git.ts
@@ -73,7 +73,7 @@ export function registerGitTools(server: McpServer, ctx: ServerContext): void {
 
   server.tool(
     'get_risk_hotspots',
-    'Code hotspots: files with both high complexity AND high git churn (Adam Tornhill methodology). Score = complexity × log(1 + commits). Heuristic triage, not a validated risk metric — treat as "look here first" (calibration notes in _methodology). Requires git. For per-file bug-risk triage use predict_bugs instead. Read-only. Returns JSON: { hotspots: [{ file, score, complexity, commits, confidence_level }], total }. Supports `output_format: "toon"`.',
+    'Code hotspots: files with both high complexity AND high git churn (Adam Tornhill methodology). Score = complexity × log(1 + commits). Heuristic triage, not validated (calibration notes in _methodology). Requires git. For per-file bug-risk triage use predict_bugs instead. Read-only. Returns JSON: { hotspots: [{ file, score, max_cyclomatic, commits, assessment, confidence_level }], total }. Supports `output_format: "toon"`.',
     {
       since_days: z
         .number()

--- a/tests/api/symbols-search-query.test.ts
+++ b/tests/api/symbols-search-query.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Contract test for the `GET /api/projects/symbols` query (TRA-1064): it
+ * filtered on `s.fqn`, a column that is NULL for the overwhelming majority of
+ * symbols (real index: 10,695 of 10,715 rows). The query builder is run
+ * against a real Store, exactly as cli.ts's route uses it — no re-typed SQL
+ * string here to drift out of sync with the route.
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { buildSymbolsSearchQuery } from '../../src/api/symbols-search-query.js';
+import { createTestStore } from '../test-utils.js';
+import type { Store } from '../../src/db/store.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const wireDir = path.resolve(here, '../fixtures/wire');
+
+function seedSymbol(
+  store: Store,
+  opts: { fileId: number; symbolId: string; name: string; kind: string; fqn?: string | null },
+) {
+  store.db
+    .prepare(
+      `INSERT INTO symbols (file_id, symbol_id, name, kind, fqn, byte_start, byte_end, line_start, line_end)
+       VALUES (?, ?, ?, ?, ?, 0, 0, 1, 1)`,
+    )
+    .run(opts.fileId, opts.symbolId, opts.name, opts.kind, opts.fqn ?? null);
+}
+
+function seedFile(store: Store, path: string): number {
+  const info = store.db
+    .prepare(`INSERT INTO files (path, indexed_at) VALUES (?, datetime('now'))`)
+    .run(path);
+  return Number(info.lastInsertRowid);
+}
+
+describe('buildSymbolsSearchQuery', () => {
+  it('finds a symbol by name when fqn is NULL — the real-world shape for ordinary symbols', () => {
+    const store = createTestStore();
+    const fileId = seedFile(store, 'src/daemon/project-manager.ts');
+    seedSymbol(store, {
+      fileId,
+      symbolId: 'src/daemon/project-manager.ts::ProjectManager#class',
+      name: 'ProjectManager',
+      kind: 'class',
+      fqn: null,
+    });
+
+    const { sql, params } = buildSymbolsSearchQuery('ProjectManager', '', 50, false);
+    const rows = store.db.prepare(sql).all(...params) as Array<{
+      name: string;
+      fqn: string | null;
+    }>;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('ProjectManager');
+  });
+
+  it('still matches on fqn for the minority of symbols that have one', () => {
+    const store = createTestStore();
+    const fileId = seedFile(store, 'src/foo.ts');
+    seedSymbol(store, {
+      fileId,
+      symbolId: 'src/foo.ts::Foo#class',
+      name: 'Foo',
+      kind: 'class',
+      fqn: 'app.foo.Foo',
+    });
+
+    const { sql, params } = buildSymbolsSearchQuery('app.foo', '', 50, false);
+    const rows = store.db.prepare(sql).all(...params) as Array<{ name: string }>;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('Foo');
+  });
+
+  it('selects `name` so the caller has something to display even on an fqn hit', () => {
+    const { sql } = buildSymbolsSearchQuery('x', '', 50, false);
+    expect(sql).toMatch(/s\.name/);
+  });
+
+  it('matches the shape recorded from a live daemon (tests/fixtures/wire/symbols_search.json)', () => {
+    const recorded = JSON.parse(
+      readFileSync(path.join(wireDir, 'symbols_search.json'), 'utf-8'),
+    ) as { symbols: Array<{ name?: string; fqn: string | null }>; count: number };
+    expect(recorded.symbols.length).toBeGreaterThan(0);
+    for (const s of recorded.symbols) {
+      expect(typeof s.name).toBe('string');
+    }
+  });
+});

--- a/tests/fixtures/wire/get_pagerank.json
+++ b/tests/fixtures/wire/get_pagerank.json
@@ -1,0 +1,46 @@
+{
+  "data": [
+    {
+      "file": "src/errors.ts",
+      "file_id": 466,
+      "score": 0.039362,
+      "in_degree": 194,
+      "out_degree": 1
+    },
+    {
+      "file": "src/plugin-api/types.ts",
+      "file_id": 863,
+      "score": 0.027545,
+      "in_degree": 307,
+      "out_degree": 1
+    },
+    {
+      "file": "src/db/store.ts",
+      "file_id": 463,
+      "score": 0.018856,
+      "in_degree": 396,
+      "out_degree": 9
+    },
+    {
+      "file": "src/logger.ts",
+      "file_id": 789,
+      "score": 0.012631,
+      "in_degree": 164,
+      "out_degree": 4
+    },
+    {
+      "file": "tests/test-utils.ts",
+      "file_id": 1812,
+      "score": 0.010028,
+      "in_degree": 323,
+      "out_degree": 5
+    },
+    {
+      "file": "src/db/types.ts",
+      "file_id": 464,
+      "score": 0.007378,
+      "in_degree": 47,
+      "out_degree": 0
+    }
+  ]
+}

--- a/tests/fixtures/wire/get_pagerank.json
+++ b/tests/fixtures/wire/get_pagerank.json
@@ -2,43 +2,43 @@
   "data": [
     {
       "file": "src/errors.ts",
-      "file_id": 466,
-      "score": 0.039362,
+      "file_id": 469,
+      "score": 0.039312,
       "in_degree": 194,
       "out_degree": 1
     },
     {
       "file": "src/plugin-api/types.ts",
-      "file_id": 863,
-      "score": 0.027545,
+      "file_id": 866,
+      "score": 0.027509,
       "in_degree": 307,
       "out_degree": 1
     },
     {
       "file": "src/db/store.ts",
-      "file_id": 463,
-      "score": 0.018856,
-      "in_degree": 396,
+      "file_id": 466,
+      "score": 0.018857,
+      "in_degree": 397,
       "out_degree": 9
     },
     {
       "file": "src/logger.ts",
-      "file_id": 789,
-      "score": 0.012631,
+      "file_id": 792,
+      "score": 0.012614,
       "in_degree": 164,
       "out_degree": 4
     },
     {
       "file": "tests/test-utils.ts",
-      "file_id": 1812,
-      "score": 0.010028,
-      "in_degree": 323,
+      "file_id": 1816,
+      "score": 0.010038,
+      "in_degree": 324,
       "out_degree": 5
     },
     {
       "file": "src/db/types.ts",
-      "file_id": 464,
-      "score": 0.007378,
+      "file_id": 467,
+      "score": 0.007374,
       "in_degree": 47,
       "out_degree": 0
     }

--- a/tests/fixtures/wire/get_risk_hotspots.json
+++ b/tests/fixtures/wire/get_risk_hotspots.json
@@ -1,0 +1,59 @@
+{
+  "hotspots": [
+    {
+      "file": "src/daemon/project-manager.ts",
+      "max_cyclomatic": 175,
+      "commits": 20,
+      "score": 532.79,
+      "assessment": "high",
+      "confidence_level": "medium",
+      "signals_fired": 2
+    },
+    {
+      "file": "src/indexer/pipeline.ts",
+      "max_cyclomatic": 143,
+      "commits": 28,
+      "score": 481.52,
+      "assessment": "high",
+      "confidence_level": "medium",
+      "signals_fired": 2
+    },
+    {
+      "file": "packages/app/src/renderer/tabs/ProjectOverview.tsx",
+      "max_cyclomatic": 149,
+      "commits": 18,
+      "score": 438.72,
+      "assessment": "high",
+      "confidence_level": "medium",
+      "signals_fired": 2
+    },
+    {
+      "file": "packages/app/src/renderer/App.tsx",
+      "max_cyclomatic": 95,
+      "commits": 35,
+      "score": 340.43,
+      "assessment": "high",
+      "confidence_level": "medium",
+      "signals_fired": 2
+    },
+    {
+      "file": "src/server/server.ts",
+      "max_cyclomatic": 118,
+      "commits": 15,
+      "score": 327.17,
+      "assessment": "high",
+      "confidence_level": "medium",
+      "signals_fired": 2
+    },
+    {
+      "file": "src/memory/decision-store.ts",
+      "max_cyclomatic": 126,
+      "commits": 11,
+      "score": 313.1,
+      "assessment": "high",
+      "confidence_level": "medium",
+      "signals_fired": 2
+    }
+  ],
+  "total": 6
+}

--- a/tests/fixtures/wire/get_symbol.json
+++ b/tests/fixtures/wire/get_symbol.json
@@ -1,0 +1,50 @@
+{
+  "symbol_id": "src/daemon/project-manager.ts::ProjectManager#class",
+  "name": "ProjectManager",
+  "kind": "class",
+  "signature": "export class ProjectManager",
+  "file": "src/daemon/project-manager.ts",
+  "line_start": 163,
+  "line_end": 1300,
+  "source": "  };\n// ... truncated",
+  "truncated": true,
+  "_freshness": "fresh",
+  "_meta": {
+    "freshness": {
+      "fresh": 1,
+      "edited_uncommitted": 0,
+      "stale_index": 0,
+      "repo_is_stale": false
+    },
+    "confidence": 1,
+    "confidence_signals": {
+      "top1_strength": 1,
+      "top_gap": 1,
+      "identity_match": 1,
+      "freshness": 1
+    }
+  },
+  "_hints": [
+    {
+      "tool": "get_call_graph",
+      "args": {
+        "symbol_id": "src/daemon/project-manager.ts::ProjectManager#class"
+      },
+      "why": "See who calls this and what it calls"
+    },
+    {
+      "tool": "get_change_impact",
+      "args": {
+        "symbol_id": "src/daemon/project-manager.ts::ProjectManager#class"
+      },
+      "why": "Check what breaks if you change this"
+    },
+    {
+      "tool": "get_tests_for",
+      "args": {
+        "symbol_id": "src/daemon/project-manager.ts::ProjectManager#class"
+      },
+      "why": "Find tests covering this symbol"
+    }
+  ]
+}

--- a/tests/fixtures/wire/get_symbol_wrong_arg_not_found.json
+++ b/tests/fixtures/wire/get_symbol_wrong_arg_not_found.json
@@ -3,6 +3,6 @@
     "code": "NOT_FOUND",
     "message": "'src/daemon/project-manager.ts::ProjectManager#class' is not in the index",
     "reason": "unknown_symbol",
-    "help": "If this is a file path, it may not match the configured include globs \u2014 check `include`/`exclude` in .trace-mcp.json and reindex. Otherwise use search() to locate the symbol."
+    "help": "If this is a file path, it may not match the configured include globs — check `include`/`exclude` in .trace-mcp.json and reindex. Otherwise use search() to locate the symbol."
   }
 }

--- a/tests/fixtures/wire/get_symbol_wrong_arg_not_found.json
+++ b/tests/fixtures/wire/get_symbol_wrong_arg_not_found.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "'src/daemon/project-manager.ts::ProjectManager#class' is not in the index",
+    "reason": "unknown_symbol",
+    "help": "If this is a file path, it may not match the configured include globs \u2014 check `include`/`exclude` in .trace-mcp.json and reindex. Otherwise use search() to locate the symbol."
+  }
+}

--- a/tests/fixtures/wire/symbols_search.json
+++ b/tests/fixtures/wire/symbols_search.json
@@ -1,7 +1,7 @@
 {
   "symbols": [
     {
-      "id": 1891,
+      "id": 1898,
       "name": "ProjectManager",
       "fqn": null,
       "kind": "class",
@@ -10,7 +10,7 @@
       "line_end": 1300
     },
     {
-      "id": 6782,
+      "id": 6789,
       "name": "SubprojectManager",
       "fqn": null,
       "kind": "class",

--- a/tests/fixtures/wire/symbols_search.json
+++ b/tests/fixtures/wire/symbols_search.json
@@ -1,0 +1,23 @@
+{
+  "symbols": [
+    {
+      "id": 1891,
+      "name": "ProjectManager",
+      "fqn": null,
+      "kind": "class",
+      "file_path": "src/daemon/project-manager.ts",
+      "line_start": 163,
+      "line_end": 1300
+    },
+    {
+      "id": 6782,
+      "name": "SubprojectManager",
+      "fqn": null,
+      "kind": "class",
+      "file_path": "src/subproject/manager.ts",
+      "line_start": 192,
+      "line_end": 890
+    }
+  ],
+  "count": 2
+}


### PR DESCRIPTION
## Summary
- TRA-1068: five production bugs shared one failure mode — a client parsed a field name the daemon never sends, and it degraded silently into "0 rows" / NOT_FOUND instead of an error. Adds `tests/fixtures/wire/*.json`, captured from a live `serve-http` daemon, and contract tests that feed them through the real client-side mapping/query code.
- TRA-1062: `flattenPagerankRows` now unwraps the `{ data: [...] }` envelope the tool-gate layer actually sends; `flattenRiskHotspotRows` reads `max_cyclomatic`/`assessment` (real fields) instead of `complexity`/`confidence_level`.
- All three Insights flatteners now throw on an unrecognized non-empty shape instead of silently rendering "nothing to report" over broken parsing (new `insights:errorUnrecognizedShape` string, translated in all 10 locales).
- TRA-1064: Notebook's `get_symbol` cell now sends `symbol_id` (the tool's real argument name — `fqn` is NULL for ~99.8% of symbols). `/api/projects/symbols` now selects and searches `s.name`, extracted into a testable `src/api/symbols-search-query.ts` so the query can't drift from what the route actually runs.
- Audited Overview/Activity/Memory/Graph: they go through dedicated REST routes, not raw MCP `tools/call`, so they aren't exposed to the tool-gate array-wrapping bug class found here.

## Test plan
- [x] `pnpm run build` — clean
- [x] `pnpm run typecheck` — clean (root + `packages/app`)
- [x] `pnpm run test` (root) — 945 files / 10545 tests passed
- [x] `packages/app`: `vitest run` — 73 files / 731 tests passed
- [x] Reviewer check: reverted `max_cyclomatic` → `complexity` in `flattenRiskHotspotRows` and reverted the `s.name` search back to `s.fqn`-only in `buildSymbolsSearchQuery` — both times the new contract tests went red; restored, green again.