### PR TITLE
fix(router): promote to local mode when a proxy send fails (TRA-1080)

### DIFF
--- a/src/daemon/router/message-router.ts
+++ b/src/daemon/router/message-router.ts
@@ -7,6 +7,17 @@ export interface MessageRouterOptions {
   sendToClient: (msg: JSONRPCMessage) => Promise<void> | void;
   /** Max time to wait for pending responses during swap (ms). */
   drainTimeoutMs?: number;
+  /**
+   * Last chance to rescue a client request whose send to the active backend
+   * threw (TRA-1080). Return `true` when the frame has been re-issued through
+   * another backend and will be answered there; the router then leaves the id
+   * alone. Return `false` (or throw) and the router answers it with the
+   * synthetic error it always did.
+   *
+   * Called only for requests — a failed notification has no id to answer and
+   * nothing to replay.
+   */
+  onSendFailure?: (msg: JSONRPCMessage, err: unknown) => Promise<boolean>;
 }
 
 type ClientMessage = JSONRPCMessage;
@@ -45,6 +56,7 @@ function isResponse(msg: JSONRPCMessage): msg is JSONRPCMessage & { id: string |
 export class MessageRouter {
   private readonly sendToClient: (msg: JSONRPCMessage) => Promise<void> | void;
   private readonly drainTimeoutMs: number;
+  private readonly onSendFailure?: (msg: JSONRPCMessage, err: unknown) => Promise<boolean>;
 
   private activeBackend: Backend | null = null;
   private transitioning = false;
@@ -55,6 +67,7 @@ export class MessageRouter {
   constructor(opts: MessageRouterOptions) {
     this.sendToClient = opts.sendToClient;
     this.drainTimeoutMs = opts.drainTimeoutMs ?? 5_000;
+    this.onSendFailure = opts.onSendFailure;
   }
 
   /** Returns the current active backend (or null if between backends). */
@@ -104,6 +117,20 @@ export class MessageRouter {
       // re-issue it elsewhere; answering anyway would give the client two
       // responses for one id.
       if (isRequest(msg) && this.pendingRequestIds.has(msg.id)) {
+        // Offer the owner a rescue before answering with an error. The handler
+        // is expected to `forgetPending` the id itself before it swaps, so the
+        // swap's drain does not answer the frame it is about to replay — which
+        // is why `clearPending` below is a no-op on the handled path and still
+        // correct on the unhandled one.
+        if (this.onSendFailure) {
+          let handled = false;
+          try {
+            handled = await this.onSendFailure(msg, err);
+          } catch (rescueErr) {
+            logger.warn({ err: String(rescueErr) }, 'MessageRouter: send-failure rescue threw');
+          }
+          if (handled) return;
+        }
         this.clearPending(msg.id);
         await this.sendErrorResponseSafely(msg.id, -32603, `Backend send failed: ${String(err)}`);
       }

--- a/src/daemon/router/session.ts
+++ b/src/daemon/router/session.ts
@@ -212,6 +212,7 @@ export class StdioSession {
         return this.sendAndSettleListChanged(msg);
       },
       drainTimeoutMs: opts.drainTimeoutMs ?? 5_000,
+      onSendFailure: (msg, err) => this.rescueFailedProxySend(msg, err),
     });
     this.watcher = new PollingDaemonWatcher({
       port: opts.daemonPort,
@@ -529,6 +530,41 @@ export class StdioSession {
     await this.swapTo(await this.buildLocalBackend(), reason);
     if (this.router.getActiveKind() !== 'local' || !this.cachedInitialize) return;
     await this.router.ingestFromClient(this.cachedInitialize);
+  }
+
+  /**
+   * A request whose send to the daemon threw: promote to local mode now and
+   * replay the frame there (TRA-1080).
+   *
+   * `PollingDaemonWatcher` would get here eventually, but it is built to
+   * debounce — 10 s poll plus a 30 s stability window — and that delay is only
+   * free in the local → proxy direction. Going the other way, every request in
+   * the window is answered `-32603 Backend send failed`, and an agent that
+   * sees that stops calling the tools for the rest of the session. Measured on
+   * a real daemon killed mid-session: 45 s, eight dead calls.
+   *
+   * `ProxyBackend.send` has already retried the transport three times by the
+   * time it throws, so this is not a blip — it is the same evidence the poller
+   * is still collecting, arriving earlier and for free. Deliberately *not*
+   * setting `proxyDisabled`: unlike a daemon that fails the handshake, one that
+   * merely died deserves to be proxied to again once the watcher sees it back.
+   */
+  private async rescueFailedProxySend(msg: JSONRPCMessage, err: unknown): Promise<boolean> {
+    const id = (msg as { id?: string | number }).id;
+    if (id === undefined || id === null) return false;
+    if (this.shuttingDown || this.proxyDisabled) return false;
+    if (this.router.getActiveKind() !== 'proxy') return false;
+    logger.warn(
+      { id, err: String(err) },
+      'StdioSession: proxy send failed — promoting to local mode and replaying the request',
+    );
+    // Claim the id before swapping, or the swap's drain answers it with a
+    // synthetic error and the client gets two responses for one request.
+    this.router.forgetPending(id);
+    await this.swapTo(await this.buildLocalBackend(), 'proxy-send-failed');
+    if (this.router.getActiveKind() !== 'local') return false;
+    await this.router.ingestFromClient(msg);
+    return true;
   }
 
   private async onDaemonStateChange(nowActive: boolean): Promise<void> {

--- a/tests/daemon/session-proxy-send-failure.test.ts
+++ b/tests/daemon/session-proxy-send-failure.test.ts
@@ -1,0 +1,164 @@
+import http from 'node:http';
+import net from 'node:net';
+import { PassThrough } from 'node:stream';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * TRA-1080: a daemon that dies mid-session must not take the client's tools
+ * with it.
+ *
+ * `PollingDaemonWatcher` is the only thing that used to notice, and it is
+ * deliberately slow: 10 s poll + 30 s stability. That delay is harmless in the
+ * local → proxy direction (local mode keeps answering while we wait) and
+ * fatal in the other one — every request in the window came back as
+ * `-32603 Backend send failed: TypeError: fetch failed`. Reproduced against a
+ * real daemon on a sandbox port: 45 s and eight failed calls before the swap
+ * landed, which for an agent is indistinguishable from the server being gone.
+ *
+ * A failed send *is* the evidence the poller is still waiting for, so the
+ * session now promotes on it and replays the frame locally — the same
+ * forget-swap-replay the initialize watchdog has used since TRA-704.
+ */
+
+vi.mock('../../src/daemon/lifecycle.js', () => ({
+  tryAutoSpawnDaemon: () => new Promise(() => {}),
+}));
+
+/** Stands in for the real indexer-backed local backend. */
+vi.mock('../../src/daemon/router/local-backend.js', () => ({
+  LocalBackend: class {
+    readonly kind = 'local' as const;
+    onmessage?: (msg: JSONRPCMessage) => void;
+    async start(): Promise<void> {}
+    async stop(): Promise<void> {}
+    async send(msg: JSONRPCMessage): Promise<void> {
+      const id = (msg as { id?: string | number }).id;
+      if (id === undefined) return;
+      this.onmessage?.({
+        jsonrpc: '2.0',
+        id,
+        result: { servedBy: 'local' },
+      } as unknown as JSONRPCMessage);
+    }
+  },
+}));
+
+const { TraceMcpConfigSchema } = await import('../../src/config.js');
+const { StdioSession } = await import('../../src/daemon/router/session.js');
+
+/** A daemon that answers /health and /mcp, until it is killed. */
+async function startDaemon(): Promise<{ port: number; kill: () => Promise<void> }> {
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => {
+      body += c;
+    });
+    req.on('end', () => {
+      if (!req.url?.startsWith('/mcp')) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, status: 'healthy' }));
+        return;
+      }
+      let id: unknown;
+      try {
+        id = JSON.parse(body).id;
+      } catch {
+        /* notification or garbage */
+      }
+      if (id === undefined || id === null) {
+        res.writeHead(202).end();
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      res.write(
+        `data: ${JSON.stringify({
+          jsonrpc: '2.0',
+          id,
+          result: { protocolVersion: '2024-11-05', capabilities: {}, serverInfo: { name: 'd' } },
+        })}\n\n`,
+      );
+      res.end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as net.AddressInfo).port;
+  return {
+    port,
+    kill: () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+describe('StdioSession: daemon dies mid-session (TRA-1080)', () => {
+  let cleanup: (() => Promise<void>) | null = null;
+
+  afterEach(async () => {
+    await cleanup?.();
+    cleanup = null;
+    vi.clearAllMocks();
+  });
+
+  it('promotes to local on a failed proxy send instead of erroring the request', async () => {
+    const daemon = await startDaemon();
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const session = new StdioSession({
+      projectRoot: process.cwd(),
+      indexRoot: process.cwd(),
+      config: TraceMcpConfigSchema.parse({}),
+      sharedDbPath: '/nonexistent/shared.db',
+      daemonPort: daemon.port,
+      idleTimeoutMs: 0,
+      // Far longer than the test: the watcher must not be what rescues this.
+      daemonStabilityMs: 600_000,
+      autoSpawnDaemon: false,
+      handshakeTimeoutMs: 0,
+      stdin,
+      stdout,
+    });
+    cleanup = async () => {
+      await session.shutdown('test');
+      await daemon.kill();
+    };
+
+    const frames: unknown[] = [];
+    stdout.on('data', (chunk: Buffer) => {
+      for (const line of chunk.toString('utf8').split('\n')) {
+        if (line.trim()) frames.push(JSON.parse(line));
+      }
+    });
+    const responseFor = (id: number) =>
+      frames.find((f) => {
+        const m = f as Record<string, unknown>;
+        return m.id === id && (Object.hasOwn(m, 'result') || Object.hasOwn(m, 'error'));
+      }) as Record<string, unknown> | undefined;
+    const waitFor = async (id: number, ms: number) => {
+      const deadline = Date.now() + ms;
+      while (Date.now() < deadline) {
+        const r = responseFor(id);
+        if (r) return r;
+        await new Promise<void>((resolve) => {
+          const t = setTimeout(resolve, 25);
+          t.unref?.();
+        });
+      }
+      return undefined;
+    };
+
+    await session.bootstrap();
+    stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })}\n`);
+    expect(await waitFor(1, 3_000)).toMatchObject({ id: 1, result: { serverInfo: { name: 'd' } } });
+
+    // The break: the daemon is gone, and nothing has told the session yet.
+    await daemon.kill();
+
+    stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })}\n`);
+    const second = await waitFor(2, 10_000);
+    expect(second).toMatchObject({ id: 2, result: { servedBy: 'local' } });
+    expect(second?.error).toBeUndefined();
+  }, 20_000);
+});


### PR DESCRIPTION
## Problem

A daemon that dies mid-session takes the client's tools with it for **45 seconds**.

`PollingDaemonWatcher` is the only thing that notices, and it debounces on purpose: 10 s poll + 30 s stability. That delay is free in the `local → proxy` direction — local mode keeps answering while we wait — and fatal in the other one: every request in the window is answered `-32603 Backend send failed: TypeError: fetch failed`. An agent that sees that stops calling the tools and finishes the session on Read/Grep, which is exactly the outage this product exists to prevent.

## Reproduction

End to end against a real `serve-http` daemon on a sandbox port (`TRACE_MCP_DATA_DIR` + `TRACE_MCP_DAEMON_PORT=3799`), client session via the real `dist/proxy.js` — the same file the launcher shim execs — then `SIGKILL` the daemon mid-session and poll `tools/call` every 5 s:

```
before:  t+0.6s … t+40.2s  -32603 Backend send failed: TypeError: fetch failed
         t+45.2s  OK          → RECOVERED after 45.2s, 8 dead calls
after:   t+1.0s  OK          → RECOVERED after 1.0s, 0 dead calls
```

## Fix

A failed send *is* the evidence the poller is still collecting, arriving earlier and for free — `ProxyBackend.send` has already retried the transport three times by the time it throws. So the session promotes to local mode on it and replays the frame there, reusing the same forget-swap-replay the initialize watchdog has used since TRA-704.

- `MessageRouter` gains an optional `onSendFailure(msg, err) => Promise<boolean>` hook, consulted only for requests whose id is still pending, before the synthetic `-32603`. Returning `false` or throwing keeps today's behaviour exactly.
- `StdioSession.rescueFailedProxySend` forgets the pending id (so the swap's drain does not answer a frame it is about to replay), swaps to `LocalBackend`, and re-ingests. If the swap fails, it returns `false` and the router answers the error as before — the client is never left hanging and never gets two responses for one id.

Deliberately **not** setting `proxyDisabled`: unlike a daemon that fails the handshake, one that merely died deserves to be proxied to again once the watcher sees it back.

## Tests

`tests/daemon/session-proxy-send-failure.test.ts` — real `StdioSession` over in-memory streams against an HTTP daemon that answers `initialize`, then dies. `daemonStabilityMs: 600_000` so the watcher cannot be what rescues it. Red before (`-32603`), green after (`{ servedBy: 'local' }`) in 665 ms.

Full suite: `Test Files 947 passed | 3 skipped`, `Tests 10547 passed | 27 skipped`. `pnpm typecheck` and `biome ci` clean.

No MCP tool-signature or on-disk schema change.

Closes TRA-1080.