### PR TITLE
feat(ops): gate the GitHub and npm descriptions against docs/_data (TRA-1120)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,35 @@ jobs:
             echo "::error::AI provenance marks in the files above - remove them"; exit 1
           fi
 
+  # The two claim surfaces that are not files (TRA-1120): the GitHub repo
+  # description and the npm registry description. The docs gates compare every
+  # in-repo surface to `docs/_data/` and can see neither of these, which is how
+  # 70.5% and 90.6% were live on the same day with CI green.
+  #
+  # Nightly and dispatch only, never on a PR. npm serves the latest PUBLISHED
+  # version, so its description legitimately lags master from the merge until
+  # the release that carries it — as a required PR check this would be red for
+  # days at a time for a reason no PR author can fix. The offline half of the
+  # gate (`tests/docs/remote-claims.test.ts`) does run on every PR.
+  remote-claims:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+      - uses: ./.github/actions/setup-pnpm
+      # `yaml` only; the full install is a build away and this reads two files.
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Remote claim surfaces agree with docs/_data/
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/check-remote-claims.mjs
+
   # ───────────────────────────────────────────────────────────────────────────
   # Build once on ubuntu, upload dist/ + node_modules/ as an artifact.
   # Downstream jobs (test shards, impact-report) skip install AND build.

--- a/ops/distribution.md
+++ b/ops/distribution.md
@@ -80,7 +80,7 @@ Rules for keeping it honest:
 | [ai-boost/awesome-harness-engineering](https://github.com/ai-boost/awesome-harness-engineering) | **Submitted, not merged** — [PR #240](https://github.com/ai-boost/awesome-harness-engineering/pull/240), opened 2026-09-05 | One line in `README.md`, section `Context Delivery & Compaction`, which already holds `codebase-memory-mcp`, `Token Savior`, `MinishLab/semble`, `headroom`, `Graft` and `context-mode` — the densest concentration of our nearest neighbours found on any single list (4,005★, 490 forks) | PR to README, format documented in `CONTRIBUTING.md` and `AGENTS.md` (`- [Title](URL) — 1–2 sentence note`), no account, no scanner, no payment. **But the queue says the PR is not how entries land:** `ai-boost` commits one new entry per day himself (20 of the last 20 commits are his, "Add X to Y section"), while ~40 external PRs sit open, two have ever been merged (#2 in April, #66 on 2026-07-22) and two were closed. Ours is therefore a low-probability ticket on a high-value list, not a submission with a queue position. Do not ping. Re-read 2026-10-05 | 2026-09-05 |
 | [yzfly/awesome-context-engineering](https://github.com/yzfly/awesome-context-engineering) | **Submitted, not merged** — [PR #44](https://github.com/yzfly/awesome-context-engineering/pull/44), opened 2026-09-05 | One line each in `README.md` and `README_CN.md`, section `Memory & Compression` / `记忆与压缩`, next to `lean-ctx`, `headroom` and `skillreaper` (140★) | PR to both READMEs — `CONTRIBUTING.md` requires the English and Chinese versions to stay in sync, so an entry that touches one file only is incomplete. **This is the door with a real merge rate in this class:** five external PRs merged in the two weeks to 2026-08-30, three of them in one batch, authors unaffiliated with the maintainer. Re-check 2026-09-19 | 2026-09-05 |
 | GitHub repo topics | **Yes** — always on, the surface is ours | **20 of 20 slots used** — the cap. Changed 2026-08-30: dropped `token` and `tokens` (3,892 / 1,572 repos, almost all auth or crypto — wrong audience for a word we only meant one way) and `claude-skill` (near-duplicate of `claude-skills`, which is the bigger of the two: 7,662 vs 4,841); added `code-graph` (208 repos), `dependency-graph` (901) and `static-analysis` (8,072) | The one listing surface we own outright: `gh api -X PUT repos/:r/topics --input <json>`, instant, reversible, no review. Topic pages are a browse surface, so a *small* exact topic like `code-graph` is worth more than a big vague one. Sizes via `gh api "search/repositories?q=topic:<t>&per_page=1" --jq .total_count`. Before rebalancing again: 7 of the 20 slots are `claude-*` variants (8 before this change), which is defensible but is where the next slot comes from; `rag` (43,793) is the other weak slot — we retrieve, but we are not a RAG pipeline | 2026-08-30 |
-| GitHub repo description | **Yes** — always on, the surface is ours, and it is **the string the auto-indexes copy verbatim** | Was "MCP server for Claude Code and Codex. One tool call replaces ~42 minutes of agent exploration" until 2026-09-05. Now: "Framework-aware code intelligence MCP server for Claude Code and Codex — 70.5% fewer input tokens to review a pull request, median over 60 merged PRs in repos we don't own. 81 languages, 87 frameworks, 100% local." | `gh api -X PATCH repos/:r -f description=...`, instant, reversible, no review — same class as topics. Keep it in step with `package.json` `description` and `server.json` `description`; all three now quote the PR-benchmark figure and none may quote a number that is not in `docs/_data/` | 2026-09-05 |
+| GitHub repo description | **Yes** — always on, the surface is ours, and it is **the string the auto-indexes copy verbatim** | Was "MCP server for Claude Code and Codex. One tool call replaces ~42 minutes of agent exploration" until 2026-09-05, then carried "100% local" until 2026-09-07. Now: "Framework-aware code intelligence MCP server for Claude Code and Codex — 70.5% fewer input tokens to review a pull request, median over 60 merged PRs in repos we don't own, comprehension at parity. 81 languages, 87 frameworks. Your code and index never leave the machine; an anonymous usage ping is on by default and opt-out." (327 of the 350 characters GitHub allows) | `gh api -X PATCH repos/:r -f description=...`, instant, reversible, no review — same class as topics. Keep it in step with `package.json` `description` and `server.json` `description`; all three now quote the PR-benchmark figure and none may quote a number that is not in `docs/_data/`. **No longer on trust: `scripts/check-remote-claims.mjs` fetches this string nightly and compares it to `docs/_data/`** (TRA-1120) | 2026-09-07 |
 | [Chat2AnyLLM/awesome-claude-plugins](https://github.com/Chat2AnyLLM/awesome-claude-plugins) | **Yes — never submitted** (115★) | README line 1339, in a machine-generated table of scanned Claude plugin repos: our repo, branch `master`, `.claude-plugin` detected, status ✅ ok | Nothing to submit — it scans repos carrying a `.claude-plugin` directory. Found by code search 2026-09-05, not by a directory hunt | 2026-09-05 |
 | [linny006/mcp-servers-live](https://github.com/linny006/mcp-servers-live) + [its Pages site](https://linny006.github.io/mcp-servers-live/r/nikolai-vysotskyi/trace-mcp/) | **Yes — never submitted** | Auto-index of MCP servers refreshed every 15 minutes; we are #49 by stars with a per-repo page. Its whole body is our GitHub description, repeated 5× on that page | Nothing to submit. Links only `github.com`, never `trace-mcp.com`, so it adds nothing to the domain count below. Its value is that it demonstrates the description-propagation above | 2026-09-05 |
 | [linny006/trending-claude-skills](https://github.com/linny006/trending-claude-skills) | **Yes — never submitted** | Trending table, **rank 3**, 133★, same auto-copied description | Same scraper family as the row above; one operator, two indexes. Nothing to submit | 2026-09-05 |
@@ -129,6 +129,10 @@ write to and no submission to make.
    one-liner is therefore longer-lived than the one-liner. That is an argument
    for the claims gate covering the two non-file surfaces (repo description and
    topics), which the 2026-09-05 note already flagged as guarded by nothing.
+   **The description half was built on 2026-09-07** —
+   `scripts/check-remote-claims.mjs`, TRA-1120, see the findings section.
+   Topics carry no number and no claim, so they are still ungated and that is
+   deliberate; revisit only if a topic ever states a figure.
 2. **What we can steer is the input, not the output.** These indexes read the
    repository — description, topics, README, `server.json`. Every one of those
    is already a surface we own and already guarded except the two named above.
@@ -510,6 +514,31 @@ do not hand-type the number into a submission form. It is generated into
 `docs/_data/pr_context_bench.json` by `scripts/bench-pr-context.ts` and guarded
 by `tests/docs/readme-claims.test.ts` — same discipline as
 `docs/_data/counts.yml`.
+
+**The two claim surfaces that are not files are now gated too** (TRA-1120,
+2026-09-07). The GitHub repo description and the npm registry `description` are
+the widest surfaces we own and neither is in the repository, so every docs gate
+was blind to both. Measured that day: GitHub said 70.5% and npm said 90.6% —
+same claim, same benchmark family, same day, CI green — and the GitHub string
+still carried "100% local" while the usage ping is on by default (TRA-1013,
+which is scoped to the README and would never have reached it).
+`scripts/check-remote-claims.mjs` now fetches both and compares them to
+`docs/_data/` on the counts.yml anchor rule: every count must equal
+`counts.yml`, every percentage must be a generated figure, no retired number
+(90.6%, "up to 99%", "~42 minutes", "40–50%", "53 frameworks / 68 languages"),
+and no unqualified locality absolute. It runs nightly in `ci.yml`, never on a
+PR — npm serves the latest *published* version, so its description lags master
+until the release that carries it and a PR author could not fix that.
+`tests/docs/remote-claims.test.ts` is the offline half and does run on every PR.
+Two consequences worth knowing before reading a red run:
+
+- **The npm row is expected red until the next release.** `package.json` has
+  said 70.5% since TRA-1090; a published description cannot be edited in place.
+  The gate says so in the failure text. Do not "fix" it by touching npm.
+- **The locality rule bans the absolute, not the claim.** "Your code and index
+  never leave the machine; an anonymous usage ping is on by default and opt-out"
+  passes and is the wording now live on GitHub. A gate that failed it would have
+  pushed the copy back to saying nothing at all.
 
 **The one-liner every directory renders is the widest surface we have, and it
 was the last to get the corrected number** (TRA-883 / TRA-904, 2026-09-05).

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "format:check": "biome format",
     "biome:ci": "biome ci",
     "serve": "tsx src/cli.ts serve",
+    "check:remote-claims": "node scripts/check-remote-claims.mjs",
     "count:tools": "node scripts/count-advertised-tools.mjs",
     "record:wire-fixtures": "tsx scripts/record-wire-fixtures.ts",
     "replay:check": "tsx scripts/replay-eval.ts",

--- a/scripts/check-remote-claims.mjs
+++ b/scripts/check-remote-claims.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * The two claim surfaces that live outside the repository — TRA-1120.
+ *
+ * `tests/docs/readme-claims.test.ts` and `savings-claims.test.ts` compare every
+ * doc surface to `docs/_data/`, but they can only see files. The GitHub repo
+ * description and the npm registry `description` are the two loudest surfaces
+ * we own and neither is a file: the auto-index layer copies the GitHub string
+ * verbatim (`linny006/mcp-servers-live` renders it five times on one page) and
+ * every `npm view` and plugin listing reads the npm one. On 2026-09-07 they
+ * disagreed with each other — 70.5% on GitHub, 90.6% on npm — with CI green,
+ * because nothing compared either to `docs/_data/`.
+ *
+ * Same anchor discipline as counts.yml (TRA-1086): the repo's own data files
+ * are the truth and each surface is compared to them, never to each other.
+ *
+ * Network, so it is a script and not a vitest case — the house rule is that
+ * `tests/docs/*` runs offline. `checkRemoteClaims` below is pure and is what
+ * `tests/docs/remote-claims.test.ts` exercises; only `main` touches the wire.
+ *
+ * Run: `node scripts/check-remote-claims.mjs`. Nightly in ci.yml.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (p) => fs.readFileSync(path.join(REPO_ROOT, p), 'utf8');
+
+const GITHUB_API = 'https://api.github.com/repos/nikolai-vysotskyi/trace-mcp';
+const NPM_API = 'https://registry.npmjs.org/trace-mcp';
+
+/** Everything a remote one-liner is allowed to assert, straight out of `docs/_data/`. */
+export function anchors() {
+  const counts = parseYaml(read('docs/_data/counts.yml'));
+  const bench = JSON.parse(read('docs/_data/pr_context_bench.json'));
+  const response = JSON.parse(read('docs/_data/response_tokens.json'));
+  const pkg = JSON.parse(read('package.json'));
+  return {
+    counts,
+    // Both published savings figures answer different questions (PR context vs
+    // per-call responses), so either is a legal number to quote — a third one
+    // is not.
+    savings: [String(bench.median_savings_pct), String(response.reduction_pct)],
+    packageDescription: pkg.description,
+  };
+}
+
+/**
+ * Figures a surface may never carry again. Each was live on a surface we own,
+ * each is retired, and each still circulates in third-party copies we cannot
+ * edit — which is the argument for never letting a new one leave.
+ */
+const RETIRED =
+  /\b90\.6\s*%|up to 99\s*%|~?\s*42 minutes|\b40\s*[–—-]\s*50\s*%|\b53 framework|\b68 languages/i;
+
+/**
+ * `100% local` is false while the usage ping POSTs to GA by default
+ * (`src/telemetry/usage-ping.ts`, off via `TRACE_MCP_TELEMETRY=off` or
+ * `telemetry.usage_ping: false`). TRA-1013 owns the wording fix for the README;
+ * this keeps the absolute from coming back on the surfaces that issue's diff
+ * cannot reach.
+ *
+ * What is banned is the *unqualified* absolute, not the locality claim — "your
+ * code and index never leave the machine, an anonymous usage ping is opt-out"
+ * is both stronger and true, and a gate that failed it would push the copy back
+ * towards the vaguer wording.
+ */
+const ABSOLUTE_LOCALITY =
+  /\b(100\s*%|fully|entirely|completely)\s+local\b|\b(nothing|no data|never)\s+leaves\b/i;
+const DISCLOSES_PING = /ping|telemetry|analytics/i;
+
+const TOKEN_CONTEXT = /token|saving|saved|reduction|fewer|less/i;
+
+/**
+ * @param {{name: string, text: string, mirrors?: string}[]} surfaces
+ * @param {ReturnType<typeof anchors>} anchor
+ * @returns {string[]} one line per violation; empty means the surfaces are clean
+ */
+export function checkRemoteClaims(surfaces, anchor) {
+  const problems = [];
+  for (const { name, text, mirrors } of surfaces) {
+    const fail = (msg) => problems.push(`${name}: ${msg}\n    live: ${text}`);
+
+    if (!text) {
+      fail('has no description at all — the auto-indexes have nothing to copy but the repo name');
+      continue;
+    }
+
+    const retired = text.match(RETIRED);
+    if (retired) {
+      fail(
+        `quotes the retired "${retired[0]}". Retiring a claim does not retire the copies of it; ` +
+          'see the TRA-1090 note in ops/distribution.md before restoring any number.',
+      );
+    }
+
+    const absolute = DISCLOSES_PING.test(text) ? null : text.match(ABSOLUTE_LOCALITY);
+    if (absolute) {
+      fail(
+        `claims "${absolute[0]}" while the usage ping is on by default (TRA-1013). Say what is ` +
+          'true instead: code and index stay on the machine, the anonymous ping is opt-out.',
+      );
+    }
+
+    // Every count the surface states has to be the count docs/_data/counts.yml
+    // states — exactly, the way every guarded in-repo surface is since TRA-1086.
+    for (const [, n, noun] of text.matchAll(
+      /(\d+)\+?\s+(languages?|frameworks?|tools?|resources?)/gi,
+    )) {
+      const key = `${noun.toLowerCase().replace(/s?$/, '')}s`;
+      const expected = anchor.counts[key];
+      if (expected !== undefined && Number(n) !== expected) {
+        fail(`says "${n} ${noun}" where docs/_data/counts.yml says ${expected}`);
+      }
+    }
+
+    // And every percentage it quotes at a stranger has to be a generated one.
+    for (const [, pct] of text.matchAll(/(\d{1,3}(?:\.\d)?)\s*%/g)) {
+      if (!TOKEN_CONTEXT.test(text)) continue;
+      if (anchor.savings.includes(pct)) continue;
+      // One number, one line. The two checks above already name the figure when
+      // it is a retired one or the locality absolute; repeating it here would
+      // make a single stale description look like three separate defects.
+      if (retired?.[0].includes(pct) || absolute?.[0].includes(pct)) continue;
+      fail(
+        `quotes ${pct}%, which is not in docs/_data/. The published figures are ` +
+          `${anchor.savings.join('% and ')}%.`,
+      );
+    }
+
+    if (mirrors !== undefined && text !== mirrors) {
+      fail(
+        'has drifted from package.json `description`. npm serves the latest PUBLISHED version, ' +
+          'so this is expected between the merge and the release that carries it — and it is a ' +
+          `real defect once that release is out.\n    want: ${mirrors}`,
+      );
+    }
+  }
+  return problems;
+}
+
+async function json(url, token) {
+  const res = await fetch(url, {
+    headers: {
+      accept: 'application/json',
+      'user-agent': 'trace-mcp-remote-claims-check',
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+  });
+  if (!res.ok) throw new Error(`${url} → HTTP ${res.status}`);
+  return res.json();
+}
+
+async function main() {
+  const anchor = anchors();
+  const [repo, npm] = await Promise.all([
+    json(GITHUB_API, process.env.GITHUB_TOKEN),
+    json(NPM_API),
+  ]);
+  const latest = npm['dist-tags']?.latest;
+
+  const problems = checkRemoteClaims(
+    [
+      { name: 'GitHub repo description', text: repo.description ?? '' },
+      {
+        name: `npm description (published ${latest})`,
+        text: npm.versions?.[latest]?.description ?? npm.description ?? '',
+        mirrors: anchor.packageDescription,
+      },
+    ],
+    anchor,
+  );
+
+  if (problems.length === 0) {
+    console.log('Both remote claim surfaces agree with docs/_data/.');
+    return;
+  }
+  console.error(`${problems.length} problem(s) on the remote claim surfaces:\n`);
+  for (const p of problems) console.error(`  - ${p}\n`);
+  console.error(
+    'The GitHub description is one `gh api -X PATCH repos/:owner/:repo -f description=...` away.\n' +
+      'The npm one is fixed by package.json plus a release — see ops/distribution.md.',
+  );
+  process.exitCode = 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) await main();

--- a/scripts/check-remote-claims.mjs
+++ b/scripts/check-remote-claims.mjs
@@ -56,6 +56,16 @@ const RETIRED =
   /\b90\.6\s*%|up to 99\s*%|~?\s*42 minutes|\b40\s*[–—-]\s*50\s*%|\b53 framework|\b68 languages/i;
 
 /**
+ * Every pattern here hunts for a `%` glyph, so a one-liner that spells the
+ * number out — "90.6 percent fewer input tokens" — would otherwise clear both
+ * the retired-figure check and the anchor sweep at once. That is not a
+ * contrived string: these descriptions are hand-edited through
+ * `gh api -X PATCH`, so the text often arrives pasted out of prose. Matching
+ * runs on the normalised copy; the failure message still prints the live one.
+ */
+const normalise = (text) => text.replace(/\s*per\s?cent(?:age)?\b/gi, '%');
+
+/**
  * `100% local` is false while the usage ping POSTs to GA by default
  * (`src/telemetry/usage-ping.ts`, off via `TRACE_MCP_TELEMETRY=off` or
  * `telemetry.usage_ping: false`). TRA-1013 owns the wording fix for the README;
@@ -68,7 +78,13 @@ const RETIRED =
  * towards the vaguer wording.
  */
 const ABSOLUTE_LOCALITY =
-  /\b(100\s*%|fully|entirely|completely)\s+local\b|\b(nothing|no data|never)\s+leaves\b/i;
+  /\b(100\s*%|fully|entirely|completely)\s+local(?:ly)?\b|\b(nothing|no data|never)\s+leaves\b/i;
+/**
+ * Presence, not proximity: any mention of the ping anywhere in the string
+ * exempts all of it. Sound for two one-line descriptions and not for a page —
+ * "100% local. We never sell your telemetry." would clear this. Tighten it to
+ * the sentence if this gate ever grows a surface longer than a sentence or two.
+ */
 const DISCLOSES_PING = /ping|telemetry|analytics/i;
 
 const TOKEN_CONTEXT = /token|saving|saved|reduction|fewer|less/i;
@@ -82,13 +98,16 @@ export function checkRemoteClaims(surfaces, anchor) {
   const problems = [];
   for (const { name, text, mirrors } of surfaces) {
     const fail = (msg) => problems.push(`${name}: ${msg}\n    live: ${text}`);
+    // Everything below matches on this; only the drift check compares the raw
+    // string, because that one is a literal equality against package.json.
+    const claim = normalise(text);
 
     if (!text) {
       fail('has no description at all — the auto-indexes have nothing to copy but the repo name');
       continue;
     }
 
-    const retired = text.match(RETIRED);
+    const retired = claim.match(RETIRED);
     if (retired) {
       fail(
         `quotes the retired "${retired[0]}". Retiring a claim does not retire the copies of it; ` +
@@ -96,7 +115,7 @@ export function checkRemoteClaims(surfaces, anchor) {
       );
     }
 
-    const absolute = DISCLOSES_PING.test(text) ? null : text.match(ABSOLUTE_LOCALITY);
+    const absolute = DISCLOSES_PING.test(claim) ? null : claim.match(ABSOLUTE_LOCALITY);
     if (absolute) {
       fail(
         `claims "${absolute[0]}" while the usage ping is on by default (TRA-1013). Say what is ` +
@@ -106,7 +125,7 @@ export function checkRemoteClaims(surfaces, anchor) {
 
     // Every count the surface states has to be the count docs/_data/counts.yml
     // states — exactly, the way every guarded in-repo surface is since TRA-1086.
-    for (const [, n, noun] of text.matchAll(
+    for (const [, n, noun] of claim.matchAll(
       /(\d+)\+?\s+(languages?|frameworks?|tools?|resources?)/gi,
     )) {
       const key = `${noun.toLowerCase().replace(/s?$/, '')}s`;
@@ -117,8 +136,8 @@ export function checkRemoteClaims(surfaces, anchor) {
     }
 
     // And every percentage it quotes at a stranger has to be a generated one.
-    for (const [, pct] of text.matchAll(/(\d{1,3}(?:\.\d)?)\s*%/g)) {
-      if (!TOKEN_CONTEXT.test(text)) continue;
+    for (const [, pct] of claim.matchAll(/(\d{1,3}(?:\.\d)?)\s*%/g)) {
+      if (!TOKEN_CONTEXT.test(claim)) continue;
       if (anchor.savings.includes(pct)) continue;
       // One number, one line. The two checks above already name the figure when
       // it is a retired one or the locality absolute; repeating it here would

--- a/tests/docs/remote-claims.test.ts
+++ b/tests/docs/remote-claims.test.ts
@@ -41,6 +41,31 @@ describe('remote claim surfaces (TRA-1120)', () => {
     expect(problems).toHaveLength(1);
   });
 
+  // Both found by review of the first cut of this gate, both confirmed by
+  // running the regexes: the adverb and the spelled-out unit each slipped a
+  // retired claim past every check with zero problems reported.
+  it('catches the adverb too — "100% locally" is the same claim as "100% local"', () => {
+    for (const phrasing of ['100% locally', 'completely locally', 'fully local']) {
+      expect(
+        checkRemoteClaims([{ name: 'gh', text: `${CLEAN}. Runs ${phrasing}.` }], anchor).join('\n'),
+        phrasing,
+      ).toContain('usage ping is on by default');
+    }
+  });
+
+  it('catches a retired figure spelled out instead of glyphed', () => {
+    // `%` is what every pattern here hunts for, and a description pasted out of
+    // prose need not carry one.
+    for (const spelling of ['90.6 percent', '90.6 per cent']) {
+      expect(
+        checkRemoteClaims([{ name: 'npm', text: CLEAN.replace('70.5%', spelling) }], anchor).join(
+          '\n',
+        ),
+        spelling,
+      ).toContain('retired');
+    }
+  });
+
   it('catches a percentage that is simply not in docs/_data/', () => {
     expect(
       checkRemoteClaims([{ name: 'gh', text: CLEAN.replace('70.5%', '75%') }], anchor).join('\n'),

--- a/tests/docs/remote-claims.test.ts
+++ b/tests/docs/remote-claims.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { anchors, checkRemoteClaims } from '../../scripts/check-remote-claims.mjs';
+
+/**
+ * The two claim surfaces that are not files — TRA-1120.
+ *
+ * `scripts/check-remote-claims.mjs` fetches the GitHub repo description and the
+ * npm registry description and compares both to `docs/_data/`. The fetch is
+ * nightly in CI; these cases are the offline half, because a `tests/docs/*` run
+ * must not depend on someone else's uptime.
+ *
+ * The strings below are the real ones, live on 2026-09-07: 70.5% on GitHub and
+ * 90.6% on npm on the same day, both unguarded, with CI green throughout.
+ */
+describe('remote claim surfaces (TRA-1120)', () => {
+  const anchor = anchors();
+  const CLEAN =
+    'Framework-aware code intelligence MCP server — 87 framework integrations, 81 languages, ' +
+    '70.5% fewer input tokens to review a pull request';
+
+  it('reads its anchors out of docs/_data/, not out of prose', () => {
+    expect(anchor.counts.languages).toBeGreaterThan(0);
+    expect(anchor.counts.frameworks).toBeGreaterThan(0);
+    // The figures a one-liner is allowed to quote are generated ones. If this
+    // list ever gains a hand-typed member, the gate has stopped being a gate.
+    expect(anchor.savings.length).toBeGreaterThanOrEqual(2);
+    expect(anchor.packageDescription).toContain(String(anchor.counts.languages));
+  });
+
+  it('passes the description we actually ship', () => {
+    expect(checkRemoteClaims([{ name: 'npm', text: CLEAN, mirrors: CLEAN }], anchor)).toEqual([]);
+  });
+
+  it('catches the retired figure npm was serving', () => {
+    const problems = checkRemoteClaims(
+      [{ name: 'npm', text: CLEAN.replace('70.5%', '90.6%') }],
+      anchor,
+    );
+    expect(problems.join('\n')).toContain('retired');
+    // One stale number, one finding — not one per rule that happens to match it.
+    expect(problems).toHaveLength(1);
+  });
+
+  it('catches a percentage that is simply not in docs/_data/', () => {
+    expect(
+      checkRemoteClaims([{ name: 'gh', text: CLEAN.replace('70.5%', '75%') }], anchor).join('\n'),
+    ).toContain('not in docs/_data/');
+  });
+
+  it('catches a count that has drifted from counts.yml', () => {
+    expect(
+      checkRemoteClaims(
+        [{ name: 'gh', text: CLEAN.replace('81 languages', '80 languages') }],
+        anchor,
+      ).join('\n'),
+    ).toContain('counts.yml says');
+  });
+
+  it('catches "100% local" while the usage ping is opt-out (TRA-1013)', () => {
+    const problems = checkRemoteClaims([{ name: 'gh', text: `${CLEAN}. 100% local.` }], anchor);
+    expect(problems.join('\n')).toContain('usage ping is on by default');
+    // "100% local" must not also be reported as an unsourced savings figure.
+    expect(problems).toHaveLength(1);
+  });
+
+  it('allows the locality claim once it says what the ping does', () => {
+    // The fix TRA-1013 asks for is a stronger sentence, not a vaguer one. A
+    // gate that failed this too would push the copy back to saying nothing.
+    expect(
+      checkRemoteClaims(
+        [
+          {
+            name: 'gh',
+            text: `${CLEAN}. Your code and index never leave the machine; an anonymous usage ping is on by default and opt-out.`,
+          },
+        ],
+        anchor,
+      ),
+    ).toEqual([]);
+  });
+
+  it('reports npm drifting from package.json as its own, softer finding', () => {
+    const problems = checkRemoteClaims(
+      [{ name: 'npm', text: CLEAN, mirrors: `${CLEAN}, 100% MIT` }],
+      anchor,
+    );
+    expect(problems.join('\n')).toContain('drifted from package.json');
+  });
+
+  it('reports an empty description rather than passing it', () => {
+    expect(checkRemoteClaims([{ name: 'gh', text: '' }], anchor).join('\n')).toContain(
+      'no description at all',
+    );
+  });
+});


### PR DESCRIPTION
Closes TRA-1120.

The GitHub repo description and the npm registry `description` are the two widest claim surfaces we own, and neither is a file, so every docs gate was blind to both. Measured 2026-09-07:

| surface | live before this change |
|---|---|
| GitHub repo description | `… 70.5% fewer input tokens … 81 languages, 87 frameworks, 100% local.` |
| npm `description` (3.22.0) | `… 87 framework integrations, 81 languages, 90.6% fewer input tokens …` |

Same claim, same benchmark family, same day, two numbers, CI green throughout — and the GitHub string carried `100% local` while the usage ping POSTs to GA by default. TRA-1013 owns that wording for the README and its diff cannot reach a string that lives in GitHub's settings.

## What this adds

- **`scripts/check-remote-claims.mjs`** — fetches both descriptions and compares them to `docs/_data/` on the same anchor rule as `counts.yml` (TRA-1086): every count equals `counts.yml` exactly, every percentage is a generated figure (`pr_context_bench.json` or `response_tokens.json`), no retired number (`90.6%`, `up to 99%`, `~42 minutes`, `40–50%`, `53 frameworks / 68 languages`), no unqualified locality absolute, and npm must mirror `package.json`.
- **`tests/docs/remote-claims.test.ts`** — the offline half. `tests/docs/*` must not depend on someone else's uptime, so the pure checker is exercised against the real strings as fixtures and runs on every PR.
- **`ci.yml` job `remote-claims`** — nightly and `workflow_dispatch` only, never on a PR. npm serves the latest *published* version, so its description legitimately lags master until the release that carries it; as a required PR check this would be red for days for a reason no PR author can fix.
- **`ops/distribution.md`** — the GitHub-description row, the ungated-surfaces note that asked for this gate twice, and a findings entry covering both carve-outs below.

## What was fixed on the live surface

The GitHub description is now (327 of GitHub's 350 characters):

> Framework-aware code intelligence MCP server for Claude Code and Codex — 70.5% fewer input tokens to review a pull request, median over 60 merged PRs in repos we don't own, comprehension at parity. 81 languages, 87 frameworks. Your code and index never leave the machine; an anonymous usage ping is on by default and opt-out.

Two deliberate calls:

1. **The locality rule bans the absolute, not the claim.** A gate that also failed the sentence above would push the copy back to saying nothing, which is worse than the absolute it replaced. The rule fires only when no ping/telemetry disclosure is present in the same string.
2. **The `−15 pp` caveat the issue asks for is superseded.** TRA-1090 struck that run on 2026-09-07 — the trace arm was assembling context with no source code in it — and re-measured comprehension at parity (65.0% naive vs 66.7% trace). `90.6%` is now a retired figure, not a figure needing a caveat, and the gate treats it as one. The corrected quality result is what the description carries instead.

## npm stays red until the next release

`package.json` has said 70.5% since TRA-1090; a published npm description cannot be edited in place. `node scripts/check-remote-claims.mjs` reports it, says so in the failure text, and clears itself when the carrying release ships — the standing rule in `ops/distribution.md` that a listing fix ships with the release, not with the merge.

## Test evidence

- `node scripts/check-remote-claims.mjs` against the live surfaces: 3 findings before, 1 after (the npm release lag) — it reproduced every defect in the issue.
- `tests/docs/remote-claims.test.ts`: 9 passed.
- Full suite: 10,612 passed, 42 skipped, 957 files.
