### PR TITLE
test(dashboard-routes): seed in one transaction instead of 2000 commits (TRA-1104)

### DIFF
--- a/tests/api/dashboard-routes.test.ts
+++ b/tests/api/dashboard-routes.test.ts
@@ -19,13 +19,21 @@ process.env.TRACE_MCP_DATA_DIR = tmpHome;
 /** Minimal schema — enough for the three COUNT(*) queries the cheap pass runs. */
 function makeDb(dbPath: string): void {
   const db = new Database(dbPath);
+  // One transaction, no rollback journal. The seed used to run its 100 inserts
+  // in autocommit: 20 databases x 100 commits = 2000 journal files created,
+  // fsynced and deleted. That is ~1s on macOS and minutes on a Windows runner
+  // whose antivirus scans every one of those creations (TRA-1104) — which is
+  // why raising the hook ceiling from 15s to 60s only moved the boundary.
+  db.pragma('journal_mode = MEMORY');
   db.exec(`
     CREATE TABLE files (id INTEGER PRIMARY KEY, path TEXT, status TEXT);
     CREATE TABLE symbols (id INTEGER PRIMARY KEY, name TEXT);
     CREATE TABLE edges (id INTEGER PRIMARY KEY, src TEXT, dst TEXT);
   `);
   const f = db.prepare("INSERT INTO files (path, status) VALUES (?, 'ok')");
-  for (let i = 0; i < 100; i++) f.run(`src/f${i}.ts`);
+  db.transaction(() => {
+    for (let i = 0; i < 100; i++) f.run(`src/f${i}.ts`);
+  })();
   db.close();
 }
 
@@ -42,14 +50,14 @@ beforeAll(() => {
     projects[root] = { name: `proj${i}`, root, dbPath, lastIndexed: null, addedAt: '' };
   }
   fs.writeFileSync(path.join(tmpHome, 'registry.json'), JSON.stringify({ version: 1, projects }));
-  // Windows CI's filesystem/SQLite baseline is slow enough that 20 synchronous
-  // better-sqlite3 file creations can clear the default 15s hook timeout, even
-  // though the same seed is well under 1s on macOS/Ubuntu.
-}, 60_000);
+  // No timeout override on purpose: the seed is ~10ms now, so the default hook
+  // ceiling is the regression guard. If this hook ever needs a bigger number
+  // again, the seed got expensive — fix the seed, not the ceiling (TRA-790).
+});
 
 afterAll(() => {
   fs.rmSync(tmpHome, { recursive: true, force: true });
-  process.env.TRACE_MCP_DATA_DIR = undefined;
+  delete process.env.TRACE_MCP_DATA_DIR;
 });
 
 /** Drive the handler without a socket: collect what it writes. */


### PR DESCRIPTION
## What

`cross-platform-test (windows-latest)` has been red on `master` with `Hook timed out in 60000ms` in `tests/api/dashboard-routes.test.ts`. #1057 already raised that ceiling 15s → 60s and it did not help.

It is not a hang. The `beforeAll` seed built 20 SQLite fixtures with 100 inserts each **in autocommit** — 2000 separate transactions, each of which creates, fsyncs and deletes a rollback journal file next to the `.db`. On a Windows runner with real-time antivirus scanning, 2000 file create/delete pairs is minutes of wall clock; on macOS the same loop is ~1s, which is why nobody saw it locally.

That also explains why raising the ceiling did nothing useful: the cost is linear in the number of commits, not near the old limit.

## Change

One transaction for the inserts plus `journal_mode = MEMORY`, so no journal file is ever created.

Measured on this machine, same loop, 20 dbs × 100 rows:

| seed | time |
|---|---:|
| autocommit (before) | 1057 ms |
| one transaction, no journal (after) | 7 ms |

With the seed at ~10ms the `60_000` hook-timeout override is removed: the default ceiling goes back to being a regression guard instead of a place a slow seed can hide (same conclusion as TRA-790 — cache the setup, don't raise the ceiling).

Drive-by in the same hook: `process.env.TRACE_MCP_DATA_DIR = undefined` assigned the literal string `"undefined"`, leaking a bogus data dir to later files in the same worker. `delete` instead.

## Test evidence

- `tests/api/dashboard-routes.test.ts`: 4 passed, file duration 1.2s → 178ms.
- Full suite: 951 files passed / 5 skipped, 10571 tests passed / 42 skipped.
- `pnpm typecheck`, `biome ci`, `pnpm build` clean.

No production code touched; no MCP tool contract or on-disk schema change.

Closes TRA-1104.
