### PR TITLE
fix(proxy): never let a failed local fallback orphan the client handshake

### DIFF
--- a/src/daemon/router/session.ts
+++ b/src/daemon/router/session.ts
@@ -561,6 +561,21 @@ export class StdioSession {
       // An error the client can surface beats a connection that never
       // resolves: clients retry, and by then the swap window has closed.
       this.router.forgetPending(id);
+      // Detach the backend we are answering over the top of. Every other path
+      // that answers a stuck id reaches `router.swap()`, whose step 3 does
+      // exactly this before anything else is forwarded; this branch is the one
+      // that answers without swapping, so it has to do it itself. Otherwise a
+      // merely slow daemon — the `proxy-initialize-timeout` trigger, as
+      // opposed to a dead one — delivers its real `initialize` response after
+      // we gave up, `wireBackend` forwards it, and the client gets two
+      // responses for one id. The interceptor's `id === this.initializeId`
+      // guard does not catch it: `clearInitializeWatchdog()` nulled that at
+      // the top of this method.
+      //
+      // Unconditional is safe here: this only ever runs for `initialize`, so
+      // no other in-flight id shares this backend yet.
+      const stale = this.router.getActiveBackend();
+      if (stale) stale.onmessage = undefined;
       await this.sendAndSettleListChanged({
         jsonrpc: '2.0',
         id,

--- a/src/daemon/router/session.ts
+++ b/src/daemon/router/session.ts
@@ -532,11 +532,47 @@ export class StdioSession {
       { id, reason, timeoutMs: PROXY_INITIALIZE_TIMEOUT_MS },
       'StdioSession: daemon did not complete initialize — serving this session in local mode',
     );
+    // Build BEFORE claiming the id. This is a genuine first load off disk —
+    // the thin proxy entry (TRA-970) never imports LocalBackend — so it can
+    // fail, and the event that gets us here is often the same one that makes
+    // it fail: a package swap (`npm i -g trace-mcp`, the app replacing its
+    // bundle) removes dist/local-backend.js at the exact moment it unsettles
+    // the daemon. Disk full and a native-module load failure land here too.
+    //
+    // Claiming the id first meant that throw orphaned the handshake: nobody
+    // answered it, the process safety net swallowed the rejection, and the
+    // client hung until its own timeout and reported `Failed to connect` —
+    // the outcome this watchdog exists to prevent (TRA-1148).
+    let local: LocalBackend;
+    try {
+      local = await this.buildLocalBackend();
+    } catch (err) {
+      logger.error(
+        { id, reason, err: String(err) },
+        'StdioSession: local-mode fallback could not be built — failing the handshake explicitly',
+      );
+      // Answer explicitly rather than through the router. On the timeout path
+      // the id is still pending, but on the `proxy-initialize-error` path the
+      // router already cleared it when the daemon's error response arrived —
+      // this method having swallowed that error precisely so it could replay
+      // the handshake locally. With the replay gone, the swallow has to be
+      // undone, and only this side knows the id was ever ours.
+      //
+      // An error the client can surface beats a connection that never
+      // resolves: clients retry, and by then the swap window has closed.
+      this.router.forgetPending(id);
+      await this.sendAndSettleListChanged({
+        jsonrpc: '2.0',
+        id,
+        error: { code: -32603, message: `Local fallback unavailable: ${String(err)}` },
+      } as unknown as JSONRPCMessage);
+      return;
+    }
     this.proxyDisabled = true;
     // Drop the in-flight id so the swap does not answer it with a synthetic
     // error; the replay below is the response the client actually receives.
     this.router.forgetPending(id);
-    await this.swapTo(await this.buildLocalBackend(), reason);
+    await this.swapTo(local, reason);
     if (this.router.getActiveKind() !== 'local' || !this.cachedInitialize) return;
     await this.router.ingestFromClient(this.cachedInitialize);
   }
@@ -567,10 +603,24 @@ export class StdioSession {
       { id, err: String(err) },
       'StdioSession: proxy send failed — promoting to local mode and replaying the request',
     );
+    // Build before claiming the id, for the reason spelled out in
+    // fallbackToLocal: this import can fail, and returning false with the id
+    // still pending lets MessageRouter answer it with -32603 rather than
+    // relying on the exact moment it last checked `pendingRequestIds`.
+    let local: LocalBackend;
+    try {
+      local = await this.buildLocalBackend();
+    } catch (buildErr) {
+      logger.error(
+        { id, err: String(buildErr) },
+        'StdioSession: local-mode rescue could not be built — leaving the request for the router to fail',
+      );
+      return false;
+    }
     // Claim the id before swapping, or the swap's drain answers it with a
     // synthetic error and the client gets two responses for one request.
     this.router.forgetPending(id);
-    await this.swapTo(await this.buildLocalBackend(), 'proxy-send-failed');
+    await this.swapTo(local, 'proxy-send-failed');
     if (this.router.getActiveKind() !== 'local') return false;
     await this.router.ingestFromClient(msg);
     return true;
@@ -585,7 +635,23 @@ export class StdioSession {
       await this.swapTo(this.buildProxyBackend(), 'daemon-appeared');
     } else {
       if (currentKind === 'local') return; // already local
-      await this.swapTo(await this.buildLocalBackend(), 'daemon-disappeared');
+      // Same fallible import as the two paths above, and this one is called
+      // fire-and-forget from the watcher, which reports a stable transition
+      // exactly once — so a throw here used to leave the session pinned to a
+      // dead daemon with nothing scheduled to try again. Swallow it: the next
+      // failed send retries the build through rescueFailedProxySend, by which
+      // time a swap window has closed (TRA-1148).
+      let local: LocalBackend;
+      try {
+        local = await this.buildLocalBackend();
+      } catch (err) {
+        logger.error(
+          { err: String(err) },
+          'StdioSession: could not build local backend after the daemon disappeared — staying in proxy mode until the next request retries',
+        );
+        return;
+      }
+      await this.swapTo(local, 'daemon-disappeared');
     }
   }
 

--- a/tests/daemon/session-local-fallback-failure.test.ts
+++ b/tests/daemon/session-local-fallback-failure.test.ts
@@ -61,7 +61,11 @@ async function startSplitHealthServer(
             JSON.stringify({
               jsonrpc: '2.0',
               id: 1,
-              result: { protocolVersion: '2024-11-05', capabilities: {}, serverInfo: { name: 'd' } },
+              result: {
+                protocolVersion: '2024-11-05',
+                capabilities: {},
+                serverInfo: { name: 'd' },
+              },
             }),
           );
         }, 2_000),
@@ -108,50 +112,52 @@ describe('StdioSession local fallback failure (TRA-1148)', () => {
   it.each(['fail', 'slow'] as const)(
     'answers initialize exactly once when the local backend cannot be built (%s daemon)',
     async (mode) => {
-    const daemon = await startSplitHealthServer(mode);
-    const stdin = new PassThrough();
-    const stdout = new PassThrough();
-    const session = new StdioSession({
-      projectRoot: process.cwd(),
-      indexRoot: process.cwd(),
-      config: TraceMcpConfigSchema.parse({}),
-      sharedDbPath: '/nonexistent/shared.db',
-      daemonPort: daemon.port,
-      idleTimeoutMs: 0,
-      daemonStabilityMs: 60_000,
-      autoSpawnDaemon: false,
-      autoSpawnTimeoutMs: 20_000,
-      handshakeTimeoutMs: 0,
-      stdin,
-      stdout,
-    });
-    cleanup = async () => {
-      await session.shutdown('test');
-      await daemon.close();
-    };
+      const daemon = await startSplitHealthServer(mode);
+      const stdin = new PassThrough();
+      const stdout = new PassThrough();
+      const session = new StdioSession({
+        projectRoot: process.cwd(),
+        indexRoot: process.cwd(),
+        config: TraceMcpConfigSchema.parse({}),
+        sharedDbPath: '/nonexistent/shared.db',
+        daemonPort: daemon.port,
+        idleTimeoutMs: 0,
+        daemonStabilityMs: 60_000,
+        autoSpawnDaemon: false,
+        autoSpawnTimeoutMs: 20_000,
+        handshakeTimeoutMs: 0,
+        stdin,
+        stdout,
+      });
+      cleanup = async () => {
+        await session.shutdown('test');
+        await daemon.close();
+      };
 
-    const frames: unknown[] = [];
-    stdout.on('data', (chunk: Buffer) => {
-      for (const line of chunk.toString('utf8').split('\n')) {
-        if (line.trim()) frames.push(JSON.parse(line));
-      }
-    });
+      const frames: unknown[] = [];
+      stdout.on('data', (chunk: Buffer) => {
+        for (const line of chunk.toString('utf8').split('\n')) {
+          if (line.trim()) frames.push(JSON.parse(line));
+        }
+      });
 
-    await session.bootstrap();
-    stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })}\n`);
+      await session.bootstrap();
+      stdin.write(
+        `${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })}\n`,
+      );
 
-    // Settle past the slow daemon's 2 s reply, so a late second frame lands
-    // inside the window rather than after the assertion.
-    await new Promise<void>((resolve) => {
-      const t = setTimeout(resolve, mode === 'slow' ? 3_000 : 1_500);
-      t.unref?.();
-    });
+      // Settle past the slow daemon's 2 s reply, so a late second frame lands
+      // inside the window rather than after the assertion.
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(resolve, mode === 'slow' ? 3_000 : 1_500);
+        t.unref?.();
+      });
 
-    // Exactly one: a failed fallback may neither silently eat the handshake
-    // (0 — the hang this PR fixes) nor answer it twice (2 — the late frame a
-    // still-wired proxy backend forwards). An error the client can surface
-    // beats a connection that never resolves.
-    expect(responsesFor(frames, 1)).toHaveLength(1);
+      // Exactly one: a failed fallback may neither silently eat the handshake
+      // (0 — the hang this PR fixes) nor answer it twice (2 — the late frame a
+      // still-wired proxy backend forwards). An error the client can surface
+      // beats a connection that never resolves.
+      expect(responsesFor(frames, 1)).toHaveLength(1);
     },
   );
 });

--- a/tests/daemon/session-local-fallback-failure.test.ts
+++ b/tests/daemon/session-local-fallback-failure.test.ts
@@ -1,0 +1,118 @@
+import http from 'node:http';
+import { PassThrough } from 'node:stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * TRA-1148: the local-mode fallback must not be able to swallow `initialize`.
+ *
+ * The thin proxy entry (TRA-970) deliberately never loads LocalBackend — it
+ * reaches it through `await import('./local-backend.js')`, a genuine first
+ * load off disk, and only when the daemon has already let the session down.
+ * A package swap (`npm i -g trace-mcp`, or the desktop app replacing its
+ * bundle) is exactly the event that kills the daemon AND removes that chunk
+ * at the same moment, so the fallback fails precisely in the scenario it was
+ * built for. Disk full and a native-module load failure land in the same spot.
+ *
+ * `fallbackToLocal` claimed the client's `initialize` id via `forgetPending`
+ * *before* that fallible build, and is invoked fire-and-forget (`void`). So
+ * the throw orphaned the handshake: nobody answered id 1, the process safety
+ * net swallowed the rejection, and the client sat until its own timeout and
+ * reported `Failed to connect` — the hung handshake TRA-704 exists to prevent.
+ */
+vi.mock('../../src/daemon/lifecycle.js', () => ({
+  tryAutoSpawnDaemon: () => new Promise(() => {}),
+}));
+
+/** Stands in for a chunk that is not on disk right now (mid-swap). */
+vi.mock('../../src/daemon/router/local-backend.js', () => ({
+  get LocalBackend(): never {
+    throw new Error(
+      "Cannot find module '/opt/homebrew/lib/node_modules/trace-mcp/dist/local-backend.js'",
+    );
+  },
+}));
+
+const { TraceMcpConfigSchema } = await import('../../src/config.js');
+const { StdioSession } = await import('../../src/daemon/router/session.js');
+
+/** /health is fine, /mcp answers the handshake with an error — forces fallbackToLocal. */
+async function startSplitHealthServer(): Promise<{ port: number; close: () => Promise<void> }> {
+  const server = http.createServer((req, res) => {
+    req.resume();
+    if (req.url?.startsWith('/mcp')) {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('daemon is not well');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, status: 'healthy' }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as { port: number }).port;
+  return {
+    port,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+function responsesFor(frames: unknown[], id: number): unknown[] {
+  return frames.filter((f) => {
+    const m = f as Record<string, unknown>;
+    return m.id === id && (Object.hasOwn(m, 'result') || Object.hasOwn(m, 'error'));
+  });
+}
+
+describe('StdioSession local fallback failure (TRA-1148)', () => {
+  let cleanup: (() => Promise<void>) | null = null;
+  afterEach(async () => {
+    await cleanup?.();
+    cleanup = null;
+  });
+
+  it('answers initialize even when the local backend cannot be built', async () => {
+    const daemon = await startSplitHealthServer();
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const session = new StdioSession({
+      projectRoot: process.cwd(),
+      indexRoot: process.cwd(),
+      config: TraceMcpConfigSchema.parse({}),
+      sharedDbPath: '/nonexistent/shared.db',
+      daemonPort: daemon.port,
+      idleTimeoutMs: 0,
+      daemonStabilityMs: 60_000,
+      autoSpawnDaemon: false,
+      autoSpawnTimeoutMs: 20_000,
+      handshakeTimeoutMs: 0,
+      stdin,
+      stdout,
+    });
+    cleanup = async () => {
+      await session.shutdown('test');
+      await daemon.close();
+    };
+
+    const frames: unknown[] = [];
+    stdout.on('data', (chunk: Buffer) => {
+      for (const line of chunk.toString('utf8').split('\n')) {
+        if (line.trim()) frames.push(JSON.parse(line));
+      }
+    });
+
+    await session.bootstrap();
+    stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })}\n`);
+
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(resolve, 1_500);
+      t.unref?.();
+    });
+
+    // A failed fallback may not silently eat the handshake. One answer, and an
+    // error the client can surface beats a connection that never resolves.
+    expect(responsesFor(frames, 1)).toHaveLength(1);
+  });
+});

--- a/tests/daemon/session-local-fallback-failure.test.ts
+++ b/tests/daemon/session-local-fallback-failure.test.ts
@@ -35,13 +35,37 @@ vi.mock('../../src/daemon/router/local-backend.js', () => ({
 const { TraceMcpConfigSchema } = await import('../../src/config.js');
 const { StdioSession } = await import('../../src/daemon/router/session.js');
 
-/** /health is fine, /mcp answers the handshake with an error — forces fallbackToLocal. */
-async function startSplitHealthServer(): Promise<{ port: number; close: () => Promise<void> }> {
+/**
+ * /health is fine; /mcp either fails fast (`fail` — a dead daemon) or answers
+ * the handshake successfully but only after the watchdog has given up (`slow`
+ * — a daemon that is merely busy). Both force `fallbackToLocal`; only `slow`
+ * can still deliver a late frame afterwards.
+ */
+async function startSplitHealthServer(
+  mcp: 'fail' | 'slow' = 'fail',
+): Promise<{ port: number; close: () => Promise<void> }> {
+  const timers: NodeJS.Timeout[] = [];
   const server = http.createServer((req, res) => {
     req.resume();
     if (req.url?.startsWith('/mcp')) {
-      res.writeHead(500, { 'Content-Type': 'text/plain' });
-      res.end('daemon is not well');
+      if (mcp === 'fail') {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('daemon is not well');
+        return;
+      }
+      // Answers correctly, just too late: past PROXY_INITIALIZE_TIMEOUT_MS.
+      timers.push(
+        setTimeout(() => {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id: 1,
+              result: { protocolVersion: '2024-11-05', capabilities: {}, serverInfo: { name: 'd' } },
+            }),
+          );
+        }, 2_000),
+      );
       return;
     }
     res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -53,6 +77,7 @@ async function startSplitHealthServer(): Promise<{ port: number; close: () => Pr
     port,
     close: () =>
       new Promise<void>((resolve) => {
+        for (const t of timers) clearTimeout(t);
         server.closeAllConnections();
         server.close(() => resolve());
       }),
@@ -73,8 +98,17 @@ describe('StdioSession local fallback failure (TRA-1148)', () => {
     cleanup = null;
   });
 
-  it('answers initialize even when the local backend cannot be built', async () => {
-    const daemon = await startSplitHealthServer();
+  // `fail` is the dead daemon: without the fix nobody answered at all.
+  // `slow` is the merely-busy one, and the harder case — the proxy backend is
+  // still wired when the fallback gives up, so its late-but-valid response
+  // gets forwarded on top of the error we already sent, and the client gets
+  // two responses for one id. Every other path that answers a stuck id goes
+  // through `router.swap()`, which detaches the old backend first; this branch
+  // answers without swapping and has to detach for itself.
+  it.each(['fail', 'slow'] as const)(
+    'answers initialize exactly once when the local backend cannot be built (%s daemon)',
+    async (mode) => {
+    const daemon = await startSplitHealthServer(mode);
     const stdin = new PassThrough();
     const stdout = new PassThrough();
     const session = new StdioSession({
@@ -106,13 +140,18 @@ describe('StdioSession local fallback failure (TRA-1148)', () => {
     await session.bootstrap();
     stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })}\n`);
 
+    // Settle past the slow daemon's 2 s reply, so a late second frame lands
+    // inside the window rather than after the assertion.
     await new Promise<void>((resolve) => {
-      const t = setTimeout(resolve, 1_500);
+      const t = setTimeout(resolve, mode === 'slow' ? 3_000 : 1_500);
       t.unref?.();
     });
 
-    // A failed fallback may not silently eat the handshake. One answer, and an
-    // error the client can surface beats a connection that never resolves.
+    // Exactly one: a failed fallback may neither silently eat the handshake
+    // (0 — the hang this PR fixes) nor answer it twice (2 — the late frame a
+    // still-wired proxy backend forwards). An error the client can surface
+    // beats a connection that never resolves.
     expect(responsesFor(frames, 1)).toHaveLength(1);
-  });
+    },
+  );
 });


### PR DESCRIPTION
## The failure

The thin proxy entry (TRA-970) deliberately never imports `LocalBackend` — it reaches it through `await import('./local-backend.js')`, a genuine first load off disk, and only once the daemon has already let the session down.

A package swap (`npm i -g trace-mcp`, or the desktop app replacing its bundle) is exactly the event that kills the daemon **and** removes `dist/local-backend.js` at the same instant. So the local-mode fallback — the mechanism whose entire job is keeping the MCP session alive when the daemon goes away — fails precisely in the scenario it was built for. Disk full and a native-module load failure land in the same spot.

`fallbackToLocal` claimed the client's `initialize` id via `forgetPending` **before** that fallible build, and is invoked fire-and-forget (`void`). The throw therefore orphaned the handshake: nobody answered id 1, `installProcessSafetyNet` swallowed the rejection, and the client sat until its own timeout and reported `Failed to connect` — the hung handshake TRA-704's watchdog exists to prevent. Silent, too: no `ERROR` in `launcher.log`, because the shim's own exec succeeded.

Reproduced before the fix (new test, unpatched): unhandled rejection at `session.ts:539`, **zero** responses for the client's `initialize`.

## The change

`src/daemon/router/session.ts` only — build the backend *before* mutating router state, in all three paths that reach it:

- **`fallbackToLocal`** — on failure, answer the handshake explicitly with `-32603` instead of leaving it unanswered. It answers through the session's own outbound path rather than the router: on the timeout path the id is still pending, but on `proxy-initialize-error` the router already cleared it when the daemon's error response arrived — this method having swallowed that error precisely so it could replay locally. With the replay gone, the swallow has to be undone, and only this side knows the id was ever ours.
- **`rescueFailedProxySend`** — return `false` on a build failure so `MessageRouter` answers the frame, instead of relying on the exact moment it last checked `pendingRequestIds`.
- **`onDaemonStateChange`** — catch and log. The watcher reports a stable transition exactly once, so a throw used to pin the session to a dead daemon with nothing scheduled to try again. The next failed send retries the build through `rescueFailedProxySend`, by which time a swap window has closed.

No MCP tool-contract, schema or token-budget change. No new API surface — an earlier draft added `MessageRouter.failPending`; it turned out not to be needed once the answer went through the session's outbound path, so it is not in the diff.

## Test evidence

New: `tests/daemon/session-local-fallback-failure.test.ts` — drives a real `StdioServerTransport` against a daemon whose `/health` is fine and whose `/mcp` fails, with `local-backend.js` mocked to throw a module-not-found. Asserts **exactly one** response for `initialize`, which catches a hang and a double-answer with the same assertion.

- Failing before the change (0 responses + unhandled rejection), passing after.
- `pnpm test`: `Test Files 970 passed | 3 skipped · Tests 10768 passed | 40 skipped`
- `pnpm build` and `pnpm lint` (`tsc --noEmit`) clean.

Closes TRA-1148.
