### PR TITLE
fix(registry): route unregistered one-shot workdirs at the ephemeral index dir (TRA-1136)

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -142,6 +142,56 @@ export const INDEX_DIR = path.join(TRACE_MCP_HOME, 'index');
  */
 export const EPHEMERAL_INDEX_DIR = path.join(INDEX_DIR, 'ephemeral');
 
+/**
+ * Path shape Multica's `repo checkout` uses for one-shot agent-run workdirs:
+ * `.../multica_workspaces_<host>/<workspace-id>/<run-id>/workdir`. Each task
+ * run gets a brand-new directory, so a project matching this shape is queried
+ * exactly once, for the lifetime of that single run, and never touched again.
+ *
+ * TRA-527: the run directory is the container, not the project root — `repo
+ * checkout` clones into `workdir/<repo>`, and a monorepo package sits deeper
+ * still. Anchoring on `workdir$` therefore missed every root an agent actually
+ * opens, and those leaked back into registry.json (three on the reported
+ * machine within hours of TRA-396 shipping). Nothing below a run's workdir
+ * outlives the run, so match the whole subtree.
+ */
+const EPHEMERAL_WORKDIR_PATTERN =
+  /[/\\]multica_workspaces[^/\\]*[/\\][^/\\]+[/\\][^/\\]+[/\\]workdir([/\\]|$)/i;
+
+/**
+ * The same runtime's other one-shot layout: a task given a scratch directory
+ * instead of a workspace checkout lands in `<tmp>/multica-task-<run-id>/...`.
+ * `EPHEMERAL_WORKDIR_PATTERN` above never matched those, so each was persisted
+ * like a real project — 17 of the 37 rows in the reported registry.json, all
+ * dead within the hour, each pinning a `.config.json` section for the full
+ * 7-day `sweepMissingRoots` grace (TRA-992).
+ *
+ * The container is matched, not the leaf: a run drops several roots under it
+ * (its own scratch dirs, benchmark fixtures) and none outlive the run. The
+ * numeric run id keeps this off a user directory that merely says
+ * "multica-task".
+ *
+ * Note for tests: such a runtime also exports TMPDIR as its own task
+ * directory, so `os.tmpdir()` itself can match this. A fixture that must stay
+ * persistent has to be built outside it — see `tmpRootOutsideTaskDir` in
+ * tests/test-utils.ts.
+ */
+const EPHEMERAL_TASK_DIR_PATTERN = /[/\\]multica-task-\d+[/\\]/i;
+
+/**
+ * True when `root` is a one-shot agent-run checkout, in either layout the
+ * runtime uses (see {@link EPHEMERAL_WORKDIR_PATTERN} and
+ * {@link EPHEMERAL_TASK_DIR_PATTERN}). Such roots are never persisted to
+ * registry.json — see the `_ephemeralEntries` note in registry.ts.
+ *
+ * Lives here rather than in registry.ts (which re-exports it) because
+ * {@link getDbPath} needs it, and global.ts must stay import-free.
+ */
+export function isEphemeralProjectRoot(root: string): boolean {
+  const abs = path.resolve(root);
+  return EPHEMERAL_WORKDIR_PATTERN.test(abs) || EPHEMERAL_TASK_DIR_PATTERN.test(abs);
+}
+
 /** Global project registry. */
 export const REGISTRY_PATH = path.join(TRACE_MCP_HOME, 'registry.json');
 
@@ -456,21 +506,19 @@ export function getSnapshotPath(projectRoot: string): string {
  * `resolveDbPath()` helper across `src/cli/*.ts`), so this function only ever
  * actually runs for a root that isn't registered yet — i.e. exactly the
  * "first checkout of this repo, or a non-git / remote-less project" case.
+ *
+ * TRA-1136: which is also why the ephemeral-subdir choice belongs here and not
+ * only in `registerProject`. A one-shot workdir's registry entry is
+ * process-local (`_ephemeralEntries`), so every *other* process — and every
+ * code path that never registers at all, notably `ProjectManager.addProject`
+ * with `persist: false` — fell through to a plain `INDEX_DIR` path and created
+ * a DB no sweep could ever reach. That is the 818 MB / 250-file orphan pile;
+ * routing on the path shape makes the two agree without a registry lookup.
  */
 export function getDbPath(projectRoot: string): string {
   const absRoot = path.resolve(projectRoot);
-  return path.join(INDEX_DIR, `${projectName(absRoot)}-${projectHash(absRoot)}.db`);
-}
-
-/**
- * Same as {@link getDbPath} but under {@link EPHEMERAL_INDEX_DIR}. Used for
- * one-shot agent-run checkouts that couldn't share a canonical sibling's DB,
- * so the leftover is collectable by age instead of sitting in the main index
- * dir forever with no registry row to explain it (TRA-396).
- */
-export function getEphemeralDbPath(projectRoot: string): string {
-  const absRoot = path.resolve(projectRoot);
-  return path.join(EPHEMERAL_INDEX_DIR, `${projectName(absRoot)}-${projectHash(absRoot)}.db`);
+  const dir = isEphemeralProjectRoot(absRoot) ? EPHEMERAL_INDEX_DIR : INDEX_DIR;
+  return path.join(dir, `${projectName(absRoot)}-${projectHash(absRoot)}.db`);
 }
 
 /**

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -9,8 +9,8 @@ import {
   ensureGlobalDirs,
   EPHEMERAL_INDEX_DIR,
   getDbPath,
-  getEphemeralDbPath,
   getProjectRemoteIdentity,
+  isEphemeralProjectRoot,
   projectName,
   REGISTRY_PATH,
 } from './global.js';
@@ -296,12 +296,10 @@ export function registerProject(
   // path (TRA-396 item 2): `listProjects()` no longer returns other ephemeral
   // checkouts, so the only match a workdir can find is the canonical project,
   // and twenty checkouts of one repo resolve to one index instead of twenty.
+  // TRA-1136: `getDbPath` routes an ephemeral root to EPHEMERAL_INDEX_DIR on
+  // its own, so this no longer needs a separate branch for it.
   const shareWithSibling = sibling ? claimSharedDb(sibling.dbPath, absRoot) : false;
-  const dbPath = shareWithSibling
-    ? sibling!.dbPath
-    : ephemeral
-      ? getEphemeralDbPath(absRoot)
-      : getDbPath(absRoot);
+  const dbPath = shareWithSibling ? sibling!.dbPath : getDbPath(absRoot);
   try {
     if (!shareWithSibling) announceDbHolder(dbPath, absRoot);
   } catch {
@@ -622,52 +620,11 @@ export function findUnregisteredNestedRepos(maxDepth = 4): UnregisteredNestedRep
   return results;
 }
 
-/**
- * Path shape Multica's `repo checkout` uses for one-shot agent-run workdirs:
- * `.../multica_workspaces_<host>/<workspace-id>/<run-id>/workdir`. Each task
- * run gets a brand-new directory, so a project matching this shape is queried
- * exactly once, for the lifetime of that single run, and never touched again.
- *
- * TRA-527: the run directory is the container, not the project root — `repo
- * checkout` clones into `workdir/<repo>`, and a monorepo package sits deeper
- * still. Anchoring on `workdir$` therefore missed every root an agent actually
- * opens, and those leaked back into registry.json (three on the reported
- * machine within hours of TRA-396 shipping). Nothing below a run's workdir
- * outlives the run, so match the whole subtree.
- */
-const EPHEMERAL_WORKDIR_PATTERN =
-  /[/\\]multica_workspaces[^/\\]*[/\\][^/\\]+[/\\][^/\\]+[/\\]workdir([/\\]|$)/i;
-
-/**
- * The same runtime's other one-shot layout: a task given a scratch directory
- * instead of a workspace checkout lands in `<tmp>/multica-task-<run-id>/...`.
- * `EPHEMERAL_WORKDIR_PATTERN` above never matched those, so each was persisted
- * like a real project — 17 of the 37 rows in the reported registry.json, all
- * dead within the hour, each pinning a `.config.json` section for the full
- * 7-day `sweepMissingRoots` grace (TRA-992).
- *
- * The container is matched, not the leaf: a run drops several roots under it
- * (its own scratch dirs, benchmark fixtures) and none outlive the run. The
- * numeric run id keeps this off a user directory that merely says
- * "multica-task".
- *
- * Note for tests: such a runtime also exports TMPDIR as its own task
- * directory, so `os.tmpdir()` itself can match this. A fixture that must stay
- * persistent has to be built outside it — see `tmpRootOutsideTaskDir` in
- * tests/test-utils.ts.
- */
-const EPHEMERAL_TASK_DIR_PATTERN = /[/\\]multica-task-\d+[/\\]/i;
-
-/**
- * True when `root` is a one-shot agent-run checkout, in either layout the
- * runtime uses (see {@link EPHEMERAL_WORKDIR_PATTERN} and
- * {@link EPHEMERAL_TASK_DIR_PATTERN}). Such roots are never persisted to
- * registry.json — see the `_ephemeralEntries` note above.
- */
-export function isEphemeralProjectRoot(root: string): boolean {
-  const abs = path.resolve(root);
-  return EPHEMERAL_WORKDIR_PATTERN.test(abs) || EPHEMERAL_TASK_DIR_PATTERN.test(abs);
-}
+// TRA-1136: the two path patterns and `isEphemeralProjectRoot` live in
+// global.ts, next to `getDbPath`, which needs them to route an unregistered
+// one-shot root at its DB in the ephemeral index dir. Re-exported here because
+// this is where every caller has always imported them from.
+export { isEphemeralProjectRoot } from './global.js';
 
 export interface EphemeralProjectCandidate {
   name: string;

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { announceDbHolder } from '../src/db-holders.js';
-import { EPHEMERAL_INDEX_DIR, ensureGlobalDirs, REGISTRY_PATH } from '../src/global.js';
+import { EPHEMERAL_INDEX_DIR, ensureGlobalDirs, getDbPath, REGISTRY_PATH } from '../src/global.js';
 import {
   findEphemeralProjects,
   findOverlapForNewRoot,
@@ -349,6 +349,32 @@ describe('ephemeral workdirs are never persisted', () => {
     expect(resolveRegisteredAncestor(path.join(workdir, 'packages', 'app'))?.root).toBe(workdir);
     // Its DB lives in the ephemeral index dir so it stays collectable by age.
     expect(entry.dbPath.startsWith(EPHEMERAL_INDEX_DIR + path.sep)).toBe(true);
+  });
+
+  // TRA-1136: the ephemeral registry entry is process-local, so every *other*
+  // process — and `ProjectManager.addProject({ persist: false })`, which never
+  // registers at all — resolved these roots through a bare `getDbPath()` and
+  // created a DB straight in INDEX_DIR. Nothing sweeps that: `sweepEphemeralDbs`
+  // only walks EPHEMERAL_INDEX_DIR and `prune` can only call it
+  // `orphan_unregistered`. 250 such files / 818 MB on the reported machine, still
+  // growing daily. Routing on the path shape is what makes the two agree.
+  it('routes an unregistered one-shot workdir at the ephemeral index dir', () => {
+    const workdir = makeEphemeralWorkdir();
+
+    expect(getProject(workdir)).toBeNull();
+    expect(getDbPath(workdir).startsWith(EPHEMERAL_INDEX_DIR + path.sep)).toBe(true);
+  });
+
+  it('routes an unregistered one-shot task scratch dir the same way', () => {
+    const dir = makeEphemeralTaskDir();
+
+    expect(getDbPath(dir).startsWith(EPHEMERAL_INDEX_DIR + path.sep)).toBe(true);
+  });
+
+  it('leaves an ordinary project fixture in the main index dir', () => {
+    const repo = makeTmpRepo();
+
+    expect(getDbPath(repo).startsWith(EPHEMERAL_INDEX_DIR + path.sep)).toBe(false);
   });
 
   it('leaves the registry empty after a saturating burst of agent runs', () => {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -363,6 +363,9 @@ describe('ephemeral workdirs are never persisted', () => {
 
     expect(getProject(workdir)).toBeNull();
     expect(getDbPath(workdir).startsWith(EPHEMERAL_INDEX_DIR + path.sep)).toBe(true);
+    // The invariant the leak broke: the registering process and every other
+    // one must name the same file for the same root.
+    expect(registerProject(workdir).dbPath).toBe(getDbPath(workdir));
   });
 
   it('routes an unregistered one-shot task scratch dir the same way', () => {


### PR DESCRIPTION
## The leak

`~/.trace/index` on the reported machine holds 250 `orphan_unregistered` DBs, 818 MB, still growing daily — long after TRA-335's sweep landed. The issue asked which of two explanations it is. It's a third one, and it's narrow.

TRA-396 gave one-shot agent-run checkouts their own index subdirectory (`index/ephemeral/`) precisely so `sweepEphemeralDbs` could collect them by age. But that routing decision lived **only** in `registerProject`, and an ephemeral root's registry entry is process-local (`_ephemeralEntries`, never written to `registry.json`). So:

- any **other process** resolving the same root — `getProject()` returns null → `getDbPath()` → plain `INDEX_DIR`;
- any path that **never registers at all** — notably `ProjectManager.addProject` with `persist: false` (read-mostly subprojects), which computes `getDbPath(indexRoot)` and hands it straight to `initializeDatabase()`.

Both create a DB no sweep can reach: `sweepEphemeralDbs` only walks `EPHEMERAL_INDEX_DIR`, and `prune` can only call it `orphan_unregistered` — a category soft GC deliberately never deletes.

### Evidence

Hashing every directory under `~/multica_workspaces*` against the orphan filenames matched **42 of them exactly**, to real one-shot checkout roots:

```
trace-mcp-e3800a3f45bd.db  <-  .../tracemcp-2a3e85da063b/tra-1122-460aa248ba36/workdir/trace-mcp
trace-mcp-6497e69e9e6a.db  <-  .../tracemcp-2a3e85da063b/tra-1119-b83c6a8600de/workdir/trace-mcp
trace-mcp-86a9a336628f.db  <-  .../tracemcp-2a3e85da063b/tra-1105-f7485090f9fd/workdir/trace-mcp
...
```

Every one matches `EPHEMERAL_WORKDIR_PATTERN` — roots `isEphemeralProjectRoot` already recognizes and `registerProject` would have routed correctly. Contents fit: 2–20 files each, ~600 KB, one new one every couple of hours. (The remaining orphans are non-workdir roots whose checkout dirs are gone, so they can't be hash-matched — but the daily growth is this class.)

## The fix

Make `getDbPath` pick the directory from the path shape itself, so registration and non-registration agree without a registry lookup:

```ts
const dir = isEphemeralProjectRoot(absRoot) ? EPHEMERAL_INDEX_DIR : INDEX_DIR;
```

`isEphemeralProjectRoot` and its two patterns move to `global.ts` (which must stay cross-module-import-free — the predicate is a pure path regex, so nothing is pulled in) and are re-exported from `registry.ts`, where every caller already imports them. `getEphemeralDbPath` and `registerProject`'s ephemeral ternary become redundant and are deleted — net −29 lines.

No persisted `dbPath` changes: `registerProject` never writes an ephemeral row to `registry.json`, so there is nothing on disk pointing at the old location for these roots.

## Test evidence

Three cases in `tests/registry.test.ts`, in the existing ephemeral describe block:

- an **unregistered** one-shot workdir resolves under `EPHEMERAL_INDEX_DIR` (`getProject()` is null — the second-process / `persist: false` case);
- same for the `multica-task-<id>` scratch layout;
- an ordinary tmp fixture still resolves in the main index dir.

Verified they fail without the fix: reverting the one-line branch turns 3 of 42 red (the two new ephemeral cases plus TRA-396's existing `entry.dbPath` assertion), green with it.

```
tests/registry.test.ts  42 passed
pnpm run lint  clean      pnpm run build  ok
pnpm run test   10657 passed, 1 failed
```

The single failure is `tests/daemon/health-starvation.test.ts` — the known load-sensitive timing test from TRA-1127 (touched twice for flakiness in the last week). It passes in isolation both on this branch and on a stashed clean tree; unrelated to this change.

## What this does not do

It stops the accumulation; it does not reclaim the existing 818 MB. Those files stay `orphan_unregistered` and are already deletable today by `trace-mcp prune --apply` (the category is in `defaultDeletable`) — a deliberate manual step, since for a normal project that category only means "not re-added yet". New ones land in `index/ephemeral/` and the daemon's hourly `sweepEphemeralDbs(24h)` collects them without anyone asking.

Closes TRA-1136.

Agent: Lead Engineer (trace-mcp)
