### PR TITLE
fix(launcher): require a non-empty cli.js before exec (TRA-1132)

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.6.8 (Windows)
+REM trace-mcp-launcher v0.6.9 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.6.8 (Windows)
+# trace-mcp-launcher v0.6.9 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.
@@ -160,10 +160,20 @@ function Test-RuntimeShim {
     return (Test-Path -LiteralPath $target -PathType Leaf)
 }
 
+# `Length -gt 0`, not merely "the file is there" (TRA-1132). Test-NodeBinary
+# above closed "exists but does not run" for node; this is the same class on
+# the other half of the pair. A zero-byte dist/cli.js - what a disk-full write,
+# an unclean shutdown or a half-restored backup leaves behind - is a valid
+# empty program to node: exit 0, no output, no stderr. The client sees a server
+# that starts, says nothing and leaves; the shim logs no ERROR because its own
+# launch worked; and the pair is already in launcher.env, so every later start
+# repeats it.
 function Test-CliFile {
     param([string]$Path)
     if (-not $Path) { return $false }
-    return (Test-Path -LiteralPath $Path -PathType Leaf)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $false }
+    $item = Get-Item -LiteralPath $Path -ErrorAction SilentlyContinue
+    return ($null -ne $item -and $item.Length -gt 0)
 }
 
 # Persist a probed (or freshly verified) pair so the next start takes the fast path.
@@ -404,7 +414,7 @@ function Find-Cli {
     $roots = @(Get-PkgRoots $NodeExe)
     foreach ($r in $roots) {
         $c = Join-Path $r 'trace-mcp\dist\cli.js'
-        if (Test-Path -LiteralPath $c -PathType Leaf) {
+        if (Test-CliFile $c) {
             return (Resolve-Path -LiteralPath $c).Path
         }
     }
@@ -422,7 +432,7 @@ function Find-Cli {
                Sort-Object @{ Expression = { if ($_.Name -like 'trace-mcp.tmcp-bak-*') { 0 } else { 1 } } },
                            @{ Expression = 'LastWriteTime'; Descending = $true } |
                ForEach-Object { Join-Path $_.FullName 'dist\cli.js' } |
-               Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
+               Where-Object { Test-CliFile $_ } |
                Select-Object -First 1
         if ($bak) { return (Resolve-Path -LiteralPath $bak).Path }
     }

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -140,6 +140,30 @@ if [ -n "${TRACE_MCP_CLI_OVERRIDE:-}"  ]; then CLI_PATH="$TRACE_MCP_CLI_OVERRIDE
 
 # --- 4. Probe fallback (stable sources only, no version globs) ---
 
+# True for a script this shim can actually hand to node: a regular file with
+# something in it.
+#
+# Both halves are load-bearing. `-f` alone was the TRA-1132 bug: it accepts a
+# zero-byte dist/cli.js, which node runs as a valid empty program — exit 0, no
+# output, no stderr — so the client sees a server that starts, says nothing and
+# leaves, the shim logs no ERROR because its own exec worked, and the pair is
+# already healed into launcher.env so every later start repeats it.
+#
+# `-s` alone reintroduces a different hole: it means "exists and size > 0",
+# which a DIRECTORY satisfies (review of #1097). A stray `dist/cli.js`
+# directory — the same half-restored-backup class this gate exists for, just
+# in another shape — would then be accepted and exec'd instead of falling
+# through to probe_cli, the swap-window backup and the app bundle, which is
+# the fallback chain this whole path exists to keep reliable.
+#
+# ponytail: this catches truncation to zero, the shape an interrupted write
+# actually leaves. A non-empty but incomplete bundle still gets exec'd —
+# detecting that needs a parse, i.e. a fork on every client start, and there
+# the exec itself is the cheaper detector.
+is_usable_script() {
+  [ -f "$1" ] && [ -s "$1" ]
+}
+
 # True for a value `[ -lt ]` can safely compare. Digits alone are not enough:
 # a long-but-numeric string makes bash arithmetic abort with "integer
 # expression expected", the test fails, and the gate would fail OPEN. Three
@@ -335,7 +359,7 @@ cli_from_app_bundle() {
   local app cli
   app=$(app_bundle) || return 1
   cli="$app/Contents/Resources/server/dist/cli.js"
-  [ -s "$cli" ] && normalise_path "$cli"
+  is_usable_script "$cli" && normalise_path "$cli"
 }
 
 # True when $1 is the app's own binary, which only runs as Node with this set.
@@ -490,7 +514,7 @@ probe_cli() {
   while IFS= read -r root; do
     [ -n "$root" ] || continue
     cli="$root/trace-mcp/dist/cli.js"
-    if [ -s "$cli" ]; then
+    if is_usable_script "$cli"; then
       normalise_path "$cli"
       return 0
     fi
@@ -519,7 +543,7 @@ probe_cli() {
       [ -n "$group" ] || continue
       while IFS= read -r bak; do
         [ -n "$bak" ] || continue
-        if [ -s "$bak/dist/cli.js" ]; then
+        if is_usable_script "$bak/dist/cli.js"; then
           normalise_path "$bak/dist/cli.js"
           return 0
         fi
@@ -631,7 +655,7 @@ resolve_exec_target() {
   local cli="$1" proxy
   shift
   proxy="$(dirname "$cli")/proxy.js"
-  if [ -s "$proxy" ] && is_plain_serve "$@" && daemon_port_open; then
+  if is_usable_script "$proxy" && is_plain_serve "$@" && daemon_port_open; then
     echo "$proxy"
   else
     echo "$cli"
@@ -683,26 +707,7 @@ if [ "$USING_NODE_OVERRIDE" = 0 ] && [ -n "$NODE_PATH" ] && [ -x "$NODE_PATH" ];
   fi
 fi
 
-# `-s`, not `-f`, on every cli.js gate in this shim (TRA-1132).
-#
-# The gate above closed "exists but does not run" for node. This is the same
-# class on the other half of the pair: `-f` proves the recorded dist/cli.js is
-# there, never that it holds a program, and a zero-byte one is what a disk-full
-# write, an unclean shutdown or a half-restored backup leaves behind.
-#
-# It fails worse than the node case, because node runs an empty file happily —
-# exit 0, no output, no stderr. The client sees a server that starts, says
-# nothing and leaves, and reports "failed to connect" with nothing to go on;
-# the shim logs no ERROR, because its own exec worked, so the launcher.log
-# error count reads clean while every session dies; and the pair was already
-# healed into the config, so every later start repeats it. Reproduced with a
-# complete copy of the package sitting unused in the same npm prefix.
-#
-# ponytail: `-s` catches truncation to zero, which is the shape an interrupted
-# write actually leaves. A non-empty but incomplete bundle still gets exec'd —
-# detecting that needs a parse, i.e. a fork on every start, and there the exec
-# itself is the cheaper detector.
-if [ -n "$NODE_PATH" ] && [ -x "$NODE_PATH" ] && [ -n "$CLI_PATH" ] && [ -s "$CLI_PATH" ]; then
+if [ -n "$NODE_PATH" ] && [ -x "$NODE_PATH" ] && [ -n "$CLI_PATH" ] && is_usable_script "$CLI_PATH"; then
   EXEC_TARGET=$(resolve_exec_target "$CLI_PATH" "$@")
   log "exec(config) node=$NODE_PATH cli=$CLI_PATH target=$EXEC_TARGET argc=$#"
   PATH="$CLIENT_PATH"
@@ -724,7 +729,7 @@ if [ -z "$NODE_PATH" ] || [ ! -x "$NODE_PATH" ]; then
   HEALED=1
 fi
 
-if [ -z "$CLI_PATH" ] || [ ! -s "$CLI_PATH" ]; then
+if [ -z "$CLI_PATH" ] || ! is_usable_script "$CLI_PATH"; then
   ROOTS=$(pkg_roots "$NODE_PATH")
   CLI_PATH=$(probe_cli "$ROOTS") || die "trace-mcp package not found in any known npm prefix — run: npm i -g trace-mcp && trace-mcp init"
   log "probe: cli=$CLI_PATH"

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.6.8
+# trace-mcp-launcher v0.6.9
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -335,7 +335,7 @@ cli_from_app_bundle() {
   local app cli
   app=$(app_bundle) || return 1
   cli="$app/Contents/Resources/server/dist/cli.js"
-  [ -f "$cli" ] && normalise_path "$cli"
+  [ -s "$cli" ] && normalise_path "$cli"
 }
 
 # True when $1 is the app's own binary, which only runs as Node with this set.
@@ -490,7 +490,7 @@ probe_cli() {
   while IFS= read -r root; do
     [ -n "$root" ] || continue
     cli="$root/trace-mcp/dist/cli.js"
-    if [ -f "$cli" ]; then
+    if [ -s "$cli" ]; then
       normalise_path "$cli"
       return 0
     fi
@@ -519,7 +519,7 @@ probe_cli() {
       [ -n "$group" ] || continue
       while IFS= read -r bak; do
         [ -n "$bak" ] || continue
-        if [ -f "$bak/dist/cli.js" ]; then
+        if [ -s "$bak/dist/cli.js" ]; then
           normalise_path "$bak/dist/cli.js"
           return 0
         fi
@@ -631,7 +631,7 @@ resolve_exec_target() {
   local cli="$1" proxy
   shift
   proxy="$(dirname "$cli")/proxy.js"
-  if [ -f "$proxy" ] && is_plain_serve "$@" && daemon_port_open; then
+  if [ -s "$proxy" ] && is_plain_serve "$@" && daemon_port_open; then
     echo "$proxy"
   else
     echo "$cli"
@@ -683,7 +683,26 @@ if [ "$USING_NODE_OVERRIDE" = 0 ] && [ -n "$NODE_PATH" ] && [ -x "$NODE_PATH" ];
   fi
 fi
 
-if [ -n "$NODE_PATH" ] && [ -x "$NODE_PATH" ] && [ -n "$CLI_PATH" ] && [ -f "$CLI_PATH" ]; then
+# `-s`, not `-f`, on every cli.js gate in this shim (TRA-1132).
+#
+# The gate above closed "exists but does not run" for node. This is the same
+# class on the other half of the pair: `-f` proves the recorded dist/cli.js is
+# there, never that it holds a program, and a zero-byte one is what a disk-full
+# write, an unclean shutdown or a half-restored backup leaves behind.
+#
+# It fails worse than the node case, because node runs an empty file happily —
+# exit 0, no output, no stderr. The client sees a server that starts, says
+# nothing and leaves, and reports "failed to connect" with nothing to go on;
+# the shim logs no ERROR, because its own exec worked, so the launcher.log
+# error count reads clean while every session dies; and the pair was already
+# healed into the config, so every later start repeats it. Reproduced with a
+# complete copy of the package sitting unused in the same npm prefix.
+#
+# ponytail: `-s` catches truncation to zero, which is the shape an interrupted
+# write actually leaves. A non-empty but incomplete bundle still gets exec'd —
+# detecting that needs a parse, i.e. a fork on every start, and there the exec
+# itself is the cheaper detector.
+if [ -n "$NODE_PATH" ] && [ -x "$NODE_PATH" ] && [ -n "$CLI_PATH" ] && [ -s "$CLI_PATH" ]; then
   EXEC_TARGET=$(resolve_exec_target "$CLI_PATH" "$@")
   log "exec(config) node=$NODE_PATH cli=$CLI_PATH target=$EXEC_TARGET argc=$#"
   PATH="$CLIENT_PATH"
@@ -705,7 +724,7 @@ if [ -z "$NODE_PATH" ] || [ ! -x "$NODE_PATH" ]; then
   HEALED=1
 fi
 
-if [ -z "$CLI_PATH" ] || [ ! -f "$CLI_PATH" ]; then
+if [ -z "$CLI_PATH" ] || [ ! -s "$CLI_PATH" ]; then
   ROOTS=$(pkg_roots "$NODE_PATH")
   CLI_PATH=$(probe_cli "$ROOTS") || die "trace-mcp package not found in any known npm prefix — run: npm i -g trace-mcp && trace-mcp init"
   log "probe: cli=$CLI_PATH"

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -112,4 +112,4 @@ export const MIRROR_HOOK_VERSION = '0.3.0';
 // 0.6.0 (TRA-755): the resolved node is version-gated against engines.node. An
 // older one used to exec fine and die on a SyntaxError the client could only
 // report as "failed to connect" — and get pinned into launcher.env on the way.
-export const LAUNCHER_VERSION = '0.6.8';
+export const LAUNCHER_VERSION = '0.6.9';

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -772,6 +772,27 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
         expect(status).toBe(0);
         expect(stdout.trim()).toBe(`NODE_ARGS:${backup} serve`);
       });
+
+      // Review of #1097: the first cut of this gate used `[ -s ]` alone, which
+      // means "exists and size > 0" — and a directory satisfies that (verified:
+      // an empty dir reports size 64 on APFS). So a stray `cli.js` directory,
+      // the same half-restored-backup class the gate exists for in another
+      // shape, would have been accepted and exec'd instead of falling through
+      // to the backup. `is_usable_script` needs both halves.
+      it('reprobes when the configured cli.js is a directory', () => {
+        const { home, traceHome, node } = setupFakeHome();
+        const asDir = path.join(home, 'cli.js');
+        fs.mkdirSync(asDir);
+        writeConfig(traceHome, node, asDir);
+        const good = plantNvmPackage(home);
+
+        const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, [
+          'serve',
+        ]);
+
+        expect(status).toBe(0);
+        expect(stdout.trim()).toBe(`NODE_ARGS:${good} serve`);
+      });
     });
 
     it('finds the package in a bundled runtime prefix recorded by a past install', () => {

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -712,6 +712,66 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
         );
         expect(fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8')).toContain('ERROR');
       });
+
+      // TRA-1132: the same class as the two cases above, on the other half of
+      // the pair. `[ -f ]` proves the recorded cli.js exists, never that it
+      // holds a program — and a zero-byte dist/cli.js is what a disk-full
+      // write, an unclean shutdown or a botched restore leaves behind.
+      //
+      // Worse than the node case, because node runs an empty file happily:
+      // exit 0, no output, no stderr. The MCP client sees a server that
+      // starts, says nothing and leaves, so it reports "failed to connect"
+      // with nothing to go on; the shim logs no ERROR (its own exec worked),
+      // so the launcher.log error count reads clean while every session dies;
+      // and the config still pins the dead path, so every later start repeats
+      // it. Reproduced with a complete copy of the package sitting unused in
+      // the same prefix.
+      it('reprobes when the configured cli.js exists but is empty', () => {
+        const { home, traceHome, node } = setupFakeHome();
+        const empty = path.join(home, 'empty-cli.js');
+        fs.writeFileSync(empty, '');
+        writeConfig(traceHome, node, empty);
+        const good = plantNvmPackage(home);
+
+        const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, [
+          'serve',
+        ]);
+
+        // Only the cli is replaced — the configured node still runs.
+        expect(status).toBe(0);
+        expect(stdout.trim()).toBe(`NODE_ARGS:${good} serve`);
+        const cfg = fs.readFileSync(path.join(traceHome, 'launcher.env'), 'utf-8');
+        expect(cfg).toContain(`TRACE_MCP_CLI="${good}"`);
+        expect(cfg).not.toContain(empty);
+      });
+
+      // The probe has to apply the same rule, or the gate above just moves the
+      // failure one step later: an update that truncated dist/cli.js in the
+      // live package directory would be picked straight back up, and the
+      // complete copy the updater renamed aside would go unused.
+      it('probe skips an empty package cli.js and falls back to the swap-window backup', () => {
+        const { home, traceHome, node } = setupFakeHome();
+        const root = path.join(home, 'prefix', 'lib', 'node_modules');
+        fs.mkdirSync(path.join(root, 'trace-mcp', 'dist'), { recursive: true });
+        fs.writeFileSync(path.join(root, 'trace-mcp', 'dist', 'cli.js'), '');
+        fs.mkdirSync(path.join(root, 'trace-mcp.tmcp-bak-4242', 'dist'), { recursive: true });
+        fs.writeFileSync(
+          path.join(root, 'trace-mcp.tmcp-bak-4242', 'dist', 'cli.js'),
+          '// complete previous build\n',
+        );
+        const backup = fs.realpathSync(
+          path.join(root, 'trace-mcp.tmcp-bak-4242', 'dist', 'cli.js'),
+        );
+        fs.writeFileSync(path.join(traceHome, 'pkg-roots'), `${root}\n`);
+        writeConfig(traceHome, node, path.join(home, 'gone', 'cli.js'));
+
+        const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, [
+          'serve',
+        ]);
+
+        expect(status).toBe(0);
+        expect(stdout.trim()).toBe(`NODE_ARGS:${backup} serve`);
+      });
     });
 
     it('finds the package in a bundled runtime prefix recorded by a past install', () => {


### PR DESCRIPTION
## Problem

`TRA-1040` closed "the recorded node exists but no longer runs" — `[ -x ]` proves a
path is there, never that it works. The same hole was still open on the other half
of the pair: every `cli.js` gate in the launcher used `[ -f ]`.

A zero-byte `dist/cli.js` — what a disk-full write, an unclean shutdown, or a
half-restored backup leaves behind — fails worse than the node case, because node
runs an empty file happily:

- **exit 0, no output, no stderr.** The MCP client sees a server that starts, says
  nothing, and leaves. It reports `failed to connect` with nothing to go on.
- **No `ERROR` line in `launcher.log`** — from the shim's own side the exec
  succeeded. The launcher error count reads clean while every session dies, so the
  metric we monitor this path with cannot see it.
- **The pair is already healed into `launcher.env`**, so every later start repeats
  it — for the rest of the machine's life, not just the session.

Reproduced on this machine against the installed shim, with a complete copy of the
package sitting unused in the same npm prefix.

## Fix

`[ -s ]` instead of `[ -f ]` on every `cli.js` / `proxy.js` gate, both platforms:

- `hooks/trace-mcp-launcher.sh` — fast path, section-5 gate, `probe_cli`'s primary
  and swap-window-backup lookups, `cli_from_app_bundle`, `resolve_exec_target`.
- `hooks/trace-mcp-launcher.ps1` — `Test-CliFile` gains a `Length -gt 0` check, and
  `Find-Cli`'s two lookups now route through it. Without the second half the gate
  just moves the failure one step later: an update that truncated the live
  `dist/cli.js` would be picked straight back up and the complete copy the updater
  renamed aside would go unused.

Launcher version 0.6.8 → 0.6.9.

**Known ceiling** (marked with a `ponytail:` comment in the shim): `-s` catches
truncation to zero, which is the shape an interrupted write actually leaves. A
non-empty but incomplete bundle still gets exec'd — detecting that needs a parse,
i.e. a fork on every client start, and there the exec itself is the cheaper
detector.

## Tests

Two cases in `tests/init/launcher-integration.test.ts`, next to the TRA-1040 node
block, both verified failing before the change:

- fast path reprobes past an empty configured `cli.js`, heals `launcher.env` to the
  working copy, and leaves the node alone;
- `probe_cli` skips an empty package `cli.js` and falls back to the swap-window
  backup.

Full suite green (10 654 passed), `tsc --noEmit` and `pnpm run build` clean.
The end-to-end repro against the real installed shim now serves the backup and
answers normally instead of exiting silently.

Closes TRA-1132.

Agent: Lead Engineer
