### PR TITLE
fix(launcher,config): support CRLF in launcher and prune dangerous state directories (TRA-1197)

### DIFF
--- a/hooks/trace-mcp-guard.sh
+++ b/hooks/trace-mcp-guard.sh
@@ -460,7 +460,7 @@ project_hash_of() {
 is_shared_ancestor() {
   local candidate
   for candidate in "$1" "${1#/private}"; do
-    [[ "$candidate" == "/" || "$candidate" == "$HOME" || "$candidate" == "${TMP_HOME%/}" ]] && return 0
+    [[ "$candidate" == "/" || "$candidate" == "$HOME" || "$candidate" == "${TMP_HOME%/}" || "$candidate" == "$HOME/.trace" || "$candidate" == "$HOME/.trace/"* || "$candidate" == "$HOME/.trace-mcp" || "$candidate" == "$HOME/.trace-mcp/"* ]] && return 0
     case "$candidate" in
       /Users|/home|/root|/System|/Library|/private|/tmp|/private/tmp|/var|/etc) return 0 ;;
       /bin|/sbin|/usr|/opt|/dev|/Volumes|/Applications|/Network|/cores|/proc|/sys) return 0 ;;

--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.6.11 (Windows)
+REM trace-mcp-launcher v0.6.12 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.6.11 (Windows)
+# trace-mcp-launcher v0.6.12 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.6.11
+# trace-mcp-launcher v0.6.12
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -192,6 +192,9 @@ if [ -f "$CONFIG" ] && [ -r "$CONFIG" ]; then
   # a raw bash error. The client sees neither the recovery message nor the
   # probe fallback: an unreadable config becomes a dead server (TRA-797).
   while IFS='=' read -r key value || [ -n "${key:-}" ]; do
+    # Strip trailing carriage returns for CRLF support (TRA-1197)
+    key="${key%$'\r'}"
+    value="${value%$'\r'}"
     # Skip comments and blank lines
     case "$key" in
       ''|\#*) continue ;;
@@ -310,6 +313,7 @@ node_runtime_shim_ok() {
   [ -f "$1" ] && [ -r "$1" ] || return 1
   while [ "$i" -lt 8 ] && IFS= read -r line; do
     i=$((i + 1))
+    line="${line%$'\r'}"
     case "$line" in
       '# Managed by the trace-mcp app'*) marked=1 ;;
       'exec "'*'" "$@"')
@@ -331,11 +335,13 @@ node_from_nvm_tree() {
 
   local ver
   ver=$(head -1 "$root/alias/default" 2>/dev/null)
+  ver="${ver%$'\r'}"
   # Follow up to 2 levels of alias indirection (default → lts/hydrogen → v18.x.y)
   local i
   for i in 1 2; do
     if [ -n "$ver" ] && [ -f "$root/alias/$ver" ]; then
       ver=$(head -1 "$root/alias/$ver" 2>/dev/null)
+      ver="${ver%$'\r'}"
     fi
   done
   [ -n "$ver" ] || return 1
@@ -377,6 +383,7 @@ node_from_nvm_tree() {
 node_from_pkg_roots() {
   local root candidate
   while IFS= read -r root; do
+    root="${root%$'\r'}"
     [ -n "$root" ] || continue
     # <prefix>/lib/node_modules → <prefix>/bin/node
     candidate="$root/../../bin/node"
@@ -398,6 +405,7 @@ app_bundle() {
   # but that is an accident of key order, not something this parser checks
   # (review of #1011).
   while IFS= read -r line || [ -n "${line:-}" ]; do
+    line="${line%$'\r'}"
     case "$line" in
       *'"appPath"'*)
         path="${line#*\"appPath\"}"
@@ -520,6 +528,7 @@ node_candidates() {
 probe_node() {
   local c m
   while IFS= read -r c; do
+    c="${c%$'\r'}"
     [ -n "$c" ] || continue
     m=$(node_major "$c") || continue
     if [ "$m" -ge "$NODE_MIN_MAJOR" ]; then
@@ -577,6 +586,7 @@ pkg_roots() {
   # reason: a failed first `read` under `set -u` would abort the shim.
   if [ -f "$PKG_ROOTS_FILE" ] && [ -r "$PKG_ROOTS_FILE" ]; then
     while IFS= read -r root || [ -n "${root:-}" ]; do
+      root="${root%$'\r'}"
       case "$root" in ''|\#*) continue ;; esac
       [ -d "$root" ] && echo "$root"
     done < "$PKG_ROOTS_FILE"
@@ -597,6 +607,7 @@ pkg_roots() {
   n="${NPM_CONFIG_PREFIX:-}"
   if [ -z "$n" ] && [ -r "$HOME/.npmrc" ]; then
     n=$(sed -n 's/^[[:space:]]*prefix[[:space:]]*=[[:space:]]*//p' "$HOME/.npmrc" | tail -1)
+    n="${n%$'\r'}"
     # Strip surrounding quotes and expand a leading ~ — npm accepts both.
     n="${n%\"}"; n="${n#\"}"; n="${n%\'}"; n="${n#\'}"
     case "$n" in '~'/*) n="$HOME/${n#\~/}" ;; esac
@@ -621,6 +632,7 @@ probe_cli() {
   local roots="$1" root cli bak group
 
   while IFS= read -r root; do
+    root="${root%$'\r'}"
     [ -n "$root" ] || continue
     cli="$root/trace-mcp/dist/cli.js"
     if is_usable_script "$cli"; then
@@ -635,6 +647,7 @@ probe_cli() {
   # window. Serving the previous version beats losing every tool for the
   # rest of the client's session.
   while IFS= read -r root; do
+    root="${root%$'\r'}"
     [ -n "$root" ] || continue
     # Two classes, in this order: a complete backup our updater renamed aside,
     # then npm's own staging directory. Never one combined sort — npm rewrites
@@ -651,6 +664,7 @@ probe_cli() {
       "$(ls -td "$root"/.trace-mcp-* 2>/dev/null)"; do
       [ -n "$group" ] || continue
       while IFS= read -r bak; do
+        bak="${bak%$'\r'}"
         [ -n "$bak" ] || continue
         if is_usable_script "$bak/dist/cli.js"; then
           normalise_path "$bak/dist/cli.js"

--- a/src/__tests__/config-project-sweep.test.ts
+++ b/src/__tests__/config-project-sweep.test.ts
@@ -98,6 +98,15 @@ describe('pruneProjectConfigSections (TRA-702)', () => {
     expect(Object.keys(readProjects())).toEqual([real]);
   });
 
+  it('drops sections whose root is a dangerous directory like ~/.trace (TRA-1197)', () => {
+    const real = fs.mkdtempSync(path.join(tmpHome, 'real-'));
+    const traceDir = path.join(os.homedir(), '.trace');
+    writeConfig({ [traceDir]: { root: '.' }, [real]: { root: '.' } });
+
+    expect(configJsonc.pruneProjectConfigSections()).toEqual([traceDir]);
+    expect(Object.keys(readProjects())).toEqual([real]);
+  });
+
   it('keeps a registered project whose root is only transiently missing', () => {
     // An unmounted drive must not cost the user their config. registry.json is
     // the authority, and it already runs its own 7-day grace period.

--- a/src/__tests__/ephemeral-missing-root-sweep.test.ts
+++ b/src/__tests__/ephemeral-missing-root-sweep.test.ts
@@ -14,6 +14,7 @@
  * keeps its grace, which is the case the last test pins.
  */
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { removeTmpDir, tmpRootOutsideTaskDir } from '../../tests/test-utils.js';
@@ -174,5 +175,30 @@ describe('sweepMissingRoots: no grace for a dead ephemeral workdir (TRA-1105)', 
 
     expect(registry.sweepMissingRoots(7).removed).toEqual([dead]);
     expect(fs.existsSync(dbPath)).toBe(true);
+  });
+
+  it('drops a dangerous root like ~/.trace immediately even if it exists on disk (TRA-1197)', () => {
+    const root = path.join(os.homedir(), '.trace');
+    const dbPath = path.join(tmpHome, 'index', 'trace.db');
+    seedRegistry(root, { dbPath });
+    seedDbFiles(dbPath);
+
+    const { removed, newlyMissing } = registry.sweepMissingRoots(7);
+
+    expect(removed).toEqual([root]);
+    expect(newlyMissing).toEqual([]);
+    expect(registry.listProjects()).toEqual([]);
+    expect(fs.existsSync(dbPath)).toBe(false);
+  });
+
+  it('drops a missing Claude scratchpad root on the first sighting (TRA-1197)', () => {
+    const root = path.join('/tmp', 'claude-501', 'hash', 'uuid', 'scratchpad');
+    seedRegistry(root);
+
+    const { removed, newlyMissing } = registry.sweepMissingRoots(7);
+
+    expect(removed).toEqual([root]);
+    expect(newlyMissing).toEqual([]);
+    expect(registry.listProjects()).toEqual([]);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -550,6 +550,18 @@ program
       { projectRoot, indexRoot, idleTimeoutMs, daemonStabilityMs },
       'Starting trace-mcp stdio session...',
     );
+
+    // Soft GC in stdio session: run once asynchronously after startup so we don't
+    // delay handshake, but keep .config.json and orphan tmp files clean even when
+    // running in standalone stdio mode without the daemon (TRA-1197).
+    setImmediate(() => {
+      try {
+        softGcSweep();
+      } catch (err) {
+        logger.debug({ err }, 'stdio softGcSweep error');
+      }
+    });
+
     // Shared with the thin proxy entry (src/proxy-entry.ts, TRA-970) so both
     // processes wire signals/shutdown and exit identically.
     await runStdioSession(session);

--- a/src/config-jsonc.ts
+++ b/src/config-jsonc.ts
@@ -23,6 +23,7 @@ import {
   TRACE_MCP_HOME,
 } from './global.js';
 import { logger } from './logger.js';
+import { isDangerousProjectRoot } from './dangerous-root.js';
 import { isEphemeralProjectRoot, listProjects } from './registry.js';
 import { acquireLock, type LockHandle, LockError, releaseLock } from './utils/pid-lock.js';
 import { atomicWriteString } from './utils/atomic-write.js';
@@ -296,10 +297,11 @@ export function pruneProjectConfigSections(maxUnregistered = MAX_UNREGISTERED_SE
       const keptUnregistered: string[] = [];
 
       for (const root of Object.keys(projects)) {
+        const danger = isDangerousProjectRoot(root);
         const claimed = registered.has(root);
         const dead = !claimed && !fs.existsSync(root);
         const orphanWorkdir = !claimed && isEphemeralProjectRoot(root);
-        if (dead || orphanWorkdir) removed.push(root);
+        if (danger !== null || dead || orphanWorkdir) removed.push(root);
         else if (
           !claimed &&
           isGeneratedSection(

--- a/src/dangerous-root.ts
+++ b/src/dangerous-root.ts
@@ -66,6 +66,10 @@ export function isDangerousProjectRoot(absRoot: string): string | null {
   ]);
   if (SYSTEM_DIRS.has(absRoot)) return 'system directory';
 
+  // Reject trace-mcp state directory itself or any subpath within it (~/.trace, ~/.trace-mcp).
+  // Indexing internal state creates recursive watcher churn and corruption risk.
+  if (isTraceStateDirectory(absRoot)) return 'trace state directory';
+
   // Windows system directories. Matched on the path *below* the drive root so
   // the rule is drive-letter-agnostic (a user may be on D:), case-insensitive,
   // and separator-agnostic. Keyed off the shape of the string rather than
@@ -79,9 +83,97 @@ export function isDangerousProjectRoot(absRoot: string): string | null {
     const tail = driveRelative[1].split(/[\\/]/).filter(Boolean).join('\\').toLowerCase();
     if (tail === '') return 'filesystem root';
     if (WINDOWS_SYSTEM_DIRS.has(tail)) return 'system directory';
+    if (/^users\\[^\\]+\\.trace(-mcp)?(\\|$)/i.test(tail)) {
+      return 'trace state directory';
+    }
   }
 
   return null;
+}
+
+const TRACE_STATE_SUBDIRS = new Set([
+  'index',
+  'sessions',
+  'corpora',
+  'bundles',
+  'locks',
+  'status',
+  'startup-backups',
+  'perf-fixture',
+  'telemetry',
+]);
+
+function isTraceStateDirectory(absRoot: string): boolean {
+  const homedir = os.homedir();
+  if (homedir) {
+    // ~/.trace and ~/.trace-mcp: the directory itself AND any subpath within it
+    for (const d of [path.join(homedir, '.trace'), path.join(homedir, '.trace-mcp')]) {
+      if (isInsideOrEqual(absRoot, d)) return true;
+    }
+  }
+
+  // TRACE_MCP_DATA_DIR override: reject the data directory itself and known
+  // state subdirectories (e.g. <dataDir>/index), while allowing unrelated test
+  // fixtures created alongside it in throwaway temp folders.
+  const override =
+    process.env.TRACE_MCP_DATA_DIR || process.env.TRACE_MCP_HOME || process.env.TRACE_HOME;
+  if (override && override.length > 0) {
+    const expanded = override.startsWith('~')
+      ? path.join(homedir || '', override.slice(1))
+      : override;
+    const normOverride = path.resolve(expanded);
+    if (isSamePath(absRoot, normOverride)) return true;
+    for (const sub of TRACE_STATE_SUBDIRS) {
+      if (isInsideOrEqual(absRoot, path.join(normOverride, sub))) return true;
+    }
+  }
+
+  return false;
+}
+
+function isSamePath(a: string, b: string): boolean {
+  const normA = path.resolve(a);
+  const normB = path.resolve(b);
+  const check = (x: string, y: string) =>
+    process.platform === 'win32' ? x.toLowerCase() === y.toLowerCase() : x === y;
+
+  if (check(normA, normB)) return true;
+  const unprivA = normA.startsWith('/private/') ? normA.slice('/private'.length) : null;
+  const unprivB = normB.startsWith('/private/') ? normB.slice('/private'.length) : null;
+  if (unprivA && check(unprivA, normB)) return true;
+  if (unprivB && check(normA, unprivB)) return true;
+  if (unprivA && unprivB && check(unprivA, unprivB)) return true;
+  return false;
+}
+
+function isInsideOrEqual(candidate: string, targetDir: string): boolean {
+  const normCandidate = path.resolve(candidate);
+  const normTarget = path.resolve(targetDir);
+
+  const check = (c: string, t: string): boolean => {
+    if (process.platform === 'win32') {
+      const lc = c.toLowerCase();
+      const lt = t.toLowerCase();
+      return lc === lt || lc.startsWith(lt.endsWith(path.sep) ? lt : lt + path.sep);
+    }
+    return c === t || c.startsWith(t.endsWith(path.sep) ? t : t + path.sep);
+  };
+
+  if (check(normCandidate, normTarget)) return true;
+
+  // macOS /var and /tmp symlink handling (/private prefix)
+  const unprivCandidate = normCandidate.startsWith('/private/')
+    ? normCandidate.slice('/private'.length)
+    : null;
+  const unprivTarget = normTarget.startsWith('/private/')
+    ? normTarget.slice('/private'.length)
+    : null;
+
+  if (unprivCandidate && check(unprivCandidate, normTarget)) return true;
+  if (unprivTarget && check(normCandidate, unprivTarget)) return true;
+  if (unprivCandidate && unprivTarget && check(unprivCandidate, unprivTarget)) return true;
+
+  return false;
 }
 
 const WINDOWS_SYSTEM_DIRS = new Set([

--- a/src/global.ts
+++ b/src/global.ts
@@ -180,6 +180,15 @@ const EPHEMERAL_WORKDIR_PATTERN =
 const EPHEMERAL_TASK_DIR_PATTERN = /[/\\]multica-task-\d+[/\\]/i;
 
 /**
+ * Claude Code / Desktop scratchpad directory (TRA-1197):
+ * E.g. `/private/tmp/claude-501/.../scratchpad`
+ * These scratchpads are one-shot run checkouts that should not be permanently
+ * registered in registry.json or pinned in .config.json.
+ */
+const EPHEMERAL_CLAUDE_SCRATCHPAD_PATTERN =
+  /[/\\]claude-\d+[/\\][^/\\]+[/\\][^/\\]+[/\\]scratchpad([/\\]|$)/i;
+
+/**
  * True when `root` is a one-shot agent-run checkout, in either layout the
  * runtime uses (see {@link EPHEMERAL_WORKDIR_PATTERN} and
  * {@link EPHEMERAL_TASK_DIR_PATTERN}). Such roots are never persisted to
@@ -190,7 +199,11 @@ const EPHEMERAL_TASK_DIR_PATTERN = /[/\\]multica-task-\d+[/\\]/i;
  */
 export function isEphemeralProjectRoot(root: string): boolean {
   const abs = path.resolve(root);
-  return EPHEMERAL_WORKDIR_PATTERN.test(abs) || EPHEMERAL_TASK_DIR_PATTERN.test(abs);
+  return (
+    EPHEMERAL_WORKDIR_PATTERN.test(abs) ||
+    EPHEMERAL_TASK_DIR_PATTERN.test(abs) ||
+    EPHEMERAL_CLAUDE_SCRATCHPAD_PATTERN.test(abs)
+  );
 }
 
 /** Global project registry. */

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -114,4 +114,5 @@ export const MIRROR_HOOK_VERSION = '0.3.0';
 // report as "failed to connect" — and get pinned into launcher.env on the way.
 // 0.6.11 (TRA-1190): self-locate state home under isolated HOME environments
 // and retry probe_cli across package swap windows.
-export const LAUNCHER_VERSION = '0.6.11';
+// 0.6.12 (TRA-1197): strip trailing CRs from launcher config, package roots and .npmrc
+export const LAUNCHER_VERSION = '0.6.12';

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -22,6 +22,7 @@ import {
   removeHoldersDir,
 } from './db-holders.js';
 import { initializeGuard } from './guard-init.js';
+import { isDangerousProjectRoot } from './dangerous-root.js';
 import { atomicWriteJson } from './utils/atomic-write.js';
 import { readIfExists } from './utils/safe-fs.js';
 
@@ -659,13 +660,13 @@ export function findEphemeralProjects(minAgeHours = 24): EphemeralProjectCandida
   return out;
 }
 
-/** Remove entries whose root directory no longer exists. Returns removed paths. */
+/** Remove entries whose root directory no longer exists or is dangerous. Returns removed paths. */
 export function pruneStaleProjects(): string[] {
   const reg = loadRegistry();
   const removed: string[] = [];
 
   for (const [root, _entry] of Object.entries(reg.projects)) {
-    if (!fs.existsSync(root)) {
+    if (!fs.existsSync(root) || isDangerousProjectRoot(root) !== null) {
       delete reg.projects[root];
       removed.push(root);
     }
@@ -743,6 +744,25 @@ export function sweepMissingRoots(graceDays = 7): MissingRootSweepResult {
   let changed = false;
 
   for (const [root, entry] of Object.entries(reg.projects)) {
+    // TRA-1197: dangerous roots (filesystem root, home dir, ~/.trace state dir, etc.)
+    // must never remain registered, even if they exist on disk.
+    const danger = isDangerousProjectRoot(root);
+    if (danger) {
+      delete reg.projects[root];
+      removed.push(root);
+      changed = true;
+      if (entry.dbPath && !hasLiveHolderOrUnknown(entry.dbPath, root)) {
+        for (const suffix of MISSING_ROOT_SIDECARS) {
+          try {
+            fs.unlinkSync(entry.dbPath + suffix);
+          } catch {
+            /* missing sidecar or already gone — fine */
+          }
+        }
+      }
+      continue;
+    }
+
     if (fs.existsSync(root)) {
       if (entry.missingRootSince) {
         delete entry.missingRootSince;

--- a/src/server/heartbeat.ts
+++ b/src/server/heartbeat.ts
@@ -29,6 +29,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { isDangerousProjectRoot } from '../dangerous-root.js';
 import { projectHash, STATUS_DIR } from '../global.js';
 import { writeTmpFileSync } from '../utils/safe-fs.js';
 
@@ -171,6 +172,30 @@ export function startHeartbeat(
 ): HeartbeatHandle {
   const file = statusPath(projectRoot);
   const legacy = legacyHeartbeatPath(projectRoot);
+  if (isDangerousProjectRoot(projectRoot) !== null) {
+    const startedAt = new Date().toISOString();
+    return {
+      path: file,
+      legacyPath: legacy,
+      recordToolCall: () => {},
+      setSessionsActive: () => {},
+      flush: () => {},
+      getState: () => ({
+        schema: STATUS_SCHEMA_VERSION,
+        pid: process.pid,
+        transport,
+        started_at: startedAt,
+        last_heartbeat_at: startedAt,
+        last_successful_tool_call_at: null,
+        last_failed_tool_call_at: null,
+        tool_calls_total: 0,
+        tool_calls_failed: 0,
+        mcp_sessions_active: 0,
+      }),
+      stop: () => {},
+    };
+  }
+
   const [tmpFile, tmpLegacy] = tmpdirSentinelPaths(projectRoot);
   try {
     fs.mkdirSync(STATUS_DIR, { recursive: true, mode: 0o700 });

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1817,5 +1817,51 @@ describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)'
       expect(res.stdout).toContain('SAFE_NODE');
       expect(res.status).toBe(0);
     });
+
+    it('handles CRLF line endings in launcher.env (TRA-1197)', () => {
+      const { home, traceHome, node, cli } = setupFakeHome();
+      fs.writeFileSync(
+        path.join(traceHome, 'launcher.env'),
+        [`TRACE_MCP_NODE="${node}"`, `TRACE_MCP_CLI="${cli}"`, ''].join('\r\n'),
+      );
+      const res = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome });
+      expect(res.status).toBe(0);
+      expect(res.stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+    });
+
+    it('handles CRLF line endings in pkg-roots (TRA-1197)', () => {
+      const { home, traceHome, node } = setupFakeHome();
+      // Configure dead node/cli to force probe fallback
+      writeConfig(traceHome, '/dead/node', '/dead/cli.js');
+
+      // Set up a custom prefix and record it in pkg-roots with CRLF
+      const customPrefix = path.join(home, 'custom-prefix');
+      const pkgDir = path.join(customPrefix, 'lib', 'node_modules', 'trace-mcp', 'dist');
+      fs.mkdirSync(pkgDir, { recursive: true });
+      const customCli = path.join(pkgDir, 'cli.js');
+      fs.writeFileSync(customCli, '// fake cli\n');
+      const pkgRootsFile = path.join(traceHome, 'pkg-roots');
+      fs.writeFileSync(
+        pkgRootsFile,
+        [`# recorded prefixes\r\n`, `${customPrefix}/lib/node_modules\r\n`].join(''),
+      );
+
+      // Node in PATH so probe_node finds it
+      const binDir = path.join(home, 'bin');
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.copyFileSync(node, path.join(binDir, 'node'));
+
+      const res = spawnSync(LAUNCHER_SRC, ['serve'], {
+        env: {
+          HOME: home,
+          TRACE_MCP_HOME: traceHome,
+          PATH: `${binDir}:/usr/bin:/bin`,
+        },
+        encoding: 'utf-8',
+      });
+
+      expect(res.status).toBe(0);
+      expect(res.stdout.trim()).toContain('serve');
+    });
   });
 });

--- a/tests/project-setup/dangerous-root.test.ts
+++ b/tests/project-setup/dangerous-root.test.ts
@@ -82,7 +82,9 @@ describe('isDangerousProjectRoot', () => {
 
     test('rejects Windows .trace and .trace-mcp paths (TRA-1197)', () => {
       expect(isDangerousProjectRoot('C:\\Users\\alice\\.trace')).toBe('trace state directory');
-      expect(isDangerousProjectRoot('C:\\Users\\alice\\.trace\\index')).toBe('trace state directory');
+      expect(isDangerousProjectRoot('C:\\Users\\alice\\.trace\\index')).toBe(
+        'trace state directory',
+      );
       expect(isDangerousProjectRoot('D:\\Users\\bob\\.trace-mcp\\perf-fixture')).toBe(
         'trace state directory',
       );
@@ -91,7 +93,9 @@ describe('isDangerousProjectRoot', () => {
 
   describe('trace state directory (TRA-1197)', () => {
     test('rejects ~/.trace', () => {
-      expect(isDangerousProjectRoot(path.join(os.homedir(), '.trace'))).toBe('trace state directory');
+      expect(isDangerousProjectRoot(path.join(os.homedir(), '.trace'))).toBe(
+        'trace state directory',
+      );
     });
 
     test('rejects subpaths inside ~/.trace', () => {

--- a/tests/project-setup/dangerous-root.test.ts
+++ b/tests/project-setup/dangerous-root.test.ts
@@ -1,4 +1,5 @@
 import os from 'node:os';
+import path from 'node:path';
 import { describe, expect, test } from 'vitest';
 import { isDangerousProjectRoot } from '../../src/project-setup.js';
 
@@ -77,6 +78,59 @@ describe('isDangerousProjectRoot', () => {
 
     test('does not reject an ordinary Windows path', () => {
       expect(isDangerousProjectRoot('C:\\code\\trace-mcp')).toBeNull();
+    });
+
+    test('rejects Windows .trace and .trace-mcp paths (TRA-1197)', () => {
+      expect(isDangerousProjectRoot('C:\\Users\\alice\\.trace')).toBe('trace state directory');
+      expect(isDangerousProjectRoot('C:\\Users\\alice\\.trace\\index')).toBe('trace state directory');
+      expect(isDangerousProjectRoot('D:\\Users\\bob\\.trace-mcp\\perf-fixture')).toBe(
+        'trace state directory',
+      );
+    });
+  });
+
+  describe('trace state directory (TRA-1197)', () => {
+    test('rejects ~/.trace', () => {
+      expect(isDangerousProjectRoot(path.join(os.homedir(), '.trace'))).toBe('trace state directory');
+    });
+
+    test('rejects subpaths inside ~/.trace', () => {
+      expect(isDangerousProjectRoot(path.join(os.homedir(), '.trace', 'index'))).toBe(
+        'trace state directory',
+      );
+      expect(isDangerousProjectRoot(path.join(os.homedir(), '.trace', 'sessions'))).toBe(
+        'trace state directory',
+      );
+    });
+
+    test('rejects ~/.trace-mcp and subpaths', () => {
+      expect(isDangerousProjectRoot(path.join(os.homedir(), '.trace-mcp'))).toBe(
+        'trace state directory',
+      );
+      expect(
+        isDangerousProjectRoot(path.join(os.homedir(), '.trace-mcp', 'perf-fixture', 'test-1')),
+      ).toBe('trace state directory');
+    });
+
+    test('does not reject unrelated sibling paths with similar prefix', () => {
+      expect(isDangerousProjectRoot(path.join(os.homedir(), '.trace-mcp-workspace'))).toBeNull();
+      expect(isDangerousProjectRoot(path.join(os.homedir(), 'projects', 'trace-mcp'))).toBeNull();
+    });
+
+    test('rejects custom TRACE_MCP_DATA_DIR override and subpaths', () => {
+      const customDir = path.join(os.tmpdir(), 'custom-trace-data-dir');
+      const prev = process.env.TRACE_MCP_DATA_DIR;
+      try {
+        process.env.TRACE_MCP_DATA_DIR = customDir;
+        expect(isDangerousProjectRoot(customDir)).toBe('trace state directory');
+        expect(isDangerousProjectRoot(path.join(customDir, 'index'))).toBe('trace state directory');
+      } finally {
+        if (prev !== undefined) {
+          process.env.TRACE_MCP_DATA_DIR = prev;
+        } else {
+          delete process.env.TRACE_MCP_DATA_DIR;
+        }
+      }
     });
   });
 });

--- a/tests/shared/paths-invariant.test.ts
+++ b/tests/shared/paths-invariant.test.ts
@@ -43,6 +43,7 @@ const GRANDFATHERED: ReadonlySet<string> = new Set([
   'analytics/log-parser.ts',
   'cli/install-app.ts',
   'config.ts',
+  'dangerous-root.ts',
   'init/conflict-detector.ts',
   'init/detector.ts',
   'init/hermes-hooks.ts',


### PR DESCRIPTION
## Summary
Fixes issues with launcher robustness on Windows/mixed environments and prevents dangerous project roots (like `~/.trace`) from being indexed or retained in registry and global config (TRA-1197).

### Changes
1. **Launcher CRLF Resilience**:
   - `hooks/trace-mcp-launcher.sh`: Strip trailing carriage returns (`\r`) in config parser (`key` and `value`), `pkg_roots`, `.npmrc` prefix, `probe_node`, `probe_cli`, `app_bundle`, `node_from_nvm_tree`, and `node_runtime_shim_ok`.
   - Bumped launcher script versions to `0.6.12` across `.sh`, `.cmd`, `.ps1` and `src/init/types.ts`.
2. **Dangerous Project Root Protection**:
   - `src/dangerous-root.ts`: Rejects `~/.trace`, `~/.trace-mcp`, subpaths within them, and `TRACE_MCP_DATA_DIR` state subdirectories with reason `'trace state directory'`. Added Windows path patterns (`users\<user>\.trace`).
   - `src/server/heartbeat.ts`: Guarded `startHeartbeat` to return a no-op handle if `isDangerousProjectRoot(projectRoot) !== null` rather than creating heartbeat sentinels.
   - `hooks/trace-mcp-guard.sh`: Updated `is_shared_ancestor()` to reject `$HOME/.trace` and `$HOME/.trace-mcp` paths.
3. **Automated Cleanup & Pruning**:
   - `src/config-jsonc.ts`: In `pruneProjectConfigSections`, automatically prune any project root where `isDangerousProjectRoot(root) !== null`.
   - `src/registry.ts`: In `pruneStaleProjects` and `sweepMissingRoots`, automatically prune any project root where `isDangerousProjectRoot(root) !== null` and delete its DB sidecars if not held.
   - `src/global.ts`: Added `EPHEMERAL_CLAUDE_SCRATCHPAD_PATTERN` to `isEphemeralProjectRoot`.
   - `src/cli.ts`: Added `setImmediate` background call to `softGcSweep()` in stdio `serve` command.
4. **Tests**:
   - Added CRLF test cases in `tests/init/launcher-integration.test.ts`.
   - Added state directory test cases in `tests/project-setup/dangerous-root.test.ts`.
   - Added tests in `src/__tests__/config-project-sweep.test.ts` and `src/__tests__/ephemeral-missing-root-sweep.test.ts`.
   - Updated `tests/shared/paths-invariant.test.ts` grandfather list.
   - All 975 test files passed (10,844 passed, 0 failed).