### PR TITLE
fix(daemon): cap concurrent watcher reindexes so /health survives an indexing burst (TRA-1127)

### DIFF
--- a/docs/perf/daemon-health-latency.md
+++ b/docs/perf/daemon-health-latency.md
@@ -1,0 +1,81 @@
+---
+layout: default
+title: How long /health stops answering while the daemon indexes
+permalink: /perf/daemon-health-latency/
+description: Internal working document. The width of the daemon's health-check starvation window, and what bounds it.
+noindex: true
+---
+
+# `/health` latency under an indexing burst (TRA-1127)
+
+`better-sqlite3` is synchronous. In a CLI that is fine; in the process that also answers the
+daemon's liveness check it means `/health` cannot be served while a batch is inside
+`sqlite3_step`. TRA-1127 caught the consequence on the production daemon (v3.22.0, 21 projects
+loaded): `/health` accepted the connection and never answered inside 5 s, at 99.3% CPU, with
+61.9% of main-thread samples inside synchronous `better-sqlite3`.
+
+That is worse than a slow endpoint. A session that cannot reach `/health` concludes the daemon
+is dead and falls back to indexing the repo itself, so a daemon that is *merely busy*
+manufactures N more indexers — the failure amplifies itself.
+
+## What actually sets the window
+
+`extractAndPersist` already yields one macrotask turn per persist batch, so a single project's
+starvation is bounded: measured at **293 ms max** for one project (1 817 files) reindexing
+725 files.
+
+What was not bounded is how many projects do that at once. Initial `indexAll` runs under a
+limiter (`indexer.parallel_initial_index`, default 2); watcher-driven `indexFiles` ran ungated,
+so every registered project could have a synchronous batch queued ahead of `/health`. The
+starvation window is therefore roughly *per-batch time × projects reindexing*, and it grows
+linearly with the number of registered projects — which is exactly the 21-project shape of the
+production report.
+
+## Measured
+
+`scripts/perf/daemon-health-latency.mjs`, macOS arm64, fixture = the pinned perf commit
+(`fc47c10f44eb`, 1 817 files / 9 705 symbols) extracted N times into separate temp roots, all
+registered at once. A probe hits `/health` every 100 ms throughout. The burst appends one new
+exported symbol to 725 source files **in every project** simultaneously and holds until the
+index settles.
+
+`/health` during the burst:
+
+| projects | arm | p50 | p95 | max | probes ≥ 2 s | burst window |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| 8 | before | 1 ms | 439 ms | 1 214 ms | 0 | 34.6 s |
+| 8 | after | 5 ms | 270 ms | **531 ms** | 0 | 35.8 s |
+| 16 | before | 1 ms | 660 ms | **2 550 ms** | 1 | 64.1 s |
+| 16 | after | 74 ms | 297 ms | **734 ms** | 0 | 74.1 s |
+
+Before the fix the worst-case doubles when the project count doubles (1 214 → 2 550 ms) and
+crosses the 2 s watchdog at 16 projects. After it, it stays in the same band (531 → 734 ms) —
+the queue depth is capped, not the project count.
+
+Initial indexing is unaffected (48 953 → 49 007 ms at N=16); it was already gated.
+
+## What it costs
+
+Catching up on 11 600 edited files across 16 repos takes **15% longer** (64.1 s → 74.1 s at
+N=16, 3.5% at N=8), and the median probe during the burst rises from 1 ms to 74 ms because the
+work is now spread over a longer window instead of stampeding. That is the trade: a bounded
+worst case in exchange for a slower bulk catch-up. It is the right side to be wrong on, because
+the failure the old shape produced was not "reindex is slow" but "every session decides the
+daemon is dead and starts its own indexer".
+
+## What this is not
+
+This does not move SQLite off the main thread; the per-batch synchronous stretch is unchanged.
+It bounds how many of those stretches can queue ahead of a health check. TRA-922 (move the
+write path off the event loop) remains the structural fix; this is the cap that keeps the
+symptom out of the 2 s watchdog until then.
+
+## Reproduction
+
+```bash
+pnpm run build
+node scripts/perf/daemon-health-latency.mjs --projects 16 --touch 900
+```
+
+Prints JSON: per-phase p50/p95/max `/health` latency and how many probes crossed 2 s. Every
+number is a reading; nothing here is modelled.

--- a/scripts/perf/daemon-health-latency.mjs
+++ b/scripts/perf/daemon-health-latency.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+/**
+ * TRA-1127 — how long does `/health` stop answering while the daemon indexes?
+ *
+ * The production symptom was a `/health` that accepted the connection and then
+ * never replied inside 5 s, at 99% CPU, with the main thread 62% inside
+ * synchronous `better-sqlite3`. A session that cannot reach `/health` concludes
+ * the daemon is dead and falls back to indexing the repo itself, so a merely
+ * busy daemon manufactures N independent indexers.
+ *
+ *   node scripts/perf/daemon-health-latency.mjs [--port 37419] [--touch 300]
+ *
+ * Phases (a probe hits `/health` every 100 ms throughout, 10 s timeout):
+ *   index — register the pinned fixture, poll until it is served
+ *   burst — touch `--touch` source files at once, poll until reindexed
+ *
+ * Prints JSON: per-phase p50/p95/max latency and how many probes exceeded the
+ * 2 s watchdog the desktop app uses. Every number is a reading.
+ */
+import { execFileSync, spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const args = process.argv.slice(2);
+const flag = (n, d) => {
+  const i = args.indexOf(`--${n}`);
+  return i >= 0 && args[i + 1] ? args[i + 1] : d;
+};
+const PORT = Number(flag('port', 37419));
+const TOUCH = Number(flag('touch', 300));
+const PROJECTS = Number(flag('projects', 1));
+const DAEMON = `http://127.0.0.1:${PORT}`;
+const repoRoot = path.resolve(import.meta.dirname, '..', '..');
+const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'tra1127-'));
+const ENV = {
+  ...process.env,
+  TRACE_MCP_DATA_DIR: DATA_DIR,
+  TRACE_MCP_HOME: DATA_DIR,
+  TRACE_MCP_AUTO_UPDATE: '0',
+  TRACE_MCP_NO_UPDATE_CHECK: '1',
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const log = (s) => process.stderr.write(`${s}\n`);
+const pct = (xs, p) =>
+  xs.length
+    ? xs.slice().sort((a, b) => a - b)[Math.min(xs.length - 1, Math.floor((xs.length - 1) * p))]
+    : null;
+
+function fixture() {
+  const pin = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, 'packages/app/scripts/perf-fixture.json'), 'utf8'),
+  );
+  // realpath: on macOS os.tmpdir() is a symlink and the watcher canonicalizes,
+  // so an uncanonicalized root silently receives no fs events. Extracting into
+  // a throwaway dir also keeps the fixture out of ~/.trace-mcp, which the
+  // watcher excludes.
+  const dirs = [];
+  for (let i = 0; i < PROJECTS; i++) {
+    const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'tra1127-fx-')));
+    execFileSync('/bin/sh', ['-c', `git archive ${pin.commit} | tar -x -C "${dir}"`], {
+      cwd: repoRoot,
+      stdio: 'inherit',
+    });
+    dirs.push(dir);
+  }
+  return dirs;
+}
+
+/** Background probe: one in-flight /health at a time, ~10/s, tagged by phase. */
+function startProbe(state) {
+  const samples = [];
+  let stop = false;
+  const loop = (async () => {
+    while (!stop) {
+      const t0 = performance.now();
+      let ok = false;
+      try {
+        const res = await fetch(`${DAEMON}/health`, { signal: AbortSignal.timeout(10_000) });
+        ok = res.ok;
+        await res.text();
+      } catch {
+        ok = false;
+      }
+      samples.push({ phase: state.phase, ms: performance.now() - t0, ok });
+      await sleep(100);
+    }
+  })();
+  return {
+    samples,
+    stop: async () => {
+      stop = true;
+      await loop;
+    },
+  };
+}
+
+function summarize(samples, phase) {
+  const xs = samples.filter((s) => s.phase === phase);
+  const ms = xs.map((s) => s.ms);
+  return {
+    probes: xs.length,
+    failed: xs.filter((s) => !s.ok).length,
+    over_2s: ms.filter((m) => m >= 2000).length,
+    p50_ms: Math.round(pct(ms, 0.5) ?? 0),
+    p95_ms: Math.round(pct(ms, 0.95) ?? 0),
+    max_ms: Math.round(Math.max(0, ...ms)),
+  };
+}
+
+async function req(method, pathname, body) {
+  const res = await fetch(DAEMON + pathname, {
+    method,
+    headers: body ? { 'content-type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(300_000),
+  });
+  if (!res.ok) throw new Error(`${method} ${pathname} -> ${res.status}`);
+  return res.json().catch(() => ({}));
+}
+
+async function totals(roots) {
+  const parts = await Promise.all(
+    roots.map((r) => indexedFiles(r).catch(() => ({ files: 0, symbols: 0, edges: 0 }))),
+  );
+  return parts.reduce(
+    (a, b) => ({
+      files: a.files + b.files,
+      symbols: a.symbols + b.symbols,
+      edges: a.edges + b.edges,
+    }),
+    { files: 0, symbols: 0, edges: 0 },
+  );
+}
+
+async function indexedFiles(root) {
+  const s = await req('GET', `/api/projects/stats?project=${encodeURIComponent(root)}`).catch(
+    () => null,
+  );
+  return s
+    ? { files: s.files ?? 0, symbols: s.symbols ?? 0, edges: s.edges ?? 0 }
+    : { files: 0, symbols: 0, edges: 0 };
+}
+
+let FIXTURES = [];
+
+async function main() {
+  const roots = fixture();
+  FIXTURES = roots;
+  const root = roots[0];
+  const cli = path.join(repoRoot, 'dist', 'cli.js');
+  if (!fs.existsSync(cli)) throw new Error(`missing ${cli} — pnpm run build first`);
+  const child = spawn(process.execPath, [cli, 'serve-http', '--port', String(PORT)], {
+    stdio: 'ignore',
+    cwd: DATA_DIR,
+    env: ENV,
+  });
+  const state = { phase: 'startup' };
+  let probe;
+  try {
+    const deadline = Date.now() + 60_000;
+    while (Date.now() < deadline) {
+      try {
+        if ((await fetch(`${DAEMON}/health`, { signal: AbortSignal.timeout(2000) })).ok) break;
+      } catch {}
+      await sleep(300);
+    }
+    probe = startProbe(state);
+
+    state.phase = 'index';
+    log(`registering ${roots.length} fixture copies…`);
+    const t0 = performance.now();
+    // All at once: the production report had 21 projects loaded, and what
+    // starves /health is the depth of the macrotask queue, not one project.
+    await Promise.all(roots.map((r) => req('POST', '/api/projects', { root: r })));
+    // Wait until the index settles: file count stops moving for 3 s.
+    let last = { files: -1 },
+      stable = 0;
+    while (stable < 3 && performance.now() - t0 < 300_000) {
+      await sleep(1000);
+      const n = await totals(roots).catch(() => last);
+      stable = n.files === last.files && n.files > 0 ? stable + 1 : 0;
+      last = n;
+    }
+    const indexMs = Math.round(performance.now() - t0);
+    log(`indexed ${last.files} files / ${last.symbols} symbols in ${indexMs} ms`);
+    await sleep(2000);
+
+    state.phase = 'burst';
+    log(`touching ${TOUCH} files…`);
+    const files = fs
+      .readdirSync(path.join(root, 'src'), { recursive: true, encoding: 'utf8' })
+      .filter((f) => f.endsWith('.ts') && !f.includes('__tests__'))
+      .slice(0, TOUCH);
+    const t1 = performance.now();
+    for (const r of roots)
+      for (const f of files) {
+        const p = path.join(r, 'src', f);
+        // A real new symbol per file — a comment-only edit is hash-different but
+        // adds nothing to `symbols`, so the settle check would never see the work.
+        fs.appendFileSync(p, `\nexport const tra1127Burst${t1 | 0} = ${Date.now()};\n`);
+      }
+    // Hold until the reindex is visibly done: symbol count moves and then
+    // settles for 5 s. A burst that never lands would measure nothing.
+    const symbolsBefore = last.symbols;
+    let bl = last,
+      bstable = 0,
+      moved = false;
+    while (performance.now() - t1 < 180_000) {
+      await sleep(1000);
+      const n = await totals(roots).catch(() => bl);
+      if (n.symbols !== bl.symbols || n.edges !== bl.edges) {
+        moved = true;
+        bstable = 0;
+      } else if (moved) bstable++;
+      bl = n;
+      if (moved && bstable >= 5) break;
+    }
+    const burstMs = Math.round(performance.now() - t1);
+    log(`burst settled after ${burstMs} ms (+${bl.symbols - symbolsBefore} symbols)`);
+
+    await probe.stop();
+    const out = {
+      version: JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')).version,
+      at: new Date().toISOString(),
+      projects: roots.length,
+      fixture: { root, ...last },
+      touched: files.length * roots.length,
+      burst_symbols_added: bl.symbols - symbolsBefore,
+      burst_observed: moved,
+      index_ms: indexMs,
+      burst_window_ms: burstMs,
+      phases: {
+        index: summarize(probe.samples, 'index'),
+        burst: summarize(probe.samples, 'burst'),
+      },
+    };
+    process.stdout.write(`${JSON.stringify(out, null, 2)}\n`);
+  } finally {
+    if (probe) await probe.stop().catch(() => {});
+    child.kill('SIGTERM');
+    await sleep(1500);
+    child.kill('SIGKILL');
+    if (!process.env.KEEP_DATA_DIR) fs.rmSync(DATA_DIR, { recursive: true, force: true });
+    else log(`data dir kept: ${DATA_DIR}`);
+    if (!process.env.KEEP_DATA_DIR)
+      for (const d of FIXTURES) fs.rmSync(d, { recursive: true, force: true });
+  }
+}
+
+main().catch((e) => {
+  log(String(e));
+  process.exit(1);
+});

--- a/src/daemon/__tests__/project-manager-watcher-concurrency.test.ts
+++ b/src/daemon/__tests__/project-manager-watcher-concurrency.test.ts
@@ -1,0 +1,118 @@
+/**
+ * TRA-1127: watcher-driven reindexes across projects were ungated, so every
+ * registered project could hold the main thread inside synchronous
+ * better-sqlite3 at the same time. Measured on the production daemon (21
+ * projects): `/health` accepted the connection and never answered inside 5 s,
+ * and a session that cannot reach `/health` falls back to indexing the repo
+ * itself — a busy daemon manufacturing N more indexers.
+ *
+ * The reproduction harness (`scripts/perf/daemon-health-latency.mjs`) shows the
+ * latency growing with the number of projects reindexing at once; this test
+ * pins the cap that bounds it, without needing a real daemon.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+type WatchCb = (paths: string[]) => Promise<void>;
+
+const watchCbs: WatchCb[] = [];
+let active = 0;
+let maxActive = 0;
+let completed = 0;
+
+vi.mock('../../indexer/pipeline.js', () => {
+  class FakeIndexingPipeline {
+    async indexAll() {
+      return { totalFiles: 0, indexed: 0, skipped: 0, errors: 0, durationMs: 0 };
+    }
+    async indexFiles(paths: string[]) {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      // One macrotask turn stands in for a batch's synchronous SQLite work.
+      await new Promise((r) => setTimeout(r, 10));
+      active--;
+      completed++;
+      return {
+        totalFiles: paths.length,
+        indexed: paths.length,
+        skipped: 0,
+        errors: 0,
+        durationMs: 1,
+      };
+    }
+    deleteFiles() {}
+    async dispose() {}
+  }
+  return { IndexingPipeline: FakeIndexingPipeline };
+});
+
+vi.mock('../../indexer/watcher.js', () => {
+  class FakeWatcher {
+    async start(_root: string, _config: unknown, onChange: WatchCb) {
+      watchCbs.push(onChange);
+    }
+    async restartWithExcludes() {}
+    async stop() {}
+  }
+  return { FileWatcher: FakeWatcher };
+});
+
+vi.mock('../../server/server.js', async (orig) => {
+  const real = (await orig()) as Record<string, unknown>;
+  return {
+    ...real,
+    createServer: () => ({ server: { close: async () => undefined }, dispose: () => undefined }),
+  };
+});
+
+let tmpHome: string;
+let pmRef: { shutdown(): Promise<void> } | undefined;
+
+beforeEach(() => {
+  watchCbs.length = 0;
+  active = 0;
+  maxActive = 0;
+  completed = 0;
+  tmpHome = mkdtempSync(join(tmpdir(), 'trace-mcp-watch-conc-'));
+  vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+  vi.resetModules();
+  pmRef = undefined;
+});
+
+afterEach(async () => {
+  if (pmRef) {
+    try {
+      await pmRef.shutdown();
+    } catch {
+      /* half-initialized manager may throw on shutdown */
+    }
+    pmRef = undefined;
+  }
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  rmSync(tmpHome, { recursive: true, force: true });
+}, 30_000);
+
+describe('ProjectManager watcher reindex concurrency (TRA-1127)', () => {
+  it('caps concurrent watcher reindexes across projects and still runs them all', async () => {
+    const { ProjectManager } = await import('../project-manager.js');
+    const pm = new ProjectManager();
+    pmRef = pm;
+
+    for (let i = 0; i < 8; i++) {
+      const dir = join(tmpHome, `repo-${i}`);
+      mkdirSync(dir, { recursive: true });
+      await pm.addProject(dir);
+    }
+    expect(watchCbs).toHaveLength(8);
+
+    // Every project's watcher fires at once — a bulk checkout, a wake from
+    // sleep, or eight agents editing eight repos.
+    await Promise.all(watchCbs.map((cb, i) => cb([join(tmpHome, `repo-${i}`, 'a.ts')])));
+
+    expect(completed).toBe(8);
+    expect(maxActive).toBeLessThanOrEqual(2);
+  }, 30_000);
+});

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -166,9 +166,16 @@ export class ProjectManager {
    *  worker thread count regardless of project count. Lazy-init on the first
    *  addProject() so we can read the project's config for sizing. */
   private sharedPool: ExtractPool | null = null;
-  /** Configurable cap on concurrent initial indexAll() calls. Watcher-driven
-   *  indexFiles() is NOT gated. Lazy-init alongside sharedPool. */
+  /** Configurable cap on concurrent initial indexAll() calls. Lazy-init
+   *  alongside sharedPool. */
   private indexAllLimit: ReturnType<typeof pLimit> | null = null;
+  /** TRA-1127: same cap for watcher-driven reindexes, on its own limiter so a
+   *  file edit never queues behind another project's full initial index.
+   *  Ungated, N projects reindexing at once put N synchronous SQLite batches
+   *  ahead of `/health` in the macrotask queue — measured at 21 projects as a
+   *  `/health` that never answered inside 5 s, which makes every session
+   *  conclude the daemon is dead and index the repo itself. */
+  private watcherIndexLimit: ReturnType<typeof pLimit> | null = null;
   /** Optional shared TopologyStore/DecisionStore pool. When provided,
    *  stopProject() force-disposes the project's pool entry so the SQLite
    *  handles plus their in-memory state don't leak across the daemon's
@@ -199,6 +206,9 @@ export class ProjectManager {
     }
     if (!this.indexAllLimit) {
       this.indexAllLimit = pLimit(config.indexer?.parallel_initial_index ?? 2);
+    }
+    if (!this.watcherIndexLimit) {
+      this.watcherIndexLimit = pLimit(config.indexer?.parallel_initial_index ?? 2);
     }
   }
 
@@ -662,7 +672,10 @@ export class ProjectManager {
             | undefined;
           let watchErr: unknown;
           try {
-            result = await pipeline.indexFiles(toIndex);
+            // Fall through ungated if the limiter is gone (shutdown cleared it
+            // while an event was in flight) — the batch still has to run.
+            const gate = this.watcherIndexLimit ?? ((fn: () => Promise<unknown>) => fn());
+            result = (await gate(() => pipeline.indexFiles(toIndex))) as typeof result;
           } catch (err) {
             watchErr = err;
             throw err;
@@ -748,7 +761,11 @@ export class ProjectManager {
           // the index silently stale. indexAll() re-walks the root and is
           // hash-gated, so unchanged files cost a stat+hash, not a reparse.
           onRescan: async () => {
-            await pipeline.indexAll();
+            // Gated too: a wake from sleep or a bulk checkout drops events for
+            // every project at once, so every rescan would otherwise start
+            // together.
+            const gate = this.indexAllLimit ?? ((fn: () => Promise<unknown>) => fn());
+            await gate(() => pipeline.indexAll());
           },
         },
       );
@@ -1207,6 +1224,7 @@ export class ProjectManager {
       this.sharedPool = null;
     }
     this.indexAllLimit = null;
+    this.watcherIndexLimit = null;
     logger.info('ProjectManager shutdown complete');
   }
 


### PR DESCRIPTION
Fixes TRA-1127.

## The defect

The production daemon (v3.22.0, 21 projects) accepted a `/health` connection and never answered
inside 5 s, at 99.3% CPU with 61.9% of main-thread samples inside synchronous `better-sqlite3`.
A session that cannot reach `/health` concludes the daemon is dead and falls back to indexing the
repo itself — so a daemon that is *merely busy* manufactures N more indexers. The failure
amplifies itself.

## What actually sets the window

`extractAndPersist` already yields one macrotask turn per persist batch, so **one** project is
bounded: 293 ms max, measured. What was ungated is how many projects do that at once. Initial
`indexAll` runs under a limiter (`indexer.parallel_initial_index`, default 2); watcher-driven
`indexFiles` did not, so the starvation window is per-batch time × projects reindexing and grows
linearly with the project count — the 21-project shape of the report. Watcher rescans (wake from
sleep, bulk checkout) fired every project's `indexAll` simultaneously for the same reason.

## The change

Both paths now run under a limiter sized by `indexer.parallel_initial_index`. Watcher reindexes
get their own limiter so a file edit never queues behind another project's full initial index.
If the limiter is gone (shutdown cleared it mid-event) the batch still runs, ungated.

## Evidence

New harness `scripts/perf/daemon-health-latency.mjs` — N fixture copies registered at once, a
probe on `/health` every 100 ms, a burst of 725 new symbols per project. `/health` during the burst:

| projects | arm | p95 | max | probes ≥ 2 s |
| --- | --- | ---: | ---: | ---: |
| 8 | before | 439 ms | 1 214 ms | 0 |
| 8 | after | 270 ms | **531 ms** | 0 |
| 16 | before | 660 ms | **2 550 ms** | 1 |
| 16 | after | 297 ms | **734 ms** | 0 |

Before, the worst case doubles when the project count doubles and crosses the 2 s watchdog at 16.
After, it stays in the same band.

**Cost, stated plainly:** the bulk catch-up of 11 600 edited files across 16 repos takes 15%
longer (64.1 s → 74.1 s; 3.5% at N=8), and the median probe during the burst rises from 1 ms to
74 ms because the work is spread instead of stampeding. Initial indexing is unchanged
(48 953 → 49 007 ms at N=16).

`src/daemon/__tests__/project-manager-watcher-concurrency.test.ts` pins the cap without a real
daemon: 8 projects fire their watchers at once, all 8 batches complete, max in-flight ≤ 2. It
fails on the pre-fix code (`expected 8 to be less than or equal to 2`).

## What this is not

It does not move SQLite off the main thread; the per-batch synchronous stretch is unchanged.
TRA-922 remains the structural fix. This bounds how many of those stretches queue ahead of a
health check, which is what keeps the symptom out of the 2 s watchdog until then.

Full suite: 10 649 passed, 40 skipped. Typecheck and biome clean.
