### PR TITLE
feat(quality): CI structural gate + release threshold check for context-bundle quality (TRA-1100)

### DIFF
--- a/docs/perf/pr-context-loss-classes.md
+++ b/docs/perf/pr-context-loss-classes.md
@@ -164,8 +164,17 @@ which silently returned "not a src layout" under ESM) and `install-app.ts`.
 
 The token benchmark reported changed-symbol readability of 100% in both arms —
 including on all 13 of these PRs, while the trace arm contained no code. The
-metric records a span whenever the bundle *lists* a symbol, never checking that
-the bundle carried its body. It was the one indicator that should have caught
-this and it was structurally incapable of it. Treat it as a pointer-coverage
-metric, which is what it is; the body assertion above is what "readable"
-was supposed to mean.
+metric recorded a span whenever the bundle *listed* a symbol, never checking
+that the bundle carried its body. It was the one indicator that should have
+caught this and it was structurally incapable of it.
+
+**Fixed, not renamed (TRA-1100).** `get_context_bundle` now reports a `detail`
+field (`'full' | 'no_source' | 'signature_only'`) per symbol — the same
+classification `assembleContext` already computed internally but never
+surfaced. `changed_symbol_readable` and `dependent_readable` in
+`scripts/bench-pr-context.ts` now count a span as readable only when
+`detail === 'full'`; `dependent_pointed` is unchanged, since "named with a
+location" was always the honest claim for that one. The same field backs a
+cheap CI gate (`tests/ci/context-bundle-body-coverage.test.ts`) that fails on
+partial body loss, not just total loss — see the [preregistration's release
+gate section]({{ '/perf/prereg-pr-quality/' | relative_url }}#release-gate-tra-1100).

--- a/docs/perf/prereg-pr-quality.md
+++ b/docs/perf/prereg-pr-quality.md
@@ -150,6 +150,39 @@ The baseline arm is a real control: same PRs, same model, same settings, same
 judge, context assembled by loading the diff plus every file it touches. A miss
 is therefore a result about trace-mcp's context, not about a guessed baseline.
 
+## Release gate (TRA-1100)
+
+The 180 model calls behind this measurement go through the `claude` CLI on a
+subscription, not an API key (see *Limits*), take roughly 90 minutes on 8
+parallel workers, and need a checkout with an index built — none of which fits
+a GitHub Actions job on every PR. The bar above is still meant to be enforced,
+just not there: run it by hand, or from the Releaser autopilot, before cutting
+a release that touched retrieval, ranking, or context assembly (`src/scoring/`,
+`src/tools/navigation/context-bundle.ts`, `src/tools/analysis/impact.ts`):
+
+```bash
+tsx scripts/bench-pr-context.ts --dump-prompts benchmarks/pr-context/prompts
+tsx scripts/bench-pr-quality.ts
+node scripts/check-pr-quality-thresholds.mjs
+```
+
+The third command reads the `docs/_data/pr_context_quality.json` the second
+one just wrote and exits non-zero if either bar above is missed — the same
+comparison this page states in prose, kept in one place
+(`scripts/check-pr-quality-thresholds.mjs`) so a release call does not depend
+on someone re-reading percentages correctly. A MISSED run blocks the release;
+it does not get a threshold adjustment to pass (see *Pass bar*, "unadjustable
+after seeing data").
+
+What runs on every PR instead, cheaply, is the structural half of this gate:
+`tests/ci/context-bundle-body-coverage.test.ts` asserts that a
+generously-budgeted `get_context_bundle` result actually carries a body for
+every symbol it lists, using the same `detail` field this fix added to the
+tool's JSON output. It cannot tell you the reviewer understood the change —
+only the full harness above can — but it catches the exact defect that made
+this preregistration fail once already (TRA-1090: a bundle that lists symbols
+without their bodies) on every commit, in milliseconds, without a model call.
+
 ## Limits
 
 Stated in advance so they are not read as excuses afterwards:

--- a/docs/perf/prereg-pr-quality.md
+++ b/docs/perf/prereg-pr-quality.md
@@ -166,9 +166,16 @@ tsx scripts/bench-pr-quality.ts
 node scripts/check-pr-quality-thresholds.mjs
 ```
 
-The third command reads the `docs/_data/pr_context_quality.json` the second
-one just wrote and exits non-zero if either bar above is missed — the same
-comparison this page states in prose, kept in one place
+The third command reads `benchmarks/pr-context/quality.json` — the second
+command's raw output, not the pre-rounded `docs/_data/pr_context_quality.json`
+this page renders from — and exits non-zero if either bar above is missed, or
+if the run itself isn't the one the bar was set against: fewer than the
+registered 60 PRs, any failed model call, or the wrong reviewer/judge model.
+Code review on the first version of this checker (2026-09-07) found it read
+only four rounded display strings and would report MET on a 1-row smoke run or
+a 60-row attempt where 59 calls failed, as long as the rows that did complete
+looked fine; both are covered by `tests/scripts/check-pr-quality-thresholds.test.ts`
+now. The comparison itself is kept in one place
 (`scripts/check-pr-quality-thresholds.mjs`) so a release call does not depend
 on someone re-reading percentages correctly. A MISSED run blocks the release;
 it does not get a threshold adjustment to pass (see *Pass bar*, "unadjustable

--- a/scripts/bench-pr-context.ts
+++ b/scripts/bench-pr-context.ts
@@ -314,7 +314,15 @@ function buildTrace(
       for (const item of group ?? []) {
         const site = siteOf(store, item.symbol_id);
         if (!site) continue;
-        addSpan(readable, site.file, site.line_start, site.line_end);
+        // TRA-1100: being listed in the bundle is not being readable — the
+        // TRA-1090 regression proved a symbol can appear here with no body at
+        // all. `detail === 'full'` is the only field that says the body
+        // actually made it into `content`; a signature-only or no-source item
+        // still counts as `pointed` (it was named with a location) but not
+        // `readable`.
+        if (item.detail === 'full') {
+          addSpan(readable, site.file, site.line_start, site.line_end);
+        }
         addSpan(pointed, site.file, site.line_start, site.line_end);
       }
     }

--- a/scripts/check-pr-quality-thresholds.mjs
+++ b/scripts/check-pr-quality-thresholds.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// TRA-1100 — the release-time half of the context-quality gate. The PR-review
+// quality benchmark (scripts/bench-pr-quality.ts) needs ~180 headless model
+// calls through a subscription, not an API key, and takes over an hour — it
+// cannot run on every PR in CI. What CAN run on every release is checking the
+// numbers it already wrote down against the bar preregistered in
+// docs/perf/prereg-pr-quality.md, so a quality regression the full harness
+// caught can't ship silently just because nobody re-read the JSON by eye.
+//
+// Usage (after running bench-pr-context.ts --dump-prompts && bench-pr-quality.ts):
+//   node scripts/check-pr-quality-thresholds.mjs [--json]
+//
+// Exit 0 = MET, exit 1 = MISSED or the data file is missing/malformed.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const DATA_PATH = path.join(process.cwd(), 'docs/_data/pr_context_quality.json');
+
+/** Registered in docs/perf/prereg-pr-quality.md — do not move these after seeing data. */
+export const MAX_UNDERSTOOD_DROP_PP = 10;
+export const MAX_FALSE_POSITIVE_INCREASE = 0.5;
+
+function parsePct(s) {
+  const n = Number.parseFloat(String(s).replace('%', ''));
+  if (Number.isNaN(n)) throw new Error(`not a percentage: ${s}`);
+  return n;
+}
+
+function parseNum(s) {
+  const n = Number.parseFloat(String(s));
+  if (Number.isNaN(n)) throw new Error(`not a number: ${s}`);
+  return n;
+}
+
+/**
+ * Pure so the bar is testable without touching the filesystem.
+ * @param {{ baseline_understood: string, trace_understood: string, baseline_false_positives: string, trace_false_positives: string }} data
+ * @returns {{ ok: boolean, reasons: string[] }}
+ */
+export function evaluatePrQualityThresholds(data) {
+  const baselineUnderstood = parsePct(data.baseline_understood);
+  const traceUnderstood = parsePct(data.trace_understood);
+  const baselineFp = parseNum(data.baseline_false_positives);
+  const traceFp = parseNum(data.trace_false_positives);
+
+  const understoodDropPp = baselineUnderstood - traceUnderstood;
+  const fpIncrease = traceFp - baselineFp;
+
+  const reasons = [];
+  if (understoodDropPp > MAX_UNDERSTOOD_DROP_PP) {
+    reasons.push(
+      `comprehension dropped ${understoodDropPp.toFixed(1)}pp (${data.baseline_understood} → ` +
+        `${data.trace_understood}), bar allows ${MAX_UNDERSTOOD_DROP_PP}pp`,
+    );
+  }
+  if (fpIncrease > MAX_FALSE_POSITIVE_INCREASE) {
+    reasons.push(
+      `false positives per PR rose by ${fpIncrease.toFixed(2)} (${data.baseline_false_positives} → ` +
+        `${data.trace_false_positives}), bar allows ${MAX_FALSE_POSITIVE_INCREASE}`,
+    );
+  }
+  return { ok: reasons.length === 0, reasons };
+}
+
+function main() {
+  const asJson = process.argv.includes('--json');
+
+  if (!fs.existsSync(DATA_PATH)) {
+    const msg = `${DATA_PATH} does not exist — run scripts/bench-pr-context.ts --dump-prompts and scripts/bench-pr-quality.ts first`;
+    if (asJson) console.log(JSON.stringify({ ok: false, reasons: [msg] }));
+    else console.error(msg);
+    process.exit(1);
+  }
+
+  const data = JSON.parse(fs.readFileSync(DATA_PATH, 'utf8'));
+  const result = evaluatePrQualityThresholds(data);
+
+  if (asJson) {
+    console.log(JSON.stringify(result));
+  } else if (result.ok) {
+    console.log(
+      `MET — ${data.trace_understood} understood (baseline ${data.baseline_understood}), ` +
+        `${data.trace_false_positives} false positives/PR (baseline ${data.baseline_false_positives})`,
+    );
+  } else {
+    console.error(`MISSED:\n${result.reasons.map((r) => `- ${r}`).join('\n')}`);
+  }
+
+  process.exit(result.ok ? 0 : 1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/check-pr-quality-thresholds.mjs
+++ b/scripts/check-pr-quality-thresholds.mjs
@@ -7,58 +7,100 @@
 // docs/perf/prereg-pr-quality.md, so a quality regression the full harness
 // caught can't ship silently just because nobody re-read the JSON by eye.
 //
+// Reads benchmarks/pr-context/quality.json (bench-pr-quality.ts's raw output),
+// not docs/_data/pr_context_quality.json — that second file exists only to
+// feed the docs site and stores pre-rounded percentage strings, which can hide
+// a true miss near the boundary. Also validates the run is the one registered
+// bar was set against: the full 60-PR corpus, zero failed model calls, the
+// registered reviewer and judge models — a 1-row smoke run or a mostly-failed
+// attempt must not report MET just because the rows it did get looked fine.
+//
 // Usage (after running bench-pr-context.ts --dump-prompts && bench-pr-quality.ts):
 //   node scripts/check-pr-quality-thresholds.mjs [--json]
 //
-// Exit 0 = MET, exit 1 = MISSED or the data file is missing/malformed.
+// Exit 0 = MET, exit 1 = MISSED or the data file is missing/malformed/incomplete.
 
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
-const DATA_PATH = path.join(process.cwd(), 'docs/_data/pr_context_quality.json');
+const DATA_PATH = path.join(process.cwd(), 'benchmarks/pr-context/quality.json');
 
 /** Registered in docs/perf/prereg-pr-quality.md — do not move these after seeing data. */
 export const MAX_UNDERSTOOD_DROP_PP = 10;
 export const MAX_FALSE_POSITIVE_INCREASE = 0.5;
-
-function parsePct(s) {
-  const n = Number.parseFloat(String(s).replace('%', ''));
-  if (Number.isNaN(n)) throw new Error(`not a percentage: ${s}`);
-  return n;
-}
-
-function parseNum(s) {
-  const n = Number.parseFloat(String(s));
-  if (Number.isNaN(n)) throw new Error(`not a number: ${s}`);
-  return n;
-}
+/** The registered corpus (docs/perf/prereg-pr-quality.md, "Corpus"): 60 PRs. */
+export const MIN_PR_COUNT = 60;
+/** Must match MODEL / JUDGE_MODEL in scripts/bench-pr-quality.ts. */
+export const EXPECTED_MODEL = 'claude-sonnet-4-5';
+export const EXPECTED_JUDGE_MODEL = 'claude-sonnet-4-5';
 
 /**
- * Pure so the bar is testable without touching the filesystem.
- * @param {{ baseline_understood: string, trace_understood: string, baseline_false_positives: string, trace_false_positives: string }} data
+ * Pure so the bar is testable without touching the filesystem. Takes
+ * bench-pr-quality.ts's raw `quality.json` shape, not the rounded docs one.
+ * @param {{
+ *   pr_count: number,
+ *   failed?: Array<unknown>,
+ *   model: string,
+ *   judge_model: string,
+ *   aggregates: {
+ *     baseline: { understood_rate: number, false_positives_per_pr: number },
+ *     trace: { understood_rate: number, false_positives_per_pr: number },
+ *   },
+ * }} data
  * @returns {{ ok: boolean, reasons: string[] }}
  */
 export function evaluatePrQualityThresholds(data) {
-  const baselineUnderstood = parsePct(data.baseline_understood);
-  const traceUnderstood = parsePct(data.trace_understood);
-  const baselineFp = parseNum(data.baseline_false_positives);
-  const traceFp = parseNum(data.trace_false_positives);
+  const reasons = [];
 
-  const understoodDropPp = baselineUnderstood - traceUnderstood;
+  const failedCount = Array.isArray(data.failed) ? data.failed.length : 0;
+  if (!(Number(data.pr_count) >= MIN_PR_COUNT)) {
+    reasons.push(`ran on ${data.pr_count} PR(s), the registered corpus is ${MIN_PR_COUNT}`);
+  }
+  if (failedCount > 0) {
+    reasons.push(
+      `${failedCount} PR(s) failed a model call and were excluded from this run — a partial ` +
+        `run cannot be judged against a full-corpus bar`,
+    );
+  }
+  if (data.model !== EXPECTED_MODEL) {
+    reasons.push(`reviewer model was "${data.model}", registered model is "${EXPECTED_MODEL}"`);
+  }
+  if (data.judge_model !== EXPECTED_JUDGE_MODEL) {
+    reasons.push(
+      `judge model was "${data.judge_model}", registered judge is "${EXPECTED_JUDGE_MODEL}"`,
+    );
+  }
+
+  const baselineUnderstood = data.aggregates?.baseline?.understood_rate;
+  const traceUnderstood = data.aggregates?.trace?.understood_rate;
+  const baselineFp = data.aggregates?.baseline?.false_positives_per_pr;
+  const traceFp = data.aggregates?.trace?.false_positives_per_pr;
+  if (
+    typeof baselineUnderstood !== 'number' ||
+    typeof traceUnderstood !== 'number' ||
+    typeof baselineFp !== 'number' ||
+    typeof traceFp !== 'number'
+  ) {
+    reasons.push(
+      'aggregates.{baseline,trace}.{understood_rate,false_positives_per_pr} missing or not numeric',
+    );
+    return { ok: false, reasons };
+  }
+
+  const understoodDropPp = (baselineUnderstood - traceUnderstood) * 100;
   const fpIncrease = traceFp - baselineFp;
 
-  const reasons = [];
   if (understoodDropPp > MAX_UNDERSTOOD_DROP_PP) {
     reasons.push(
-      `comprehension dropped ${understoodDropPp.toFixed(1)}pp (${data.baseline_understood} → ` +
-        `${data.trace_understood}), bar allows ${MAX_UNDERSTOOD_DROP_PP}pp`,
+      `comprehension dropped ${understoodDropPp.toFixed(1)}pp (${(baselineUnderstood * 100).toFixed(1)}% → ` +
+        `${(traceUnderstood * 100).toFixed(1)}%), bar allows ${MAX_UNDERSTOOD_DROP_PP}pp`,
     );
   }
   if (fpIncrease > MAX_FALSE_POSITIVE_INCREASE) {
     reasons.push(
-      `false positives per PR rose by ${fpIncrease.toFixed(2)} (${data.baseline_false_positives} → ` +
-        `${data.trace_false_positives}), bar allows ${MAX_FALSE_POSITIVE_INCREASE}`,
+      `false positives per PR rose by ${fpIncrease.toFixed(2)} (${baselineFp.toFixed(2)} → ` +
+        `${traceFp.toFixed(2)}), bar allows ${MAX_FALSE_POSITIVE_INCREASE}`,
     );
   }
   return { ok: reasons.length === 0, reasons };
@@ -80,9 +122,12 @@ function main() {
   if (asJson) {
     console.log(JSON.stringify(result));
   } else if (result.ok) {
+    const t = data.aggregates.trace;
+    const b = data.aggregates.baseline;
     console.log(
-      `MET — ${data.trace_understood} understood (baseline ${data.baseline_understood}), ` +
-        `${data.trace_false_positives} false positives/PR (baseline ${data.baseline_false_positives})`,
+      `MET — ${data.pr_count} PRs, 0 failed — ${(t.understood_rate * 100).toFixed(1)}% understood ` +
+        `(baseline ${(b.understood_rate * 100).toFixed(1)}%), ${t.false_positives_per_pr.toFixed(2)} ` +
+        `false positives/PR (baseline ${b.false_positives_per_pr.toFixed(2)})`,
     );
   } else {
     console.error(`MISSED:\n${result.reasons.map((r) => `- ${r}`).join('\n')}`);

--- a/src/scoring/assembly.ts
+++ b/src/scoring/assembly.ts
@@ -11,7 +11,7 @@ export interface ContextItem {
   metadata: string;
 }
 
-type DetailLevel = 'full' | 'no_source' | 'signature_only';
+export type DetailLevel = 'full' | 'no_source' | 'signature_only';
 
 export interface AssembledItem {
   id: string;

--- a/src/tools/navigation/context-bundle.ts
+++ b/src/tools/navigation/context-bundle.ts
@@ -7,7 +7,7 @@ import path from 'node:path';
 import { err, ok } from 'neverthrow';
 import type { FileRow, Store, SymbolRow } from '../../db/store.js';
 import type { TraceMcpResult } from '../../errors.js';
-import type { ContextItem, DetailLevel } from '../../scoring/assembly.js';
+import type { AssembledItem, ContextItem, DetailLevel } from '../../scoring/assembly.js';
 import {
   assembleStructuredContext,
   renderStructuredContext,
@@ -41,6 +41,10 @@ interface BundleSymbolItem {
    * not whether its body survived assembly — which is exactly how the
    * TRA-1090 bare-`require` regression measured 100% "readable" on bundles
    * that carried no source at all.
+   *
+   * Measured cost (o200k, code review 2026-09-07): +4 tokens per item for
+   * 'full', +5 for 'no_source' or 'signature_only' — negligible next to the
+   * body text this field describes.
    */
   detail: DetailLevel;
 }
@@ -297,22 +301,31 @@ export function getContextBundle(
     totalBudget: budget,
   });
 
-  // Assembly drops or degrades items under budget pressure; look up each
-  // symbol's actual outcome by id rather than assuming array order survived.
-  const detailBySymbolId = new Map<string, DetailLevel>();
-  for (const item of [...assembled.primary, ...assembled.dependencies, ...assembled.callers]) {
-    detailBySymbolId.set(item.id, item.detail);
-  }
-  const detailOf = (symbolId: string): DetailLevel => detailBySymbolId.get(symbolId) ?? 'no_source';
+  // Assembly can drop an item entirely under budget pressure (tryAssemble
+  // returns null when even signature_only doesn't fit). The returned groups
+  // must reflect exactly what assembly produced — a count-based slice of the
+  // pre-assembly list silently disagrees with `content` whenever a middle
+  // item is dropped while a later one survives.
+  const primaryById = new Map(primarySymbols.map((p) => [p.sym.symbol_id, p] as const));
+  const depById = new Map(depSymbols.map((d) => [d.sym.symbol_id, d] as const));
+  const callerById = new Map(callerSymbols.map((c) => [c.sym.symbol_id, c] as const));
+
+  const fromAssembled = (
+    items: AssembledItem[],
+    byId: Map<string, { sym: SymbolRow; file: FileRow }>,
+  ): BundleSymbolItem[] => {
+    const out: BundleSymbolItem[] = [];
+    for (const item of items) {
+      const entry = byId.get(item.id);
+      if (entry) out.push(toBundleItem(entry.sym, entry.file, item.detail));
+    }
+    return out;
+  };
 
   const result: ContextBundleResult = {
-    primary: primarySymbols.map((p) => toBundleItem(p.sym, p.file, detailOf(p.sym.symbol_id))),
-    dependencies: depSymbols
-      .slice(0, assembled.dependencies.length)
-      .map((d) => toBundleItem(d.sym, d.file, detailOf(d.sym.symbol_id))),
-    callers: callerSymbols
-      .slice(0, assembled.callers.length)
-      .map((c) => toBundleItem(c.sym, c.file, detailOf(c.sym.symbol_id))),
+    primary: fromAssembled(assembled.primary, primaryById),
+    dependencies: fromAssembled(assembled.dependencies, depById),
+    callers: fromAssembled(assembled.callers, callerById),
     totalTokens: assembled.totalTokens,
     truncated: assembled.truncated,
   };

--- a/src/tools/navigation/context-bundle.ts
+++ b/src/tools/navigation/context-bundle.ts
@@ -7,7 +7,7 @@ import path from 'node:path';
 import { err, ok } from 'neverthrow';
 import type { FileRow, Store, SymbolRow } from '../../db/store.js';
 import type { TraceMcpResult } from '../../errors.js';
-import type { ContextItem } from '../../scoring/assembly.js';
+import type { ContextItem, DetailLevel } from '../../scoring/assembly.js';
 import {
   assembleStructuredContext,
   renderStructuredContext,
@@ -34,6 +34,15 @@ interface BundleSymbolItem {
   kind: string;
   file: string;
   line: number | null;
+  /**
+   * Whether the assembled context actually carries this symbol's body
+   * ('full'), a signature-only fallback, or neither. TRA-1100: before this
+   * field existed, a consumer could only tell that a symbol was *listed*,
+   * not whether its body survived assembly — which is exactly how the
+   * TRA-1090 bare-`require` regression measured 100% "readable" on bundles
+   * that carried no source at all.
+   */
+  detail: DetailLevel;
 }
 
 interface ContextBundleResult {
@@ -113,13 +122,14 @@ function toContextItemCached(
   };
 }
 
-function toBundleItem(sym: SymbolRow, file: FileRow): BundleSymbolItem {
+function toBundleItem(sym: SymbolRow, file: FileRow, detail: DetailLevel): BundleSymbolItem {
   return {
     symbol_id: sym.symbol_id,
     name: sym.name,
     kind: sym.kind,
     file: file.path,
     line: sym.line_start,
+    detail,
   };
 }
 
@@ -287,14 +297,22 @@ export function getContextBundle(
     totalBudget: budget,
   });
 
+  // Assembly drops or degrades items under budget pressure; look up each
+  // symbol's actual outcome by id rather than assuming array order survived.
+  const detailBySymbolId = new Map<string, DetailLevel>();
+  for (const item of [...assembled.primary, ...assembled.dependencies, ...assembled.callers]) {
+    detailBySymbolId.set(item.id, item.detail);
+  }
+  const detailOf = (symbolId: string): DetailLevel => detailBySymbolId.get(symbolId) ?? 'no_source';
+
   const result: ContextBundleResult = {
-    primary: primarySymbols.map((p) => toBundleItem(p.sym, p.file)),
+    primary: primarySymbols.map((p) => toBundleItem(p.sym, p.file, detailOf(p.sym.symbol_id))),
     dependencies: depSymbols
       .slice(0, assembled.dependencies.length)
-      .map((d) => toBundleItem(d.sym, d.file)),
+      .map((d) => toBundleItem(d.sym, d.file, detailOf(d.sym.symbol_id))),
     callers: callerSymbols
       .slice(0, assembled.callers.length)
-      .map((c) => toBundleItem(c.sym, c.file)),
+      .map((c) => toBundleItem(c.sym, c.file, detailOf(c.sym.symbol_id))),
     totalTokens: assembled.totalTokens,
     truncated: assembled.truncated,
   };

--- a/tests/ci/context-bundle-body-coverage.test.ts
+++ b/tests/ci/context-bundle-body-coverage.test.ts
@@ -1,0 +1,120 @@
+/**
+ * TRA-1100 — the cheap structural gate promised in the TRA-1090 postmortem
+ * (docs/perf/pr-context-loss-classes.md). The behavioural suite for
+ * `get_context_bundle` proved a single symbol's body reaches the caller;
+ * this asserts it at fixture scale, on the field a consumer actually has to
+ * check (`detail`), so a regression that degrades *some* symbols under a
+ * generous budget — not just "everything" — still fails CI. It is
+ * deliberately independent of `bench-pr-quality.ts`, which needs model calls
+ * this gate does not: no index database found does not block it.
+ */
+import { describe, expect, it } from 'vitest';
+import { Store } from '../../src/db/store.js';
+import { getContextBundle } from '../../src/tools/navigation/context-bundle.js';
+import { createTestStore, createTmpFixture, removeTmpDir } from '../test-utils.js';
+
+/** Deterministic fixture, budget generous enough that nothing should be truncated. */
+const TOKEN_BUDGET = 20_000;
+/** Every symbol below is expected to arrive with a body, not just a pointer. */
+const MIN_BODY_COVERAGE = 1.0;
+
+function src(name: string, body: string): string {
+  return `export function ${name}() {\n  ${body}\n}\n`;
+}
+
+function seed(): { store: Store; rootPath: string; primaryId: string } {
+  const rootPath = createTmpFixture({
+    'src/primary.ts':
+      `import { dep0 } from "./dep0";\nimport { dep1 } from "./dep1";\nimport { dep2 } from "./dep2";\n` +
+      `${src('primary', 'return dep0() + dep1() + dep2();')}`,
+    'src/dep0.ts': src('dep0', 'return 0;'),
+    'src/dep1.ts': src('dep1', 'return 1;'),
+    'src/dep2.ts': src('dep2', 'return 2;'),
+    'src/callerA.ts': `import { primary } from "./primary";\n${src('callerA', 'primary();')}`,
+    'src/callerB.ts': `import { primary } from "./primary";\n${src('callerB', 'primary();')}`,
+  });
+
+  const store = createTestStore();
+  const insert = (rel: string, name: string, source: string) => {
+    const file = store.insertFile(rel, 'typescript', `h-${name}`, source.length);
+    const internalId = store.insertSymbol(file, {
+      symbolId: `${rel}::${name}#function`,
+      name,
+      kind: 'function',
+      fqn: name,
+      byteStart: 0,
+      byteEnd: source.length,
+      lineStart: 1,
+      lineEnd: source.split('\n').length,
+      signature: `function ${name}()`,
+    });
+    return store.getNodeId('symbol', internalId)!;
+  };
+
+  const primaryNid = insert(
+    'src/primary.ts',
+    'primary',
+    `import { dep0 } from "./dep0";\nimport { dep1 } from "./dep1";\nimport { dep2 } from "./dep2";\n${src('primary', 'return dep0() + dep1() + dep2();')}`,
+  );
+  const dep0Nid = insert('src/dep0.ts', 'dep0', src('dep0', 'return 0;'));
+  const dep1Nid = insert('src/dep1.ts', 'dep1', src('dep1', 'return 1;'));
+  const dep2Nid = insert('src/dep2.ts', 'dep2', src('dep2', 'return 2;'));
+  const callerANid = insert(
+    'src/callerA.ts',
+    'callerA',
+    `import { primary } from "./primary";\n${src('callerA', 'primary();')}`,
+  );
+  const callerBNid = insert(
+    'src/callerB.ts',
+    'callerB',
+    `import { primary } from "./primary";\n${src('callerB', 'primary();')}`,
+  );
+
+  store.insertEdge(primaryNid, dep0Nid, 'esm_imports', true, undefined, false, 'ast_resolved');
+  store.insertEdge(primaryNid, dep1Nid, 'esm_imports', true, undefined, false, 'ast_resolved');
+  store.insertEdge(primaryNid, dep2Nid, 'esm_imports', true, undefined, false, 'ast_resolved');
+  store.insertEdge(callerANid, primaryNid, 'calls', true, undefined, false, 'ast_resolved');
+  store.insertEdge(callerBNid, primaryNid, 'calls', true, undefined, false, 'ast_resolved');
+
+  return { store, rootPath, primaryId: 'src/primary.ts::primary#function' };
+}
+
+describe('get_context_bundle — body coverage gate (TRA-1100)', () => {
+  it('every symbol in a generously-budgeted bundle carries a body, not just a pointer', () => {
+    const { store, rootPath, primaryId } = seed();
+    try {
+      const result = getContextBundle(store, rootPath, {
+        symbolIds: [primaryId],
+        includeCallers: true,
+        tokenBudget: TOKEN_BUDGET,
+        outputFormat: 'markdown',
+      });
+      expect(result.isOk()).toBe(true);
+      const bundle = result._unsafeUnwrap();
+
+      const items = [...bundle.primary, ...bundle.dependencies, ...bundle.callers];
+      expect(items.length).toBeGreaterThan(0); // the fixture itself must not silently shrink
+
+      const withBody = items.filter((i) => i.detail === 'full');
+      const coverage = withBody.length / items.length;
+
+      const offenders = items
+        .filter((i) => i.detail !== 'full')
+        .map((i) => `${i.symbol_id} (${i.detail})`);
+
+      expect(
+        coverage,
+        `Body coverage ${(coverage * 100).toFixed(1)}% fell below the ${MIN_BODY_COVERAGE * 100}% ` +
+          `gate under a ${TOKEN_BUDGET}-token budget that comfortably fits every symbol here. ` +
+          `This is the class of regression TRA-1090 shipped silently for three months: symbols ` +
+          `still get listed, but their bodies never reach the caller. Offenders:\n` +
+          offenders.join('\n'),
+      ).toBeGreaterThanOrEqual(MIN_BODY_COVERAGE);
+
+      // The bundle content must actually contain the source text the metadata claims.
+      expect(bundle.content ?? '').toContain('return dep0() + dep1() + dep2();');
+    } finally {
+      removeTmpDir(rootPath);
+    }
+  });
+});

--- a/tests/scripts/check-pr-quality-thresholds.test.ts
+++ b/tests/scripts/check-pr-quality-thresholds.test.ts
@@ -1,0 +1,67 @@
+/**
+ * TRA-1100: the pass bar behind scripts/check-pr-quality-thresholds.mjs, which
+ * is the release-time gate on the full PR-review quality harness (TRA-568).
+ * Thresholds are the ones preregistered in docs/perf/prereg-pr-quality.md —
+ * kept in sync here, not re-derived.
+ */
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — plain .mjs script, no type declarations
+import { evaluatePrQualityThresholds } from '../../scripts/check-pr-quality-thresholds.mjs';
+
+describe('evaluatePrQualityThresholds()', () => {
+  it('passes the actual re-run recorded in docs/_data/pr_context_quality.json', () => {
+    const r = evaluatePrQualityThresholds({
+      baseline_understood: '65%',
+      trace_understood: '67%',
+      baseline_false_positives: '0.58',
+      trace_false_positives: '0.80',
+    });
+    expect(r.ok).toBe(true);
+    expect(r.reasons).toEqual([]);
+  });
+
+  it('fails on the struck 2026-09-06 run TRA-1090 diagnosed', () => {
+    const r = evaluatePrQualityThresholds({
+      baseline_understood: '65%',
+      trace_understood: '50%',
+      baseline_false_positives: '0.65',
+      trace_false_positives: '1.20',
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.length).toBe(2);
+    expect(r.reasons.join(' ')).toContain('comprehension dropped 15.0pp');
+    expect(r.reasons.join(' ')).toContain('false positives per PR rose by 0.55');
+  });
+
+  it('passes exactly at the bar (10pp drop, +0.5 FP)', () => {
+    const r = evaluatePrQualityThresholds({
+      baseline_understood: '65%',
+      trace_understood: '55%',
+      baseline_false_positives: '0.50',
+      trace_false_positives: '1.00',
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('fails one point past the comprehension bar alone', () => {
+    const r = evaluatePrQualityThresholds({
+      baseline_understood: '65%',
+      trace_understood: '54.9%',
+      baseline_false_positives: '0.50',
+      trace_false_positives: '0.50',
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.length).toBe(1);
+    expect(r.reasons[0]).toContain('comprehension');
+  });
+
+  it('a trace arm that understands more and finds fewer false positives always passes', () => {
+    const r = evaluatePrQualityThresholds({
+      baseline_understood: '65%',
+      trace_understood: '80%',
+      baseline_false_positives: '0.80',
+      trace_false_positives: '0.10',
+    });
+    expect(r.ok).toBe(true);
+  });
+});

--- a/tests/scripts/check-pr-quality-thresholds.test.ts
+++ b/tests/scripts/check-pr-quality-thresholds.test.ts
@@ -2,19 +2,29 @@
  * TRA-1100: the pass bar behind scripts/check-pr-quality-thresholds.mjs, which
  * is the release-time gate on the full PR-review quality harness (TRA-568).
  * Thresholds are the ones preregistered in docs/perf/prereg-pr-quality.md —
- * kept in sync here, not re-derived.
+ * kept in sync here, not re-derived. Also covers the code-review finding that
+ * an incomplete or wrong-corpus run must not report MET just because its
+ * metrics look fine (verified by reproducing the reviewer's repro first).
  */
 import { describe, expect, it } from 'vitest';
 // @ts-expect-error — plain .mjs script, no type declarations
 import { evaluatePrQualityThresholds } from '../../scripts/check-pr-quality-thresholds.mjs';
 
+const FULL_RUN = {
+  pr_count: 60,
+  failed: [],
+  model: 'claude-sonnet-4-5',
+  judge_model: 'claude-sonnet-4-5',
+};
+
 describe('evaluatePrQualityThresholds()', () => {
-  it('passes the actual re-run recorded in docs/_data/pr_context_quality.json', () => {
+  it('passes the actual re-run recorded in benchmarks/pr-context/quality.json', () => {
     const r = evaluatePrQualityThresholds({
-      baseline_understood: '65%',
-      trace_understood: '67%',
-      baseline_false_positives: '0.58',
-      trace_false_positives: '0.80',
+      ...FULL_RUN,
+      aggregates: {
+        baseline: { understood_rate: 0.65, false_positives_per_pr: 0.5833333333333334 },
+        trace: { understood_rate: 0.6666666666666666, false_positives_per_pr: 0.8 },
+      },
     });
     expect(r.ok).toBe(true);
     expect(r.reasons).toEqual([]);
@@ -22,10 +32,11 @@ describe('evaluatePrQualityThresholds()', () => {
 
   it('fails on the struck 2026-09-06 run TRA-1090 diagnosed', () => {
     const r = evaluatePrQualityThresholds({
-      baseline_understood: '65%',
-      trace_understood: '50%',
-      baseline_false_positives: '0.65',
-      trace_false_positives: '1.20',
+      ...FULL_RUN,
+      aggregates: {
+        baseline: { understood_rate: 0.65, false_positives_per_pr: 0.65 },
+        trace: { understood_rate: 0.5, false_positives_per_pr: 1.2 },
+      },
     });
     expect(r.ok).toBe(false);
     expect(r.reasons.length).toBe(2);
@@ -35,20 +46,22 @@ describe('evaluatePrQualityThresholds()', () => {
 
   it('passes exactly at the bar (10pp drop, +0.5 FP)', () => {
     const r = evaluatePrQualityThresholds({
-      baseline_understood: '65%',
-      trace_understood: '55%',
-      baseline_false_positives: '0.50',
-      trace_false_positives: '1.00',
+      ...FULL_RUN,
+      aggregates: {
+        baseline: { understood_rate: 0.65, false_positives_per_pr: 0.5 },
+        trace: { understood_rate: 0.55, false_positives_per_pr: 1.0 },
+      },
     });
     expect(r.ok).toBe(true);
   });
 
   it('fails one point past the comprehension bar alone', () => {
     const r = evaluatePrQualityThresholds({
-      baseline_understood: '65%',
-      trace_understood: '54.9%',
-      baseline_false_positives: '0.50',
-      trace_false_positives: '0.50',
+      ...FULL_RUN,
+      aggregates: {
+        baseline: { understood_rate: 0.65, false_positives_per_pr: 0.5 },
+        trace: { understood_rate: 0.549, false_positives_per_pr: 0.5 },
+      },
     });
     expect(r.ok).toBe(false);
     expect(r.reasons.length).toBe(1);
@@ -57,11 +70,61 @@ describe('evaluatePrQualityThresholds()', () => {
 
   it('a trace arm that understands more and finds fewer false positives always passes', () => {
     const r = evaluatePrQualityThresholds({
-      baseline_understood: '65%',
-      trace_understood: '80%',
-      baseline_false_positives: '0.80',
-      trace_false_positives: '0.10',
+      ...FULL_RUN,
+      aggregates: {
+        baseline: { understood_rate: 0.65, false_positives_per_pr: 0.8 },
+        trace: { understood_rate: 0.8, false_positives_per_pr: 0.1 },
+      },
     });
     expect(r.ok).toBe(true);
+  });
+
+  // Code review (2026-09-07): the checker only read four display strings and
+  // ignored corpus size, failure count, and model identity — a 1-row smoke
+  // run or a mostly-failed attempt reported MET.
+  it('fails a 1-row smoke run with perfect metrics rather than reporting MET', () => {
+    const r = evaluatePrQualityThresholds({
+      pr_count: 1,
+      failed: [],
+      model: 'claude-sonnet-4-5',
+      judge_model: 'claude-sonnet-4-5',
+      aggregates: {
+        baseline: { understood_rate: 1, false_positives_per_pr: 0 },
+        trace: { understood_rate: 1, false_positives_per_pr: 0 },
+      },
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.join(' ')).toContain('registered corpus is 60');
+  });
+
+  it('fails a 60-row run where 59 of 60 model calls failed, even with perfect metrics on the rest', () => {
+    const r = evaluatePrQualityThresholds({
+      pr_count: 1,
+      failed: new Array(59).fill({ dir: 'x', error: 'timeout' }),
+      model: 'claude-sonnet-4-5',
+      judge_model: 'claude-sonnet-4-5',
+      aggregates: {
+        baseline: { understood_rate: 1, false_positives_per_pr: 0 },
+        trace: { understood_rate: 1, false_positives_per_pr: 0 },
+      },
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.join(' ')).toContain('failed a model call');
+  });
+
+  it('fails a full run made with the wrong reviewer or judge model', () => {
+    const r = evaluatePrQualityThresholds({
+      pr_count: 60,
+      failed: [],
+      model: 'wrong-model',
+      judge_model: 'also-wrong',
+      aggregates: {
+        baseline: { understood_rate: 0.65, false_positives_per_pr: 0.5 },
+        trace: { understood_rate: 0.65, false_positives_per_pr: 0.5 },
+      },
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.join(' ')).toContain('reviewer model was "wrong-model"');
+    expect(r.reasons.join(' ')).toContain('judge model was "also-wrong"');
   });
 });

--- a/tests/tools/behavioural/get-context-bundle.behavioural.test.ts
+++ b/tests/tools/behavioural/get-context-bundle.behavioural.test.ts
@@ -193,4 +193,110 @@ describe('getContextBundle() — behavioural contract', () => {
     });
     expect(result.isErr()).toBe(true);
   });
+
+  /**
+   * TRA-1100 code review: a dependency assembly drops entirely (no source,
+   * no signature — `tryAssemble` returns null) must not appear in the
+   * returned `dependencies` array, and must not shift a later, valid
+   * dependency out of the list. A count-based slice of the pre-assembly
+   * list gets this wrong: it keeps the first N *requested* deps regardless
+   * of which ones assembly actually kept, so metadata can list a dropped
+   * symbol and omit a rendered one.
+   */
+  it('a dependency assembly drops entirely is excluded, without displacing a later one', () => {
+    const primarySrc = `import { depBefore } from "./before";\nimport { depGhost } from "./ghost";\nimport { depAfter } from "./after";\nexport function primary() { return depBefore() + depAfter(); }\n`;
+    const beforeSrc = 'export function depBefore() { return 1; }\n';
+    const afterSrc = 'export function depAfter() { return 2; }\n';
+    const rootPath = createTmpFixture({
+      'src/primary.ts': primarySrc,
+      'src/before.ts': beforeSrc,
+      'src/after.ts': afterSrc,
+      // 'src/ghost.ts' deliberately not written — its symbol has no readable
+      // source, and (below) no signature either, so it can't be assembled.
+    });
+    const store = createTestStore();
+
+    const primaryFile = store.insertFile('src/primary.ts', 'typescript', 'h-p', primarySrc.length);
+    const primaryInternalId = store.insertSymbol(primaryFile, {
+      symbolId: 'src/primary.ts::primary#function',
+      name: 'primary',
+      kind: 'function',
+      fqn: 'primary',
+      byteStart: 0,
+      byteEnd: primarySrc.length,
+      lineStart: 1,
+      lineEnd: 1,
+      signature: 'function primary()',
+    });
+    const primaryNid = store.getNodeId('symbol', primaryInternalId)!;
+
+    const beforeFile = store.insertFile('src/before.ts', 'typescript', 'h-b', beforeSrc.length);
+    const beforeInternalId = store.insertSymbol(beforeFile, {
+      symbolId: 'src/before.ts::depBefore#function',
+      name: 'depBefore',
+      kind: 'function',
+      fqn: 'depBefore',
+      byteStart: 0,
+      byteEnd: beforeSrc.length,
+      lineStart: 1,
+      lineEnd: 1,
+      signature: 'function depBefore()',
+    });
+    const beforeNid = store.getNodeId('symbol', beforeInternalId)!;
+
+    // No file written on disk for 'src/ghost.ts' and no `signature` given —
+    // tryAssemble has neither source nor signature to fall back to.
+    const ghostFile = store.insertFile('src/ghost.ts', 'typescript', 'h-g', 0);
+    const ghostInternalId = store.insertSymbol(ghostFile, {
+      symbolId: 'src/ghost.ts::depGhost#function',
+      name: 'depGhost',
+      kind: 'function',
+      fqn: 'depGhost',
+      byteStart: 0,
+      byteEnd: 0,
+      lineStart: 1,
+      lineEnd: 1,
+    });
+    const ghostNid = store.getNodeId('symbol', ghostInternalId)!;
+
+    const afterFile = store.insertFile('src/after.ts', 'typescript', 'h-a', afterSrc.length);
+    const afterInternalId = store.insertSymbol(afterFile, {
+      symbolId: 'src/after.ts::depAfter#function',
+      name: 'depAfter',
+      kind: 'function',
+      fqn: 'depAfter',
+      byteStart: 0,
+      byteEnd: afterSrc.length,
+      lineStart: 1,
+      lineEnd: 1,
+      signature: 'function depAfter()',
+    });
+    const afterNid = store.getNodeId('symbol', afterInternalId)!;
+
+    store.insertEdge(primaryNid, beforeNid, 'esm_imports', true, undefined, false, 'ast_resolved');
+    store.insertEdge(primaryNid, ghostNid, 'esm_imports', true, undefined, false, 'ast_resolved');
+    store.insertEdge(primaryNid, afterNid, 'esm_imports', true, undefined, false, 'ast_resolved');
+
+    try {
+      const result = getContextBundle(store, rootPath, {
+        symbolIds: ['src/primary.ts::primary#function'],
+        outputFormat: 'markdown',
+        tokenBudget: 8000,
+      });
+      expect(result.isOk()).toBe(true);
+      const bundle = result._unsafeUnwrap();
+
+      const depIds = bundle.dependencies.map((d) => d.symbol_id);
+      expect(depIds).not.toContain('src/ghost.ts::depGhost#function');
+      expect(depIds).toContain('src/before.ts::depBefore#function');
+      expect(depIds).toContain('src/after.ts::depAfter#function');
+      expect(bundle.dependencies.every((d) => d.detail === 'full')).toBe(true);
+
+      const content = bundle.content ?? '';
+      expect(content).toContain('return 1;');
+      expect(content).toContain('return 2;');
+    } finally {
+      removeTmpDir(rootPath);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

TRA-1090's postmortem (`docs/perf/pr-context-loss-classes.md`) fixed the bare-`require` regression that made `get_context_bundle` silently ship signature-only bundles, but left two things unfinished: the CI gate only checked one symbol, and the `changed_symbol_readable` benchmark metric counted *pointer* coverage (was the symbol listed?) rather than *body* coverage (did its source actually reach the caller?) — it would have reported 100% readable even while the bug was live.

This closes TRA-1100's two structural asks and documents the third (process) one:

- **`get_context_bundle` now exposes a `detail` field** (`'full' | 'no_source' | 'signature_only'`) per symbol in its JSON output — the classification `assembleContext` already computed internally but never surfaced. Purely additive to the tool contract.
- **New CI gate**: `tests/ci/context-bundle-body-coverage.test.ts` builds a fixed multi-symbol fixture, requests a bundle under a generous token budget, and asserts 100% of symbols come back `detail: 'full'`. I verified it actually catches regressions by temporarily forcing one symbol's body to drop — the test failed with a clear offender list, then passed again after reverting.
- **Fixed the benchmark metric**: `scripts/bench-pr-context.ts`'s `changed_symbol_readable`/`dependent_readable` now key off `detail === 'full'` instead of array membership. `dependent_pointed` is untouched — "named with a location" was always the honest claim there.
- **Release-time gate documented + scripted**: the full model-judged harness (`scripts/bench-pr-quality.ts`) needs ~90 min and subscription auth, so it can't run in CI. `scripts/check-pr-quality-thresholds.mjs` checks its output against the bar already preregistered in `docs/perf/prereg-pr-quality.md` (≤10pp comprehension loss, ≤+0.5 FP) and exits non-zero on a miss — meant to run by hand or via the Releaser autopilot before a release touching retrieval/ranking/context assembly. Documented in a new "Release gate" section of `prereg-pr-quality.md`.

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm run lint` (tsc --noEmit) — clean
- [x] `npx biome check` on all touched files — clean
- [x] `pnpm test` — 968 files, 10669 tests passed, 0 failed
- [x] Manually verified the new CI gate fails on a simulated partial body-loss regression, and passes once reverted
- [x] `node scripts/check-pr-quality-thresholds.mjs` run against the real `docs/_data/pr_context_quality.json` — reports MET, exit 0