### PR TITLE
fix(registry,dangerous-root): preserve shared index DB and protect state subdirs (TRA-1197)

### DIFF
--- a/src/__tests__/ephemeral-missing-root-sweep.test.ts
+++ b/src/__tests__/ephemeral-missing-root-sweep.test.ts
@@ -191,6 +191,26 @@ describe('sweepMissingRoots: no grace for a dead ephemeral workdir (TRA-1105)', 
     expect(fs.existsSync(dbPath)).toBe(false);
   });
 
+  it('does NOT delete the index DB when a dangerous root shares it with a live project (TRA-1197)', () => {
+    const dangerous = path.join(os.homedir(), '.trace');
+    const live = path.join(tmpHome, 'live-project');
+    fs.mkdirSync(live, { recursive: true });
+    const sharedDb = path.join(tmpHome, 'index', 'shared.db');
+
+    seedRegistryRows([
+      { root: dangerous, dbPath: sharedDb },
+      { root: live, dbPath: sharedDb },
+    ]);
+    seedDbFiles(sharedDb);
+
+    const { removed } = registry.sweepMissingRoots(7);
+
+    expect(removed).toEqual([dangerous]);
+    expect(registry.listProjects().map((p) => p.root)).toEqual([live]);
+    expect(fs.existsSync(sharedDb)).toBe(true);
+    expect(fs.existsSync(`${sharedDb}-wal`)).toBe(true);
+  });
+
   it('drops a missing Claude scratchpad root on the first sighting (TRA-1197)', () => {
     const root = path.join('/tmp', 'claude-501', 'hash', 'uuid', 'scratchpad');
     seedRegistry(root);

--- a/src/dangerous-root.ts
+++ b/src/dangerous-root.ts
@@ -101,6 +101,11 @@ const TRACE_STATE_SUBDIRS = new Set([
   'startup-backups',
   'perf-fixture',
   'telemetry',
+  'decisions',
+  'logs',
+  'metrics',
+  'bin',
+  'mirror',
 ]);
 
 function isTraceStateDirectory(absRoot: string): boolean {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -751,7 +751,10 @@ export function sweepMissingRoots(graceDays = 7): MissingRootSweepResult {
       delete reg.projects[root];
       removed.push(root);
       changed = true;
-      if (entry.dbPath && !hasLiveHolderOrUnknown(entry.dbPath, root)) {
+      const sharedWithSibling = Object.values(reg.projects).some(
+        (other) => other.dbPath === entry.dbPath,
+      );
+      if (entry.dbPath && !sharedWithSibling && !hasLiveHolderOrUnknown(entry.dbPath, root)) {
         for (const suffix of MISSING_ROOT_SIDECARS) {
           try {
             fs.unlinkSync(entry.dbPath + suffix);

--- a/tests/project-setup/dangerous-root.test.ts
+++ b/tests/project-setup/dangerous-root.test.ts
@@ -128,6 +128,40 @@ describe('isDangerousProjectRoot', () => {
         process.env.TRACE_MCP_DATA_DIR = customDir;
         expect(isDangerousProjectRoot(customDir)).toBe('trace state directory');
         expect(isDangerousProjectRoot(path.join(customDir, 'index'))).toBe('trace state directory');
+        expect(isDangerousProjectRoot(path.join(customDir, 'decisions'))).toBe(
+          'trace state directory',
+        );
+        expect(isDangerousProjectRoot(path.join(customDir, 'logs'))).toBe('trace state directory');
+        expect(isDangerousProjectRoot(path.join(customDir, 'metrics'))).toBe(
+          'trace state directory',
+        );
+        expect(isDangerousProjectRoot(path.join(customDir, 'sessions'))).toBe(
+          'trace state directory',
+        );
+        expect(isDangerousProjectRoot(path.join(customDir, 'locks'))).toBe('trace state directory');
+      } finally {
+        if (prev !== undefined) {
+          process.env.TRACE_MCP_DATA_DIR = prev;
+        } else {
+          delete process.env.TRACE_MCP_DATA_DIR;
+        }
+      }
+    });
+
+    test('rejects decisions, logs, metrics under arbitrary TRACE_MCP_DATA_DIR', () => {
+      const reviewDir = '/tmp/trace-review-state';
+      const prev = process.env.TRACE_MCP_DATA_DIR;
+      try {
+        process.env.TRACE_MCP_DATA_DIR = reviewDir;
+        expect(isDangerousProjectRoot('/tmp/trace-review-state/decisions')).toBe(
+          'trace state directory',
+        );
+        expect(isDangerousProjectRoot('/tmp/trace-review-state/logs')).toBe(
+          'trace state directory',
+        );
+        expect(isDangerousProjectRoot('/tmp/trace-review-state/metrics')).toBe(
+          'trace state directory',
+        );
       } finally {
         if (prev !== undefined) {
           process.env.TRACE_MCP_DATA_DIR = prev;


### PR DESCRIPTION
## Summary
Follow-up to #1137 addressing findings from code review:
1. **`src/registry.ts` (`sweepMissingRoots`)**: Apply `sharedWithSibling` check before unlinking index database and sidecar files (`-wal`, `-shm`, `-journal`) when sweeping dangerous project roots. If a dangerous row shares an index DB with a live project, the dangerous row is deregistered while the shared index DB is preserved intact.
2. **`src/dangerous-root.ts` (`TRACE_STATE_SUBDIRS`)**: Included `decisions`, `logs`, `metrics`, `bin`, and `mirror` in `TRACE_STATE_SUBDIRS` so that state subpaths under custom `TRACE_MCP_DATA_DIR` / `TRACE_MCP_HOME` overrides (e.g. `/tmp/trace-review-state/decisions`) are properly rejected.

### Verification
- `pnpm vitest run src/__tests__/ephemeral-missing-root-sweep.test.ts tests/project-setup/dangerous-root.test.ts src/__tests__/config-project-sweep.test.ts`: 48/48 tests passed.
- `pnpm typecheck`: clean (0 errors).
- `pnpm biome:ci`: clean (0 errors, 1,902 files).