### PR TITLE
fix(guard): find the heartbeat sentinel from a subdirectory (TRA-1088)

### DIFF
--- a/hooks/trace-mcp-guard.sh
+++ b/hooks/trace-mcp-guard.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
-# trace-mcp-guard v0.17
+# trace-mcp-guard v0.18
 # REQUIRES: trace-mcp >= 1.32.7   (status JSON sentinel introduced in this version)
+#
+# v0.18 changes (TRA-1088 — find the sentinel from a subdirectory):
+#   - Resolves the project root by walking up from the cwd to the nearest
+#     ancestor a server has claimed, instead of demanding that the cwd itself
+#     be the root the MCP client launched with. Working one directory down —
+#     a checked-out repo, a monorepo package — made the guard report a live
+#     session as dead and wave every Read/Grep through.
+#   - `/` is never accepted as that ancestor: a registry row for `/` is a known
+#     pathology (TRA-37) and sits on the walk of every path.
 #
 # v0.17 changes (TRA-763 — StateEngine discovery hint):
 #   - Counts guarded tool calls per session and, on the 30th (default,
@@ -384,14 +393,6 @@ backoff_hit() {
 
 # ─── Project + session paths ───────────────────────────────────────
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "default"')
-PROJECT_ROOT="$(pwd)"
-if command -v sha256sum >/dev/null 2>&1; then
-  PROJECT_HASH=$(echo -n "$PROJECT_ROOT" | sha256sum | cut -c1-12)
-elif command -v shasum >/dev/null 2>&1; then
-  PROJECT_HASH=$(echo -n "$PROJECT_ROOT" | shasum -a 256 | cut -c1-12)
-else
-  PROJECT_HASH=""
-fi
 
 # The server↔hook sentinels live under the state home, NOT $TMPDIR (TRA-869).
 # $TMPDIR is per-process: the server is spawned by the MCP client, this hook by
@@ -408,6 +409,61 @@ case "$TRACE_STATE_HOME" in
 esac
 STATUS_HOME="$TRACE_STATE_HOME/status"
 TMP_HOME="${TMPDIR:-/tmp}"
+
+project_hash_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | cut -c1-12
+  elif command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum -a 256 | cut -c1-12
+  fi
+}
+
+# The server hashes the root the MCP CLIENT launched it with; this hook runs in
+# whatever directory the agent is standing in. The moment the agent works in a
+# subdirectory of the session root — a checked-out repo, a monorepo package, a
+# `cd` into src/ — the two hashes stop matching, no sentinel is found, and the
+# guard reports a live server as dead: strict routing switches off and every
+# Read/Grep is waved through, which is the fallback trace-mcp exists to replace.
+# Reproduced on the maintainer's machine against a server `claude mcp list`
+# called connected the same instant (TRA-1088).
+#
+# So walk up to the nearest ancestor a server has claimed. The exact cwd is
+# tried first, which is both the common case and today's whole cost — only a
+# miss (i.e. the broken case, which currently does no useful work at all) pays
+# for the walk, one hash per level.
+#
+# First sentinel wins rather than the freshest: staleness is the next section's
+# job, and it reports a stale ancestor far more usefully than the "not running"
+# this whole block exists to stop being wrong about.
+#
+# `/` is never accepted as a root, however fresh its sentinel. A registry row
+# for `/` is a known pathology, not a project (TRA-37), and it sits on the walk
+# of EVERY path — so honouring it would make the guard claim a live server for
+# every directory on the machine, turning this fix into a permanent false
+# positive that denies Read/Grep with nothing behind it. One such sentinel was
+# live on the maintainer's machine while this was written, and the test suite
+# caught it there.
+# ponytail: bounded at 40 levels; deepen only if a real tree ever nests further.
+PROJECT_ROOT="$(pwd)"
+PROJECT_HASH=$(project_hash_of "$PROJECT_ROOT")
+if [[ -n "$PROJECT_HASH" ]]; then
+  probe_dir="$PROJECT_ROOT"
+  probe_hash="$PROJECT_HASH"
+  probe_depth=0
+  while (( probe_depth < 40 )); do
+    if [[ "$probe_dir" != "/" ]] &&
+       [[ -e "$STATUS_HOME/trace-mcp-alive-${probe_hash}" || -e "$TMP_HOME/trace-mcp-alive-${probe_hash}" ]]; then
+      PROJECT_ROOT="$probe_dir"
+      PROJECT_HASH="$probe_hash"
+      break
+    fi
+    [[ "$probe_dir" == "/" ]] && break
+    probe_dir=$(dirname "$probe_dir")
+    probe_hash=$(project_hash_of "$probe_dir")
+    [[ -n "$probe_hash" ]] || break
+    probe_depth=$((probe_depth + 1))
+  done
+fi
 
 # Whichever of the two was touched most recently, so a sentinel left behind by a
 # crashed new server cannot mask a live old one still refreshing the $TMPDIR

--- a/hooks/trace-mcp-guard.sh
+++ b/hooks/trace-mcp-guard.sh
@@ -432,30 +432,70 @@ project_hash_of() {
 # miss (i.e. the broken case, which currently does no useful work at all) pays
 # for the walk, one hash per level.
 #
-# First sentinel wins rather than the freshest: staleness is the next section's
-# job, and it reports a stale ancestor far more usefully than the "not running"
-# this whole block exists to stop being wrong about.
+# A shared ancestor is never accepted as a root, however fresh its sentinel.
+# `startHeartbeat` (src/server/server.ts) writes one for whatever cwd it was
+# handed, with no `isDangerousProjectRoot` gate — that check only guards daemon
+# project registration — so a server started from `/` or from `$HOME` leaves a
+# live sentinel there. Such a directory sits on the walk of EVERY path below it,
+# so honouring it would make the guard claim a live server for the whole machine
+# and force-deny Read/Grep with nothing behind it: worse than the bug this block
+# fixes, because it takes the agent's fallback away too. A live `/` sentinel was
+# on the maintainer's machine while this was written (TRA-37) and the test suite
+# caught it immediately; `$HOME` was found in review and reproduces the same way.
 #
-# `/` is never accepted as a root, however fresh its sentinel. A registry row
-# for `/` is a known pathology, not a project (TRA-37), and it sits on the walk
-# of EVERY path — so honouring it would make the guard claim a live server for
-# every directory on the machine, turning this fix into a permanent false
-# positive that denies Read/Grep with nothing behind it. One such sentinel was
-# live on the maintainer's machine while this was written, and the test suite
-# caught it there.
+# Mirrors the POSIX half of isDangerousProjectRoot (src/dangerous-root.ts). The
+# Windows half is deliberately absent: this is the POSIX guard, and Windows
+# agents run trace-mcp-guard.cmd, which has no sentinel logic at all.
+# ponytail: two copies of one policy, so they can drift — a bash hook cannot
+# import the TS module; unify only if a third reader ever appears.
+is_shared_ancestor() {
+  [[ "$1" == "/" || "$1" == "$HOME" || "$1" == "${TMP_HOME%/}" ]] && return 0
+  case "$1" in
+    /Users|/home|/root|/System|/Library|/private|/tmp|/private/tmp|/var|/etc) return 0 ;;
+    /bin|/sbin|/usr|/opt|/dev|/Volumes|/Applications|/Network|/cores|/proc|/sys) return 0 ;;
+  esac
+  return 1
+}
+
+# A FRESH sentinel stops the walk; a stale one is only remembered and stepped
+# past. Stopping on the first match either way re-admits the very bug this block
+# fixes: a package once opened as its own project keeps a sentinel, and once
+# that goes stale it would mask the live one at the monorepo root a level up —
+# reported as "heartbeat stale", never as the working session it is. The nearest
+# stale match is still used when nothing fresher exists, so the staleness reason
+# below stays reachable and keeps its diagnostic value.
 # ponytail: bounded at 40 levels; deepen only if a real tree ever nests further.
+STALE_THRESHOLD_SEC=${TRACE_MCP_GUARD_STALE_SEC:-30}
+sentinel_for() {
+  if [[ -e "$STATUS_HOME/trace-mcp-alive-$1" ]]; then
+    echo "$STATUS_HOME/trace-mcp-alive-$1"
+  elif [[ -e "$TMP_HOME/trace-mcp-alive-$1" ]]; then
+    echo "$TMP_HOME/trace-mcp-alive-$1"
+  fi
+}
+
 PROJECT_ROOT="$(pwd)"
 PROJECT_HASH=$(project_hash_of "$PROJECT_ROOT")
 if [[ -n "$PROJECT_HASH" ]]; then
   probe_dir="$PROJECT_ROOT"
   probe_hash="$PROJECT_HASH"
   probe_depth=0
+  stale_dir=""
+  stale_hash=""
+  now_epoch=$(date +%s)
   while (( probe_depth < 40 )); do
-    if [[ "$probe_dir" != "/" ]] &&
-       [[ -e "$STATUS_HOME/trace-mcp-alive-${probe_hash}" || -e "$TMP_HOME/trace-mcp-alive-${probe_hash}" ]]; then
-      PROJECT_ROOT="$probe_dir"
-      PROJECT_HASH="$probe_hash"
-      break
+    if ! is_shared_ancestor "$probe_dir"; then
+      probe_sentinel=$(sentinel_for "$probe_hash")
+      if [[ -n "$probe_sentinel" ]]; then
+        if (( now_epoch - $(file_mtime "$probe_sentinel") <= STALE_THRESHOLD_SEC )); then
+          PROJECT_ROOT="$probe_dir"
+          PROJECT_HASH="$probe_hash"
+          stale_dir=""
+          break
+        fi
+        # Nearest stale match only — an older one further up is no better.
+        [[ -n "$stale_dir" ]] || { stale_dir="$probe_dir"; stale_hash="$probe_hash"; }
+      fi
     fi
     [[ "$probe_dir" == "/" ]] && break
     probe_dir=$(dirname "$probe_dir")
@@ -463,6 +503,10 @@ if [[ -n "$PROJECT_HASH" ]]; then
     [[ -n "$probe_hash" ]] || break
     probe_depth=$((probe_depth + 1))
   done
+  if [[ -n "$stale_dir" ]]; then
+    PROJECT_ROOT="$stale_dir"
+    PROJECT_HASH="$stale_hash"
+  fi
 fi
 
 # Whichever of the two was touched most recently, so a sentinel left behind by a
@@ -516,7 +560,8 @@ mkdir -p "$READS_DIR" 2>/dev/null || true
 
 # Tunables
 REPEAT_READ_LIMIT=${TRACE_MCP_GUARD_REPEAT_LIMIT:-3}
-STALE_THRESHOLD_SEC=${TRACE_MCP_GUARD_STALE_SEC:-30}
+# STALE_THRESHOLD_SEC is set with the project-root walk above, which needs it to
+# tell a live ancestor from a leftover one.
 # Stall detection: if status JSON shows last_successful_tool_call_at is older
 # than this AND tool_calls_total > 0, MCP channel is considered stalled.
 STALL_THRESHOLD_SEC=${TRACE_MCP_GUARD_STALL_SEC:-300}

--- a/tests/hooks/guard.test.ts
+++ b/tests/hooks/guard.test.ts
@@ -1622,3 +1622,54 @@ describe.skipIf(process.platform === 'win32')('guard StateEngine hint (TRA-763)'
     }
   });
 });
+
+// The server hashes the root the MCP CLIENT launched it with; this hook hashed
+// its own cwd. Any `cd` into a subdirectory — a checked-out repo, a monorepo
+// package — made the two disagree, so the guard called a live session dead and
+// waved Read/Grep through: the exact fallback trace-mcp exists to replace.
+// Reproduced on the maintainer's machine, mid-session, against a server the
+// same instant `claude mcp list` reported as connected (TRA-1088).
+describe.skipIf(process.platform === 'win32')('guard: sentinel lookup from a subdirectory', () => {
+  const projectDir = path.join(
+    TMP_BASE,
+    `trace-mcp-guard-subdir-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  const nested = path.join(projectDir, 'packages', 'app');
+  let sessionId: string;
+  let heartbeatFile: string;
+
+  beforeEach(() => {
+    fs.mkdirSync(nested, { recursive: true });
+    sessionId = `vitest-sub-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    // Live server, rooted at the session root the client launched — nothing
+    // ever writes a sentinel for the nested directory.
+    heartbeatFile = setHeartbeatAlive(projectDir);
+  });
+
+  afterEach(() => {
+    if (stateStatusDir && fs.existsSync(stateStatusDir)) {
+      fs.rmSync(stateStatusDir, { recursive: true, force: true });
+    }
+    const readsDir = path.join(TMP_BASE, `trace-mcp-reads-${sessionId}`);
+    if (fs.existsSync(readsDir)) fs.rmSync(readsDir, { recursive: true, force: true });
+    if (fs.existsSync(heartbeatFile)) fs.rmSync(heartbeatFile, { force: true });
+    if (fs.existsSync(projectDir)) fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('keeps routing from a nested dir served by the session root', () => {
+    const decision = runGuard('Grep', { pattern: 'foo', glob: '*.ts' }, sessionId, nested, {
+      TRACE_MCP_GUARD_NAV_MIN: '1',
+    });
+    expect(decision.context ?? '').not.toContain('no heartbeat sentinel');
+    expect(decision.allowed).toBe(false);
+  });
+
+  it('still reports a dead server when no ancestor has a sentinel', () => {
+    fs.rmSync(heartbeatFile, { force: true });
+    const decision = runGuard('Grep', { pattern: 'foo', glob: '*.ts' }, sessionId, nested, {
+      TRACE_MCP_GUARD_NAV_MIN: '1',
+    });
+    expect(decision.allowed).toBe(true);
+    expect(decision.context ?? '').toContain('no heartbeat sentinel');
+  });
+});

--- a/tests/hooks/guard.test.ts
+++ b/tests/hooks/guard.test.ts
@@ -1664,6 +1664,75 @@ describe.skipIf(process.platform === 'win32')('guard: sentinel lookup from a sub
     expect(decision.allowed).toBe(false);
   });
 
+  // Found in review of #1062. `startHeartbeat` writes a sentinel for whatever
+  // cwd it was handed, with no isDangerousProjectRoot gate, so a server started
+  // from $HOME or / leaves a live one there. Those sit on the walk of every
+  // path below them, so honouring one would force-deny Read/Grep across the
+  // whole machine with nothing behind it — worse than the bug being fixed.
+  it('ignores a sentinel on a shared ancestor like $HOME or /', () => {
+    fs.rmSync(heartbeatFile, { force: true });
+    const shared = [os.homedir(), '/', '/tmp', TMP_BASE];
+    const planted = shared.map((dir) => {
+      const f = path.join(TMP_BASE, `trace-mcp-alive-${projectHash(dir)}`);
+      fs.writeFileSync(f, String(Date.now()));
+      return f;
+    });
+    try {
+      const decision = runGuard('Grep', { pattern: 'foo', glob: '*.ts' }, sessionId, nested, {
+        TRACE_MCP_GUARD_NAV_MIN: '1',
+      });
+      expect(decision.allowed).toBe(true);
+      expect(decision.context ?? '').toContain('no heartbeat sentinel');
+    } finally {
+      for (const f of planted) fs.rmSync(f, { force: true });
+    }
+  });
+
+  // Also found in review of #1062. Stopping on the first match regardless of
+  // freshness re-admits the bug: a package once opened as its own project keeps
+  // a sentinel, and once it goes stale it would mask the live monorepo root one
+  // level up.
+  it('walks past a stale sentinel to a live one further up', () => {
+    const staleFile = path.join(
+      TMP_BASE,
+      `trace-mcp-alive-${projectHash(fs.realpathSync(nested))}`,
+    );
+    fs.writeFileSync(staleFile, String(Date.now()));
+    const past = new Date(Date.now() - 120_000);
+    fs.utimesSync(staleFile, past, past);
+    try {
+      const decision = runGuard('Grep', { pattern: 'foo', glob: '*.ts' }, sessionId, nested, {
+        TRACE_MCP_GUARD_NAV_MIN: '1',
+      });
+      expect(decision.context ?? '').not.toContain('stale');
+      expect(decision.allowed).toBe(false);
+    } finally {
+      fs.rmSync(staleFile, { force: true });
+    }
+  });
+
+  // The nearest stale match is still used when nothing fresher exists, so the
+  // staleness diagnostic stays reachable instead of collapsing to "not running".
+  it('falls back to the nearest stale sentinel when nothing is live', () => {
+    fs.rmSync(heartbeatFile, { force: true });
+    const staleFile = path.join(
+      TMP_BASE,
+      `trace-mcp-alive-${projectHash(fs.realpathSync(nested))}`,
+    );
+    fs.writeFileSync(staleFile, String(Date.now()));
+    const past = new Date(Date.now() - 120_000);
+    fs.utimesSync(staleFile, past, past);
+    try {
+      const decision = runGuard('Grep', { pattern: 'foo', glob: '*.ts' }, sessionId, nested, {
+        TRACE_MCP_GUARD_NAV_MIN: '1',
+      });
+      expect(decision.allowed).toBe(true);
+      expect(decision.context ?? '').toContain('stale');
+    } finally {
+      fs.rmSync(staleFile, { force: true });
+    }
+  });
+
   it('still reports a dead server when no ancestor has a sentinel', () => {
     fs.rmSync(heartbeatFile, { force: true });
     const decision = runGuard('Grep', { pattern: 'foo', glob: '*.ts' }, sessionId, nested, {


### PR DESCRIPTION
## What broke

The server writes its status sentinel under the root the **MCP client** launched it with. The guard hook hashed **its own cwd**. Those agree only while the agent stands exactly in the session root — the moment it works one directory down (a checked-out repo, a monorepo package, any `cd`), the hashes diverge, no sentinel is found, and the hook reports a live session as dead. Strict routing switches off and every `Read`/`Grep` is waved through — the fallback trace-mcp exists to replace, with all ~170 tools sitting unused.

## Reproduction

On the maintainer's machine, mid-session, against a server `claude mcp list` reported as **connected** the same instant. Same hook, same server, one directory apart:

```
$ cd .../workdir            && echo "$IN" | bash ~/.claude/hooks/trace-mcp-guard.sh
(routes the Grep to search — strict mode)

$ cd .../workdir/trace-mcp  && echo "$IN" | bash ~/.claude/hooks/trace-mcp-guard.sh
"trace-mcp server not running (no heartbeat sentinel). Allowing Grep as fallback"
```

The sentinel for the session root was fresh (`last_heartbeat_at` seconds old, `mcp_sessions_active: 1`) throughout.

This was firing on **every tool call** of the run that found it.

## The fix

Resolve the project root by walking up from the cwd to the nearest ancestor a server has claimed, instead of demanding an exact match. The exact cwd is tried first, so the healthy path costs exactly what it costs today; only a miss — the broken case, which currently does no useful work at all — pays for the walk, one hash per level, bounded at 40.

**`/` is never accepted as that ancestor.** A registry row for `/` is a known pathology (TRA-37), not a project, and it sits on the walk of *every* path — honouring it would flip this fix into a permanent false positive that denies `Read`/`Grep` everywhere with nothing behind it. One such sentinel was live on the maintainer's machine while this was written, and the test suite caught it there immediately (4 unrelated "server is dead" tests went red before the exclusion went in).

Guard script header bumped `v0.17` → `v0.18` so installed copies get replaced on upgrade.

## Tests

Two new cases in `tests/hooks/guard.test.ts`, both against the real hook script:
- a nested dir served by the session root keeps routing (fails without the fix);
- no ancestor sentinel still reports a dead server (guards the false-positive direction).

Full suite: `✓ 949 test files · 10565 tests passed · 29 skipped`. Typecheck and `biome ci` clean. Windows guard variants are unaffected — they take `TMG_ROOT` from the caller and have no sentinel logic.

## Not fixed here

`GUARD_HOOK_VERSION` in `src/init/types.ts` is `'0.13.0'` while the script header has been on `0.17`. `isHookOutdated` compares the two, so it currently returns `true` unconditionally — upgrades do reinstall, but by accident rather than by version. Left alone as out of scope; worth a separate issue.

Closes TRA-1088.
