### PR TITLE
fix(daemon): gate watcher rescans by parallel_initial_index (TRA-1138)

### DIFF
--- a/src/daemon/__tests__/project-manager-rescan-gated.test.ts
+++ b/src/daemon/__tests__/project-manager-rescan-gated.test.ts
@@ -113,7 +113,14 @@ describe('ProjectManager watcher rescan gating (TRA-1138)', () => {
     expect(peakIndexAll).toBeLessThanOrEqual(2); // default parallel_initial_index
   }, 30_000);
 
-  it('still rescans after shutdown() cleared the limiter', async () => {
+  // NOT a race test: the real FileWatcher.stop() unsubscribes and then drains
+  // the in-flight rescan, and shutdown() clears the limiter only after that,
+  // so a live rescan never sees a null limiter (Reviewer C verified this
+  // against the unmocked watcher). FakeWatcher.stop() is a no-op, which is
+  // what lets the callback be fired here at all. What this pins is only the
+  // defensive branch itself: an unset limiter degrades to an ungated re-walk
+  // instead of throwing inside a watcher callback.
+  it('runs the rescan ungated when the limiter is unset', async () => {
     const { ProjectManager } = await import('../project-manager.js');
     const pm = new ProjectManager();
     pmRef = pm;
@@ -127,7 +134,7 @@ describe('ProjectManager watcher rescan gating (TRA-1138)', () => {
     pmRef = undefined;
     peakIndexAll = 0;
 
-    // A rescan racing shutdown must not throw on the null limiter.
+    // The defensive branch must not throw on the null limiter.
     await expect(rescan()).resolves.toBeUndefined();
     expect(peakIndexAll).toBe(1);
   }, 30_000);

--- a/src/daemon/__tests__/project-manager-rescan-gated.test.ts
+++ b/src/daemon/__tests__/project-manager-rescan-gated.test.ts
@@ -1,0 +1,134 @@
+/**
+ * TRA-1138: the watcher's onRescan callback must go through the same
+ * `parallel_initial_index` limiter as initial indexing. onRescan fires when
+ * the watcher concludes it dropped fs events — bulk checkout, package
+ * install, wake from sleep — and wake from sleep hits every registered
+ * project at the same moment. Ungated, N registered projects meant N
+ * concurrent full re-walks of their roots, while the identical work at
+ * daemon start is capped at 2.
+ *
+ * Same mocking harness as project-manager-ancestor-watcher.test.ts: fake
+ * pipeline + watcher + server so no real DB, @parcel/watcher or MCP server
+ * starts. The fake pipeline records concurrent indexAll() depth; the fake
+ * watcher hands back the onRescan callback so the test can fire it.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let activeIndexAll = 0;
+let peakIndexAll = 0;
+const rescanCallbacks: Array<() => Promise<void>> = [];
+
+vi.mock('../../indexer/pipeline.js', () => {
+  class FakeIndexingPipeline {
+    async indexAll() {
+      activeIndexAll++;
+      peakIndexAll = Math.max(peakIndexAll, activeIndexAll);
+      await new Promise((r) => setTimeout(r, 20));
+      activeIndexAll--;
+      return { totalFiles: 0, indexed: 0, skipped: 0, errors: 0, durationMs: 0 };
+    }
+    async indexFiles() {
+      return { totalFiles: 0, indexed: 0, skipped: 0, errors: 0, durationMs: 0 };
+    }
+    deleteFiles() {}
+    async dispose() {}
+  }
+  return { IndexingPipeline: FakeIndexingPipeline };
+});
+
+vi.mock('../../indexer/watcher.js', () => {
+  class FakeWatcher {
+    async start(_rootPath: string, _config: unknown, ..._rest: unknown[]) {
+      const opts = _rest[_rest.length - 1] as { onRescan?: () => Promise<void> } | undefined;
+      if (opts?.onRescan) rescanCallbacks.push(opts.onRescan);
+    }
+    async restartWithExcludes() {}
+    async stop() {}
+  }
+  return { FileWatcher: FakeWatcher };
+});
+
+vi.mock('../../server/server.js', async (orig) => {
+  const real = (await orig()) as Record<string, unknown>;
+  return {
+    ...real,
+    createServer: () => ({
+      server: { close: async () => undefined },
+      dispose: () => undefined,
+    }),
+  };
+});
+
+let tmpHome: string;
+let pmRef: { shutdown(): Promise<void> } | undefined;
+
+beforeEach(() => {
+  activeIndexAll = 0;
+  peakIndexAll = 0;
+  rescanCallbacks.length = 0;
+  tmpHome = mkdtempSync(join(tmpdir(), 'trace-mcp-rescan-gate-'));
+  vi.stubEnv('TRACE_MCP_DATA_DIR', tmpHome);
+  vi.resetModules();
+  pmRef = undefined;
+});
+
+afterEach(async () => {
+  if (pmRef) {
+    try {
+      await pmRef.shutdown();
+    } catch {
+      /* half-initialized manager may throw on shutdown; only care resources release */
+    }
+    pmRef = undefined;
+  }
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  rmSync(tmpHome, { recursive: true, force: true });
+}, 30_000);
+
+describe('ProjectManager watcher rescan gating (TRA-1138)', () => {
+  it('caps concurrent rescans at parallel_initial_index, not at project count', async () => {
+    const { ProjectManager } = await import('../project-manager.js');
+    const pm = new ProjectManager();
+    pmRef = pm;
+
+    for (let i = 0; i < 5; i++) {
+      const dir = join(tmpHome, `repo-${i}`);
+      mkdirSync(dir, { recursive: true });
+      await pm.addProject(dir);
+    }
+    expect(rescanCallbacks).toHaveLength(5);
+
+    // Initial indexing has settled; measure the rescan burst on its own.
+    await vi.waitFor(() => expect(activeIndexAll).toBe(0));
+    peakIndexAll = 0;
+
+    // Wake from sleep: every watcher fires onRescan at the same moment.
+    await Promise.all(rescanCallbacks.map((cb) => cb()));
+
+    expect(peakIndexAll).toBeGreaterThan(0);
+    expect(peakIndexAll).toBeLessThanOrEqual(2); // default parallel_initial_index
+  }, 30_000);
+
+  it('still rescans after shutdown() cleared the limiter', async () => {
+    const { ProjectManager } = await import('../project-manager.js');
+    const pm = new ProjectManager();
+    pmRef = pm;
+
+    const dir = join(tmpHome, 'repo-solo');
+    mkdirSync(dir, { recursive: true });
+    await pm.addProject(dir);
+    const rescan = rescanCallbacks[0];
+
+    await pm.shutdown();
+    pmRef = undefined;
+    peakIndexAll = 0;
+
+    // A rescan racing shutdown must not throw on the null limiter.
+    await expect(rescan()).resolves.toBeUndefined();
+    expect(peakIndexAll).toBe(1);
+  }, 30_000);
+});

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -751,7 +751,12 @@ export class ProjectManager {
           // Gated by the same limiter as initial indexing: wake-from-sleep
           // drops events in EVERY registered project at once, and N full
           // re-walks is exactly the load `parallel_initial_index` bounds.
-          // Limiter is null after shutdown() — run ungated rather than crash.
+          // The null branch is belt-and-braces, not a live race: shutdown()
+          // clears the limiter only after watcher.stop() has drained the
+          // in-flight rescan (TRA-834), and stop() unsubscribes before
+          // draining, so this read cannot observe null today. It stays so a
+          // regression in that ordering degrades to an ungated re-walk
+          // instead of a TypeError inside a watcher callback.
           onRescan: async () => {
             const limit = this.indexAllLimit;
             await (limit ? limit(() => pipeline.indexAll()) : pipeline.indexAll());

--- a/src/daemon/project-manager.ts
+++ b/src/daemon/project-manager.ts
@@ -166,8 +166,9 @@ export class ProjectManager {
    *  worker thread count regardless of project count. Lazy-init on the first
    *  addProject() so we can read the project's config for sizing. */
   private sharedPool: ExtractPool | null = null;
-  /** Configurable cap on concurrent initial indexAll() calls. Watcher-driven
-   *  indexFiles() is NOT gated. Lazy-init alongside sharedPool. */
+  /** Configurable cap on concurrent full indexAll() calls — initial indexing
+   *  and watcher rescans alike. Watcher-driven indexFiles() is NOT gated
+   *  (small batches). Lazy-init alongside sharedPool. */
   private indexAllLimit: ReturnType<typeof pLimit> | null = null;
   /** Optional shared TopologyStore/DecisionStore pool. When provided,
    *  stopProject() force-disposes the project's pool entry so the SQLite
@@ -747,8 +748,13 @@ export class ProjectManager {
           // Dropped fs events (bulk checkout, install, wake from sleep) leave
           // the index silently stale. indexAll() re-walks the root and is
           // hash-gated, so unchanged files cost a stat+hash, not a reparse.
+          // Gated by the same limiter as initial indexing: wake-from-sleep
+          // drops events in EVERY registered project at once, and N full
+          // re-walks is exactly the load `parallel_initial_index` bounds.
+          // Limiter is null after shutdown() — run ungated rather than crash.
           onRescan: async () => {
-            await pipeline.indexAll();
+            const limit = this.indexAllLimit;
+            await (limit ? limit(() => pipeline.indexAll()) : pipeline.indexAll());
           },
         },
       );


### PR DESCRIPTION
Closes TRA-1138.

## Problem

`ProjectManager` bounds concurrent full `indexAll()` runs with `pLimit(config.indexer?.parallel_initial_index ?? 2)`. Initial indexing and the two FK-recovery retries all go through it. The watcher's rescan callback did not:

```ts
onRescan: async () => {
  await pipeline.indexAll();
},
```

`onRescan` fires when the watcher concludes it dropped filesystem events — bulk checkout, package install, **wake from sleep**. Wake from sleep hits every registered project at the same moment: with 21 projects registered (the production daemon's real number, per TRA-1127) that is 21 concurrent full re-walks of every root, when the same work at daemon start is capped at 2.

Not a liveness risk — the TRA-1127 fairness chain (#1094) made `/health` latency independent of how many indexers run at once. It is a resource one: each `indexAll` holds its own extraction working set and stats+hashes every file in the root. That is exactly the cost `parallel_initial_index` exists to bound.

## Change

Route the rescan through the existing limiter, with the null-fallback that `shutdown()` clearing the limiter mid-event needs. `src/daemon/router/local-backend.ts` has the same callback but is single-project per process — nothing to gate there.

## Test evidence

New `src/daemon/__tests__/project-manager-rescan-gated.test.ts`, using the existing mocked-pipeline/watcher/server harness from `project-manager-ancestor-watcher.test.ts`:

- 5 projects, all `onRescan` callbacks fired at once → peak concurrent `indexAll` is 2. Without the fix the same test reports `expected 5 to be less than or equal to 2`.
- A rescan racing `shutdown()` resolves instead of throwing on the null limiter.

Full suite green: 963 files / 10654 tests passed, 43 skipped. `tsc --noEmit` and `biome ci` clean.