### PR TITLE
docs(contributing): require screen-to-code path for UI defect fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,32 @@ against a moving base is what `test` and `build` are for — they run on every P
 `master` after merge. Don't switch strict mode back on to fix a bad merge; set up GitHub's
 merge queue instead, which handles the same problem without the busy-wait.
 
+## Fixing a user-visible defect
+
+Most operations here exist twice: once as an MCP tool for agents, once behind
+an HTTP route for the desktop app's UI. They often converge on shared logic,
+but nothing enforces that — two independently-written implementations of "label
+this community" or "disambiguate this project name" can each look correct
+while producing different results, and the one you didn't touch is the one the
+screen actually calls. A unit test staying green while the screen still shows
+the bug is not evidence the fix worked — it's evidence the test exercises the
+sibling, not the path.
+
+Before fixing a defect reported from the app:
+
+1. **Name the path, one line, in the PR description**: which UI element sent
+   which request, which route/handler served it, which function computed the
+   value — e.g. `GET /api/projects/graph → buildGraphData() → labelCommunities()`.
+2. **Test through that same path.** Call the function the screen calls, not a
+   sibling with a similar name or purpose.
+3. **If a second, independently-computed implementation of the same value
+   exists** (e.g. one used only by an MCP tool), collapse them onto one
+   function instead of patching both — delete the other, don't mirror the fix
+   into it.
+
+Reviewing a UI-facing fix: ask the author to show that the screen calls the
+function the diff touches, before looking at the diff itself.
+
 ## How to Contribute
 
 1. Fork the repository


### PR DESCRIPTION
## Summary
- Closes the remaining action item from TRA-1079: codifies the rule that a UI-visible-defect PR must name the path from screen → route/handler → computing function, and test through that same path.
- Motivated by two of three PRs from the 2026-09-06 QA pass patching a duplicate of the function the screen actually calls (community label, project name); both had green unit tests on the sibling that the screen doesn't call.
- Adds a new "Fixing a user-visible defect" section to `CONTRIBUTING.md`, between "Review Model" and "How to Contribute".

## Test plan
- [x] Docs-only change; `pnpm run build` / `pnpm test` not required but repo state otherwise untouched.