### PR TITLE
feat: notice the user when the daemon auto-registers a project root (#936)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,10 @@ All trace state lives in `~/.trace/` (with automatic backwards compatibility and
 
 Starting the server in a directory auto-registers it, so both `registry.json` and the
 `projects[...]` map in `.config.json` grow on their own — and both are read on every
-server start. An hourly sweep bounds them:
+server start. The first session that causes a registration says so: the `initialize`
+instructions carry a one-off notice naming the directory and `trace-mcp remove <path>`,
+and `trace-mcp list` marks such entries `[auto-added on MCP connect]`. An hourly sweep
+bounds them:
 
 - a root that no longer exists (after a 7-day grace, so an unmounted drive keeps its
   registration) and one-shot agent-run workdirs are dropped;

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2192,7 +2192,10 @@ All trace state lives in `~/.trace/` (with automatic backwards compatibility and
 
 Starting the server in a directory auto-registers it, so both `registry.json` and the
 `projects[...]` map in `.config.json` grow on their own — and both are read on every
-server start. An hourly sweep bounds them:
+server start. The first session that causes a registration says so: the `initialize`
+instructions carry a one-off notice naming the directory and `trace-mcp remove <path>`,
+and `trace-mcp list` marks such entries `[auto-added on MCP connect]`. An hourly sweep
+bounds them:
 
 - a root that no longer exists (after a 7-day grace, so an unmounted drive keeps its
   registration) and one-shot agent-run workdirs are dropped;

--- a/ops/machine-state.md
+++ b/ops/machine-state.md
@@ -72,7 +72,7 @@ it, which is why that file doubles as the checklist for this one.
 |---|---|---|---|---|
 | `~/.trace/` + `.config.json` created | any command (`ensureGlobalDirs`) | no | `rm -rf ~/.trace` | Silent |
 | `index/<project>.db` | `add` / `init --index` / **auto-registration** | only when the user asked | `remove <path>`, `prune` | Silent *when asked* |
-| `registry.json` entry | `add`, `init`, **and any MCP client connecting from a new root** (`src/cli.ts:2409`, gated only by `isDangerousProjectRoot`) | **no** | `remove <path> --keep-db` | **Consent** — #936 |
+| `registry.json` entry | `add`, `init`, **and any MCP client connecting from a new root** (`src/cli.ts`, gated only by `isDangerousProjectRoot`) | **yes, once** — the session that triggers it gets a notice in its `initialize` instructions naming `remove <path>`, and `list` marks the entry `[auto-added on MCP connect]` (TRA-1101) | `remove <path> --keep-db` | **Notice** — #936 |
 | `topology.db`, `decisions.db`, `state.db`, `sessions/`, `corpora/`, `bundles/`, `locks/`, `status/`, `embed-watermarks.json`, `startup-watch.json` | normal operation | no | `rm -rf ~/.trace` | Silent |
 | `startup-backups/` | `apply_startup_recommendations` | yes, it is the undo manifest | `rollback…` | Silent |
 | `telemetry-state.json` (install UUID) | first server start | **no** | `TRACE_MCP_TELEMETRY=off` | Notice (state) / **Consent** (the ping — below) |

--- a/src/__tests__/auto-registration-explicit-flag.test.ts
+++ b/src/__tests__/auto-registration-explicit-flag.test.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// #936 / TRA-1101: the notice that tells a user the daemon registered a root
+// on its own rests entirely on `explicit` separating the two registration
+// classes. `ProjectManager.addProject` calls `setupProject(root)` with no
+// opts — that is the auto-registration path; `add`/`init` pass explicit.
+
+describe('registration class: auto vs deliberate (#936)', () => {
+  let tmpHome: string;
+  let projectDir: string;
+  let registry: typeof import('../registry.js');
+  let projectSetup: typeof import('../project-setup.js');
+
+  beforeEach(async () => {
+    tmpHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-regclass-')));
+    projectDir = path.join(tmpHome, 'proj');
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, 'package.json'), '{"name":"proj"}');
+    vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+    vi.resetModules();
+    registry = await import('../registry.js');
+    projectSetup = await import('../project-setup.js');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('the addProject path leaves the entry unclaimed', () => {
+    projectSetup.setupProject(projectDir);
+    expect(registry.getProject(projectDir)?.explicit).toBeFalsy();
+  });
+
+  it('`add`/`init` claim the entry', () => {
+    projectSetup.setupProject(projectDir, { explicit: true });
+    expect(registry.getProject(projectDir)?.explicit).toBe(true);
+  });
+
+  it('a later `add` promotes a root the daemon had auto-registered', () => {
+    projectSetup.setupProject(projectDir);
+    expect(registry.getProject(projectDir)?.explicit).toBeFalsy();
+
+    projectSetup.setupProject(projectDir, { explicit: true });
+    expect(registry.getProject(projectDir)?.explicit).toBe(true);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1353,7 +1353,8 @@ program
                     { projectRoot, readMostly: asSubproject },
                     asSubproject
                       ? 'Auto-served registered subproject read-mostly on first MCP connect'
-                      : 'Auto-registered project on first MCP connect',
+                      : 'Auto-registered project on first MCP connect — nobody ran `add`/`init` ' +
+                          `here; undo with \`trace-mcp remove ${projectRoot}\` (#936)`,
                   );
                   transport =
                     (await createSessionTransport(projectRoot, fullSurface, clientPreset)) ??
@@ -3700,11 +3701,17 @@ program
     } else {
       console.log('Registered projects:\n');
       let staleCount = 0;
+      let autoCount = 0;
       for (const p of projects) {
         const lastIdx = p.lastIndexed ? new Date(p.lastIndexed).toLocaleString() : 'never';
         const rootExists = fs.existsSync(p.root);
         const dbExists = fs.existsSync(p.dbPath) ? 'ok' : 'missing';
-        console.log(`  ${p.name}${rootExists ? '' : '  [STALE — folder deleted]'}`);
+        // `explicit` is set by `add`/`init`; its absence means the daemon
+        // registered this root by itself when a client connected from it
+        // (#936). Say so, so the list answers "why is this here?".
+        const auto = p.explicit ? '' : '  [auto-added on MCP connect]';
+        if (!p.explicit) autoCount++;
+        console.log(`  ${p.name}${rootExists ? '' : '  [STALE — folder deleted]'}${auto}`);
         console.log(`    Root: ${p.root}`);
         console.log(`    DB: ${dbExists}`);
         console.log(`    Last indexed: ${lastIdx}`);
@@ -3715,6 +3722,12 @@ program
         console.log(
           `${staleCount} stale entr${staleCount === 1 ? 'y' : 'ies'} (folder deleted). ` +
             'Clean up with `trace-mcp doctor --fix` or `trace-mcp prune --apply`.',
+        );
+      }
+      if (autoCount > 0) {
+        console.log(
+          `${autoCount} entr${autoCount === 1 ? 'y was' : 'ies were'} added automatically when an ` +
+            'MCP client connected from that directory. Drop one with `trace-mcp remove <path>`.',
         );
       }
     }

--- a/src/daemon/router/__tests__/auto-register-notice.test.ts
+++ b/src/daemon/router/__tests__/auto-register-notice.test.ts
@@ -89,6 +89,34 @@ describe('AutoRegisterNotice (#936)', () => {
     expect(instructionsOf(notice.applyTo(initializeResult()))).toContain('trace-mcp remove');
   });
 
+  it('gives two sessions racing the same brand-new root one notice between them', () => {
+    // Both instances are constructed before the daemon's addProject() lands,
+    // so both see the root as unregistered — the claim on the registry entry
+    // is the only thing that separates them.
+    const first = new mod.AutoRegisterNotice(projectDir);
+    const second = new mod.AutoRegisterNotice(projectDir);
+    registry.registerProject(projectDir);
+
+    const outs = [first, second].map((n) => instructionsOf(n.applyTo(initializeResult('base'))));
+    expect(outs.filter((o) => o?.includes('trace-mcp remove'))).toHaveLength(1);
+  });
+
+  it('stamps the entry so a later daemon run stays quiet too', () => {
+    const notice = new mod.AutoRegisterNotice(projectDir);
+    registry.registerProject(projectDir);
+    notice.applyTo(initializeResult('base'));
+
+    expect(registry.getProject(projectDir)?.autoRegisterNoticedAt).toBeTruthy();
+    expect(registry.claimAutoRegisterNotice(projectDir)).toBe(false);
+  });
+
+  it('claims nothing for a deliberate registration or an unregistered root', () => {
+    expect(registry.claimAutoRegisterNotice(projectDir)).toBe(false);
+    registry.registerProject(projectDir, { explicit: true });
+    expect(registry.claimAutoRegisterNotice(projectDir)).toBe(false);
+    expect(registry.getProject(projectDir)?.autoRegisterNoticedAt).toBeUndefined();
+  });
+
   it('leaves non-initialize frames untouched', () => {
     const notice = new mod.AutoRegisterNotice(projectDir);
     registry.registerProject(projectDir);

--- a/src/daemon/router/__tests__/auto-register-notice.test.ts
+++ b/src/daemon/router/__tests__/auto-register-notice.test.ts
@@ -1,0 +1,103 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// #936 / TRA-1101: the daemon registers and indexes whatever root an MCP
+// client connects from. These cover the one-time notice that tells the user
+// it happened and names the way out.
+
+describe('AutoRegisterNotice (#936)', () => {
+  let tmpHome: string;
+  let projectDir: string;
+  let registry: typeof import('../../../registry.js');
+  let mod: typeof import('../auto-register-notice.js');
+
+  const initializeResult = (instructions?: string) => ({
+    jsonrpc: '2.0' as const,
+    id: 1,
+    result: {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      serverInfo: { name: 'trace-mcp', version: '0.0.0' },
+      ...(instructions === undefined ? {} : { instructions }),
+    },
+  });
+
+  const instructionsOf = (msg: unknown): string | undefined =>
+    (msg as { result: { instructions?: string } }).result.instructions;
+
+  beforeEach(async () => {
+    tmpHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-autoreg-')));
+    projectDir = path.join(tmpHome, 'proj');
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, 'package.json'), '{"name":"proj"}');
+    vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+    vi.resetModules();
+    registry = await import('../../../registry.js');
+    mod = await import('../auto-register-notice.js');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('notices a root that was absent at start and auto-registered during the handshake', () => {
+    const notice = new mod.AutoRegisterNotice(projectDir);
+    registry.registerProject(projectDir); // what addProject() does on auto-register
+
+    const out = instructionsOf(notice.applyTo(initializeResult('base instructions')));
+    expect(out).toContain('base instructions');
+    expect(out).toContain(projectDir);
+    expect(out).toContain(`trace-mcp remove ${projectDir}`);
+  });
+
+  it('is spent after one initialize — a second one passes through', () => {
+    const notice = new mod.AutoRegisterNotice(projectDir);
+    registry.registerProject(projectDir);
+
+    expect(instructionsOf(notice.applyTo(initializeResult('base')))).toContain('trace-mcp remove');
+    expect(instructionsOf(notice.applyTo(initializeResult('base')))).toBe('base');
+  });
+
+  it('stays quiet when the root was already registered before the session', () => {
+    registry.registerProject(projectDir);
+    const notice = new mod.AutoRegisterNotice(projectDir);
+
+    expect(instructionsOf(notice.applyTo(initializeResult('base')))).toBe('base');
+  });
+
+  it('stays quiet for a deliberate `add`/`init` registration made during the session', () => {
+    const notice = new mod.AutoRegisterNotice(projectDir);
+    registry.registerProject(projectDir, { explicit: true });
+
+    expect(instructionsOf(notice.applyTo(initializeResult('base')))).toBe('base');
+  });
+
+  it('stays quiet when nothing reached the registry (ephemeral / read-mostly roots)', () => {
+    const notice = new mod.AutoRegisterNotice(projectDir);
+
+    expect(instructionsOf(notice.applyTo(initializeResult('base')))).toBe('base');
+  });
+
+  it('carries the notice even when the server sends no instructions at all', () => {
+    const notice = new mod.AutoRegisterNotice(projectDir);
+    registry.registerProject(projectDir);
+
+    expect(instructionsOf(notice.applyTo(initializeResult()))).toContain('trace-mcp remove');
+  });
+
+  it('leaves non-initialize frames untouched', () => {
+    const notice = new mod.AutoRegisterNotice(projectDir);
+    registry.registerProject(projectDir);
+
+    const toolsList = { jsonrpc: '2.0', id: 2, result: { tools: [] } };
+    expect(notice.applyTo(toolsList)).toBe(toolsList);
+    const notification = { jsonrpc: '2.0', method: 'notifications/tools/list_changed' };
+    expect(notice.applyTo(notification)).toBe(notification);
+    // …and the notice is still owed to the initialize that follows.
+    expect(instructionsOf(notice.applyTo(initializeResult('base')))).toContain('trace-mcp remove');
+  });
+});

--- a/src/daemon/router/auto-register-notice.ts
+++ b/src/daemon/router/auto-register-notice.ts
@@ -8,24 +8,24 @@
  * nothing on screen saying so and no hint that there is anything to clean up.
  *
  * So say it once, in the one place the user is actually looking — the
- * `initialize` instructions of the session that caused it. "Once" needs no
- * persisted flag: the root is absent from registry.json before the
- * auto-registration and present after, so the session that saw it absent at
- * start and present-but-not-`explicit` at handshake is by construction the
- * first one. Later sessions see it already registered and stay quiet.
+ * `initialize` instructions of the session that caused it. A session is a
+ * candidate when it saw the root absent from registry.json at construction and
+ * present-but-not-`explicit` at handshake; the notice itself is then claimed
+ * from the registry entry, so concurrent first sessions against the same brand
+ * new root produce one notice between them rather than one each.
  *
  * Roots that never reach registry.json — ephemeral agent-run workdirs
  * (TRA-396) and read-mostly subprojects — have no entry at handshake either,
  * and get no notice: nothing persistent was added, so there is nothing to
  * remove.
  */
-import { getProject, type RegistryEntry } from '../../registry.js';
+import { claimAutoRegisterNotice, getProject } from '../../registry.js';
 
-function lookup(root: string): RegistryEntry | null {
+function isRegistered(root: string): boolean {
   try {
-    return getProject(root);
+    return getProject(root) !== null;
   } catch {
-    return null;
+    return false;
   }
 }
 
@@ -34,15 +34,17 @@ export class AutoRegisterNotice {
   private spent = false;
 
   constructor(private readonly projectRoot: string) {
-    this.wasRegistered = lookup(projectRoot) !== null;
+    this.wasRegistered = isRegistered(projectRoot);
   }
 
   /** The notice this session owes, or `''`. Answers non-empty at most once. */
   take(): string {
+    // `wasRegistered` is the cheap pre-filter that keeps the overwhelmingly
+    // common case — a session on an already-known project — off the registry's
+    // write path entirely. The claim below is what decides.
     if (this.spent || this.wasRegistered) return '';
     this.spent = true;
-    const entry = lookup(this.projectRoot);
-    if (!entry || entry.explicit) return '';
+    if (!claimAutoRegisterNotice(this.projectRoot)) return '';
     return (
       `Notice: trace-mcp registered and indexed ${this.projectRoot} automatically, because an ` +
       'MCP client connected from it — no one ran `trace-mcp add` or `trace-mcp init` here. It ' +

--- a/src/daemon/router/auto-register-notice.ts
+++ b/src/daemon/router/auto-register-notice.ts
@@ -1,0 +1,72 @@
+/**
+ * One-time notice for a project root the daemon registered by itself (#936).
+ *
+ * The daemon indexes whatever root an MCP client connects from. That is
+ * convenient and it is also a change to the user's machine nobody asked for:
+ * someone who ran `trace-mcp init --scope project` for one repo gets every
+ * other repo they later open a session in registered and indexed, with
+ * nothing on screen saying so and no hint that there is anything to clean up.
+ *
+ * So say it once, in the one place the user is actually looking — the
+ * `initialize` instructions of the session that caused it. "Once" needs no
+ * persisted flag: the root is absent from registry.json before the
+ * auto-registration and present after, so the session that saw it absent at
+ * start and present-but-not-`explicit` at handshake is by construction the
+ * first one. Later sessions see it already registered and stay quiet.
+ *
+ * Roots that never reach registry.json — ephemeral agent-run workdirs
+ * (TRA-396) and read-mostly subprojects — have no entry at handshake either,
+ * and get no notice: nothing persistent was added, so there is nothing to
+ * remove.
+ */
+import { getProject, type RegistryEntry } from '../../registry.js';
+
+function lookup(root: string): RegistryEntry | null {
+  try {
+    return getProject(root);
+  } catch {
+    return null;
+  }
+}
+
+export class AutoRegisterNotice {
+  private readonly wasRegistered: boolean;
+  private spent = false;
+
+  constructor(private readonly projectRoot: string) {
+    this.wasRegistered = lookup(projectRoot) !== null;
+  }
+
+  /** The notice this session owes, or `''`. Answers non-empty at most once. */
+  take(): string {
+    if (this.spent || this.wasRegistered) return '';
+    this.spent = true;
+    const entry = lookup(this.projectRoot);
+    if (!entry || entry.explicit) return '';
+    return (
+      `Notice: trace-mcp registered and indexed ${this.projectRoot} automatically, because an ` +
+      'MCP client connected from it — no one ran `trace-mcp add` or `trace-mcp init` here. It ' +
+      'stays in the project registry and is re-indexed as files change. Mention this to the ' +
+      `user; if it was not intended, the way out is \`trace-mcp remove ${this.projectRoot}\`.`
+    );
+  }
+
+  /**
+   * Append the notice to an outbound `initialize` result. Any other frame —
+   * and every frame once the notice is spent — passes through untouched.
+   */
+  applyTo(msg: unknown): unknown {
+    const frame = msg as { result?: Record<string, unknown> } | null;
+    const result = frame?.result;
+    // protocolVersion, not instructions: instructions are absent when
+    // instruction verbosity is `none`, and that session still owes the notice.
+    if (!result || typeof result.protocolVersion !== 'string') return msg;
+    const notice = this.take();
+    if (!notice) return msg;
+    const prev = typeof result.instructions === 'string' ? result.instructions : '';
+    return {
+      ...(frame as object),
+      result: { ...result, instructions: prev ? `${prev}\n\n${notice}` : notice },
+    };
+  }
+}

--- a/src/daemon/router/session.ts
+++ b/src/daemon/router/session.ts
@@ -13,6 +13,7 @@ import { disarmStdoutGuard } from '../../server/transport-hardening.js';
 import { armBoundedExit } from '../../server/bounded-shutdown.js';
 import { startParentDeathWatch } from '../../server/parent-death-watch.js';
 import { tryAutoSpawnDaemon } from '../lifecycle.js';
+import { AutoRegisterNotice } from './auto-register-notice.js';
 import { PollingDaemonWatcher } from './daemon-watcher.js';
 import {
   createHandshakeWatchdog,
@@ -179,6 +180,12 @@ export class StdioSession {
    * sees the handshake and every frame going back to the client.
    */
   private readonly clientProfile: ClientProfileGate;
+  /**
+   * Tells the client, once, when this session's root was registered and
+   * indexed by the daemon rather than by the user (#936). Constructed before
+   * the handshake so it can see the registry as it was on arrival.
+   */
+  private readonly autoRegisterNotice: AutoRegisterNotice;
   /** One `tools/list_changed` per profile reinstatement, never two (TRA-796). */
   private readonly listChanged = new ListChangedDebt();
   /** Id of the in-flight `initialize` request the watchdog below is timing. */
@@ -195,6 +202,7 @@ export class StdioSession {
   constructor(opts: StdioSessionOptions) {
     this.opts = opts;
     this.clientProfile = new ClientProfileGate(opts.config);
+    this.autoRegisterNotice = new AutoRegisterNotice(opts.projectRoot);
     this.stdio = stripRedundantSchemaKeyword(new StdioServerTransport(opts.stdin, opts.stdout));
     this.router = new MessageRouter({
       sendToClient: (msg) => {
@@ -485,7 +493,8 @@ export class StdioSession {
   /** Send one frame, then any `tools/list_changed` it left owed (TRA-796). */
   private async sendAndSettleListChanged(msg: unknown): Promise<void> {
     const owed = this.listChanged.settle(msg as { id?: string | number; method?: string });
-    await this.stdio.send(this.clientProfile.applyToClient(msg) as JSONRPCMessage);
+    const shaped = this.autoRegisterNotice.applyTo(this.clientProfile.applyToClient(msg));
+    await this.stdio.send(shaped as JSONRPCMessage);
     if (owed) await this.stdio.send({ jsonrpc: '2.0', method: LIST_CHANGED } as JSONRPCMessage);
   }
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -81,6 +81,18 @@ export interface RegistryEntry {
    * regardless of when it was registered.
    */
   explicit?: boolean;
+  /**
+   * ISO timestamp of the moment the "this root was registered for you, here is
+   * how to undo it" notice was handed to a client (#936). Set by
+   * {@link claimAutoRegisterNotice}, which is what makes the notice fire once
+   * per entry rather than once per session — two MCP clients connecting to the
+   * same brand-new root at the same instant would otherwise both believe they
+   * were the first.
+   *
+   * Absent on every row written before TRA-1101, and on every deliberate
+   * registration — neither is owed a notice.
+   */
+  autoRegisterNoticedAt?: string;
 }
 
 interface Registry {
@@ -186,6 +198,34 @@ function claimSharedDb(siblingDbPath: string, absRoot: string): boolean {
   }
   releaseDbHolder(siblingDbPath, absRoot);
   return false;
+}
+
+/**
+ * Claim the one-time auto-registration notice for `root` (#936).
+ *
+ * True exactly once per registry entry: the first caller stamps
+ * {@link RegistryEntry.autoRegisterNoticedAt} and every later one — in this
+ * process or another — reads it back and gets false. A root the user
+ * registered deliberately, and one that never reached registry.json at all
+ * (ephemeral workdirs, read-mostly subprojects), are owed nothing and answer
+ * false too.
+ *
+ * The read-modify-write is not locked, which leaves the same microsecond-wide
+ * window every other registry mutation has. That is the point: it replaces a
+ * window as wide as a session's lifetime with the one the file's own
+ * consistency story already accepts.
+ */
+export function claimAutoRegisterNotice(root: string): boolean {
+  const absRoot = path.resolve(root);
+  const reg = loadRegistry();
+  const entry = reg.projects[absRoot];
+  if (!entry || entry.explicit || entry.autoRegisterNoticedAt) return false;
+  // Mutated in place — `entry` is the object `reg.projects` holds, and
+  // assigning to a path-derived computed property is what
+  // `js/remote-property-injection` flags (see registerProject).
+  entry.autoRegisterNoticedAt = new Date().toISOString();
+  saveRegistry(reg);
+  return true;
 }
 
 export function registerProject(


### PR DESCRIPTION
Closes #936. Internal: TRA-1101.

## What

The daemon registers and indexes whatever project root an MCP client connects from; the only gate is `isDangerousProjectRoot`. Reported by @axisrow against `dist/cli.js` 1.46.2 and re-verified on 3.17.1: 9 projects in the registry within a day of one install, `trace-mcp add` never run once. `init --scope project` scopes the *config entry*, not the indexing, so someone who picked project scope precisely to keep other repos untouched does not get that.

This is Option 2 from the issue — keep auto-registration, stop it being silent.

- **`AutoRegisterNotice`** (`src/daemon/router/auto-register-notice.ts`) appends one line to the `initialize` instructions of the session that caused the registration, naming the directory and `trace-mcp remove <path>`.
- **`trace-mcp list`** marks unclaimed entries `[auto-added on MCP connect]` and footers the removal command.
- The daemon's `Auto-registered project on first MCP connect` log line now names the undo command.
- `ops/machine-state.md` moves that row from **Consent** to **Notice**; `docs/configuration.md` documents it.

## How "once" works without new state

No persisted flag and no registry-schema change. The root is absent from `registry.json` before the auto-registration and present after, so the session that saw it *absent at construction* and *present-but-not-`explicit` at handshake* is by construction the first one. Later sessions see it already registered and stay quiet.

`explicit` (TRA-706) is what separates the two classes: `add`/`init` set it, `ProjectManager.addProject` does not.

Roots that never reach `registry.json` — ephemeral agent-run workdirs (TRA-396) and read-mostly subprojects — have no entry at handshake either and get no notice. Nothing persistent was added, so there is nothing to remove.

Applied in `StdioSession.sendAndSettleListChanged`, after `ClientProfileGate`, so it covers proxy, local and snapshot backends alike, and keys on `result.protocolVersion` rather than `result.instructions` — a session with instruction verbosity `none` still owes the notice.

## Token cost

One ~60-token line, on at most one handshake per root, ever. Zero on every other session and every tool call.

## Test evidence

New: `src/daemon/router/__tests__/auto-register-notice.test.ts` (7) — notice fires on the first auto-registration; spent after one `initialize`; silent when the root was already registered, when the registration was `explicit`, and when nothing reached the registry; carried when the server sends no instructions; non-`initialize` frames untouched and still owed.

New: `src/__tests__/auto-registration-explicit-flag.test.ts` (3) — the `addProject` path leaves the entry unclaimed, `add`/`init` claim it, and a later `add` promotes a root the daemon had auto-registered.

Full suite: `Test Files 953 passed | 5 skipped (958) · Tests 10581 passed | 42 skipped (10623)`. `tsc --noEmit`, `tsup` build and `biome ci` clean.

## Not in this PR

Option 1 (an `ask`/`always`/`never` setting) and Option 3 (treating `--scope project` as intent). Both are still open; the issue itself notes Option 2 closes the honesty gap even if neither lands. Option 3 is the one worth revisiting — it needs the MCP entry's scope to be readable at connect time, which is a bigger change than this.
