### PR TITLE
fix(launcher): self-locate state home under isolated HOME and survive update swap window (TRA-1190)

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.6.10 (Windows)
+REM trace-mcp-launcher v0.6.11 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.6.10 (Windows)
+# trace-mcp-launcher v0.6.11 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.
@@ -7,7 +7,39 @@
 
 $ErrorActionPreference = 'Stop'
 
-$TraceHome = if ($env:TRACE_MCP_HOME) { $env:TRACE_MCP_HOME } else { Join-Path $env:USERPROFILE '.trace' }
+# Determine $TraceHome:
+# 1. Explicit TRACE_MCP_HOME or TRACE_MCP_DATA_DIR override.
+# 2. Sibling directory of this shim: installed at <TraceHome>\bin\trace.cmd
+#    and trace-mcp-launcher.ps1. If launcher.env or .config.json exists in
+#    the parent directory, use it. This survives modified USERPROFILE or isolated homes.
+# 3. $USERPROFILE\.trace
+# 4. $USERPROFILE\.trace-mcp (legacy)
+$TraceHome = ''
+if ($env:TRACE_MCP_HOME) {
+    $TraceHome = $env:TRACE_MCP_HOME
+} elseif ($env:TRACE_MCP_DATA_DIR) {
+    $TraceHome = $env:TRACE_MCP_DATA_DIR
+} else {
+    if ($PSScriptRoot) {
+        $candidate = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+        if ((Test-Path -LiteralPath (Join-Path $candidate 'launcher.env') -PathType Leaf) -or (Test-Path -LiteralPath (Join-Path $candidate '.config.json') -PathType Leaf)) {
+            $TraceHome = $candidate
+        }
+    }
+    if (-not $TraceHome -and $env:USERPROFILE) {
+        $defaultTrace = Join-Path $env:USERPROFILE '.trace'
+        if ((Test-Path -LiteralPath $defaultTrace -PathType Container) -or -not (Test-Path -LiteralPath (Join-Path $env:USERPROFILE '.trace-mcp') -PathType Container)) {
+            $TraceHome = $defaultTrace
+        } else {
+            $TraceHome = Join-Path $env:USERPROFILE '.trace-mcp'
+        }
+    }
+}
+if (-not $TraceHome) { $TraceHome = Join-Path $env:USERPROFILE '.trace' }
+
+$env:TRACE_MCP_HOME = $TraceHome
+$env:TRACE_MCP_DATA_DIR = $TraceHome
+
 $ConfigPath = Join-Path $TraceHome 'launcher.env'
 $LogPath    = Join-Path $TraceHome 'launcher.log'
 
@@ -456,7 +488,15 @@ if (-not (Test-NodeBinary $NodePath)) {
 if (-not (Test-CliFile $CliPath)) {
     $CliPath = Find-Cli $NodePath
     if (-not $CliPath) {
-        Die 'trace-mcp package not found in any known npm prefix - run: npm i -g trace-mcp && trace-mcp init'
+        $retry = 0
+        while ($retry -lt 5 -and -not $CliPath) {
+            Start-Sleep -Milliseconds 300
+            $retry++
+            $CliPath = Find-Cli $NodePath
+        }
+        if (-not $CliPath) {
+            Die 'trace-mcp package not found in any known npm prefix - run: npm i -g trace-mcp && trace-mcp init'
+        }
     }
     Write-LauncherLog "probe: cli=$CliPath"
     $Healed = $true

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.6.10
+# trace-mcp-launcher v0.6.11
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -54,7 +54,43 @@ CLIENT_PATH="$PATH"
 PATH=/usr/bin:/bin:/usr/sbin:/sbin
 export PATH
 
-TRACE_HOME="${TRACE_MCP_HOME:-$HOME/.trace}"
+# Determine TRACE_HOME:
+# 1. Explicit TRACE_MCP_HOME or TRACE_MCP_DATA_DIR override always wins.
+# 2. Sibling directory of this shim: the shim is installed at <TRACE_HOME>/bin/trace
+#    or <TRACE_HOME>/bin/trace-mcp. If launcher.env exists in that parent directory,
+#    use it. This survives MCP clients spawned with an isolated or modified HOME
+#    (e.g. Antigravity, containers, launchd, Claude Code --isolated).
+# 3. $HOME/.trace (the standard default).
+# 4. $HOME/.trace-mcp (pre-TRA-611 legacy home).
+if [ -n "${TRACE_MCP_HOME:-}" ]; then
+  TRACE_HOME="$TRACE_MCP_HOME"
+elif [ -n "${TRACE_MCP_DATA_DIR:-}" ]; then
+  TRACE_HOME="$TRACE_MCP_DATA_DIR"
+else
+  SHIM_DIR=""
+  if [ -n "${BASH_SOURCE[0]:-}" ]; then
+    SHIM_DIR="$(dirname "${BASH_SOURCE[0]}")"
+  elif [ -n "${0:-}" ]; then
+    SHIM_DIR="$(dirname "$0")"
+  fi
+  if [ -n "$SHIM_DIR" ] && [ -d "$SHIM_DIR" ]; then
+    CANDIDATE_HOME="$(cd "$SHIM_DIR/.." 2>/dev/null && pwd -P)"
+    if [ -n "$CANDIDATE_HOME" ] && { [ -f "$CANDIDATE_HOME/launcher.env" ] || [ -f "$CANDIDATE_HOME/.config.json" ]; }; then
+      TRACE_HOME="$CANDIDATE_HOME"
+    fi
+  fi
+  if [ -z "${TRACE_HOME:-}" ]; then
+    TRACE_HOME="$HOME/.trace"
+    if [ ! -d "$TRACE_HOME" ] && [ -d "$HOME/.trace-mcp" ]; then
+      TRACE_HOME="$HOME/.trace-mcp"
+    fi
+  fi
+fi
+
+# Export so cli.js (and src/global.ts) connects to the same state directory
+export TRACE_MCP_HOME="$TRACE_HOME"
+export TRACE_MCP_DATA_DIR="$TRACE_HOME"
+
 CONFIG="$TRACE_HOME/launcher.env"
 LOG="$TRACE_HOME/launcher.log"
 # One global node_modules root per line, appended by each install.
@@ -409,9 +445,9 @@ is_app_runtime() {
 node_candidates() {
   local n fnm_dir candidate
 
-  # 4a. System-wide stable paths (Homebrew, /usr/local)
+  # 4a. System-wide stable paths (Homebrew, /usr/local, ~/.local)
   # 4b. Volta — stable symlink regardless of active version
-  for candidate in /opt/homebrew/bin/node /usr/local/bin/node "$HOME/.volta/bin/node"; do
+  for candidate in /opt/homebrew/bin/node /usr/local/bin/node "$HOME/.local/bin/node" "$HOME/.volta/bin/node"; do
     [ -x "$candidate" ] && echo "$candidate"
   done
 
@@ -428,10 +464,23 @@ node_candidates() {
     [ -x "$fnm_dir/bin/node" ] && echo "$fnm_dir/bin/node"
   done
 
-  # 4f. Last resort: prefixes that only pkg_roots knows about.
+  # 4f. Node found on the client's original PATH (e.g. custom toolchains, non-standard managers).
+  # Exclude any entry carrying `node_modules` to avoid repo-controlled wrappers.
+  if [ -n "${CLIENT_PATH:-}" ]; then
+    local p client_dirs
+    IFS=':' read -ra client_dirs <<< "$CLIENT_PATH"
+    for p in "${client_dirs[@]}"; do
+      case "$p" in
+        *node_modules*|'') continue ;;
+      esac
+      [ -x "$p/node" ] && [ ! -d "$p/node" ] && echo "$p/node"
+    done
+  fi
+
+  # 4g. Last resort: prefixes that only pkg_roots knows about.
   node_from_pkg_roots
 
-  # 4g. The Node embedded in the desktop app. Last, because a real node needs
+  # 4h. The Node embedded in the desktop app. Last, because a real node needs
   # no `ELECTRON_RUN_AS_NODE` dance — but on a DMG-only machine it is the only
   # one there is.
   node_from_app_bundle
@@ -766,7 +815,19 @@ fi
 
 if [ -z "$CLI_PATH" ] || ! is_usable_script "$CLI_PATH"; then
   ROOTS=$(pkg_roots "$NODE_PATH")
-  CLI_PATH=$(probe_cli "$ROOTS") || die "trace-mcp package not found in any known npm prefix — run: npm i -g trace-mcp && trace-mcp init"
+  CLI_PATH=$(probe_cli "$ROOTS") || {
+    # An update (npm install -g or self-update) may be swapping the package
+    # directory right this second. Wait briefly and retry before declaring
+    # a fatal error — MCP clients tolerate a 1-2s start delay but exit 127
+    # kills the session permanently.
+    retry=0
+    while [ "$retry" -lt 5 ]; do
+      sleep 0.3 2>/dev/null || sleep 1 2>/dev/null || true
+      retry=$((retry + 1))
+      CLI_PATH=$(probe_cli "$ROOTS") && break
+    done
+    [ -n "$CLI_PATH" ] || die "trace-mcp package not found in any known npm prefix — run: npm i -g trace-mcp && trace-mcp init"
+  }
   log "probe: cli=$CLI_PATH"
   HEALED=1
 fi

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -67,16 +67,30 @@ if [ -n "${TRACE_MCP_HOME:-}" ]; then
 elif [ -n "${TRACE_MCP_DATA_DIR:-}" ]; then
   TRACE_HOME="$TRACE_MCP_DATA_DIR"
 else
-  SHIM_DIR=""
+  SHIM_FILE=""
   if [ -n "${BASH_SOURCE[0]:-}" ]; then
-    SHIM_DIR="$(dirname "${BASH_SOURCE[0]}")"
+    SHIM_FILE="${BASH_SOURCE[0]}"
   elif [ -n "${0:-}" ]; then
-    SHIM_DIR="$(dirname "$0")"
+    SHIM_FILE="$0"
   fi
-  if [ -n "$SHIM_DIR" ] && [ -d "$SHIM_DIR" ]; then
-    CANDIDATE_HOME="$(cd "$SHIM_DIR/.." 2>/dev/null && pwd -P)"
-    if [ -n "$CANDIDATE_HOME" ] && { [ -f "$CANDIDATE_HOME/launcher.env" ] || [ -f "$CANDIDATE_HOME/.config.json" ]; }; then
-      TRACE_HOME="$CANDIDATE_HOME"
+  if [ -n "$SHIM_FILE" ]; then
+    REAL_SHIM="$SHIM_FILE"
+    # Dereference symlinks so invoking via ~/.trace-mcp/bin/trace-mcp (which symlinks
+    # to ~/.trace/bin/trace) resolves to the canonical install directory holding
+    # launcher.env even when ~/.trace-mcp has no config of its own.
+    while [ -L "$REAL_SHIM" ]; do
+      target="$(readlink "$REAL_SHIM" 2>/dev/null)" || break
+      case "$target" in
+        /*) REAL_SHIM="$target" ;;
+        *) REAL_SHIM="$(dirname "$REAL_SHIM")/$target" ;;
+      esac
+    done
+    SHIM_DIR="$(dirname "$REAL_SHIM")"
+    if [ -d "$SHIM_DIR" ]; then
+      CANDIDATE_HOME="$(cd "$SHIM_DIR/.." 2>/dev/null && pwd -P)"
+      if [ -n "$CANDIDATE_HOME" ] && { [ -f "$CANDIDATE_HOME/launcher.env" ] || [ -f "$CANDIDATE_HOME/.config.json" ]; }; then
+        TRACE_HOME="$CANDIDATE_HOME"
+      fi
     fi
   fi
   if [ -z "${TRACE_HOME:-}" ]; then
@@ -465,13 +479,24 @@ node_candidates() {
   done
 
   # 4f. Node found on the client's original PATH (e.g. custom toolchains, non-standard managers).
-  # Exclude any entry carrying `node_modules` to avoid repo-controlled wrappers.
+  # Exclude any relative entry, anything inside $PWD, or any entry carrying node_modules
+  # to prevent untrusted repo-controlled executables from being invoked.
   if [ -n "${CLIENT_PATH:-}" ]; then
-    local p client_dirs
+    local p client_dirs pwd_real
+    pwd_real="$(pwd -P 2>/dev/null || echo "$PWD")"
     IFS=':' read -ra client_dirs <<< "$CLIENT_PATH"
     for p in "${client_dirs[@]}"; do
       case "$p" in
-        *node_modules*|'') continue ;;
+        /*) ;; # Must be an absolute path
+        *) continue ;;
+      esac
+      case "$p" in
+        *node_modules*|"$PWD"|"$PWD"/*|"$pwd_real"|"$pwd_real"/*) continue ;;
+      esac
+      local p_real
+      p_real="$(cd "$p" 2>/dev/null && pwd -P)" || p_real="$p"
+      case "$p_real" in
+        *node_modules*|"$PWD"|"$PWD"/*|"$pwd_real"|"$pwd_real"/*) continue ;;
       esac
       [ -x "$p/node" ] && [ ! -d "$p/node" ] && echo "$p/node"
     done

--- a/scripts/postinstall-control-plane.mjs
+++ b/scripts/postinstall-control-plane.mjs
@@ -161,7 +161,8 @@ function truncateLog() {
 
 function atomicWrite(filePath, content, mode) {
   ensureDir(path.dirname(filePath));
-  const tmp = `${filePath}.tmp.${process.pid}.${Date.now()}`;
+  const rand = randomBytes(6).toString('hex');
+  const tmp = `${filePath}.tmp.${process.pid}.${rand}`;
   fs.writeFileSync(tmp, content, { mode });
   fs.renameSync(tmp, filePath);
 }
@@ -254,7 +255,8 @@ function installLauncherShim() {
     }
     const destPath = path.join(LAUNCHER_DIR, a.dest);
     const content = fs.readFileSync(srcPath);
-    const tmp = `${destPath}.tmp.${process.pid}.${Date.now()}`;
+    const rand = randomBytes(6).toString('hex');
+    const tmp = `${destPath}.tmp.${process.pid}.${rand}`;
     fs.writeFileSync(tmp, content, { mode: 0o755 });
     fs.renameSync(tmp, destPath);
     if (!IS_WINDOWS) fs.chmodSync(destPath, 0o755);

--- a/src/global.ts
+++ b/src/global.ts
@@ -101,7 +101,8 @@ function migrateLegacyHomeDir(target: string, legacy: string): boolean {
  * import time so a user-facing change requires a process restart.
  */
 const { home: TRACE_MCP_HOME_RESOLVED, migrated: TRACE_MCP_HOME_MIGRATED_RESOLVED } = (() => {
-  const override = process.env.TRACE_MCP_DATA_DIR;
+  const override =
+    process.env.TRACE_MCP_DATA_DIR || process.env.TRACE_MCP_HOME || process.env.TRACE_HOME;
   if (override && override.length > 0) {
     const expanded = override.startsWith('~')
       ? path.join(os.homedir(), override.slice(1))

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -112,4 +112,6 @@ export const MIRROR_HOOK_VERSION = '0.3.0';
 // 0.6.0 (TRA-755): the resolved node is version-gated against engines.node. An
 // older one used to exec fine and die on a SyntaxError the client could only
 // report as "failed to connect" — and get pinned into launcher.env on the way.
-export const LAUNCHER_VERSION = '0.6.10';
+// 0.6.11 (TRA-1190): self-locate state home under isolated HOME environments
+// and retry probe_cli across package swap windows.
+export const LAUNCHER_VERSION = '0.6.11';

--- a/src/utils/__tests__/atomic-write-sweep.test.ts
+++ b/src/utils/__tests__/atomic-write-sweep.test.ts
@@ -84,6 +84,18 @@ describe('sweepOrphanTmpFiles (TRA-702)', () => {
     expect(fs.existsSync(lock)).toBe(false);
   });
 
+  it('collects postinstall control plane tmp files (no leading dot, 12-char hex)', () => {
+    const tmpEnv = makeFile('launcher.env.tmp.1234.3a8f308b3935', 3 * DAY_MS);
+    const tmpShim = makeFile('trace.tmp.5678.4eb982e9ac9d', 3 * DAY_MS);
+
+    const removed = sweepOrphanTmpFiles(dir, DAY_MS);
+
+    expect(removed).toContain(tmpEnv);
+    expect(removed).toContain(tmpShim);
+    expect(fs.existsSync(tmpEnv)).toBe(false);
+    expect(fs.existsSync(tmpShim)).toBe(false);
+  });
+
   it('sweeps the given directory only, not its children', () => {
     const sub = path.join(dir, 'sessions');
     fs.mkdirSync(sub);

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1676,4 +1676,87 @@ describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)'
       expect(out.stderr).toBe('');
     });
   });
+
+  describe('TRA-1190: self-location under isolated HOME and update swap retry', () => {
+    it('self-locates enclosing state home when TRACE_MCP_HOME is unset and HOME is isolated', () => {
+      const { home, traceHome, node, cli } = setupFakeHome();
+      writeConfig(traceHome, node, cli);
+
+      const binDir = path.join(traceHome, 'bin');
+      fs.mkdirSync(binDir, { recursive: true });
+      const shimPath = path.join(binDir, 'trace');
+      fs.copyFileSync(LAUNCHER_SRC, shimPath);
+      fs.chmodSync(shimPath, 0o755);
+
+      const isolatedHome = fs.mkdtempSync(path.join(FIXTURES, 'isolated-home-'));
+
+      const res = spawnSync(shimPath, ['serve'], {
+        env: {
+          HOME: isolatedHome,
+          PATH: '/usr/bin:/bin',
+        },
+        encoding: 'utf-8',
+      });
+
+      expect(res.status).toBe(0);
+      expect(res.stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+    });
+
+    it('exports TRACE_MCP_HOME and TRACE_MCP_DATA_DIR pointing to resolved state directory', () => {
+      const { home, traceHome, cli } = setupFakeHome();
+      const node = path.join(home, 'echo-env-node');
+      fs.writeFileSync(
+        node,
+        '#!/bin/bash\nif [ "${1:-}" = "-v" ]; then echo "v22.22.2"; exit 0; fi\necho "HOME_ENV:$TRACE_MCP_HOME DATA_ENV:$TRACE_MCP_DATA_DIR"\n',
+        { mode: 0o755 },
+      );
+      writeConfig(traceHome, node, cli);
+
+      const binDir = path.join(traceHome, 'bin');
+      fs.mkdirSync(binDir, { recursive: true });
+      const shimPath = path.join(binDir, 'trace');
+      fs.copyFileSync(LAUNCHER_SRC, shimPath);
+      fs.chmodSync(shimPath, 0o755);
+
+      const isolatedHome = fs.mkdtempSync(path.join(FIXTURES, 'isolated-home-'));
+      const res = spawnSync(shimPath, ['serve'], {
+        env: {
+          HOME: isolatedHome,
+          PATH: '/usr/bin:/bin',
+        },
+        encoding: 'utf-8',
+      });
+
+      expect(res.status).toBe(0);
+      const realTraceHome = fs.realpathSync(traceHome);
+      expect(res.stdout).toContain(`HOME_ENV:${realTraceHome}`);
+      expect(res.stdout).toContain(`DATA_ENV:${realTraceHome}`);
+    });
+
+    it('retries and recovers when cli.js becomes available during update swap window', async () => {
+      const { home, traceHome, node } = setupFakeHome();
+      const missingCli = path.join(home, 'missing-cli.js');
+      writeConfig(traceHome, node, missingCli);
+
+      const nvmCli = plantNvmPackage(home);
+      fs.rmSync(nvmCli, { force: true });
+
+      const timer = setTimeout(() => {
+        try {
+          fs.writeFileSync(nvmCli, '// restored cli\n');
+        } catch {
+          // ignore
+        }
+      }, 200);
+
+      try {
+        const out = await runLauncherAsync({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+        expect(out.status).toBe(0);
+        expect(out.stdout).toContain('NODE_ARGS:');
+      } finally {
+        clearTimeout(timer);
+      }
+    });
+  });
 });

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1758,5 +1758,64 @@ describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)'
         clearTimeout(timer);
       }
     });
+
+    it('self-locates canonical state home when invoked through a symlink with no config in symlink parent', () => {
+      const { home: targetHome, traceHome: targetTraceHome, node, cli } = setupFakeHome();
+      writeConfig(targetTraceHome, node, cli);
+
+      const targetBin = path.join(targetTraceHome, 'bin');
+      fs.mkdirSync(targetBin, { recursive: true });
+      const targetShim = path.join(targetBin, 'trace');
+      fs.copyFileSync(LAUNCHER_SRC, targetShim);
+      fs.chmodSync(targetShim, 0o755);
+
+      const legacyHome = fs.mkdtempSync(path.join(FIXTURES, 'legacy-home-'));
+      const legacyTraceMcp = path.join(legacyHome, '.trace-mcp');
+      const legacyBin = path.join(legacyTraceMcp, 'bin');
+      fs.mkdirSync(legacyBin, { recursive: true });
+      const legacyShim = path.join(legacyBin, 'trace-mcp');
+      fs.symlinkSync(targetShim, legacyShim);
+
+      const isolatedHome = fs.mkdtempSync(path.join(FIXTURES, 'isolated-home-'));
+
+      const res = spawnSync(legacyShim, ['serve'], {
+        env: {
+          HOME: isolatedHome,
+          PATH: '/usr/bin:/bin',
+        },
+        encoding: 'utf-8',
+      });
+
+      expect(res.status).toBe(0);
+      expect(res.stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+    });
+
+    it('never executes a node found via relative path or inside PWD from CLIENT_PATH', () => {
+      const { home, traceHome, cli } = setupFakeHome();
+      writeConfig(traceHome, '/nonexistent/node', cli);
+
+      const untrustedRepo = fs.mkdtempSync(path.join(FIXTURES, 'untrusted-repo-'));
+      const maliciousNode = path.join(untrustedRepo, 'node');
+      fs.writeFileSync(maliciousNode, '#!/bin/bash\necho "EXPLOITED"\nexit 0\n', { mode: 0o755 });
+
+      const validLocalBin = path.join(home, '.local', 'bin');
+      fs.mkdirSync(validLocalBin, { recursive: true });
+      const validNode = path.join(validLocalBin, 'node');
+      fs.writeFileSync(validNode, fakeNodeBody('22.22.2', 'SAFE_NODE'), { mode: 0o755 });
+
+      const res = spawnSync(LAUNCHER_SRC, ['serve'], {
+        cwd: untrustedRepo,
+        env: {
+          HOME: home,
+          TRACE_MCP_HOME: traceHome,
+          PATH: `.:./bin:${untrustedRepo}:/usr/bin:/bin`,
+        },
+        encoding: 'utf-8',
+      });
+
+      expect(res.stdout).not.toContain('EXPLOITED');
+      expect(res.stdout).toContain('SAFE_NODE');
+      expect(res.status).toBe(0);
+    });
   });
 });

--- a/tests/scripts/postinstall-control-plane.test.ts
+++ b/tests/scripts/postinstall-control-plane.test.ts
@@ -393,4 +393,10 @@ describe('postinstall-control-plane', () => {
       expect(src).toContain('<integer>${PLIST_EXIT_TIMEOUT_SEC}</integer>');
     }
   });
+
+  it('atomic writes in postinstall script use 12-char hex random suffix matching ORPHAN_TMP_PATTERN', () => {
+    const script = fs.readFileSync(SCRIPT_PATH, 'utf-8');
+    expect(script).not.toMatch(/\.tmp\.\$\{process\.pid\}\.\$\{Date\.now\(\)\}/);
+    expect(script).toMatch(/const rand = randomBytes\(6\)\.toString\('hex'\)/);
+  });
 });


### PR DESCRIPTION
## Summary
This PR hardens MCP launcher resilience and connection stability across client lifecycles:

1. **State Home Self-Location under Isolated `$HOME`**:
   - Self-locate canonical state home (`TRACE_HOME`) from the enclosing parent directory of the shim (`<SHIM_DIR>/..`) when `TRACE_MCP_HOME` / `TRACE_MCP_DATA_DIR` are unset and a valid configuration exists (`launcher.env` or `.config.json`).
   - Recursively dereference symlink invocations (e.g. `~/.trace-mcp/bin/trace-mcp` -> `~/.trace/bin/trace`) via `readlink` before deriving `SHIM_DIR` so that migrated symlink setups locate their config under isolated `$HOME`.
   - Prevents `'node binary not found'` and `'package not found'` when MCP clients run under isolated or altered `$HOME` (e.g. Antigravity, container runners, Claude Code isolated sessions).
   - Export `TRACE_MCP_HOME` and `TRACE_MCP_DATA_DIR` to the child process so `src/global.ts` aligns with the launcher's resolved root.

2. **Survive In-Flight Package Directory Swap during Updates**:
   - Add a retry loop in `probe_cli` (up to 5 attempts, ~1.5s backoff) in bash and PowerShell shims. When `npm i -g trace-mcp` or self-updater removes `cli.js` momentarily during update directory replacement, client launcher invocations retry rather than terminating with exit 127.

3. **Node Discovery & Security Containment**:
   - Add discovery for `~/.local/bin/node`.
   - Strictly sanitize `CLIENT_PATH` (candidate 4f): require absolute paths (`/*`), and reject entries resolving inside `$PWD`, physical `pwd_real`, or containing `node_modules` to prevent executing untrusted workspace-local binaries.

4. **State Hygiene**:
   - Standardize atomic write tmp file suffix in `scripts/postinstall-control-plane.mjs` to `.<filename>.tmp.<randomBytes(6).hex>` so orphaned temporary files are cleaned up by the background sweep.
   - Bump `LAUNCHER_VERSION` to `0.6.11`.

## Verification & Testing
- `tests/init/launcher-integration.test.ts`: 77/77 passing (including isolated HOME, symlink resolution, CLIENT_PATH containment, and update swap retry).
- Full `tests/init/` suite: 18 test files, 334 tests passing.
- `tests/scripts/postinstall-control-plane.test.ts`: 9/9 passing.
- `src/utils/__tests__/atomic-write-sweep.test.ts`: 15/15 passing.
- `pnpm typecheck`: 0 errors.
- `pnpm biome:ci`: 1,902 files checked, 0 errors.
- Live client check: `claude mcp list` connected; live shim invocation verified under isolated `$HOME`.
- Second-model review: APPROVED by Reviewer C.
