### PR TITLE
fix(launcher): survive an MCP client spawned without HOME (TRA-1163)

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.6.9 (Windows)
+REM trace-mcp-launcher v0.6.10 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.6.9 (Windows)
+# trace-mcp-launcher v0.6.10 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.6.9
+# trace-mcp-launcher v0.6.10
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -8,6 +8,24 @@
 # Managed by trace-mcp — do not edit by hand. Re-run `trace-mcp init` to refresh.
 
 set -u
+
+# HOME is not guaranteed. A systemd unit with `User=` but no `Environment=HOME`,
+# a container ENTRYPOINT, a bare launchd job, an `env -i` wrapper — all of them
+# spawn the MCP client without it, and every bare `$HOME` below is then a hard
+# abort under `set -u`: exit 1, a raw bash error into the client's stderr, no
+# recovery message, no log line, no probe. The probe loss is the worse half:
+# `node_candidates` expands its whole `for` list before the first iteration, so
+# `/opt/homebrew/bin/node` — listed *before* the `$HOME` entry — is never even
+# emitted, and a machine with a perfectly good node reports "node binary not
+# found" (TRA-1163, reproduced both ways).
+#
+# One guard here rather than `${HOME:-}` at ~15 call sites: the failure is the
+# class, not any one path. Bash expands `~` from the passwd database when HOME
+# is unset, which is exactly the value the missing variable should have had.
+# Exported, because cli.js resolves its own state directory from it and an
+# unset HOME there is a second outage hiding behind this one.
+[ -n "${HOME:-}" ] || HOME=~
+export HOME
 
 # The shim inherits the MCP client's PATH, and a client started in a project
 # directory routinely carries that repository's `node_modules/.bin` on it. Every

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -22,9 +22,26 @@ set -u
 # One guard here rather than `${HOME:-}` at ~15 call sites: the failure is the
 # class, not any one path. Bash expands `~` from the passwd database when HOME
 # is unset, which is exactly the value the missing variable should have had.
+#
+# The `unset` is load-bearing, not tidiness. HOME set to the EMPTY STRING is a
+# real spawn shape (a launcher that exports every variable it knows, known or
+# not), and `~` consults the passwd database ONLY when HOME is unset — with
+# HOME="" it expands to the current value, i.e. stays empty, and every path
+# below resolves against `/`: `$HOME/.trace` becomes `/.trace`, which is
+# unwritable for a normal user and, in a container running as root, is
+# silently CREATED at the filesystem root.
+#
+# If passwd has no home either, refuse to root paths at `/` — a nonexistent
+# directory makes the probe fall through to its npm-prefix sources and, at
+# worst, die with the recovery message, which is the honest outcome.
+#
 # Exported, because cli.js resolves its own state directory from it and an
 # unset HOME there is a second outage hiding behind this one.
-[ -n "${HOME:-}" ] || HOME=~
+if [ -z "${HOME:-}" ]; then
+  unset HOME
+  HOME=~
+  [ -n "$HOME" ] || HOME=/nonexistent
+fi
 export HOME
 
 # The shim inherits the MCP client's PATH, and a client started in a project

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -112,4 +112,4 @@ export const MIRROR_HOOK_VERSION = '0.3.0';
 // 0.6.0 (TRA-755): the resolved node is version-gated against engines.node. An
 // older one used to exec fine and die on a SyntaxError the client could only
 // report as "failed to connect" — and get pinned into launcher.env on the way.
-export const LAUNCHER_VERSION = '0.6.9';
+export const LAUNCHER_VERSION = '0.6.10';

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1087,6 +1087,62 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
       fs.chmodSync(traceHome, 0o700);
     }
   });
+
+  // TRA-1163. HOME is not guaranteed: a systemd unit with `User=` but no
+  // `Environment=HOME`, a container ENTRYPOINT, a bare launchd job and `env -i`
+  // wrappers all spawn the MCP client without it. Under `set -u` every bare
+  // `$HOME` in the shim is then a hard abort — exit 1, a raw bash error into
+  // the client's stderr, no recovery message, no log line, and (critically) no
+  // probe: `node_candidates` expands its whole `for` list before the first
+  // iteration, so a perfectly good /opt/homebrew/bin/node listed BEFORE the
+  // `$HOME` entry never gets emitted either. Both reproduced.
+  describe('client spawned without HOME (TRA-1163)', () => {
+    it('starts from the config instead of aborting on an unbound HOME', () => {
+      const { traceHome, node, cli } = setupFakeHome();
+      writeConfig(traceHome, node, cli);
+
+      const { status, stdout, stderr } = runLauncher({ TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(stderr).not.toMatch(SHELL_DIAGNOSTIC);
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+    });
+
+    // The probe half. Which node it lands on is not assertable here — the
+    // passwd fallback is the machine's REAL home, so the runner's own nvm /
+    // Homebrew install outranks anything the fixture can plant. Assert the
+    // property that is the bug instead: the shim reaches an exec at all.
+    // Before the fix `node_candidates` aborted while expanding its `for` list
+    // and this exited 127 with "node binary not found".
+    it('still probes — an unbound HOME must not empty the candidate list', () => {
+      const { traceHome } = setupHealingHome();
+      writeConfig(traceHome, '/nonexistent/node', '/nonexistent/cli.js');
+
+      const { status, stderr } = runLauncher({ TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(stderr).not.toMatch(SHELL_DIAGNOSTIC);
+      expect(stderr).not.toContain('node binary not found');
+      expect(status).toBe(0);
+      expect(fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8')).toContain('exec(');
+    });
+
+    it('hands node an absolute HOME, so the server can find its state directory', () => {
+      const { traceHome, node, cli } = setupFakeHome();
+      // Report HOME rather than argv: cli.js resolves ~/.trace from it, and an
+      // unset HOME there is a second outage hiding behind the first.
+      fs.writeFileSync(
+        node,
+        `#!/bin/bash\nif [ "\${1:-}" = "-v" ]; then echo v22.22.2; exit 0; fi\necho "HOME_SEEN:\${HOME:-UNSET}"\n`,
+        { mode: 0o755 },
+      );
+      writeConfig(traceHome, node, cli);
+
+      const { status, stdout } = runLauncher({ TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toMatch(/^HOME_SEEN:\/./);
+    });
+  });
 });
 
 // TRA-965. The desktop app records `~/.trace/bin/node-runtime` as

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1097,15 +1097,29 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
   // iteration, so a perfectly good /opt/homebrew/bin/node listed BEFORE the
   // `$HOME` entry never gets emitted either. Both reproduced.
   describe('client spawned without HOME (TRA-1163)', () => {
-    it('starts from the config instead of aborting on an unbound HOME', () => {
+    // HOME="" is the other real spawn shape: a launcher that exports every
+    // variable it knows of, set or not. `-n` catches it, but `~` does NOT —
+    // tilde consults passwd only when HOME is *unset*, so a plain
+    // `[ -n "$HOME" ] || HOME=~` leaves it empty and every path below roots at
+    // `/`. That is why the guard unsets first.
+    it('does not root its paths at / when HOME is set but empty', () => {
       const { traceHome, node, cli } = setupFakeHome();
       writeConfig(traceHome, node, cli);
+      // Report HOME rather than argv — the empty value is what has to be gone.
+      fs.writeFileSync(
+        node,
+        `#!/bin/bash\nif [ "\${1:-}" = "-v" ]; then echo v22.22.2; exit 0; fi\necho "HOME_SEEN:\${HOME:-EMPTY}"\n`,
+        { mode: 0o755 },
+      );
 
-      const { status, stdout, stderr } = runLauncher({ TRACE_MCP_HOME: traceHome }, ['serve']);
+      const { status, stdout, stderr } = runLauncher({ HOME: '', TRACE_MCP_HOME: traceHome }, [
+        'serve',
+      ]);
 
       expect(stderr).not.toMatch(SHELL_DIAGNOSTIC);
       expect(status).toBe(0);
-      expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+      expect(stdout.trim()).not.toBe('HOME_SEEN:EMPTY');
+      expect(stdout.trim()).toMatch(/^HOME_SEEN:\/./);
     });
 
     // The probe half. Which node it lands on is not assertable here — the


### PR DESCRIPTION
## The failure

`HOME` is not guaranteed. A systemd unit with `User=` but no `Environment=HOME`, a container `ENTRYPOINT`, a bare launchd job and `env -i` wrappers all spawn the MCP client without it. Under `set -u`, every bare `$HOME` in the shim was then a hard abort — exit 1, a raw bash error into the client's stderr, no recovery message, no `ERROR` line in `launcher.log`.

Reproduced against the shipped shim (v0.6.9):

```
$ env -u HOME ~/.trace-mcp/bin/trace-mcp serve
trace-mcp-launcher.sh: line 22: HOME: unbound variable
rc=1
```

**The probe loss is the worse half.** `node_candidates` expands its whole `for` list *before* the first iteration:

```bash
for candidate in /opt/homebrew/bin/node /usr/local/bin/node "$HOME/.volta/bin/node"; do
```

so the abort at the `$HOME` entry means `/opt/homebrew/bin/node` — listed *before* it — is never emitted either. The whole candidate list comes back empty and the shim dies with `node binary not found` on a machine that has a perfectly good node on disk:

```
$ env -u HOME TRACE_MCP_HOME=... ~/.trace-mcp/bin/trace-mcp serve
trace-mcp-launcher.sh: line 374: HOME: unbound variable
trace-mcp launcher: node binary not found — install Node.js ...
rc=127
```

Also silent: `launcher.log` records nothing, so the daily "zero ERROR lines" health check reads clean through the outage — the same blind spot TRA-965 and TRA-1040 closed for other causes.

## The fix

One guard after `set -u`, not `${HOME:-}` at ~15 call sites — the failure is the class, not any one path:

```bash
[ -n "${HOME:-}" ] || HOME=~
export HOME
```

Bash expands `~` from the passwd database when `HOME` is unset, which is exactly the value the missing variable should have had. `export`ed because `cli.js` resolves its own state directory from it, and an unset `HOME` there is a second outage hiding behind the first.

## Tests

Three regression tests in `tests/init/launcher-integration.test.ts`, under `client spawned without HOME (TRA-1163)`:

- starts from the config instead of aborting on an unbound `HOME`
- **still probes** — an unbound `HOME` must not empty the candidate list
- hands node an absolute `HOME`, so the server can find its state directory

Verified non-vacuous: with the guard removed, 2 of the 3 fail (the first passes because `${TRACE_MCP_HOME:-$HOME/.trace}` short-circuits before touching `$HOME`, and it guards the fast path against future regressions).

The probe test asserts that the shim *reaches an exec* rather than which node it picks: the passwd fallback resolves to the runner's real home, so a fixture-planted node can never outrank the machine's own — asserting on `NODE_ARGS` there would be machine-dependent.

## Evidence

- `npx vitest run tests/init/ src/cli/__tests__/doctor* tests/scripts/postinstall-control-plane.test.ts` → 340 passed. One unrelated timeout (`stays on cli.js when the package ships no proxy.js`, 188 s under full-suite contention) that passes standalone in 745 ms and sets `HOME` explicitly.
- `pnpm run lint` (tsc --noEmit) → clean.
- `biome ci` on the touched files → clean.

## Contract

No MCP tool signature, on-disk schema or token-budget change. `LAUNCHER_VERSION` 0.6.9 → 0.6.10 (and the three `hooks/trace-mcp-launcher.*` header markers, which `readInstalledLauncherVersion` parses) so `trace-mcp init` reinstalls the shim on existing machines rather than reporting it up to date.

Closes TRA-1163.
