### PR TITLE
docs(site): carry the quality half in the homepage hero, and drop the locality absolutes (TRA-1122)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -176,7 +176,7 @@ updated: 2026-09-07
         "name": "What is the best MCP server for giving Claude Code codebase context?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across {{ site.data.counts.languages }} languages) and exposes {{ site.data.counts.tools }} MCP tools — outline, symbol lookup, call graph, impact analysis, dead code detection — so Claude Code queries precomputed structure instead of re-reading files every turn. It runs entirely locally with no API keys, works with {{ site.data.counts.frameworks }} framework integrations. Measured on its own repository, its responses cost {{ site.data.response_tokens.reduction_pct }}% fewer tokens than the file reads they replace across {{ site.data.response_tokens.calls_weighted }} real calls — against a baseline that is still an estimate — and answers stay more consistent as the codebase grows. It's open source (MIT), installs with 'npm install -g trace-mcp', and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf."
+          "text": "trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across {{ site.data.counts.languages }} languages) and exposes {{ site.data.counts.tools }} MCP tools — outline, symbol lookup, call graph, impact analysis, dead code detection — so Claude Code queries precomputed structure instead of re-reading files every turn. It runs on your machine with no API keys and no account, works with {{ site.data.counts.frameworks }} framework integrations. Measured on its own repository, its responses cost {{ site.data.response_tokens.reduction_pct }}% fewer tokens than the file reads they replace across {{ site.data.response_tokens.calls_weighted }} real calls — against a baseline that is still an estimate — and answers stay more consistent as the codebase grows. It's open source (MIT), installs with 'npm install -g trace-mcp', and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf."
         }
       },
       {
@@ -192,7 +192,7 @@ updated: 2026-09-07
         "name": "Do I need API keys or a cloud account?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "No. trace-mcp is fully local. The default semantic search uses a bundled ONNX model (~23 MB, downloaded once on first use). For optional LLM summarization you can plug in Ollama or OpenAI — but everything else runs without external services."
+          "text": "No. There is no account and no key to buy: your code and your index stay on the machine. The default semantic search uses a bundled ONNX model (~23 MB, downloaded once on first use). For optional LLM summarization you can plug in Ollama or OpenAI — but everything else runs without external services."
         }
       },
       {
@@ -2314,6 +2314,21 @@ updated: 2026-09-07
         median over {{ site.data.pr_context_bench.pr_count }} merged pull requests in open-source repos we don't own.
       </p>
 
+      <!-- TRA-1122: the saving never travels alone. The same PRs were reviewed twice
+           and scored blind, and that half is what says the cheap context was worth
+           having — a page that publishes only the saving asks the reader to take the
+           rest on trust. Reuses .hero-boundary rather than adding a class: same
+           treatment, same measure, one less thing in the hero to keep in step.
+           Gated by tests/docs/readme-claims.test.ts. -->
+      <p class="hero-boundary">
+        Cheaper is not better, so the same PRs were reviewed twice and scored blind:
+        {{ site.data.pr_context_quality.trace_understood }} understood the change against
+        {{ site.data.pr_context_quality.baseline_understood }} for naive file loading,
+        {{ site.data.pr_context_quality.trace_false_positives }} false positives per PR against
+        {{ site.data.pr_context_quality.baseline_false_positives }} &mdash;
+        <a href="/pr-context-benchmark.html#does-the-thinner-context-produce-a-worse-review">parity, against a bar set before the run</a>.
+      </p>
+
       <!-- The honesty boundary travels with the claim, not as a footnote further down
            the page (ops/positioning.md &sect; The boundary, carried with the claim). -->
       <p class="hero-boundary">
@@ -2354,7 +2369,10 @@ updated: 2026-09-07
       <p class="hero-trust">
         <span>Open source</span>
         <span class="dot"></span>
-        <span>100% local</span>
+        <!-- No absolute about locality (TRA-1013): src/telemetry/usage-ping.ts POSTs
+             one anonymous daily ping unless it is switched off, so `grep
+             google-analytics` over our own repo disproves it. Say the true thing. -->
+        <span>Code stays local</span>
         <span class="dot"></span>
         <span>Claude Code</span>
         <span class="dot"></span>
@@ -2888,7 +2906,7 @@ updated: 2026-09-07
         <div class="section-meta-tag"><span class="label">010 / Security</span></div>
         <div>
           <h2 class="section-title">Built for <span class="em">real-world environments.</span></h2>
-          <p class="section-lede">Runs fully local. No code leaves your machine. Refactors are reversible. Destructive operations require explicit confirmation.</p>
+          <p class="section-lede">Runs on your machine. No code leaves it. Refactors are reversible. Destructive operations require explicit confirmation.</p>
         </div>
       </div>
 
@@ -3095,7 +3113,7 @@ updated: 2026-09-07
             <h3>What is the best MCP server for giving Claude Code codebase context?</h3>
             <span class="toggle">+</span>
           </summary>
-          <div class="answer">trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across {{ site.data.counts.languages }} languages) and exposes {{ site.data.counts.tools }} MCP tools &mdash; outline, symbol lookup, call graph, impact analysis, dead code detection &mdash; so Claude Code queries precomputed structure instead of re-reading files every turn. It runs entirely locally with no API keys, works with {{ site.data.counts.frameworks }} framework integrations. Measured on its own repository, its responses cost {{ site.data.response_tokens.reduction_pct }}% fewer tokens than the file reads they replace across {{ site.data.response_tokens.calls_weighted }} real calls — against a baseline that is still an estimate — and answers stay more consistent as the codebase grows. It's open source (MIT), installs with <code>npm install -g trace-mcp</code>, and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf.</div>
+          <div class="answer">trace-mcp is built specifically for this: it indexes a codebase once into a local dependency graph (SQLite + FTS5, tree-sitter parsing across {{ site.data.counts.languages }} languages) and exposes {{ site.data.counts.tools }} MCP tools &mdash; outline, symbol lookup, call graph, impact analysis, dead code detection &mdash; so Claude Code queries precomputed structure instead of re-reading files every turn. It runs on your machine with no API keys and no account, works with {{ site.data.counts.frameworks }} framework integrations. Measured on its own repository, its responses cost {{ site.data.response_tokens.reduction_pct }}% fewer tokens than the file reads they replace across {{ site.data.response_tokens.calls_weighted }} real calls — against a baseline that is still an estimate — and answers stay more consistent as the codebase grows. It's open source (MIT), installs with <code>npm install -g trace-mcp</code>, and works over stdio or HTTP with any MCP-compatible client, including Claude Code, Cursor, and Windsurf.</div>
         </details>
         <details class="faq">
           <summary>
@@ -3109,7 +3127,7 @@ updated: 2026-09-07
             <h3>Do I need API keys or a cloud account?</h3>
             <span class="toggle">+</span>
           </summary>
-          <div class="answer">No. trace-mcp is fully local. The default semantic search uses a bundled ONNX model (~23 MB, downloaded once on first use). For optional LLM summarization you can plug in Ollama or OpenAI &mdash; but everything else runs without external services.</div>
+          <div class="answer">No. There is no account and no key to buy: your code and your index stay on the machine. The default semantic search uses a bundled ONNX model (~23 MB, downloaded once on first use). For optional LLM summarization you can plug in Ollama or OpenAI &mdash; but everything else runs without external services.</div>
         </details>
         <details class="faq">
           <summary>

--- a/ops/positioning.md
+++ b/ops/positioning.md
@@ -27,13 +27,14 @@ Rules for keeping it honest, same three as the sibling ledgers:
   the quality result from `docs/_data/pr_context_quality.json` in the same
   breath. Cheaper is not better, and one number stating a claim it does not
   support is the defect we documented in a competitor before we shipped it
-  ourselves. Gated by `tests/docs/readme-claims.test.ts` (TRA-1013):
-  `README.md` and `docs/comparisons.md` carry the four numbers; `package.json`,
-  `plugin.json` and `server.json` are one-liners with no room for a table, so
-  they carry the verdict instead — **comprehension at parity**. That phrase is
-  silent on false positives (0.58 → 0.80, inside the preregistered bound but not
-  nothing), so it belongs on a line that has no room for the pair and nowhere
-  else.
+  ourselves. Gated by `tests/docs/readme-claims.test.ts` (TRA-1013, TRA-1122):
+  `README.md`, `docs/index.html` and `docs/comparisons.md` carry the four
+  numbers — on a Jekyll surface as `{{ site.data.pr_context_quality.* }}` tags,
+  never typed; `package.json`, `plugin.json` and `server.json` are one-liners
+  with no room for a table, so they carry the verdict instead — **comprehension
+  at parity**. That phrase is silent on false positives (0.58 → 0.80, inside the
+  preregistered bound but not nothing), so it belongs on a line that has no room
+  for the pair and nowhere else.
 
 ## The question this answers
 
@@ -171,7 +172,14 @@ anonymous daily ping unless the user sets `TRACE_MCP_TELEMETRY=off` or
 absolute. The banner chip and its `alt` text said it until 2026-09-07 (TRA-1013),
 on the surface auto-indexes copy verbatim. Gated by
 `tests/docs/readme-claims.test.ts` for `README.md`, `package.json`,
-`server.json` and `scripts/gen-readme-banner.mjs`.
+`server.json`, `scripts/gen-readme-banner.mjs` and `docs/index.html`.
+
+The homepage joined that list on 2026-09-07 (TRA-1122) and said it in three
+places, not one: the trust line at the fold ("100% local"), the security lede
+("Runs fully local"), and the "Do I need API keys or a cloud account?" answer
+("trace-mcp is fully local") — the last one duplicated into the FAQ JSON-LD, so
+it was also the answer we handed Google. One phrase per surface is the wrong
+mental model when the page is long: grep the claim, not the file.
 
 And say the reachable share out loud, because "manages your context budget"
 implies a whole we do not have. The measured decomposition of one real start

--- a/tests/docs/readme-claims.test.ts
+++ b/tests/docs/readme-claims.test.ts
@@ -632,18 +632,21 @@ describe('docs site numeric claims (TRA-174)', () => {
    * and then shipped ourselves. So: a surface that quotes the saving quotes the
    * quality result too, and both come from the generated data.
    *
-   * README.md and docs/comparisons.md (TRA-1123) are the surfaces this gates
-   * today. A Jekyll page reads the figures through Liquid rather than typing
-   * them, so a `site.data.pr_context_quality.<key>` reference counts as
+   * QUOTES_THE_SAVING below is the list; a surface joins it in the change that
+   * makes it carry the quality half (docs/comparisons.md TRA-1123, the homepage
+   * hero TRA-1122). A Jekyll page reads the figures through Liquid rather than
+   * typing them, so a `site.data.pr_context_quality.<key>` reference counts as
    * carrying the number — the literal one never appears in its source.
-   * docs/index.html (the hero) still quotes the saving without the quality
-   * half; it belongs to the site mandate and is filed as TRA-1122 — add its
-   * path here once it carries it.
    */
   const QUALITY = JSON.parse(
     readFileSync(join(REPO_ROOT, 'docs/_data/pr_context_quality.json'), 'utf-8'),
   ) as Record<string, unknown>;
-  const QUOTES_THE_SAVING = ['README.md', 'docs/comparisons.md', 'docs/code-graph-mcp.md'];
+  const QUOTES_THE_SAVING = [
+    'README.md',
+    'docs/comparisons.md',
+    'docs/code-graph-mcp.md',
+    'docs/index.html',
+  ];
 
   /** One-line surfaces cannot carry four numbers, so they carry the verdict
    *  instead — the same phrase the live GitHub repo description already runs.
@@ -700,6 +703,8 @@ describe('docs site numeric claims (TRA-174)', () => {
       'package.json',
       'server.json',
       'scripts/gen-readme-banner.mjs',
+      // TRA-1122: the homepage trust line ran the same absolute as the banner chip.
+      'docs/index.html',
     ]) {
       const hit = readFileSync(join(REPO_ROOT, path), 'utf-8').match(absolute);
       expect(


### PR DESCRIPTION
Closes TRA-1122. Stacked on #1088 (TRA-1013) — it adds the `QUOTES_THE_SAVING` gate this PR extends. Base retargets to `main` automatically once #1088 merges.

## The defect

`docs/index.html` published `{{ site.data.pr_context_bench.median_savings_pct }}%` in the hero and again in the metrics strip, with no quality figure anywhere on the page. The same 60 PRs were reviewed twice and scored blind, verdict `MET` against a bar written before the run, and that result has sat in `docs/_data/pr_context_quality.json` since 2026-09-07. Publishing the saving alone asked the reader to take on trust the thing we can actually show.

## What changed

**The hero carries the quality half**, right under the saving, reusing `.hero-boundary` rather than adding a class — same treatment, same measure, no new CSS. All four figures render from `{{ site.data.pr_context_quality.* }}`; nothing is typed.

**`docs/index.html` joins `QUOTES_THE_SAVING`** in `tests/docs/readme-claims.test.ts`. The check was a raw substring search over the file, which on a Jekyll surface would have demanded the literal `67%` — exactly the hardcoding the TRA-647 test forbids two blocks up. It now accepts either the literal or the `site.data.pr_context_quality.<key>` tag; which form is right for a given file stays TRA-647's business.

**Three locality absolutes on the same page, from the same audit as TRA-1013.** Not filed separately because they are the identical false claim on the surface with the most traffic, and I was already in the file:

- the trust line at the fold — `100% local` → `Code stays local`
- the security section lede — `Runs fully local. No code leaves your machine.` → `Runs on your machine. No code leaves it.`
- the "Do I need API keys or a cloud account?" answer — `trace-mcp is fully local` → `There is no account and no key to buy: your code and your index stay on the machine`, in the visible FAQ **and** in the FAQ JSON-LD, which is the copy Google was being handed

`src/telemetry/usage-ping.ts` POSTs one anonymous daily ping unless the user switches it off, so an absolute is false — `grep google-analytics` over our own repo disproves it. `docs/index.html` is added to the locality gate so it stays fixed.

**`ops/positioning.md`** records both: the homepage is now on the gated list for the saving/quality pairing and for locality, with the note that the page said the locality absolute in three places, not one — grep the claim, not the file.

## Test evidence

- `tests/docs/readme-claims.test.ts` — 76 passed. Both new gates fail on the pre-change file: the quality gate named the missing `67%`, the locality gate named `entirely local`, then `fully local`, then `100% local` in turn.
- `tests/docs/` — 377 passed, 4 skipped (includes `internal-links`, which validates the new anchor into `/pr-context-benchmark.html`).
- `pnpm test` — 10,608 passed, 42 skipped, 962 files.

## Not done here

`docs/comparisons.md` still quotes the saving without the quality half — TRA-1123, competitor mandate. The homepage metrics strip carries the saving too but sits directly under the hero line and already links the benchmark page that renders both halves; a second copy of four numbers on one screen is noise, not honesty.
