### PR TITLE
fix(activity): keep tool-call history on disk so the tab stops reading zero (TRA-1071)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,6 +98,7 @@ All state is centralized in `~/.trace/`, and what goes in it is set by
   registry.json             # project registry (all added projects)
   topology.db               # cross-service topology + subproject graph
   analytics.db              # session analytics (cross-project)
+  activity.db               # tool-call history behind the Activity tab (7-day retention)
   savings.json              # cumulative token savings tracker
   index/
     my-app-a1b2c3d4e5f6.db  # per-project SQLite databases
@@ -119,6 +120,17 @@ The **decision memory database** (`decisions.db`) is also shared across all proj
 - **Decisions** — architectural decisions, tech choices, bug root causes, preferences, etc., each with temporal validity (`valid_from`/`valid_until`) and optional code linkage (`symbol_id`, `file_path`, `service_name`)
 - **Session chunks** — chunked conversation content from AI session logs, FTS5-indexed for cross-session search
 - **Mined sessions tracker** — prevents re-processing already-mined session files
+
+The **activity database** (`activity.db`) records every MCP tool call the daemon
+serves, keyed by project root: timestamp, tool, params summary, result count and
+tokens, latency, error flag, session id. It answers one question — *what has been
+happening in this project* — which is why it is on disk rather than in the
+`SessionJournal`: a journal belongs to one MCP session and dies with it, so the
+Activity tab read `0 calls` in every window while agents were actively working
+(TRA-1071). Entries are batched (128 rows or 2 s) and pruned to 7 days, which is
+what lets the tab offer a 24h window honestly. The API reports `recording_since`
+so the UI can say when recording started instead of presenting a young install's
+empty 24h window as a confident zero.
 
 Decisions are auto-enriched into code intelligence tool responses (`get_change_impact`, `plan_turn`, `get_wake_up`) via the enrichment layer in `src/memory/enrichment.ts`.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3706,6 +3706,7 @@ All state is centralized in `~/.trace/`, and what goes in it is set by
   registry.json             # project registry (all added projects)
   topology.db               # cross-service topology + subproject graph
   analytics.db              # session analytics (cross-project)
+  activity.db               # tool-call history behind the Activity tab (7-day retention)
   savings.json              # cumulative token savings tracker
   index/
     my-app-a1b2c3d4e5f6.db  # per-project SQLite databases
@@ -3727,6 +3728,17 @@ The **decision memory database** (`decisions.db`) is also shared across all proj
 - **Decisions** — architectural decisions, tech choices, bug root causes, preferences, etc., each with temporal validity (`valid_from`/`valid_until`) and optional code linkage (`symbol_id`, `file_path`, `service_name`)
 - **Session chunks** — chunked conversation content from AI session logs, FTS5-indexed for cross-session search
 - **Mined sessions tracker** — prevents re-processing already-mined session files
+
+The **activity database** (`activity.db`) records every MCP tool call the daemon
+serves, keyed by project root: timestamp, tool, params summary, result count and
+tokens, latency, error flag, session id. It answers one question — *what has been
+happening in this project* — which is why it is on disk rather than in the
+`SessionJournal`: a journal belongs to one MCP session and dies with it, so the
+Activity tab read `0 calls` in every window while agents were actively working
+(TRA-1071). Entries are batched (128 rows or 2 s) and pruned to 7 days, which is
+what lets the tab offer a 24h window honestly. The API reports `recording_since`
+so the UI can say when recording started instead of presenting a young install's
+empty 24h window as a confident zero.
 
 Decisions are auto-enriched into code intelligence tool responses (`get_change_impact`, `plan_turn`, `get_wake_up`) via the enrichment layer in `src/memory/enrichment.ts`.
 

--- a/packages/app/src/renderer/tabs/ToolActivity.tsx
+++ b/packages/app/src/renderer/tabs/ToolActivity.tsx
@@ -142,6 +142,11 @@ interface JournalStats {
   // caller can confirm which window the response covers. Optional — the
   // "window ends at now" path omits it.
   window_end?: number;
+  // Unix ms from which the daemon has actually been recording activity. A
+  // window that reaches further back than this cannot be full, and the bar
+  // says so rather than presenting a confident zero (TRA-1071). Absent on
+  // daemons older than this field.
+  recording_since?: number;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────
@@ -806,6 +811,18 @@ function StatsSummaryBar({
           aria-label={t('statsWindow')}
         />
       </div>
+      {/* The window can outrun the recorded history — a fresh install has
+          minutes of data behind a "24h" label. Say which, instead of letting
+          the zero read as "nothing happened". */}
+      {typeof stats.recording_since === 'number' && Date.now() - windowMs < stats.recording_since && (
+        <span
+          className="shrink-0 text-[11px] leading-[13px]"
+          style={{ color: 'var(--label-secondary)' }}
+          title={formatDate(stats.recording_since, { dateStyle: 'medium', timeStyle: 'short' })}
+        >
+          {t('recordingStarted', { when: relativeTime(stats.recording_since) })}
+        </span>
+      )}
       <span
         className="flex items-center gap-1 text-[13px] leading-4"
         style={{ color: 'var(--label)' }}

--- a/packages/app/src/shared/i18n/catalog/de/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/de/activity.ts
@@ -15,6 +15,7 @@ export const activity = {
   window1h: '1 Std.',
   window6h: '6 Std.',
   window24h: '24 Std.',
+  recordingStarted: 'Aufzeichnung begann {{when}}',
 
   // ── Feed state ──
   feedLive: 'Live',

--- a/packages/app/src/shared/i18n/catalog/en/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/en/activity.ts
@@ -24,6 +24,8 @@ export const activity = {
   window1h: '1h',
   window6h: '6h',
   window24h: '24h',
+  /** `when` is a relative time from i18n/format.ts, e.g. "12 minutes ago". */
+  recordingStarted: 'recording started {{when}}',
 
   // ── Feed state, shared by both surfaces ──
   feedLive: 'Live',

--- a/packages/app/src/shared/i18n/catalog/es/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/es/activity.ts
@@ -13,6 +13,7 @@ export const activity = {
   window1h: '1 h',
   window6h: '6 h',
   window24h: '24 h',
+  recordingStarted: 'registro iniciado {{when}}',
 
   feedLive: 'En vivo',
   feedIdle: 'Inactivo',

--- a/packages/app/src/shared/i18n/catalog/fr/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/fr/activity.ts
@@ -13,6 +13,7 @@ export const activity = {
   window1h: '1 h',
   window6h: '6 h',
   window24h: '24 h',
+  recordingStarted: 'enregistrement commencé {{when}}',
 
   feedLive: 'En direct',
   feedIdle: 'Inactif',

--- a/packages/app/src/shared/i18n/catalog/hi/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/hi/activity.ts
@@ -13,6 +13,7 @@ export const activity = {
   window1h: '1घं',
   window6h: '6घं',
   window24h: '24घं',
+  recordingStarted: 'रिकॉर्डिंग {{when}} शुरू हुई',
 
   feedLive: 'लाइव',
   feedIdle: 'निष्क्रिय',

--- a/packages/app/src/shared/i18n/catalog/ja/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/ja/activity.ts
@@ -13,6 +13,7 @@ export const activity = {
   window1h: '1時間',
   window6h: '6時間',
   window24h: '24時間',
+  recordingStarted: '記録開始: {{when}}',
 
   feedLive: 'ライブ',
   feedIdle: '待機中',

--- a/packages/app/src/shared/i18n/catalog/ko/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/ko/activity.ts
@@ -13,6 +13,7 @@ export const activity = {
   window1h: '1시간',
   window6h: '6시간',
   window24h: '24시간',
+  recordingStarted: '기록 시작: {{when}}',
 
   feedLive: '실시간',
   feedIdle: '대기',

--- a/packages/app/src/shared/i18n/catalog/pt-BR/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/pt-BR/activity.ts
@@ -13,6 +13,7 @@ export const activity = {
   window1h: '1h',
   window6h: '6h',
   window24h: '24h',
+  recordingStarted: 'registro iniciado {{when}}',
 
   feedLive: 'Ao vivo',
   feedIdle: 'Ocioso',

--- a/packages/app/src/shared/i18n/catalog/ru/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/ru/activity.ts
@@ -20,6 +20,7 @@ export const activity = {
   window1h: '1ч',
   window6h: '6ч',
   window24h: '24ч',
+  recordingStarted: 'запись началась {{when}}',
 
   feedLive: 'В эфире',
   feedIdle: 'Простой',

--- a/packages/app/src/shared/i18n/catalog/zh/activity.ts
+++ b/packages/app/src/shared/i18n/catalog/zh/activity.ts
@@ -13,6 +13,7 @@ export const activity = {
   window1h: '1 小时',
   window6h: '6 小时',
   window24h: '24 小时',
+  recordingStarted: '开始记录于{{when}}',
 
   feedLive: '实时',
   feedIdle: '空闲',

--- a/src/api/journal-stats-routes.ts
+++ b/src/api/journal-stats-routes.ts
@@ -53,7 +53,23 @@ export interface JournalEntryForStats {
  * newest-first or any order (the handler sorts by ts internally).
  */
 export interface JournalStatsContext {
-  listEntriesForProject(projectRoot: string): JournalEntryForStats[];
+  /**
+   * Entries for a project. `since`/`until` bound the read when given — the
+   * durable store windows in SQL rather than handing back every row it has.
+   * Callers that omit them get whatever the implementation considers "recent".
+   */
+  listEntriesForProject(
+    projectRoot: string,
+    since?: number,
+    until?: number,
+  ): JournalEntryForStats[];
+  /**
+   * Unix ms from which activity has actually been recorded — the point before
+   * which a wider window cannot have data. Undefined when the integrator has no
+   * durable store, in which case the response omits `recording_since` and the
+   * UI keeps its old "no idea" behaviour.
+   */
+  recordingSince?(): number | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -91,6 +107,13 @@ export interface ByMinute {
 
 export interface JournalStatsResponse {
   window_ms: number;
+  /**
+   * Unix ms from which activity has been recorded. A window reaching further
+   * back than this is not empty because nothing happened — it is empty because
+   * nobody was writing it down yet, and the UI says so instead of showing a
+   * confident zero (TRA-1071).
+   */
+  recording_since?: number;
   /** Window end timestamp (Unix ms) — echoes the `before` query param (or now). */
   window_end?: number;
   total_calls: number;
@@ -305,7 +328,21 @@ export function handleJournalStatsRequest(
     return true;
   }
 
+  // `parseInt` used to accept "24h" and silently return a 24-millisecond
+  // window. The app only ever sends digits, so nothing broke visibly — but an
+  // external caller got a plausible-looking answer to a question it did not
+  // ask (TRA-1071). Milliseconds or a 400.
   const rawWindow = url.searchParams.get('window');
+  if (rawWindow !== null && !/^\d+$/.test(rawWindow.trim())) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        error: 'window must be a positive integer number of milliseconds',
+        got: rawWindow,
+      }),
+    );
+    return true;
+  }
   const windowMs = rawWindow
     ? Math.min(MAX_WINDOW_MS, Math.max(1, parseInt(rawWindow, 10) || DEFAULT_WINDOW_MS))
     : DEFAULT_WINDOW_MS;
@@ -316,8 +353,10 @@ export function handleJournalStatsRequest(
   const beforeParsed = beforeRaw ? Number(beforeRaw) : Date.now();
   const before = Number.isFinite(beforeParsed) && beforeParsed > 0 ? beforeParsed : Date.now();
 
-  const entries = ctx.listEntriesForProject(projectRoot);
+  const entries = ctx.listEntriesForProject(projectRoot, before - windowMs, before);
   const stats = aggregate(entries, windowMs, before);
+  const recordingSince = ctx.recordingSince?.();
+  if (typeof recordingSince === 'number') stats.recording_since = recordingSince;
 
   res.writeHead(200, {
     'Content-Type': 'application/json',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -921,6 +921,18 @@ program
     // Reverse lookup: projectRoot → Set<sessionId> (for cleanup)
     const projectSessions = new Map<string, Set<string>>();
 
+    // Durable activity log. Journals die with their session — every agent run
+    // is a client that disconnects — so the Activity tab read zero on every
+    // window regardless of how busy the project was (TRA-1071). Entries are
+    // appended here as they are broadcast and read back per time window.
+    let activityStore: import('./session/activity-store.js').ActivityStore | null = null;
+    try {
+      const { ActivityStore } = await import('./session/activity-store.js');
+      activityStore = new ActivityStore();
+    } catch (e) {
+      logger.warn(`activity store unavailable: ${(e as Error)?.message ?? e}`);
+    }
+
     async function createSessionTransport(
       projectRoot: string,
       /**
@@ -967,9 +979,9 @@ program
         onJournalEntry: (
           data: import('./server/journal-broadcast.js').JournalEntryCallbackData,
         ) => {
-          broadcastEvent(
-            buildJournalEvent({ ...data, project: projectRoot, session_id: sessionId }),
-          );
+          const entry = { ...data, project: projectRoot, session_id: sessionId };
+          broadcastEvent(buildJournalEvent(entry));
+          activityStore?.record(entry);
         },
         // R09 v2: lets MCP tools (embed_repo, snapshot_graph) emit
         // pipeline-lifecycle events through the existing SSE bus.
@@ -2978,15 +2990,39 @@ program
           res.end(JSON.stringify({ error: 'project query param is required' }));
           return;
         }
-        const sids = projectSessions.get(projectRoot);
+        // Read the durable log: it covers every session of this project, not
+        // just the newest one, and it survives the disconnects and daemon
+        // restarts that used to empty this feed (TRA-1071). Without a store
+        // (open failed) fall back to the live journals so the tab still shows
+        // the current session.
         let snapshot: ReturnType<typeof buildJournalSnapshot> = [];
-        if (sids && sids.size > 0) {
-          // Pick the most recently created session (last inserted into the Set).
-          const sid = [...sids].pop()!;
-          const handle = sessionHandles.get(sid);
-          if (handle) {
-            snapshot = buildJournalSnapshot(handle.journal, projectRoot, sid, limit);
+        if (activityStore) {
+          const now = Date.now();
+          snapshot = activityStore
+            .listForProject(projectRoot, now - 24 * 60 * 60 * 1000, now)
+            .slice(-limit)
+            .reverse()
+            .map((r) => ({
+              type: 'journal_entry' as const,
+              project: projectRoot,
+              ts: r.ts,
+              tool: r.tool,
+              params_summary: r.params_summary,
+              result_count: r.result_count,
+              result_tokens: r.result_tokens ?? undefined,
+              latency_ms: r.latency_ms ?? undefined,
+              is_error: r.is_error === 1,
+              session_id: r.session_id,
+            }));
+        } else {
+          const sids = projectSessions.get(projectRoot);
+          for (const sid of sids ?? []) {
+            const handle = sessionHandles.get(sid);
+            if (handle)
+              snapshot.push(...buildJournalSnapshot(handle.journal, projectRoot, sid, limit));
           }
+          snapshot.sort((a, b) => b.ts - a.ts);
+          snapshot = snapshot.slice(0, limit);
         }
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(snapshot));
@@ -2995,7 +3031,21 @@ program
 
       // ── Activity stats — aggregated journal metrics for the Activity tab ─
       const journalStatsCtx: JournalStatsContext = {
-        listEntriesForProject(projectRoot) {
+        listEntriesForProject(projectRoot, since, until) {
+          const end = until ?? Date.now();
+          const start = since ?? end - 24 * 60 * 60 * 1000;
+          if (activityStore) {
+            return activityStore.listForProject(projectRoot, start, end).map((r) => ({
+              ts: r.ts,
+              tool: r.tool,
+              params_summary: r.params_summary,
+              result_count: r.result_count,
+              result_tokens: r.result_tokens ?? undefined,
+              latency_ms: r.latency_ms ?? undefined,
+              is_error: r.is_error === 1,
+              session_id: r.session_id,
+            }));
+          }
           const sids = projectSessions.get(projectRoot);
           if (!sids || sids.size === 0) return [];
           const out: ReturnType<typeof buildJournalSnapshot> = [];
@@ -3003,8 +3053,9 @@ program
             const handle = sessionHandles.get(sid);
             if (handle) out.push(...buildJournalSnapshot(handle.journal, projectRoot, sid, 10_000));
           }
-          return out;
+          return out.filter((e) => e.ts >= start && e.ts <= end);
         },
+        recordingSince: () => activityStore?.recordingSince(),
       };
       if (handleJournalStatsRequest(req, res, url, journalStatsCtx)) return;
 
@@ -3115,6 +3166,7 @@ program
       }
       sessionHandles.clear();
       sessionClients.clear();
+      activityStore?.close();
       // Close all session transports
       for (const transport of sessionTransports.values()) {
         await transport.close().catch(() => {});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2977,8 +2977,9 @@ program
 
       // ── Activity tab — snapshot of recent journal entries for a project ──
       // Live updates flow through /api/events as `journal_entry` events; this
-      // endpoint returns the last N entries from the most-recently-active
-      // session's journal so the tab can populate on first mount.
+      // endpoint returns the last N recorded entries for the project — every
+      // session of it, past ones included — so the tab can populate on first
+      // mount.
       if (req.method === 'GET' && url.pathname === '/api/projects/journal') {
         const projectRoot = url.searchParams.get('project');
         const limit = Math.min(

--- a/src/session/activity-store.ts
+++ b/src/session/activity-store.ts
@@ -22,6 +22,7 @@
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { ensureGlobalDirs, TRACE_MCP_HOME } from '../global.js';
+import { logger } from '../logger.js';
 import { restrictDbPerms } from '../shared/db-perms.js';
 
 export const ACTIVITY_DB_PATH = path.join(TRACE_MCP_HOME, 'activity.db');
@@ -85,6 +86,8 @@ export class ActivityStore {
   private buffer: ActivityEntry[] = [];
   private flushTimer: NodeJS.Timeout | null = null;
   private lastPruneAt = 0;
+  /** One log line per failure kind — a full disk would otherwise write a line per batch. */
+  private warned = { flush: false, prune: false };
   private readonly insertStmt: Database.Statement;
   private readonly recordingSinceMs: number;
 
@@ -160,9 +163,16 @@ export class ActivityStore {
           });
         }
       })(batch);
-    } catch {
+    } catch (e) {
       // A failed batch is a hole in a chart, not a reason to take the daemon
       // down. Dropped deliberately — retrying would grow the buffer unbounded.
+      // Silently, though, this reproduces the very bug this store exists to
+      // fix: a disk that fills up after the daemon opened the DB sends Activity
+      // back to zero with nothing in the log to say why. Say it once.
+      if (!this.warned.flush) {
+        this.warned.flush = true;
+        logger.warn({ err: e }, 'activity store write failed — Activity history will have gaps');
+      }
     }
     this.prune();
   }
@@ -203,8 +213,12 @@ export class ActivityStore {
     this.lastPruneAt = now;
     try {
       this.db.prepare('DELETE FROM journal_entries WHERE ts < ?').run(now - RETENTION_MS);
-    } catch {
+    } catch (e) {
       // Retention is best-effort; a locked DB just means we prune next hour.
+      if (!this.warned.prune) {
+        this.warned.prune = true;
+        logger.warn({ err: e }, 'activity store prune failed — retrying next hour');
+      }
     }
   }
 

--- a/src/session/activity-store.ts
+++ b/src/session/activity-store.ts
@@ -1,0 +1,219 @@
+/**
+ * Activity store — the durable half of the session journal.
+ *
+ * `SessionJournal` keeps its entries in memory because that is what the
+ * dedup/coaching logic needs: one session, one array, gone when the session
+ * ends. The Activity tab asks a different question — "what has been happening
+ * in this project" — and answering it from those arrays means the answer is
+ * always zero: a client disconnect drops the journal, and every agent run is a
+ * client that disconnects. Measured on a live daemon (TRA-1071): one tool call
+ * is visible while the session is open, and `total_calls` is back to 0 one
+ * second after the client sends DELETE /mcp.
+ *
+ * So Activity is project history, and history lives on disk. Every journal
+ * entry the daemon broadcasts is also appended here, keyed by project root, and
+ * read back per time window.
+ *
+ * Its own DB file rather than a table in `analytics.db`: that one is written by
+ * the log-sync path (a Stop hook fires one per turn) and is 100 MB+ on this
+ * machine. Two writers with different cadences on one WAL buys nothing here.
+ */
+
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { ensureGlobalDirs, TRACE_MCP_HOME } from '../global.js';
+import { restrictDbPerms } from '../shared/db-perms.js';
+
+export const ACTIVITY_DB_PATH = path.join(TRACE_MCP_HOME, 'activity.db');
+
+/** How far back the store keeps entries. Covers the widest UI window (24h) with room to spare. */
+export const RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Flush when this many entries are buffered, whatever the timer says. */
+const FLUSH_AT = 128;
+/** …or this long after the first buffered entry, whichever comes first. */
+const FLUSH_INTERVAL_MS = 2_000;
+/** Pruning old rows is bookkeeping, not user-visible work — hourly is plenty. */
+const PRUNE_INTERVAL_MS = 60 * 60 * 1000;
+
+export interface ActivityEntry {
+  ts: number;
+  project: string;
+  session_id: string;
+  tool: string;
+  params_summary: string;
+  result_count: number;
+  result_tokens?: number;
+  latency_ms?: number;
+  is_error: boolean;
+}
+
+interface ActivityRow {
+  ts: number;
+  session_id: string;
+  tool: string;
+  params_summary: string;
+  result_count: number;
+  result_tokens: number | null;
+  latency_ms: number | null;
+  is_error: number;
+}
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS journal_entries (
+  ts INTEGER NOT NULL,
+  project TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  tool TEXT NOT NULL,
+  params_summary TEXT NOT NULL DEFAULT '',
+  result_count INTEGER NOT NULL DEFAULT 0,
+  result_tokens INTEGER,
+  latency_ms INTEGER,
+  is_error INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_je_project_ts ON journal_entries(project, ts);
+
+CREATE TABLE IF NOT EXISTS meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+`;
+
+export class ActivityStore {
+  private db: Database.Database;
+  private buffer: ActivityEntry[] = [];
+  private flushTimer: NodeJS.Timeout | null = null;
+  private lastPruneAt = 0;
+  private readonly insertStmt: Database.Statement;
+  private readonly recordingSinceMs: number;
+
+  constructor(dbPath: string = ACTIVITY_DB_PATH) {
+    ensureGlobalDirs();
+    this.db = new Database(dbPath);
+    restrictDbPerms(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('busy_timeout = 5000');
+    // Entry loss on a hard crash costs a few seconds of a stats chart. Paying a
+    // per-batch fsync on the daemon's main thread for that is a bad trade.
+    this.db.pragma('synchronous = NORMAL');
+    this.db.exec(SCHEMA_SQL);
+
+    const now = Date.now();
+    const existing = this.db
+      .prepare('SELECT value FROM meta WHERE key = ?')
+      .get('recording_since') as { value: string } | undefined;
+    if (existing) {
+      this.recordingSinceMs = Number(existing.value) || now;
+    } else {
+      this.db
+        .prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)')
+        .run('recording_since', String(now));
+      this.recordingSinceMs = now;
+    }
+
+    this.insertStmt = this.db.prepare(
+      `INSERT INTO journal_entries
+         (ts, project, session_id, tool, params_summary, result_count, result_tokens, latency_ms, is_error)
+       VALUES (@ts, @project, @session_id, @tool, @params_summary, @result_count, @result_tokens, @latency_ms, @is_error)`,
+    );
+  }
+
+  /**
+   * Buffer one entry. Writes are batched: better-sqlite3 is synchronous, and
+   * this runs on the same thread that answers /health.
+   */
+  record(entry: ActivityEntry): void {
+    this.buffer.push(entry);
+    if (this.buffer.length >= FLUSH_AT) {
+      this.flush();
+      return;
+    }
+    if (this.flushTimer === null) {
+      this.flushTimer = setTimeout(() => this.flush(), FLUSH_INTERVAL_MS);
+      this.flushTimer.unref?.();
+    }
+  }
+
+  /** Write buffered entries out. Safe to call at any time; a no-op when empty. */
+  flush(): void {
+    if (this.flushTimer !== null) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    if (this.buffer.length === 0) return;
+    const batch = this.buffer;
+    this.buffer = [];
+    try {
+      this.db.transaction((rows: ActivityEntry[]) => {
+        for (const e of rows) {
+          this.insertStmt.run({
+            ts: e.ts,
+            project: e.project,
+            session_id: e.session_id,
+            tool: e.tool,
+            params_summary: e.params_summary ?? '',
+            result_count: e.result_count ?? 0,
+            result_tokens: e.result_tokens ?? null,
+            latency_ms: e.latency_ms ?? null,
+            is_error: e.is_error ? 1 : 0,
+          });
+        }
+      })(batch);
+    } catch {
+      // A failed batch is a hole in a chart, not a reason to take the daemon
+      // down. Dropped deliberately — retrying would grow the buffer unbounded.
+    }
+    this.prune();
+  }
+
+  /**
+   * Entries for one project inside [since, until], oldest-first.
+   * Flushes first so a call made a second ago is not missing from its own tab.
+   */
+  listForProject(project: string, since: number, until: number): ActivityRow[] {
+    this.flush();
+    return this.db
+      .prepare(
+        `SELECT ts, session_id, tool, params_summary, result_count, result_tokens, latency_ms, is_error
+           FROM journal_entries
+          WHERE project = ? AND ts >= ? AND ts <= ?
+          ORDER BY ts ASC`,
+      )
+      .all(project, since, until) as ActivityRow[];
+  }
+
+  /**
+   * Earliest moment this store can have data for: when it started recording, or
+   * the retention cutoff, whichever is later. The UI needs this to stop offering
+   * a 24h window over 12 minutes of data.
+   *
+   * ponytail: this is "recording started at", not "covered without gaps" — a
+   * daemon that was off for two hours leaves a hole this number does not
+   * describe. Track uptime intervals here if the gap ever matters.
+   */
+  recordingSince(): number {
+    return Math.max(this.recordingSinceMs, Date.now() - RETENTION_MS);
+  }
+
+  /** Drop rows past the retention horizon. Throttled — see PRUNE_INTERVAL_MS. */
+  private prune(): void {
+    const now = Date.now();
+    if (now - this.lastPruneAt < PRUNE_INTERVAL_MS) return;
+    this.lastPruneAt = now;
+    try {
+      this.db.prepare('DELETE FROM journal_entries WHERE ts < ?').run(now - RETENTION_MS);
+    } catch {
+      // Retention is best-effort; a locked DB just means we prune next hour.
+    }
+  }
+
+  close(): void {
+    this.flush();
+    try {
+      this.db.close();
+    } catch {
+      // already closed
+    }
+  }
+}

--- a/tests/api/journal-stats-coverage.test.ts
+++ b/tests/api/journal-stats-coverage.test.ts
@@ -1,0 +1,84 @@
+/**
+ * GET /api/projects/journal/stats — window parsing and honest coverage (TRA-1071).
+ *
+ *  - `window=24h` used to parse as 24 milliseconds and answer 200 with
+ *    `window_ms: 24`. An external caller got a plausible answer to a question
+ *    it never asked; now it gets a 400.
+ *  - `recording_since` tells the tab how far back the data can possibly go, so
+ *    a "24h" window over 12 minutes of history stops reading as a hard zero.
+ */
+
+import http from 'node:http';
+import { describe, expect, it } from 'vitest';
+
+import {
+  handleJournalStatsRequest,
+  type JournalEntryForStats,
+  type JournalStatsContext,
+} from '../../src/api/journal-stats-routes.js';
+
+function call(
+  query: string,
+  ctx: JournalStatsContext,
+): { status: number; body: Record<string, unknown> } {
+  const url = new URL(`http://127.0.0.1:3741/api/projects/journal/stats?${query}`);
+  const req = { method: 'GET' } as http.IncomingMessage;
+  let status = 0;
+  let chunk = '';
+  const res = {
+    writeHead(code: number) {
+      status = code;
+      return res;
+    },
+    end(body?: string) {
+      chunk = body ?? '';
+    },
+  } as unknown as http.ServerResponse;
+
+  expect(handleJournalStatsRequest(req, res, url, ctx)).toBe(true);
+  return { status, body: JSON.parse(chunk) };
+}
+
+const emptyCtx: JournalStatsContext = { listEntriesForProject: () => [] };
+
+describe('journal stats route', () => {
+  it('rejects a non-numeric window instead of reading it as milliseconds', () => {
+    const { status, body } = call('project=/p&window=24h', emptyCtx);
+    expect(status).toBe(400);
+    expect(body.got).toBe('24h');
+  });
+
+  it('still accepts a plain millisecond window', () => {
+    const { status, body } = call('project=/p&window=3600000', emptyCtx);
+    expect(status).toBe(200);
+    expect(body.window_ms).toBe(3_600_000);
+  });
+
+  it('passes the window bounds down to the store rather than filtering in JS', () => {
+    const seen: Array<[string, number | undefined, number | undefined]> = [];
+    const ctx: JournalStatsContext = {
+      listEntriesForProject: (root, since, until) => {
+        seen.push([root, since, until]);
+        return [];
+      },
+    };
+    call('project=/p&window=300000&before=1000000000', ctx);
+    expect(seen).toEqual([['/p', 1000000000 - 300_000, 1000000000]]);
+  });
+
+  it('reports how far back recording actually goes', () => {
+    const recordedFrom = Date.now() - 12 * 60_000;
+    const entries: JournalEntryForStats[] = [];
+    const ctx: JournalStatsContext = {
+      listEntriesForProject: () => entries,
+      recordingSince: () => recordedFrom,
+    };
+    const { body } = call('project=/p&window=86400000', ctx);
+    expect(body.recording_since).toBe(recordedFrom);
+  });
+
+  it('omits recording_since when the daemon has no durable store', () => {
+    const { body } = call('project=/p&window=86400000', emptyCtx);
+    expect(body).not.toHaveProperty('recording_since');
+  });
+});

--- a/tests/session/activity-store.test.ts
+++ b/tests/session/activity-store.test.ts
@@ -1,0 +1,152 @@
+/**
+ * ActivityStore — the durable half of the session journal (TRA-1071).
+ *
+ * What must hold:
+ *   - an entry written by one session is still there after that session's
+ *     store instance is closed and a new one opens (this is the whole point:
+ *     the in-memory journal died with the client and Activity always read 0);
+ *   - entries from several sessions of the same project all come back;
+ *   - a project only sees its own entries;
+ *   - the window bounds are applied in SQL, not by the caller;
+ *   - `recordingSince` never claims coverage older than the retention horizon.
+ *
+ * The last test is the perf guard: reading a 24h window out of a week of
+ * entries must stay well under the frame budget of the tab that calls it.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ActivityStore, RETENTION_MS } from '../../src/session/activity-store.js';
+
+let dir: string;
+let dbPath: string;
+const stores: ActivityStore[] = [];
+
+function open(): ActivityStore {
+  const s = new ActivityStore(dbPath);
+  stores.push(s);
+  return s;
+}
+
+function entry(over: Partial<Parameters<ActivityStore['record']>[0]> = {}) {
+  return {
+    ts: Date.now(),
+    project: '/proj/a',
+    session_id: 's1',
+    tool: 'search',
+    params_summary: 'query=foo src/bar.ts',
+    result_count: 3,
+    result_tokens: 120,
+    latency_ms: 42,
+    is_error: false,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'activity-store-'));
+  dbPath = path.join(dir, 'activity.db');
+});
+
+afterEach(() => {
+  for (const s of stores.splice(0)) s.close();
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('ActivityStore', () => {
+  it('survives the session that wrote it', () => {
+    const now = Date.now();
+    const first = open();
+    first.record(entry({ ts: now - 1000 }));
+    first.close();
+
+    const second = open();
+    const rows = second.listForProject('/proj/a', now - 60_000, now);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].tool).toBe('search');
+    expect(rows[0].latency_ms).toBe(42);
+    expect(rows[0].is_error).toBe(0);
+  });
+
+  it('keeps every session of a project, not just the newest', () => {
+    const now = Date.now();
+    const s = open();
+    s.record(entry({ ts: now - 3000, session_id: 'old' }));
+    s.record(entry({ ts: now - 1000, session_id: 'new' }));
+
+    const rows = s.listForProject('/proj/a', now - 60_000, now);
+    expect(rows.map((r) => r.session_id)).toEqual(['old', 'new']);
+  });
+
+  it('scopes reads to one project', () => {
+    const now = Date.now();
+    const s = open();
+    s.record(entry({ ts: now - 1000, project: '/proj/a' }));
+    s.record(entry({ ts: now - 1000, project: '/proj/b' }));
+
+    expect(s.listForProject('/proj/a', now - 60_000, now)).toHaveLength(1);
+    expect(s.listForProject('/proj/b', now - 60_000, now)).toHaveLength(1);
+    expect(s.listForProject('/proj/c', now - 60_000, now)).toHaveLength(0);
+  });
+
+  it('applies the requested window', () => {
+    const now = Date.now();
+    const s = open();
+    s.record(entry({ ts: now - 7_200_000 })); // 2h ago
+    s.record(entry({ ts: now - 60_000 })); // 1 min ago
+
+    expect(s.listForProject('/proj/a', now - 300_000, now)).toHaveLength(1);
+    expect(s.listForProject('/proj/a', now - 86_400_000, now)).toHaveLength(2);
+  });
+
+  it('reads back an entry written a moment ago, before the flush timer fires', () => {
+    const now = Date.now();
+    const s = open();
+    s.record(entry({ ts: now }));
+    // No flush() call — listForProject must not miss the buffer.
+    expect(s.listForProject('/proj/a', now - 1000, now + 1000)).toHaveLength(1);
+  });
+
+  it('never claims coverage older than the retention horizon', () => {
+    const s = open();
+    const since = s.recordingSince();
+    expect(since).toBeGreaterThanOrEqual(Date.now() - RETENTION_MS);
+    expect(since).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('remembers when recording started across restarts', () => {
+    const first = open();
+    const started = first.recordingSince();
+    first.close();
+    expect(open().recordingSince()).toBe(started);
+  });
+
+  it('reads a 24h window out of a week of entries in well under a frame', () => {
+    const now = Date.now();
+    const s = open();
+    // A week at ~50k calls/week — the rate measured on this machine's
+    // analytics.db (47 866 trace tool calls in the last 7 days).
+    const WEEK = 7 * 24 * 60 * 60 * 1000;
+    for (let i = 0; i < 50_000; i++) {
+      s.record(
+        entry({
+          ts: now - Math.floor((i / 50_000) * WEEK),
+          project: i % 5 === 0 ? '/proj/a' : `/proj/other-${i % 7}`,
+        }),
+      );
+    }
+    s.flush();
+
+    const t0 = performance.now();
+    const rows = s.listForProject('/proj/a', now - 86_400_000, now);
+    const elapsed = performance.now() - t0;
+
+    expect(rows.length).toBeGreaterThan(0);
+    // Measured ~2 ms locally. The ceiling is generous on purpose — it is here
+    // to catch a dropped index or a full-table scan, not to police jitter.
+    expect(elapsed).toBeLessThan(150);
+  });
+});


### PR DESCRIPTION
## What was wrong

The Activity tab showed `0 calls` in all four windows, on every project, including one with two live MCP clients attached (TRA-1071).

Not because nothing happened. The tab reads `SessionJournal`, an in-memory array owned by one MCP session. Measured against the running daemon on this machine:

```
session A open, 2 tool calls   → total_calls 2
DELETE /mcp (client disconnect) → total_calls 0
```

Every agent run is a client that disconnects, so the 1h window was empty for the same reason the 24h one was. Daemon restarts are the second-order version of the same loss, not the main one — that is a correction to the issue's framing, which put the restart first.

The stats endpoint already aggregated across all sessions of a project; only the raw feed (`GET /api/projects/journal`) still took the most-recently-created session and ignored the rest.

## The decision this required

**Activity is project history, not a live feed of the current session** — so it goes on disk. Recorded in `docs/architecture.md`.

The alternative, showing `analytics.db` (221 475 rows here), was rejected: that DB is parsed out of Claude Code JSONL logs, so it never sees Cursor or the desktop app, carries no real latency, and lags by design (TRA-1072). The daemon's own journal is the only source that sees every client.

## What changed

- `src/session/activity-store.ts` — `~/.trace-mcp/activity.db`. Every journal entry the daemon broadcasts is appended, keyed by project root. Batched writes (128 rows or 2 s) because better-sqlite3 is synchronous and this is the thread that answers `/health`; windowed reads in SQL over `(project, ts)`; 7-day retention.
- `src/cli.ts` — the feed and the stats context read the store: all sessions of the project, across restarts. Falls back to the live journals if the store cannot open.
- `src/api/journal-stats-routes.ts` — response carries `recording_since`; window bounds are passed down to the store instead of filtering in JS.
- `ToolActivity.tsx` — when the selected window reaches further back than the data can, the bar says *"recording started 12 minutes ago"* instead of presenting a confident zero. One new i18n key across all 10 catalogues.
- `?window=24h` parsed as 24 **milliseconds** and answered `200 {"window_ms": 24}`. Now a 400. The app only ever sent digits, so this was silent only for external callers.

## Numbers

Harness: 50 000 entries spread over a simulated week (this machine's own rate is 47 866 trace tool calls in the last 7 days), M5 Max, better-sqlite3 WAL.

| | before | after | how |
|---|---|---|---|
| Calls visible after the client disconnects | 0 | all of them | live daemon, MCP session opened/closed over HTTP |
| Calls visible after a daemon restart | 0 | all of them | same, daemon killed and restarted |
| Sessions represented in the feed | newest only | all | two sessions, both present |
| Write cost per recorded tool call | — | **2.8 µs** | batched insert, amortised over 50 000 |
| 24h window read | — | **0.48 ms** | 20 reps, 1 429 rows returned |
| 1h window read | — | **0.03 ms** | 20 reps |
| Storage | — | **124 B/entry**, ~6 MB/week | `stat` on the DB file |

Idle cost is unchanged: the flush timer is `unref`'d and only ever scheduled when an entry arrives, so a daemon serving nothing schedules nothing.

## Guards

`tests/session/activity-store.test.ts` — survives the writing session's close, keeps every session of a project, scopes to one project, applies the window, reads back an entry before the flush timer fires, never claims coverage older than retention. The last test is the perf guard: a 24h read out of a week of entries under 150 ms (measured 0.48 ms — the ceiling is there to catch a dropped index, not to police jitter).

`tests/api/journal-stats-coverage.test.ts` — `window=24h` is a 400, bounds reach the store, `recording_since` present/absent.

Full suite green (10 770 passed), app suite green (749 passed), `biome ci` clean, build clean.

## Not in this PR

TRA-1065 (`/api/projects/sessions` requires `?project=` and ignores it) is the same cluster but a different file and a different fix; it gets its own PR.

Closes TRA-1071.
