### PR TITLE
fix(app): drop the false role=grid on the projects list (TRA-1108)

### DIFF
--- a/packages/app/src/renderer/workspace/WorkspaceCompactView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceCompactView.tsx
@@ -5,6 +5,11 @@
  * head-truncated paths, 24×24 hit targets, labelled actions, a right-click
  * menu with the same actions, and ↑ / ↓ + ⏎ list navigation. Selection and
  * mutation contracts match WorkspaceTableView.
+ *
+ * `role="list"` / `role="listitem"`, not `"grid"` (TRA-1108) — rows are not
+ * cells and there is no roving-tabindex/arrow-key-between-cells behaviour to
+ * back a grid role's promise; each row's checkbox and actions stay separate
+ * Tab stops.
  */
 import { type MouseEvent, type UIEvent, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -72,7 +77,7 @@ function CompactRow({
 
   return (
     <div
-      role="row"
+      role="listitem"
       aria-selected={selected}
       className="flex items-center gap-2 px-3 cursor-pointer transition-colors"
       style={{
@@ -173,7 +178,7 @@ export function WorkspaceCompactView({
     <div
       ref={scrollRef}
       tabIndex={0}
-      role="grid"
+      role="list"
       aria-label={t('projectsGrid')}
       className="flex-1 overflow-auto"
       style={{

--- a/packages/app/src/renderer/workspace/WorkspaceCompactView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceCompactView.tsx
@@ -78,7 +78,6 @@ function CompactRow({
   return (
     <div
       role="listitem"
-      aria-selected={selected}
       className="flex items-center gap-2 px-3 cursor-pointer transition-colors"
       style={{
         minHeight: COMPACT_ROW_H,

--- a/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
@@ -476,7 +476,7 @@ export function WorkspaceTableView({
           box-shadow on cells in the collapsed model, which is why the pinned
           seams below have declared a hairline since TRA-265 and never drawn
           one. The row hairline lives on the cells there. */}
-      <table className="ws-table w-full text-[13px]">
+      <table className="ws-table w-full text-[13px]" aria-label={t('projectsGrid')}>
         {/* STICKY_HEADER_BG, not a bare --fill-quaternary: that token is
             translucent, so rows scrolling under a sticky header showed
             straight through the column labels. Same reason the pinned cells

--- a/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
@@ -434,12 +434,14 @@ export function WorkspaceTableView({
   return (
     <div
       ref={scrollRef}
-      // One tab stop for the whole grid, then ↑↓ to move and ⏎ to open — the
-      // list-navigation contract every Mac list follows.
+      // ↑↓ move a row cursor, ⏎ opens it — the list-navigation contract every
+      // Mac list follows. No role here: the `<table>` below already carries
+      // native table/row/cell semantics, and this wrapper is just the
+      // scrollable, keyboard-focusable region around it (TRA-1108 — a prior
+      // `role="grid"` promised row/cell/roving-tabindex structure this view
+      // never implemented).
       tabIndex={0}
-      role="grid"
       aria-label={t('projectsGrid')}
-      aria-rowcount={projects.length}
       className="flex-1 overflow-auto"
       style={
         {


### PR DESCRIPTION
## Summary
- Workspace Table view: removed `role="grid"` + `aria-rowcount` from the scroll wrapper. The `<table>` inside already carries native `table`/`row`/`cell` semantics; the wrapper is just a focusable scroll region.
- Workspace Compact view: switched the wrapper from `role="grid"` to `role="list"`, and each row from `role="row"` to `role="listitem"` — a list correctly permits interactive descendants (checkbox, per-row actions) as separate Tab stops.

Neither view had `role="row"`/`role="gridcell"` structure, `tabindex` management, or arrow-key-between-cells navigation to back a grid role's promise — verified via computed accessibility tree in a running instance (TRA-1108): `role="grid"` announced structure that wasn't there. Chose the "drop the misleading role" fix over implementing a full ARIA data-grid pattern (roving tabindex across 40+ rows with 70/80 actions disabled) as the cheaper of the two options the issue accepted.

No visual change — this is an attribute-only fix, confirmed no rendering diff via screenshot before/after.

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test --run` — 749/749 passing
- [x] `pnpm run build` — clean
- [x] Verified in a running dev instance via chrome-devtools: `document.querySelector('[role="grid"]')` → `null` in both Table and Compact views; native `<table>`/`<tr>` intact (95 rows); Compact view exposes `role="list"` with 95 `role="listitem"` children
- [x] Screenshot comparison — no visual regression