### PR TITLE
fix(launcher): keep the legacy shim path delegating so upgrades reach it

### DIFF
--- a/packages/app/src/main/__tests__/daemon-install.test.ts
+++ b/packages/app/src/main/__tests__/daemon-install.test.ts
@@ -287,9 +287,44 @@ describe('ensureDaemonInstalled', () => {
         cli: path.join(resources, 'server', 'dist', 'cli.js'),
         version: '3.7.0',
       });
-      expect(fs.existsSync(path.join(home, 'bin', 'trace-mcp'))).toBe(true);
+      // The current name, the same one npm writes — so both installers feed one
+      // shim file instead of two that drift apart (TRA-1156).
+      expect(fs.existsSync(path.join(home, 'bin', 'trace'))).toBe(true);
+      // Nothing was registered at the legacy path, so none is invented.
+      expect(fs.existsSync(path.join(home, 'bin', 'trace-mcp'))).toBe(false);
       expect(fs.readFileSync(launchAgent, 'utf-8')).toContain(PLIST_MARKER);
       expect(calls.some((c) => c[0] === 'bootstrap')).toBe(true);
+    },
+  );
+
+  it.runIf(process.platform === 'darwin')(
+    'repoints a legacy shim an MCP client is still registered at (TRA-1156)',
+    async () => {
+      // A pre-TRA-611 copy at the path the client spawns, frozen several
+      // launcher versions back.
+      const legacy = path.join(home, 'bin', 'trace-mcp');
+      fs.mkdirSync(path.dirname(legacy), { recursive: true });
+      fs.writeFileSync(legacy, '#!/bin/bash\n# trace-mcp-launcher v0.1.0\nexit 0\n', { mode: 0o755 });
+
+      await run('3.7.0');
+
+      expect(fs.lstatSync(legacy).isSymbolicLink()).toBe(true);
+      expect(fs.realpathSync(legacy)).toBe(fs.realpathSync(path.join(home, 'bin', 'trace')));
+    },
+  );
+
+  it.runIf(process.platform === 'darwin')(
+    'leaves a wrapper at the legacy path that is not ours alone',
+    async () => {
+      const legacy = path.join(home, 'bin', 'trace-mcp');
+      const wrapper = '#!/bin/sh\nexec my-own-thing "$@"\n';
+      fs.mkdirSync(path.dirname(legacy), { recursive: true });
+      fs.writeFileSync(legacy, wrapper, { mode: 0o755 });
+
+      await run('3.7.0');
+
+      expect(fs.lstatSync(legacy).isSymbolicLink()).toBe(false);
+      expect(fs.readFileSync(legacy, 'utf-8')).toBe(wrapper);
     },
   );
 

--- a/packages/app/src/main/daemon-install.ts
+++ b/packages/app/src/main/daemon-install.ts
@@ -161,6 +161,56 @@ function writeIfChanged(filePath: string, content: string, mode: number): boolea
   return true;
 }
 
+/**
+ * Point an already-registered legacy shim path at the current one, so it tracks
+ * every later upgrade instead of freezing at whatever copy is on disk (TRA-1156,
+ * same reasoning as src/init/launcher.ts::installLegacyBinCompat).
+ *
+ * Only ever *repairs* — never creates. A machine with no `bin/trace-mcp` has no
+ * client registered there, and inventing one would just be litter. Windows gets
+ * no symlink (it needs a privileged mode this app does not ask for); the CLI's
+ * `trace init` writes a delegating `.cmd` there instead.
+ */
+function delegateLegacyShim(binDir: string): boolean {
+  if (IS_WINDOWS) return false;
+  const [current, legacy] = SHIM_NAMES;
+  const legacyPath = path.join(binDir, legacy);
+  let st: fs.Stats;
+  try {
+    st = fs.lstatSync(legacyPath);
+  } catch {
+    return false; // nothing registered there
+  }
+  // A symlink that still resolves is already delegating. A dangling one is the
+  // single state that spawns nothing at all, so it is repaired.
+  if (st.isSymbolicLink() && fs.existsSync(legacyPath)) return false;
+  if (!st.isSymbolicLink() && !isOwnedShim(legacyPath)) return false; // user's own wrapper
+  const tmp = `${legacyPath}.tmp.${process.pid}.${randomBytes(6).toString('hex')}`;
+  try {
+    fs.symlinkSync(current, tmp);
+    fs.renameSync(tmp, legacyPath);
+    return true;
+  } catch {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* nothing to clean up */
+    }
+    return false;
+  }
+}
+
+/** Header line every shim we ship carries. Mirrors src/init/launcher.ts. */
+const LAUNCHER_HEADER_RE = /trace-mcp-launcher v[0-9]+\.[0-9]+\.[0-9]+/;
+
+function isOwnedShim(file: string): boolean {
+  try {
+    return LAUNCHER_HEADER_RE.test(fs.readFileSync(file, 'utf-8').slice(0, 256));
+  } catch {
+    return false;
+  }
+}
+
 function isExecutable(p: string | undefined): boolean {
   if (!p) return false;
   try {
@@ -561,17 +611,23 @@ export async function ensureDaemonInstalled(opts: EnsureOptions): Promise<Ensure
       changed = writeIfChanged(runtimeShim, runtimeShimContent(execPath), 0o755) || changed;
 
       // The launcher shim itself ships in the payload's hooks/, so a DMG-only
-      // machine gets the same shim an npm install would have written.
+      // machine gets the same shim an npm install would have written — under
+      // the same name, SHIM_NAMES[0]. Writing the pre-TRA-611 name here instead
+      // gave the machine two real shim files fed by two installers: npm wrote
+      // `trace`, the app wrote `trace-mcp`, and the path MCP clients spawn
+      // advanced only when the app did. A launcher fix shipped through npm
+      // never reached it (TRA-1156).
       const shimSources = IS_WINDOWS
         ? [
-            ['trace-mcp-launcher.cmd', 'trace-mcp.cmd'],
+            ['trace-mcp-launcher.cmd', SHIM_NAMES[0]],
             ['trace-mcp-launcher.ps1', 'trace-mcp-launcher.ps1'],
           ]
-        : [['trace-mcp-launcher.sh', 'trace-mcp']];
+        : [['trace-mcp-launcher.sh', SHIM_NAMES[0]]];
       for (const [src, dest] of shimSources) {
         const from = path.join(serverDir, 'hooks', src);
         changed = writeIfChanged(path.join(binDir, dest), fs.readFileSync(from, 'utf-8'), 0o755) || changed;
       }
+      changed = delegateLegacyShim(binDir) || changed;
 
       changed =
         writeIfChanged(

--- a/scripts/postinstall-control-plane.mjs
+++ b/scripts/postinstall-control-plane.mjs
@@ -10,7 +10,8 @@
  *   2. Writes ~/.trace/launcher.env with absolute Node + dist/cli.js paths.
  *   3. Installs the launcher shim at ~/.trace/bin/trace (POSIX) or
  *      ~/.trace/bin/trace.cmd (Windows) by copying from hooks/, and preserves
- *      ~/.trace-mcp/bin/trace-mcp as a compat symlink when (1) migrated.
+ *      repoints ~/.trace-mcp/bin/trace-mcp at it as a compat symlink whenever a
+ *      client may still be registered there, so an upgrade reaches that path too.
  *   4. On macOS: installs/refreshes ~/Library/LaunchAgents/com.trace-mcp.server.plist
  *      and bootstraps it with launchd. Kickstarts the service if it was
  *      already loaded so the new binary is picked up.
@@ -28,6 +29,7 @@
  */
 
 import { execFileSync, spawnSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -259,25 +261,93 @@ function installLauncherShim() {
   }
 }
 
+/** Header line every shim we ship carries. Mirrors src/init/launcher.ts. */
+const LAUNCHER_HEADER_RE = /trace-mcp-launcher v[0-9]+\.[0-9]+\.[0-9]+/;
+
+/** True only for a shim this project wrote, so we never clobber a user's file. */
+function isOwnedShim(file) {
+  try {
+    return LAUNCHER_HEADER_RE.test(fs.readFileSync(file, 'utf-8').slice(0, 256));
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Preserve `~/.trace-mcp/bin/trace-mcp` as a symlink to the new
  * `~/.trace/bin/trace` shim, mirroring src/init/launcher.ts's
  * installLegacyBinCompat(). Gated on LEGACY_MIGRATION_MARKER (durable) rather
  * than TRACE_MCP_HOME_MIGRATED (true only for the one process that performed
  * the rename) so a failed symlink attempt gets retried on the next install.
+ *
+ * The legacy path must *delegate*, not be a copy — and this is the only
+ * installer an upgrade actually runs, since `npm i -g trace-mcp` never reaches
+ * `trace init` (TRA-1156). Returning early on "already present in any shape"
+ * was the bug: an MCP client registered at the legacy absolute path kept
+ * spawning whatever shim happened to be there — the pre-rename copy, or the one
+ * the desktop app writes from its own bundled payload — and no launcher fix
+ * shipped through npm could ever reach it. That is the frozen-copy outage
+ * TRA-716 closed on the `trace init` path and this one still had.
+ *
+ * Three states are repaired: nothing there, a stale regular file we recognise
+ * as ours, and a symlink whose target is gone (TRA-910 — the one state that
+ * really does spawn nothing). Anything else at that path is a user's own
+ * wrapper and is left alone.
  */
 function installLegacyBinCompat(shimPath) {
-  if (!fs.existsSync(path.join(TRACE_MCP_HOME, LEGACY_MIGRATION_MARKER))) return;
   const legacyDir = path.join(os.homedir(), '.trace-mcp', 'bin');
   const legacyPath = path.join(legacyDir, LEGACY_PRIMARY_DEST);
+  // Either durable signal that a legacy path may still be registered. The bin
+  // directory matters on its own: a machine that migrated by symlinking its
+  // home has no marker, yet its clients still spawn the legacy name.
+  if (
+    !fs.existsSync(path.join(TRACE_MCP_HOME, LEGACY_MIGRATION_MARKER)) &&
+    !fs.existsSync(legacyDir)
+  ) {
+    return;
+  }
+  // When the legacy home *is* the launcher home, this path would point at
+  // itself. Compare real paths: a `~/.trace-mcp` symlinked onto `~/.trace`
+  // makes the two lexically different and physically the same.
   try {
-    if (fs.lstatSync(legacyPath)) return; // already present (symlink or file)
+    if (fs.realpathSync(legacyPath) === fs.realpathSync(shimPath)) return;
+  } catch {
+    /* one of them is missing — nothing resolved, carry on */
+  }
+  let existing = null;
+  try {
+    existing = fs.lstatSync(legacyPath);
   } catch {
     /* ENOENT — proceed to create it */
   }
+  if (existing) {
+    // A symlink that still resolves is already delegating; a dangling one is
+    // repaired. existsSync follows the link, lstat above did not.
+    if (existing.isSymbolicLink() && fs.existsSync(legacyPath)) return;
+    if (!existing.isSymbolicLink() && !isOwnedShim(legacyPath)) return;
+  }
   try {
     ensureDir(legacyDir);
-    fs.symlinkSync(shimPath, legacyPath);
+    // Build beside the old entry and swap with one rename: unlinking first and
+    // then failing would take the client's launcher away entirely, which is
+    // worse than the stale shim we came to replace. `.tmp.<pid>.<12 hex>` is
+    // the shape the server's orphan sweeper collects (TRA-982).
+    // ponytail: symlink only. Windows needs a delegating `.cmd` instead, and
+    // writing one means carrying the version marker isOwnedShim looks for —
+    // `trace init` already does that (src/init/launcher.ts::writeLegacyCompat),
+    // so a Windows machine keeps recovering there rather than here.
+    const tmp = `${legacyPath}.tmp.${process.pid}.${randomBytes(6).toString('hex')}`;
+    try {
+      fs.symlinkSync(shimPath, tmp);
+      fs.renameSync(tmp, legacyPath);
+    } catch (err) {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {
+        /* nothing to clean up */
+      }
+      throw err;
+    }
   } catch {
     /* best-effort — a legacy script can still recover via `trace init` */
   }

--- a/tests/scripts/postinstall-control-plane.test.ts
+++ b/tests/scripts/postinstall-control-plane.test.ts
@@ -61,8 +61,41 @@ function runScript(env: Record<string, string | undefined>): {
   }
 }
 
+/** Minimal installed-package layout with no .git, so the script doesn't skip. */
+function stageFakePkg(fakePkg: string): void {
+  fs.mkdirSync(path.join(fakePkg, 'scripts'), { recursive: true });
+  fs.mkdirSync(path.join(fakePkg, 'hooks'), { recursive: true });
+  fs.mkdirSync(path.join(fakePkg, 'dist'), { recursive: true });
+  fs.copyFileSync(SCRIPT_PATH, path.join(fakePkg, 'scripts', 'postinstall-control-plane.mjs'));
+  fs.copyFileSync(ATTRIBUTION_PATH, path.join(fakePkg, 'scripts', 'daemon-attribution.mjs'));
+  for (const name of ['trace-mcp-launcher.sh', 'trace-mcp-launcher.cmd', 'trace-mcp-launcher.ps1']) {
+    const src = path.join(REPO_ROOT, 'hooks', name);
+    if (fs.existsSync(src)) fs.copyFileSync(src, path.join(fakePkg, 'hooks', name));
+  }
+  fs.writeFileSync(path.join(fakePkg, 'dist', 'cli.js'), '// fake\n');
+  fs.writeFileSync(
+    path.join(fakePkg, 'package.json'),
+    JSON.stringify({ name: 'trace-mcp', version: '9.9.9-test' }),
+  );
+}
+
 describe('postinstall-control-plane', () => {
   let home: string;
+
+  /** Run the staged script against the fake home, with the real default paths. */
+  function runFakePkg(fakePkg: string): void {
+    execFileSync(process.execPath, [path.join(fakePkg, 'scripts', 'postinstall-control-plane.mjs')], {
+      env: buildEnv({
+        HOME: home,
+        USERPROFILE: home,
+        CI: 'true',
+        TRACE_MCP_DATA_DIR: undefined,
+        TRACE_MCP_HOME: undefined,
+      }),
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+    });
+  }
 
   beforeEach(() => {
     home = mkTmp('trace-mcp-postinstall-');
@@ -248,6 +281,68 @@ describe('postinstall-control-plane', () => {
       fs.rmSync(fakePkg, { recursive: true, force: true });
     }
   });
+
+  // `npm i -g trace-mcp` runs this script and never reaches `trace init`, so
+  // this is the only installer an upgrade has. It used to return early whenever
+  // the legacy path existed in any shape, which left an MCP client registered
+  // there spawning a frozen copy no launcher fix could reach (TRA-1156).
+  it.skipIf(process.platform === 'win32')(
+    'repoints a stale legacy shim copy at the current one instead of leaving it frozen',
+    () => {
+      const fakePkg = mkTmp('trace-mcp-fakepkg-');
+      try {
+        stageFakePkg(fakePkg);
+
+        // A pre-rename install: a real shim file at the legacy absolute path,
+        // several launcher versions behind, plus the migration marker a past
+        // run left behind.
+        const legacyBin = path.join(home, '.trace-mcp', 'bin');
+        fs.mkdirSync(legacyBin, { recursive: true });
+        const legacyShim = path.join(legacyBin, 'trace-mcp');
+        fs.writeFileSync(legacyShim, '#!/bin/bash\n# trace-mcp-launcher v0.1.0\nexit 0\n', {
+          mode: 0o755,
+        });
+        const newHome = path.join(home, '.trace');
+        fs.mkdirSync(newHome, { recursive: true });
+        fs.writeFileSync(path.join(newHome, '.migrated-from-trace-mcp'), '');
+
+        runFakePkg(fakePkg);
+
+        const currentShim = path.join(newHome, 'bin', 'trace');
+        expect(fs.lstatSync(legacyShim).isSymbolicLink()).toBe(true);
+        expect(fs.realpathSync(legacyShim)).toBe(fs.realpathSync(currentShim));
+        // No orphaned tmp left beside it.
+        expect(fs.readdirSync(legacyBin).filter((n) => n.includes('.tmp.'))).toEqual([]);
+      } finally {
+        fs.rmSync(fakePkg, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    "leaves a wrapper at the legacy path that isn't ours alone",
+    () => {
+      const fakePkg = mkTmp('trace-mcp-fakepkg-');
+      try {
+        stageFakePkg(fakePkg);
+
+        const legacyBin = path.join(home, '.trace-mcp', 'bin');
+        fs.mkdirSync(legacyBin, { recursive: true });
+        const legacyShim = path.join(legacyBin, 'trace-mcp');
+        const userWrapper = '#!/bin/sh\nexec my-own-thing "$@"\n';
+        fs.writeFileSync(legacyShim, userWrapper, { mode: 0o755 });
+        fs.mkdirSync(path.join(home, '.trace'), { recursive: true });
+        fs.writeFileSync(path.join(home, '.trace', '.migrated-from-trace-mcp'), '');
+
+        runFakePkg(fakePkg);
+
+        expect(fs.lstatSync(legacyShim).isSymbolicLink()).toBe(false);
+        expect(fs.readFileSync(legacyShim, 'utf-8')).toBe(userWrapper);
+      } finally {
+        fs.rmSync(fakePkg, { recursive: true, force: true });
+      }
+    },
+  );
 
   it('PLIST_VERSION constant matches src/daemon/lifecycle.ts', () => {
     const script = fs.readFileSync(SCRIPT_PATH, 'utf-8');

--- a/tests/scripts/postinstall-control-plane.test.ts
+++ b/tests/scripts/postinstall-control-plane.test.ts
@@ -68,7 +68,11 @@ function stageFakePkg(fakePkg: string): void {
   fs.mkdirSync(path.join(fakePkg, 'dist'), { recursive: true });
   fs.copyFileSync(SCRIPT_PATH, path.join(fakePkg, 'scripts', 'postinstall-control-plane.mjs'));
   fs.copyFileSync(ATTRIBUTION_PATH, path.join(fakePkg, 'scripts', 'daemon-attribution.mjs'));
-  for (const name of ['trace-mcp-launcher.sh', 'trace-mcp-launcher.cmd', 'trace-mcp-launcher.ps1']) {
+  for (const name of [
+    'trace-mcp-launcher.sh',
+    'trace-mcp-launcher.cmd',
+    'trace-mcp-launcher.ps1',
+  ]) {
     const src = path.join(REPO_ROOT, 'hooks', name);
     if (fs.existsSync(src)) fs.copyFileSync(src, path.join(fakePkg, 'hooks', name));
   }
@@ -84,17 +88,21 @@ describe('postinstall-control-plane', () => {
 
   /** Run the staged script against the fake home, with the real default paths. */
   function runFakePkg(fakePkg: string): void {
-    execFileSync(process.execPath, [path.join(fakePkg, 'scripts', 'postinstall-control-plane.mjs')], {
-      env: buildEnv({
-        HOME: home,
-        USERPROFILE: home,
-        CI: 'true',
-        TRACE_MCP_DATA_DIR: undefined,
-        TRACE_MCP_HOME: undefined,
-      }),
-      stdio: ['ignore', 'pipe', 'pipe'],
-      encoding: 'utf-8',
-    });
+    execFileSync(
+      process.execPath,
+      [path.join(fakePkg, 'scripts', 'postinstall-control-plane.mjs')],
+      {
+        env: buildEnv({
+          HOME: home,
+          USERPROFILE: home,
+          CI: 'true',
+          TRACE_MCP_DATA_DIR: undefined,
+          TRACE_MCP_HOME: undefined,
+        }),
+        stdio: ['ignore', 'pipe', 'pipe'],
+        encoding: 'utf-8',
+      },
+    );
   }
 
   beforeEach(() => {


### PR DESCRIPTION
## What broke

`~/.trace-mcp/bin/trace-mcp` is the absolute path a pre-TRA-611 MCP client registration still spawns — on this machine it is what `claude mcp list` shows for trace-mcp today. Two installers write into that `bin` directory, and neither kept that path current:

- **`scripts/postinstall-control-plane.mjs`** is the only installer an upgrade actually runs (`npm i -g trace-mcp` never reaches `trace init`). Its `installLegacyBinCompat` returned early whenever the legacy path existed *in any shape* — `if (fs.lstatSync(legacyPath)) return; // already present (symlink or file)`. A stale pre-rename copy, or a symlink whose target is gone, was left exactly as found.
- **`packages/app/src/main/daemon-install.ts`** still wrote the shim under the pre-TRA-611 name `trace-mcp`, while npm writes `trace`. So the machine carried two real shim files fed by two installers, and the one clients spawn advanced only when the desktop app did.

Net effect: every launcher fix shipped through npm — TRA-965, TRA-1040, TRA-1132, the TRA-970 proxy routing — could not reach a client registered at that path. This is the frozen-copy outage TRA-716 closed on the `trace init` path and these two still had.

**Observed live, not hypothesised.** `~/.trace/bin/trace` written by npm postinstall at `16:48:37Z`; `~/.trace/bin/trace-mcp` — the registered path — last written 40 minutes earlier by the desktop app, from a different package's payload. Both happen to be launcher `v0.6.9` right now; nothing in either install path keeps them that way.

A second, pre-existing bug fell out: the app's `writeIfChanged` clobbered a user's own wrapper at `bin/trace-mcp` with our shim content.

## The change

Both installers converge on the design `src/init/launcher.ts` already documents: **one real shim at the current name, the legacy path a symlink to it.**

- Postinstall repairs three states — nothing there, a stale regular file whose header marks it as ours, a dangling symlink (TRA-910's "spawns nothing" state). Anything else is a user's wrapper and is left alone. Written tmp-then-rename, with the `.tmp.<pid>.<12 hex>` name the orphan sweeper collects (TRA-982), so a failed replacement never takes the client's launcher away.
- The gate now also fires on a bare `~/.trace-mcp/bin` directory, not just the migration marker: a machine that migrated by symlinking its home has no marker, yet its clients still spawn the legacy name.
- The app writes `SHIM_NAMES[0]` (the current name, which `trace-home.ts` already declares) and delegates an existing legacy path to it — repairs, never creates. No `bin/trace-mcp` means no client registered there, and inventing one would be litter.

Windows still gets no symlink from postinstall (it needs a privileged mode the app does not ask for); `trace init` writes the delegating `.cmd` there, as it already did. Marked with a `ponytail:` comment naming the upgrade path.

## Test evidence

Four new tests, all verified red against the old code:

```
× repoints a stale legacy shim copy at the current one instead of leaving it frozen   (postinstall)
× leaves a wrapper at the legacy path that isn't ours alone                           (postinstall)
× repoints a legacy shim an MCP client is still registered at (TRA-1156)              (app)
× leaves a wrapper at the legacy path that is not ours alone                          (app)
```

The existing app test `installs a whole control plane on a machine that has none` was updated: it asserted `bin/trace-mcp` exists, and now asserts `bin/trace` exists and `bin/trace-mcp` is *not* invented.

Full suite: `Test Files 971 passed · Tests 10795 passed · 40 skipped` (one unrelated flake in `tests/hooks/precompact-hook.test.ts` — a 10s timeout under parallel load; green on its own rerun). `pnpm run build` and `tsc --noEmit` clean. `packages/app` suite: 31/32 via the root vitest — the one failure is a cwd artefact of `--root` (that test resolves `../../scripts` from `process.cwd()`) and is untouched by this diff.

## No contract change

No MCP tool signature, no on-disk schema, no token-budget surface touched.

Closes TRA-1156.

Agent: Lead Engineer
