### PR TITLE
test(daemon): close the guard's SQLite handles so Windows can clean up (TRA-1127)

### DIFF
--- a/tests/daemon/health-starvation.test.ts
+++ b/tests/daemon/health-starvation.test.ts
@@ -115,34 +115,47 @@ describe('real indexing load: many projects at once', () => {
   });
 
   afterAll(() => {
-    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    fs.rmSync(tmpRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
   });
 
-  function makePipeline(root: string, dbName: string): IndexingPipeline {
+  /** The DB handle comes back with the pipeline because `dispose()` does not
+   *  close it — in the daemon that is the caller's job, and a test that skips
+   *  it leaves ten open SQLite files per arm. POSIX unlinks them anyway;
+   *  Windows fails the whole suite with `EBUSY ... unlink conc.db`. */
+  function makePipeline(
+    root: string,
+    dbName: string,
+  ): { pipeline: IndexingPipeline; close: () => void } {
     const db = initializeDatabase(path.join(root, dbName));
-    return new IndexingPipeline(
-      new Store(db),
-      PluginRegistry.createWithDefaults(),
-      TraceMcpConfigSchema.parse({ root }),
-      root,
-    );
+    return {
+      pipeline: new IndexingPipeline(
+        new Store(db),
+        PluginRegistry.createWithDefaults(),
+        TraceMcpConfigSchema.parse({ root }),
+        root,
+      ),
+      close: () => db.close(),
+    };
   }
 
   async function delayIndexing(
     dbName: string,
     mode: 'concurrent' | 'sequential',
   ): Promise<{ max: number; p99: number }> {
-    const pipelines = roots.map((r) => makePipeline(r, dbName));
+    const made = roots.map((r) => makePipeline(r, dbName));
     try {
       return await loopDelayDuring(async () => {
         if (mode === 'concurrent') {
-          await Promise.all(pipelines.map((p) => p.indexAll(false)));
+          await Promise.all(made.map((m) => m.pipeline.indexAll(false)));
         } else {
-          for (const p of pipelines) await p.indexAll(false);
+          for (const m of made) await m.pipeline.indexAll(false);
         }
       });
     } finally {
-      for (const p of pipelines) await p.dispose();
+      for (const m of made) {
+        await m.pipeline.dispose();
+        m.close();
+      }
     }
   }
 


### PR DESCRIPTION
Second half of the same red master as #1098. On Windows the real-load case in
`tests/daemon/health-starvation.test.ts` failed as a **suite error**, not an assertion — the p99
comparison passed there (`sequential=171.3ms concurrent=144.3ms`):

```
Error: EBUSY: resource busy or locked, unlink 'C:\...\tra1127-.../proj0/conc.db'
```

`IndexingPipeline.dispose()` deliberately does not close the store — in the daemon that is
`stopProject`'s job — so the case left ten open SQLite files per arm. POSIX unlinks an open file
happily; Windows refuses and fails the whole suite. `makePipeline` now hands the db handle back
and the `finally` closes it after `dispose()`, and `afterAll`'s `rmSync` gets retries for the same
class of lag.

Failed on master at 4e9b1b92 and again on #1098's run, both with the same path — it is not
intermittent on Windows, it is every run.

Test-only. Local: 3 passed (`loop delay p99: sequential=27.9ms concurrent=24.9ms`).
