### PR TITLE
fix(tests): raise dashboard-routes beforeAll hook timeout for Windows CI

### DIFF
--- a/tests/api/dashboard-routes.test.ts
+++ b/tests/api/dashboard-routes.test.ts
@@ -42,7 +42,10 @@ beforeAll(() => {
     projects[root] = { name: `proj${i}`, root, dbPath, lastIndexed: null, addedAt: '' };
   }
   fs.writeFileSync(path.join(tmpHome, 'registry.json'), JSON.stringify({ version: 1, projects }));
-});
+  // Windows CI's filesystem/SQLite baseline is slow enough that 20 synchronous
+  // better-sqlite3 file creations can clear the default 15s hook timeout, even
+  // though the same seed is well under 1s on macOS/Ubuntu.
+}, 60_000);
 
 afterAll(() => {
   fs.rmSync(tmpHome, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- `cross-platform-test (windows-latest)` was red on master: `tests/api/dashboard-routes.test.ts`'s `beforeAll` (seeding a 40-project registry, 20 real SQLite files via `better-sqlite3`) exceeded the default 15s vitest hook timeout on Windows CI, while macOS/Ubuntu stayed well under 1s.
- Raised the hook's own timeout to 60s instead of shrinking the seed — TRA-1053's regression guard specifically needs 40 projects / a mixed real+missing-db registry to catch inline-computation regressions at scale.

## Test plan
- [x] `pnpm run test --run tests/api/dashboard-routes.test.ts` — 4/4 pass locally (881ms)
- [x] `npx tsc --noEmit -p .` — clean
- [ ] Windows CI on this PR (not a required check, but should confirm the fix)

Fixes TRA-1081.