### PR TITLE
fix(app): disambiguate Open/Re-index/Remove aria-labels too (TRA-1058)

### DIFF
--- a/packages/app/src/renderer/workspace/WorkspaceCompactView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceCompactView.tsx
@@ -134,6 +134,7 @@ function CompactRow({
         <ProjectMetricsBadges project={project} dense />
         <ProjectRowActions
           project={project}
+          label={label}
           canMutate={canMutate}
           confirming={confirming}
           onRequestRemove={onRequestRemove}
@@ -234,6 +235,7 @@ export function WorkspaceCompactView({
       {menu && (
         <ProjectContextMenu
           project={menu.project}
+          label={labelByRoot.get(menu.project.root) ?? menu.project.name}
           canMutate={canMutate}
           x={menu.x}
           y={menu.y}

--- a/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
+++ b/packages/app/src/renderer/workspace/WorkspaceTableView.tsx
@@ -357,6 +357,7 @@ function Row({
       <td className="px-3" style={stickyCell('right', 0, bg)}>
         <ProjectRowActions
           project={project}
+          label={label}
           canMutate={canMutate}
           confirming={confirming}
           onRequestRemove={onRequestRemove}
@@ -587,6 +588,7 @@ export function WorkspaceTableView({
       {menu && (
         <ProjectContextMenu
           project={menu.project}
+          label={labelByRoot.get(menu.project.root) ?? menu.project.name}
           canMutate={canMutate}
           x={menu.x}
           y={menu.y}

--- a/packages/app/src/renderer/workspace/__tests__/Workspace.duplicateNames.test.tsx
+++ b/packages/app/src/renderer/workspace/__tests__/Workspace.duplicateNames.test.tsx
@@ -47,10 +47,28 @@ vi.mock('../useWorkspaceProjects', () => ({
 
 /** Row labels in DOM order, read off the per-row select checkboxes. */
 function renderedLabels(container: HTMLElement): string[] {
-  return [...container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')]
-    .map((c) => c.getAttribute('aria-label') ?? '')
-    .filter((l) => l.startsWith('Select ') && l !== 'Select all projects')
-    .map((l) => l.slice('Select '.length));
+  return ariaLabelsWithPrefix(container, 'Select ').filter((l) => l !== 'all projects');
+}
+
+/**
+ * Every `aria-label` in the container that starts with `prefix`, with the
+ * prefix stripped — i.e. the disambiguated name each one embeds. Reads
+ * checkboxes AND buttons, so it catches the row-level Open/Re-index/Remove
+ * actions (`ProjectRowActions`) as well as Select.
+ *
+ * TRA-1058 follow-up #2: the first pass disambiguated the Select checkbox's
+ * aria-label (`labelByRoot` reached `Row`/`CompactRow`) but not Open/Re-index/
+ * Remove, which stayed on raw `project.name` inside the shared
+ * `ProjectRowActions` component one level down — a second, independent
+ * consumer of the same ambiguous field that the first fix never touched.
+ * Iterating every prefix here, rather than asserting Select alone, is the
+ * one-line guard Lead Engineer asked for so a fourth consumer can't repeat it.
+ */
+function ariaLabelsWithPrefix(container: HTMLElement, prefix: string): string[] {
+  return [...container.querySelectorAll<HTMLElement>('[aria-label]')]
+    .map((el) => el.getAttribute('aria-label') ?? '')
+    .filter((l) => l.startsWith(prefix))
+    .map((l) => l.slice(prefix.length));
 }
 
 describe('Workspace duplicate project names', () => {
@@ -74,4 +92,26 @@ describe('Workspace duplicate project names', () => {
     const labels = renderedLabels(container);
     expect(new Set(labels).size).toBe(labels.length);
   });
+
+  it.each(['table', 'compact'] as const)(
+    'disambiguates every row action label in %s view, not just Select',
+    (view) => {
+      localStorage.setItem('trace-mcp.workspace.view', view);
+      const { container } = render(<Workspace />);
+      for (const prefix of ['Select ', 'Open ', 'Re-index ']) {
+        const labels = ariaLabelsWithPrefix(container, prefix).filter((l) => l !== 'all projects');
+        expect(new Set(labels).size, `${prefix.trim()} labels: ${JSON.stringify(labels)}`).toBe(
+          labels.length,
+        );
+      }
+      // "Remove {{name}} from the workspace" has its own suffix — same check,
+      // different prefix/suffix pair.
+      const removeLabels = [...container.querySelectorAll<HTMLElement>('[aria-label]')]
+        .map((el) => el.getAttribute('aria-label') ?? '')
+        .filter((l) => l.startsWith('Remove ') && l.endsWith(' from the workspace'));
+      expect(new Set(removeLabels).size, `Remove labels: ${JSON.stringify(removeLabels)}`).toBe(
+        removeLabels.length,
+      );
+    },
+  );
 });

--- a/packages/app/src/renderer/workspace/components/ProjectRowActions.tsx
+++ b/packages/app/src/renderer/workspace/components/ProjectRowActions.tsx
@@ -30,6 +30,11 @@ export interface RemoveConfirmState {
 
 export interface ProjectRowActionsProps extends ProjectActionHandlers, RemoveConfirmState {
   project: ProjectViewModel;
+  /** Disambiguated display name — see Workspace.tsx (TRA-1058). Required, not
+      defaulted to `project.name`: a missing prop should fail to compile, not
+      silently reintroduce the ambiguity (this is the third time a consumer of
+      `project.name` was found still unpatched after the first fix). */
+  label: string;
   /** false = daemon disconnected; Re-index/Remove are disabled. */
   canMutate: boolean;
 }
@@ -46,6 +51,7 @@ function canOpen(project: ProjectViewModel): boolean {
 
 export function ProjectRowActions({
   project,
+  label,
   canMutate,
   confirming,
   onRequestRemove,
@@ -90,24 +96,24 @@ export function ProjectRowActions({
         disabled={!canOpen(project)}
         onClick={() => onOpen(project.root)}
         style={{ color: 'var(--accent)' }}
-        aria-label={t('openProject', { name: project.name })}
-        title={t('openProject', { name: project.name })}
+        aria-label={t('openProject', { name: label })}
+        title={t('openProject', { name: label })}
       />
       <Button
         variant="icon"
         icon="refresh"
         disabled={!canReindex(project, canMutate)}
         onClick={() => onReindex(project.root)}
-        aria-label={t('reindexProject', { name: project.name })}
-        title={t('reindexProject', { name: project.name })}
+        aria-label={t('reindexProject', { name: label })}
+        title={t('reindexProject', { name: label })}
       />
       <Button
         variant="icon"
         icon="close"
         disabled={!mutationAllowed}
         onClick={() => onRequestRemove(project.root)}
-        aria-label={t('removeProjectFrom', { name: project.name })}
-        title={t('removeProjectFrom', { name: project.name })}
+        aria-label={t('removeProjectFrom', { name: label })}
+        title={t('removeProjectFrom', { name: label })}
       />
     </div>
   );
@@ -115,6 +121,9 @@ export function ProjectRowActions({
 
 export interface ProjectContextMenuProps {
   project: ProjectViewModel;
+  /** Disambiguated display name — see Workspace.tsx (TRA-1058). Required, same
+      reasoning as {@link ProjectRowActionsProps.label}. */
+  label: string;
   canMutate: boolean;
   x: number;
   y: number;
@@ -126,6 +135,7 @@ export interface ProjectContextMenuProps {
 
 export function ProjectContextMenu({
   project,
+  label,
   canMutate,
   x,
   y,
@@ -146,7 +156,7 @@ export function ProjectContextMenu({
         disabled={!canOpen(project)}
         onClick={run(() => onOpen(project.root))}
       >
-        {t('openProject', { name: project.name })}
+        {t('openProject', { name: label })}
       </MenuItem>
       <MenuItem
         icon="refresh"


### PR DESCRIPTION
## Summary
- Lead Engineer verified 3.23.1 live: the Select checkbox's aria-label got `labelByRoot` in the previous pass, but Open/Re-index/Remove — the other three of four row actions — sit in the shared `ProjectRowActions`/`ProjectContextMenu` component and stayed on raw `project.name`. Two projects named `trace-mcp` announced as "Open trace-mcp" / "Open trace-mcp" to VoiceOver with no way to tell them apart — the exact bug TRA-1058 was filed for, just on the accessibility layer instead of the visual one.
- `label` is now a **required** prop on `ProjectRowActionsProps` and `ProjectContextMenuProps` (not defaulted to `project.name`), so a future call site that forgets to thread it through fails to compile instead of silently reintroducing the ambiguity.
- Both call sites (`WorkspaceTableView.tsx`, `WorkspaceCompactView.tsx`) now pass `labelByRoot.get(root)` through, for both the inline row buttons and the right-click context menu.

## Test plan
- [x] Extended `Workspace.duplicateNames.test.tsx` per Lead Engineer's suggestion: a parametrized test (table + compact) collects every row `aria-label` by prefix (`Select `/`Open `/`Re-index `/`Remove … from the workspace`) and asserts each group is unique — so a fifth unpatched consumer fails a test instead of shipping.
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 755/755 passing (1 pre-existing skip)