### PR TITLE
fix(sweep): collect leaked tmp symlinks, and bound the shim header read

### DIFF
--- a/packages/app/src/main/daemon-install.ts
+++ b/packages/app/src/main/daemon-install.ts
@@ -203,9 +203,21 @@ function delegateLegacyShim(binDir: string): boolean {
 /** Header line every shim we ship carries. Mirrors src/init/launcher.ts. */
 const LAUNCHER_HEADER_RE = /trace-mcp-launcher v[0-9]+\.[0-9]+\.[0-9]+/;
 
+/**
+ * Bounded read, like the original in src/init/launcher.ts. `ensureDaemonInstalled`
+ * runs on every app launch, so whatever a user has parked at this path must not
+ * be loaded whole to answer a question about its first line.
+ */
 function isOwnedShim(file: string): boolean {
   try {
-    return LAUNCHER_HEADER_RE.test(fs.readFileSync(file, 'utf-8').slice(0, 256));
+    const fd = fs.openSync(file, 'r');
+    try {
+      const buf = Buffer.alloc(256);
+      fs.readSync(fd, buf, 0, 256, 0);
+      return LAUNCHER_HEADER_RE.test(buf.toString('utf-8'));
+    } finally {
+      fs.closeSync(fd);
+    }
   } catch {
     return false;
   }

--- a/scripts/postinstall-control-plane.mjs
+++ b/scripts/postinstall-control-plane.mjs
@@ -264,10 +264,21 @@ function installLauncherShim() {
 /** Header line every shim we ship carries. Mirrors src/init/launcher.ts. */
 const LAUNCHER_HEADER_RE = /trace-mcp-launcher v[0-9]+\.[0-9]+\.[0-9]+/;
 
-/** True only for a shim this project wrote, so we never clobber a user's file. */
+/**
+ * True only for a shim this project wrote, so we never clobber a user's file.
+ * Bounded read, like the original in src/init/launcher.ts: whatever sits at
+ * this path is not ours to load into memory whole.
+ */
 function isOwnedShim(file) {
   try {
-    return LAUNCHER_HEADER_RE.test(fs.readFileSync(file, 'utf-8').slice(0, 256));
+    const fd = fs.openSync(file, 'r');
+    try {
+      const buf = Buffer.alloc(256);
+      fs.readSync(fd, buf, 0, 256, 0);
+      return LAUNCHER_HEADER_RE.test(buf.toString('utf-8'));
+    } finally {
+      fs.closeSync(fd);
+    }
   } catch {
     return false;
   }
@@ -306,14 +317,11 @@ function installLegacyBinCompat(shimPath) {
   ) {
     return;
   }
-  // When the legacy home *is* the launcher home, this path would point at
-  // itself. Compare real paths: a `~/.trace-mcp` symlinked onto `~/.trace`
-  // makes the two lexically different and physically the same.
-  try {
-    if (fs.realpathSync(legacyPath) === fs.realpathSync(shimPath)) return;
-  } catch {
-    /* one of them is missing — nothing resolved, carry on */
-  }
+  // No self-reference guard here, unlike the twin in src/init/launcher.ts: that
+  // one compares two paths that can share a basename, this one cannot. shimPath
+  // is always `trace`/`trace.cmd` and legacyPath always `trace-mcp`, so their
+  // real paths coincide only once legacyPath is already a symlink to it — which
+  // the healthy-symlink check below returns on anyway.
   let existing = null;
   try {
     existing = fs.lstatSync(legacyPath);

--- a/src/utils/atomic-write.ts
+++ b/src/utils/atomic-write.ts
@@ -172,7 +172,13 @@ export function sweepOrphanTmpFiles(dir: string, maxAgeMs = ORPHAN_TMP_MAX_AGE_M
     const full = path.join(dir, name);
     try {
       const st = fs.lstatSync(full);
-      if (!st.isFile() || st.mtimeMs > cutoff) continue;
+      // Symlinks count. `writeLegacyCompat` (src/init/launcher.ts) and the two
+      // legacy-shim repairs that mirror it stage a *symlink* under this exact
+      // name before renaming it into place, so an `isFile()`-only gate skipped
+      // the one shape those writers can leak — in `bin`, a directory this sweep
+      // already lists. `lstat` does not follow, so this is the link's own mtime
+      // and a dangling one is collected too (TRA-1156).
+      if ((!st.isFile() && !st.isSymbolicLink()) || st.mtimeMs > cutoff) continue;
       fs.unlinkSync(full);
       removed.push(full);
     } catch {

--- a/tests/init/launcher-legacy-compat.test.ts
+++ b/tests/init/launcher-legacy-compat.test.ts
@@ -227,14 +227,23 @@ describe.skipIf(process.platform === 'win32')('legacy compat tmp is sweepable', 
     });
 
     installLauncher({ force: true });
+    // Stop recording before the assertions below create symlinks of their own —
+    // the spy appends to `tmpNames`, and a loop over an array the loop body
+    // keeps growing never ends.
+    vi.restoreAllMocks();
 
     expect(tmpNames.length).toBeGreaterThan(0);
     for (const name of tmpNames) {
-      // Must survive a full sweep pass, not just look right.
+      // Must survive a full sweep pass, not just look right — and as the shape
+      // this writer actually leaks. Planting a regular file here passed while
+      // the sweeper still gated on `isFile()`, so the one shape a crash between
+      // symlinkSync and renameSync can leave was never covered (TRA-1156).
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-sweep-'));
-      fs.writeFileSync(path.join(dir, name), '');
-      fs.utimesSync(path.join(dir, name), new Date(0), new Date(0));
+      const leaked = path.join(dir, name);
+      fs.symlinkSync(path.join(dir, 'target-that-never-arrived'), leaked);
+      fs.lutimesSync(leaked, new Date(0), new Date(0));
       expect(sweepOrphanTmpFiles(dir).map((f) => path.basename(f))).toEqual([name]);
+      expect(fs.existsSync(leaked)).toBe(false);
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
Follow-up to #1125. Reviewer C reviewed that PR and returned **needs work** with one medium and two low findings; Reviewer B approved and merged it in parallel before the fixes landed. The core delegating-symlink change shipped — these three did not. This PR is exactly the commit that was pushed to #1125's branch a few minutes after it merged.

## 1. [medium] Leaked tmp symlinks were never swept

`sweepOrphanTmpFiles` gated on `st.isFile()` (`src/utils/atomic-write.ts:175`), and `lstat` on a symlink never satisfies that. `writeLegacyCompat` and the two legacy-shim repairs #1125 added all stage a **symlink** under `.tmp.<pid>.<12 hex>` before renaming it into place — so the one shape these writers can leak was the one shape the sweeper skipped. In `bin`, a directory already listed in `SWEPT_STATE_DIRS`. The intent was there; the gate contradicted it.

```diff
-      if (!st.isFile() || st.mtimeMs > cutoff) continue;
+      if ((!st.isFile() && !st.isSymbolicLink()) || st.mtimeMs > cutoff) continue;
```

`lstat` doesn't follow, so that is the link's own mtime and a dangling one is collected too. One line, covering all three writers — including the pre-existing `writeLegacyCompat`, which had the same leak and a comment claiming otherwise.

This is the "orphaned `.tmp.*` from interrupted atomic writes" item TRA-1156 lists under state hygiene, closed in the code path that actually produces them.

**The test was the real gap.** `tests/init/launcher-legacy-compat.test.ts:217` — "names its tmp so the orphan sweeper collects it after a crash" — planted a **regular file** with the right name, so it asserted the pattern and never the behaviour. It now plants a symlink, the shape the writer actually leaves, and asserts the file is gone afterwards. Verified red against the old gate.

That test change bit me in a way worth recording: the surrounding `vi.spyOn(fs, 'symlinkSync')` appends to `tmpNames`, and creating the symlink *inside* the loop over `tmpNames` fed the array it was iterating — an infinite loop that spun a vitest worker at 87% CPU for eleven minutes before I traced it. `vi.restoreAllMocks()` now runs before the assertions.

## 2. [low] `isOwnedShim` read whole files to look at 256 bytes

Both copies added in #1125 did `fs.readFileSync(file, 'utf-8').slice(0, 256)`, where the original in `src/init/launcher.ts` does a bounded `openSync`/`readSync`. `ensureDaemonInstalled` runs on every app launch, so that is a needless full read and UTF-8 decode of whatever a user has parked at that path. Both now use the bounded form.

## 3. [low] Unreachable `realpathSync` guard removed

`shimPath` is always `trace`/`trace.cmd` and `legacyPath` always `trace-mcp`, so their basenames can never coincide, and their real paths can only coincide once `legacyPath` is already a symlink to `shimPath` — which the healthy-symlink check immediately below returns on. I'd carried the guard over from the twin in `src/init/launcher.ts`, where it *is* reachable because that one compares two paths that can share a basename. Replaced with a comment saying why this copy doesn't need it, so the next person porting between the two doesn't re-add it.

## Test evidence

`launcher-legacy-compat` 15/15, `postinstall-control-plane` 8/8, `atomic-write` 16/16 — 39 passed in 423ms. `pnpm run build`, `tsc --noEmit` and `biome ci` all clean.

I am not claiming a green full local suite: runs on this machine currently produce 21–49 failures whose identity changes between runs, all bare 35s/90s timeouts spread across unrelated subsystems (topology git shortlog, indexer watcher, CI report generator). The desktop app, the daemon and concurrent test runs saturate it. CI on a clean runner is the signal to trust here.

## No contract change

No MCP tool signature, on-disk schema or token-budget surface touched.

Refs TRA-1156.

Agent: Lead Engineer
