### PR TITLE
fix(guard): match shared ancestors across the macOS /private symlink

### DIFF
--- a/hooks/trace-mcp-guard.sh
+++ b/hooks/trace-mcp-guard.sh
@@ -448,12 +448,24 @@ project_hash_of() {
 # agents run trace-mcp-guard.cmd, which has no sentinel logic at all.
 # ponytail: two copies of one policy, so they can drift — a bash hook cannot
 # import the TS module; unify only if a third reader ever appears.
+#
+# Each candidate is also tested with a leading `/private` stripped. macOS
+# resolves /tmp and /var through that symlink, and the two spellings reach this
+# function from different sides: `pwd` yields the resolved form while $TMPDIR
+# holds the unresolved one, so `/private/var/folders/.../T` never compared equal
+# to a TMP_HOME of `/var/folders/.../T` and the per-user scratch root sailed
+# through the check. dangerous-root.ts hits the same seam and answers it the
+# same way, with an explicit '/private/tmp' beside '/tmp'. Caught by CI on
+# macOS; invisible locally, where the two spellings happened to agree.
 is_shared_ancestor() {
-  [[ "$1" == "/" || "$1" == "$HOME" || "$1" == "${TMP_HOME%/}" ]] && return 0
-  case "$1" in
-    /Users|/home|/root|/System|/Library|/private|/tmp|/private/tmp|/var|/etc) return 0 ;;
-    /bin|/sbin|/usr|/opt|/dev|/Volumes|/Applications|/Network|/cores|/proc|/sys) return 0 ;;
-  esac
+  local candidate
+  for candidate in "$1" "${1#/private}"; do
+    [[ "$candidate" == "/" || "$candidate" == "$HOME" || "$candidate" == "${TMP_HOME%/}" ]] && return 0
+    case "$candidate" in
+      /Users|/home|/root|/System|/Library|/private|/tmp|/private/tmp|/var|/etc) return 0 ;;
+      /bin|/sbin|/usr|/opt|/dev|/Volumes|/Applications|/Network|/cores|/proc|/sys) return 0 ;;
+    esac
+  done
   return 1
 }
 


### PR DESCRIPTION
Follow-up to #1062, which was merged at 02:26Z before its `cross-platform-test` run finished at 02:29Z. That run went red, so **master is currently failing `cross-platform-test (macos-latest)`** on a test #1062 itself added.

## The bug

`is_shared_ancestor` compares raw strings. The two spellings of a macOS scratch path reach it from different sides:

- `pwd` yields the resolved form — `/private/var/folders/.../T`
- `$TMPDIR` holds the unresolved one — `/var/folders/.../T`

They never compared equal, so the per-user temp root sailed through the exclusion and a sentinel planted there was honoured as a project root. That is the false-positive direction: it force-denies `Read`/`Grep` for everything under the temp root with no server behind it.

## The fix

Test each candidate with a leading `/private` stripped as well. `src/dangerous-root.ts` meets the same seam and answers it the same way, with an explicit `'/private/tmp'` beside `'/tmp'`.

## Why local runs missed it

On the machine this was developed on the two spellings happened to agree for the paths the suite exercised. Reproduced directly afterwards by planting a sentinel for `realpath(os.tmpdir())` and running the hook from a directory beneath it — fails before, passes after.

## Tests

No new test needed: the case that catches this is the one already on master from #1062 — `ignores a sentinel on a shared ancestor like $HOME or /` — which is exactly what is red. `tests/hooks/guard.test.ts` 113/113 locally with this change.

Refs TRA-1088.
