### PR TITLE
feat(server): say what the server is in serverInfo (TRA-1119)

### DIFF
--- a/ops/distribution.md
+++ b/ops/distribution.md
@@ -440,6 +440,42 @@ The measured case for the whole rename was **0.74–1.23%** of the advertised
 tool surface (TRA-613, #720). Anything that would cost this table a listing is
 not worth that, and this row exists so the next run does not re-derive it.
 
+### The name reads as "distributed tracing" to anyone who never read a description (2026-09-07, TRA-1119)
+
+Field evidence, not a hypothesis. Three independent parties filed us as an
+observability/tracing server:
+
+- `Timothy191/Arch-Mk2` and `Timothy191/arch-systems-portal` — same author, two
+  repos, `.vscode/README.md` (2026-07-07, 2026-07-22): *"`trace-mcp` (Tracing
+  Utility) — Standard tracing and debugger logging MCP server."* The setup block
+  right below it runs `claude mcp add trace-mcp npx -y trace-mcp@latest`. He had
+  us installed and working, and wrote down the wrong category.
+- `kansei-link/kansei-mcp-server`, an MCP registry: its classifier filed us
+  under "DeFi & Web3"; the human remediation pass
+  (`scripts/audit-remediation-20260424.mjs`, 2026-04-24) corrected it to
+  "AI observability/tracing" — still wrong, from the same file.
+
+The mechanism is visible in the same sweep and it is the useful part: **wherever
+an aggregator copied our README or Glama text the category is right**
+(`clauderules/turbo-claude`, `metinduraktr-44/claude-otonom-sistem`,
+`alpha-1-design/Nexus` all carry "Framework-aware code intelligence…").
+Wherever someone worked from the package name alone, it lands next to
+`dynatrace-mcp`. Prose we wrote travels correctly; the name alone does not.
+
+What we did about it, so it is not re-derived: **not a rename** (the section
+above stands). The fix is that the server now says what it is in the one string
+every user meets before any documentation — `serverInfo` at `initialize`, which
+a client renders in its server list:
+
+- `name` stays `trace` (protocol id, in everyone's config).
+- `title`: "Trace — Code Intelligence".
+- `description`: names the category and explicitly denies the wrong one
+  ("Not a distributed-tracing or logging server").
+
+Checked at the same time and found already correct — no change needed:
+`server.json`, `plugin.json`, both `.claude-plugin`/`.codex-plugin` manifests,
+and all four `skills/*/SKILL.md` descriptions. The gap was only the handshake.
+
 ## Findings that should not be re-derived
 
 **The official registry was the root cause of everything else** (TRA-352,

--- a/ops/positioning.md
+++ b/ops/positioning.md
@@ -278,6 +278,7 @@ ordinary issue, not part of this pass. Ordered by how much a reader sees it.
 | Site IA | Two second-level entries, one per door; door 2 has no page today | The real gap; see Doors |
 | `comparisons.md` | Compares graph-to-graph today. The `/vs/` claim changes shape | Coordinate with SEO — TRA-876 just landed benchmark copy on three `/vs/` pages |
 | `server.json` `description` | **Tools only** — do not carry the category sentence | Deliberate; see Doors |
+| `serverInfo` at `initialize` (`src/server/server.ts`, `SERVER_IDENTITY`) | **Done (TRA-1119).** `title` names the category, `description` is tools-only phrasing plus an explicit denial of the wrong one | The client's server list — the first and often only description a user reads. Three parties filed us as a tracing/observability server from the bare name; evidence in `ops/distribution.md`. No counts here |
 | Directory listings (`ops/distribution.md`) | Only where copy is ours to edit, and **only together with the rename** | See Sequencing |
 | `docs/ROADMAP.md` item 8 | Superseded by this file | Roadmap autopilot's next revision |
 

--- a/src/server/__tests__/daemon-full-surface.test.ts
+++ b/src/server/__tests__/daemon-full-surface.test.ts
@@ -154,3 +154,20 @@ describe('serveFullSurface (TRA-951)', () => {
     expect(handle.toolHandlers.has(OUTSIDE_MINIMAL)).toBe(false);
   });
 });
+
+// TRA-1119: `serverInfo` is what a client renders in its server list, before
+// any documentation. It travels the same construction path as the preset above,
+// so it is guarded here rather than in a second server-building fixture.
+describe('serverInfo reaches the handshake (TRA-1119)', () => {
+  it('advertises the title and description, not just the bare name', async () => {
+    const { SERVER_IDENTITY } = await import('../server.js');
+    const handle = await build({});
+    const info = (handle.server as unknown as { server: { _serverInfo: Record<string, unknown> } })
+      .server._serverInfo;
+
+    expect(info.name).toBe('trace');
+    expect(info.title).toBe(SERVER_IDENTITY.title);
+    expect(info.description).toBe(SERVER_IDENTITY.description);
+    expect(info.version).toBeTypeOf('string');
+  });
+});

--- a/src/server/__tests__/server-identity.test.ts
+++ b/src/server/__tests__/server-identity.test.ts
@@ -1,0 +1,30 @@
+/**
+ * TRA-1119: the `initialize` handshake must say what this server is.
+ *
+ * Three independent parties filed trace-mcp as a tracing/observability server,
+ * one of them from his own working install — the bare name `trace-mcp` carries
+ * that prior and nothing a stranger meets first corrected it. `serverInfo` is
+ * the correction: it is rendered in the client's server list before any
+ * documentation, and it passes through the daemon proxy untouched.
+ */
+import { describe, expect, it } from 'vitest';
+import { SERVER_IDENTITY } from '../server.js';
+
+describe('serverInfo (TRA-1119)', () => {
+  it('keeps the protocol name stable — existing client configs reference it', () => {
+    expect(SERVER_IDENTITY.name).toBe('trace');
+  });
+
+  it('names the category in the title, not just the brand', () => {
+    expect(SERVER_IDENTITY.title).toMatch(/code intelligence/i);
+  });
+
+  it('says what the server is, and what it is not', () => {
+    expect(SERVER_IDENTITY.description).toMatch(/code graph/i);
+    expect(SERVER_IDENTITY.description).toMatch(/not a distributed-tracing/i);
+  });
+
+  it('carries no hardcoded counts — those belong to docs/_data/counts.yml', () => {
+    expect(`${SERVER_IDENTITY.title} ${SERVER_IDENTITY.description}`).not.toMatch(/\d/);
+  });
+});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4,6 +4,27 @@ declare const PKG_VERSION_INJECTED: string;
 const PKG_VERSION =
   typeof PKG_VERSION_INJECTED !== 'undefined' ? PKG_VERSION_INJECTED : '0.0.0-dev';
 
+/**
+ * What this server calls itself at `initialize` (TRA-1119).
+ *
+ * `name` is the protocol id and stays `trace` — renaming it breaks every
+ * existing client config. `title`/`description` exist because the bare name
+ * reads as a distributed-tracing or debug-logging server to anyone who meets it
+ * in a client's server list before reading any documentation: TRA-1119
+ * collected three independent parties who filed us under tracing/observability,
+ * one of them copying it out of his own working install. This is the one string
+ * every user sees, so it has to say what the server is in its first four words.
+ *
+ * No counts here — those live in `docs/_data/counts.yml` and go stale silently.
+ */
+export const SERVER_IDENTITY = {
+  name: 'trace',
+  title: 'Trace — Code Intelligence',
+  description:
+    'Precomputed code graph for AI agents: symbol search, file outlines, call graphs, and change-impact analysis, served instead of raw file reads. Not a distributed-tracing or logging server.',
+  websiteUrl: 'https://trace-mcp.com',
+} as const;
+
 import {
   type AIProvider,
   BlobVectorStore,
@@ -339,7 +360,12 @@ export function createServer(
   const agentBehavior = config.tools?.agent_behavior ?? 'off';
   const onSurface = createToolFilter(config, sessionSurface);
   const server = new McpServer(
-    { name: 'trace', version: PKG_VERSION },
+    // `name` is the protocol id and stays `trace`. The rest exists because the
+    // bare name reads as a distributed-tracing/debug-logger server to anyone who
+    // meets it in a client's server list before any documentation — TRA-1119
+    // collected three independent parties who filed us that way, one of them
+    // from his own installed config. This is the only line every user sees.
+    { ...SERVER_IDENTITY, version: PKG_VERSION },
     {
       instructions: buildInstructions(
         detectedFrameworks,


### PR DESCRIPTION
## What

`serverInfo` at `initialize` now says what this server is:

```
name:        trace                              (unchanged — protocol id)
title:       Trace — Code Intelligence
description: Precomputed code graph for AI agents: symbol search, file
             outlines, call graphs, and change-impact analysis, served
             instead of raw file reads. Not a distributed-tracing or
             logging server.
websiteUrl:  https://trace-mcp.com
```

## Why (TRA-1119)

Field evidence, not a hypothesis — three independent parties filed us as an observability/tracing server:

- `Timothy191/Arch-Mk2` and `Timothy191/arch-systems-portal`, same author, `.vscode/README.md`: *"`trace-mcp` (Tracing Utility) — Standard tracing and debugger logging MCP server"* — directly above a setup block that runs `claude mcp add trace-mcp npx -y trace-mcp@latest`. He had us installed and wrote down the wrong category.
- `kansei-link/kansei-mcp-server`, an MCP registry: classifier filed us under "DeFi & Web3"; the human remediation pass corrected it to "AI observability/tracing" — still wrong.

The mechanism is the useful part: wherever an aggregator copied our README the category is right; wherever someone worked from the package name alone we land next to `dynatrace-mcp`. Prose we write travels correctly, the name alone does not.

**This is not a rename** — `ops/rename-to-trace.md` and the distribution ledger's rename section stand. `serverInfo` is what a client renders in its server list, before any documentation, and it was the one surface still saying nothing.

## Scope

- `src/server/server.ts` — `SERVER_IDENTITY` exported and spread into the `McpServer` constructor. `serverInfo` passes through the daemon proxy and the client-profile shim untouched, so stdio, HTTP and daemon-backed sessions are all covered by this one line.
- Checked in the same pass, already correct, unchanged: `server.json`, `plugin.json`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, all four `skills/*/SKILL.md`.
- `ops/distribution.md` — the finding and the decision recorded so the next run does not re-derive it.
- No counts in the new strings (a test asserts the absence of digits) — those stay in `docs/_data/counts.yml`.

## Tests

- `src/server/__tests__/server-identity.test.ts` — new: the constant keeps `name: 'trace'`, names the category, denies the wrong one, carries no counts.
- `src/server/__tests__/daemon-full-surface.test.ts` — new case asserting the fields actually reach `_serverInfo` on a built server, so dropping the spread fails.
- `pnpm test`: 10608 passed / 42 skipped, 957 files. `pnpm typecheck`, `pnpm biome:ci`, `pnpm build` all clean.

No MCP tool signature or on-disk schema change. Closes TRA-1119.
