### PR TITLE
test(hooks): raise hook subprocess timeouts from 5s to 30s

### DIFF
--- a/tests/hooks/guard.test.ts
+++ b/tests/hooks/guard.test.ts
@@ -59,7 +59,7 @@ function runGuard(
     },
     cwd,
     encoding: 'utf-8',
-    timeout: 5000,
+    timeout: 30_000,
   });
 
   if (result.status !== 0) {

--- a/tests/hooks/precompact-hook.test.ts
+++ b/tests/hooks/precompact-hook.test.ts
@@ -39,7 +39,7 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-precompact.sh', () => {
     const result = execSync(`bash ${HOOK_SCRIPT}`, {
       cwd: testProjectDir,
       encoding: 'utf-8',
-      timeout: 5000,
+      timeout: 30_000,
     });
     // Should produce no output
     expect(result.trim()).toBe('');
@@ -64,7 +64,7 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-precompact.sh', () => {
     const result = execSync(`bash ${HOOK_SCRIPT}`, {
       cwd: testProjectDir,
       encoding: 'utf-8',
-      timeout: 5000,
+      timeout: 30_000,
     });
 
     const output = JSON.parse(result.trim());
@@ -92,7 +92,7 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-precompact.sh', () => {
       execSync(`bash ${HOOK_SCRIPT}`, {
         cwd: testProjectDir,
         encoding: 'utf-8',
-        timeout: 5000,
+        timeout: 30_000,
       });
 
       expect(fs.existsSync(stale1)).toBe(false);
@@ -128,7 +128,7 @@ describe.skipIf(process.platform === 'win32')('trace-mcp-precompact.sh', () => {
     const result = execSync(`bash ${HOOK_SCRIPT}`, {
       cwd: testProjectDir,
       encoding: 'utf-8',
-      timeout: 5000,
+      timeout: 30_000,
     });
 
     // Should produce no output (stale file)


### PR DESCRIPTION
Fixes TRA-1117.

`tests/hooks/precompact-hook.test.ts` failed with `spawnSync /bin/sh ETIMEDOUT` during a full local suite run (961 files, 10645 tests), then passed 4/4 in isolation — the whole file runs in 1.19s. The 5s subprocess budget has no margin once many vitest workers contend for CPU, which is exactly what a full local or CI run creates.

Raised all four `execSync` timeouts there to 30s, and the identical 5s budget in `tests/hooks/guard.test.ts` (same shape of call, same exposure). 30s matches the neighbouring hook tests (`mirror.test.ts` 30s, `guard-windows.test.ts` 60s) and still fails fast if the hook genuinely hangs.

Test-only; no product behaviour touched. I looked at `hooks/trace-mcp-precompact.sh` for a legitimate stall: the only unbounded work is the `find` GC over `$TMPDIR` at maxdepth 1. That is a real (if small) load-dependent cost — worth remembering if this recurs — but it is not the cause here, and narrowing it is not this issue.

Evidence:
- `pnpm run test --run tests/hooks/precompact-hook.test.ts tests/hooks/guard.test.ts` → 117 passed
- `pnpm run test --run` (full) → 956 files passed, 5 skipped; 10603 passed, 42 skipped
- `pnpm run typecheck` / `pnpm run lint` clean
