### PR TITLE
test(proxy): retry the Windows sandbox teardown instead of failing on EBUSY

### DIFF
--- a/tests/integration/proxy-daemon-death.test.ts
+++ b/tests/integration/proxy-daemon-death.test.ts
@@ -21,6 +21,7 @@
 
 import { type ChildProcess, spawn } from 'node:child_process';
 import http from 'node:http';
+import { once } from 'node:events';
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
@@ -152,7 +153,19 @@ describeIfBuilt('built proxy.js survives the daemon dying mid-session (TRA-1112)
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     cleanup = async () => {
+      // Wait for the child to actually be gone before removing the sandbox.
+      // `kill()` only posts the request — the process is still alive when it
+      // returns — and this child's cwd IS `sandbox/proj`, which Windows locks
+      // for as long as it lives. So teardown raced the exit and threw
+      // `EBUSY: rmdir`, failing a test whose assertions had already passed.
+      //
+      // Retrying the rmSync does not fix it: the lock is held by a process,
+      // not by a lingering handle, so the retries just burn their budget while
+      // it is still running. Waiting is both the correct fix and the cheaper
+      // one — on a healthy run the exit has usually already happened.
+      const exited = once(child, 'exit');
       child.kill('SIGKILL');
+      await exited;
       await daemon.kill().catch(() => {});
       rmSync(sandbox, { recursive: true, force: true });
     };


### PR DESCRIPTION
`cross-platform-test (windows-latest)` reported this test as failed after its
assertions had already passed:

```
Error: EBUSY: resource busy or locked, rmdir 'C:\...\trace-proxy-death-7Ydd0r\proj'
  at cleanup tests/integration/proxy-daemon-death.test.ts
```

`child.kill()` only posts the termination request — the process is still alive
when it returns — and this child's `cwd` **is** the directory being removed,
which Windows locks for as long as the process lives.

I first tried `rmSync`'s `maxRetries`/`retryDelay` and pushed it; CI proved that
wrong, which is the useful part of this PR's history. Retries cannot work here:
the lock is held by a running process, not by a lingering handle, so a 1 s retry
budget just burns while the child is still up. Awaiting the exit is both correct
and cheaper — on a healthy run the exit has usually already happened.

Test-only change, no production code touched.