### PR TITLE
test(db): cover DomainRepository (TRA-1111)

### DIFF
--- a/ops/test-coverage-ledger.md
+++ b/ops/test-coverage-ledger.md
@@ -14,7 +14,7 @@ parsing, the MCP tool surface.
 | Date | Area | What was covered | PR |
 |------|------|------------------|----|
 | 2026-08-30 | `src/init/hermes-hooks.ts` | Guard-script install, `config.yaml` wiring (idempotency, stale refresh, foreign hooks, parse errors), shell-hook allowlist (shape, idempotency, malformed recovery), dry-run | #649 |
-| 2026-09-07 | `src/db/repositories/domain-repository.ts` | `DomainRepository` (routes, components, migrations, ORM models/associations, RN screens) had zero direct tests despite being core DB/schema surface — round-trip + lookup for each entity, `findRouteByPattern`'s LIKE-wildcard matching, `getMigrationsByTable` ordering, and `getAllOrmAssociations`' file-scoped resolved-vs-unresolved-association filter (the exact query TRA-1005 is about to touch for SQLite chunking) | TBD |
+| 2026-09-07 | `src/db/repositories/domain-repository.ts` | `DomainRepository` (routes, components, migrations, ORM models/associations, RN screens) had zero direct tests despite being core DB/schema surface — round-trip + lookup for each entity, `findRouteByPattern`'s LIKE-wildcard matching, `getMigrationsByTable` ordering, and `getAllOrmAssociations`' file-scoped resolved-vs-unresolved-association filter (the exact query TRA-1005 is about to touch for SQLite chunking) | #1080 |
 
 ## Next candidates (highest untested-symbol counts in `src/**`, unreached)
 
@@ -28,9 +28,10 @@ Re-derive before picking — this list ages. As of 2026-09-07:
 - `src/init/tweakcc.ts` (9) — writes into another tool's config dir
 - `src/api/dashboard-routes.ts` (7) — cache + cross-project queries
 
-Edge resolvers (`src/indexer/edge-resolvers/**`) still show up heavily in `unreached` (c-imports, csharp-imports, go-imports, java-imports, kotlin-imports, fastapi-mounts, php-calls, member-of, heritage, iac-imports, phantom-externals, file-projection, …) — per the note below, treat that group as a classification artefact, not a genuine gap.
-
-Edge resolvers (`src/indexer/edge-resolvers/**`) also show up as unreached, but
-they are exercised indirectly through the indexing e2e tests — `test_covers`
-only records direct call edges from a test, so treat that group as a
-classification artefact rather than a genuine gap.
+Edge resolvers (`src/indexer/edge-resolvers/**`) still show up heavily in
+`unreached` (c-imports, csharp-imports, go-imports, java-imports,
+kotlin-imports, fastapi-mounts, php-calls, member-of, heritage, iac-imports,
+phantom-externals, file-projection, …), but they are exercised indirectly
+through the indexing e2e tests — `test_covers` only records direct call edges
+from a test, so treat that group as a classification artefact rather than a
+genuine gap.

--- a/ops/test-coverage-ledger.md
+++ b/ops/test-coverage-ledger.md
@@ -14,16 +14,21 @@ parsing, the MCP tool surface.
 | Date | Area | What was covered | PR |
 |------|------|------------------|----|
 | 2026-08-30 | `src/init/hermes-hooks.ts` | Guard-script install, `config.yaml` wiring (idempotency, stale refresh, foreign hooks, parse errors), shell-hook allowlist (shape, idempotency, malformed recovery), dry-run | #649 |
+| 2026-09-07 | `src/db/repositories/domain-repository.ts` | `DomainRepository` (routes, components, migrations, ORM models/associations, RN screens) had zero direct tests despite being core DB/schema surface — round-trip + lookup for each entity, `findRouteByPattern`'s LIKE-wildcard matching, `getMigrationsByTable` ordering, and `getAllOrmAssociations`' file-scoped resolved-vs-unresolved-association filter (the exact query TRA-1005 is about to touch for SQLite chunking) | TBD |
 
 ## Next candidates (highest untested-symbol counts in `src/**`, unreached)
 
-Re-derive before picking — this list ages. As of 2026-08-30:
+Re-derive before picking — this list ages. As of 2026-09-07:
 
-- `src/api/ask-sessions-routes-handlers.ts` (15) — HTTP handlers over the DB
-- `src/api/memory-routes-handlers.ts` (15) — decision-store HTTP surface
+- `src/api/memory-routes.ts::handleMemoryRequest` — decision-store HTTP surface (renamed/refactored since the 2026-08-30 pass; re-check `src/api/memory-routes-handlers.ts` too)
+- `src/db/repositories/analytics-repository.ts::AnalyticsRepository` — DB/schema surface, same shape of gap as domain-repository (env vars, workspace stats, cross-workspace edges, graph snapshots), zero direct tests
+- `src/db/repositories/graph-repository.ts::GraphRepository` — DB/schema surface, zero direct tests
+- `src/daemon/log-error.ts::serializeError` — error serialization helper
 - `src/init/md-block.ts` (11) — rewrites the user's CLAUDE.md
 - `src/init/tweakcc.ts` (9) — writes into another tool's config dir
 - `src/api/dashboard-routes.ts` (7) — cache + cross-project queries
+
+Edge resolvers (`src/indexer/edge-resolvers/**`) still show up heavily in `unreached` (c-imports, csharp-imports, go-imports, java-imports, kotlin-imports, fastapi-mounts, php-calls, member-of, heritage, iac-imports, phantom-externals, file-projection, …) — per the note below, treat that group as a classification artefact, not a genuine gap.
 
 Edge resolvers (`src/indexer/edge-resolvers/**`) also show up as unreached, but
 they are exercised indirectly through the indexing e2e tests — `test_covers`

--- a/tests/db/domain-repository.test.ts
+++ b/tests/db/domain-repository.test.ts
@@ -105,22 +105,26 @@ describe('DomainRepository ORM models and associations', () => {
     const userId = store.insertOrmModel({ name: 'User', orm: 'sequelize' }, fileA);
     const postId = store.insertOrmModel({ name: 'Post', orm: 'sequelize' }, fileB);
 
+    // Declared directly in fileA — covers the `file_id IN (${ph})` branch.
+    store.insertOrmAssociation(userId, postId, 'Post', 'hasMany', undefined, fileA);
     // Already resolved (target_model_id set) and declared in fileB — out of
     // scope for fileA: it doesn't need re-resolving, the edge already exists.
     store.insertOrmAssociation(postId, userId, 'User', 'belongsTo', undefined, fileB);
-    // Unresolved (no target_model_id, no file_id) but its target name matches
+    // Unresolved (no target_model_id) — as it would read after fileA's model
+    // node was dropped by deleteEntitiesByFile — but its target name matches
     // a model that lives in fileA — must surface when scoped to fileA so a
-    // reindex of fileA can re-link it.
-    store.insertOrmAssociation(postId, null, 'User', 'hasMany', undefined, undefined);
+    // reindex of fileA can re-link it. Declared in fileB, matching the
+    // reindex lifecycle: only the *target's* file is scoped, not the source's.
+    store.insertOrmAssociation(postId, null, 'User', 'hasMany', undefined, fileB);
     // Unrelated: neither declared in, nor targeting, the scoped files.
     const fileC = store.insertFile('src/Comment.ts', 'typescript', 'h', 10, null, null);
     const commentId = store.insertOrmModel({ name: 'Comment', orm: 'sequelize' }, fileC);
     store.insertOrmAssociation(commentId, null, 'Other', 'hasMany', undefined, fileC);
 
     const scoped = store.getAllOrmAssociations([fileA]);
-    expect(scoped.map((r) => r.kind).sort()).toEqual(['hasMany']);
+    expect(scoped.map((r) => r.kind).sort()).toEqual(['hasMany', 'hasMany']);
 
-    expect(store.getAllOrmAssociations()).toHaveLength(3);
+    expect(store.getAllOrmAssociations()).toHaveLength(4);
     expect(
       store
         .getOrmAssociationsByModel(postId)

--- a/tests/db/domain-repository.test.ts
+++ b/tests/db/domain-repository.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import { createTestStore } from '../test-utils.js';
+
+describe('DomainRepository routes', () => {
+  it('round-trips a route and looks it up by uri+method', () => {
+    const store = createTestStore();
+    const fileId = store.insertFile('src/routes.ts', 'typescript', 'h', 10, null, null);
+
+    const id = store.insertRoute(
+      { method: 'GET', uri: '/users/{id}', name: 'users.show', middleware: ['auth'] },
+      fileId,
+    );
+
+    const row = store.getRouteByUriAndMethod('/users/{id}', 'GET');
+    expect(row?.id).toBe(id);
+    expect(row?.name).toBe('users.show');
+    expect(JSON.parse(row!.middleware!)).toEqual({ middleware: ['auth'] });
+  });
+
+  it('findRouteByPattern replaces {param} with a wildcard and matches stored uris', () => {
+    const store = createTestStore();
+    const fileId = store.insertFile('src/routes.ts', 'typescript', 'h', 10, null, null);
+    store.insertRoute({ method: 'GET', uri: '/users/new' }, fileId);
+    store.insertRoute({ method: 'GET', uri: '/users/42' }, fileId);
+
+    // Two stored routes both match the `/users/%` LIKE pattern; with no exact
+    // match among them, the first one found wins.
+    expect(store.findRouteByPattern('/users/{id}', 'GET')?.uri).toBe('/users/new');
+    // A literal uri that is itself stored is preferred over any other match.
+    expect(store.findRouteByPattern('/users/42', 'GET')?.uri).toBe('/users/42');
+  });
+
+  it('updateRouteUri rewrites the served uri in place', () => {
+    const store = createTestStore();
+    const fileId = store.insertFile('src/routes.ts', 'typescript', 'h', 10, null, null);
+    const id = store.insertRoute({ method: 'GET', uri: '/old' }, fileId);
+
+    store.updateRouteUri(id, '/new');
+
+    expect(store.getRouteByUriAndMethod('/old', 'GET')).toBeUndefined();
+    expect(store.getRouteByUriAndMethod('/new', 'GET')?.id).toBe(id);
+  });
+});
+
+describe('DomainRepository components', () => {
+  it('round-trips a component and looks it up by name and by file', () => {
+    const store = createTestStore();
+    const fileId = store.insertFile('src/Button.tsx', 'typescript', 'h', 10, null, null);
+
+    const id = store.insertComponent(
+      { name: 'Button', kind: 'component', framework: 'react', props: { label: 'string' } },
+      fileId,
+    );
+
+    expect(store.getComponentByFileId(fileId)?.id).toBe(id);
+    expect(store.getComponentByName('Button')?.id).toBe(id);
+    expect(JSON.parse(store.getComponentByName('Button')!.props!)).toEqual({ label: 'string' });
+  });
+});
+
+describe('DomainRepository migrations', () => {
+  it('orders migrations for a table by timestamp ascending', () => {
+    const store = createTestStore();
+    const fileId = store.insertFile('src/migrations.ts', 'typescript', 'h', 10, null, null);
+
+    store.insertMigration(
+      { tableName: 'users', operation: 'alter', timestamp: '2026-02-01' },
+      fileId,
+    );
+    store.insertMigration(
+      { tableName: 'users', operation: 'create', timestamp: '2026-01-01' },
+      fileId,
+    );
+    store.insertMigration(
+      { tableName: 'posts', operation: 'create', timestamp: '2026-01-15' },
+      fileId,
+    );
+
+    const rows = store.getMigrationsByTable('users');
+    expect(rows.map((r) => r.operation)).toEqual(['create', 'alter']);
+    expect(store.getAllMigrations().map((r) => r.table_name)).toEqual(['users', 'posts', 'users']);
+  });
+});
+
+describe('DomainRepository ORM models and associations', () => {
+  it('round-trips an ORM model and finds it by name and by orm', () => {
+    const store = createTestStore();
+    const fileId = store.insertFile('src/User.ts', 'typescript', 'h', 10, null, null);
+
+    const id = store.insertOrmModel(
+      { name: 'User', orm: 'sequelize', collectionOrTable: 'users' },
+      fileId,
+    );
+
+    expect(store.getOrmModelByName('User')?.id).toBe(id);
+    expect(store.getOrmModelsByOrm('sequelize').map((r) => r.id)).toEqual([id]);
+    expect(store.getOrmModelsByOrm('mongoose')).toEqual([]);
+  });
+
+  it('scopes getAllOrmAssociations by fileIds, including unresolved associations targeting a model in that file', () => {
+    const store = createTestStore();
+    const fileA = store.insertFile('src/User.ts', 'typescript', 'h', 10, null, null);
+    const fileB = store.insertFile('src/Post.ts', 'typescript', 'h', 10, null, null);
+
+    const userId = store.insertOrmModel({ name: 'User', orm: 'sequelize' }, fileA);
+    const postId = store.insertOrmModel({ name: 'Post', orm: 'sequelize' }, fileB);
+
+    // Already resolved (target_model_id set) and declared in fileB — out of
+    // scope for fileA: it doesn't need re-resolving, the edge already exists.
+    store.insertOrmAssociation(postId, userId, 'User', 'belongsTo', undefined, fileB);
+    // Unresolved (no target_model_id, no file_id) but its target name matches
+    // a model that lives in fileA — must surface when scoped to fileA so a
+    // reindex of fileA can re-link it.
+    store.insertOrmAssociation(postId, null, 'User', 'hasMany', undefined, undefined);
+    // Unrelated: neither declared in, nor targeting, the scoped files.
+    const fileC = store.insertFile('src/Comment.ts', 'typescript', 'h', 10, null, null);
+    const commentId = store.insertOrmModel({ name: 'Comment', orm: 'sequelize' }, fileC);
+    store.insertOrmAssociation(commentId, null, 'Other', 'hasMany', undefined, fileC);
+
+    const scoped = store.getAllOrmAssociations([fileA]);
+    expect(scoped.map((r) => r.kind).sort()).toEqual(['hasMany']);
+
+    expect(store.getAllOrmAssociations()).toHaveLength(3);
+    expect(
+      store
+        .getOrmAssociationsByModel(postId)
+        .map((r) => r.kind)
+        .sort(),
+    ).toEqual(['belongsTo', 'hasMany']);
+  });
+});
+
+describe('DomainRepository React Native screens', () => {
+  it('round-trips a screen and looks it up by name', () => {
+    const store = createTestStore();
+    const fileId = store.insertFile('src/HomeScreen.tsx', 'typescript', 'h', 10, null, null);
+
+    const id = store.insertRnScreen(
+      { name: 'Home', navigatorType: 'stack', deepLink: 'app://home' },
+      fileId,
+    );
+
+    const row = store.getRnScreenByName('Home');
+    expect(row?.id).toBe(id);
+    expect(row?.navigator_type).toBe('stack');
+    expect(store.getAllRnScreens().map((r) => r.id)).toEqual([id]);
+  });
+});


### PR DESCRIPTION
## Summary
- `DomainRepository` (`src/db/repositories/domain-repository.ts`) had zero direct test coverage despite being core DB/schema surface — routes, components, migrations, ORM models/associations, RN screens.
- Adds round-trip + lookup coverage for each entity, `findRouteByPattern`'s LIKE-wildcard matching semantics, `getMigrationsByTable` ordering, and `getAllOrmAssociations`' file-scoped resolved-vs-unresolved filter — the exact query TRA-1005 is about to touch for SQLite variable-limit chunking, so this locks down current behavior before that refactor lands.
- Updates `ops/test-coverage-ledger.md` with what was covered and the re-derived next-candidate list.

Part of the recurring Test & Quality Health mandate (TRA-1111).

## Test plan
- [x] `pnpm run test --run tests/db/domain-repository.test.ts` — 8/8 pass
- [x] `pnpm run test --run` — 10604 passed, 40 skipped, 0 failed (one pre-existing flaky test unrelated to this change, filed separately)
- [x] `pnpm run build` — passes
- [x] `pnpm run lint` (tsc --noEmit) — passes
- [x] `biome check` — clean