### PR TITLE
feat(doctor): answer 'what would serve index from here' first (TRA-1087)

### DIFF
--- a/src/__tests__/project-root-serve-roots.test.ts
+++ b/src/__tests__/project-root-serve-roots.test.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveServeRoots } from '../project-root.js';
+
+// TRA-1087: serve's session root. The override has to replace cwd for the whole
+// session — it previously reached only the auto-register check, so a client
+// launched in the wrong directory kept serving that directory silently.
+describe('resolveServeRoots', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-serve-roots-')));
+    vi.stubEnv('TRACE_MCP_REPO_ROOT', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('falls back to cwd with no override and no worktree', () => {
+    const r = resolveServeRoots(tmp);
+    expect(r).toMatchObject({ cwd: tmp, projectRoot: tmp, indexRoot: tmp, envOverride: null });
+  });
+
+  it('serves the override instead of cwd', () => {
+    const repo = path.join(tmp, 'repo');
+    fs.mkdirSync(path.join(tmp, 'elsewhere'), { recursive: true });
+    fs.mkdirSync(repo);
+    fs.writeFileSync(path.join(repo, 'package.json'), '{}');
+    vi.stubEnv('TRACE_MCP_REPO_ROOT', repo);
+
+    const r = resolveServeRoots(path.join(tmp, 'elsewhere'));
+    expect(r.projectRoot).toBe(repo);
+    expect(r.indexRoot).toBe(repo);
+    expect(r.envOverride).toBe(repo);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -115,7 +115,12 @@ import { TRACE_MCP_HOME } from './global.js';
 import { ensureInitialized, warmUpGrammars } from './parser/tree-sitter.js';
 import { checkBindHost, isLoopbackHost } from './daemon/bind-host.js';
 import { PluginRegistry } from './plugin-api/registry.js';
-import { detectGitWorktree, findProjectRoot, hasRootMarkers } from './project-root.js';
+import {
+  detectGitWorktree,
+  findProjectRoot,
+  hasRootMarkers,
+  resolveServeRoots,
+} from './project-root.js';
 import { isDangerousProjectRoot, setupProject } from './project-setup.js';
 import { sweepEphemeralTopology } from './daemon/project-artifacts.js';
 import {
@@ -437,7 +442,9 @@ program
     // the whole MCP session — log it and stay alive instead (see #202-adjacent
     // "disconnects/crashes" reports).
     installProcessSafetyNet('serve');
-    const projectRoot = process.cwd();
+    // cwd, or TRACE_MCP_REPO_ROOT when a client spawned us somewhere the user
+    // never chose. `doctor` reports these same roots (TRA-1087).
+    const { projectRoot, indexRoot, worktreeMainRoot, envOverride } = resolveServeRoots();
 
     // Auto-update + post-update migrations. TRA-703: both run in the background,
     // never on the path to the `initialize` response — awaiting them here made
@@ -452,17 +459,17 @@ program
       install: globalRaw.auto_update !== false,
     });
 
-    // Detect git linked worktrees so we share the main repo's index instead
-    // of building a redundant copy.  projectRoot stays as the worktree path
-    // (file watcher, path validation), but the DB comes from the main repo.
-    const worktreeInfo = detectGitWorktree(projectRoot);
-    const indexRoot = worktreeInfo?.mainRoot ?? projectRoot;
-
-    if (worktreeInfo) {
+    // Linked git worktrees share the main repo's index instead of building a
+    // redundant copy: projectRoot stays the worktree path (file watcher, path
+    // validation), the DB comes from the main repo.
+    if (worktreeMainRoot) {
       logger.info(
-        { worktreeRoot: projectRoot, mainRoot: worktreeInfo.mainRoot },
+        { worktreeRoot: projectRoot, mainRoot: worktreeMainRoot },
         'Git worktree detected — sharing main repo index',
       );
+    }
+    if (envOverride) {
+      logger.info({ envOverride }, 'Serving TRACE_MCP_REPO_ROOT instead of cwd');
     }
 
     // Auto-register the index root (main repo if worktree, otherwise current project).

--- a/src/cli/__tests__/doctor-serve-root.test.ts
+++ b/src/cli/__tests__/doctor-serve-root.test.ts
@@ -50,13 +50,20 @@ describe('diagnoseServeRoot (TRA-1087)', () => {
     expect(r.detail).toContain('proj2');
   });
 
-  it('honours TRACE_MCP_REPO_ROOT', async () => {
+  // The override used to reach only serve's auto-register check, so serve kept
+  // indexing the cwd while doctor reported the override. Both now go through
+  // resolveServeRoots, so this pins the two together.
+  it('reports the same root serve resolves when TRACE_MCP_REPO_ROOT is set', async () => {
     const proj = path.join(tmpHome, 'proj3');
-    fs.mkdirSync(proj);
+    fs.mkdirSync(path.join(proj, 'sub'), { recursive: true });
     fs.writeFileSync(path.join(proj, 'package.json'), '{}');
     vi.stubEnv('TRACE_MCP_REPO_ROOT', proj);
-    const r = doctor.diagnoseServeRoot(tmpHome);
+    const { resolveServeRoots } = await import('../../project-root.js');
+
+    const r = doctor.diagnoseServeRoot(path.join(proj, 'sub'));
     expect(r.indexRoot).toBe(proj);
     expect(r.envOverride).toBe(proj);
+    expect(r.status).toBe('will-register');
+    expect(r.indexRoot).toBe(resolveServeRoots(path.join(proj, 'sub')).indexRoot);
   });
 });

--- a/src/cli/__tests__/doctor-serve-root.test.ts
+++ b/src/cli/__tests__/doctor-serve-root.test.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// TRA-1087: a live opencode config runs `["trace-mcp", "serve"]` with no project
+// root — the client picks the cwd and the user never learns which directory that
+// was. `doctor` now answers that first.
+
+describe('diagnoseServeRoot (TRA-1087)', () => {
+  let tmpHome: string;
+  let doctor: typeof import('../doctor.js');
+
+  beforeEach(async () => {
+    tmpHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-serve-root-')));
+    vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+    vi.stubEnv('TRACE_MCP_REPO_ROOT', '');
+    vi.resetModules();
+    doctor = await import('../doctor.js');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('flags the filesystem root as dangerous', () => {
+    const r = doctor.diagnoseServeRoot(path.parse(process.cwd()).root);
+    expect(r.status).toBe('dangerous');
+    expect(r.dangerReason).toBe('filesystem root');
+  });
+
+  it('reports an unregistered project dir as auto-registering', () => {
+    const proj = path.join(tmpHome, 'proj');
+    fs.mkdirSync(proj);
+    fs.writeFileSync(path.join(proj, 'package.json'), '{}');
+    const r = doctor.diagnoseServeRoot(proj);
+    expect(r.status).toBe('will-register');
+    expect(r.indexRoot).toBe(proj);
+  });
+
+  it('warns when the nearest project root sits above the cwd — serve indexes nothing', () => {
+    const proj = path.join(tmpHome, 'proj2');
+    const sub = path.join(proj, 'src');
+    fs.mkdirSync(sub, { recursive: true });
+    fs.writeFileSync(path.join(proj, 'package.json'), '{}');
+    const r = doctor.diagnoseServeRoot(sub);
+    expect(r.status).toBe('root-above-cwd');
+    expect(r.detail).toContain('proj2');
+  });
+
+  it('honours TRACE_MCP_REPO_ROOT', async () => {
+    const proj = path.join(tmpHome, 'proj3');
+    fs.mkdirSync(proj);
+    fs.writeFileSync(path.join(proj, 'package.json'), '{}');
+    vi.stubEnv('TRACE_MCP_REPO_ROOT', proj);
+    const r = doctor.diagnoseServeRoot(tmpHome);
+    expect(r.indexRoot).toBe(proj);
+    expect(r.envOverride).toBe(proj);
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -22,7 +22,10 @@ import {
 } from '../init/launcher.js';
 import { checkRegisteredLaunchers, type RegisteredLauncherCheck } from '../init/launcher-health.js';
 import { LAUNCHER_VERSION } from '../init/types.js';
-import { findProjectRoot } from '../project-root.js';
+import path from 'node:path';
+import { isDangerousProjectRoot } from '../dangerous-root.js';
+import { detectGitWorktree, findProjectRoot, hasRootMarkers } from '../project-root.js';
+import { getProject } from '../registry.js';
 import {
   type EphemeralProjectCandidate,
   findEphemeralProjects,
@@ -47,6 +50,87 @@ const SEVERITY_LABEL: Record<ConflictSeverity, string> = {
   info: 'INFO',
 };
 
+/**
+ * What `trace-mcp serve` would index if it were launched from this directory.
+ *
+ * Field evidence (TRA-1087): a real opencode config runs `["trace-mcp","serve"]`
+ * with no project root at all — the client picks the cwd and the user never
+ * sees which directory that was. This is the first thing doctor answers.
+ */
+export interface ServeRootReport {
+  cwd: string;
+  /** Directory serve would index: TRACE_MCP_REPO_ROOT, worktree main root, or cwd. */
+  indexRoot: string;
+  envOverride: string | null;
+  worktreeMainRoot: string | null;
+  registered: boolean;
+  /** Non-null reason when the root is one serve refuses to register. */
+  dangerReason: string | null;
+  status: 'ok' | 'will-register' | 'not-a-project' | 'root-above-cwd' | 'dangerous';
+  detail: string;
+}
+
+export function diagnoseServeRoot(from?: string): ServeRootReport {
+  const cwd = path.resolve(from ?? process.cwd());
+  const envOverride = process.env.TRACE_MCP_REPO_ROOT || null;
+  const worktree = detectGitWorktree(cwd);
+  const worktreeMainRoot = worktree?.mainRoot ?? null;
+  // Same precedence serve uses: env override wins, then worktree main repo, then cwd.
+  let indexRoot = worktreeMainRoot ?? cwd;
+  // findProjectRoot short-circuits on the override and returns it verbatim.
+  if (envOverride) indexRoot = findProjectRoot(cwd);
+
+  const dangerReason = isDangerousProjectRoot(indexRoot);
+  const registered = !!getProject(indexRoot);
+
+  let status: ServeRootReport['status'];
+  let detail: string;
+  if (dangerReason) {
+    status = 'dangerous';
+    detail = `${shortPath(indexRoot)} is a ${dangerReason} — serve refuses to index it. Launch trace-mcp with the project as cwd, or set TRACE_MCP_REPO_ROOT.`;
+  } else if (registered) {
+    status = 'ok';
+    detail = `${shortPath(indexRoot)} is registered and would be served.`;
+  } else if (hasRootMarkers(indexRoot)) {
+    status = 'will-register';
+    detail = `${shortPath(indexRoot)} is not registered yet — serve would auto-register and index it.`;
+  } else {
+    let above: string | null = null;
+    try {
+      above = findProjectRoot(indexRoot);
+    } catch {
+      above = null;
+    }
+    if (above && above !== indexRoot) {
+      status = 'root-above-cwd';
+      detail = `${shortPath(indexRoot)} has no project markers; the nearest project root is ${shortPath(above)}, above it. Serve will NOT auto-register — it indexes nothing until you launch it from the project or set TRACE_MCP_REPO_ROOT.`;
+    } else {
+      status = 'not-a-project';
+      detail = `${shortPath(indexRoot)} has no project markers — serve would index nothing. Launch trace-mcp with the project as cwd, or set TRACE_MCP_REPO_ROOT.`;
+    }
+  }
+
+  return {
+    cwd,
+    indexRoot,
+    envOverride,
+    worktreeMainRoot,
+    registered,
+    dangerReason,
+    status,
+    detail,
+  };
+}
+
+function printServeRootReport(r: ServeRootReport): void {
+  const label = r.status === 'ok' || r.status === 'will-register' ? 'Serve root' : 'SERVE ROOT';
+  console.log(`${label}: would index ${shortPath(r.indexRoot)} (cwd ${shortPath(r.cwd)})`);
+  if (r.envOverride) console.log(`  TRACE_MCP_REPO_ROOT=${r.envOverride}`);
+  if (r.worktreeMainRoot)
+    console.log(`  git worktree — main repo ${shortPath(r.worktreeMainRoot)}`);
+  if (r.status !== 'ok') console.log(`  ${r.detail}`);
+}
+
 export const doctorCommand = new Command('doctor')
   .description('Check trace-mcp health: registry/DB integrity and competing tools')
   .option('--fix', 'Automatically fix all fixable conflicts')
@@ -66,6 +150,10 @@ export const doctorCommand = new Command('doctor')
         const code = diagnoseLauncher({ json: opts.json });
         process.exit(code);
       }
+
+      // What `serve` would index from here — the first question a user
+      // launching us through an MCP client with no cwd needs answered.
+      const serveRoot = diagnoseServeRoot();
 
       // Registry/DB integrity (#168) — independent of project conflicts. Surfaces
       // stale registrations (deleted folders, missing/corrupt DBs) that would
@@ -120,6 +208,7 @@ export const doctorCommand = new Command('doctor')
           console.log(
             JSON.stringify(
               {
+                serveRoot,
                 registry,
                 registryFix,
                 topology,
@@ -134,11 +223,14 @@ export const doctorCommand = new Command('doctor')
             ),
           );
         } else {
-          console.log(JSON.stringify({ registry, topology, decisions, ...report }, null, 2));
+          console.log(
+            JSON.stringify({ serveRoot, registry, topology, decisions, ...report }, null, 2),
+          );
         }
         return;
       }
 
+      printServeRootReport(serveRoot);
       printRegistryReport(registry);
       printTopologyReport(topology);
       printDecisionsReport(decisions);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -22,9 +22,8 @@ import {
 } from '../init/launcher.js';
 import { checkRegisteredLaunchers, type RegisteredLauncherCheck } from '../init/launcher-health.js';
 import { LAUNCHER_VERSION } from '../init/types.js';
-import path from 'node:path';
 import { isDangerousProjectRoot } from '../dangerous-root.js';
-import { detectGitWorktree, findProjectRoot, hasRootMarkers } from '../project-root.js';
+import { findProjectRoot, hasRootMarkers, resolveServeRoots } from '../project-root.js';
 import { getProject } from '../registry.js';
 import {
   type EphemeralProjectCandidate,
@@ -71,14 +70,8 @@ export interface ServeRootReport {
 }
 
 export function diagnoseServeRoot(from?: string): ServeRootReport {
-  const cwd = path.resolve(from ?? process.cwd());
-  const envOverride = process.env.TRACE_MCP_REPO_ROOT || null;
-  const worktree = detectGitWorktree(cwd);
-  const worktreeMainRoot = worktree?.mainRoot ?? null;
-  // Same precedence serve uses: env override wins, then worktree main repo, then cwd.
-  let indexRoot = worktreeMainRoot ?? cwd;
-  // findProjectRoot short-circuits on the override and returns it verbatim.
-  if (envOverride) indexRoot = findProjectRoot(cwd);
+  // Exactly what serve resolves — same function, no second copy of the rule.
+  const { cwd, envOverride, worktreeMainRoot, indexRoot } = resolveServeRoots(from);
 
   const dangerReason = isDangerousProjectRoot(indexRoot);
   const registered = !!getProject(indexRoot);

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -279,3 +279,40 @@ export function findProjectRoot(from?: string): string {
     dir = parent;
   }
 }
+
+export interface ServeRoots {
+  /** Directory the process was launched from. */
+  cwd: string;
+  /** Resolved TRACE_MCP_REPO_ROOT, or null when unset. */
+  envOverride: string | null;
+  /** Main repo root when `projectRoot` is a linked git worktree. */
+  worktreeMainRoot: string | null;
+  /** Session root: config, file watcher, path validation. */
+  projectRoot: string;
+  /** Root whose index/DB is used — the main repo when in a worktree. */
+  indexRoot: string;
+}
+
+/**
+ * The roots `trace-mcp serve` runs on. Shared with `doctor` so its
+ * "here is what serve would index" report cannot drift from what serve does
+ * (TRA-1087: doctor and serve disagreed on TRACE_MCP_REPO_ROOT).
+ *
+ * The override names the repo outright — for Docker/CI, and for MCP clients
+ * that spawn us with a cwd the user never chose — so it replaces cwd for the
+ * whole session, not just the auto-register check.
+ */
+export function resolveServeRoots(from?: string): ServeRoots {
+  const cwd = path.resolve(from ?? process.cwd());
+  const raw = process.env.TRACE_MCP_REPO_ROOT;
+  const envOverride = raw && raw.length > 0 ? findProjectRoot(cwd) : null;
+  const projectRoot = envOverride ?? cwd;
+  const worktreeMainRoot = detectGitWorktree(projectRoot)?.mainRoot ?? null;
+  return {
+    cwd,
+    envOverride,
+    worktreeMainRoot,
+    projectRoot,
+    indexRoot: worktreeMainRoot ?? projectRoot,
+  };
+}


### PR DESCRIPTION
Field evidence, not a bug report: a live `opencode.json` (found via the fixed GitHub code-search sweep, TRA-1085) runs

```json
"trace-mcp": { "type": "local", "command": ["trace-mcp", "serve"], "enabled": true, "timeout": 60000 }
```

on Windows — `serve` with no project root, launched by a client whose working directory the user never set. TRA-893 fixed the `cwd=/` blast radius; nothing tells the user *which* directory we picked, or that we picked nothing.

`trace-mcp doctor` now opens with that answer:

```
Serve root: would index ~/projects/app (cwd ~/projects/app)
```

and, when it is not fine, why:

- `dangerous` — filesystem/home/system root; serve refuses to register it
- `not-a-project` — no root markers, serve indexes nothing
- `root-above-cwd` — the nearest project root is above the cwd, so serve skips auto-register and indexes nothing (the silent case)
- `will-register` / `ok`

Honours `TRACE_MCP_REPO_ROOT` and git worktrees with the same precedence `serve` itself uses. Included in `doctor --json` as `serveRoot`.

Tests: 4 new cases in `src/cli/__tests__/doctor-serve-root.test.ts` (dangerous root, auto-register, root-above-cwd, env override). Full suite green locally: 10558 passed / 29 skipped, typecheck and biome clean.

Not in this PR: the `timeout: 60000` half of TRA-1087 (every other stdio server in that file gets 5–30 s; ours is tied for longest). That is a startup-latency signal for the daemon side, not something doctor can fix.

Closes TRA-1087.
