### PR TITLE
fix(daemon): stop reporting a busy daemon as idle, and name the idle RSS ceiling (TRA-1125)

### DIFF
--- a/docs/perf/daemon-idle-memory.md
+++ b/docs/perf/daemon-idle-memory.md
@@ -12,6 +12,11 @@ Measured 2026-09-04 on darwin 25.5.0 / arm64, daemon v3.16.0 (`serve-http`, 8 pr
 registered). TRA-811. Everything below is a reading, not an estimate — the commands are
 in each section so the next run can repeat them instead of re-deriving.
 
+> **Correction, 2026-09-07 (TRA-1125): the 949 MB below is not an idle measurement.**
+> The `projects_indexing == 0` filter it relies on could never see incremental reindex
+> work, so "idle" samples include the daemon at 99% CPU. The honest single-project idle
+> figure is **301 MB**. See the 2026-09-07 section at the end before quoting anything here.
+
 ## The starting number
 
 `Daemon vitals` in `~/.trace/daemon.log` reported, over 2 178 idle samples
@@ -80,3 +85,92 @@ hour of a workday kept the pool warm the whole time. `KEEPALIVE_IDLE_TERMINATE_M
 45 seconds — comfortably inside the 60s idle bar from the acceptance criteria — with a
 per-instance `keepAliveIdleMs` override on `ExtractPoolOptions` so tests don't have to
 wait out the real default.
+
+---
+
+## 2026-09-07 — the field confirmation, and why it took three weeks (TRA-1125)
+
+Two results, and the second one invalidates how we had been reading the first.
+
+### The prediction held. Idle RSS settles at 301 MB.
+
+Measured on darwin 25.5.0 / arm64, daemon v3.22.0, built from `c148138e`, isolated
+`TRACE_MCP_DATA_DIR` on port 3799 so nothing else on the machine could touch it. One
+project (this repo, 2 240 files indexed in 3.8 s), then left alone:
+
+| Since index finished | RSS | CPU |
+|---|---|---|
+| 0 s | 624 MB | — |
+| 15 s | 410 MB | 0.0% |
+| **45 s** | **301 MB** | 0.0% |
+| 45 s → 255 s | 301 MB, flat | 0.0% |
+
+The step at 45 s is `KEEPALIVE_IDLE_TERMINATE_MS` releasing the extract pool, exactly as
+TRA-971 intended. It is flat afterwards to the sample resolution, at 0.0% CPU. The
+`-420 MB` this document predicted in 2026-09-04 and could not confirm is real: **624 → 301
+MB, -323 MB, and the remainder never accumulates.**
+
+Repeating with four projects registered (four full trace-mcp checkouts):
+
+| | RSS |
+|---|---|
+| peak during the concurrent index | 1 222 MB |
+| settled, flat | 478 MB |
+
+So, from two points: **base ≈ 242 MB + ≈ 59 MB per loaded project**, and a transient peak
+during concurrent indexing of ~2.6× the settled floor.
+
+### The ceiling
+
+A flat number is the wrong shape — this daemon is asked to hold 1 project on one machine
+and 23 on another. The ceiling scales with what it was asked to hold:
+
+> **`idle_rss_mb ≤ 250 + 75 × projects_loaded`**, measured ≥ 45 s after the last indexing
+> work finishes, with CPU at 0.0%.
+
+Measured today: 301 MB against a 325 MB ceiling at N=1; 478 MB against 550 MB at N=4.
+Both inside, with ~10% of headroom. The 75 MB slope is the measured 59 MB plus room for
+repositories larger than this one — this corpus is 2 240 files, and field repositories run
+several times bigger, so the slope is a floor and must be re-measured on a large repo
+before it is quoted as a general law.
+
+This replaces the flat `tree_rss_idle_mb > 500` trigger in the autopilot brief, which
+cannot be right: at four ordinary projects a correctly-behaving daemon exceeds it.
+
+### The number that was wrong for three weeks: 949 MB was never an idle measurement
+
+The 949 MB median at the top of this document, and every figure since derived by filtering
+`Daemon vitals` on `projects_indexing == 0`, is a mix of idle and busy samples.
+
+`projects_indexing` was computed only from `ManagedProject.status`, which
+`project-manager.ts` sets on the **initial load** path.
+`reindex-file-handler.ts` — every incremental reindex, which is what a daemon on an active
+machine spends its day doing — *requires* status `ready` to proceed (it returns 503
+otherwise) and never changes it. By construction, incremental reindex work could not
+appear in the counter.
+
+Observed directly on 2026-09-07: daemon pid 2113 logged **264 vitals samples, 264 of them
+reporting `projects_indexing: 0`**, over a 4.5 h window that includes the moment
+`/health` timed out with no response at all after 5 s while the process burned 99.3% CPU
+and held 1 454 MB. `sample(1)` on it put 4 652 of 7 519 main-thread samples — **62% of the
+wall clock — inside synchronous `better-sqlite3` `sqlite3_step`** (`JS_run` 3 565,
+`JS_all` 1 087) on the same thread that serves `/health`. The daemon called that idle.
+
+Consequences worth stating plainly:
+
+1. Filtered on the fixed counter, the honest single-project idle figure is **301 MB**, not
+   949 MB. The old number was measuring indexing bursts and calling them rest.
+2. The `922 MB` median this run first computed from the same filter is contaminated the
+   same way, and is not published as an idle number here.
+3. Any conclusion drawn from "idle" daemon RSS before v3.23.0 should be re-derived.
+
+Fixed in this PR: `countReindexingProjects()` in `reindex-file-handler.ts` tracks in-flight
+single-file reindexes, and `getCounts` in `cli.ts` adds them to `projects_indexing`.
+Guarded by `src/daemon/__tests__/reindex-in-flight-vitals.test.ts`, which fails if the
+counter goes back to reporting a busy reindex as zero.
+
+### Still open
+
+`/health` returning nothing for 5 s while the main thread sits in synchronous SQLite is a
+separate defect from the counter that hid it — a health endpoint starved by the work it
+reports on. Not fixed here; filed separately.

--- a/docs/perf/daemon-idle-memory.md
+++ b/docs/perf/daemon-idle-memory.md
@@ -164,10 +164,14 @@ Consequences worth stating plainly:
    same way, and is not published as an idle number here.
 3. Any conclusion drawn from "idle" daemon RSS before v3.23.0 should be re-derived.
 
-Fixed in this PR: `countReindexingProjects()` in `reindex-file-handler.ts` tracks in-flight
-single-file reindexes, and `getCounts` in `cli.ts` adds them to `projects_indexing`.
-Guarded by `src/daemon/__tests__/reindex-in-flight-vitals.test.ts`, which fails if the
-counter goes back to reporting a busy reindex as zero.
+Fixed in this PR: `beginReindex()` / `countReindexingProjects()` in
+`reindex-file-handler.ts` track in-flight single-file reindexes, and `getCounts` in
+`cli.ts` adds them to `projects_indexing`. **Both** reindex paths are counted — the HTTP
+handler and `register_edit` in `src/tools/register/core.ts`, which reindexes in-process on
+the daemon's own MCP server and is the path CLAUDE.md tells every agent to call after
+every edit. Covering only the HTTP path (as the first revision of this change did) would
+have left the dominant share of a busy daemon's work still reporting idle. Guarded by
+`src/daemon/__tests__/reindex-in-flight-vitals.test.ts`.
 
 ### Still open
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,7 +79,7 @@ import { MemoryScheduler } from './memory/scheduler/memory-scheduler.js';
 import { ProjectManager } from './daemon/project-manager.js';
 import type { ManagedProject } from './daemon/project-manager.js';
 import { createDaemonProjectRelay } from './daemon/project-relay.js';
-import { handleReindexFile } from './daemon/reindex-file-handler.js';
+import { countReindexingProjects, handleReindexFile } from './daemon/reindex-file-handler.js';
 import { startVitalsLog } from './daemon/vitals-log.js';
 import { runStdioSession, StdioSession } from './daemon/router/session.js';
 // Statically imported (unlike session.ts's own default dynamic import) so
@@ -3222,7 +3222,12 @@ program
         const loaded = projectManager.listProjects();
         return {
           loaded: loaded.length,
-          indexing: loaded.filter((p) => p.status === 'indexing' || p.status === 'starting').length,
+          // TRA-1125: initial-load status alone under-reports. Incremental
+          // reindex runs with the project still marked `ready`, so a busy
+          // daemon logged itself idle — see countReindexingProjects().
+          indexing:
+            loaded.filter((p) => p.status === 'indexing' || p.status === 'starting').length +
+            countReindexingProjects(),
         };
       },
     });

--- a/src/daemon/__tests__/reindex-in-flight-vitals.test.ts
+++ b/src/daemon/__tests__/reindex-in-flight-vitals.test.ts
@@ -10,7 +10,11 @@
  * figure we had.
  */
 import { describe, expect, it, vi } from 'vitest';
-import { countReindexingProjects, handleReindexFile } from '../reindex-file-handler.js';
+import {
+  beginReindex,
+  countReindexingProjects,
+  handleReindexFile,
+} from '../reindex-file-handler.js';
 
 vi.mock('../../logger.js', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -73,6 +77,33 @@ describe('countReindexingProjects', () => {
         lock: (async (_o: unknown, fn: () => unknown) => await fn()) as never,
       },
     );
+    expect(countReindexingProjects()).toBe(0);
+  });
+});
+
+/**
+ * `register_edit` (`src/tools/register/core.ts`) reindexes in-process on the
+ * daemon's own MCP server, and CLAUDE.md tells every agent to call it after
+ * every edit — so it is the dominant reindex path, not the HTTP one. Counting
+ * only the HTTP handler would leave most of a busy daemon still reporting
+ * idle. Caught in review of PR #1092.
+ */
+describe('beginReindex', () => {
+  it('counts a project while held and releases it once done', () => {
+    expect(countReindexingProjects()).toBe(0);
+    const end = beginReindex('/some/project');
+    expect(countReindexingProjects()).toBe(1);
+    end();
+    expect(countReindexingProjects()).toBe(0);
+  });
+
+  it('is idempotent — a double release cannot drop a concurrent reindex', () => {
+    const first = beginReindex('/some/project');
+    const second = beginReindex('/some/project');
+    first();
+    first(); // the extra call must not cancel `second`
+    expect(countReindexingProjects()).toBe(1);
+    second();
     expect(countReindexingProjects()).toBe(0);
   });
 });

--- a/src/daemon/__tests__/reindex-in-flight-vitals.test.ts
+++ b/src/daemon/__tests__/reindex-in-flight-vitals.test.ts
@@ -1,0 +1,78 @@
+/**
+ * TRA-1125: the daemon logged itself idle while it was busy.
+ *
+ * `projects_indexing` was derived only from `ManagedProject.status`, which the
+ * initial-load path sets. `handleReindexFile` requires status `ready` to
+ * proceed and never changes it, so incremental reindex — the dominant workload
+ * on an active machine — was invisible. 264 of 264 measured vitals samples
+ * reported `projects_indexing: 0` across a window in which the daemon burned
+ * 99.3% CPU on a reindex burst, which silently contaminated every "idle RSS"
+ * figure we had.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { countReindexingProjects, handleReindexFile } from '../reindex-file-handler.js';
+
+vi.mock('../../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const root = process.cwd();
+
+describe('countReindexingProjects', () => {
+  it('counts a project whose reindex is in flight, and clears it after', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    let entered!: () => void;
+    const started = new Promise<void>((r) => {
+      entered = r;
+    });
+
+    expect(countReindexingProjects()).toBe(0);
+
+    const pending = handleReindexFile(
+      { project: root, path: `${root}/package.json` },
+      {
+        getProject: () => ({
+          status: 'ready',
+          pipeline: {
+            indexFiles: async () => {
+              entered();
+              await gate;
+              return { indexed: 1, skipped: 0, durationMs: 1 };
+            },
+          } as never,
+        }),
+        lock: (async (_o: unknown, fn: () => unknown) => await fn()) as never,
+      },
+    );
+
+    await started;
+    // The project is still `ready` — this is exactly the state that used to
+    // read as idle.
+    expect(countReindexingProjects()).toBe(1);
+
+    release();
+    await pending;
+    expect(countReindexingProjects()).toBe(0);
+  });
+
+  it('releases the count when the reindex throws', async () => {
+    await handleReindexFile(
+      { project: root, path: `${root}/tsconfig.json` },
+      {
+        getProject: () => ({
+          status: 'ready',
+          pipeline: {
+            indexFiles: () => {
+              throw new Error('boom');
+            },
+          } as never,
+        }),
+        lock: (async (_o: unknown, fn: () => unknown) => await fn()) as never,
+      },
+    );
+    expect(countReindexingProjects()).toBe(0);
+  });
+});

--- a/src/daemon/reindex-file-handler.ts
+++ b/src/daemon/reindex-file-handler.ts
@@ -17,6 +17,24 @@ export type ReindexFileResult =
   | { ok: false; status: 400 | 404 | 500; error: string }
   | { ok: false; status: 503; error: string; retryAfterSec: number };
 
+/**
+ * Projects with a single-file reindex in flight right now.
+ *
+ * TRA-1125: `projects_indexing` in the vitals line only ever counted projects
+ * in the initial-load path — `project-manager.ts` sets `status = 'indexing'`
+ * there. This handler *requires* status `ready` to proceed and never changes
+ * it, so by construction every incremental reindex was logged as idle. In the
+ * measured window 264 of 264 vitals samples reported `projects_indexing: 0`
+ * while the daemon burned 99.3% CPU on a reindex burst, which made every
+ * "idle RSS" figure in docs/perf a silent mix of idle and busy.
+ */
+const inFlight = new Map<string, number>();
+
+/** Distinct projects with reindex work in flight. Feeds the vitals line. */
+export function countReindexingProjects(): number {
+  return inFlight.size;
+}
+
 export interface ReindexFileDeps {
   getProject: (root: string) =>
     | {
@@ -107,6 +125,7 @@ export async function handleReindexFile(
 
   const lock = deps.lock ?? withLock;
 
+  inFlight.set(project, (inFlight.get(project) ?? 0) + 1);
   try {
     const result = (await lock(
       { lockDir: LOCKS_DIR, name: `${projectHash(project)}-reindex`, op: 'reindex-file-http' },
@@ -172,5 +191,9 @@ export async function handleReindexFile(
       error: true,
     });
     return { ok: false, status: 500, error: String(err) };
+  } finally {
+    const n = (inFlight.get(project) ?? 1) - 1;
+    if (n > 0) inFlight.set(project, n);
+    else inFlight.delete(project);
   }
 }

--- a/src/daemon/reindex-file-handler.ts
+++ b/src/daemon/reindex-file-handler.ts
@@ -35,6 +35,26 @@ export function countReindexingProjects(): number {
   return inFlight.size;
 }
 
+/**
+ * Mark a reindex as started; the returned function marks it finished and is
+ * safe to call more than once. Both reindex paths must use this — the HTTP
+ * handler below and `register_edit` in `src/tools/register/core.ts`, which
+ * reindexes in-process on the daemon's own MCP server. `register_edit` is the
+ * path CLAUDE.md tells every agent to call after every edit, so counting only
+ * the HTTP one would still report most of a busy daemon's work as idle.
+ */
+export function beginReindex(project: string): () => void {
+  inFlight.set(project, (inFlight.get(project) ?? 0) + 1);
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    const n = (inFlight.get(project) ?? 1) - 1;
+    if (n > 0) inFlight.set(project, n);
+    else inFlight.delete(project);
+  };
+}
+
 export interface ReindexFileDeps {
   getProject: (root: string) =>
     | {
@@ -125,7 +145,7 @@ export async function handleReindexFile(
 
   const lock = deps.lock ?? withLock;
 
-  inFlight.set(project, (inFlight.get(project) ?? 0) + 1);
+  const endReindex = beginReindex(project);
   try {
     const result = (await lock(
       { lockDir: LOCKS_DIR, name: `${projectHash(project)}-reindex`, op: 'reindex-file-http' },
@@ -192,8 +212,6 @@ export async function handleReindexFile(
     });
     return { ok: false, status: 500, error: String(err) };
   } finally {
-    const n = (inFlight.get(project) ?? 1) - 1;
-    if (n > 0) inFlight.set(project, n);
-    else inFlight.delete(project);
+    endReindex();
   }
 }

--- a/src/tools/register/core.ts
+++ b/src/tools/register/core.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { redactEnvFile } from '../../utils/env-parser.js';
 import { optionalNonEmptyString } from './_zod-helpers.js';
 import { EmbeddingPipeline } from '../../ai/embedding-pipeline.js';
+import { beginReindex } from '../../daemon/reindex-file-handler.js';
 import { getReindexStats } from '../../daemon/reindex-stats.js';
 import { repairIndex, type RepairMode } from '../../db/repair.js';
 import { verifyIndex } from '../../db/verify.js';
@@ -496,6 +497,10 @@ export function registerCoreTools(server: McpServer, ctx: ServerContext): void {
         progress ?? undefined,
       );
       let result: Awaited<ReturnType<typeof pipeline.indexFiles>>;
+      // TRA-1125: this path reindexes in-process on the daemon's own MCP
+      // server, so it has to show up in `projects_indexing` too — otherwise
+      // the vitals line still calls a busy daemon idle.
+      const endReindex = beginReindex(projectRoot);
       try {
         // Share the reindex lock so a single-file edit cannot race with a
         // running full-project reindex. The two paths mutate the same SQLite
@@ -548,6 +553,8 @@ export function registerCoreTools(server: McpServer, ctx: ServerContext): void {
           };
         }
         throw e;
+      } finally {
+        endReindex();
       }
 
       // Record in journal so session knows this file was edited


### PR DESCRIPTION
## The result that overturns the plan, first

I set out to confirm the daemon's idle RSS and name a ceiling (roadmap item 5). The
measurement I needed to do that turned out to be impossible, because **the field the
"idle" filter depends on could never report a busy daemon.**

`projects_indexing` in the `Daemon vitals` line was computed only from
`ManagedProject.status`, which `project-manager.ts:461` sets on the **initial load** path.
`reindex-file-handler.ts:60` *requires* status `ready` to proceed — it returns 503
otherwise — and never changes it. So by construction, incremental reindex work, which is
what a daemon on an active machine spends its day doing, could not appear in the counter.

Observed on 2026-09-07: daemon pid 2113 logged **264 vitals samples, 264 of them reporting
`projects_indexing: 0`**, over a 4.5 h window that includes the moment `/health` timed out
with no response at all after 5 s while the process held 1 454 MB and burned 99.3% CPU.
`sample(1)` on it put 4 652 of 7 519 main-thread samples — **62% of the wall clock** —
inside synchronous `better-sqlite3` `sqlite3_step` (`JS_run` 3 565, `JS_all` 1 087), on the
same thread that serves `/health`. The daemon called all of that idle.

That makes the **949 MB idle baseline in `docs/perf/daemon-idle-memory.md` wrong** — it is
a mix of idle and busy samples, as is every figure derived from that filter since.

## The fix

`countReindexingProjects()` tracks in-flight single-file reindexes; `getCounts` in `cli.ts`
adds them to `projects_indexing`. The two sources are disjoint by construction (the handler
503s unless the project is `ready`), so there is no double count.

## The numbers the roadmap item asked for

Isolated daemon, `TRACE_MCP_DATA_DIR` on port 3799, v3.22.0 built from `c148138e`, darwin
25.5.0 / arm64. One project, 2 240 files indexed in 3.8 s, then left alone:

| Since index finished | RSS | CPU |
|---|---|---|
| 0 s | 624 MB | — |
| 15 s | 410 MB | 0.0% |
| **45 s** | **301 MB** | 0.0% |
| 45 s → 255 s | 301 MB, flat | 0.0% |

The step at 45 s is `KEEPALIVE_IDLE_TERMINATE_MS` releasing the extract pool. **This is the
field confirmation TRA-811/971 never got** — the doc predicted −420 MB and could not verify
it; measured −323 MB, and it does not creep back.

Four projects: peak 1 222 MB during the concurrent index, settles flat at **478 MB**. So
base ≈242 MB + ≈59 MB per loaded project.

### Ceiling

> **`idle_rss_mb ≤ 250 + 75 × projects_loaded`**, measured ≥45 s after the last indexing
> work, CPU at 0.0%.

301/325 at N=1, 478/550 at N=4. This replaces the flat `tree_rss_idle_mb > 500` trigger,
which cannot be right — four ordinary projects put a correctly-behaving daemon over it.

**Honest limit:** the corpus is 2 240 files. Field repos run several times bigger, so the
59 MB slope is a floor and must be re-measured on a large repo before being quoted as a
general law. Stated as such in the doc.

## Guard

`src/daemon/__tests__/reindex-in-flight-vitals.test.ts` — verified to fail when the counter
is stubbed back to 0, and covers the throw path so a failed reindex can't leak the count.

## Not fixed here

`/health` returning nothing for 5 s while the main thread sits in synchronous SQLite is a
separate defect from the counter that hid it — a health endpoint starved by the work it
reports on. Filed separately.

## Verification

`pnpm test` — 10 648 passed, 40 skipped, 964 files. `pnpm run typecheck` and `pnpm run
biome:ci` clean. Token cost and the MCP tool contract are untouched.

Closes TRA-1125 (partially — the /health starvation is tracked separately).
