### PR TITLE
fix(daemon): stop /health starvation scaling with the number of indexing projects (TRA-1127)

### DIFF
--- a/docs/perf/health-starvation.md
+++ b/docs/perf/health-starvation.md
@@ -1,3 +1,11 @@
+---
+layout: default
+title: /health starvation during indexing
+permalink: /perf/health-starvation/
+description: Internal working document. Why the trace-mcp daemon stopped answering /health while indexing, and what bounds it now.
+noindex: true
+---
+
 # /health starvation during indexing (TRA-1127)
 
 Measured 2026-09-07 on an M-series MacBook Pro, Node 22, `trace-mcp` at

--- a/docs/perf/health-starvation.md
+++ b/docs/perf/health-starvation.md
@@ -1,0 +1,72 @@
+# /health starvation during indexing (TRA-1127)
+
+Measured 2026-09-07 on an M-series MacBook Pro, Node 22, `trace-mcp` at
+v3.22.0 + this change. Reproduce with `npx tsx scripts/probe-health-stall.ts`
+(`PROBE_N=<projects>`); the regression guard is
+`tests/daemon/health-starvation.test.ts`.
+
+## What the field saw
+
+The production daemon (21 projects loaded) did not answer `/health` for 5 s+
+while reindexing, at 99% CPU. `sample` on the live process put 61.9% of main
+thread samples inside synchronous `better-sqlite3` (`sqlite3_step` under
+`Statement::JS_run` / `JS_all`), doing index seeks during writes. Once the
+burst ended `/health` answered in 0.6–1.5 ms.
+
+That matters beyond latency: a session that cannot reach `/health` concludes
+the daemon is dead and starts its own full local index. A merely busy daemon
+manufactures N independent indexers, which makes it busier — the failure
+amplifies itself.
+
+## The mechanism is not "SQLite is synchronous"
+
+The indexing paths already yielded with `setImmediate` between chunks. But
+Node drains the whole check-phase queue before returning to poll, so N
+concurrent indexers that each yield still stack N chunks into a single turn.
+The window a pending health request waits for is the **sum** of every
+project's chunk, not the largest one.
+
+Isolated harness — a bare HTTP server plus N workers doing 40 × 50 ms
+synchronous chunks with a yield between chunks. The table is from an ad-hoc
+harness; the same property (window flat as N grows) is what the guard test
+asserts:
+
+| N workers | plain `setImmediate` p50 / max | fair yield p50 / max | wall |
+|---:|---:|---:|---:|
+| 1 | 100 / 151 ms | 100 / 152 ms | 2.0 s both |
+| 5 | 500 / 753 ms | 100 / 152 ms | 10.0 s both |
+| 21 | 2 100 / 3 152 ms | 100 / 152 ms | 42.0 s both |
+
+Latency scaled linearly with the number of indexers; throughput is identical
+either way, because they were sharing one thread regardless. 21 projects × the
+real (larger) chunks is the 5 s the field measured.
+
+## The fix
+
+`yieldToEventLoopFair()` / `runInOwnTurn()` in `src/utils/event-loop.ts`: a
+process-wide FIFO chain so each event-loop turn carries exactly one caller's
+synchronous unit. Applied to the three units that dominate a reindex — the
+persist transaction, each edge-resolver stage, and in-process extraction
+chunks. The yield has to sit *immediately before* the unit; placed after it,
+an intervening `await` (extraction workers) lets two projects' units share a
+turn anyway.
+
+## What it buys, on this repo (2 584 files, worker pool active)
+
+| | before | after |
+|---|---:|---:|
+| 1 project, `/health` p99 / max | — | 241 / 322 ms |
+| 4 projects, `/health` p99 / max | 420 / 768 ms | 379 / 640 ms |
+| 4 projects, max loop delay | 757 ms | 637 ms |
+
+The scaling term is gone; what remains is one monolithic unit. At N=4 every
+observed stall is now attributable to a *single* call, the largest being
+`EdgeResolver.resolveEdges` (~260–300 ms) and `resolveEsmImportEdges`
+(~220 ms) — both single `db.transaction()` passes over the whole pending set.
+
+## What is not fixed
+
+`/health` p99 is bounded, not yet under 100 ms. The floor is the largest
+single resolver transaction, and lowering it means chunking those
+transactions, which changes when partial edge writes become visible. Tracked
+separately — do not raise the client-side timeout instead.

--- a/scripts/probe-health-stall.ts
+++ b/scripts/probe-health-stall.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env tsx
+/**
+ * TRA-1127 probe: how long does a full index block the event loop, and which
+ * synchronous unit is responsible? Attribution by wrapping the suspect call
+ * sites and recording each call's own synchronous wall time.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { performance, monitorEventLoopDelay } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+
+import { TraceMcpConfigSchema } from '../src/config.js';
+import * as schema from '../src/db/schema.js';
+import { initializeDatabase } from '../src/db/schema.js';
+import * as snapshots from '../src/graph/snapshots.js';
+import { Store } from '../src/db/store.js';
+import { EdgeResolver } from '../src/indexer/edge-resolver.js';
+import { FilePersister } from '../src/indexer/file-persister.js';
+import { IndexingPipeline } from '../src/indexer/pipeline.js';
+import { PluginRegistry } from '../src/plugin-api/registry.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '../..');
+const ROOT = process.argv[2] ?? REPO_ROOT;
+
+const T0abs = performance.now();
+const calls: Array<{ name: string; ms: number; start: number }> = [];
+function wrap(obj: any, label: string): void {
+  for (const key of Object.getOwnPropertyNames(obj)) {
+    const d = Object.getOwnPropertyDescriptor(obj, key);
+    if (!d || typeof d.value !== 'function' || key === 'constructor') continue;
+    const orig = d.value;
+    obj[key] = function (this: unknown, ...args: unknown[]) {
+      const t = performance.now();
+      try {
+        return orig.apply(this, args);
+      } finally {
+        calls.push({ name: `${label}.${key}`, ms: performance.now() - t, start: t - T0abs });
+      }
+    };
+  }
+}
+wrap(FilePersister.prototype, 'FilePersister');
+wrap(EdgeResolver.prototype, 'EdgeResolver');
+wrap(Store.prototype, 'Store');
+{
+  const Database = (await import('better-sqlite3')).default as any;
+  wrap(Database.prototype, 'DB');
+}
+// module-level synchronous suspects
+{
+  const Database = (await import('better-sqlite3')).default as any;
+  wrap(Database.prototype, 'DB');
+}
+
+// Worker shim: ExtractPool checks for a sibling extract-worker.js on disk.
+const WORKER_SHIM = path.join(REPO_ROOT, 'src/indexer/extract-worker.js');
+let shimmed = false;
+if (!fs.existsSync(WORKER_SHIM)) {
+  fs.copyFileSync(path.join(REPO_ROOT, 'dist/extract-worker.js'), WORKER_SHIM);
+  shimmed = true;
+}
+process.on('exit', () => {
+  if (shimmed) fs.rmSync(WORKER_SHIM, { force: true });
+});
+
+const N = Number(process.env.PROBE_N ?? '1');
+const config = TraceMcpConfigSchema.parse({ root: ROOT });
+const pipelines = Array.from({ length: N }, () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-probe-'));
+  const db = initializeDatabase(path.join(tmp, 'index.db'));
+  const store = new Store(db);
+  return {
+    tmp,
+    db,
+    pipeline: new IndexingPipeline(store, PluginRegistry.createWithDefaults(), config, ROOT),
+  };
+});
+
+// Real HTTP probe against a trivial handler — same shape as the daemon's /health.
+const http = await import('node:http');
+const srv = http.createServer((_q, res) => res.end('ok')).listen(3997);
+const httpLat: number[] = [];
+const httpProbe = setInterval(() => {
+  const t = performance.now();
+  http.get('http://127.0.0.1:3997/', (r) => {
+    r.resume();
+    r.on('end', () => httpLat.push(performance.now() - t));
+  });
+}, 20);
+
+// Health probe: a timer that should fire every 10ms. Its overshoot is exactly
+// what a /health request would wait.
+const h = monitorEventLoopDelay({ resolution: 5 });
+h.enable();
+let worstTick = 0;
+let last = performance.now();
+const stalls: Array<{ at: number; ms: number }> = [];
+const T0 = performance.now();
+const ticker = setInterval(() => {
+  const now = performance.now();
+  const over = now - last - 10;
+  if (over > 50) stalls.push({ at: now - T0, ms: over });
+  worstTick = Math.max(worstTick, over);
+  last = now;
+}, 10);
+
+const t0 = performance.now();
+const results = await Promise.all(pipelines.map((p) => p.pipeline.indexAll(false)));
+const r = results[0];
+const wall = performance.now() - t0;
+clearInterval(httpProbe);
+httpLat.sort((a, b) => a - b);
+clearInterval(ticker);
+h.disable();
+for (const p of pipelines) {
+  await p.pipeline.dispose();
+  p.db.close();
+  fs.rmSync(p.tmp, { recursive: true, force: true });
+}
+srv.close();
+console.log(
+  `http /health latency (n=${httpLat.length}): p50=${httpLat[Math.floor(httpLat.length * 0.5)]?.toFixed(1)}ms p99=${httpLat[Math.floor(httpLat.length * 0.99)]?.toFixed(1)}ms max=${httpLat.at(-1)?.toFixed(1)}ms`,
+);
+
+console.log('stalls > 50ms (offset ms, stall ms) with top-level calls inside:');
+const offset = T0 - T0abs;
+for (const s of stalls) {
+  const from = s.at + offset - s.ms - 10;
+  const to = s.at + offset;
+  const inside = calls
+    .filter((c) => c.start >= from && c.start < to && c.ms > 5)
+    .filter(
+      (c, _i, arr) =>
+        !arr.some((o) => o !== c && o.start <= c.start && o.start + o.ms >= c.start + c.ms),
+    )
+    .sort((a, b) => b.ms - a.ms)
+    .slice(0, 6)
+    .map((c) => `${c.name}:${c.ms.toFixed(0)}`);
+  console.log(`  @${s.at.toFixed(0)}  ${s.ms.toFixed(0)}ms  [${inside.join(', ')}]`);
+}
+const marks = calls.map((c, i) => c);
+const top = calls.sort((a, b) => b.ms - a.ms).slice(0, 20);
+const agg = new Map<string, { n: number; total: number; max: number }>();
+for (const c of calls) {
+  const a = agg.get(c.name) ?? { n: 0, total: 0, max: 0 };
+  a.n++;
+  a.total += c.ms;
+  a.max = Math.max(a.max, c.ms);
+  agg.set(c.name, a);
+}
+console.log(
+  `N=${N} root=${ROOT} indexed=${r.indexed} skipped=${r.skipped} wall=${Math.round(wall)}ms`,
+);
+console.log(
+  `loop delay: p50=${(h.percentile(50) / 1e6).toFixed(1)}ms p99=${(h.percentile(99) / 1e6).toFixed(1)}ms max=${(h.max / 1e6).toFixed(1)}ms  worstTimerOvershoot=${worstTick.toFixed(1)}ms`,
+);
+console.log('\ntop 20 single synchronous calls:');
+for (const c of top) console.log(`  ${c.ms.toFixed(1)}ms  ${c.name}`);
+console.log('\nby call site (total ms, n, max):');
+for (const [name, a] of [...agg].sort((x, y) => y[1].total - x[1].total).slice(0, 20)) {
+  console.log(`  ${a.total.toFixed(0)}ms  n=${a.n}  max=${a.max.toFixed(1)}ms  ${name}`);
+}

--- a/src/indexer/extract-and-persist.ts
+++ b/src/indexer/extract-and-persist.ts
@@ -4,6 +4,7 @@ import { disableFts5Triggers, enableFts5Triggers, ensureFts5Triggers } from '../
 import { logger } from '../logger.js';
 import type { PluginRegistry } from '../plugin-api/registry.js';
 import type { ProjectContext } from '../plugin-api/types.js';
+import { runInOwnTurn, yieldToEventLoopFair } from '../utils/event-loop.js';
 import type { GitignoreMatcher } from '../utils/gitignore.js';
 import { EdgeResolver } from './edge-resolver.js';
 import type { ExtractPool, ExtractRequest } from './extract-pool.js';
@@ -203,6 +204,11 @@ export async function extractAndPersist(
         );
       } else {
         for (let c = 0; c < batch.length; c += CONCURRENCY) {
+          // In-process extraction (no worker pool: dev mode, tests, sub-100
+          // file batches) parses on the main thread, so a chunk is a synchronous
+          // unit like any other and has to take its turn — otherwise every
+          // project's chunk lands in the same one.
+          await yieldToEventLoopFair();
           const chunk = batch.slice(c, c + CONCURRENCY);
           const results = await Promise.all(
             chunk.map((relPath) => extractor.extract(relPath, force)),
@@ -230,7 +236,12 @@ export async function extractAndPersist(
       }
 
       if (extractions.length > 0) {
-        persister.persistBatch(extractions);
+        // persistBatch is one synchronous SQLite transaction over up to 500
+        // files — stacked back-to-back across batches (or across projects) it
+        // starves the event loop, /health stops answering, and the desktop
+        // app's watchdog kills the daemon mid-warm-up. Giving it a turn of its
+        // own bounds that window at negligible cost.
+        await runInOwnTurn(() => persister.persistBatch(extractions));
         result.indexed += extractions.length;
       }
 
@@ -249,12 +260,6 @@ export async function extractAndPersist(
 
       const processed = result.indexed + result.skipped + result.errors;
       progress?.update('indexing', { processed });
-      // persistBatch is one synchronous SQLite transaction over up to 500
-      // files — stacked back-to-back across batches it starves the event
-      // loop, /health stops answering, and the desktop app's watchdog kills
-      // the daemon mid-warm-up. One macrotask turn per batch keeps the
-      // process responsive at negligible cost.
-      await new Promise<void>((r) => setImmediate(r));
     }
   } finally {
     // Always restore FTS triggers + rebuild if we dropped them for the bulk

--- a/src/indexer/extract-and-persist.ts
+++ b/src/indexer/extract-and-persist.ts
@@ -243,6 +243,10 @@ export async function extractAndPersist(
         // own bounds that window at negligible cost.
         await runInOwnTurn(() => persister.persistBatch(extractions));
         result.indexed += extractions.length;
+      } else {
+        // Nothing to persist, but the batch still did work — keep the
+        // once-per-batch boundary the old unconditional yield gave.
+        await yieldToEventLoopFair();
       }
 
       // Bound in-process content residency to one batch: Pass 2

--- a/src/indexer/pipeline.ts
+++ b/src/indexer/pipeline.ts
@@ -929,6 +929,10 @@ export class IndexingPipeline {
     // only processed once it finished — i.e. this phase starves the event loop
     // and /health. Yield before the first (heaviest, cross-file) resolver pass
     // so the loop can service a health check between extraction and resolution.
+    // Not wrapped in runInOwnTurn: resolveEdges is async, so only its first
+    // synchronous span is covered by the yield. That is enough while every
+    // FrameworkPlugin.resolveEdges is synchronous (plugin-api/types.ts); a
+    // plugin that genuinely awaits I/O would need its own boundary.
     await yieldToEventLoopFair();
     await edgeResolver.resolveEdges(
       this.buildProjectContext(),

--- a/src/indexer/pipeline.ts
+++ b/src/indexer/pipeline.ts
@@ -16,6 +16,7 @@ import type {
 import { invalidatePageRankCache } from '../scoring/pagerank.js';
 import { invalidateSearchCache } from '../scoring/search-cache.js';
 import { captureGraphSnapshots } from '../tools/analysis/history.js';
+import { runInOwnTurn, yieldToEventLoopFair } from '../utils/event-loop.js';
 import { safeGitEnv } from '../utils/git-env.js';
 import { initContentHasher } from '../util/hash.js';
 import { descendantExcludeGlobs } from '../registry.js';
@@ -784,7 +785,7 @@ export class IndexingPipeline {
       // #237: yield before the (synchronous, potentially multi-second) graph
       // snapshot capture so /health can be serviced between edge resolution and
       // snapshotting on a full reindex.
-      await new Promise<void>((r) => setImmediate(r));
+      await yieldToEventLoopFair();
       try {
         // P02 Task DAG: graph-snapshots is scheduled via this._dag. The Task
         // wrapper is a pure adapter — it calls `captureGraphSnapshots(store,
@@ -922,14 +923,13 @@ export class IndexingPipeline {
    */
   private async runEdgeResolvers(scope: ChangeScope | undefined): Promise<void> {
     if (scope === undefined) this._lastFullResolveMs = Date.now();
-    const yieldLoop = () => new Promise<void>((r) => setImmediate(r));
     const edgeResolver = new EdgeResolver(this.getPipelineState());
     // #237: the postprocess (edge-resolution) phase runs right after extraction
     // hits 100%, and in the field SIGTERMs delivered during this window were
     // only processed once it finished — i.e. this phase starves the event loop
     // and /health. Yield before the first (heaviest, cross-file) resolver pass
     // so the loop can service a health check between extraction and resolution.
-    await yieldLoop();
+    await yieldToEventLoopFair();
     await edgeResolver.resolveEdges(
       this.buildProjectContext(),
       this.buildResolveContext(scope),
@@ -971,8 +971,7 @@ export class IndexingPipeline {
       () => edgeResolver.resolveFileProjectionEdges(scope),
     ];
     for (const stage of stages) {
-      await yieldLoop();
-      stage();
+      await runInOwnTurn(stage);
     }
   }
 

--- a/src/utils/event-loop.ts
+++ b/src/utils/event-loop.ts
@@ -50,3 +50,43 @@ export function getYieldCount(): number {
 export function _resetYieldCountForTests(): void {
   yieldCount = 0;
 }
+
+/**
+ * TRA-1127: a *fair* macrotask boundary — only one caller's synchronous unit
+ * runs per event-loop turn, process-wide.
+ *
+ * `yieldToEventLoop()` alone is not enough when several indexers run at once.
+ * Node drains the whole check-phase queue before returning to poll, so N
+ * concurrent workers that each "yield" between chunks still stack N chunks
+ * into a single turn — measured on a plain HTTP server: 40 × 50 ms chunks give
+ * a p50 request latency of 100 ms at N=1 and 2 100 ms at N=21, i.e. the
+ * daemon's /health latency scales linearly with the number of projects
+ * indexing. That is the starvation window this fixes.
+ *
+ * Callers queue behind each other, so each turn carries exactly one unit and
+ * the wait a pending health check sees is bounded by the largest single unit
+ * rather than by their sum. Total throughput is unchanged — they were sharing
+ * one thread either way — only the interleaving is.
+ */
+let fairChain: Promise<void> = Promise.resolve();
+
+export function yieldToEventLoopFair(): Promise<void> {
+  const mine = fairChain.then(() => yieldToEventLoop());
+  fairChain = mine.catch(() => {});
+  return mine;
+}
+
+/**
+ * Run one synchronous unit of work in an event-loop turn of its own.
+ *
+ * The yield must come *immediately before* the sync work, not after it: a
+ * yield placed after the unit is only fair if nothing else can resume the
+ * caller in between. Awaiting extraction workers does exactly that, which is
+ * how two projects' persist transactions ended up in one turn even with the
+ * fair yield in place. Wrapping the unit makes the invariant impossible to
+ * get wrong at the call site.
+ */
+export async function runInOwnTurn<T>(fn: () => T): Promise<T> {
+  await yieldToEventLoopFair();
+  return fn();
+}

--- a/src/utils/event-loop.ts
+++ b/src/utils/event-loop.ts
@@ -67,6 +67,13 @@ export function _resetYieldCountForTests(): void {
  * the wait a pending health check sees is bounded by the largest single unit
  * rather than by their sum. Total throughput is unchanged — they were sharing
  * one thread either way — only the interleaving is.
+ *
+ * The chain is one unscoped process-wide queue, which is what makes it work:
+ * scoping it per project would restore the stacking it exists to prevent. The
+ * cost is shared fate — a new caller from an unrelated subsystem (MCP request
+ * handlers, LSP enrichment, the subproject scanner) queues behind indexing and
+ * indexing queues behind it. Only adopt it for work that is already CPU-bound
+ * on the main thread, and never for anything that awaits I/O inside its unit.
  */
 let fairChain: Promise<void> = Promise.resolve();
 

--- a/tests/daemon/health-starvation.test.ts
+++ b/tests/daemon/health-starvation.test.ts
@@ -1,0 +1,147 @@
+/**
+ * TRA-1127 — /health must stay answerable while the daemon indexes.
+ *
+ * The field report: the production daemon (21 projects loaded) did not answer
+ * `/health` for over 5 s during a reindex burst, at 99% CPU, with 62% of main
+ * thread samples inside synchronous `sqlite3_step`. A session that cannot reach
+ * /health concludes the daemon is dead and starts its own full local index —
+ * so a merely busy daemon manufactures N independent indexers, which makes it
+ * busier. The failure amplifies itself.
+ *
+ * The mechanism is not "SQLite is synchronous" on its own. The indexing paths
+ * already yield with `setImmediate` between chunks. But Node drains the whole
+ * check-phase queue before returning to poll, so N concurrent indexers that
+ * each yield still stack N chunks into a single turn: the window a pending
+ * health request waits for is the SUM of every project's chunk, not the
+ * largest one. Measured on a bare HTTP server with 50 ms chunks, p50 request
+ * latency was 100 ms at N=1 and 2 100 ms at N=21.
+ *
+ * These two tests guard the two halves of that: the primitive
+ * (`runInOwnTurn`) under synthetic load, and real indexing of several projects
+ * at once.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { monitorEventLoopDelay } from 'node:perf_hooks';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { TraceMcpConfigSchema } from '../../src/config.js';
+import { initializeDatabase } from '../../src/db/schema.js';
+import { Store } from '../../src/db/store.js';
+import { IndexingPipeline } from '../../src/indexer/pipeline.js';
+import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import { runInOwnTurn } from '../../src/utils/event-loop.js';
+
+/** Burn `ms` of CPU on the main thread — stands in for a persist transaction. */
+function spin(ms: number): void {
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    /* busy */
+  }
+}
+
+/** Max event-loop stall observed while `run()` is in flight, in ms. This is
+ *  what a pending /health request waits for: the handler itself is a constant
+ *  -time JSON reply, so its latency IS the loop delay. */
+async function maxLoopDelayDuring(run: () => Promise<unknown>): Promise<number> {
+  const h = monitorEventLoopDelay({ resolution: 5 });
+  h.enable();
+  await run();
+  h.disable();
+  return h.max / 1e6;
+}
+
+describe('runInOwnTurn keeps the stall window flat as concurrency grows', () => {
+  const UNIT_MS = 30;
+  const UNITS = 12;
+
+  async function worker(): Promise<void> {
+    for (let i = 0; i < UNITS; i++) await runInOwnTurn(() => spin(UNIT_MS));
+  }
+
+  it('one indexer: the window is one unit', async () => {
+    const max = await maxLoopDelayDuring(() => worker());
+    expect(max).toBeLessThan(UNIT_MS * 3);
+  }, 30_000);
+
+  it('eight indexers: the window is still one unit, not eight', async () => {
+    const max = await maxLoopDelayDuring(() =>
+      Promise.all(Array.from({ length: 8 }, () => worker())),
+    );
+    // Pre-fix this is ~8 x UNIT_MS (the whole check-phase queue drains before
+    // poll). The bound below is deliberately far from both: it fails loudly on
+    // a regression to summing behaviour and does not flake on a slow CI box.
+    expect(max).toBeLessThan(UNIT_MS * 4);
+  }, 30_000);
+});
+
+describe('real indexing load: many projects at once', () => {
+  const PROJECTS = 10;
+  const FILES = 400;
+  let tmpRoot: string;
+  const roots: string[] = [];
+
+  beforeAll(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'tra1127-'));
+    for (let p = 0; p < PROJECTS; p++) {
+      const root = path.join(tmpRoot, `proj${p}`);
+      fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+      for (let f = 0; f < FILES; f++) {
+        const prev = f === 0 ? '' : `import { fn${f - 1} } from './mod${f - 1}.js';\n`;
+        fs.writeFileSync(
+          path.join(root, 'src', `mod${f}.ts`),
+          `${prev}export class Cls${f} { run(): number { return ${f}; } }\n` +
+            `export function fn${f}(): number { return new Cls${f}().run(); }\n` +
+            `export const CONST${f} = fn${f}();\n`,
+        );
+      }
+      roots.push(root);
+    }
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  function makePipeline(root: string, dbName: string): IndexingPipeline {
+    const db = initializeDatabase(path.join(root, dbName));
+    return new IndexingPipeline(
+      new Store(db),
+      PluginRegistry.createWithDefaults(),
+      TraceMcpConfigSchema.parse({ root }),
+      root,
+    );
+  }
+
+  async function maxDelayIndexing(
+    dbName: string,
+    mode: 'concurrent' | 'sequential',
+  ): Promise<number> {
+    const pipelines = roots.map((r) => makePipeline(r, dbName));
+    try {
+      return await maxLoopDelayDuring(async () => {
+        if (mode === 'concurrent') {
+          await Promise.all(pipelines.map((p) => p.indexAll(false)));
+        } else {
+          for (const p of pipelines) await p.indexAll(false);
+        }
+      });
+    } finally {
+      for (const p of pipelines) await p.dispose();
+    }
+  }
+
+  it(`indexing ${PROJECTS} projects at once stalls no longer than indexing one`, async () => {
+    // Same corpus, same machine, back-to-back: indexing the projects one after
+    // another gives the width of a single project's largest synchronous unit.
+    // Doing all of them at once must not make that window wider — pre-fix it
+    // grew with the project count, which is how a busy daemon stopped
+    // answering /health for seconds at a time with 21 projects loaded.
+    const sequential = await maxDelayIndexing('seq.db', 'sequential');
+    const concurrent = await maxDelayIndexing('conc.db', 'concurrent');
+    console.log(
+      `max loop delay: sequential=${sequential.toFixed(1)}ms concurrent=${concurrent.toFixed(1)}ms`,
+    );
+    expect(concurrent).toBeLessThan(sequential * 2);
+  }, 300_000);
+});

--- a/tests/daemon/health-starvation.test.ts
+++ b/tests/daemon/health-starvation.test.ts
@@ -19,6 +19,12 @@
  * These two tests guard the two halves of that: the primitive
  * (`runInOwnTurn`) under synthetic load, and real indexing of several projects
  * at once.
+ *
+ * The primitive test is the sharp one — it fails on any regression in the
+ * fairness chain itself. The real-load test is coarser by construction: the
+ * pipeline yields at several points, so breaking one of them can be masked by
+ * the others on a small corpus. It is here to catch the wiring coming undone
+ * wholesale, not to localise which yield was lost.
  */
 import fs from 'node:fs';
 import os from 'node:os';


### PR DESCRIPTION
Fixes TRA-1127.

## What was wrong

The production daemon (21 projects loaded) did not answer `/health` for 5 s+ during a reindex burst, at 99% CPU, with 61.9% of main-thread samples inside synchronous `better-sqlite3`. That is not just a latency problem: a session that cannot reach `/health` concludes the daemon is dead and starts its own full local index, so a *merely busy* daemon manufactures N independent indexers, which makes it busier.

## The mechanism is not "better-sqlite3 is synchronous"

The indexing paths already yielded with `setImmediate` between chunks. But Node drains the whole check-phase queue before returning to poll, so N concurrent indexers that each yield still stack N chunks into a single turn — the window a pending health request waits for is the **sum** of every project's chunk, not the largest one.

Measured on a bare HTTP server, N workers doing 40 × 50 ms synchronous chunks with a yield between them:

| N | plain `setImmediate` p50 / max | fair yield p50 / max | wall |
|---:|---:|---:|---:|
| 1 | 100 / 151 ms | 100 / 152 ms | 2.0 s both |
| 5 | 500 / 753 ms | 100 / 152 ms | 10.0 s both |
| 21 | 2 100 / 3 152 ms | 100 / 152 ms | 42.0 s both |

Linear in the number of indexers, and wall time is identical either way — they share one thread regardless, so only the interleaving changes. 21 projects × the real (larger) chunks is the 5 s the field saw.

## The change

`yieldToEventLoopFair()` / `runInOwnTurn()` put callers on a process-wide FIFO chain, so each event-loop turn carries exactly one synchronous unit. Applied to the three units a reindex is made of: the persist transaction, each edge-resolver stage, and in-process extraction chunks.

The yield has to sit *immediately before* the unit. Placed after it, the `await` on extraction workers lets two projects' persist transactions share a turn anyway — which is why `runInOwnTurn` wraps the work instead of just marking a boundary. That was found by measurement, not by reading.

## What it buys, and what it does not

On this repo (2 584 files, worker pool active, 4 concurrent projects): `/health` p99 420 → 379 ms, max 768 → 640 ms. More importantly, every remaining stall is now attributable to a **single** call instead of a pile-up — the scaling term is gone.

It does not reach the suggested p99 < 100 ms. The residual floor is one monolithic resolver transaction (`resolveEdges` ~300 ms, `resolveEsmImportEdges` ~220 ms), each a single `db.transaction()` over the whole pending set. Chunking those changes when partial edge writes become visible, so it is filed separately rather than smuggled in here. Raising the client-side timeout remains not the fix.

## Test evidence

`tests/daemon/health-starvation.test.ts` — both cases fail without the fix and pass with wide margin after it:

| | pre-fix | bound | post-fix |
|---|---:|---:|---:|
| primitive, 8 concurrent callers × 30 ms units | 240 ms | < 120 ms | ~35 ms |
| 10 real projects indexed at once vs one at a time | 280 ms | < 2× sequential (98 ms) | 24–34 ms |

Full suite: 10 651 passed, 40 skipped, 964 files. `tsc --noEmit` and `biome ci` clean.

Method and numbers in `docs/perf/health-starvation.md`; `scripts/probe-health-stall.ts` reproduces the attribution run against any repo.

Reviewed independently by a second model before merge; four findings applied in the second commit (all-skip batches lost their boundary; the process-wide-chain hazard is now documented; the `resolveEdges` call site says why it is a bare yield; the real-load test says what it actually guards).

Agent: Lead Engineer
