### PR TITLE
fix(registry): sweep a dead one-shot workdir without the 7-day grace

### DIFF
--- a/src/__tests__/ephemeral-missing-root-sweep.test.ts
+++ b/src/__tests__/ephemeral-missing-root-sweep.test.ts
@@ -40,24 +40,30 @@ describe('sweepMissingRoots: no grace for a dead ephemeral workdir (TRA-1105)', 
     removeTmpDir(tmpHome);
   });
 
-  /** Write a registry row for a root that does not exist on disk. */
+  /** Write registry rows for roots that do not exist on disk. */
   function seedRegistry(root: string, extra: Record<string, unknown> = {}): void {
+    seedRegistryRows([{ root, ...extra }]);
+  }
+
+  function seedRegistryRows(rows: Array<{ root: string } & Record<string, unknown>>): void {
     fs.mkdirSync(path.dirname(REGISTRY_PATH), { recursive: true });
-    fs.writeFileSync(
-      REGISTRY_PATH,
-      JSON.stringify({
-        version: 1,
-        projects: {
-          [root]: {
-            name: path.basename(root),
-            root,
-            dbPath: path.join(tmpHome, 'index', `${path.basename(root)}.db`),
-            addedAt: new Date().toISOString(),
-            ...extra,
-          },
-        },
-      }),
-    );
+    const projects: Record<string, unknown> = {};
+    for (const { root, ...extra } of rows) {
+      projects[root] = {
+        name: path.basename(root),
+        root,
+        dbPath: path.join(tmpHome, 'index', `${path.basename(root)}.db`),
+        addedAt: new Date().toISOString(),
+        ...extra,
+      };
+    }
+    fs.writeFileSync(REGISTRY_PATH, JSON.stringify({ version: 1, projects }));
+  }
+
+  /** Create the DB file + sidecars the sweep would unlink. */
+  function seedDbFiles(dbPath: string): void {
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    for (const suffix of ['', '-wal', '-shm']) fs.writeFileSync(dbPath + suffix, 'x');
   }
 
   function seedConfigSection(root: string): void {
@@ -122,5 +128,51 @@ describe('sweepMissingRoots: no grace for a dead ephemeral workdir (TRA-1105)', 
 
     expect(removed).toEqual([]);
     expect(newlyMissing).toEqual([root]);
+  });
+
+  // TRA-1105 review finding: `dbPath` is shared with a sibling whose git
+  // remote matches (`registerProject`), and the choice is persisted. A legacy
+  // ephemeral row can therefore name a live canonical project's index — and
+  // the sweep deletes the DB *and its WAL/SHM* along with the row.
+  it('does not delete an index another registered project still shares', () => {
+    const dead = path.join(tmpHome, 'multica-task-3265850447', 'checkout');
+    const live = path.join(tmpHome, 'real-project');
+    fs.mkdirSync(live, { recursive: true });
+    const shared = path.join(tmpHome, 'index', 'shared.db');
+    seedRegistryRows([
+      { root: dead, dbPath: shared },
+      { root: live, dbPath: shared },
+    ]);
+    seedDbFiles(shared);
+
+    expect(registry.sweepMissingRoots(7).removed).toEqual([dead]);
+
+    // Row gone, index intact — the live project keeps its DB and its WAL.
+    expect(registry.listProjects().map((p) => p.root)).toEqual([live]);
+    expect(fs.existsSync(shared)).toBe(true);
+    expect(fs.existsSync(`${shared}-wal`)).toBe(true);
+  });
+
+  it('does delete the index when the dead row is its only owner', () => {
+    const dead = path.join(tmpHome, 'multica-task-3265850447', 'solo');
+    const dbPath = path.join(tmpHome, 'index', 'solo.db');
+    seedRegistry(dead);
+    seedDbFiles(dbPath);
+
+    expect(registry.sweepMissingRoots(7).removed).toEqual([dead]);
+    expect(fs.existsSync(dbPath)).toBe(false);
+    expect(fs.existsSync(`${dbPath}-wal`)).toBe(false);
+  });
+
+  it('leaves the index alone while a live holder marker names another root', async () => {
+    const dead = path.join(tmpHome, 'multica-task-3265850447', 'held');
+    const dbPath = path.join(tmpHome, 'index', 'held.db');
+    seedRegistry(dead);
+    seedDbFiles(dbPath);
+    const { announceDbHolder } = await import('../db-holders.js');
+    announceDbHolder(dbPath, path.join(tmpHome, 'some-other-live-root'));
+
+    expect(registry.sweepMissingRoots(7).removed).toEqual([dead]);
+    expect(fs.existsSync(dbPath)).toBe(true);
   });
 });

--- a/src/__tests__/ephemeral-missing-root-sweep.test.ts
+++ b/src/__tests__/ephemeral-missing-root-sweep.test.ts
@@ -1,0 +1,126 @@
+/**
+ * TRA-1105: a one-shot agent workdir that is already gone still got the full
+ * 7-day `sweepMissingRoots` grace, and its registry row kept the matching
+ * `.config.json` section alive for the same week (a registered root is what
+ * `pruneProjectConfigSections` protects). On the reported machine that was
+ * 17 of 47 sections — 46 KB of a 62 KB file that is parsed on every start.
+ *
+ * The grace exists for a root that can come back: an unmounted volume, a
+ * detached external disk. An ephemeral run directory cannot — the run that
+ * created it finished, and `registerProject` refuses to persist such a root at
+ * all since TRA-396. Missing + ephemeral is therefore unambiguously dead.
+ *
+ * An explicit `add`/`init` of a workdir-shaped path is a deliberate act and
+ * keeps its grace, which is the case the last test pins.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { removeTmpDir, tmpRootOutsideTaskDir } from '../../tests/test-utils.js';
+
+describe('sweepMissingRoots: no grace for a dead ephemeral workdir (TRA-1105)', () => {
+  let tmpHome: string;
+  let registry: typeof import('../registry.js');
+  let configJsonc: typeof import('../config-jsonc.js');
+  let GLOBAL_CONFIG_PATH: string;
+  let REGISTRY_PATH: string;
+
+  beforeEach(async () => {
+    tmpHome = tmpRootOutsideTaskDir('trace-ephemeral-sweep-');
+    vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+    vi.resetModules();
+    registry = await import('../registry.js');
+    configJsonc = await import('../config-jsonc.js');
+    ({ GLOBAL_CONFIG_PATH, REGISTRY_PATH } = await import('../global.js'));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    removeTmpDir(tmpHome);
+  });
+
+  /** Write a registry row for a root that does not exist on disk. */
+  function seedRegistry(root: string, extra: Record<string, unknown> = {}): void {
+    fs.mkdirSync(path.dirname(REGISTRY_PATH), { recursive: true });
+    fs.writeFileSync(
+      REGISTRY_PATH,
+      JSON.stringify({
+        version: 1,
+        projects: {
+          [root]: {
+            name: path.basename(root),
+            root,
+            dbPath: path.join(tmpHome, 'index', `${path.basename(root)}.db`),
+            addedAt: new Date().toISOString(),
+            ...extra,
+          },
+        },
+      }),
+    );
+  }
+
+  function seedConfigSection(root: string): void {
+    fs.mkdirSync(path.dirname(GLOBAL_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(
+      GLOBAL_CONFIG_PATH,
+      JSON.stringify({ projects: { [root]: { root: '.', include: ['src/**'] } } }, null, 2),
+    );
+  }
+
+  it('drops a missing multica-task scratch root on the first sighting', () => {
+    const root = path.join(tmpHome, 'multica-task-3265850447', 'tmpl06qk62l');
+    seedRegistry(root);
+
+    const { removed, newlyMissing } = registry.sweepMissingRoots(7);
+
+    expect(removed).toEqual([root]);
+    expect(newlyMissing).toEqual([]);
+    expect(registry.listProjects()).toEqual([]);
+  });
+
+  it('drops a missing repo-checkout workdir root on the first sighting', () => {
+    const root = path.join(
+      tmpHome,
+      'multica_workspaces_host',
+      'ws-id',
+      'run-id',
+      'workdir',
+      'repo',
+    );
+    seedRegistry(root);
+
+    expect(registry.sweepMissingRoots(7).removed).toEqual([root]);
+  });
+
+  it('lets the same pass collect the config section it was pinning', () => {
+    const root = path.join(tmpHome, 'multica-task-3265850447', 'tmpust64rmw');
+    seedRegistry(root);
+    seedConfigSection(root);
+
+    // The order softGcSweep runs them in.
+    registry.sweepMissingRoots(7);
+    expect(configJsonc.pruneProjectConfigSections()).toEqual([root]);
+    expect(JSON.parse(fs.readFileSync(GLOBAL_CONFIG_PATH, 'utf-8')).projects).toEqual({});
+  });
+
+  it('still grants the grace to a missing root that is not ephemeral', () => {
+    const root = path.join(tmpHome, 'unmounted-volume', 'project');
+    seedRegistry(root);
+
+    const { removed, newlyMissing } = registry.sweepMissingRoots(7);
+
+    expect(removed).toEqual([]);
+    expect(newlyMissing).toEqual([root]);
+  });
+
+  it('still grants the grace to an explicitly added workdir-shaped root', () => {
+    const root = path.join(tmpHome, 'multica-task-3265850447', 'deliberate');
+    seedRegistry(root, { explicit: true });
+
+    const { removed, newlyMissing } = registry.sweepMissingRoots(7);
+
+    expect(removed).toEqual([]);
+    expect(newlyMissing).toEqual([root]);
+  });
+});

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -794,15 +794,26 @@ export function sweepMissingRoots(graceDays = 7): MissingRootSweepResult {
       continue;
     }
 
-    if (!entry.missingRootSince) {
+    // TRA-1105: the grace is for a root that can come back — an unmounted
+    // volume, a detached disk. A one-shot agent workdir cannot: the run that
+    // created it is over, and `registerProject` has refused to persist such a
+    // root since TRA-396, so any row here is legacy. Giving it the full week
+    // also pinned its `.config.json` section for the week (being registered is
+    // what `pruneProjectConfigSections` protects) — 17 of 47 sections on the
+    // reported machine. An explicit `add`/`init` of a workdir-shaped path is a
+    // deliberate act and keeps the grace.
+    const disposable =
+      isEphemeralProjectRoot(root) && !entry.explicit && entry.type !== 'multi-root';
+
+    if (!disposable && !entry.missingRootSince) {
       entry.missingRootSince = new Date().toISOString();
       newlyMissing.push(root);
       changed = true;
       continue;
     }
 
-    const missingSinceMs = Date.parse(entry.missingRootSince);
-    if (Number.isNaN(missingSinceMs) || now - missingSinceMs < graceMs) continue;
+    const missingSinceMs = Date.parse(entry.missingRootSince ?? '');
+    if (!disposable && (Number.isNaN(missingSinceMs) || now - missingSinceMs < graceMs)) continue;
 
     delete reg.projects[root];
     removed.push(root);

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -818,6 +818,20 @@ export function sweepMissingRoots(graceDays = 7): MissingRootSweepResult {
     delete reg.projects[root];
     removed.push(root);
     changed = true;
+
+    // TRA-1105: `dbPath` is not private to this row. `registerProject` points a
+    // checkout at a sibling's DB when both resolve to the same git remote, and
+    // persists that choice — so a legacy ephemeral row can name the index of a
+    // live, canonical project. Deregistering the row is always right;
+    // unlinking the file is only right if nobody else is on it. Same two
+    // guards `removeProjectArtifacts` uses, for the same reason: a live holder
+    // marker (or an unreadable holder dir) means some process has this DB open
+    // right now, and guessing wrong here deletes someone else's index.
+    const sharedWithSibling = Object.values(reg.projects).some(
+      (other) => other.dbPath === entry.dbPath,
+    );
+    if (sharedWithSibling || hasLiveHolderOrUnknown(entry.dbPath, root)) continue;
+
     for (const suffix of MISSING_ROOT_SIDECARS) {
       try {
         fs.unlinkSync(entry.dbPath + suffix);

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -53,3 +53,19 @@ export function writeFixtureFile(baseDir: string, relPath: string, content: stri
   fs.mkdirSync(path.dirname(absPath), { recursive: true });
   fs.writeFileSync(absPath, content, 'utf-8');
 }
+
+/**
+ * `os.tmpdir()` that is guaranteed not to look like a one-shot agent workdir.
+ *
+ * The Multica agent runtime exports TMPDIR as its own `multica-task-<id>`
+ * scratch directory, so a fixture built under `os.tmpdir()` there matches
+ * `isEphemeralProjectRoot` and is treated as disposable — registry rows for it
+ * are not persisted, and a missing one is swept without grace. A fixture that
+ * must read as a real, persistent project has to live outside that shape.
+ */
+export function tmpRootOutsideTaskDir(prefix: string): string {
+  const base = /[/\\]multica-task-\d+[/\\]?$/i.test(os.tmpdir())
+    ? path.dirname(os.tmpdir())
+    : os.tmpdir();
+  return fs.mkdtempSync(path.join(base, prefix));
+}


### PR DESCRIPTION
## What

`sweepMissingRoots` applied the same 7-day grace to every registered root whose directory is gone. The grace exists for a root that can come back — an unmounted volume, a detached disk. A one-shot agent workdir cannot: the run that created it is over, and `registerProject` has refused to persist such a root since TRA-396, so any registry row matching `isEphemeralProjectRoot` is legacy.

Holding that row for a week also pinned the matching `.config.json` section for the week, because a *registered* root is exactly what `pruneProjectConfigSections` protects (`dead = !claimed && !existsSync`).

Missing + ephemeral is now removed on the first sighting, so the config sweep that runs right after it in `softGcSweep` collects the section in the same pass. An explicit `add`/`init` of a workdir-shaped path (`explicit`, or multi-root) keeps its grace, as does every non-ephemeral root.

## Measured on this machine

```
.config.json          62 391 bytes, 47 project sections
  of which missing    17  ← all /private/tmp/multica-task-<id>/...
  bytes in `projects` 46 761 of 62 391
registry.json         38 rows, 17 of them the same dead workdirs
                      missingRootSince 2026-09-06 → removal due 2026-09-13
```

That file is parsed on every server start. With this change the same 17 drain on the next hourly sweep instead of a week later.

## Also

`src/registry.ts:656` has referenced a test helper `tmpRootOutsideTaskDir` in `tests/test-utils.ts` by name since TRA-992, but it was never written. Added it: on the Multica agent runtime `TMPDIR` is itself a `multica-task-<id>` directory, so a fixture built under `os.tmpdir()` there reads as ephemeral and any test that needs a *persistent* root silently tests the wrong thing. (Under vitest `os.tmpdir()` resolves to `/private/tmp`, so no existing test changes behaviour — the helper is the guard for the ones that call it directly.)

## Tests

`src/__tests__/ephemeral-missing-root-sweep.test.ts` — 5 cases: both ephemeral layouts dropped on first sighting; the config section collected in the same pass; grace preserved for a non-ephemeral missing root and for an explicitly-added workdir-shaped one. 3 of the 5 fail on `main`.

Full suite green (10 589 passed / 42 skipped), `pnpm typecheck` and `biome check` clean, `pnpm build` clean.

No MCP tool signature or on-disk schema change.

Closes TRA-1105.
