### PR TITLE
test(proxy): guard the daemon-death rescue against the built bundle (TRA-1112)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,6 +449,22 @@ jobs:
         # Exclude both for the 1.38 release — re-include after root-cause fix.
         run: pnpm exec vitest run --exclude='tests/perf/**' --exclude='tests/fixtures/**' --exclude='tests/languages/test_xml.test.ts' --exclude='tests/integration/**' --exclude='tests/daemon/**' --exclude='src/telemetry/__tests__/**' --exclude='src/tools/register/__tests__/toon-drift.test.ts' --exclude='tests/util/debounce-abort.test.ts' --reporter=verbose --reporter=./tests/file-start-reporter.ts --testTimeout=30000 --hookTimeout=15000 --teardownTimeout=15000
 
+      # TRA-1112: `tests/integration/**` and `tests/daemon/**` sit in the exclude
+      # list above without appearing in the reasons documented beside it — they
+      # are not the fixture dirs, the perf benchmarks or the two files the 1.38
+      # hang bisection named. What that quietly bought is the whole daemon /
+      # proxy connection suite, mid-session daemon-death guards included,
+      # running in no required gate at all: `cross-platform-test` is the only
+      # job that loads them and it is deliberately not a required check. A
+      # regression that costs an agent all its tools would have merged green.
+      #
+      # Run them as their own step rather than deleting the two excludes: the
+      # invocation above is load-order-sensitive (see the bisection note) and
+      # this keeps a hang here attributable to these files instead of
+      # reopening that hunt. 86 files / ~30 s, against a 12-minute budget.
+      - name: Test (integration + daemon)
+        run: pnpm exec vitest run tests/integration tests/daemon --testTimeout=30000 --hookTimeout=15000 --teardownTimeout=15000
+
       - name: Job summary
         if: always()
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,6 +269,11 @@ jobs:
           '
       # Same exclusions as ci.yml :: test step (hang in toon-drift etc).
       - run: pnpm exec vitest run --exclude='tests/perf/**' --exclude='tests/fixtures/**' --exclude='tests/languages/test_xml.test.ts' --exclude='tests/integration/**' --exclude='tests/daemon/**' --exclude='src/telemetry/__tests__/**' --exclude='src/tools/register/__tests__/toon-drift.test.ts' --exclude='tests/util/debounce-abort.test.ts' --testTimeout=30000 --hookTimeout=15000 --teardownTimeout=15000
+      # TRA-1112: same second step as ci.yml :: test — the two excludes above
+      # that are not covered by that note (`tests/integration/**`,
+      # `tests/daemon/**`) hold the daemon/proxy connection suite, and this is
+      # the last gate before the artifact ships.
+      - run: pnpm exec vitest run tests/integration tests/daemon --testTimeout=30000 --hookTimeout=15000 --teardownTimeout=15000
       # pnpm 10's `--provenance` flow signs the sigstore attestation
       # successfully but the subsequent `PUT /trace-mcp` to the npm
       # registry returns 404 — the OIDC-token-to-npm-scoped-token swap

--- a/tests/integration/proxy-daemon-death.test.ts
+++ b/tests/integration/proxy-daemon-death.test.ts
@@ -1,0 +1,186 @@
+/**
+ * TRA-1112: the daemon dies mid-session and the client keeps its tools —
+ * asserted against the *built* dist/proxy.js, not the source modules.
+ *
+ * tests/daemon/session-proxy-send-failure.test.ts already covers the routing
+ * decision (promote on a failed send, replay the frame locally), but it mocks
+ * `LocalBackend` away. That mock is exactly the part the shipped artifact has
+ * to get right on its own: proxy.js reaches local mode through a *dynamic*
+ * import of a separate bundle chunk (dist/local-backend.js), which is the one
+ * code path in this file's module graph that pulls in better-sqlite3 and
+ * web-tree-sitter. A chunk that fails to load there — a bundler change that
+ * drops it, a native binding the runtime node cannot open — turns every
+ * request after the daemon's death into `-32603 Backend send failed`, with the
+ * mocked unit test still green. Observed while writing this: under a runtime
+ * node that could not open one napi binding, the rescue threw and all three
+ * follow-up calls came back as transport errors.
+ *
+ * Skips when dist/proxy.js is absent (pre-build CI steps), like the eval CLI
+ * smoke test next door.
+ */
+
+import { type ChildProcess, spawn } from 'node:child_process';
+import http from 'node:http';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const PROXY = join(REPO_ROOT, 'dist', 'proxy.js');
+const describeIfBuilt = existsSync(PROXY) ? describe : describe.skip;
+
+/** Answers /health and /mcp with canned frames, until `kill()`. */
+async function startFakeDaemon(): Promise<{ port: number; kill: () => Promise<void> }> {
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => {
+      body += c;
+    });
+    req.on('end', () => {
+      if (!req.url?.startsWith('/mcp')) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, status: 'healthy' }));
+        return;
+      }
+      let msg: { id?: unknown; method?: string } = {};
+      try {
+        msg = JSON.parse(body);
+      } catch {
+        /* notification or garbage */
+      }
+      if (msg.id === undefined || msg.id === null) {
+        res.writeHead(202).end();
+        return;
+      }
+      const result =
+        msg.method === 'initialize'
+          ? {
+              protocolVersion: '2024-11-05',
+              capabilities: { tools: {} },
+              serverInfo: { name: 'fake-daemon', version: '0' },
+            }
+          : { servedBy: 'daemon', tools: [] };
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      res.write(`data: ${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result })}\n\n`);
+      res.end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return {
+    port: (server.address() as AddressInfo).port,
+    kill: () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+interface RpcResponse {
+  id: number;
+  result?: { tools?: unknown[]; servedBy?: string };
+  error?: { code: number; message: string };
+}
+
+/** Line-delimited JSON-RPC over the child's stdio, keyed by request id. */
+function attachClient(child: ChildProcess) {
+  const pending = new Map<number, (m: RpcResponse) => void>();
+  let buf = '';
+  child.stdout?.on('data', (d: Buffer) => {
+    buf += d.toString('utf8');
+    let i: number;
+    while ((i = buf.indexOf('\n')) >= 0) {
+      const line = buf.slice(0, i);
+      buf = buf.slice(i + 1);
+      if (!line.trim()) continue;
+      let m: RpcResponse;
+      try {
+        m = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      pending.get(m.id)?.(m);
+      pending.delete(m.id);
+    }
+  });
+  return {
+    request(id: number, method: string, params: unknown = {}): Promise<RpcResponse> {
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`timeout: ${method}`)), 60_000);
+        pending.set(id, (m) => {
+          clearTimeout(timer);
+          resolve(m);
+        });
+        child.stdin?.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`);
+      });
+    },
+    notify(method: string) {
+      child.stdin?.write(`${JSON.stringify({ jsonrpc: '2.0', method })}\n`);
+    },
+  };
+}
+
+describeIfBuilt('built proxy.js survives the daemon dying mid-session (TRA-1112)', () => {
+  let cleanup: (() => Promise<void>) | null = null;
+
+  afterEach(async () => {
+    await cleanup?.();
+    cleanup = null;
+  });
+
+  it('answers tools/list from local mode after the daemon goes away', async () => {
+    const sandbox = mkdtempSync(join(tmpdir(), 'trace-proxy-death-'));
+    const project = join(sandbox, 'proj');
+    const home = join(sandbox, 'home');
+    mkdirSync(project);
+    mkdirSync(home);
+    writeFileSync(join(project, 'a.ts'), 'export function alpha() {\n  return 1;\n}\n');
+
+    const daemon = await startFakeDaemon();
+    const child = spawn(process.execPath, [PROXY, 'serve'], {
+      cwd: project,
+      env: {
+        ...process.env,
+        TRACE_MCP_HOME: home,
+        TRACE_MCP_DAEMON_PORT: String(daemon.port),
+        // Local mode has to come from the rescue path, not from a daemon this
+        // test then races with.
+        TRACE_MCP_NO_DAEMON: '1',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    cleanup = async () => {
+      child.kill('SIGKILL');
+      await daemon.kill().catch(() => {});
+      rmSync(sandbox, { recursive: true, force: true });
+    };
+
+    const client = attachClient(child);
+    const init = await client.request(1, 'initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'daemon-death-test', version: '0' },
+    });
+    expect(init.error).toBeUndefined();
+    client.notify('notifications/initialized');
+
+    // Proxy mode: the fake daemon is the one answering.
+    const served = await client.request(2, 'tools/list');
+    expect(served.result?.servedBy).toBe('daemon');
+
+    await daemon.kill();
+
+    // The frame that discovers the dead daemon must still come back as a real
+    // answer, not as a transport error the agent reads as "server is gone".
+    const afterDeath = await client.request(3, 'tools/list');
+    expect(afterDeath.error).toBeUndefined();
+    expect(afterDeath.result?.tools?.length ?? 0).toBeGreaterThan(0);
+
+    // And the session stays usable, rather than degrading for one lucky call.
+    const next = await client.request(4, 'tools/list');
+    expect(next.error).toBeUndefined();
+    expect(next.result?.tools?.length ?? 0).toBeGreaterThan(0);
+  }, 120_000);
+});


### PR DESCRIPTION
## What

An end-to-end regression guard for the mid-session daemon death path, driven against the **built** `dist/proxy.js` instead of the source modules.

## Why

`tests/daemon/session-proxy-send-failure.test.ts` (TRA-1080) already covers the routing decision — promote to local on a failed proxy send, replay the frame — but it `vi.mock`s `LocalBackend` away. That mock is exactly the part the shipped artifact has to get right on its own: `proxy.js` reaches local mode through a *dynamic* import of a separate bundle chunk (`dist/local-backend.js`), which is the only path in its module graph that pulls in better-sqlite3 and web-tree-sitter.

If that chunk fails to load — a bundler change that drops it, a native binding the runtime node cannot open — every request after the daemon dies comes back as `-32603 Backend send failed`, and the agent silently loses all its tools for the rest of the session. The mocked unit test stays green throughout.

This is not hypothetical: while writing the test, a runtime node that could not open one napi binding made the rescue throw, and all three follow-up calls returned transport errors. The `MessageRouter: send-failure rescue threw` branch is reachable and its only symptom is the original `-32603`.

## Test evidence

- Passes on `main`'s build — after the daemon is killed, `tools/list` answers from local mode in ~800 ms and stays usable.
- Fails against the shipped 3.22.0 bundle (built before TRA-1080 landed): `AssertionError: expected { code: -32603 } to be undefined`, `"Backend send failed: TypeError: fetch failed"` — so the guard is not vacuous.
- Full suite: `958 files / 10598 tests passed`, typecheck and biome clean.

Skips when `dist/` is absent, matching `tests/integration/eval-cli-smoke.test.ts`.

## Note for the release side

The reproduction above also means the currently installed 3.22.0 **does** drop a client's tools when the daemon dies mid-session. TRA-1080 fixes it and is on `main` unreleased.
