### PR TITLE
fix(app): "Get help" opens a prefilled issue form, not a closed-issue list (TRA-1155)

### DIFF
--- a/packages/app/src/main/__tests__/menu.test.ts
+++ b/packages/app/src/main/__tests__/menu.test.ts
@@ -31,7 +31,7 @@ const focusedWindow = {
 };
 
 vi.mock('electron', () => ({
-  app: { name: 'trace-mcp', on: vi.fn() },
+  app: { name: 'trace-mcp', on: vi.fn(), getVersion: () => '3.21.0', isPackaged: true },
   BrowserWindow: {
     getFocusedWindow: () => (focusedId === null ? null : focusedWindow),
     getAllWindows: () => [],
@@ -49,6 +49,7 @@ vi.mock('electron', () => ({
 
 vi.mock('../tray', () => ({ showMenuWindow: vi.fn(), refreshTrayMenu: vi.fn() }));
 
+import { shell } from 'electron';
 import { GLOBAL_ACTIONS } from '../../shared/global-actions.js';
 import { startI18n, t } from '../i18n';
 import { buildAppMenu, forgetWindowSections, setWindowSections } from '../menu';
@@ -139,6 +140,19 @@ describe('application menu', () => {
     click(menu('Help'), 'Get help');
     click(menu('Help'), 'View changelog');
     expect(sent).toEqual([]); // neither is an app-command
+  });
+
+  /* TRA-1155: the app has never received a bug report, and "Get help" landing
+     on a list of closed issues is most of the reason. It opens the form, and
+     the form arrives carrying the three facts every app bug has needed. */
+  it('opens "Get help" on a new issue prefilled with this copy’s environment', () => {
+    click(menu('Help'), 'Get help');
+    const [url] = vi.mocked(shell.openExternal).mock.calls.at(-1) as [string];
+    expect(url.startsWith('https://github.com/nikolai-vysotskyi/trace-mcp/issues/new?')).toBe(true);
+    const body = new URL(url).searchParams.get('body') ?? '';
+    expect(body).toContain('App version: 3.21.0');
+    expect(body).toContain(`Platform: ${process.platform} ${process.arch}`);
+    expect(body).toContain('Updates: electron-updater');
   });
 
   it('keeps Edit on plain roles so text fields keep working', () => {

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import fs from 'fs';
 import { resolveAutoUpdaterExport } from './autoupdater-interop';
 import { t } from './i18n';
-import { registerAppMenu } from './menu';
+import { currentHelpUrl, registerAppMenu } from './menu';
 import { getLauncherDir } from './trace-home';
 import { appendUpdateLog, updateLogPath } from './update-log';
 import { ACCESSORY_APP, createTray, restoreAppearance, showMenuWindow } from './tray';
@@ -76,6 +76,11 @@ ipcMain.handle('open-external', async (_event, url: string) => {
   await shell.openExternal(url);
   return { ok: true };
 });
+
+// IPC: the "Get help" destination, with this copy's version, platform and
+// update channel already in the issue body (TRA-1155). Built here because the
+// renderer knows none of those.
+ipcMain.handle('help-url', () => currentHelpUrl());
 
 // IPC: reveal a path in Finder/Explorer. Reveals, never opens: the duplicate
 // install the app menu points at is an `.app`, and `shell.openPath` on one would

--- a/packages/app/src/main/menu.ts
+++ b/packages/app/src/main/menu.ts
@@ -26,7 +26,7 @@ import {
   shell,
   type MenuItemConstructorOptions,
 } from 'electron';
-import { type GlobalActionId, globalAction } from '../shared/global-actions.js';
+import { type GlobalActionId, globalAction, helpUrl } from '../shared/global-actions.js';
 import { isLocale } from '../shared/i18n/locales.js';
 import { startI18n, t } from './i18n';
 import { readLocale, writeLocale } from './locale';
@@ -70,12 +70,27 @@ function closeWindowGroup(): void {
   }
 }
 
+/** The "Get help" destination for THIS copy of the app. The main process is
+    the only one that knows all four facts, so the renderer asks it for the
+    finished URL over IPC rather than assembling its own (TRA-1155). */
+export function currentHelpUrl(): string {
+  return helpUrl({
+    version: app.getVersion(),
+    platform: process.platform,
+    arch: process.arch,
+    autoUpdate: app.isPackaged,
+  });
+}
+
 /** One item of the shared global-action list (TRA-363). The sidebar's app menu
     renders the SAME entry, so the label and the key are read here, never typed
     here — that is the whole point of `src/shared/global-actions.ts`. */
 function actionItem(id: GlobalActionId): MenuItemConstructorOptions {
   const action = globalAction(id);
-  const url = action.url;
+  // "Get help" is the one link whose destination depends on this copy of the
+  // app: the issue form arrives with the version, platform and update channel
+  // already in it (TRA-1155).
+  const url = action.id === 'get-help' ? currentHelpUrl() : action.url;
   return url
     ? { label: t(action.labelKey), click: () => void shell.openExternal(url) }
     : {

--- a/packages/app/src/main/preload.ts
+++ b/packages/app/src/main/preload.ts
@@ -16,6 +16,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   openInEditor: (filePath: string): Promise<void> => ipcRenderer.invoke('open-in-editor', filePath),
   openExternal: (url: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('open-external', url),
+  /** TRA-1155: "Get help" opens a new issue prefilled with this copy's facts. */
+  helpUrl: (): Promise<string> => ipcRenderer.invoke('help-url'),
   showInFolder: (target: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('show-in-folder', target),
   detectIdeApps: (): Promise<{ id: string; name: string; bundlePath: string }[]> =>

--- a/packages/app/src/renderer/components/AppMenu.tsx
+++ b/packages/app/src/renderer/components/AppMenu.tsx
@@ -156,7 +156,16 @@ export function AppMenu({
   const runAction = (action: GlobalAction): (() => void) => {
     if (action.url) {
       const url = action.url;
-      return run(() => void window.electronAPI?.openExternal?.(url));
+      /* "Get help" opens the issue FORM with this copy's version, platform and
+         update channel already in the body (TRA-1155). Only the main process
+         knows those, so ask it; the static URL in the action list is the
+         fallback for a `vite dev` browser, where there is no main process. */
+      const open = async () => {
+        const target =
+          action.id === 'get-help' ? ((await window.electronAPI?.helpUrl?.()) ?? url) : url;
+        await window.electronAPI?.openExternal?.(target);
+      };
+      return run(() => void open());
     }
     if (action.id === 'settings') return run(onSettings);
     return run(onCheckForUpdate);

--- a/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
+++ b/packages/app/src/renderer/components/__tests__/AppMenu.test.tsx
@@ -18,6 +18,7 @@ import type { DaemonUpdateState, UpdateState } from '../../update-check.js';
 import { AppMenu, type AppMenuProps } from '../AppMenu';
 
 const openExternal = vi.fn();
+const helpUrl = vi.fn(async () => 'https://github.com/x/y/issues/new?body=prefilled');
 
 function renderMenu(props: Partial<AppMenuProps> = {}) {
   const onAppearanceChange = vi.fn();
@@ -53,7 +54,7 @@ function openMenu(trigger: HTMLElement): HTMLElement {
 
 beforeEach(() => {
   openExternal.mockReset();
-  (window as unknown as { electronAPI: unknown }).electronAPI = { openExternal };
+  (window as unknown as { electronAPI: unknown }).electronAPI = { openExternal, helpUrl };
 });
 
 /* The Language row switches for real — there is no store to fake, which is the
@@ -267,18 +268,41 @@ describe('sidebar app menu', () => {
     expect(document.activeElement?.textContent).toContain('View changelog');
   });
 
-  it('runs the commands and opens the links', () => {
+  it('runs the commands and opens the links', async () => {
     const { trigger, onSettings, onCheckForUpdate } = renderMenu();
     fireEvent.click(within(openMenu(trigger)).getByRole('menuitem', { name: /Settings/ }));
     expect(onSettings).toHaveBeenCalled();
 
+    fireEvent.click(within(openMenu(trigger)).getByRole('menuitem', { name: /View changelog/ }));
+    await vi.waitFor(() =>
+      expect(openExternal).toHaveBeenCalledWith(
+        'https://github.com/nikolai-vysotskyi/trace-mcp/releases',
+      ),
+    );
+
+    /* TRA-1155: "Get help" is the one link whose destination the main process
+       builds — the issue form, prefilled with this copy's version, platform and
+       update channel. The static URL in the shared list is only the fallback. */
     fireEvent.click(within(openMenu(trigger)).getByRole('menuitem', { name: /Get help/ }));
-    expect(openExternal).toHaveBeenCalledWith(
-      'https://github.com/nikolai-vysotskyi/trace-mcp/issues',
+    await vi.waitFor(() =>
+      expect(openExternal).toHaveBeenCalledWith('https://github.com/x/y/issues/new?body=prefilled'),
     );
 
     fireEvent.click(within(openMenu(trigger)).getByRole('menuitem', { name: /Check for updates/ }));
     expect(onCheckForUpdate).toHaveBeenCalled();
+  });
+
+  /* In a `vite dev` browser there is no main process to ask, so the link must
+     still go somewhere useful rather than nowhere. */
+  it('falls back to the shared list’s URL when no main process answers', async () => {
+    (window as unknown as { electronAPI: unknown }).electronAPI = { openExternal };
+    const { trigger } = renderMenu();
+    fireEvent.click(within(openMenu(trigger)).getByRole('menuitem', { name: /Get help/ }));
+    await vi.waitFor(() =>
+      expect(openExternal).toHaveBeenCalledWith(
+        'https://github.com/nikolai-vysotskyi/trace-mcp/issues/new',
+      ),
+    );
   });
 
   /* TRA-376. "Check for updates…" acts on the app; the two above it leave for

--- a/packages/app/src/renderer/electron.d.ts
+++ b/packages/app/src/renderer/electron.d.ts
@@ -22,6 +22,8 @@ declare global {
       selectFolder: () => Promise<string | null>;
       openInEditor: (filePath: string) => Promise<void>;
       openExternal: (url: string) => Promise<{ ok: boolean; error?: string }>;
+      /** "Get help" with the environment prefilled (TRA-1155). */
+      helpUrl?: () => Promise<string>;
       /** Reveal a path in Finder — never opens it (TRA-692). */
       showInFolder?: (target: string) => Promise<{ ok: boolean; error?: string }>;
       detectIdeApps: () => Promise<{ id: string; name: string; bundlePath: string }[]>;

--- a/packages/app/src/shared/global-actions.ts
+++ b/packages/app/src/shared/global-actions.ts
@@ -40,6 +40,40 @@ export interface GlobalAction {
   icon: string;
 }
 
+const ISSUES_URL = 'https://github.com/nikolai-vysotskyi/trace-mcp/issues';
+
+/** The environment facts every app bug report so far has needed. Filled in by
+    whichever process knows them: the main process reads them off `app` and
+    `process`, the renderer asks the main process for the finished URL. */
+export interface HelpEnv {
+  version: string;
+  platform: string;
+  arch: string;
+  /** Packaged builds update themselves through electron-updater; a dev run
+      does not, and that difference has explained bug reports before. */
+  autoUpdate: boolean;
+}
+
+/** "Get help" as a pre-filled new issue (TRA-1155). Windows installs are the
+    only deliberate acquisition this project has and the app has never received
+    a single report — sending someone to a list of closed issues with no form
+    and no hint of what we need is most of the reason. */
+export function helpUrl(env: HelpEnv): string {
+  const body = [
+    'What happened:',
+    '',
+    'What you expected:',
+    '',
+    'Steps to reproduce:',
+    '',
+    '---',
+    `App version: ${env.version}`,
+    `Platform: ${env.platform} ${env.arch}`,
+    `Updates: ${env.autoUpdate ? 'electron-updater' : 'none'}`,
+  ].join('\n');
+  return `${ISSUES_URL}/new?title=${encodeURIComponent('[app] ')}&body=${encodeURIComponent(body)}`;
+}
+
 /** Order here is the order the in-app menu renders them in. */
 export const GLOBAL_ACTIONS: readonly GlobalAction[] = [
   {
@@ -60,11 +94,16 @@ export const GLOBAL_ACTIONS: readonly GlobalAction[] = [
     icon: 'scroll',
   },
   /* A question mark, not a speech bubble: this opens GitHub issues, and a
-     speech bubble would promise a person on the other end. */
+     speech bubble would promise a person on the other end.
+
+     The issue FORM, not the issue list: the list is where every issue is
+     closed and nothing tells a reporter what we would need to know (TRA-1155).
+     This URL is the fallback — both surfaces replace it with `helpUrl()`,
+     which prefills the environment. */
   {
     id: 'get-help',
     labelKey: 'menu:getHelp',
-    url: 'https://github.com/nikolai-vysotskyi/trace-mcp/issues',
+    url: `${ISSUES_URL}/new`,
     icon: 'help',
   },
   {


### PR DESCRIPTION
Closes TRA-1155.

## Why

GitHub release assets carry a public `download_count`. Windows `trace-mcp.Setup.<v>.exe`: **117 all time, 51 since 2026-09-01**. macOS `.dmg`: **10, all time** — because on macOS the app is pushed (`init` installs it, the npm postinstall keeps it in sync), so nobody visits the release page. Every Windows download is a person deciding to install the desktop app, which makes it the largest deliberate acquisition signal the project has.

That app has received zero public feedback of any kind, ever, and its only feedback affordance opened the issue **list** — where every issue is closed, nothing is prefilled, and nothing tells a reporter what we need.

## What changed

`get-help` now opens `/issues/new` with a body carrying the three facts every app bug has needed: app version, platform + arch, and whether this copy updates itself through electron-updater.

- `shared/global-actions.ts` — `helpUrl(env)`, a pure function; the entry's static `url` becomes `/issues/new` and stays as the fallback.
- `main/menu.ts` — `currentHelpUrl()` reads the facts off `app`/`process`; the native menu item uses it.
- `main/index.ts` + `preload.ts` + `renderer/electron.d.ts` — one `help-url` IPC channel, because the renderer knows none of those facts.
- `renderer/components/AppMenu.tsx` — the sidebar menu asks the main process, falling back to the static URL in a `vite dev` browser (no main process there).

Deliberately not here: in-app feedback UI, crash reporter, telemetry. An issue template follows from a report arriving, not the other way round.

## Tests

- `main/__tests__/menu.test.ts` — new: the native "Get help" item opens `/issues/new?…` and the decoded body carries version, platform/arch and `Updates: electron-updater`.
- `components/__tests__/AppMenu.test.tsx` — updated: the sidebar item opens what the main process hands it; new test pins the browser fallback.

`pnpm run test` in `packages/app`: **78 files, 754 tests passed**. `typecheck` and `check:i18n` clean. The root suite excludes `packages/app/**` and this diff touches nothing outside it.
