### PR TITLE
docs(site): stop setting the hero's quality evidence as fine print (TRA-1143)

### DIFF
--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -877,8 +877,15 @@ one tested step wider than the failure. Inline behaviour is what you get above
 700px, not at it.
 
 **The first screen fits a 13" laptop, and that is a measurement.** Measured
-on the live page at 1440×900: the button top sits at 630px and the trust line
-at 841px, with the metrics strip below the fold. The rule is the button, not
+on the **live published page** at 1440×900 — `getBoundingClientRect().top`
+plus `scrollY`, document coordinates: the button top sits at 630px and the
+trust line at 841px, with the metrics strip below the fold.
+
+Take the figure on `trace-mcp.com`, not on a local preview, and say which you
+took. Without a Jekyll build there is no faithful local render of this page —
+a Liquid-lite substitution reads roughly 48px lower on every hero element than
+the live page does, so a preview number recorded here as the baseline is a
+regression the next run will chase and not find. The rule is the button, not
 the hero — a first screen whose button falls below 900px is a regression
 however good it looks at 1440×1080.
 

--- a/docs/DESIGN-WEB.md
+++ b/docs/DESIGN-WEB.md
@@ -800,6 +800,28 @@ the exact machine — `Download for Mac (Apple Silicon)`, `Download for Mac
 (Intel)`, `Download for Windows` — never a platform the page has not confirmed
 and never an architecture the visitor is left to guess at.
 
+**Three body sizes under the headline, and shade says which kind of sentence
+it is** (TRA-1143). `.hero-desc` is the claim — 19px, `--text-primary`, its
+number at `--text-display` through `.accent-text`. `.hero-evidence` is the
+other half of the same measurement, the quality result that says the cheap
+context was worth having — 15px, but `--text-primary` too, with its four
+numbers on the same `.accent-text`. `.hero-boundary` is the scope note about
+what the product does to your machine — 15px, `--text-secondary`.
+
+Size separates evidence from claim; shade groups them and drops the scope note
+out. Getting this wrong is not a nuance: for one release the evidence and the
+scope note shared `.hero-boundary` and rendered identically at
+15px/`--text-secondary`, so the answer to "is the thinner context worse?" was
+set in the same grey as a legal boundary and read as small print under the
+number it qualifies. The saving was loud and the proof it had not been bought
+with worse reviews was quiet — the exact shape the page exists to avoid.
+
+**A number that qualifies a claim gets the claim's own emphasis, on both
+sides of the comparison.** All four of `.hero-evidence`'s figures take
+`.accent-text`, including the ones where we lose: `0.80 false positives per PR
+against 0.58` is us being worse, and it is set as brightly as the half we win.
+Dimming the losing number is how a comparison becomes a boast.
+
 **Three mono caps rows, one treatment, three greys.** `.hero-eyebrow`
 (`--text-secondary`, above the headline, carrying the service label and the
 version + licence the old two-column `.hero-meta` used to spend a whole row on),
@@ -854,13 +876,18 @@ never lands on a separator.
 one tested step wider than the failure. Inline behaviour is what you get above
 700px, not at it.
 
-**The first screen fits a 13" laptop, and that is a measurement.** At
-1440×900 with the header, `.hero` bottom sits at 720px, the button at 483px and
-the trust line at 656px — 180px of clearance, with the metrics strip already
-showing underneath.
-Re-measure `getBoundingClientRect().bottom` on `.hero` after any change to the
-headline wording, the description, or the hero's padding; a first screen whose
-button falls below 900px is a regression however good it looks at 1440×1080.
+**The first screen fits a 13" laptop, and that is a measurement.** Measured
+on the live page at 1440×900: the button top sits at 630px and the trust line
+at 841px, with the metrics strip below the fold. The rule is the button, not
+the hero — a first screen whose button falls below 900px is a regression
+however good it looks at 1440×1080.
+
+Re-measure `getBoundingClientRect()` on `.hero-cta` and `.hero-trust` after any
+change to the headline wording, either paragraph, or the hero's padding. The
+figures here have been refreshed once already (TRA-1143): they read 483px and
+656px from before the evidence line existed, which made a stale record look
+like a passing check. If you change the hero and do not re-measure, the next
+run reads your numbers as the truth.
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -666,16 +666,26 @@ updated: 2026-09-07
     /* The payoff half of the subtitle separates on colour, not weight — a second
        weight here would spend a budget slot on what one shade already says. */
     .hero-desc .accent-text { color: var(--text-display); }
-    /* The boundary line reads as the quiet half of the same paragraph: same
-       measure, one step down in size and shade, so it is carried with the claim
-       without competing with it. */
-    .hero-boundary {
+    /* Two lines sit under the claim and they are not the same kind of sentence,
+       so they no longer share one class (TRA-1143). `.hero-evidence` is the other
+       half of the measurement — the quality result that says the cheap context was
+       worth having — and it carries the claim's own shade and the same
+       `.accent-text` treatment on its numbers, so the two read as one body of
+       evidence at two sizes. `.hero-boundary` is a scope note about what the
+       product does to your machine; that one is genuinely the quiet half and stays
+       a step down in shade. They were identical at 15px/--text-secondary, which
+       made the result that answers "is it worse?" look like the small print
+       underneath the number it qualifies. Size still separates evidence from
+       claim; shade now groups them. */
+    .hero-evidence, .hero-boundary {
       margin: 14px auto 0;
       max-width: 660px;
       font-size: 15px;
       line-height: 1.5;
-      color: var(--text-secondary);
     }
+    .hero-evidence { color: var(--text-primary); }
+    .hero-evidence .accent-text { color: var(--text-display); }
+    .hero-boundary { color: var(--text-secondary); }
     /* The three mono caps rows of the hero — eyebrow above the headline, the
        alternative platforms under the button, the trust line at the fold — are one
        treatment at three opacities, not three components. Only the distance from the
@@ -751,7 +761,7 @@ updated: 2026-09-07
       .hero { padding: 64px 0 40px; }
       .hero-headline { font-size: clamp(30px, 8vw, 44px); max-width: 100%; }
       .hero-desc { margin-top: 20px; font-size: 16px; }
-      .hero-boundary { margin-top: 12px; font-size: 14px; }
+      .hero-evidence, .hero-boundary { margin-top: 12px; font-size: 14px; }
       /* Full width, one button: on a phone the download is a target, not a pill
          floating in the middle of a 390px row. */
       .hero-cta { margin-top: 28px; }
@@ -2319,13 +2329,19 @@ updated: 2026-09-07
            having — a page that publishes only the saving asks the reader to take the
            rest on trust. Reuses .hero-boundary rather than adding a class: same
            treatment, same measure, one less thing in the hero to keep in step.
-           Gated by tests/docs/readme-claims.test.ts. -->
-      <p class="hero-boundary">
+           Gated by tests/docs/readme-claims.test.ts.
+
+           TRA-1143: `.hero-evidence`, not `.hero-boundary`. Both classes rendered
+           identically, so the half that answers "is the thinner context worse?" was
+           set in the same grey as the scope note below it and read as small print
+           under the saving. Its four numbers take the claim's own `.accent-text`
+           treatment for the same reason. -->
+      <p class="hero-evidence">
         Cheaper is not better, so the same PRs were reviewed twice and scored blind:
-        {{ site.data.pr_context_quality.trace_understood }} understood the change against
-        {{ site.data.pr_context_quality.baseline_understood }} for naive file loading,
-        {{ site.data.pr_context_quality.trace_false_positives }} false positives per PR against
-        {{ site.data.pr_context_quality.baseline_false_positives }} &mdash;
+        <span class="accent-text">{{ site.data.pr_context_quality.trace_understood }}</span> understood the change against
+        <span class="accent-text">{{ site.data.pr_context_quality.baseline_understood }}</span> for naive file loading,
+        <span class="accent-text">{{ site.data.pr_context_quality.trace_false_positives }}</span> false positives per PR against
+        <span class="accent-text">{{ site.data.pr_context_quality.baseline_false_positives }}</span> &mdash;
         <a href="/pr-context-benchmark.html#does-the-thinner-context-produce-a-worse-review">parity, against a bar set before the run</a>.
       </p>
 


### PR DESCRIPTION
## What

The landing hero carries two sentences under the claim, and they are not the same kind of sentence:

- **the other half of the measurement** — the blind-scored review quality that says the cheap context was worth having;
- **a scope note** — what the product does to your machine.

They shared `.hero-boundary` and rendered identically. Measured on the live page at 1440×900:

| | size | colour | numbers |
|---|---|---|---|
| claim (`.hero-desc`) | 19px | `#E8E8E8` | `#FFF` via `.accent-text` |
| quality evidence | 15px | `#999` | none |
| scope note | 15px | `#999` | none |

So the answer to "is the thinner context worse?" was set in the same grey as a legal boundary, one size and three shades below the saving it qualifies. The saving was loud; the proof it had not been bought with worse reviews was quiet. That is the shape [the roadmap's item 20](https://github.com/nikolai-vysotskyi/trace-mcp/blob/master/docs/ROADMAP.md) asks the hero not to have — honesty as a disclaimer rather than as a strength.

## Change

Split the class. `.hero-evidence` keeps the **15px size** — size is what separates evidence from claim — and takes `--text-primary` plus the claim's own `.accent-text` on its four figures. Shade now groups the two halves of one measurement and drops the scope note out. `.hero-boundary` is unchanged and now means only the scope note.

All four figures are emphasised, including `0.80 false positives per PR against 0.58`, which is us being worse. Dimming the losing number is how a comparison becomes a boast.

`docs/DESIGN-WEB.md` §8 records the ladder, and its "first screen fits a 13-inch laptop" figures are refreshed — they still read 483px/656px from before the evidence line existed, so a stale record was reading as a passing check.

## Verification

- **Layout-neutral, measured not assumed.** Rendered before and after in the same local preview, 1440×900 and 390×844: every element top identical (cta 678/767, trust 889/952). Only colour changed.
- **Contrast sweep green** in both themes — `node scripts/contrast-sweep.mjs /` → 484 elements × 2, 0 failures. Full site sweep also 0/49 pages.
- **`pnpm vitest run tests/docs/`** → 24 files, 395 passed.
- Colour greps from the §5 checklist unchanged: no red outside the two token definitions, no accent outside `.btn-primary`.
- Screenshots below, dark and light at 1440.

## Also swept this run (no findings, recorded so the next run goes further)

Geometry and a11y half of the §5 checklist, driven over CDP against the **live published DOM**, 49 pages × {1440, 390} × {dark, light}:

- sideways page scroll — 0
- centred table cells — 0
- unpaired app screenshots — 0
- `img` without `alt` — 0
- `.prose th` without `scope` — 0
- focus rings by real Tab traversal (84 stops on `/`, 88 on `/configuration.html` at 390px) — every stop rings at `--text-display`, no Chrome blue, no missing ring
- one dead scroll stop: `.table-scroll` on `/configuration.html` @390 takes a tab stop while it does not overflow. Small; noting it rather than fixing it in this diff.
