### PR TITLE
fix(analytics): stop reporting stale:false when project freshness is unknown (TRA-1072)

### DIFF
--- a/src/analytics/sync.ts
+++ b/src/analytics/sync.ts
@@ -47,7 +47,11 @@ export interface SyncResult {
   tool_calls_stored: number;
   errors: number;
   duration_ms: number;
-  /** mtime (epoch ms) of the newest session log seen on disk, null when none. */
+  /**
+   * mtime (epoch ms) of the newest session log seen on disk, null when none.
+   * Always the machine-wide newest, even for a project-scoped sync — see
+   * `buildIngestionStatus`'s doc comment for why.
+   */
   newest_log_mtime: number | null;
 }
 
@@ -65,7 +69,16 @@ export interface IngestionStatus {
   newest_session_log_at: string | null;
   /** True when a session log on disk is newer than the ingestion watermark. */
   stale: boolean;
-  /** How far the watermark trails the newest log, in hours (null when fresh). */
+  /**
+   * Tri-state freshness read. 'unknown' means we could not find a log to
+   * compare the watermark against (no session logs anywhere on disk) — this
+   * is NOT the same claim as 'fresh' and must not be reported as `stale:
+   * false` without distinction. See TRA-1072.
+   */
+  freshness: 'fresh' | 'stale' | 'unknown';
+  /** When this status was computed, ISO-8601 — lets a caller show the age of the read. */
+  computed_at: string;
+  /** How far the watermark trails the newest log, in hours (null when fresh/unknown). */
   behind_hours: number | null;
 }
 
@@ -73,19 +86,32 @@ export interface IngestionStatus {
  * Derive ingestion freshness from a just-completed sync plus the store's
  * watermark. Takes the sync result rather than re-listing the filesystem so
  * this costs nothing beyond one SELECT.
+ *
+ * `newestLogMtime` MUST be the newest session log mtime across the whole
+ * machine, not scoped to one project — a project with no logs of its own
+ * has nothing to say about whether the DB is stale, so scoping this input
+ * silently collapsed "couldn't check" into "fresh" (TRA-1072).
  */
 export function buildIngestionStatus(
   watermark: { parsed_at: string | null; files_tracked: number },
   newestLogMtime: number | null,
+  now: number = Date.now(),
 ): IngestionStatus {
   const parsedAtMs = watermark.parsed_at ? Date.parse(watermark.parsed_at) : NaN;
-  const stale =
-    newestLogMtime !== null && (Number.isNaN(parsedAtMs) || newestLogMtime > parsedAtMs);
+  const freshness: IngestionStatus['freshness'] =
+    newestLogMtime === null
+      ? 'unknown'
+      : Number.isNaN(parsedAtMs) || newestLogMtime > parsedAtMs
+        ? 'stale'
+        : 'fresh';
+  const stale = freshness === 'stale';
   return {
     ingested_through: watermark.parsed_at,
     files_tracked: watermark.files_tracked,
     newest_session_log_at: newestLogMtime === null ? null : new Date(newestLogMtime).toISOString(),
     stale,
+    freshness,
+    computed_at: new Date(now).toISOString(),
     behind_hours:
       stale && !Number.isNaN(parsedAtMs)
         ? Math.round((((newestLogMtime as number) - parsedAtMs) / 3_600_000) * 10) / 10
@@ -213,6 +239,9 @@ export function syncProjectAnalytics(
     tool_calls_stored: toolCallsCount,
     errors,
     duration_ms: Date.now() - start,
-    newest_log_mtime: newestMtime(sessions),
+    // Freshness must be judged against every log on disk, not just this
+    // project's — `allSessions` is already in hand from the listAllSessions()
+    // call above, so this is free. See TRA-1072.
+    newest_log_mtime: newestMtime(allSessions),
   };
 }

--- a/tests/analytics/sync-project-freshness.test.ts
+++ b/tests/analytics/sync-project-freshness.test.ts
@@ -1,0 +1,53 @@
+/**
+ * TRA-1072: `syncProjectAnalytics()` must report the machine-wide newest
+ * session log mtime, not just the mtime of the requested project's own
+ * logs. Before this fix, a project with no session logs of its own got
+ * `newest_log_mtime: null` from its scoped sync, and `buildIngestionStatus`
+ * turned that into `stale: false` even while the DB trailed a fresher log
+ * sitting under a different project — the exact "stale: false" trap this
+ * issue reports.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+const OTHER_PROJECT_MTIME = Date.parse('2026-09-06T21:39:00.000Z');
+
+vi.mock('../../src/analytics/log-parser.js', () => ({
+  listAllSessions: () => [
+    {
+      filePath: '/fake/.claude/projects/other-proj/sess-fresh.jsonl',
+      projectPath: '/other/project',
+      client: 'claude-code',
+      mtime: OTHER_PROJECT_MTIME,
+    },
+  ],
+  parseSessionFile: () => null,
+}));
+
+import { AnalyticsStore } from '../../src/analytics/analytics-store.js';
+import { buildIngestionStatus, syncProjectAnalytics } from '../../src/analytics/sync.js';
+import { createTmpDir, removeTmpDir } from '../test-utils.js';
+import path from 'node:path';
+
+describe('syncProjectAnalytics() — freshness must be machine-wide (TRA-1072)', () => {
+  it("reports the other project's newer log as newest_log_mtime, not null", () => {
+    const tmpDir = createTmpDir('sync-project-freshness-');
+    const store = new AnalyticsStore(path.join(tmpDir, 'analytics.db'));
+    try {
+      const sync = syncProjectAnalytics(store, '/project/without/its/own/logs');
+
+      expect(sync.newest_log_mtime).toBe(OTHER_PROJECT_MTIME);
+
+      // Feed that into the same pipeline get_session_analytics uses: an old
+      // watermark plus this sync result must come out stale, not silently fresh.
+      const status = buildIngestionStatus(
+        { parsed_at: '2026-09-04T08:02:57.929Z', files_tracked: 3601 },
+        sync.newest_log_mtime,
+      );
+      expect(status.stale).toBe(true);
+      expect(status.freshness).toBe('stale');
+    } finally {
+      store.close();
+      removeTmpDir(tmpDir);
+    }
+  });
+});

--- a/tests/analytics/sync.test.ts
+++ b/tests/analytics/sync.test.ts
@@ -72,18 +72,30 @@ describe('buildIngestionStatus()', () => {
       parsedAtMs + 7 * 24 * HOUR,
     );
     expect(status.stale).toBe(true);
+    expect(status.freshness).toBe('stale');
     expect(status.behind_hours).toBe(168);
   });
 
   it('is stale when nothing was ever ingested but logs exist', () => {
     const status = buildIngestionStatus({ parsed_at: null, files_tracked: 0 }, parsedAtMs);
     expect(status.stale).toBe(true);
+    expect(status.freshness).toBe('stale');
     expect(status.behind_hours).toBeNull();
   });
 
-  it('is not stale when there are no logs on disk at all', () => {
+  // TRA-1072: newestLogMtime === null must not be reported as "checked,
+  // fresh" — that's indistinguishable from a genuine fresh reading and was
+  // exactly the trap that let a 3-day-stale DB claim `stale: false`.
+  it('is "unknown", not "fresh", when there are no logs on disk at all — and stale stays false', () => {
     const status = buildIngestionStatus({ parsed_at: null, files_tracked: 0 }, null);
     expect(status.stale).toBe(false);
+    expect(status.freshness).toBe('unknown');
+  });
+
+  it('stamps computed_at with the supplied clock', () => {
+    const now = parsedAtMs + HOUR;
+    const status = buildIngestionStatus({ parsed_at: parsedAt, files_tracked: 10 }, null, now);
+    expect(status.computed_at).toBe(new Date(now).toISOString());
   });
 });
 


### PR DESCRIPTION
## Summary
- `syncProjectAnalytics()` scoped `newest_log_mtime` to the requested project's own session logs. A project with no logs of its own always got `null`, and `buildIngestionStatus` turned that into `stale: false` — even while the DB trailed a fresher log under a *different* project by days. This is the TRA-695 trap returning through `get_session_analytics`/`get_optimization_report` (which always pass `projectPath`).
- Fix: score freshness against the machine-wide newest log. `syncProjectAnalytics` already fetches every session via `listAllSessions()` before filtering to the project, so using that unfiltered list for `newest_log_mtime` costs nothing extra.
- Added `IngestionStatus.freshness: 'fresh' | 'stale' | 'unknown'` so "no log anywhere to compare against" is a distinct, explicit state rather than being silently reported as `stale: false`. Kept the `stale` boolean for backward compatibility (`stale === (freshness === 'stale')`).
- Added `IngestionStatus.computed_at` (ISO timestamp) so a caller can show the age of a freshness read, mirroring the `computedAt` pattern from TRA-1053's dashboard cache.

Out of scope (flagged, not decided here): TRA-1072's item 3 — whether to actively resync on a timer/on screen-open — is a product/architecture call, not implemented in this PR. Lead Engineer's follow-up comment on the issue scoped this pass to the stale-flag correctness fix only.

## Test plan
- [x] `pnpm run build` — clean
- [x] `pnpm run typecheck` — clean
- [x] New regression test `tests/analytics/sync-project-freshness.test.ts`: mocks a global session list where only a *different* project has a fresh log, calls `syncProjectAnalytics` for a project with none of its own, asserts `newest_log_mtime` is the other project's mtime (not null) and that feeding it through `buildIngestionStatus` with an old watermark yields `stale: true` — this is the exact TRA-1072 issue repro.
- [x] Extended `tests/analytics/sync.test.ts` for the new `freshness` tri-state and `computed_at`.
- [x] `pnpm run test --run` — 957 files / 10591 tests passed, 0 failed.
- [x] `biome check` on changed files — clean.