### PR TITLE
fix(memory): ensure mined decision titles are complete statements and preserve wording (TRA-1056)

### DIFF
--- a/src/memory/conversation-miner-types.ts
+++ b/src/memory/conversation-miner-types.ts
@@ -17,7 +17,11 @@
  */
 
 import type { DecisionType } from './decision-types.js';
-import { minedDecisionRejectReason } from './decision-quality.js';
+import {
+  isCompleteStatement,
+  isSingleLineEndingWithColon,
+  minedDecisionRejectReason,
+} from './decision-quality.js';
 import { isContentNonEnglish, sanitizeTitle } from './title-extractor.js';
 
 // ════════════════════════════════════════════════════════════════════════
@@ -172,6 +176,39 @@ function truncateTitle(s: string): string | null {
   return sanitizeTitle(s);
 }
 
+function cleanComparisonPrefix(prefix: string): string {
+  let s = prefix.trim();
+  s = s.replace(/^(?:[#>*\-]+\s+|\d+\.\s+)+/, '');
+  const lastComma = s.lastIndexOf(',');
+  if (lastComma !== -1) {
+    const afterComma = s.slice(lastComma + 1).trim();
+    if (afterComma.length >= 10) {
+      s = afterComma;
+    }
+  }
+  if (s.length > 80) {
+    const spaceIdx = s.indexOf(' ', s.length - 80);
+    if (spaceIdx !== -1) {
+      s = s.slice(spaceIdx + 1).trim();
+    }
+  }
+  return s;
+}
+
+function cleanComparisonSuffix(suffix: string): string {
+  let s = suffix.trim();
+  s = s.replace(/[:;—–].*$/, '').trim();
+  s = s.replace(/\s+(?:because|since|due to|as it|as we)\b.*$/i, '').trim();
+  s = s.replace(/[\s,;:—–\-]+$/, '').trim();
+  if (s.length > 60) {
+    const spaceIdx = s.lastIndexOf(' ', 60);
+    if (spaceIdx !== -1) {
+      s = s.slice(0, spaceIdx).trim();
+    }
+  }
+  return s;
+}
+
 const DECISION_PATTERNS: DecisionPattern[] = [
   // Architecture decisions: "decided to", "we'll use", "going with", "chose X over Y"
   {
@@ -189,19 +226,23 @@ const DECISION_PATTERNS: DecisionPattern[] = [
     confidence: 0.8,
     titleExtractor: (m) => truncateTitle(`Use ${m[1].trim()}: ${m[2].trim()}`),
   },
-  // "X instead of Y" / "X rather than Y". `over` was dropped from this
-  // alternation (#TRA-34): it's an ordinary preposition ("the issue in
-  // `in_progress` over `in_review`", "the contentious zone over the pool")
-  // that fires on any comparison-shaped sentence, decision or not. "instead
-  // of" / "rather than" are decision-specific idioms with far lower false
-  // positive rates. Genuine "chose X over Y" phrasing is still caught by the
-  // decided/chose/going-with pattern above, which requires an explicit
-  // decision verb.
+  // "X instead of Y" / "X rather than Y".
+  // Captures the full clause before the connector (preserving verbs like "Left")
+  // and the alternative after the connector (cleanly bounded by punctuation).
+  // Preserves the author's exact connector ("instead of" vs "rather than")
+  // without replacing it with "over" or "instead of" (TRA-1056).
   {
-    pattern: /(\S+(?:\s+\S+){0,3})\s+(?:instead of|rather than)\s+(\S+(?:\s+\S+){0,3})\b/gi,
+    pattern:
+      /([^.\n!?—–;]{2,100}?)\s+\b(instead of|rather than)\b\s+([^.\n!?—–;]{2,80}?)(?=[.!?,;—–\n]|\s+(?:because|since|due to|as it)\b|$)/gi,
     type: 'tech_choice',
     confidence: 0.75,
-    titleExtractor: (m) => truncateTitle(`${m[1].trim()} instead of ${m[2].trim()}`),
+    titleExtractor: (m) => {
+      const prefix = cleanComparisonPrefix(m[1]);
+      const connector = m[2].trim();
+      const suffix = cleanComparisonSuffix(m[3]);
+      if (!prefix || !suffix) return null;
+      return truncateTitle(`${prefix} ${connector} ${suffix}`);
+    },
   },
   // Bug root causes: "the bug was", "root cause", "the issue was", "caused by"
   {
@@ -310,20 +351,45 @@ export function extractDecisions(turns: ConversationTurn[]): ExtractedDecision[]
       let match: RegExpExecArray | null;
 
       while ((match = pattern.pattern.exec(turn.text)) !== null) {
-        const title = pattern.titleExtractor(match, contextText);
-        // Title-sanitizer rejects non-English / unbalanced / empty fragments
-        // by returning null. Skip these candidates entirely — falling back
-        // to a worse title would just pollute the decision graph.
-        if (title === null) continue;
-        // Deduplicate by title similarity
-        const titleKey = title.toLowerCase().replace(/\s+/g, ' ').trim();
-        if (seen.has(titleKey)) continue;
-        seen.add(titleKey);
+        let title = pattern.titleExtractor(match, contextText);
 
         // Extract surrounding context (±200 chars around match)
         const start = Math.max(0, match.index - 200);
         const end = Math.min(turn.text.length, match.index + match[0].length + 200);
         const content = turn.text.slice(start, end).trim();
+
+        // Quality gate (TRA-1056 Point 1):
+        // The title of a mined decision must be a complete statement.
+        // If a complete statement does not assemble from the fragment, try
+        // taking the line containing the match or the first line of content.
+        // If neither yields a complete statement: do not create the entry at all.
+        if (title === null || !isCompleteStatement(title)) {
+          const matchLineStart = turn.text.lastIndexOf('\n', match.index) + 1;
+          const matchLineEnd = turn.text.indexOf('\n', match.index);
+          const matchLine = (
+            matchLineEnd === -1
+              ? turn.text.slice(matchLineStart)
+              : turn.text.slice(matchLineStart, matchLineEnd)
+          ).trim();
+          const firstLineContent = content.split('\n')[0].trim();
+
+          const candidateFromMatch = truncateTitle(matchLine);
+          const candidateFromContent = truncateTitle(firstLineContent);
+
+          if (candidateFromMatch && isCompleteStatement(candidateFromMatch)) {
+            title = candidateFromMatch;
+          } else if (candidateFromContent && isCompleteStatement(candidateFromContent)) {
+            title = candidateFromContent;
+          } else {
+            // Do not create the entry at all ("не создавать запись вовсе")
+            continue;
+          }
+        }
+
+        // Deduplicate by title similarity
+        const titleKey = title.toLowerCase().replace(/\s+/g, ' ').trim();
+        if (seen.has(titleKey)) continue;
+        seen.add(titleKey);
 
         // English-only rule applies to the long content field too — drop
         // candidates whose surrounding context is predominantly non-English
@@ -331,14 +397,18 @@ export function extractDecisions(turns: ConversationTurn[]): ExtractedDecision[]
         if (isContentNonEnglish(content)) continue;
 
         // Quality gate: reject truncated mid-sentence / mid-word fragments
-        // before they become stored "knowledge". The title is a bounded regex
-        // group that can open on a mid-clause conjunction ("so let's monitor
-        // it over the rest of this"); the content is a raw ±200-char window
-        // that can be a single chopped token ("ming).", "budget |") or carry
-        // a broken UTF-8 decode ("оп."). See decision-quality.ts.
+        // before they become stored "knowledge".
         if (minedDecisionRejectReason(title, content) !== null) continue;
 
-        const confidence = Math.min(pattern.confidence * boosterMultiplier, 0.99);
+        let confidence = Math.min(pattern.confidence * boosterMultiplier, 0.99);
+
+        // Meaningfulness threshold (TRA-1056 Point 3):
+        // A single-line content ending in a colon is not a decision.
+        // Lower confidence below the review threshold (0.75) so it is placed in pending
+        // and not shown in the main list.
+        if (isSingleLineEndingWithColon(content)) {
+          confidence = Math.min(confidence, 0.45);
+        }
 
         // Infer tags from content
         const tags = inferTags(content);

--- a/src/memory/conversation-miner.ts
+++ b/src/memory/conversation-miner.ts
@@ -15,7 +15,7 @@ import { logger } from '../logger.js';
 import { detectGitWorktree } from '../project-root.js';
 import { getCurrentBranch } from '../utils/git-branch.js';
 import { computeConfidence } from './decision-confidence.js';
-import { minedDecisionRejectReason } from './decision-quality.js';
+import { isSingleLineEndingWithColon, minedDecisionRejectReason } from './decision-quality.js';
 import { mineProviderSessions } from './conversation-miner-providers.js';
 import type { DecisionInput, DecisionStore, DecisionType } from './decision-store.js';
 import { type LlmExtractedDecision, extractDecisionsWithLlm } from './llm-extractor.js';
@@ -702,13 +702,18 @@ function adaptLlmDecisions(
       file_path: fileHint,
       tags: d.tags,
     });
+    let confidence = Math.max(heuristic, d.confidence);
+    if (isSingleLineEndingWithColon(d.content)) {
+      confidence = Math.min(confidence, 0.45);
+    }
     out.push({
       title: cleanTitle,
       content: d.content,
       type: d.type,
       // Take the higher of the LLM's self-estimate and the heuristic — LLM
       // overconfidence is real, but so is heuristic blindness to nuance.
-      confidence: Math.max(heuristic, d.confidence),
+      // Clamped if content is a single line ending with colon (TRA-1056).
+      confidence,
       file_path: fileHint,
       symbol_id: symbolHint,
       tags: d.tags ?? [],

--- a/src/memory/decision-confidence.ts
+++ b/src/memory/decision-confidence.ts
@@ -26,6 +26,7 @@ import {
   scoreWithWeights,
   WEIGHTS_PATH,
 } from './confidence-tuner.js';
+import { isSingleLineEndingWithColon } from './decision-quality.js';
 import type { DecisionInput } from './decision-types.js';
 
 const BASE = 0.4;
@@ -55,7 +56,11 @@ export function computeConfidenceLegacy(input: DecisionInputForScoring): number 
   if ((input.tags?.length ?? 0) > 0) c += W_TAGS;
   if (HIGH_SIGNAL_TYPES.has(input.type)) c += W_TYPE;
   if (input.service_name) c += W_SERVICE;
-  return Math.max(0, Math.min(1, c));
+  let score = Math.max(0, Math.min(1, c));
+  if (input.content && isSingleLineEndingWithColon(input.content)) {
+    score = Math.min(score, 0.45);
+  }
+  return score;
 }
 
 // ─── Cached learned-weights loader ─────────────────────────────────
@@ -145,5 +150,9 @@ function inputToSignals(input: DecisionInputForScoring) {
 export function computeConfidence(input: DecisionInputForScoring): number {
   if (!weightTuningEnabled) return computeConfidenceLegacy(input);
   const weights = getCachedWeights();
-  return scoreWithWeights(inputToSignals(input), weights);
+  let score = scoreWithWeights(inputToSignals(input), weights);
+  if (input.content && isSingleLineEndingWithColon(input.content)) {
+    score = Math.min(score, 0.45);
+  }
+  return score;
 }

--- a/src/memory/decision-quality.ts
+++ b/src/memory/decision-quality.ts
@@ -340,6 +340,402 @@ function countWords(s: string): number {
 }
 
 /**
+ * Recognizes common English verbs (modal, auxiliary, decision, action, or inflectional).
+ */
+const COMMON_VERBS = new Set([
+  'is',
+  'are',
+  'was',
+  'were',
+  'be',
+  'been',
+  'being',
+  'have',
+  'has',
+  'had',
+  'having',
+  'do',
+  'does',
+  'did',
+  'doing',
+  'can',
+  'could',
+  'will',
+  'would',
+  'shall',
+  'should',
+  'may',
+  'might',
+  'must',
+  'use',
+  'uses',
+  'used',
+  'using',
+  'prefer',
+  'prefers',
+  'preferred',
+  'preferring',
+  'choose',
+  'chooses',
+  'chose',
+  'chosen',
+  'choosing',
+  'select',
+  'selects',
+  'selected',
+  'selecting',
+  'opt',
+  'opts',
+  'opted',
+  'opting',
+  'switch',
+  'switches',
+  'switched',
+  'switching',
+  'migrate',
+  'migrates',
+  'migrated',
+  'migrating',
+  'adopt',
+  'adopts',
+  'adopted',
+  'adopting',
+  'pick',
+  'picks',
+  'picked',
+  'picking',
+  'keep',
+  'keeps',
+  'kept',
+  'keeping',
+  'leave',
+  'leaves',
+  'left',
+  'leaving',
+  'move',
+  'moves',
+  'moved',
+  'moving',
+  'set',
+  'sets',
+  'setting',
+  'make',
+  'makes',
+  'made',
+  'making',
+  'drop',
+  'drops',
+  'dropped',
+  'dropping',
+  'add',
+  'adds',
+  'added',
+  'adding',
+  'remove',
+  'removes',
+  'removed',
+  'removing',
+  'replace',
+  'replaces',
+  'replaced',
+  'replacing',
+  'deploy',
+  'deploys',
+  'deployed',
+  'deploying',
+  'implement',
+  'implements',
+  'implemented',
+  'implementing',
+  'enable',
+  'enables',
+  'enabled',
+  'enabling',
+  'disable',
+  'disables',
+  'disabled',
+  'disabling',
+  'change',
+  'changes',
+  'changed',
+  'changing',
+  'split',
+  'splits',
+  'splitting',
+  'merge',
+  'merges',
+  'merged',
+  'merging',
+  'avoid',
+  'avoids',
+  'avoided',
+  'avoiding',
+  'defer',
+  'defers',
+  'deferred',
+  'deferring',
+  'guard',
+  'guards',
+  'guarded',
+  'guarding',
+  'prevent',
+  'prevents',
+  'prevented',
+  'preventing',
+  'run',
+  'runs',
+  'ran',
+  'running',
+  'build',
+  'builds',
+  'built',
+  'building',
+  'write',
+  'writes',
+  'wrote',
+  'written',
+  'writing',
+  'read',
+  'reads',
+  'reading',
+  'find',
+  'finds',
+  'found',
+  'finding',
+  'fix',
+  'fixes',
+  'fixed',
+  'fixing',
+  'solve',
+  'solves',
+  'solved',
+  'solving',
+  'flip',
+  'flips',
+  'flipped',
+  'flipping',
+  'route',
+  'routes',
+  'routed',
+  'routing',
+  'wrap',
+  'wraps',
+  'wrapped',
+  'wrapping',
+  'handle',
+  'handles',
+  'handled',
+  'handling',
+  'support',
+  'supports',
+  'supported',
+  'supporting',
+  'draw',
+  'draws',
+  'drew',
+  'drawn',
+  'drawing',
+  'stick',
+  'sticks',
+  'stuck',
+  'sticking',
+  'take',
+  'takes',
+  'took',
+  'taken',
+  'taking',
+  'give',
+  'gives',
+  'gave',
+  'given',
+  'giving',
+  'put',
+  'puts',
+  'putting',
+  'cut',
+  'cuts',
+  'cutting',
+  'stop',
+  'stops',
+  'stopped',
+  'stopping',
+  'start',
+  'starts',
+  'started',
+  'starting',
+  'need',
+  'needs',
+  'needed',
+  'needing',
+  'require',
+  'requires',
+  'required',
+  'requiring',
+  'allow',
+  'allows',
+  'allowed',
+  'allowing',
+  'ensure',
+  'ensures',
+  'ensured',
+  'ensuring',
+  'store',
+  'stores',
+  'stored',
+  'storing',
+  'load',
+  'loads',
+  'loaded',
+  'loading',
+  'save',
+  'saves',
+  'saved',
+  'saving',
+  'serve',
+  'serves',
+  'served',
+  'serving',
+  'send',
+  'sends',
+  'sent',
+  'sending',
+  'emit',
+  'emits',
+  'emitted',
+  'emitting',
+  'pass',
+  'passes',
+  'passed',
+  'passing',
+  'fail',
+  'fails',
+  'failed',
+  'failing',
+  'check',
+  'checks',
+  'checked',
+  'checking',
+  'verify',
+  'verifies',
+  'verified',
+  'verifying',
+  'test',
+  'tests',
+  'tested',
+  'testing',
+  'monitor',
+  'monitors',
+  'monitored',
+  'monitoring',
+  'track',
+  'tracks',
+  'tracked',
+  'tracking',
+  'ship',
+  'ships',
+  'shipped',
+  'shipping',
+]);
+
+/** True when text carries at least one recognized verb or verb inflection. */
+export function hasVerb(s: string): boolean {
+  const words = s.match(/[\p{L}\p{N}]+(?:['-][\p{L}\p{N}]+)*/gu);
+  if (!words) return false;
+  for (const w of words) {
+    const lower = w.toLowerCase();
+    if (COMMON_VERBS.has(lower)) return true;
+    // Inflectional verb endings: -ed, -ing, -ize, -ized, -ise, -ised
+    if (lower.length >= 4 && /(?:ed|ing|ize|ized|ise|ised)$/.test(lower)) return true;
+  }
+  return false;
+}
+
+/** Prepositions that indicate a severed phrase when appearing at the start of a title. */
+const SEVERED_PREPOSITIONS = new Set([
+  'from',
+  'into',
+  'onto',
+  'out of',
+  'per',
+  'via',
+  'above',
+  'under',
+  'during',
+  'against',
+  'between',
+  'through',
+]);
+
+/** True when a string opens with a severed preposition like "from the contentious zone...". */
+export function startsSeveredPreposition(s: string): boolean {
+  const trimmed = s.trimStart();
+  if (!trimmed) return false;
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith('out of ') || lower === 'out of') return true;
+  const firstWord = trimmed.match(/^[a-zA-Z]+/)?.[0]?.toLowerCase();
+  if (!firstWord) return false;
+  return SEVERED_PREPOSITIONS.has(firstWord);
+}
+
+/**
+ * True when a string begins with an amputated subject lacking a verb,
+ * e.g. "the issue in `in_progress` rather than `in_review`".
+ */
+export function startsAmputatedSubject(s: string): boolean {
+  const trimmed = s.trimStart();
+  if (!trimmed) return false;
+  if (/^(?:the|a|an)\s+[a-zA-Z0-9_-]+\s+(?:in|of|for|with|at|on|from|about)\b/i.test(trimmed)) {
+    const compIdx = trimmed.search(/\b(?:instead of|rather than|over)\b/i);
+    if (compIdx !== -1) {
+      const beforeComp = trimmed.slice(0, compIdx);
+      if (!hasVerb(beforeComp)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * True when content consists of a single line ending in a colon,
+ * e.g. "Now variant E — few-shot drawn from the contentious zone instead of the first-N-per-class pool:".
+ * Such content is an introductory line, not a standalone decision (TRA-1056 Point 3).
+ */
+export function isSingleLineEndingWithColon(content: string): boolean {
+  if (!content) return false;
+  const trimmed = content.trim();
+  const lines = trimmed.split('\n').filter((l) => l.trim().length > 0);
+  return lines.length === 1 && trimmed.endsWith(':');
+}
+
+/**
+ * True when a title represents a complete, self-contained statement (TRA-1056 Point 1).
+ * Rejects mid-clause continuations, severed prepositions, amputated subjects,
+ * trailing dangling tokens, trailing colons/dashes, unbalanced markers, and verbless fragments.
+ */
+export function isCompleteStatement(title: string): boolean {
+  if (!title) return false;
+  const t = title.trim();
+  if (t.length < MIN_TITLE_CHARS) return false;
+
+  if (startsMidClause(t)) return false;
+  if (startsSeveredPreposition(t)) return false;
+  if (startsAmputatedSubject(t)) return false;
+  if (endsMidClause(t)) return false;
+  if (/[:;—–\-]$/.test(t)) return false;
+  if (hasUnbalancedMarkers(t) || hasTableRemnant(t) || hasNarrationMarker(t)) return false;
+
+  // Must have a verb, or start with Root cause:/Decision:, or be a clean entity comparison
+  const isEntityComparison =
+    /^`?[A-Za-z0-9_.-]+`?\s+(?:instead of|rather than|over)\s+`?[A-Za-z0-9_.-]+`?$/i.test(t);
+  const isSpecialPrefix =
+    /^(?:root cause|decision|the fix|the bug|the issue|the problem)\s*[:—–]/i.test(t);
+  if (!hasVerb(t) && !isEntityComparison && !isSpecialPrefix) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
  * True when a string BEGINS mid-sentence: it starts with a lowercase word
  * that is a known continuation token (conjunction / pronoun / bare article).
  * A leading capital, a leading code token (backtick / bracket / quote), or a
@@ -495,8 +891,9 @@ export function minedDecisionRejectReason(title: string, content: string): strin
   if (isPredominantlyNonLatin(t)) return 'non_english';
   if (c && isPredominantlyNonLatin(c)) return 'non_english';
 
-  // Title must not be a dangling continuation of an earlier clause.
-  if (startsMidClause(t)) return 'title_mid_clause';
+  // Title must not be a dangling continuation of an earlier clause or severed preposition.
+  if (startsMidClause(t) || startsSeveredPreposition(t)) return 'title_mid_clause';
+  if (startsAmputatedSubject(t)) return 'title_incomplete';
 
   // Title reads as narration lifted from chat prose, not a standalone
   // decision statement (bare result verb, first-person planning, generic
@@ -504,10 +901,14 @@ export function minedDecisionRejectReason(title: string, content: string): strin
   if (hasNarrationMarker(t)) return 'title_narration';
 
   // Title truncation: cut on a dangling tail token, an unbalanced structural
-  // marker (open code span / paren / bold), or an orphan table-row remnant.
-  if (endsMidClause(t) || hasUnbalancedMarkers(t) || hasTableRemnant(t)) {
+  // marker (open code span / paren / bold), an orphan table-row remnant, or
+  // trailing colon/dash/semicolon.
+  if (endsMidClause(t) || hasUnbalancedMarkers(t) || hasTableRemnant(t) || /[:;—–\-]$/.test(t)) {
     return 'title_truncated';
   }
+
+  // Title must be a complete, self-contained statement (TRA-1056).
+  if (!isCompleteStatement(t)) return 'title_incomplete';
 
   // Content must carry enough real words to be a usable summary.
   if (c.length < MIN_CONTENT_CHARS) return 'content_too_short';

--- a/tests/memory/computeConfidence-tuned.test.ts
+++ b/tests/memory/computeConfidence-tuned.test.ts
@@ -123,4 +123,18 @@ describe('computeConfidence with learned weights', () => {
     // With tuning disabled, the legacy 0.4 baseline wins regardless of the file.
     expect(computeConfidence(input)).toBe(computeConfidenceLegacy(input));
   });
+
+  it('clamps confidence to <= 0.45 when content is a single line ending in a colon (TRA-1056)', () => {
+    const input = {
+      title: 'Variant E comparison',
+      content:
+        'Now variant E — few-shot drawn from the contentious zone instead of the first-N-per-class pool:',
+      type: 'tech_choice' as const,
+      file_path: 'src/model.ts',
+      tags: ['evaluation'],
+    };
+    // Normally code_ref + tags + tech_choice would boost confidence > 0.75
+    expect(computeConfidenceLegacy(input)).toBeLessThanOrEqual(0.45);
+    expect(computeConfidence(input)).toBeLessThanOrEqual(0.45);
+  });
 });

--- a/tests/memory/conversation-miner.test.ts
+++ b/tests/memory/conversation-miner.test.ts
@@ -253,6 +253,56 @@ describe('Conversation Miner — "X over Y" noise (TRA-34)', () => {
     ]);
     expect(decisions.length).toBeGreaterThan(0);
   });
+
+  describe('TRA-1056 — decision title quality and exact wording', () => {
+    it('extracts complete statement for "Left X rather than Y" preserving verb and exact connector', async () => {
+      const { extractDecisions } = await import('../../src/memory/conversation-miner.js');
+      const text =
+        'Left the issue in `in_progress` rather than `in_review` — no work exists to review yet; Builder owns it from here.';
+      const decisions = extractDecisions([assistantTurn(text)]);
+      expect(decisions.length).toBe(1);
+      expect(decisions[0].title).toBe('Left the issue in `in_progress` rather than `in_review`');
+      expect(decisions[0].title).not.toContain('over');
+      expect(decisions[0].title).not.toContain('no work');
+    });
+
+    it('preserves exact comparison connector rather than vs instead of without substitution', async () => {
+      const { extractDecisions } = await import('../../src/memory/conversation-miner.js');
+      const d1 = extractDecisions([
+        assistantTurn('Use Vitest rather than Jest for unit testing in the repo.'),
+      ]);
+      expect(d1.length).toBe(1);
+      expect(d1[0].title).toContain('rather than');
+      expect(d1[0].title).not.toContain('over');
+      expect(d1[0].title).not.toContain('instead of');
+
+      const d2 = extractDecisions([
+        assistantTurn('Use Vitest instead of Jest for unit testing in the repo.'),
+      ]);
+      expect(d2.length).toBe(1);
+      expect(d2[0].title).toContain('instead of');
+      expect(d2[0].title).not.toContain('over');
+      expect(d2[0].title).not.toContain('rather than');
+    });
+
+    it('clamps confidence <= 0.45 or drops single line ending with colon (#205)', async () => {
+      const { extractDecisions } = await import('../../src/memory/conversation-miner.js');
+      const text =
+        'Now variant E — few-shot drawn from the contentious zone instead of the first-N-per-class pool:';
+      const decisions = extractDecisions([assistantTurn(text)]);
+      for (const d of decisions) {
+        expect(d.confidence).toBeLessThanOrEqual(0.45);
+      }
+    });
+
+    it('does not create entry when fragment cannot assemble a complete statement', async () => {
+      const { extractDecisions } = await import('../../src/memory/conversation-miner.js');
+      // A fragmentary mention with no complete statement anywhere in line or content
+      const text = 'from the contentious zone instead of the pool:';
+      const decisions = extractDecisions([assistantTurn(text)]);
+      expect(decisions.length).toBe(0);
+    });
+  });
 });
 
 describe('Conversation Miner — privacy filtering', () => {
@@ -402,5 +452,33 @@ describe('Conversation Miner — worktree adoption', () => {
     // Second call must read from cache, not re-stat (we can't easily prove
     // no fs read, but at least result is stable).
     expect(adoptWorktreeRoot(root, cache)).toBe(root);
+  });
+});
+
+describe('Conversation Miner — live session extraction (TRA-1056 Point 4)', () => {
+  it('mines real session and ensures complete statement titles without severed fragments', async () => {
+    const { parseConversationTurns, extractDecisions } = await import(
+      '../../src/memory/conversation-miner.js'
+    );
+    const sessionPath =
+      '/Users/nikolai/.claude/projects/-Users-nikolai-PhpstormProjects-assetfeed/fbb9e724-1055-444b-a51e-351b7687f02c.jsonl';
+    if (!fs.existsSync(sessionPath)) {
+      return;
+    }
+
+    const { turns } = parseConversationTurns(sessionPath);
+    expect(turns.length).toBeGreaterThan(0);
+
+    const decisions = extractDecisions(turns);
+    for (const d of decisions) {
+      // 1. Title must not start with severed preposition
+      expect(d.title).not.toMatch(
+        /^(?:from|into|onto|per|via|above|under|during|against|between|through)\s+/i,
+      );
+      // 2. Title must not end with trailing punctuation or colon
+      expect(d.title).not.toMatch(/[:;—–\-]$/);
+      // 3. Title must not contain 'over' substituted for rather than / instead of
+      expect(d.title).not.toMatch(/over\s+`in_review`/);
+    }
   });
 });

--- a/tests/memory/decision-quality.test.ts
+++ b/tests/memory/decision-quality.test.ts
@@ -18,9 +18,14 @@ import {
   hasEllipsis,
   hasNarrationMarker,
   hasTableRemnant,
+  hasVerb,
+  isCompleteStatement,
+  isSingleLineEndingWithColon,
   isValidMinedDecision,
   minedDecisionRejectReason,
+  startsAmputatedSubject,
   startsMidClause,
+  startsSeveredPreposition,
 } from '../../src/memory/decision-quality.js';
 
 describe('minedDecisionRejectReason — reporter garbage examples', () => {
@@ -339,5 +344,118 @@ describe('hasTableRemnant', () => {
     'Pipe build output through `tsc | biome` in CI',
   ])('does not flag legit prose: %s', (s) => {
     expect(hasTableRemnant(s)).toBe(false);
+  });
+});
+
+describe('TRA-1056 — complete statements and quality helpers', () => {
+  describe('startsSeveredPreposition', () => {
+    it.each([
+      'from the contentious zone over the first-N-per-class pool',
+      'into the database directly instead of API',
+      'via HTTP proxy rather than direct socket',
+      'through the worker thread instead of main',
+    ])('flags severed preposition opening: %s', (s) => {
+      expect(startsSeveredPreposition(s)).toBe(true);
+    });
+
+    it.each([
+      'Draw samples from the contentious zone',
+      'Migrate into the database directly',
+      'Send via HTTP proxy rather than direct socket',
+    ])('does not flag when verb precedes: %s', (s) => {
+      expect(startsSeveredPreposition(s)).toBe(false);
+    });
+  });
+
+  describe('startsAmputatedSubject', () => {
+    it.each([
+      'the issue in `in_progress` rather than `in_review`',
+      'the parameter in config rather than env',
+      'a table in sqlite instead of postgres',
+    ])('flags amputated subject: %s', (s) => {
+      expect(startsAmputatedSubject(s)).toBe(true);
+    });
+
+    it.each([
+      'Left the issue in `in_progress` rather than `in_review`',
+      'Keep the parameter in config rather than env',
+      'Created a table in sqlite instead of postgres',
+    ])('does not flag complete clause with verb: %s', (s) => {
+      expect(startsAmputatedSubject(s)).toBe(false);
+    });
+  });
+
+  describe('isSingleLineEndingWithColon', () => {
+    it('detects single line ending with colon', () => {
+      expect(
+        isSingleLineEndingWithColon(
+          'Now variant E — few-shot drawn from the contentious zone instead of the first-N-per-class pool:',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for multi-line content or lines without colon', () => {
+      expect(
+        isSingleLineEndingWithColon(
+          'Now variant E:\nLine two explanation of the decision.\nLine three details.',
+        ),
+      ).toBe(false);
+      expect(
+        isSingleLineEndingWithColon(
+          'Now variant E — few-shot drawn from the contentious zone instead of the first-N-per-class pool.',
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('isCompleteStatement', () => {
+    it.each([
+      'the issue in `in_progress` over `in_review` — no work',
+      'from the contentious zone over the first-N-per-class pool',
+      'the issue in `in_progress` rather than `in_review`',
+      'Ending with colon:',
+      'Ending with dash —',
+      'so let us monitor it over time',
+    ])('rejects incomplete fragment: %s', (s) => {
+      expect(isCompleteStatement(s)).toBe(false);
+    });
+
+    it.each([
+      'Left the issue in `in_progress` rather than `in_review`',
+      'Use PostgreSQL instead of MySQL for JSONB support',
+      'Decision: use Redis for caching',
+      'Root cause: missing null check in auth middleware',
+      '`atomicWriteJson` instead of `fs.writeFileSync`',
+    ])('accepts complete statement: %s', (s) => {
+      expect(isCompleteStatement(s)).toBe(true);
+    });
+  });
+
+  describe('minedDecisionRejectReason with TRA-1056 live examples', () => {
+    it('rejects live #204 broken fragment', () => {
+      const reason = minedDecisionRejectReason(
+        'the issue in `in_progress` over `in_review` — no work',
+        'Left the issue in `in_progress` rather than `in_review` — no work exists to review yet; Builder owns it from here.',
+      );
+      expect(reason).not.toBeNull();
+      expect(['title_incomplete', 'title_truncated']).toContain(reason);
+    });
+
+    it('rejects live #205 broken fragment', () => {
+      const reason = minedDecisionRejectReason(
+        'from the contentious zone over the first-N-per-class pool',
+        'Now variant E — few-shot drawn from the contentious zone instead of the first-N-per-class pool:',
+      );
+      expect(reason).not.toBeNull();
+      expect(['title_mid_clause', 'title_incomplete']).toContain(reason);
+    });
+
+    it('accepts repaired #204 title', () => {
+      const reason = minedDecisionRejectReason(
+        'Left the issue in `in_progress` rather than `in_review`',
+        'Left the issue in `in_progress` rather than `in_review` — no work exists to review yet; Builder owns it from here.',
+      );
+      expect(reason).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Summary
Fixes issues with mined decision extraction on live sessions (such as assetfeed #204 and #205):
1. Ensures decision titles are complete, self-contained statements (`isCompleteStatement`). Rejects severed prepositions ("from the contentious zone..."), amputated subjects lacking a verb ("the issue in `in_progress` rather than `in_review`"), dangling tokens, and trailing colons/dashes. If the matched fragment cannot form a complete statement, falls back to the match line or first line of content; if neither qualifies, skips creating the entry.
2. Preserves author's exact connector phrasing ("instead of" vs "rather than") without replacing with "over".
3. Clamps confidence to <= 0.45 (`tier: 'pending'`) when content consists of a single line ending with a colon (`isSingleLineEndingWithColon`), keeping introductory sentences out of the auto-approved main list.
4. Added comprehensive test coverage and verified live against real assetfeed sessions.

Fixes TRA-1056.