### PR TITLE
fix(dashboard): a real grade needs a real sample size (TRA-1057)

### DIFF
--- a/src/api/dashboard-routes.ts
+++ b/src/api/dashboard-routes.ts
@@ -260,6 +260,15 @@ async function enrich(entry: RegistryEntry, basics: ProjectHealth): Promise<Proj
  */
 const DASHBOARD_CACHE_PATH = path.join(TRACE_MCP_HOME, 'dashboard-cache.json');
 const CACHE_TTL_MS = 300_000; // 5 minutes
+/**
+ * Bump whenever the grading logic changes in a way that makes an
+ * already-cached `techDebtGrade` wrong. A dbPath fingerprint only detects
+ * changes to the *project's* index, not to trace-mcp's own scoring code — so
+ * without this, a stale-but-still-fingerprint-matching grade computed by a
+ * pre-fix build (e.g. "A" for an empty or 1-symbol project, TRA-1057) would
+ * survive an upgrade forever, since nothing ever marks it stale.
+ */
+const DASHBOARD_CACHE_VERSION = 2;
 
 const cache = new Map<string, ProjectHealth>();
 /** dbPath fingerprint at the time each project's expensive pass last ran. */
@@ -273,10 +282,15 @@ function loadCacheFromDisk(): void {
   loadedFromDisk = true;
   try {
     const raw = JSON.parse(fs.readFileSync(DASHBOARD_CACHE_PATH, 'utf-8')) as {
+      version?: number;
       computedAt?: number;
       projects?: ProjectHealth[];
       enrichedAt?: Array<[string, number]>;
     };
+    // Missing/older version → a pre-fix build wrote this file. Discard it
+    // rather than trust grades it computed; refreshAll() recomputes from
+    // scratch on the next tick.
+    if (raw.version !== DASHBOARD_CACHE_VERSION) return;
     for (const p of raw.projects ?? []) if (p?.root) cache.set(p.root, p);
     for (const [root, at] of raw.enrichedAt ?? []) enrichedAt.set(root, at);
     if (typeof raw.computedAt === 'number') computedAt = raw.computedAt;
@@ -291,6 +305,7 @@ function saveCacheToDisk(): void {
     fs.writeFileSync(
       tmp,
       JSON.stringify({
+        version: DASHBOARD_CACHE_VERSION,
         computedAt,
         projects: [...cache.values()],
         enrichedAt: [...enrichedAt],

--- a/src/api/dashboard-routes.ts
+++ b/src/api/dashboard-routes.ts
@@ -213,11 +213,17 @@ async function enrich(entry: RegistryEntry, basics: ProjectHealth): Promise<Proj
 
     try {
       const debtResult = getTechDebt(store, entry.root, {});
-      if (debtResult.isOk() && debtResult.value.project_grade) {
-        out.techDebtGrade = debtResult.value.project_grade;
-      }
+      // Explicit undefined on the "nothing to grade" branch, not a skipped
+      // assignment — `out` was seeded from `basics`, which can carry a stale
+      // grade forward from before a project shrank below the "enough data"
+      // floor (TRA-1057 review: a skipped assignment here left a project
+      // that dropped to 1 symbol permanently reading its old grade B).
+      out.techDebtGrade =
+        debtResult.isOk() && debtResult.value.project_grade
+          ? debtResult.value.project_grade
+          : undefined;
     } catch {
-      /* leave undefined */
+      out.techDebtGrade = undefined;
     }
     await tick();
 

--- a/src/tools/analysis/predictive-intelligence.ts
+++ b/src/tools/analysis/predictive-intelligence.ts
@@ -130,8 +130,9 @@ interface TechDebtModule {
 export interface TechDebtResult {
   modules: TechDebtModule[];
   project_score: number;
-  /** `null` when there are no modules to score — an empty index has nothing
-   *  to grade, which is not the same claim as "grade A" (TRA-1057). */
+  /** `null` when there are no modules to score, or too few indexed symbols
+   *  for the score to mean anything — neither case is the same claim as
+   *  "grade A" (TRA-1057). */
   project_grade: 'A' | 'B' | 'C' | 'D' | 'F' | null;
 }
 
@@ -374,6 +375,9 @@ function riskLevel(score: number): 'low' | 'medium' | 'high' | 'critical' {
   if (score < 0.75) return 'high';
   return 'critical';
 }
+
+/** Minimum indexed symbols before a project-level tech-debt grade is meaningful (TRA-1057). */
+const MIN_SYMBOLS_FOR_GRADE = 20;
 
 function debtGrade(score: number): 'A' | 'B' | 'C' | 'D' | 'F' {
   if (score < 0.2) return 'A';
@@ -743,6 +747,13 @@ export function getTechDebt(
     if (row.tested_path) testedFiles.add(row.tested_path);
   }
 
+  // Below this many indexed symbols, per-file averages, coupling instability,
+  // and churn percentiles are dominated by 1-2 data points — not a signal
+  // worth grading (TRA-1057: a 1-symbol project scored grade B).
+  const totalSymbolCount =
+    (store.db.prepare('SELECT COUNT(*) AS c FROM symbols').get() as { c: number } | undefined)?.c ??
+    0;
+
   // Group files by module
   const allFiles = store.getAllFiles();
   const moduleFiles = new Map<string, string[]>();
@@ -848,13 +859,16 @@ export function getTechDebt(
   const totalScore =
     modules.length > 0 ? modules.reduce((s, m) => s + m.score, 0) / modules.length : 0;
 
+  // Zero modules means zero files — nothing was scored, so there is nothing
+  // to grade. debtGrade(0) reads as "A", the best possible score, which is
+  // exactly backwards for an empty project. Same reasoning below
+  // MIN_SYMBOLS_FOR_GRADE: too little data to mean anything (TRA-1057).
+  const hasEnoughDataToGrade = modules.length > 0 && totalSymbolCount >= MIN_SYMBOLS_FOR_GRADE;
+
   return ok({
     modules: modules.slice(0, 50),
     project_score: round(totalScore),
-    // Zero modules means zero files — nothing was scored, so there is
-    // nothing to grade. debtGrade(0) reads as "A", the best possible score,
-    // which is exactly backwards for an empty project (TRA-1057).
-    project_grade: modules.length > 0 ? debtGrade(totalScore) : null,
+    project_grade: hasEnoughDataToGrade ? debtGrade(totalScore) : null,
   });
 }
 

--- a/tests/api/dashboard-cache-version.test.ts
+++ b/tests/api/dashboard-cache-version.test.ts
@@ -1,0 +1,116 @@
+/**
+ * TRA-1057 (part 2): a dbPath fingerprint only detects changes to the
+ * *project's* index — not to trace-mcp's own grading code. A grade computed
+ * and cached to disk by a pre-fix build (e.g. "A" for a project with no
+ * symbols to score) would otherwise survive a binary upgrade forever, since
+ * nothing ever marks that cache entry stale.
+ *
+ * This seeds `dashboard-cache.json` exactly as an old build would have left
+ * it — a poisoned "A" grade, plus an `enrichedAt` fingerprint that matches
+ * the on-disk DB so the ordinary staleness check would NOT recompute it —
+ * and asserts the current build refuses to serve that cached grade.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tra1057-cache-'));
+process.env.TRACE_MCP_DATA_DIR = tmpHome;
+
+const root = path.join(tmpHome, 'empty-project');
+const dbPath = path.join(tmpHome, 'empty-project.db');
+
+beforeAll(async () => {
+  fs.mkdirSync(root, { recursive: true });
+
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = MEMORY');
+  db.exec(`
+    CREATE TABLE files (id INTEGER PRIMARY KEY, path TEXT, status TEXT);
+    CREATE TABLE symbols (id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE edges (id INTEGER PRIMARY KEY, src TEXT, dst TEXT);
+  `);
+  db.close();
+
+  fs.writeFileSync(
+    path.join(tmpHome, 'registry.json'),
+    JSON.stringify({
+      version: 1,
+      projects: {
+        [root]: { name: 'empty-project', root, dbPath, lastIndexed: null, addedAt: '' },
+      },
+    }),
+  );
+
+  const { indexFingerprint } = await import('../../src/api/dashboard-routes.js');
+  const fingerprint = indexFingerprint(dbPath);
+
+  // No `version` field — the shape a pre-TRA-1057 build wrote.
+  fs.writeFileSync(
+    path.join(tmpHome, 'dashboard-cache.json'),
+    JSON.stringify({
+      computedAt: Date.now(),
+      projects: [
+        {
+          root,
+          name: 'empty-project',
+          status: 'ok',
+          lastIndexed: null,
+          totalFiles: 0,
+          totalSymbols: 0,
+          totalEdges: 0,
+          deadExports: 0,
+          untestedSymbols: 0,
+          techDebtGrade: 'A', // the poison: TRA-1057's exact symptom
+          securityFindings: 0,
+        },
+      ],
+      enrichedAt: [[root, fingerprint]], // matches → ordinary staleness check would trust it
+    }),
+  );
+});
+
+afterAll(async () => {
+  const { waitForIdleForTests } = await import('../../src/api/dashboard-routes.js');
+  await waitForIdleForTests();
+  try {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup, see dashboard-routes.test.ts */
+  }
+  delete process.env.TRACE_MCP_DATA_DIR;
+});
+
+async function get(): Promise<{ techDebtGrade?: string; status: string } | undefined> {
+  const { handleDashboardRequest } = await import('../../src/api/dashboard-routes.js');
+  let body = '';
+  const res = {
+    writeHead() {},
+    end(chunk?: string) {
+      body = chunk ?? '';
+    },
+  };
+  await handleDashboardRequest(
+    { method: 'GET', url: '/api/dashboard/projects', headers: {} } as never,
+    res as never,
+  );
+  const parsed = JSON.parse(body) as {
+    projects: Array<{ root: string; status: string; techDebtGrade?: string }>;
+  };
+  return parsed.projects.find((p) => p.root === root);
+}
+
+describe('dashboard cache version invalidation (TRA-1057)', () => {
+  it('never serves a pre-fix cached grade for a project with nothing to grade', async () => {
+    let project = await get();
+    // Poll rather than assert on the first response: the route never computes
+    // inline (TRA-1053), so a fresh pass runs in the background.
+    for (let i = 0; i < 50 && project?.status === 'computing'; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+      project = await get();
+    }
+    expect(project?.techDebtGrade).not.toBe('A');
+  });
+});

--- a/tests/api/dashboard-stale-grade.test.ts
+++ b/tests/api/dashboard-stale-grade.test.ts
@@ -1,0 +1,127 @@
+/**
+ * TRA-1057 review finding (Reviewer B, CONFIRMED): `enrich()` seeded `out`
+ * from `basics`, which can carry a `techDebtGrade` forward from a previous
+ * pass (TRA-1072's "don't blank the screen mid-recompute" carry-forward).
+ * The old code only *overwrote* `out.techDebtGrade` when `getTechDebt()`
+ * returned a truthy grade — so a project that shrinks below
+ * `MIN_SYMBOLS_FOR_GRADE` (or whose analysis throws) kept its last real
+ * grade forever, which is exactly the "Healthy" tile lie this issue is
+ * about, just reached through an update instead of day one.
+ *
+ * This seeds a project with enough symbols to earn a real grade, lets the
+ * background pass cache it, then shrinks the project below the floor and
+ * asserts the grade is dropped rather than carried forward.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { initializeDatabase } from '../../src/db/schema.js';
+import { Store } from '../../src/db/store.js';
+
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tra1057-stale-grade-'));
+process.env.TRACE_MCP_DATA_DIR = tmpHome;
+
+const root = path.join(tmpHome, 'shrinking-project');
+const dbPath = path.join(tmpHome, 'shrinking-project.db');
+
+function insertGradeableSymbols(store: Store, count: number): void {
+  const fileId = store.insertFile('src/big.ts', 'typescript', `h-${count}`, 100);
+  for (let i = 0; i < count; i++) {
+    store.insertSymbol(fileId, {
+      symbolId: `sym:big::fn${i}`,
+      name: `fn${i}`,
+      kind: 'function',
+      byteStart: 0,
+      byteEnd: 10,
+      metadata: { cyclomatic: 12 }, // non-trivial, so a grade actually computes
+    });
+  }
+}
+
+beforeAll(() => {
+  fs.mkdirSync(root, { recursive: true });
+
+  const db = initializeDatabase(dbPath);
+  const store = new Store(db);
+  insertGradeableSymbols(store, 25); // above MIN_SYMBOLS_FOR_GRADE
+  db.close();
+
+  fs.writeFileSync(
+    path.join(tmpHome, 'registry.json'),
+    JSON.stringify({
+      version: 1,
+      projects: {
+        [root]: { name: 'shrinking-project', root, dbPath, lastIndexed: null, addedAt: '' },
+      },
+    }),
+  );
+});
+
+afterAll(async () => {
+  const { waitForIdleForTests } = await import('../../src/api/dashboard-routes.js');
+  await waitForIdleForTests();
+  try {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup, see dashboard-routes.test.ts */
+  }
+  delete process.env.TRACE_MCP_DATA_DIR;
+});
+
+async function get(): Promise<{ techDebtGrade?: string; status: string } | undefined> {
+  const { handleDashboardRequest } = await import('../../src/api/dashboard-routes.js');
+  let body = '';
+  const res = {
+    writeHead() {},
+    end(chunk?: string) {
+      body = chunk ?? '';
+    },
+  };
+  await handleDashboardRequest(
+    { method: 'GET', url: '/api/dashboard/projects', headers: {} } as never,
+    res as never,
+  );
+  const parsed = JSON.parse(body) as {
+    projects: Array<{ root: string; status: string; techDebtGrade?: string }>;
+  };
+  return parsed.projects.find((p) => p.root === root);
+}
+
+async function refreshAndSettle(): Promise<{ techDebtGrade?: string; status: string } | undefined> {
+  const { handleDashboardRequest, waitForIdleForTests } = await import(
+    '../../src/api/dashboard-routes.js'
+  );
+  let body = '';
+  await handleDashboardRequest(
+    { method: 'POST', url: '/api/dashboard/refresh', headers: {} } as never,
+    { writeHead() {}, end: (c?: string) => (body = c ?? '') } as never,
+  );
+  void body;
+  await waitForIdleForTests();
+  return get();
+}
+
+describe('dashboard drops a stale grade when a project shrinks (TRA-1057)', () => {
+  it('never carries a prior real grade forward once the project is too small to grade', async () => {
+    // Pass 1 must actually reach `ok`/graded before we shrink anything.
+    let project = await get();
+    for (let i = 0; i < 50 && project?.status === 'computing'; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+      project = await get();
+    }
+    expect(project?.status).toBe('ok');
+    expect(['A', 'B', 'C', 'D', 'F']).toContain(project?.techDebtGrade);
+
+    // Shrink the project to 1 symbol — below MIN_SYMBOLS_FOR_GRADE — and
+    // force the fingerprint to move so refreshAll() treats it as stale.
+    const db = new Database(dbPath);
+    db.exec('DELETE FROM symbols WHERE id NOT IN (SELECT id FROM symbols LIMIT 1)');
+    db.close();
+
+    project = await refreshAndSettle();
+    expect(project?.status).toBe('ok');
+    expect(project?.techDebtGrade).toBeUndefined();
+  });
+});

--- a/tests/api/dashboard-stale-grade.test.ts
+++ b/tests/api/dashboard-stale-grade.test.ts
@@ -105,12 +105,18 @@ async function refreshAndSettle(): Promise<{ techDebtGrade?: string; status: str
 
 describe('dashboard drops a stale grade when a project shrinks (TRA-1057)', () => {
   it('never carries a prior real grade forward once the project is too small to grade', async () => {
-    // Pass 1 must actually reach `ok`/graded before we shrink anything.
+    // The first GET's snapshot() fires refreshAll() as a side effect but does
+    // not await it (TRA-1053: the route never computes inline) — so drive it
+    // to completion with waitForIdleForTests() rather than polling the
+    // per-project status. That polling loop raced refreshAll(true) below on a
+    // loaded CI runner: if the POST landed in the gap between this pass
+    // reaching `status: 'ok'` and its `computing` flag actually flipping back
+    // to false, `refreshAll`'s `if (computing) return;` guard silently
+    // dropped the forced recompute, so the shrink was never picked up.
+    const { waitForIdleForTests } = await import('../../src/api/dashboard-routes.js');
+    await get();
+    await waitForIdleForTests();
     let project = await get();
-    for (let i = 0; i < 50 && project?.status === 'computing'; i++) {
-      await new Promise((r) => setTimeout(r, 20));
-      project = await get();
-    }
     expect(project?.status).toBe('ok');
     expect(['A', 'B', 'C', 'D', 'F']).toContain(project?.techDebtGrade);
 

--- a/tests/tools/behavioural/get-tech-debt.behavioural.test.ts
+++ b/tests/tools/behavioural/get-tech-debt.behavioural.test.ts
@@ -65,6 +65,11 @@ function seedTwoModuleProject(store: Store): void {
 
   // Low complexity in src/lib.
   insertFn(store, fLeaf, 'simpleFn', 2);
+
+  // Padding above MIN_SYMBOLS_FOR_GRADE (TRA-1057) — cyclomatic 0 so these
+  // don't skew the complexity average, they exist only to keep this fixture
+  // past the "enough data to grade" floor the other tests below exercise.
+  for (let i = 0; i < 20; i++) insertFn(store, fFoo, `helper${i}`, 0);
 }
 
 describe('getTechDebt() — behavioural contract (get_tech_debt)', () => {
@@ -147,6 +152,20 @@ describe('getTechDebt() — behavioural contract (get_tech_debt)', () => {
     expect(value.project_score).toBe(0);
     // No modules → nothing was scored. `null`, not the "A" a naive
     // mean-of-zero would produce — an empty project isn't a healthy one.
+    expect(value.project_grade).toBeNull();
+  });
+
+  it('a handful of symbols scores modules but withholds project_grade (TRA-1057)', () => {
+    // 1 file / 1 symbol — same shape as the real `tra925proj` fixture that
+    // shipped a grade B on essentially no data.
+    const fLeaf = insertFile(store, 'src/lib/leaf.ts');
+    insertFn(store, fLeaf, 'simpleFn', 2);
+
+    const value = getTechDebt(store, '/project')._unsafeUnwrap();
+    // The module itself is still scored/returned — useful detail for anyone
+    // calling get_tech_debt directly — only the project-level rollup grade
+    // is withheld for being too small a sample to mean anything.
+    expect(value.modules.length).toBeGreaterThan(0);
     expect(value.project_grade).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- `getTechDebt()` already returned `project_grade: null` for zero-symbol projects (TRA-1054/1057/1077, released in 3.23.2) — but nothing stopped a near-empty project from still getting a real letter grade off almost no data. Added `MIN_SYMBOLS_FOR_GRADE = 20`: below that, `project_grade` is `null`. Per-module grades in `modules[]` are untouched.
- `dashboard-cache.json` had no version marker, so a grade cached by a pre-fix build survives a binary upgrade forever — the staleness check only tracks the project's own DB fingerprint, never trace-mcp's own grading code. Added `DASHBOARD_CACHE_VERSION`; a missing/mismatched version now discards the cache instead of trusting it.

Closes TRA-1057.

## Test plan
- [x] `tests/tools/behavioural/get-tech-debt.behavioural.test.ts` — new case: 1 file / 1 symbol still scores `modules[]` but `project_grade` is `null`
- [x] `tests/api/dashboard-cache-version.test.ts` (new) — seeds a poisoned pre-fix cache (`techDebtGrade: 'A'`, matching fingerprint) and asserts it's never served
- [x] `pnpm run test` — full suite, 973 files / 10793 tests passed (1 unrelated bash-hook flake reproduced only under full-suite parallel load, verified passing standalone)
- [x] `pnpm run build` — clean
- [x] `pnpm run typecheck` — clean, root + `packages/app`
- [x] `pnpm exec biome check` — clean on touched files