### PR TITLE
fix(activity): stop cross-project filter leak and contradictory empty state (TRA-1055)

### DIFF
--- a/packages/app/src/renderer/tabs/ToolActivity.tsx
+++ b/packages/app/src/renderer/tabs/ToolActivity.tsx
@@ -1029,7 +1029,18 @@ function HotFilesList({ files }: { files: HotFile[] }) {
  */
 function LatencyHistogram({ buckets }: { buckets: LatencyBucket[] }) {
   const { t } = useTranslation('activity');
+  const totalCount = buckets.reduce((s, b) => s + b.count, 0);
   const maxCount = Math.max(...buckets.map((b) => b.count), 1);
+  if (totalCount === 0) {
+    return (
+      <div>
+        <ChartTitle>{t('chartLatency')}</ChartTitle>
+        <div className="text-[11px] leading-[13px]" style={{ color: 'var(--label-secondary)' }}>
+          {t('noLatencyInWindow')}
+        </div>
+      </div>
+    );
+  }
   return (
     <div>
       <ChartTitle>{t('chartLatency')}</ChartTitle>
@@ -1419,14 +1430,27 @@ function StatsPanel({
 // ── Main component ────────────────────────────────────────────────────────
 
 // ── localStorage keys for filter & control persistence ───────────────────
+// Tool filter and errors-only are scoped per project root: without this, the
+// chip a user set for one project reappeared as an already-active "1 filter"
+// on the next unrelated project they opened, looking like a preset default
+// they never chose (TRA-1055). Group-by-session is a display preference, not
+// a filter that hides data, so it stays global.
 const TOOL_FILTER_STORAGE_KEY = 'toolactivity.tools';
 const ERRORS_ONLY_STORAGE_KEY = 'toolactivity.errorsOnly';
 const GROUP_BY_SESSION_STORAGE_KEY = 'toolactivity.groupBySession';
 
-function loadToolFilter(): Set<string> {
+function toolFilterKey(root: string): string {
+  return `${TOOL_FILTER_STORAGE_KEY}:${root}`;
+}
+
+function errorsOnlyKey(root: string): string {
+  return `${ERRORS_ONLY_STORAGE_KEY}:${root}`;
+}
+
+function loadToolFilter(root: string): Set<string> {
   if (typeof window === 'undefined') return new Set();
   try {
-    const raw = window.localStorage.getItem(TOOL_FILTER_STORAGE_KEY);
+    const raw = window.localStorage.getItem(toolFilterKey(root));
     if (raw === null) return new Set();
     const parsed = JSON.parse(raw) as unknown;
     if (Array.isArray(parsed)) {
@@ -1438,10 +1462,10 @@ function loadToolFilter(): Set<string> {
   }
 }
 
-function loadErrorsOnly(): boolean {
+function loadErrorsOnly(root: string): boolean {
   if (typeof window === 'undefined') return false;
   try {
-    return window.localStorage.getItem(ERRORS_ONLY_STORAGE_KEY) === '1';
+    return window.localStorage.getItem(errorsOnlyKey(root)) === '1';
   } catch {
     return false;
   }
@@ -1664,9 +1688,9 @@ export function ToolActivity({
   const { t } = useTranslation('activity');
   const [entries, setEntries] = useState<JournalEntry[]>([]);
   // Multi-select tool filter — empty set means "no tool restriction".
-  const [toolFilter, setToolFilter] = useState<Set<string>>(() => loadToolFilter());
+  const [toolFilter, setToolFilter] = useState<Set<string>>(() => loadToolFilter(root));
   // Combinable errors-only toggle, independent of tool filter.
-  const [errorsOnly, setErrorsOnly] = useState<boolean>(() => loadErrorsOnly());
+  const [errorsOnly, setErrorsOnly] = useState<boolean>(() => loadErrorsOnly(root));
   // Group flat list by session_id when on. Persisted.
   const [groupBySession, setGroupBySession] = useState<boolean>(() => loadGroupBySession());
   // Collapsed session ids when grouping is on. Not persisted — refresh resets
@@ -1796,25 +1820,46 @@ export function ToolActivity({
     }
   }, []);
 
-  // Persist filter state across refresh.
+  // Reload the per-project filter state whenever the project switches. This
+  // component instance is reused across projects (no `key={root}` upstream),
+  // so without this the previous project's filter chip stayed lit on the new
+  // one (TRA-1055). The skip-refs stop the persist effects below from
+  // re-saving the *previous* project's still-in-state values under the *new*
+  // root during the one render where root has changed but the reloaded
+  // toolFilter/errorsOnly haven't landed yet.
+  const skipToolPersistRef = useRef(true);
+  const skipErrorsPersistRef = useRef(true);
   useEffect(() => {
+    skipToolPersistRef.current = true;
+    skipErrorsPersistRef.current = true;
+    setToolFilter(loadToolFilter(root));
+    setErrorsOnly(loadErrorsOnly(root));
+  }, [root]);
+
+  // Persist filter state across refresh, scoped to this project.
+  useEffect(() => {
+    if (skipToolPersistRef.current) {
+      skipToolPersistRef.current = false;
+      return;
+    }
     try {
-      window.localStorage.setItem(
-        TOOL_FILTER_STORAGE_KEY,
-        JSON.stringify(Array.from(toolFilter)),
-      );
+      window.localStorage.setItem(toolFilterKey(root), JSON.stringify(Array.from(toolFilter)));
     } catch {
       /* localStorage may be unavailable — ignore */
     }
-  }, [toolFilter]);
+  }, [toolFilter, root]);
 
   useEffect(() => {
+    if (skipErrorsPersistRef.current) {
+      skipErrorsPersistRef.current = false;
+      return;
+    }
     try {
-      window.localStorage.setItem(ERRORS_ONLY_STORAGE_KEY, errorsOnly ? '1' : '0');
+      window.localStorage.setItem(errorsOnlyKey(root), errorsOnly ? '1' : '0');
     } catch {
       /* localStorage may be unavailable — ignore */
     }
-  }, [errorsOnly]);
+  }, [errorsOnly, root]);
 
   useEffect(() => {
     try {
@@ -2458,7 +2503,13 @@ export function ToolActivity({
         style={{ background: 'var(--surface)' }}
       >
         {filtered.length === 0 ? (
-          historyFailed && activeFilterCount === 0 && query === '' ? (
+          // Which empty state applies is decided by whether ANY call has
+          // landed at all (entries.length), not by whether a filter/search is
+          // currently set. A stray active filter with nothing to hide is not
+          // "filtered" — it's just an empty feed, and saying "0 calls are
+          // hidden by the current filters" over it was self-contradictory
+          // (TRA-1055).
+          historyFailed && entries.length === 0 ? (
             <EmptyState
               icon="warning"
               iconSize={32}
@@ -2470,7 +2521,7 @@ export function ToolActivity({
                 </Button>
               }
             />
-          ) : activeFilterCount === 0 && query === '' ? (
+          ) : entries.length === 0 ? (
             <EmptyState
               icon="monitoring"
               iconSize={32}
@@ -2492,7 +2543,7 @@ export function ToolActivity({
               iconSize={32}
               title={t('emptyMatchTitle')}
               subtitle={
-                activeFilterCount > 0
+                activeFilterCount > 0 && filteredOutCount > 0
                   ? t('emptyMatchFiltered', {
                       count: filteredOutCount,
                       n: formatNumber(filteredOutCount),

--- a/packages/app/src/shared/i18n/catalog/de/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/de/activity.ts
@@ -70,6 +70,7 @@ export const activity = {
   errorSampleHideShort: 'Beispiel ausblenden',
   errorGroupFilter: 'Nur Fehler von {{tool}} anzeigen',
   noErrorsInWindow: 'Keine Fehler in diesem Zeitraum.',
+  noLatencyInWindow: 'Keine Latenzdaten in diesem Zeitraum.',
   clearTimeRange: 'Zeitraumfilter zurücksetzen',
   clear: 'Zurücksetzen',
   sparklineTitle: '{{time}}: {{calls}} Aufrufe',

--- a/packages/app/src/shared/i18n/catalog/en/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/en/activity.ts
@@ -81,6 +81,7 @@ export const activity = {
   errorSampleHideShort: 'Hide sample',
   errorGroupFilter: 'Show only {{tool}} errors',
   noErrorsInWindow: 'No errors in this window.',
+  noLatencyInWindow: 'No latency data in this window.',
   clearTimeRange: 'Clear time-range filter',
   clear: 'Clear',
   sparklineTitle: '{{time}}: {{calls}} calls',

--- a/packages/app/src/shared/i18n/catalog/es/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/es/activity.ts
@@ -68,6 +68,7 @@ export const activity = {
   errorSampleHideShort: 'Ocultar ejemplo',
   errorGroupFilter: 'Mostrar solo los errores de {{tool}}',
   noErrorsInWindow: 'Sin errores en esta ventana.',
+  noLatencyInWindow: 'Sin datos de latencia en esta ventana.',
   clearTimeRange: 'Quitar el filtro de intervalo',
   clear: 'Limpiar',
   sparklineTitle: '{{time}}: {{calls}} llamadas',

--- a/packages/app/src/shared/i18n/catalog/fr/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/fr/activity.ts
@@ -68,6 +68,7 @@ export const activity = {
   errorSampleHideShort: 'Masquer l’exemple',
   errorGroupFilter: 'Afficher uniquement les erreurs de {{tool}}',
   noErrorsInWindow: 'Aucune erreur sur cette période.',
+  noLatencyInWindow: 'Aucune donnée de latence sur cette période.',
   clearTimeRange: 'Effacer le filtre de période',
   clear: 'Effacer',
   sparklineTitle: '{{time}} : {{calls}} appels',

--- a/packages/app/src/shared/i18n/catalog/hi/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/hi/activity.ts
@@ -64,6 +64,7 @@ export const activity = {
   errorSampleHideShort: 'नमूना छिपाएँ',
   errorGroupFilter: 'केवल {{tool}} के एरर दिखाएँ',
   noErrorsInWindow: 'इस अवधि में कोई एरर नहीं।',
+  noLatencyInWindow: 'इस अवधि में कोई लेटेंसी डेटा नहीं।',
   clearTimeRange: 'समय-सीमा फ़िल्टर हटाएँ',
   clear: 'हटाएँ',
   sparklineTitle: '{{time}}: {{calls}} कॉल',

--- a/packages/app/src/shared/i18n/catalog/ja/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/ja/activity.ts
@@ -60,6 +60,7 @@ export const activity = {
   errorSampleHideShort: '例を隠す',
   errorGroupFilter: '{{tool}} のエラーだけを表示',
   noErrorsInWindow: 'この期間にエラーはありません。',
+  noLatencyInWindow: 'この期間にレイテンシデータはありません。',
   clearTimeRange: '期間フィルタを解除',
   clear: '解除',
   sparklineTitle: '{{time}}: 呼び出し {{calls}} 件',

--- a/packages/app/src/shared/i18n/catalog/ko/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/ko/activity.ts
@@ -60,6 +60,7 @@ export const activity = {
   errorSampleHideShort: '예시 숨기기',
   errorGroupFilter: '{{tool}} 오류만 표시',
   noErrorsInWindow: '이 구간에는 오류가 없습니다.',
+  noLatencyInWindow: '이 구간에는 지연 시간 데이터가 없습니다.',
   clearTimeRange: '시간 범위 필터 지우기',
   clear: '지우기',
   sparklineTitle: '{{time}}: 호출 {{calls}}회',

--- a/packages/app/src/shared/i18n/catalog/pt-BR/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/pt-BR/activity.ts
@@ -68,6 +68,7 @@ export const activity = {
   errorSampleHideShort: 'Ocultar exemplo',
   errorGroupFilter: 'Mostrar somente os erros de {{tool}}',
   noErrorsInWindow: 'Nenhum erro nesta janela.',
+  noLatencyInWindow: 'Nenhum dado de latência nesta janela.',
   clearTimeRange: 'Limpar o filtro de período',
   clear: 'Limpar',
   sparklineTitle: '{{time}}: {{calls}} chamadas',

--- a/packages/app/src/shared/i18n/catalog/ru/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/activity.ts
@@ -79,6 +79,7 @@ export const activity = {
   errorSampleHideShort: 'Скрыть пример',
   errorGroupFilter: 'Показать только ошибки {{tool}}',
   noErrorsInWindow: 'За это время ошибок не было.',
+  noLatencyInWindow: 'За это время данных о задержке не было.',
   clearTimeRange: 'Сбросить фильтр по времени',
   clear: 'Сбросить',
   sparklineTitle: '{{time}}: вызовов {{calls}}',

--- a/packages/app/src/shared/i18n/catalog/zh/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/activity.ts
@@ -60,6 +60,7 @@ export const activity = {
   errorSampleHideShort: '隐藏示例',
   errorGroupFilter: '只看 {{tool}} 的错误',
   noErrorsInWindow: '这个时间窗口内没有错误。',
+  noLatencyInWindow: '这个时间窗口内没有延迟数据。',
   clearTimeRange: '清除时间范围筛选',
   clear: '清除',
   sparklineTitle: '{{time}}：{{calls}} 次调用',


### PR DESCRIPTION
## Summary
Fixes 3 of the 4 items in TRA-1055 (item — the fourth, Latency empty state — is also included):

1. **Filter chip carried over between projects.** `toolactivity.tools` / `toolactivity.errorsOnly` were single global localStorage keys, so a filter you set on one project reappeared as an already-active "1 filter" chip on the next, unrelated project — looking like a preset you never chose. Both are now scoped per project root, with a guarded reload effect so the previous project's in-memory filter state doesn't get persisted under the new root during the switch.
2. **Self-contradictory empty state.** The feed picked between "No tool calls yet" and "No matching calls / N calls are hidden by the current filters" based on whether a filter/search was *active*, not on whether any call had actually *landed*. A stray active filter with 0 calls in the feed rendered the filtered message with `N=0` — self-contradictory. It now branches on `entries.length` instead.
3. **"0 calls are hidden" guard.** Belt-and-suspenders guard so the filtered-count copy can't print when there's nothing to report (structurally unreachable after #2, but explicit).
4. **Latency block empty state.** Drew a bare zeroed axis at 0 calls instead of an empty state, unlike the neighboring Errors panel. Now shows "No latency data in this window." to match.

Added the new `noLatencyInWindow` string to all 10 locale catalogs (`catalog-parity` test enforces this).

The "Activity shows 0 everywhere" root cause (in-memory single-session journal) is TRA-1071, assigned to Implementation Engineer — out of scope here per plan.

## Test plan
- [x] `vitest run` — 749/749 tests pass (packages/app)
- [x] `vitest run catalog-parity` — passes (all 10 locales have the new key)
- [x] `tsc --noEmit` — clean
- [x] Verified live in the renderer against the real daemon (project with 0 recorded calls): empty feed shows "No tool calls yet" + Connect a client, even with "Errors only" toggled on (chip shows "1 filter" but body isn't self-contradictory); Latency shows "No latency data in this window."; toggling the filter on one project and switching to another confirms no cross-project leak, and switching back confirms the filter is still remembered per-project.

Agent: Design/UX Agent