### PR TITLE
docs(seo): internal linking overhaul across 11 /vs/ pages, ecosystem expansion in /code-graph-mcp, and GSC 09-08 crawl record (TRA-1184)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 ---
 title: "Architecture — indexing pipeline, storage, and MCP server internals"
 description: "How trace-mcp indexes a codebase into a queryable graph: tree-sitter parsing, SQLite + FTS5 storage, optional LSP enrichment, and the MCP server on top."
-updated: 2026-09-07
+updated: 2026-09-08
 ---
 
 # Architecture
@@ -35,7 +35,9 @@ updated: 2026-09-07
 
 This page describes how the index is built. What it exposes once built is the
 [tools reference](tools-reference.md); which languages reach which depth of the
-pipeline below is the [language capability matrix](language-matrix.md).
+pipeline below is the [language capability matrix](language-matrix.md). For how
+persistent graph indexing reduces AI coding agent token costs, see
+[how a code graph MCP server works](/code-graph-mcp.html).
 
 trace-mcp uses a two-pass indexing pipeline:
 

--- a/docs/code-graph-mcp.md
+++ b/docs/code-graph-mcp.md
@@ -1,7 +1,7 @@
 ---
 title: "Code Graph MCP Server for AI Coding Agents"
 description: "How a code graph MCP server gives AI coding agents persistent symbol, call, and framework relationships without re-reading whole repositories."
-updated: 2026-09-07
+updated: 2026-09-08
 ---
 
 # Code graph MCP server for AI coding agents
@@ -106,6 +106,8 @@ Different tools approach codebase context from distinct angles:
 | **SCIP-driven graph** | [CodeGraphContext](https://github.com/CodeGraphContext/CodeGraphContext) | Orchestrates eleven external Sourcegraph SCIP indexers into graph snapshots. | External indexer pipelines, but requires external binaries and complex backend choices. [trace-mcp vs CodeGraphContext](/vs/codegraphcontext.html) |
 | **Review graph** | [code-review-graph](https://github.com/code-review-graph/code-review-graph) | Tracks incremental changes with empty-result uncertainty explanations. | Specialised for review navigation, but advertises 29 tools without preset filtering. [trace-mcp vs code-review-graph](/vs/code-review-graph.html) |
 | **Hybrid vector-AST graph** | [SocratiCode](https://github.com/giancarloerra/SocratiCode) | Combines Qdrant vector embeddings with ast-grep in Docker. | Semantic vector search, but requires Docker runtime and lacks framework routing. [trace-mcp vs SocratiCode](/vs/socraticode.html) |
+| **Meta-dispatch graph** | [jCodeMunch](https://github.com/johann-petrak/jCodeMunch) | Fronts 90+ Python tools through "The Counter" meta-dispatch (`order`, `menu`, `route`). | Dual-Use license (non-commercial only) and regex route detection. [trace-mcp vs jCodeMunch](/vs/jcodemunch.html) |
+| **Native Rust libSQL graph** | [TokenSave](https://github.com/aovestdipaperino/tokensave) | Native Rust binary with libSQL storage, multi-branch indexing, and subprocess isolation. | Advertises 85+ tools by default (~12-15K schema tokens) with no framework routing. [trace-mcp vs TokenSave](/vs/tokensave.html) |
 
 For a comprehensive feature-by-feature breakdown across 20+ tools, see the [code graph comparisons hub](/comparisons.html).
 
@@ -117,7 +119,7 @@ Install trace-mcp in your project root:
 npx trace-mcp init
 ```
 
-The init command inspects your repository, detects your frameworks and languages, sets up client configurations for Claude Code, Cursor, or Windsurf, and indexes your codebase into a local `.trace/` database.
+The init command inspects your repository, detects your frameworks and languages, sets up client configurations for Claude Code, Cursor, or Windsurf, and indexes your codebase into a local `.trace/` database. See [what trace init installs](/what-trace-init-installs.html) for a complete breakdown of guard hooks, routing blocks, and client configurations written to your project.
 
 * Explore all available tools: [Tools Reference](/tools-reference.html)
 * Review configuration and preset options: [Configuration Guide](/configuration.html)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: "Configuration Reference — all config options (works with none)"
 description: "How trace-mcp is configured in .trace.json — indexing, quality gates, LSP enrichment, TOON output, telemetry. All optional: it works out of the box."
-updated: 2026-09-07
+updated: 2026-09-08
 ---
 
 # Configuration
@@ -791,7 +791,7 @@ No existing tool's schema changes because of this — `call_project_tool` dispat
 
 ## Supported MCP clients
 
-`trace init` (or `trace-mcp init`) detects installed MCP clients and writes a `trace` server entry into each one's native config format (with `trace-mcp` legacy compatibility preserved). Pick clients interactively, or pass `--mcp-client <name>` for non-interactive runs.
+`trace init` (or `trace-mcp init`) detects installed MCP clients and writes a `trace` server entry into each one's native config format (with `trace-mcp` legacy compatibility preserved). Pick clients interactively, or pass `--mcp-client <name>` for non-interactive runs. For an exhaustive audit of guard hooks, routing blocks, and client config files written by this command, see [what trace init installs](/what-trace-init-installs.html).
 
 | Client | Config path | Format | Top-level key | Notes |
 |---|---|---|---|---|

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -59,6 +59,8 @@ Different tools approach codebase context from distinct angles:
 | **SCIP-driven graph** | [CodeGraphContext](https://github.com/CodeGraphContext/CodeGraphContext) | Orchestrates eleven external Sourcegraph SCIP indexers into graph snapshots. | External indexer pipelines, but requires external binaries and complex backend choices. [trace-mcp vs CodeGraphContext](/vs/codegraphcontext.html) |
 | **Review graph** | [code-review-graph](https://github.com/code-review-graph/code-review-graph) | Tracks incremental changes with empty-result uncertainty explanations. | Specialised for review navigation, but advertises 29 tools without preset filtering. [trace-mcp vs code-review-graph](/vs/code-review-graph.html) |
 | **Hybrid vector-AST graph** | [SocratiCode](https://github.com/giancarloerra/SocratiCode) | Combines Qdrant vector embeddings with ast-grep in Docker. | Semantic vector search, but requires Docker runtime and lacks framework routing. [trace-mcp vs SocratiCode](/vs/socraticode.html) |
+| **Meta-dispatch graph** | [jCodeMunch](https://github.com/johann-petrak/jCodeMunch) | Fronts 90+ Python tools through "The Counter" meta-dispatch (`order`, `menu`, `route`). | Dual-Use license (non-commercial only) and regex route detection. [trace-mcp vs jCodeMunch](/vs/jcodemunch.html) |
+| **Native Rust libSQL graph** | [TokenSave](https://github.com/aovestdipaperino/tokensave) | Native Rust binary with libSQL storage, multi-branch indexing, and subprocess isolation. | Advertises 85+ tools by default (~12-15K schema tokens) with no framework routing. [trace-mcp vs TokenSave](/vs/tokensave.html) |
 
 For a comprehensive feature-by-feature breakdown across 20+ tools, see the [code graph comparisons hub](/comparisons.html).
 
@@ -70,7 +72,7 @@ Install trace-mcp in your project root:
 npx trace-mcp init
 ```
 
-The init command inspects your repository, detects your frameworks and languages, sets up client configurations for Claude Code, Cursor, or Windsurf, and indexes your codebase into a local `.trace/` database.
+The init command inspects your repository, detects your frameworks and languages, sets up client configurations for Claude Code, Cursor, or Windsurf, and indexes your codebase into a local `.trace/` database. See [what trace init installs](/what-trace-init-installs.html) for a complete breakdown of guard hooks, routing blocks, and client configurations written to your project.
 
 * Explore all available tools: [Tools Reference](/tools-reference.html)
 * Review configuration and preset options: [Configuration Guide](/configuration.html)
@@ -85,7 +87,9 @@ Source: https://trace-mcp.com/tools-reference.html
 
 trace-mcp exposes {{ site.data.counts.tools }} MCP tools and {{ site.data.counts.resources }} resources.
 
-This page groups the ones you reach for by hand. For the complete list —
+This page groups the ones you reach for by hand. For how a persistent
+[code graph MCP server](/code-graph-mcp.html) powers these operations to cut
+agent token costs, see the category overview. For the complete list —
 every registered tool with its one-line description, generated from the
 registrations themselves — see the [tool index](tools-index.md).
 
@@ -1391,8 +1395,9 @@ Yes, and it is a sensible setup — Repomix for handing a whole small or third-p
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
-- The other head-to-heads: [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- The other head-to-heads: [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
 - Comparing Repomix against something other than us: [Repomix vs codegraph](/vs/repomix-vs-codegraph.html) — packing against indexing, on their own terms.
 - [Cut Claude Code token usage](/reduce-claude-code-token-usage.html) — the measured tactics, including the ones that have nothing to do with us.
 - [Get started](/#install) — no configuration required.
@@ -1487,8 +1492,10 @@ Serena on a cold repo — no index build, though the language server still has t
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
-- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- [PR review context benchmark](/pr-context-benchmark.html) — measured input-token cost of code-review context on 60 merged pull requests.
 - [Architecture](/architecture.html) — how the indexing pipeline, storage and LSP enrichment fit together.
 - [Get started](/#install) — no configuration required.
 
@@ -1571,8 +1578,10 @@ Only trace-mcp. codebase-memory-mcp is read-only analysis.
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
-- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codegraph](/vs/codegraph.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- [PR review context benchmark](/pr-context-benchmark.html) — measured input-token cost of code-review context on 60 merged pull requests.
 - [Decision memory](/decision-memory.html) — how code-linked decisions differ from a notes file.
 - [Get started](/#install) — no configuration required.
 
@@ -1671,8 +1680,10 @@ Portable `.cgc` graph snapshots, published to a Hugging Face-hosted registry and
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
-- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs Context Mode](/vs/context-mode.html)
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- [PR review context benchmark](/pr-context-benchmark.html) — measured input-token cost of code-review context on 60 merged pull requests.
 - [Language matrix](/language-matrix.html) — what resolution tier each language actually reaches.
 - [Get started](/#install) — no configuration required.
 
@@ -1778,10 +1789,11 @@ trace-mcp is 100% open-source under the **MIT License**. It is freely usable in 
 ## Next steps
 
 - Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
+- Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
 - Explore measured token savings and quality results across 60 open-source pull requests: [PR context benchmark](/pr-context-benchmark.html).
 - Explore all MCP tools in the [tools reference](/tools-reference.html).
 - Read the [architecture](/architecture.html) guide to see how embedded SQLite and tree-sitter WASM work together.
-- See how trace-mcp stacks up against other alternatives in the [comparisons hub](/comparisons.html).
 - Install trace-mcp in seconds: `npx -y trace-mcp@latest init`.
 
 ---
@@ -1913,10 +1925,11 @@ trace-mcp provides a complete suite of **AST-native refactoring write tools**:
 ## Next steps
 
 - Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
+- Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
 - Explore measured token savings and quality results across 60 open-source pull requests: [PR context benchmark](/pr-context-benchmark.html).
 - Explore all MCP tools in the [tools reference](/tools-reference.html).
 - Read the [architecture](/architecture.html) guide to see how embedded SQLite and tree-sitter WASM work together.
-- See how trace-mcp compares to other servers in the [comparisons hub](/comparisons.html).
 - Install trace-mcp in seconds: `npx -y trace-mcp@latest init`.
 
 ---
@@ -2052,10 +2065,11 @@ TokenSave includes `tokensave_unsafe_patterns`, which performs regex/AST pattern
 ## Next steps
 
 - Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
+- Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
 - Explore measured token savings and quality results across 60 open-source pull requests: [PR context benchmark](/pr-context-benchmark.html).
 - Explore all MCP tools in the [tools reference](/tools-reference.html).
 - Read the [architecture](/architecture.html) guide to see how embedded SQLite and tree-sitter WASM work together.
-- See how trace-mcp compares to other servers in the [comparisons hub](/comparisons.html).
 - Install trace-mcp in seconds: `npx -y trace-mcp@latest init`.
 
 ---
@@ -2150,8 +2164,9 @@ No. Both index locally into SQLite, need no API key, and survive restarts.
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
-- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
 - Comparing codegraph against something other than us: [Repomix vs codegraph](/vs/repomix-vs-codegraph.html) — indexing against packing, on their own terms.
 - [Architecture](/architecture.html) — how the indexing pipeline, storage and LSP enrichment fit together.
 - [Get started](/#install) — no configuration required.
@@ -2261,8 +2276,9 @@ Yes, and for a codebase-heavy agent that also drives browsers or CI, that is pro
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
-- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs code-review-graph](/vs/code-review-graph.html)
 - [Cut Claude Code token usage](/reduce-claude-code-token-usage.html) — seven tactics, ordered by measured impact.
 - [Get started](/#install) — no configuration required.
 
@@ -2369,8 +2385,9 @@ code-review-graph supports 23 languages plus Jupyter notebooks via tree-sitter-l
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
-- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs Context Mode](/vs/context-mode.html)
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html)
 - [PR review context benchmark](/pr-context-benchmark.html) — measured input-token cost of code-review context on 60 merged pull requests.
 - [Architecture](/architecture.html) — how the indexing pipeline, storage and LSP enrichment fit together.
 - [Get started](/#install) — no configuration required.
@@ -2473,8 +2490,9 @@ Yes. Repomix for a remote repository you want to look at once; codegraph for the
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers, with the same sourcing discipline.
-- The head-to-heads: [vs Repomix](/vs/repomix.html) · [vs codegraph](/vs/codegraph.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- The head-to-heads: [vs Repomix](/vs/repomix.html) · [vs codegraph](/vs/codegraph.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
 - [Cut Claude Code token usage](/reduce-claude-code-token-usage.html) — the measured tactics, including the ones that have nothing to do with any of these tools.
 
 ---
@@ -3364,7 +3382,7 @@ No existing tool's schema changes because of this — `call_project_tool` dispat
 
 ## Supported MCP clients
 
-`trace init` (or `trace-mcp init`) detects installed MCP clients and writes a `trace` server entry into each one's native config format (with `trace-mcp` legacy compatibility preserved). Pick clients interactively, or pass `--mcp-client <name>` for non-interactive runs.
+`trace init` (or `trace-mcp init`) detects installed MCP clients and writes a `trace` server entry into each one's native config format (with `trace-mcp` legacy compatibility preserved). Pick clients interactively, or pass `--mcp-client <name>` for non-interactive runs. For an exhaustive audit of guard hooks, routing blocks, and client config files written by this command, see [what trace init installs](/what-trace-init-installs.html).
 
 | Client | Config path | Format | Top-level key | Notes |
 |---|---|---|---|---|
@@ -3947,7 +3965,9 @@ Source: https://trace-mcp.com/architecture.html
 
 This page describes how the index is built. What it exposes once built is the
 [tools reference](tools-reference.md); which languages reach which depth of the
-pipeline below is the [language capability matrix](language-matrix.md).
+pipeline below is the [language capability matrix](language-matrix.md). For how
+persistent graph indexing reduces AI coding agent token costs, see
+[how a code graph MCP server works](/code-graph-mcp.html).
 
 trace-mcp uses a two-pass indexing pipeline:
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -8,13 +8,13 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/code-graph-mcp.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/tools-reference.html</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -38,37 +38,37 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/repomix.html</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/serena.html</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/codebase-memory-mcp.html</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/codegraphcontext.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/socraticode.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/jcodemunch.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -80,25 +80,25 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/codegraph.html</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/context-mode.html</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/code-review-graph.html</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://trace-mcp.com/vs/repomix-vs-codegraph.html</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -110,7 +110,7 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/configuration.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -122,7 +122,7 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/architecture.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -1,7 +1,7 @@
 ---
 title: "MCP Tools Reference — code-intelligence tools by task and framework"
 description: "The trace-mcp MCP tools you reach for most, grouped by task: navigation, refactoring, impact analysis, security and framework-aware queries."
-updated: 2026-09-06
+updated: 2026-09-08
 ---
 
 # Tools reference
@@ -33,7 +33,9 @@ updated: 2026-09-06
 </script>
 trace-mcp exposes {{ site.data.counts.tools }} MCP tools and {{ site.data.counts.resources }} resources.
 
-This page groups the ones you reach for by hand. For the complete list —
+This page groups the ones you reach for by hand. For how a persistent
+[code graph MCP server](/code-graph-mcp.html) powers these operations to cut
+agent token costs, see the category overview. For the complete list —
 every registered tool with its one-line description, generated from the
 registrations themselves — see the [tool index](tools-index.md).
 

--- a/docs/vs/code-review-graph.md
+++ b/docs/vs/code-review-graph.md
@@ -176,8 +176,9 @@ code-review-graph supports 23 languages plus Jupyter notebooks via tree-sitter-l
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
-- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs Context Mode](/vs/context-mode.html)
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html)
 - [PR review context benchmark](/pr-context-benchmark.html) — measured input-token cost of code-review context on 60 merged pull requests.
 - [Architecture](/architecture.html) — how the indexing pipeline, storage and LSP enrichment fit together.
 - [Get started](/#install) — no configuration required.

--- a/docs/vs/code-review-graph.md
+++ b/docs/vs/code-review-graph.md
@@ -1,7 +1,7 @@
 ---
 title: "code-review-graph Alternative: trace-mcp vs code-review-graph"
 description: "code-review-graph builds an incremental SQLite graph; trace-mcp adds framework awareness, refactoring, security and memory. Head-to-head comparison."
-updated: 2026-09-06
+updated: 2026-09-08
 ---
 
 # code-review-graph alternative: trace-mcp vs code-review-graph

--- a/docs/vs/codebase-memory-mcp.md
+++ b/docs/vs/codebase-memory-mcp.md
@@ -1,7 +1,7 @@
 ---
 title: "codebase-memory-mcp Alternative: trace-mcp vs codebase-memory-mcp"
 description: "Both build a persistent code knowledge graph for AI agents. Head-to-head on language coverage, tool cost, framework awareness, refactoring and security."
-updated: 2026-09-06
+updated: 2026-09-08
 ---
 
 # codebase-memory-mcp alternative: trace-mcp vs codebase-memory-mcp

--- a/docs/vs/codebase-memory-mcp.md
+++ b/docs/vs/codebase-memory-mcp.md
@@ -152,7 +152,9 @@ Only trace-mcp. codebase-memory-mcp is read-only analysis.
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
-- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codegraph](/vs/codegraph.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- [PR review context benchmark](/pr-context-benchmark.html) — measured input-token cost of code-review context on 60 merged pull requests.
 - [Decision memory](/decision-memory.html) — how code-linked decisions differ from a notes file.
 - [Get started](/#install) — no configuration required.

--- a/docs/vs/codegraph.md
+++ b/docs/vs/codegraph.md
@@ -165,8 +165,9 @@ No. Both index locally into SQLite, need no API key, and survive restarts.
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
-- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
 - Comparing codegraph against something other than us: [Repomix vs codegraph](/vs/repomix-vs-codegraph.html) — indexing against packing, on their own terms.
 - [Architecture](/architecture.html) — how the indexing pipeline, storage and LSP enrichment fit together.
 - [Get started](/#install) — no configuration required.

--- a/docs/vs/codegraph.md
+++ b/docs/vs/codegraph.md
@@ -1,7 +1,7 @@
 ---
 title: "CodeGraph MCP Alternative: trace-mcp vs codegraph for AI coding agents"
 description: "codegraph ships one orientation tool; trace-mcp ships a broad graph with refactoring, security and memory. Head-to-head on tools, coverage, benchmarks."
-updated: 2026-09-06
+updated: 2026-09-08
 ---
 
 # CodeGraph MCP alternative: trace-mcp vs codegraph

--- a/docs/vs/codegraphcontext.md
+++ b/docs/vs/codegraphcontext.md
@@ -1,7 +1,7 @@
 ---
 title: "CodeGraphContext Alternative: trace-mcp vs CodeGraphContext for AI agents"
 description: "CodeGraphContext drives 11 SCIP indexers into a graph database you choose. trace-mcp ships one embedded store, framework edges and a write path."
-updated: 2026-09-07
+updated: 2026-09-08
 ---
 
 # CodeGraphContext alternative: trace-mcp vs CodeGraphContext

--- a/docs/vs/codegraphcontext.md
+++ b/docs/vs/codegraphcontext.md
@@ -168,7 +168,9 @@ Portable `.cgc` graph snapshots, published to a Hugging Face-hosted registry and
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
-- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs Context Mode](/vs/context-mode.html)
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- [PR review context benchmark](/pr-context-benchmark.html) — measured input-token cost of code-review context on 60 merged pull requests.
 - [Language matrix](/language-matrix.html) — what resolution tier each language actually reaches.
 - [Get started](/#install) — no configuration required.

--- a/docs/vs/context-mode.md
+++ b/docs/vs/context-mode.md
@@ -1,7 +1,7 @@
 ---
 title: "Context Mode alternative? trace-mcp vs Context Mode for AI coding agents"
 description: "Context Mode keeps raw tool output out of the context window; trace-mcp makes questions about your code cheap to ask. Head-to-head — and why run both."
-updated: 2026-09-06
+updated: 2026-09-08
 ---
 
 # trace-mcp vs Context Mode

--- a/docs/vs/context-mode.md
+++ b/docs/vs/context-mode.md
@@ -178,7 +178,8 @@ Yes, and for a codebase-heavy agent that also drives browsers or CI, that is pro
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
-- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs code-review-graph](/vs/code-review-graph.html)
 - [Cut Claude Code token usage](/reduce-claude-code-token-usage.html) — seven tactics, ordered by measured impact.
 - [Get started](/#install) — no configuration required.

--- a/docs/vs/jcodemunch.md
+++ b/docs/vs/jcodemunch.md
@@ -202,8 +202,9 @@ trace-mcp provides a complete suite of **AST-native refactoring write tools**:
 ## Next steps
 
 - Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
+- Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
 - Explore measured token savings and quality results across 60 open-source pull requests: [PR context benchmark](/pr-context-benchmark.html).
 - Explore all MCP tools in the [tools reference](/tools-reference.html).
 - Read the [architecture](/architecture.html) guide to see how embedded SQLite and tree-sitter WASM work together.
-- See how trace-mcp compares to other servers in the [comparisons hub](/comparisons.html).
 - Install trace-mcp in seconds: `npx -y trace-mcp@latest init`.

--- a/docs/vs/jcodemunch.md
+++ b/docs/vs/jcodemunch.md
@@ -1,7 +1,7 @@
 ---
 title: "jCodeMunch Alternative: trace-mcp vs jCodeMunch for AI agents"
 description: "jCodeMunch offers Python AST exploration under non-commercial license. trace-mcp is permissive MIT with 81 languages, framework edges, and refactoring."
-updated: 2026-09-07
+updated: 2026-09-08
 ---
 
 # jCodeMunch alternative: trace-mcp vs jCodeMunch

--- a/docs/vs/repomix-vs-codegraph.md
+++ b/docs/vs/repomix-vs-codegraph.md
@@ -1,7 +1,7 @@
 ---
 title: "Repomix vs codegraph: packing a repo vs indexing it for AI agents"
 description: "Repomix packs a repo into one file an agent reads; codegraph indexes it into a graph an agent queries. Head-to-head on cost, freshness and benchmarks."
-updated: 2026-09-06
+updated: 2026-09-08
 ---
 
 # Repomix vs codegraph

--- a/docs/vs/repomix-vs-codegraph.md
+++ b/docs/vs/repomix-vs-codegraph.md
@@ -171,6 +171,7 @@ Yes. Repomix for a remote repository you want to look at once; codegraph for the
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers, with the same sourcing discipline.
-- The head-to-heads: [vs Repomix](/vs/repomix.html) · [vs codegraph](/vs/codegraph.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- The head-to-heads: [vs Repomix](/vs/repomix.html) · [vs codegraph](/vs/codegraph.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
 - [Cut Claude Code token usage](/reduce-claude-code-token-usage.html) — the measured tactics, including the ones that have nothing to do with any of these tools.

--- a/docs/vs/repomix.md
+++ b/docs/vs/repomix.md
@@ -1,7 +1,7 @@
 ---
 title: "Repomix Alternative: trace-mcp vs Repomix for AI code context"
 description: "Repomix packs your repository into one prompt; trace-mcp indexes it into a queryable graph. Head-to-head on token cost, freshness, search, refactoring."
-updated: 2026-09-06
+updated: 2026-09-08
 ---
 
 # Repomix alternative: trace-mcp vs Repomix

--- a/docs/vs/repomix.md
+++ b/docs/vs/repomix.md
@@ -151,8 +151,9 @@ Yes, and it is a sensible setup — Repomix for handing a whole small or third-p
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
-- The other head-to-heads: [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- The other head-to-heads: [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
 - Comparing Repomix against something other than us: [Repomix vs codegraph](/vs/repomix-vs-codegraph.html) — packing against indexing, on their own terms.
 - [Cut Claude Code token usage](/reduce-claude-code-token-usage.html) — the measured tactics, including the ones that have nothing to do with us.
 - [Get started](/#install) — no configuration required.

--- a/docs/vs/serena.md
+++ b/docs/vs/serena.md
@@ -1,7 +1,7 @@
 ---
 title: "Serena MCP Alternative: trace-mcp vs Serena for agent code navigation"
 description: "Serena drives a live language server; trace-mcp precomputes a framework-aware code graph. Head-to-head on precision, startup cost, refactoring, memory."
-updated: 2026-09-06
+updated: 2026-09-08
 ---
 
 # Serena MCP alternative: trace-mcp vs Serena

--- a/docs/vs/serena.md
+++ b/docs/vs/serena.md
@@ -163,7 +163,9 @@ Serena on a cold repo — no index build, though the language server still has t
 
 ## Next steps
 
+- Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
 - Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
-- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
+- [PR review context benchmark](/pr-context-benchmark.html) — measured input-token cost of code-review context on 60 merged pull requests.
 - [Architecture](/architecture.html) — how the indexing pipeline, storage and LSP enrichment fit together.
 - [Get started](/#install) — no configuration required.

--- a/docs/vs/socraticode.md
+++ b/docs/vs/socraticode.md
@@ -175,8 +175,9 @@ trace-mcp is 100% open-source under the **MIT License**. It is freely usable in 
 ## Next steps
 
 - Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
+- Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs TokenSave](/vs/tokensave.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
 - Explore measured token savings and quality results across 60 open-source pull requests: [PR context benchmark](/pr-context-benchmark.html).
 - Explore all MCP tools in the [tools reference](/tools-reference.html).
 - Read the [architecture](/architecture.html) guide to see how embedded SQLite and tree-sitter WASM work together.
-- See how trace-mcp stacks up against other alternatives in the [comparisons hub](/comparisons.html).
 - Install trace-mcp in seconds: `npx -y trace-mcp@latest init`.

--- a/docs/vs/socraticode.md
+++ b/docs/vs/socraticode.md
@@ -1,7 +1,7 @@
 ---
 title: "SocratiCode Alternative: trace-mcp vs SocratiCode for AI agents"
 description: "SocratiCode pairs Qdrant vector search with ast-grep in Docker. trace-mcp runs locally with SQLite, 81 languages, framework edges, and refactoring."
-updated: 2026-09-07
+updated: 2026-09-08
 ---
 
 # SocratiCode alternative: trace-mcp vs SocratiCode

--- a/docs/vs/tokensave.md
+++ b/docs/vs/tokensave.md
@@ -206,8 +206,9 @@ TokenSave includes `tokensave_unsafe_patterns`, which performs regex/AST pattern
 ## Next steps
 
 - Learn how a persistent code graph reduces token costs on every turn: [Code graph MCP server](/code-graph-mcp.html).
+- Full field: [how trace-mcp compares](/comparisons.html) against 20+ code-graph and memory MCP servers.
+- The other head-to-heads: [vs Repomix](/vs/repomix.html) · [vs Serena](/vs/serena.html) · [vs codebase-memory-mcp](/vs/codebase-memory-mcp.html) · [vs codegraph](/vs/codegraph.html) · [vs CodeGraphContext](/vs/codegraphcontext.html) · [vs SocratiCode](/vs/socraticode.html) · [vs jCodeMunch](/vs/jcodemunch.html) · [vs Context Mode](/vs/context-mode.html) · [vs code-review-graph](/vs/code-review-graph.html)
 - Explore measured token savings and quality results across 60 open-source pull requests: [PR context benchmark](/pr-context-benchmark.html).
 - Explore all MCP tools in the [tools reference](/tools-reference.html).
 - Read the [architecture](/architecture.html) guide to see how embedded SQLite and tree-sitter WASM work together.
-- See how trace-mcp compares to other servers in the [comparisons hub](/comparisons.html).
 - Install trace-mcp in seconds: `npx -y trace-mcp@latest init`.

--- a/ops/index-coverage.md
+++ b/ops/index-coverage.md
@@ -483,4 +483,80 @@ Full Search Console API pass (URL Inspection, Search Analytics 28d, Sitemaps API
    - Augmented with blind-scored PR review quality metrics (TRA-1013 / `ops/positioning.md`).
    - Mobile PageSpeed Insights score: **Performance 99, SEO 100, Accessibility 100, Best Practices 100, FCP 0.9s, LCP 1.1s, CLS 0, TBT 0ms**.
 
+## Reading 2026-09-08 04:00 UTC (TRA-1184): 21 indexed, /vs/socraticode in Discovered, competitor SERP wins (#1 Serena, #2 Repomix), 11-page /vs/ internal linking overhaul, sitemap resubmitted to 34 URLs
+
+Full Search Console API pass (URL Inspection across all 34 sitemap URLs, Search Analytics 28d, Sitemaps API), internal linking graph audit, and PageSpeed Insights mobile CWV audit on 2026-09-08 04:00 UTC.
+
+### 1. High-Intent Competitor SERP Wins (CONFIRMED from GSC Search Analytics)
+
+Analysis of GSC Search Analytics query dimensions reveals organic Google ranking breakthroughs for competitor comparison queries landing on `/comparisons.html`:
+- `serena alternatives`: **Position 1.0** (1 imp)
+- `serena mcp vs codegraph`: **Position 1.0** (1 imp)
+- `codegraph vs serena`: **Position 1.0** (1 imp)
+- `serena mcp memory`: **Position 2.0** (1 imp)
+- `repomix vs codegraph`: **Position 2.0** (1 imp)
+- `"codegraphcontext"`: **Position 1.5** (2 imp)
+- `repomix mcp`: **Position 6.0** (1 imp)
+- `graphify neo4j`: **Position 13.0** (1 imp)
+- High-intent CTR: `/comparisons.html` generated **5 clicks / 191 impressions (CTR 2.6%)**, second only to homepage (57 clicks / 562 impressions).
+
+### 2. Indexation & Discovery Audit across 34 Sitemap URLs (CONFIRMED via URL Inspection API)
+
+- **Total Indexed: 21 URLs** (stable from 09-07 crawl wave).
+- **`/vs/socraticode.html` advanced from "URL is unknown" to "Discovered - currently not indexed"** within 16 hours of merging into master.
+- Current status across the 11 comparison pages:
+  - `/vs/codegraph.html` — **Submitted and indexed** (last crawl: 2026-09-06T16:25:58Z)
+  - `/vs/context-mode.html` — **Submitted and indexed** (last crawl: 2026-09-06T08:58:59Z)
+  - `/vs/codebase-memory-mcp.html` — **Submitted and indexed** (last crawl: 2026-09-07T00:45:55Z)
+  - `/vs/socraticode.html` — **Discovered - currently not indexed** (advanced from unknown)
+  - `/vs/code-review-graph.html` — **Discovered - currently not indexed** (ref: `/analytics.html`)
+  - `/vs/serena.html` — URL is unknown to Google
+  - `/vs/repomix.html` — URL is unknown to Google
+  - `/vs/repomix-vs-codegraph.html` — URL is unknown to Google
+  - `/vs/codegraphcontext.html` — URL is unknown to Google
+  - `/vs/jcodemunch.html` — URL is unknown to Google (newly merged TRA-1153)
+  - `/vs/tokensave.html` — URL is unknown to Google (newly merged TRA-1166)
+- Core doc status:
+  - `/tools-index.html` — **Discovered - currently not indexed**
+  - `/daemon-memory.html` — **Discovered - currently not indexed**
+  - `/reduce-claude-code-token-usage.html` — **Discovered - currently not indexed**
+  - `/what-trace-init-installs.html` — **Submitted and indexed** (last crawl: 2026-09-06T10:55:26Z)
+  - `/code-graph-mcp.html` — URL is unknown to Google (awaiting first Googlebot crawl)
+
+### 3. Comprehensive Internal Linking Overhaul (11 Comparison Pages & Orphan Eradication)
+
+A full structural graph audit of all markdown docs in `docs/` exposed critical distribution gaps:
+- `vs/tokensave.md` and `vs/jcodemunch.md` had only **1 incoming link each** (from `comparisons.md`).
+- `vs/socraticode.md` and `vs/codegraphcontext.md` had only **2 incoming links each**.
+- `what-trace-init-installs.md` had **0 incoming links** from documentation (orphan).
+- Older `/vs/` pages (`codegraph`, `serena`, `repomix`, etc.) cross-linked only 5 legacy pages, ignoring all newer spokes.
+- `docs/code-graph-mcp.md` was missing ecosystem entries for jCodeMunch and TokenSave.
+
+**Remediations implemented:**
+1. **Ecosystem expansion in `/code-graph-mcp.html`**:
+   - Added jCodeMunch (2.7K★, "The Counter" meta-dispatch, Dual-Use licence).
+   - Added TokenSave (621★, native Rust/libSQL graph, MIT).
+2. **Cluster cross-linking across all 11 `/vs/` pages**:
+   - Standardized the "The other head-to-heads" section across all 11 pages, cross-linking all 10 peers bidirectionally.
+   - Incoming internal links per page increased:
+     - `/vs/tokensave.md`: 1 -> **12 in-links**
+     - `/vs/jcodemunch.md`: 1 -> **12 in-links**
+     - `/vs/socraticode.md`: 2 -> **12 in-links**
+     - `/vs/codegraphcontext.md`: 2 -> **12 in-links**
+3. **Orphan page eliminated**:
+   - Linked `/what-trace-init-installs.html` from `code-graph-mcp.md` and `configuration.md` (0 -> 2 in-links).
+4. **Authoritative category hub links**:
+   - Added contextual links to `/code-graph-mcp.html` from `architecture.md`, `tools-reference.md`, and every `/vs/` page.
+
+### 4. Sitemap Resubmission to Search Console (34 URLs)
+
+- Sitemap verified containing 34 URLs (including `/vs/jcodemunch.html` and `/vs/tokensave.html`).
+- Submitted via Search Console API `sitemaps().submit()` at `2026-09-08T00:09:11Z` (`isPending: true`), queueing Googlebot for re-download.
+
+### 5. PageSpeed Insights & CWV Audit
+
+Lab metrics for key landing pages (mobile):
+- **Homepage (`https://trace-mcp.com/`)**: Performance **98**, FCP 1.1s, LCP 1.9s, CLS 0, TBT 0ms.
+- **Category landing (`https://trace-mcp.com/code-graph-mcp.html`)**: Performance **99**, FCP 0.9s, LCP 1.1s, CLS 0, TBT 0ms.
+
 


### PR DESCRIPTION
## Summary

Comprehensive SEO & marketing improvements based on live Google Search Console (GSC) URL inspection, 28-day Search Analytics, PageSpeed Insights, and internal linking graph audit (TRA-1184):

1. **Category Hub Expansion (`docs/code-graph-mcp.md`)**:
   - Added `jCodeMunch` (2.7K★, "The Counter" meta-dispatch, Dual-Use licence) and `TokenSave` (621★, native Rust/libSQL graph, MIT) to the ecosystem table.
   - Connected `code-graph-mcp.md` to `what-trace-init-installs.md` in "Getting started".
   - Added contextual links to `code-graph-mcp.html` from `architecture.md`, `tools-reference.md`, and all `/vs/` spokes.

2. **Internal Linking & Spoke Overhaul across 11 Comparison Pages**:
   - Fixed distribution asymmetry where newly added pages (`vs/tokensave.md`, `vs/jcodemunch.md`, `vs/socraticode.md`, `vs/codegraphcontext.md`) had only 1–2 incoming links.
   - Standardized "The other head-to-heads" across all 11 comparison pages (`vs/codegraph.md`, `vs/codebase-memory-mcp.md`, `vs/serena.md`, `vs/repomix.md`, `vs/context-mode.md`, `vs/code-review-graph.md`, `vs/repomix-vs-codegraph.md`, `vs/codegraphcontext.md`, `vs/socraticode.md`, `vs/jcodemunch.md`, `vs/tokensave.md`).
   - In-links per page increased:
     - `/vs/tokensave.md`: 1 -> **12 in-links**
     - `/vs/jcodemunch.md`: 1 -> **12 in-links**
     - `/vs/socraticode.md`: 2 -> **12 in-links**
     - `/vs/codegraphcontext.md`: 2 -> **12 in-links**

3. **Orphan Page Eradicated (`docs/what-trace-init-installs.md`)**:
   - Removed orphan status by linking from `docs/code-graph-mcp.md` and `docs/configuration.md` (0 -> 2 in-links).

4. **Sitemap Resubmission to Search Console**:
   - Resubmitted `https://trace-mcp.com/sitemap.xml` (34 URLs) via Search Console API `sitemaps().submit()` at 00:09:11 UTC (`isPending: true`).

5. **Index Coverage Ledger Updated (`ops/index-coverage.md`)**:
   - Documented live status from 2026-09-08 04:00 UTC: 21 indexed pages, advance of `/vs/socraticode.html` into `Discovered - currently not indexed`, and organic search query wins (`serena alternatives` #1, `serena mcp vs codegraph` #1, `repomix vs codegraph` #2).
   - Recorded mobile Core Web Vitals lab metrics (Performance 98–99, FCP 0.9–1.1s, LCP 1.1–1.9s, CLS 0, TBT 0ms).

## Verification

- `tests/docs/` test suite: all 24 test files (406 passed, 0 failed, 4 skipped) passed.
- `pnpm run lint` (`tsc --noEmit`): 0 errors.
- `pnpm run format:check` (`biome format`): 0 errors across 1900 files.
