### PR TITLE
test: stop subproject-clone ref test from doing a real git clone (TRA-1118)

### DIFF
--- a/tests/tools/subproject-clone.test.ts
+++ b/tests/tools/subproject-clone.test.ts
@@ -100,12 +100,15 @@ describe('cloneRemoteRepo ref validation', () => {
   });
 
   it('does not invoke ref validation when ref is undefined', async () => {
-    // No ref means cloneRemoteRepo proceeds past the validator into the SSRF
-    // check and (possibly) DNS / git. We expect either Ok (when destination
-    // already exists from a prior run) or Err with a non-ref reason.
-    const r = await cloneRemoteRepo('/tmp/p', safeUrl, {});
+    // Use a URL the SSRF guard blocks on a literal address (no DNS, no git):
+    // the call still gets past the ref validator, which is all this asserts.
+    // Pointing at a real host here would run an actual `git clone` and made
+    // this test flake out on CI (TRA-1118).
+    const r = await cloneRemoteRepo('/tmp/p', 'https://0.0.0.0/owner/repo.git', {});
+    expect(r.isErr()).toBe(true);
     if (r.isErr()) {
       expect(r.error.message).not.toContain('unsafe git ref');
+      expect(r.error.message).toContain('SSRF');
     }
   });
 });


### PR DESCRIPTION
`tests/tools/subproject-clone.test.ts > does not invoke ref validation when ref is undefined` failed the required `cross-platform-test (macos-latest)` check on PR #1080 and passed on an unmodified re-run of the same commit (TRA-1118).

**Cause.** With no `ref`, `cloneRemoteRepo` runs past the ref validator, past the SSRF guard (live DNS for `github.com`), creates `/tmp/p/.trace-mcp/subprojects/owner/`, and then shells out to a real `git clone https://github.com/owner/repo.git` — a repo that does not exist. That `execFileSync` carries its own `timeout: 120_000`, nested inside vitest's default 30000ms, so on a runner where the clone hangs on auth/network the test blows the 30s budget. Nothing about the test's assertion needed any of that.

**Fix.** Point the call at `https://0.0.0.0/owner/repo.git`, which the SSRF guard rejects on a literal address — no DNS, no `git`, no `mkdir`. The call still passes through the ref validator, which is the only thing this test claims to observe, and the assertion is now stronger than before (previously the whole body was inside `if (r.isErr())` and could pass vacuously).

**Evidence.** File runs in 3ms, down from a network-bound wait. `pnpm test`: 956 files / 10603 tests passed, 5 files / 42 tests skipped. `pnpm typecheck` and `pnpm lint` clean.

Scanned the rest of `tests/` for the same pattern — the two other hits on `github.com` (`code-smells.test.ts`, `ssrf-guard.test.ts`) are pure string handling and never reach the network.
