### PR TITLE
docs(perf): republish PR-context coverage under the corrected readability metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ trace add                  # index the repo you are in
 
 **70.5% fewer input tokens** to review a pull request — median over 60 merged PRs in six repos that are not ours, 13,595 → 3,951 per pull request. [Method and reproduction →](https://trace-mcp.com/pr-context-benchmark.html)
 
-<sub>Measured at trace-mcp 3.22.0 (`3edecbfb`) on 7 September 2026 — a result from that build, not a claim about the current one. What it set out to measure, the bar it had to clear and the verdict: [preregistration](https://trace-mcp.com/perf/prereg-pr-context/).</sub>
+<sub>Measured at trace-mcp 3.22.0 (`9a432d87`) on 7 September 2026 — a result from that build, not a claim about the current one. What it set out to measure, the bar it had to clear and the verdict: [preregistration](https://trace-mcp.com/perf/prereg-pr-context/).</sub>
 
 Cheaper is not the same as better, so the same 60 pull requests were reviewed twice and scored blind. The trace-mcp arm **understood the change in 67%** of them against **65%** for naive file loading, at **0.80** false positives per PR against **0.58**. [Quality half of the benchmark →](https://trace-mcp.com/perf/prereg-pr-quality/)
 

--- a/benchmarks/pr-context/results.json
+++ b/benchmarks/pr-context/results.json
@@ -1,8 +1,8 @@
 {
-  "generated_at": "2026-09-07T02:42:23.011Z",
+  "generated_at": "2026-09-07T13:51:11.398Z",
   "measured_build": {
     "version": "3.22.0",
-    "commit": "3edecbfb"
+    "commit": "9a432d87"
   },
   "model_for_pricing": "claude-sonnet-4-5",
   "input_usd_per_mtok": 3,
@@ -95,12 +95,12 @@
     "baseline_overflow_rate": 0,
     "trace_overflow_rate": 0,
     "baseline_changed_symbol_readable": 1,
-    "trace_changed_symbol_readable": 1,
+    "trace_changed_symbol_readable": 0.6666666666666666,
     "baseline_dependent_readable": 0.2,
-    "trace_dependent_readable": 0.5789473684210527,
+    "trace_dependent_readable": 0.2830188679245283,
     "baseline_dependent_pointed": 0.2,
     "trace_dependent_pointed": 1,
-    "median_index_ms": 227.5
+    "median_index_ms": 387
   },
   "losses": [
     {
@@ -126,7 +126,7 @@
       "trace_changed_symbol_readable": 1
     },
     {
-      "reason": "costlier",
+      "reason": "truncated",
       "url": "https://github.com/axios/axios/pull/11109",
       "changed_files": 3,
       "changed_symbols": 6,
@@ -134,7 +134,7 @@
       "trace_tokens": 5588,
       "savings_pct": -59.794109236488424,
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.8333333333333334
     },
     {
       "reason": "costlier",
@@ -258,7 +258,7 @@
       "trace_changed_symbol_readable": 1
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/axios/axios/pull/11094",
       "changed_files": 6,
       "changed_symbols": 14,
@@ -266,10 +266,10 @@
       "trace_tokens": 7512,
       "savings_pct": 31.45985401459854,
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.9285714285714286
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/sindresorhus/got/pull/2458",
       "changed_files": 4,
       "changed_symbols": 8,
@@ -277,10 +277,10 @@
       "trace_tokens": 8629,
       "savings_pct": 34.75729623468925,
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.75
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/axios/axios/pull/11087",
       "changed_files": 5,
       "changed_symbols": 15,
@@ -288,10 +288,10 @@
       "trace_tokens": 6556,
       "savings_pct": 39.002605135839225,
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.8666666666666667
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/sindresorhus/got/pull/2380",
       "changed_files": 2,
       "changed_symbols": 4,
@@ -299,10 +299,10 @@
       "trace_tokens": 8060,
       "savings_pct": 42.28014895445431,
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.5
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/axios/axios/pull/11121",
       "changed_files": 8,
       "changed_symbols": 21,
@@ -310,10 +310,10 @@
       "trace_tokens": 10219,
       "savings_pct": 43.11717227943223,
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.47619047619047616
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/honojs/hono/pull/5268",
       "changed_files": 2,
       "changed_symbols": 4,
@@ -321,10 +321,10 @@
       "trace_tokens": 5386,
       "savings_pct": 43.73171750940242,
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.75
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/sindresorhus/got/pull/2388",
       "changed_files": 2,
       "changed_symbols": 4,
@@ -332,10 +332,10 @@
       "trace_tokens": 6935,
       "savings_pct": 44.95157961581203,
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.5
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/psf/requests/pull/6806",
       "changed_files": 1,
       "changed_symbols": 3,
@@ -343,10 +343,10 @@
       "trace_tokens": 3207,
       "savings_pct": 46.701013794249626,
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.3333333333333333
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/axios/axios/pull/11172",
       "changed_files": 8,
       "changed_symbols": 20,
@@ -354,7 +354,370 @@
       "trace_tokens": 15731,
       "savings_pct": 49.81817021819574,
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.65
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/psf/requests/pull/7425",
+      "changed_files": 2,
+      "changed_symbols": 3,
+      "baseline_tokens": 9160,
+      "trace_tokens": 4379,
+      "savings_pct": 52.19432314410481,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.6666666666666666
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2399",
+      "changed_files": 3,
+      "changed_symbols": 5,
+      "baseline_tokens": 11384,
+      "trace_tokens": 4399,
+      "savings_pct": 61.358046380885455,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.6
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2391",
+      "changed_files": 1,
+      "changed_symbols": 3,
+      "baseline_tokens": 9670,
+      "trace_tokens": 3541,
+      "savings_pct": 63.38159255429162,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.3333333333333333
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/psf/requests/pull/7431",
+      "changed_files": 3,
+      "changed_symbols": 7,
+      "baseline_tokens": 18827,
+      "trace_tokens": 6608,
+      "savings_pct": 64.90147129123068,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.8571428571428571
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2367",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 6604,
+      "trace_tokens": 2171,
+      "savings_pct": 67.1259842519685,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/pallets/flask/pull/5620",
+      "changed_files": 10,
+      "changed_symbols": 27,
+      "baseline_tokens": 44519,
+      "trace_tokens": 10939,
+      "savings_pct": 75.42846874368247,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.3333333333333333
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5283",
+      "changed_files": 2,
+      "changed_symbols": 4,
+      "baseline_tokens": 19517,
+      "trace_tokens": 4751,
+      "savings_pct": 75.6571194343393,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.75
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/pallets/flask/pull/5808",
+      "changed_files": 1,
+      "changed_symbols": 3,
+      "baseline_tokens": 8617,
+      "trace_tokens": 2040,
+      "savings_pct": 76.3258674712777,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.3333333333333333
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5291",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 19866,
+      "trace_tokens": 4213,
+      "savings_pct": 78.79291251384275,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/psf/requests/pull/7433",
+      "changed_files": 2,
+      "changed_symbols": 7,
+      "baseline_tokens": 34845,
+      "trace_tokens": 6894,
+      "savings_pct": 80.21523891519587,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5714285714285714
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5236",
+      "changed_files": 4,
+      "changed_symbols": 9,
+      "baseline_tokens": 44246,
+      "trace_tokens": 8594,
+      "savings_pct": 80.5767753017222,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.7777777777777778
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/pallets/flask/pull/6096",
+      "changed_files": 4,
+      "changed_symbols": 10,
+      "baseline_tokens": 32753,
+      "trace_tokens": 6060,
+      "savings_pct": 81.49787805697189,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.7
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2471",
+      "changed_files": 2,
+      "changed_symbols": 4,
+      "baseline_tokens": 31642,
+      "trace_tokens": 5446,
+      "savings_pct": 82.78869856519815,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.25
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2470",
+      "changed_files": 2,
+      "changed_symbols": 6,
+      "baseline_tokens": 32118,
+      "trace_tokens": 5189,
+      "savings_pct": 83.84395043277912,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/psf/requests/pull/6963",
+      "changed_files": 2,
+      "changed_symbols": 9,
+      "baseline_tokens": 16057,
+      "trace_tokens": 2545,
+      "savings_pct": 84.15021485956281,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.7777777777777778
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5244",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 18133,
+      "trace_tokens": 2793,
+      "savings_pct": 84.59714332984062,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5282",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 9829,
+      "trace_tokens": 1488,
+      "savings_pct": 84.86112524163191,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/expressjs/express/pull/4893",
+      "changed_files": 3,
+      "changed_symbols": 6,
+      "baseline_tokens": 51767,
+      "trace_tokens": 7649,
+      "savings_pct": 85.22417756485791,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/pallets/flask/pull/5917",
+      "changed_files": 7,
+      "changed_symbols": 26,
+      "baseline_tokens": 64258,
+      "trace_tokens": 9444,
+      "savings_pct": 85.30299729216595,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.8461538461538461
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5288",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 9886,
+      "trace_tokens": 1422,
+      "savings_pct": 85.61602265830467,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5202",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 17078,
+      "trace_tokens": 2272,
+      "savings_pct": 86.69633446539407,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5280",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 18190,
+      "trace_tokens": 2374,
+      "savings_pct": 86.94887300714679,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5215",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 17101,
+      "trace_tokens": 2169,
+      "savings_pct": 87.31653119700601,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/axios/axios/pull/11096",
+      "changed_files": 8,
+      "changed_symbols": 13,
+      "baseline_tokens": 70417,
+      "trace_tokens": 8795,
+      "savings_pct": 87.51011829529801,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.46153846153846156
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/psf/requests/pull/7395",
+      "changed_files": 2,
+      "changed_symbols": 6,
+      "baseline_tokens": 30835,
+      "trace_tokens": 3652,
+      "savings_pct": 88.15631587481758,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/psf/requests/pull/7502",
+      "changed_files": 2,
+      "changed_symbols": 8,
+      "baseline_tokens": 34807,
+      "trace_tokens": 3956,
+      "savings_pct": 88.63447007785791,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.75
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2454",
+      "changed_files": 3,
+      "changed_symbols": 5,
+      "baseline_tokens": 55721,
+      "trace_tokens": 6075,
+      "savings_pct": 89.0974677410671,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.4
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2362",
+      "changed_files": 2,
+      "changed_symbols": 3,
+      "baseline_tokens": 18777,
+      "trace_tokens": 1363,
+      "savings_pct": 92.74111945465197,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.6666666666666666
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2266",
+      "changed_files": 1,
+      "changed_symbols": 1,
+      "baseline_tokens": 9655,
+      "trace_tokens": 329,
+      "savings_pct": 96.59243915069912,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/expressjs/express/pull/7390",
+      "changed_files": 2,
+      "changed_symbols": 3,
+      "baseline_tokens": 43097,
+      "trace_tokens": 1463,
+      "savings_pct": 96.6053321576908,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.3333333333333333
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/expressjs/express/pull/5555",
+      "changed_files": 3,
+      "changed_symbols": 3,
+      "baseline_tokens": 46454,
+      "trace_tokens": 1550,
+      "savings_pct": 96.66336591036294,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.3333333333333333
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/psf/requests/pull/7371",
+      "changed_files": 1,
+      "changed_symbols": 4,
+      "baseline_tokens": 25197,
+      "trace_tokens": 828,
+      "savings_pct": 96.71389451125134,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/axios/axios/pull/11119",
+      "changed_files": 1,
+      "changed_symbols": 2,
+      "baseline_tokens": 24348,
+      "trace_tokens": 476,
+      "savings_pct": 98.04501396418597,
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
     }
   ],
   "rows": [
@@ -373,12 +736,12 @@
       },
       "trace": {
         "tokens": 4213,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.875,
+        "changed_symbol_readable": 0.5,
+        "dependent_readable": 0.375,
         "dependent_pointed": 1
       },
       "savings_pct": 78.79291251384275,
-      "index_ms": 301
+      "index_ms": 392
     },
     {
       "repo": "honojs/hono",
@@ -395,12 +758,12 @@
       },
       "trace": {
         "tokens": 4751,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.8888888888888888,
+        "changed_symbol_readable": 0.75,
+        "dependent_readable": 0.4444444444444444,
         "dependent_pointed": 1
       },
       "savings_pct": 75.6571194343393,
-      "index_ms": 242
+      "index_ms": 252
     },
     {
       "repo": "honojs/hono",
@@ -422,7 +785,7 @@
         "dependent_pointed": 1
       },
       "savings_pct": -7.0381703978096315,
-      "index_ms": 506
+      "index_ms": 552
     },
     {
       "repo": "honojs/hono",
@@ -439,12 +802,12 @@
       },
       "trace": {
         "tokens": 1422,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.5,
+        "changed_symbol_readable": 0.5,
+        "dependent_readable": 0.25,
         "dependent_pointed": 1
       },
       "savings_pct": 85.61602265830467,
-      "index_ms": 500
+      "index_ms": 529
     },
     {
       "repo": "honojs/hono",
@@ -461,12 +824,12 @@
       },
       "trace": {
         "tokens": 5386,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.2894736842105263,
+        "changed_symbol_readable": 0.75,
+        "dependent_readable": 0.21052631578947367,
         "dependent_pointed": 1
       },
       "savings_pct": 43.73171750940242,
-      "index_ms": 331
+      "index_ms": 382
     },
     {
       "repo": "honojs/hono",
@@ -483,12 +846,12 @@
       },
       "trace": {
         "tokens": 2169,
-        "changed_symbol_readable": 1,
+        "changed_symbol_readable": 0.5,
         "dependent_readable": 0.2,
         "dependent_pointed": 1
       },
       "savings_pct": 87.31653119700601,
-      "index_ms": 403
+      "index_ms": 423
     },
     {
       "repo": "honojs/hono",
@@ -505,12 +868,12 @@
       },
       "trace": {
         "tokens": 8594,
-        "changed_symbol_readable": 1,
+        "changed_symbol_readable": 0.7777777777777778,
         "dependent_readable": 0.8,
         "dependent_pointed": 1
       },
       "savings_pct": 80.5767753017222,
-      "index_ms": 275
+      "index_ms": 426
     },
     {
       "repo": "honojs/hono",
@@ -527,12 +890,12 @@
       },
       "trace": {
         "tokens": 1488,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.5,
+        "changed_symbol_readable": 0.5,
+        "dependent_readable": 0.25,
         "dependent_pointed": 1
       },
       "savings_pct": 84.86112524163191,
-      "index_ms": 392
+      "index_ms": 761
     },
     {
       "repo": "honojs/hono",
@@ -549,12 +912,12 @@
       },
       "trace": {
         "tokens": 2793,
-        "changed_symbol_readable": 1,
+        "changed_symbol_readable": 0.5,
         "dependent_readable": 0.2,
         "dependent_pointed": 1
       },
       "savings_pct": 84.59714332984062,
-      "index_ms": 478
+      "index_ms": 849
     },
     {
       "repo": "honojs/hono",
@@ -571,12 +934,12 @@
       },
       "trace": {
         "tokens": 2272,
-        "changed_symbol_readable": 1,
+        "changed_symbol_readable": 0.5,
         "dependent_readable": 0.2,
         "dependent_pointed": 1
       },
       "savings_pct": 86.69633446539407,
-      "index_ms": 235
+      "index_ms": 399
     },
     {
       "repo": "honojs/hono",
@@ -598,7 +961,7 @@
         "dependent_pointed": null
       },
       "savings_pct": 23.947998631542937,
-      "index_ms": 262
+      "index_ms": 479
     },
     {
       "repo": "honojs/hono",
@@ -615,12 +978,12 @@
       },
       "trace": {
         "tokens": 2374,
-        "changed_symbol_readable": 1,
+        "changed_symbol_readable": 0.5,
         "dependent_readable": 0.2,
         "dependent_pointed": 1
       },
       "savings_pct": 86.94887300714679,
-      "index_ms": 453
+      "index_ms": 1062
     },
     {
       "repo": "axios/axios",
@@ -637,12 +1000,12 @@
       },
       "trace": {
         "tokens": 15731,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.75,
+        "changed_symbol_readable": 0.65,
+        "dependent_readable": 0.625,
         "dependent_pointed": 1
       },
       "savings_pct": 49.81817021819574,
-      "index_ms": 365
+      "index_ms": 1171
     },
     {
       "repo": "axios/axios",
@@ -664,7 +1027,7 @@
         "dependent_pointed": 1
       },
       "savings_pct": -46.38130104196001,
-      "index_ms": 667
+      "index_ms": 1713
     },
     {
       "repo": "axios/axios",
@@ -681,12 +1044,12 @@
       },
       "trace": {
         "tokens": 476,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 1,
+        "changed_symbol_readable": 0.5,
+        "dependent_readable": 0,
         "dependent_pointed": 1
       },
       "savings_pct": 98.04501396418597,
-      "index_ms": 264
+      "index_ms": 502
     },
     {
       "repo": "axios/axios",
@@ -703,12 +1066,12 @@
       },
       "trace": {
         "tokens": 8795,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.5789473684210527,
+        "changed_symbol_readable": 0.46153846153846156,
+        "dependent_readable": 0.42105263157894735,
         "dependent_pointed": 1
       },
       "savings_pct": 87.51011829529801,
-      "index_ms": 271
+      "index_ms": 1255
     },
     {
       "repo": "axios/axios",
@@ -725,12 +1088,12 @@
       },
       "trace": {
         "tokens": 6556,
-        "changed_symbol_readable": 1,
+        "changed_symbol_readable": 0.8666666666666667,
         "dependent_readable": 1,
         "dependent_pointed": 1
       },
       "savings_pct": 39.002605135839225,
-      "index_ms": 269
+      "index_ms": 1029
     },
     {
       "repo": "axios/axios",
@@ -747,12 +1110,12 @@
       },
       "trace": {
         "tokens": 10219,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.8,
+        "changed_symbol_readable": 0.47619047619047616,
+        "dependent_readable": 0.2,
         "dependent_pointed": 1
       },
       "savings_pct": 43.11717227943223,
-      "index_ms": 280
+      "index_ms": 691
     },
     {
       "repo": "axios/axios",
@@ -769,12 +1132,12 @@
       },
       "trace": {
         "tokens": 7512,
-        "changed_symbol_readable": 1,
+        "changed_symbol_readable": 0.9285714285714286,
         "dependent_readable": 0.375,
         "dependent_pointed": 1
       },
       "savings_pct": 31.45985401459854,
-      "index_ms": 263
+      "index_ms": 582
     },
     {
       "repo": "axios/axios",
@@ -791,12 +1154,12 @@
       },
       "trace": {
         "tokens": 5588,
-        "changed_symbol_readable": 1,
+        "changed_symbol_readable": 0.8333333333333334,
         "dependent_readable": 0.7,
         "dependent_pointed": 1
       },
       "savings_pct": -59.794109236488424,
-      "index_ms": 115
+      "index_ms": 339
     },
     {
       "repo": "axios/axios",
@@ -818,7 +1181,7 @@
         "dependent_pointed": 1
       },
       "savings_pct": -43.71108343711084,
-      "index_ms": 310
+      "index_ms": 333
     },
     {
       "repo": "axios/axios",
@@ -836,11 +1199,11 @@
       "trace": {
         "tokens": 3372,
         "changed_symbol_readable": 1,
-        "dependent_readable": 0.5,
+        "dependent_readable": 0.16666666666666666,
         "dependent_pointed": 1
       },
       "savings_pct": -97.42388758782201,
-      "index_ms": 287
+      "index_ms": 255
     },
     {
       "repo": "axios/axios",
@@ -858,11 +1221,11 @@
       "trace": {
         "tokens": 3941,
         "changed_symbol_readable": 1,
-        "dependent_readable": 0.625,
+        "dependent_readable": 0.5,
         "dependent_pointed": 1
       },
       "savings_pct": -42.58321273516643,
-      "index_ms": 122
+      "index_ms": 137
     },
     {
       "repo": "axios/axios",
@@ -884,7 +1247,7 @@
         "dependent_pointed": null
       },
       "savings_pct": -23.333333333333332,
-      "index_ms": 274
+      "index_ms": 317
     },
     {
       "repo": "expressjs/express",
@@ -901,12 +1264,12 @@
       },
       "trace": {
         "tokens": 1463,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 1,
+        "changed_symbol_readable": 0.3333333333333333,
+        "dependent_readable": 0,
         "dependent_pointed": 1
       },
       "savings_pct": 96.6053321576908,
-      "index_ms": 87
+      "index_ms": 185
     },
     {
       "repo": "expressjs/express",
@@ -928,7 +1291,7 @@
         "dependent_pointed": null
       },
       "savings_pct": -0.36994877632327827,
-      "index_ms": 53
+      "index_ms": 61
     },
     {
       "repo": "expressjs/express",
@@ -945,12 +1308,12 @@
       },
       "trace": {
         "tokens": 1550,
-        "changed_symbol_readable": 1,
+        "changed_symbol_readable": 0.3333333333333333,
         "dependent_readable": null,
         "dependent_pointed": null
       },
       "savings_pct": 96.66336591036294,
-      "index_ms": 193
+      "index_ms": 259
     },
     {
       "repo": "expressjs/express",
@@ -967,12 +1330,12 @@
       },
       "trace": {
         "tokens": 7649,
-        "changed_symbol_readable": 1,
+        "changed_symbol_readable": 0.5,
         "dependent_readable": null,
         "dependent_pointed": null
       },
       "savings_pct": 85.22417756485791,
-      "index_ms": 186
+      "index_ms": 190
     },
     {
       "repo": "expressjs/express",
@@ -994,7 +1357,7 @@
         "dependent_pointed": 1
       },
       "savings_pct": -7.823657249301459,
-      "index_ms": 77
+      "index_ms": 93
     },
     {
       "repo": "expressjs/express",
@@ -1016,7 +1379,7 @@
         "dependent_pointed": 1
       },
       "savings_pct": -3.8077403245942576,
-      "index_ms": 60
+      "index_ms": 67
     },
     {
       "repo": "expressjs/express",
@@ -1038,7 +1401,7 @@
         "dependent_pointed": null
       },
       "savings_pct": -0.4242965609647164,
-      "index_ms": 53
+      "index_ms": 97
     },
     {
       "repo": "expressjs/express",
@@ -1060,7 +1423,7 @@
         "dependent_pointed": null
       },
       "savings_pct": -14.65919701213819,
-      "index_ms": 70
+      "index_ms": 77
     },
     {
       "repo": "psf/requests",
@@ -1077,12 +1440,12 @@
       },
       "trace": {
         "tokens": 3207,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.7333333333333333,
+        "changed_symbol_readable": 0.3333333333333333,
+        "dependent_readable": 0.4,
         "dependent_pointed": 1
       },
       "savings_pct": 46.701013794249626,
-      "index_ms": 209
+      "index_ms": 490
     },
     {
       "repo": "psf/requests",
@@ -1104,7 +1467,7 @@
         "dependent_pointed": null
       },
       "savings_pct": 73.93114385779423,
-      "index_ms": 152
+      "index_ms": 596
     },
     {
       "repo": "psf/requests",
@@ -1121,12 +1484,12 @@
       },
       "trace": {
         "tokens": 6608,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.5454545454545454,
+        "changed_symbol_readable": 0.8571428571428571,
+        "dependent_readable": 0.36363636363636365,
         "dependent_pointed": 1
       },
       "savings_pct": 64.90147129123068,
-      "index_ms": 225
+      "index_ms": 652
     },
     {
       "repo": "psf/requests",
@@ -1143,12 +1506,12 @@
       },
       "trace": {
         "tokens": 2545,
-        "changed_symbol_readable": 1,
+        "changed_symbol_readable": 0.7777777777777778,
         "dependent_readable": 0.4,
         "dependent_pointed": 1
       },
       "savings_pct": 84.15021485956281,
-      "index_ms": 221
+      "index_ms": 357
     },
     {
       "repo": "psf/requests",
@@ -1165,12 +1528,12 @@
       },
       "trace": {
         "tokens": 3956,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.3157894736842105,
+        "changed_symbol_readable": 0.75,
+        "dependent_readable": 0.13157894736842105,
         "dependent_pointed": 1
       },
       "savings_pct": 88.63447007785791,
-      "index_ms": 232
+      "index_ms": 251
     },
     {
       "repo": "psf/requests",
@@ -1187,12 +1550,12 @@
       },
       "trace": {
         "tokens": 4379,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.625,
+        "changed_symbol_readable": 0.6666666666666666,
+        "dependent_readable": 0.375,
         "dependent_pointed": 1
       },
       "savings_pct": 52.19432314410481,
-      "index_ms": 199
+      "index_ms": 289
     },
     {
       "repo": "psf/requests",
@@ -1209,12 +1572,12 @@
       },
       "trace": {
         "tokens": 3652,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.7894736842105263,
+        "changed_symbol_readable": 0.5,
+        "dependent_readable": 0.3157894736842105,
         "dependent_pointed": 1
       },
       "savings_pct": 88.15631587481758,
-      "index_ms": 188
+      "index_ms": 306
     },
     {
       "repo": "psf/requests",
@@ -1231,12 +1594,12 @@
       },
       "trace": {
         "tokens": 828,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 1,
+        "changed_symbol_readable": 0.5,
+        "dependent_readable": 0,
         "dependent_pointed": 1
       },
       "savings_pct": 96.71389451125134,
-      "index_ms": 183
+      "index_ms": 189
     },
     {
       "repo": "psf/requests",
@@ -1253,12 +1616,12 @@
       },
       "trace": {
         "tokens": 6894,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.6,
+        "changed_symbol_readable": 0.5714285714285714,
+        "dependent_readable": 0.35,
         "dependent_pointed": 1
       },
       "savings_pct": 80.21523891519587,
-      "index_ms": 212
+      "index_ms": 229
     },
     {
       "repo": "psf/requests",
@@ -1280,7 +1643,7 @@
         "dependent_pointed": 1
       },
       "savings_pct": 50.22341376228776,
-      "index_ms": 214
+      "index_ms": 526
     },
     {
       "repo": "pallets/flask",
@@ -1297,12 +1660,12 @@
       },
       "trace": {
         "tokens": 6060,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.7872340425531915,
+        "changed_symbol_readable": 0.7,
+        "dependent_readable": 0.2978723404255319,
         "dependent_pointed": 1
       },
       "savings_pct": 81.49787805697189,
-      "index_ms": 362
+      "index_ms": 1721
     },
     {
       "repo": "pallets/flask",
@@ -1319,12 +1682,12 @@
       },
       "trace": {
         "tokens": 9444,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.3584905660377358,
+        "changed_symbol_readable": 0.8461538461538461,
+        "dependent_readable": 0.2830188679245283,
         "dependent_pointed": 1
       },
       "savings_pct": 85.30299729216595,
-      "index_ms": 285
+      "index_ms": 1407
     },
     {
       "repo": "pallets/flask",
@@ -1341,12 +1704,12 @@
       },
       "trace": {
         "tokens": 2040,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.1276595744680851,
+        "changed_symbol_readable": 0.3333333333333333,
+        "dependent_readable": 0.0425531914893617,
         "dependent_pointed": 1
       },
       "savings_pct": 76.3258674712777,
-      "index_ms": 320
+      "index_ms": 556
     },
     {
       "repo": "pallets/flask",
@@ -1364,11 +1727,11 @@
       "trace": {
         "tokens": 1865,
         "changed_symbol_readable": 1,
-        "dependent_readable": 0.14285714285714285,
+        "dependent_readable": 0.047619047619047616,
         "dependent_pointed": 1
       },
       "savings_pct": 90.83132589351555,
-      "index_ms": 88
+      "index_ms": 453
     },
     {
       "repo": "pallets/flask",
@@ -1385,12 +1748,12 @@
       },
       "trace": {
         "tokens": 10939,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.7478260869565218,
+        "changed_symbol_readable": 0.3333333333333333,
+        "dependent_readable": 0.14782608695652175,
         "dependent_pointed": 1
       },
       "savings_pct": 75.42846874368247,
-      "index_ms": 231
+      "index_ms": 1358
     },
     {
       "repo": "pallets/flask",
@@ -1412,7 +1775,7 @@
         "dependent_pointed": 1
       },
       "savings_pct": 60.67886268459335,
-      "index_ms": 77
+      "index_ms": 234
     },
     {
       "repo": "sindresorhus/got",
@@ -1429,12 +1792,12 @@
       },
       "trace": {
         "tokens": 5189,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.2631578947368421,
+        "changed_symbol_readable": 0.5,
+        "dependent_readable": 0.13157894736842105,
         "dependent_pointed": 1
       },
       "savings_pct": 83.84395043277912,
-      "index_ms": 433
+      "index_ms": 1461
     },
     {
       "repo": "sindresorhus/got",
@@ -1451,12 +1814,12 @@
       },
       "trace": {
         "tokens": 5446,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.3170731707317073,
+        "changed_symbol_readable": 0.25,
+        "dependent_readable": 0.12195121951219512,
         "dependent_pointed": 1
       },
       "savings_pct": 82.78869856519815,
-      "index_ms": 175
+      "index_ms": 716
     },
     {
       "repo": "sindresorhus/got",
@@ -1473,12 +1836,12 @@
       },
       "trace": {
         "tokens": 8629,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.35526315789473684,
+        "changed_symbol_readable": 0.75,
+        "dependent_readable": 0.21052631578947367,
         "dependent_pointed": 1
       },
       "savings_pct": 34.75729623468925,
-      "index_ms": 266
+      "index_ms": 1192
     },
     {
       "repo": "sindresorhus/got",
@@ -1495,12 +1858,12 @@
       },
       "trace": {
         "tokens": 6075,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.43243243243243246,
+        "changed_symbol_readable": 0.4,
+        "dependent_readable": 0.13513513513513514,
         "dependent_pointed": 1
       },
       "savings_pct": 89.0974677410671,
-      "index_ms": 56
+      "index_ms": 133
     },
     {
       "repo": "sindresorhus/got",
@@ -1517,12 +1880,12 @@
       },
       "trace": {
         "tokens": 4399,
-        "changed_symbol_readable": 1,
+        "changed_symbol_readable": 0.6,
         "dependent_readable": 0.25,
         "dependent_pointed": 1
       },
       "savings_pct": 61.358046380885455,
-      "index_ms": 230
+      "index_ms": 899
     },
     {
       "repo": "sindresorhus/got",
@@ -1539,12 +1902,12 @@
       },
       "trace": {
         "tokens": 6935,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.35294117647058826,
+        "changed_symbol_readable": 0.5,
+        "dependent_readable": 0.20588235294117646,
         "dependent_pointed": 1
       },
       "savings_pct": 44.95157961581203,
-      "index_ms": 71
+      "index_ms": 161
     },
     {
       "repo": "sindresorhus/got",
@@ -1561,12 +1924,12 @@
       },
       "trace": {
         "tokens": 3541,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.37142857142857144,
+        "changed_symbol_readable": 0.3333333333333333,
+        "dependent_readable": 0.2,
         "dependent_pointed": 1
       },
       "savings_pct": 63.38159255429162,
-      "index_ms": 79
+      "index_ms": 143
     },
     {
       "repo": "sindresorhus/got",
@@ -1583,12 +1946,12 @@
       },
       "trace": {
         "tokens": 8060,
-        "changed_symbol_readable": 1,
-        "dependent_readable": 0.40540540540540543,
+        "changed_symbol_readable": 0.5,
+        "dependent_readable": 0.1891891891891892,
         "dependent_pointed": 1
       },
       "savings_pct": 42.28014895445431,
-      "index_ms": 70
+      "index_ms": 104
     },
     {
       "repo": "sindresorhus/got",
@@ -1606,11 +1969,11 @@
       "trace": {
         "tokens": 6439,
         "changed_symbol_readable": 1,
-        "dependent_readable": 0.2978723404255319,
+        "dependent_readable": 0.0851063829787234,
         "dependent_pointed": 1
       },
       "savings_pct": -129.3091168091168,
-      "index_ms": 63
+      "index_ms": 88
     },
     {
       "repo": "sindresorhus/got",
@@ -1627,12 +1990,12 @@
       },
       "trace": {
         "tokens": 1363,
-        "changed_symbol_readable": 1,
+        "changed_symbol_readable": 0.6666666666666666,
         "dependent_readable": 1,
         "dependent_pointed": 1
       },
       "savings_pct": 92.74111945465197,
-      "index_ms": 97
+      "index_ms": 136
     },
     {
       "repo": "sindresorhus/got",
@@ -1649,12 +2012,12 @@
       },
       "trace": {
         "tokens": 2171,
-        "changed_symbol_readable": 1,
+        "changed_symbol_readable": 0.5,
         "dependent_readable": 1,
         "dependent_pointed": 1
       },
       "savings_pct": 67.1259842519685,
-      "index_ms": 110
+      "index_ms": 108
     },
     {
       "repo": "sindresorhus/got",
@@ -1671,12 +2034,12 @@
       },
       "trace": {
         "tokens": 329,
-        "changed_symbol_readable": 1,
+        "changed_symbol_readable": 0,
         "dependent_readable": null,
         "dependent_pointed": null
       },
       "savings_pct": 96.59243915069912,
-      "index_ms": 180
+      "index_ms": 193
     }
   ]
 }

--- a/docs/_data/pr_context_bench.json
+++ b/docs/_data/pr_context_bench.json
@@ -1,8 +1,8 @@
 {
-  "generated_at": "2026-09-07T02:42:23.011Z",
+  "generated_at": "2026-09-07T13:51:11.398Z",
   "measured_build": {
     "version": "3.22.0",
-    "commit": "3edecbfb"
+    "commit": "9a432d87"
   },
   "pr_count": 60,
   "repo_count": 6,
@@ -21,13 +21,13 @@
   "trace_median_cost": "0.0119",
   "trace_p90_cost": "0.0258",
   "baseline_dependent_readable": "20%",
-  "trace_dependent_readable": "58%",
+  "trace_dependent_readable": "28%",
   "baseline_dependent_pointed": "20%",
   "trace_dependent_pointed": "100%",
   "baseline_changed_symbol_readable": "100%",
-  "trace_changed_symbol_readable": "100%",
-  "median_index_ms": 228,
-  "loss_count": 23,
+  "trace_changed_symbol_readable": "67%",
+  "median_index_ms": 387,
+  "loss_count": 56,
   "losses": [
     {
       "reason": "costlier",
@@ -52,7 +52,7 @@
       "trace_changed_symbol_readable": 1
     },
     {
-      "reason": "costlier",
+      "reason": "truncated",
       "url": "https://github.com/axios/axios/pull/11109",
       "changed_files": 3,
       "changed_symbols": 6,
@@ -60,7 +60,7 @@
       "trace_tokens": 5588,
       "savings_pct": "-59.8",
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.8333333333333334
     },
     {
       "reason": "costlier",
@@ -184,7 +184,7 @@
       "trace_changed_symbol_readable": 1
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/axios/axios/pull/11094",
       "changed_files": 6,
       "changed_symbols": 14,
@@ -192,10 +192,10 @@
       "trace_tokens": 7512,
       "savings_pct": "31.5",
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.9285714285714286
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/sindresorhus/got/pull/2458",
       "changed_files": 4,
       "changed_symbols": 8,
@@ -203,10 +203,10 @@
       "trace_tokens": 8629,
       "savings_pct": "34.8",
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.75
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/axios/axios/pull/11087",
       "changed_files": 5,
       "changed_symbols": 15,
@@ -214,10 +214,10 @@
       "trace_tokens": 6556,
       "savings_pct": "39.0",
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.8666666666666667
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/sindresorhus/got/pull/2380",
       "changed_files": 2,
       "changed_symbols": 4,
@@ -225,10 +225,10 @@
       "trace_tokens": 8060,
       "savings_pct": "42.3",
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.5
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/axios/axios/pull/11121",
       "changed_files": 8,
       "changed_symbols": 21,
@@ -236,10 +236,10 @@
       "trace_tokens": 10219,
       "savings_pct": "43.1",
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.47619047619047616
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/honojs/hono/pull/5268",
       "changed_files": 2,
       "changed_symbols": 4,
@@ -247,10 +247,10 @@
       "trace_tokens": 5386,
       "savings_pct": "43.7",
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.75
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/sindresorhus/got/pull/2388",
       "changed_files": 2,
       "changed_symbols": 4,
@@ -258,10 +258,10 @@
       "trace_tokens": 6935,
       "savings_pct": "45.0",
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.5
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/psf/requests/pull/6806",
       "changed_files": 1,
       "changed_symbols": 3,
@@ -269,10 +269,10 @@
       "trace_tokens": 3207,
       "savings_pct": "46.7",
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.3333333333333333
     },
     {
-      "reason": "marginal",
+      "reason": "truncated",
       "url": "https://github.com/axios/axios/pull/11172",
       "changed_files": 8,
       "changed_symbols": 20,
@@ -280,7 +280,370 @@
       "trace_tokens": 15731,
       "savings_pct": "49.8",
       "baseline_changed_symbol_readable": 1,
-      "trace_changed_symbol_readable": 1
+      "trace_changed_symbol_readable": 0.65
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/psf/requests/pull/7425",
+      "changed_files": 2,
+      "changed_symbols": 3,
+      "baseline_tokens": 9160,
+      "trace_tokens": 4379,
+      "savings_pct": "52.2",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.6666666666666666
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2399",
+      "changed_files": 3,
+      "changed_symbols": 5,
+      "baseline_tokens": 11384,
+      "trace_tokens": 4399,
+      "savings_pct": "61.4",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.6
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2391",
+      "changed_files": 1,
+      "changed_symbols": 3,
+      "baseline_tokens": 9670,
+      "trace_tokens": 3541,
+      "savings_pct": "63.4",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.3333333333333333
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/psf/requests/pull/7431",
+      "changed_files": 3,
+      "changed_symbols": 7,
+      "baseline_tokens": 18827,
+      "trace_tokens": 6608,
+      "savings_pct": "64.9",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.8571428571428571
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2367",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 6604,
+      "trace_tokens": 2171,
+      "savings_pct": "67.1",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/pallets/flask/pull/5620",
+      "changed_files": 10,
+      "changed_symbols": 27,
+      "baseline_tokens": 44519,
+      "trace_tokens": 10939,
+      "savings_pct": "75.4",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.3333333333333333
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5283",
+      "changed_files": 2,
+      "changed_symbols": 4,
+      "baseline_tokens": 19517,
+      "trace_tokens": 4751,
+      "savings_pct": "75.7",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.75
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/pallets/flask/pull/5808",
+      "changed_files": 1,
+      "changed_symbols": 3,
+      "baseline_tokens": 8617,
+      "trace_tokens": 2040,
+      "savings_pct": "76.3",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.3333333333333333
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5291",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 19866,
+      "trace_tokens": 4213,
+      "savings_pct": "78.8",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/psf/requests/pull/7433",
+      "changed_files": 2,
+      "changed_symbols": 7,
+      "baseline_tokens": 34845,
+      "trace_tokens": 6894,
+      "savings_pct": "80.2",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5714285714285714
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5236",
+      "changed_files": 4,
+      "changed_symbols": 9,
+      "baseline_tokens": 44246,
+      "trace_tokens": 8594,
+      "savings_pct": "80.6",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.7777777777777778
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/pallets/flask/pull/6096",
+      "changed_files": 4,
+      "changed_symbols": 10,
+      "baseline_tokens": 32753,
+      "trace_tokens": 6060,
+      "savings_pct": "81.5",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.7
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2471",
+      "changed_files": 2,
+      "changed_symbols": 4,
+      "baseline_tokens": 31642,
+      "trace_tokens": 5446,
+      "savings_pct": "82.8",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.25
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2470",
+      "changed_files": 2,
+      "changed_symbols": 6,
+      "baseline_tokens": 32118,
+      "trace_tokens": 5189,
+      "savings_pct": "83.8",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/psf/requests/pull/6963",
+      "changed_files": 2,
+      "changed_symbols": 9,
+      "baseline_tokens": 16057,
+      "trace_tokens": 2545,
+      "savings_pct": "84.2",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.7777777777777778
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5244",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 18133,
+      "trace_tokens": 2793,
+      "savings_pct": "84.6",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5282",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 9829,
+      "trace_tokens": 1488,
+      "savings_pct": "84.9",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/expressjs/express/pull/4893",
+      "changed_files": 3,
+      "changed_symbols": 6,
+      "baseline_tokens": 51767,
+      "trace_tokens": 7649,
+      "savings_pct": "85.2",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/pallets/flask/pull/5917",
+      "changed_files": 7,
+      "changed_symbols": 26,
+      "baseline_tokens": 64258,
+      "trace_tokens": 9444,
+      "savings_pct": "85.3",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.8461538461538461
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5288",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 9886,
+      "trace_tokens": 1422,
+      "savings_pct": "85.6",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5202",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 17078,
+      "trace_tokens": 2272,
+      "savings_pct": "86.7",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5280",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 18190,
+      "trace_tokens": 2374,
+      "savings_pct": "86.9",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/honojs/hono/pull/5215",
+      "changed_files": 2,
+      "changed_symbols": 2,
+      "baseline_tokens": 17101,
+      "trace_tokens": 2169,
+      "savings_pct": "87.3",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/axios/axios/pull/11096",
+      "changed_files": 8,
+      "changed_symbols": 13,
+      "baseline_tokens": 70417,
+      "trace_tokens": 8795,
+      "savings_pct": "87.5",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.46153846153846156
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/psf/requests/pull/7395",
+      "changed_files": 2,
+      "changed_symbols": 6,
+      "baseline_tokens": 30835,
+      "trace_tokens": 3652,
+      "savings_pct": "88.2",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/psf/requests/pull/7502",
+      "changed_files": 2,
+      "changed_symbols": 8,
+      "baseline_tokens": 34807,
+      "trace_tokens": 3956,
+      "savings_pct": "88.6",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.75
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2454",
+      "changed_files": 3,
+      "changed_symbols": 5,
+      "baseline_tokens": 55721,
+      "trace_tokens": 6075,
+      "savings_pct": "89.1",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.4
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2362",
+      "changed_files": 2,
+      "changed_symbols": 3,
+      "baseline_tokens": 18777,
+      "trace_tokens": 1363,
+      "savings_pct": "92.7",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.6666666666666666
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/sindresorhus/got/pull/2266",
+      "changed_files": 1,
+      "changed_symbols": 1,
+      "baseline_tokens": 9655,
+      "trace_tokens": 329,
+      "savings_pct": "96.6",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/expressjs/express/pull/7390",
+      "changed_files": 2,
+      "changed_symbols": 3,
+      "baseline_tokens": 43097,
+      "trace_tokens": 1463,
+      "savings_pct": "96.6",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.3333333333333333
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/expressjs/express/pull/5555",
+      "changed_files": 3,
+      "changed_symbols": 3,
+      "baseline_tokens": 46454,
+      "trace_tokens": 1550,
+      "savings_pct": "96.7",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.3333333333333333
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/psf/requests/pull/7371",
+      "changed_files": 1,
+      "changed_symbols": 4,
+      "baseline_tokens": 25197,
+      "trace_tokens": 828,
+      "savings_pct": "96.7",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
+    },
+    {
+      "reason": "truncated",
+      "url": "https://github.com/axios/axios/pull/11119",
+      "changed_files": 1,
+      "changed_symbols": 2,
+      "baseline_tokens": 24348,
+      "trace_tokens": 476,
+      "savings_pct": "98.0",
+      "baseline_changed_symbol_readable": 1,
+      "trace_changed_symbol_readable": 0.5
     }
   ]
 }

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4465,8 +4465,17 @@ repo so the run reproduces.
 
 Assembling review context for a pull request with trace-mcp costs a median
 **{{ site.data.pr_context_bench.median_savings_pct }}% fewer input tokens** than
-loading the diff plus every file it touches — while making *more* of the code
-the change can break visible, not less.
+loading the diff plus every file it touches. It makes *more* of the code the
+change can break visible — {{ site.data.pr_context_bench.trace_dependent_readable }}
+of affected call sites readable against
+{{ site.data.pr_context_bench.baseline_dependent_readable }}, and
+{{ site.data.pr_context_bench.trace_dependent_pointed }} at least located — and
+*less* of the changed code itself:
+{{ site.data.pr_context_bench.trace_changed_symbol_readable }} of changed symbols
+arrive with their bodies, against
+{{ site.data.pr_context_bench.baseline_changed_symbol_readable }} for whole
+files. That second number misses a
+[preregistered bar]({{ '/perf/prereg-pr-context/' | relative_url }}).
 
 The review written from it holds up. Sending both contexts to the same model on
 the same PRs, the trace-mcp arm understood the change as often as the naive one
@@ -4581,21 +4590,31 @@ a reviewer does not need.
 
 Two further limits worth stating plainly:
 
-- **The truncation failure mode did not fire here.** The trace-mcp arm is
-  capped at an 8,000-token context bundle; on this dataset no PR was large
-  enough for that cap to drop a changed symbol, so changed-symbol readability
-  is {{ site.data.pr_context_bench.trace_changed_symbol_readable }} in both
-  arms. On a substantially larger PR it would bite, and the benchmark reports
-  it as a `truncated` loss when it does. We have not measured that regime.
+- **The truncation failure mode fires on most of this dataset.** The trace-mcp
+  arm is capped at an 8,000-token context bundle, and changed-symbol
+  readability is {{ site.data.pr_context_bench.trace_changed_symbol_readable }}
+  against the naive arm's
+  {{ site.data.pr_context_bench.baseline_changed_symbol_readable }} — a third of
+  changed symbols arrive without their bodies, 113 of 338 across the corpus.
+  This page said the opposite until 2026-09-07, because the metric counted
+  whether the bundle *listed* a symbol rather than whether it carried the body;
+  it now scores `detail === 'full'`. That miss is registered against the
+  [preregistered quality floor]({{ '/perf/prereg-pr-context/' | relative_url }}),
+  which the bar does not move for. The token figure is unaffected — it was
+  always counted on the assembled text. Whether the missing bodies are
+  module-level pseudo-symbols (whose body is a whole file, which is what this
+  index exists not to ship) or symbols the budget drops is not yet measured.
 - **Call-site coverage is structural, not semantic.** "Readable" means the
   symbol's body is in the context; "located" means it is named with its file
   and line. It does not mean a model used it correctly.
-- **"Readable" counts pointers, not bodies.** The metric records a span
-  whenever the bundle lists a symbol; it never checks that the body arrived.
-  That is how it read 100% through a three-month stretch in which the
-  benchmark's trace arm carried no source code at all — see the
-  [diagnosis]({{ '/perf/pr-context-loss-classes/' | relative_url }}) of that
-  defect and the correction it forced on the figures above.
+- **"Readable" counted pointers, not bodies — until 2026-09-07.** The metric
+  recorded a span whenever the bundle listed a symbol and never checked that the
+  body arrived, which is how it read 100% through a three-month stretch in which
+  the benchmark's trace arm carried no source code at all. It now scores the
+  bundle's own `detail` field, and every coverage figure on this page is the
+  first measured under that definition. The
+  [diagnosis]({{ '/perf/pr-context-loss-classes/' | relative_url }}) has the
+  account of the original defect.
 
 ## Does the thinner context produce a worse review?
 

--- a/docs/perf/prereg-pr-context.md
+++ b/docs/perf/prereg-pr-context.md
@@ -8,7 +8,7 @@ measurement: pr_context
 data_file: docs/_data/pr_context_bench.json
 preregistration: retrospective
 written_on: 2026-09-05
-verdict: MET
+verdict: MISSED
 ---
 
 # Preregistration — PR review context benchmark
@@ -78,7 +78,11 @@ result would be a result about trace-mcp, not about a guessed baseline. It is
 also the reason this figure, and not the aggregate in
 [prereg-response-tokens](./prereg-response-tokens.md), leads the storefront.
 
-## Verdict — MET (retrospective), at a corrected 70.5%
+## Verdict — MISSED: primary bar met at 70.5%, quality floor failed at 67%
+
+A run that misses any registered bar publishes as MISSED, so that is the verdict
+even though the headline saving cleared its bar comfortably. Which bar failed,
+and why it failed only now, is below.
 
 **Corrected 2026-09-07 (TRA-1090).** The 2026-08-30 run measured a trace-mcp arm
 that contained no source code: `get_context_bundle` read symbol bodies through a
@@ -91,12 +95,42 @@ the product does not serve. The [diagnosis]({{ '/perf/pr-context-loss-classes/'
 
 The same 60 pull requests, same pinned SHAs, re-run with bodies restored:
 **median 70.5%** (13,595 → 3,951 input tokens), against the 90.6% first
-published. The bar was ≥50% and is still met; the previous figure is struck, not
-defended. Changed symbols read 100% readable in both arms then and now — a
-metric [since shown to count pointers, not
-bodies]({{ '/perf/pr-context-loss-classes/' | relative_url }}), which is why it
-did not fire. Pull requests where the index did not pay off went from 5 to 23,
-13 of which now cost more than reading the files outright; they are published in
+published. The primary bar was ≥50% and is still met; the previous figure is
+struck, not defended.
+
+**The quality floor is a different story, and it now fails.** It reads
+`trace_changed_symbol_readable` ≥ `baseline_changed_symbol_readable`. That
+metric counted whether the bundle *listed* a symbol, never whether it carried
+the body, so it read 100% in both arms — including through the period when the
+trace arm had no source code in it at all. TRA-1100 rewrote it to score
+`detail === 'full'`, and this is the first run measured under the corrected
+definition:
+
+| | naive | trace-mcp |
+|---|---:|---:|
+| changed symbols readable (median per PR) | {{ site.data.pr_context_bench.baseline_changed_symbol_readable }} | **{{ site.data.pr_context_bench.trace_changed_symbol_readable }}** |
+| affected call sites readable | {{ site.data.pr_context_bench.baseline_dependent_readable }} | {{ site.data.pr_context_bench.trace_dependent_readable }} |
+| affected call sites at least located | {{ site.data.pr_context_bench.baseline_dependent_pointed }} | {{ site.data.pr_context_bench.trace_dependent_pointed }} |
+
+A third of the changed symbols arrive without their bodies (113 of 338 across
+the corpus), and the previously-published 58% call-site readability was the same
+pointer count — it is 28% when bodies are required. **The bar was registered as
+unadjustable and it is not being adjusted: this publishes as MISSED.** The
+token saving is unaffected — 70.5% is the same number under either definition,
+because tokens were always counted on the assembled text.
+
+What it does *not* say is that the review suffers: the
+[quality arm]({{ '/perf/prereg-pr-quality/' | relative_url }}), which asks a
+model rather than a metric, came back at parity on the same corpus. Both are
+true, and the gap between them — a third of changed symbols missing without a
+measurable comprehension cost — is the open question, not a resolved one. The
+decomposition (module-level pseudo-symbols, whose "body" is a whole file, versus
+symbols the 8,000-token budget drops) is not yet measured.
+
+Pull requests where the index did not pay off went from 5 to 56 under the
+corrected metric — 43 of them classified `truncated`, which is that same
+finding counted per PR rather than per symbol, and 12 costing more than reading
+the files outright; they are published in
 [`docs/_data/pr_context_bench.json`](../_data/pr_context_bench.json) and on the
 [benchmark page]({{ '/pr-context-benchmark.html' | relative_url }}).
 

--- a/docs/perf/prereg-pr-context.md
+++ b/docs/perf/prereg-pr-context.md
@@ -113,19 +113,21 @@ definition:
 | affected call sites at least located | {{ site.data.pr_context_bench.baseline_dependent_pointed }} | {{ site.data.pr_context_bench.trace_dependent_pointed }} |
 
 A third of the changed symbols arrive without their bodies (113 of 338 across
-the corpus), and the previously-published 58% call-site readability was the same
-pointer count — it is 28% when bodies are required. **The bar was registered as
-unadjustable and it is not being adjusted: this publishes as MISSED.** The
-token saving is unaffected — 70.5% is the same number under either definition,
-because tokens were always counted on the assembled text.
+the corpus) — though how much of that is module-level pseudo-symbols, whose
+"body" is an entire file and is exactly what this index exists not to ship,
+versus symbols the 8,000-token budget drops, is **not yet measured**. The
+previously-published 58% call-site readability was the same pointer count; it is
+28% when bodies are required. **The bar was registered as unadjustable and it is
+not being adjusted: this publishes as MISSED.** The token saving is unaffected —
+70.5% is the same number under either definition, because tokens were always
+counted on the assembled text.
 
 What it does *not* say is that the review suffers: the
 [quality arm]({{ '/perf/prereg-pr-quality/' | relative_url }}), which asks a
 model rather than a metric, came back at parity on the same corpus. Both are
 true, and the gap between them — a third of changed symbols missing without a
-measurable comprehension cost — is the open question, not a resolved one. The
-decomposition (module-level pseudo-symbols, whose "body" is a whole file, versus
-symbols the 8,000-token budget drops) is not yet measured.
+measurable comprehension cost — is the open question, not a resolved one, and
+measuring the decomposition named above is the way into it.
 
 Pull requests where the index did not pay off went from 5 to 56 under the
 corrected metric — 43 of them classified `truncated`, which is that same

--- a/docs/pr-context-benchmark.md
+++ b/docs/pr-context-benchmark.md
@@ -44,8 +44,17 @@ repo so the run reproduces.
 
 Assembling review context for a pull request with trace-mcp costs a median
 **{{ site.data.pr_context_bench.median_savings_pct }}% fewer input tokens** than
-loading the diff plus every file it touches — while making *more* of the code
-the change can break visible, not less.
+loading the diff plus every file it touches. It makes *more* of the code the
+change can break visible — {{ site.data.pr_context_bench.trace_dependent_readable }}
+of affected call sites readable against
+{{ site.data.pr_context_bench.baseline_dependent_readable }}, and
+{{ site.data.pr_context_bench.trace_dependent_pointed }} at least located — and
+*less* of the changed code itself:
+{{ site.data.pr_context_bench.trace_changed_symbol_readable }} of changed symbols
+arrive with their bodies, against
+{{ site.data.pr_context_bench.baseline_changed_symbol_readable }} for whole
+files. That second number misses a
+[preregistered bar]({{ '/perf/prereg-pr-context/' | relative_url }}).
 
 The review written from it holds up. Sending both contexts to the same model on
 the same PRs, the trace-mcp arm understood the change as often as the naive one
@@ -160,21 +169,31 @@ a reviewer does not need.
 
 Two further limits worth stating plainly:
 
-- **The truncation failure mode did not fire here.** The trace-mcp arm is
-  capped at an 8,000-token context bundle; on this dataset no PR was large
-  enough for that cap to drop a changed symbol, so changed-symbol readability
-  is {{ site.data.pr_context_bench.trace_changed_symbol_readable }} in both
-  arms. On a substantially larger PR it would bite, and the benchmark reports
-  it as a `truncated` loss when it does. We have not measured that regime.
+- **The truncation failure mode fires on most of this dataset.** The trace-mcp
+  arm is capped at an 8,000-token context bundle, and changed-symbol
+  readability is {{ site.data.pr_context_bench.trace_changed_symbol_readable }}
+  against the naive arm's
+  {{ site.data.pr_context_bench.baseline_changed_symbol_readable }} — a third of
+  changed symbols arrive without their bodies, 113 of 338 across the corpus.
+  This page said the opposite until 2026-09-07, because the metric counted
+  whether the bundle *listed* a symbol rather than whether it carried the body;
+  it now scores `detail === 'full'`. That miss is registered against the
+  [preregistered quality floor]({{ '/perf/prereg-pr-context/' | relative_url }}),
+  which the bar does not move for. The token figure is unaffected — it was
+  always counted on the assembled text. Whether the missing bodies are
+  module-level pseudo-symbols (whose body is a whole file, which is what this
+  index exists not to ship) or symbols the budget drops is not yet measured.
 - **Call-site coverage is structural, not semantic.** "Readable" means the
   symbol's body is in the context; "located" means it is named with its file
   and line. It does not mean a model used it correctly.
-- **"Readable" counts pointers, not bodies.** The metric records a span
-  whenever the bundle lists a symbol; it never checks that the body arrived.
-  That is how it read 100% through a three-month stretch in which the
-  benchmark's trace arm carried no source code at all — see the
-  [diagnosis]({{ '/perf/pr-context-loss-classes/' | relative_url }}) of that
-  defect and the correction it forced on the figures above.
+- **"Readable" counted pointers, not bodies — until 2026-09-07.** The metric
+  recorded a span whenever the bundle listed a symbol and never checked that the
+  body arrived, which is how it read 100% through a three-month stretch in which
+  the benchmark's trace arm carried no source code at all. It now scores the
+  bundle's own `detail` field, and every coverage figure on this page is the
+  first measured under that definition. The
+  [diagnosis]({{ '/perf/pr-context-loss-classes/' | relative_url }}) has the
+  account of the original defect.
 
 ## Does the thinner context produce a worse review?
 


### PR DESCRIPTION
## Why this exists

TRA-1100 rewrote `changed_symbol_readable` / `dependent_readable` to score the bundle's new `detail` field instead of bundle-array membership — the right fix, and the one TRA-1090's postmortem asked for. Nothing regenerated the artifacts afterwards, so `docs/_data/pr_context_bench.json` and the site kept publishing coverage numbers computed by a definition the repository no longer implements.

That is the same defect class TRA-1090 exists to close: a published number whose meaning has drifted from what the code measures. So: re-ran the token benchmark on `9a432d87`, same 60 pinned PRs, and published what came back.

## What came back

| | before (pointer count) | after (`detail === 'full'`) |
|---|---:|---:|
| changed symbols readable, trace | 100% | **67%** |
| affected call sites readable, trace | 58% | **28%** |
| PRs where the index did not pay off | 23 | **56** (43 `truncated`) |
| median token saving | 70.5% | **70.5%** |

113 of 338 changed symbols across the corpus arrive without their bodies. The token figure does not move at all — tokens were always counted on the assembled text, so that side was never affected by the metric bug.

## The preregistered consequence

`docs/perf/prereg-pr-context.md` registers a quality floor: `trace_changed_symbol_readable ≥ baseline_changed_symbol_readable`. At 67% against 100% that **fails**, and the file now publishes `verdict: MISSED` — a run that misses any registered bar is MISSED, even though the primary saving bar cleared at 70.5%. The bar was registered unadjustable and is not adjusted.

The benchmark page carried a bullet titled "The truncation failure mode did not fire here", asserting no PR was large enough for the budget to drop a changed symbol. It fires on most of the dataset. That bullet is rewritten rather than softened.

## What this does not say

**It does not say the review suffers.** The model-judged quality arm, on this same corpus, is at parity (65.0% naive vs 66.7% trace). A third of changed symbols missing without a measurable comprehension cost is an open question, and both pages now say so instead of picking whichever number reads better.

**It does not decompose the loss.** How much of the 33% is module-level pseudo-symbols — whose "body" is an entire file, which is precisely what this index exists not to ship — versus symbols the 8,000-token budget genuinely drops is *not measured*, and is labelled unmeasured on both pages rather than guessed at. That decomposition is the natural next issue.

## Blast radius

Small on purpose: the headline 70.5% is unchanged, so README prose, `server.json`, `package.json`, `plugin.json`, the GitHub description and the `ops/` ledgers all stay as they are. Only the build stamp moves (`3edecbfb` → `9a432d87`).

## Test evidence

`npx vitest run` — 10,766 passed, 41 skipped, 0 failed. `tests/docs/` green including `savings-claims` (which is what forced the verdict enum to be one of MET/MISSED/NOT-RUN rather than a hedge) and `readme-claims`. Artifacts regenerated from a clean tree, so `measured_build` records `9a432d87` without `dirty`.
