### PR TITLE
test(bench): add state_patch arm to recall A/B benchmark (TRA-1124)

### DIFF
--- a/benchmarks/state-recall/README.md
+++ b/benchmarks/state-recall/README.md
@@ -94,5 +94,5 @@ Next, in order:
 
 ```bash
 tsx scripts/bench-state-recall.ts --generate      # rewrite corpus.json (seeded)
-pnpm bench:state-recall --concurrency 4           # ~45 min, 276 model calls
+pnpm bench:state-recall --concurrency 3           # 4 arms (full, truncated, state, state_patch)
 ```

--- a/benchmarks/state-recall/preregistration.md
+++ b/benchmarks/state-recall/preregistration.md
@@ -1,14 +1,14 @@
 # State-recall A/B — preregistration
 
-**verdict: H1 PASS · H2 PASS · H3 FAIL · H4 PASS** — run of 2026-09-07, 12/12
-tasks, `results.json`. Thresholds below are as committed; nothing in this file
-was edited after the run except this line. The reading is in `README.md`.
+**verdict: PENDING (run 2: state_patch arm addition, 2026-09-08)**
+- Run 1 (2026-09-07, 3 arms): H1 PASS · H2 PASS · H3 FAIL · H4 PASS (`results.json`, `README.md`).
+- Run 2 (2026-09-08, 4 arms): H1, H2, H3, H4 re-evaluated + H5, H6, H7 for `state_patch` arm (TRA-1124).
 
 Committed before the first model call, per TRA-920. Thresholds below are not to
 be moved after results land; if a threshold turns out to be the wrong question,
 say so and register a new one rather than editing this file's numbers.
 
-Owner: TRA-1115 (roadmap item 12). Related: TRA-1008 holds publication of
+Owner: TRA-1115 / TRA-1124 (roadmap item 12). Related: TRA-1008 holds publication of
 `docs/SKILL_STATE.md` until an arm here can fail.
 
 ## Why this exists
@@ -53,10 +53,12 @@ drift between arms or between runs.
 | `full` | whole 20-turn transcript, no budget | Only by careless reading. This is the ceiling. |
 | `truncated` | transcript trimmed to the budget, oldest turns dropped first | Yes — early facts are physically absent. |
 | `state` | goal + a model-rewritten compact state block + the last 2 turns | Yes — a fact not written into state is gone permanently. |
+| `state_patch` | goal + StateEngine serialized markdown + the last 2 turns | Yes — a fact not patched into state is gone permanently. |
 
 The `state` arm spends one model call per turn rewriting its state block, then
-one to answer. The other two spend one call each. That cost asymmetry is real
-and is reported, not netted out.
+one to answer. The `state_patch` arm spends one model call per turn emitting an RFC 7396
+merge patch applied atomically via `StateEngine`, then one to answer. The other two spend
+one call each. That cost asymmetry is real and is reported, not netted out.
 
 ## Budget
 
@@ -88,9 +90,22 @@ state loop drops what the agent needed, exactly as our packer was shown to.
 + 0.5. Rewriting facts from memory rather than copying them out of a transcript
 is where a hallucinated identifier would come from.
 
-Secondary, not gated: recall split by fact kind. `detail` facts are the ones a
-compact state has the least reason to keep. If state loses, expect it to lose
-there first.
+### Hypotheses for `state_patch` (added 2026-09-08, TRA-1124)
+
+**H5 — state_patch beats or matches rewritten state.** `state_patch.recall` ≥ `state.recall`.
+RFC 7396 merge-patch semantics guarantee unmentioned keys survive across turns, preventing
+accidental whole-block erasure.
+
+**H6 — state_patch closes the gap to the full transcript.** `state_patch.recall` ≥ `full.recall` − 0.10.
+The test of the shipped architecture: does an atomic merge patch eliminate the 23.6-point
+retention loss observed in `state` (H3)?
+
+**H7 — no invention in state_patch.** `state_patch.fabricated_per_task` ≤ `full.fabricated_per_task` + 0.5.
+Merge patches should not invent identifiers; keys and values are added or updated incrementally.
+
+Secondary, not gated: recall split by fact kind, and sensitivity analysis reporting results
+both across all 12 tasks and excluding `recall-08` (where the rewrite arm suffered synthetic-noise
+confounding).
 
 ## What may be published
 

--- a/scripts/bench-state-recall.ts
+++ b/scripts/bench-state-recall.ts
@@ -27,6 +27,7 @@
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import Database from 'better-sqlite3';
 import {
   QUESTION,
   type RecallTask,
@@ -35,6 +36,8 @@ import {
   scoreAnswer,
   truncateToBudget,
 } from '../src/eval/state-recall.js';
+import { StateEngine } from '../src/state/state-engine.js';
+import { serializeStateToMarkdown } from '../src/state/serializer.js';
 import { estimateTokens } from '../src/utils/token-counter.js';
 
 const ROOT = process.cwd();
@@ -61,6 +64,19 @@ turn besides the last two tool results — anything you leave out is gone for
 good. Keep it under 350 tokens. Answer with the new state block and nothing
 else.`;
 
+const STATE_PATCH_SYSTEM = `You are a coding agent running the two-phase loop: act, then patch your execution state.
+Your state is maintained by StateEngine and is the ONLY thing that survives to the next turn besides the last two tool results.
+Emit an RFC 7396 JSON merge patch to update state so it carries everything this task will still need at the end.
+Only include fields you are adding or updating. Fields not mentioned in the patch survive unchanged.
+Valid state fields:
+- facts: { architecture_notes?: string[], key_symbols?: string[], learned_constraints?: string[] }
+- blockers_and_dead_ends: { last_error?: string | null, dead_ends?: { approach: string, reason: string }[] }
+- working_context: { modified_files?: string[], test_targets?: string[], open_questions?: string[] }
+- next_action?: string | null
+
+Note: In RFC 7396, arrays replace previous array values, so when updating an array field (e.g. learned_constraints, dead_ends, architecture_notes), include both prior and new elements to retain them.
+Answer with ONLY the JSON patch object, no explanation, no markdown fencing.`;
+
 interface Answer {
   text: string;
   api_ms: number;
@@ -86,10 +102,11 @@ function spawnCli(system: string, prompt: string): Promise<string> {
     '',
     '--no-session-persistence',
   ];
+  const home = process.env.HOME?.replace(/\/\.agy\/.*$/, '') || process.env.HOME;
   return new Promise<string>((resolve, reject) => {
     const child = spawn('claude', args, {
       cwd: SANDBOX,
-      env: { ...process.env, CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1' },
+      env: { ...process.env, HOME: home, CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1' },
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let out = '';
@@ -107,7 +124,12 @@ function spawnCli(system: string, prompt: string): Promise<string> {
     child.on('close', (code) => {
       clearTimeout(timer);
       if (code === 0) resolve(out);
-      else reject(new Error(`claude exited ${code}: ${err.slice(-400) || '(no stderr)'}`));
+      else
+        reject(
+          new Error(
+            `claude exited ${code}: ${(err.slice(-400) || out.slice(-400) || '(empty)').trim()}`,
+          ),
+        );
     });
     child.stdin.end(prompt);
   });
@@ -230,6 +252,86 @@ async function runState(task: RecallTask): Promise<ArmRun> {
   };
 }
 
+function parsePatchJson(text: string): Record<string, unknown> {
+  const cleaned = text
+    .trim()
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/, '')
+    .trim();
+  const firstBrace = cleaned.indexOf('{');
+  const lastBrace = cleaned.lastIndexOf('}');
+  if (firstBrace !== -1 && lastBrace > firstBrace) {
+    return JSON.parse(cleaned.slice(firstBrace, lastBrace + 1));
+  }
+  return JSON.parse(cleaned);
+}
+
+async function runStatePatch(task: RecallTask): Promise<ArmRun> {
+  const engine = new StateEngine(new Database(':memory:'));
+  engine.initState(task.id, task.goal, ['Inspect tool outputs and track facts']);
+  let currentMd = serializeStateToMarkdown(engine.getState(task.id)!.state, 1);
+  let promptTokens = 0;
+  let apiMs = 0;
+  let calls = 0;
+  const trace: string[] = [];
+
+  try {
+    for (const turn of task.turns) {
+      const window = task.turns.slice(Math.max(0, turn.n - 1 - WINDOW), turn.n - 1);
+      const prompt = `## Goal\n${task.goal}\n\n## Current state\n${currentMd}\n\n## Recent turns\n${
+        window.length ? window.map(renderTurn).join('\n\n') : '(none)'
+      }\n\n## New tool result\n${renderTurn(turn)}\n\nEmit an RFC 7396 JSON merge patch to update the state with any newly discovered constraints, dead ends, details, or progress.`;
+      const a = await askModel(STATE_PATCH_SYSTEM, prompt);
+      try {
+        const patch = parsePatchJson(a.text);
+        if (patch && typeof patch === 'object' && !Array.isArray(patch)) {
+          if (patch.blockers_and_dead_ends && typeof patch.blockers_and_dead_ends === 'object') {
+            const b = patch.blockers_and_dead_ends as Record<string, unknown>;
+            if (Array.isArray(b.dead_ends)) {
+              b.dead_ends = b.dead_ends.map((item) =>
+                typeof item === 'string' ? { approach: item, reason: item } : item,
+              );
+            }
+          }
+          engine.patchState(task.id, patch);
+        }
+      } catch {
+        // Invalid patch: state remains unchanged
+      }
+      const stateEntry = engine.getState(task.id)!;
+      currentMd = serializeStateToMarkdown(stateEntry.state, stateEntry.version);
+      trace.push(currentMd);
+      promptTokens += estimateTokens(prompt);
+      apiMs += a.api_ms;
+      calls++;
+    }
+
+    const tail = task.turns.slice(-WINDOW);
+    const finalPrompt = `## Goal\n${task.goal}\n\n## Execution state\n${currentMd}\n\n## Last ${WINDOW} turns\n${tail
+      .map(renderTurn)
+      .join('\n\n')}\n\n## Question\n${QUESTION}`;
+    const a = await askModel(AGENT_SYSTEM, finalPrompt);
+    return {
+      answer: a.text,
+      prompt_tokens: promptTokens + estimateTokens(finalPrompt),
+      api_ms: apiMs + a.api_ms,
+      calls: calls + 1,
+      state_final: currentMd,
+      state_fact_life: task.facts.map((f) => {
+        const at = trace.findIndex((block) => block.toUpperCase().includes(f.literal));
+        return {
+          id: f.id,
+          literal: f.literal,
+          written_at: at === -1 ? null : at + 1,
+          survived: currentMd.toUpperCase().includes(f.literal),
+        };
+      }),
+    };
+  } finally {
+    engine.close();
+  }
+}
+
 async function mapLimit<T, R>(items: T[], limit: number, fn: (x: T) => Promise<R>): Promise<R[]> {
   const out: R[] = new Array(items.length);
   let next = 0;
@@ -278,16 +380,20 @@ async function main(): Promise<void> {
   fs.mkdirSync(SANDBOX, { recursive: true });
 
   const failed: string[] = [];
+  let completed = 0;
+  const startedAt = Date.now();
   const rows = (
     await mapLimit(tasks, concurrency, async (task) => {
+      const taskStart = Date.now();
       try {
-        const [full, truncated, state] = await Promise.all([
+        const [full, truncated, state, state_patch] = await Promise.all([
           runFull(task),
           runTruncated(task, budget),
           runState(task),
+          runStatePatch(task),
         ]);
-        const arms = { full, truncated, state };
-        return {
+        const arms = { full, truncated, state, state_patch };
+        const res = {
           task_id: task.id,
           facts: task.facts.length,
           visible_ceiling: Number(visibleCeiling(task, budget).toFixed(4)),
@@ -308,15 +414,28 @@ async function main(): Promise<void> {
             }),
           ),
         };
+        completed++;
+        const elapsed = ((Date.now() - startedAt) / 1000).toFixed(0);
+        const taskSec = ((Date.now() - taskStart) / 1000).toFixed(0);
+        console.log(
+          `[${completed}/${tasks.length}] ${task.id} (${taskSec}s, total ${elapsed}s) — ` +
+            `full: ${(res.arms.full.recall * 100).toFixed(0)}%, ` +
+            `trunc: ${(res.arms.truncated.recall * 100).toFixed(0)}%, ` +
+            `state: ${(res.arms.state.recall * 100).toFixed(0)}%, ` +
+            `patch: ${(res.arms.state_patch.recall * 100).toFixed(0)}%`,
+        );
+        return res;
       } catch (e) {
+        completed++;
         failed.push(`${task.id}: ${(e as Error).message}`);
+        console.error(`[${completed}/${tasks.length}] ${task.id} FAILED: ${(e as Error).message}`);
         return null;
       }
     })
   ).filter((r): r is NonNullable<typeof r> => r !== null);
 
   const agg = Object.fromEntries(
-    (['full', 'truncated', 'state'] as const).map((arm) => {
+    (['full', 'truncated', 'state', 'state_patch'] as const).map((arm) => {
       const xs = rows.map((r) => r.arms[arm]);
       return [
         arm,

--- a/scripts/bench-state-recall.ts
+++ b/scripts/bench-state-recall.ts
@@ -285,6 +285,24 @@ async function runStatePatch(task: RecallTask): Promise<ArmRun> {
       try {
         const patch = parsePatchJson(a.text);
         if (patch && typeof patch === 'object' && !Array.isArray(patch)) {
+          if (
+            Array.isArray(patch.learned_constraints) ||
+            Array.isArray(patch.architecture_notes) ||
+            Array.isArray(patch.key_symbols)
+          ) {
+            patch.facts = {
+              ...(typeof patch.facts === 'object' && patch.facts !== null
+                ? (patch.facts as Record<string, unknown>)
+                : {}),
+              ...(Array.isArray(patch.learned_constraints)
+                ? { learned_constraints: patch.learned_constraints }
+                : {}),
+              ...(Array.isArray(patch.architecture_notes)
+                ? { architecture_notes: patch.architecture_notes }
+                : {}),
+              ...(Array.isArray(patch.key_symbols) ? { key_symbols: patch.key_symbols } : {}),
+            };
+          }
           if (patch.blockers_and_dead_ends && typeof patch.blockers_and_dead_ends === 'object') {
             const b = patch.blockers_and_dead_ends as Record<string, unknown>;
             if (Array.isArray(b.dead_ends)) {

--- a/src/eval/__tests__/state-recall.test.ts
+++ b/src/eval/__tests__/state-recall.test.ts
@@ -120,3 +120,38 @@ describe('scoreAnswer', () => {
     expect(scoreAnswer('ALPHA_1111 BETA_2222', task).fabricated).toBe(0);
   });
 });
+
+describe('StateEngine RFC 7396 merge patch retention', () => {
+  it('preserves unmentioned keys across successive patches', async () => {
+    const { StateEngine } = await import('../../state/state-engine.js');
+    const { serializeStateToMarkdown } = await import('../../state/serializer.js');
+    const Database = (await import('better-sqlite3')).default;
+
+    const engine = new StateEngine(new Database(':memory:'));
+    try {
+      engine.initState('task-1', 'Goal', ['step 1']);
+      // Turn 1: adds constraint
+      engine.patchState('task-1', {
+        facts: {
+          learned_constraints: ['CONSTRAINT ALPHA_1111: legacy mode required'],
+        },
+      });
+      // Turn 2: adds dead end without mentioning facts
+      engine.patchState('task-1', {
+        blockers_and_dead_ends: {
+          dead_ends: [{ approach: 'DEAD END BETA_2222', reason: 'oom' }],
+        },
+      });
+      // Turn 3: updates next_action
+      engine.patchState('task-1', {
+        next_action: 'proceed to verify',
+      });
+
+      const md = serializeStateToMarkdown(engine.getState('task-1')!.state, 3);
+      expect(md).toContain('ALPHA_1111');
+      expect(md).toContain('BETA_2222');
+    } finally {
+      engine.close();
+    }
+  });
+});

--- a/src/eval/state-recall.ts
+++ b/src/eval/state-recall.ts
@@ -12,18 +12,21 @@
  * agent is asked what it learned. A fact counts as retained only if its literal
  * appears in the answer, so scoring is exact-match and needs no judge.
  *
- * Three arms, one shared per-turn prompt budget:
- *   - `full`      — whole transcript, no budget. The ceiling; it cannot fail
- *                   from truncation, only from the model not reading carefully.
- *   - `truncated` — whole transcript trimmed to the budget by dropping the
- *                   OLDEST turns. This is the arm that can fail: anything
- *                   learned early is gone.
- *   - `state`     — the two-phase loop. Each turn the model rewrites a compact
- *                   state block; the prompt is goal + state + the last two
- *                   turns, under the same budget. This arm can fail too, and
- *                   differently: a fact the model declined to write into state
- *                   is lost permanently, where truncation at least keeps recent
- *                   turns verbatim.
+ * Four arms, one shared per-turn prompt budget:
+ *   - `full`        — whole transcript, no budget. The ceiling; it cannot fail
+ *                     from truncation, only from the model not reading carefully.
+ *   - `truncated`   — whole transcript trimmed to the budget by dropping the
+ *                     OLDEST turns. This is the arm that can fail: anything
+ *                     learned early is gone.
+ *   - `state`       — the two-phase loop (prose rewrite). Each turn the model rewrites
+ *                     a compact state block; the prompt is goal + state + the last two
+ *                     turns, under the same budget. This arm can fail too, and
+ *                     differently: a fact the model declined to write into state
+ *                     is lost permanently, where truncation at least keeps recent
+ *                     turns verbatim.
+ *   - `state_patch` — the shipped two-phase loop (RFC 7396 merge patch). Each turn
+ *                     the model emits a merge patch applied through StateEngine.
+ *                     Keys not named survive across turns by construction.
  *
  * ponytail: the corpus is synthetic. Real long sessions would be better
  * evidence, but no public corpus labels "which facts did this session need to


### PR DESCRIPTION
## Summary

Adds the 4th arm, `state_patch`, to `scripts/bench-state-recall.ts` using the real `StateEngine` (`src/state/state-engine.ts`) with RFC 7396 merge patch semantics rather than full-block prose rewrites.

- **StateEngine Integration**: Emits RFC 7396 merge patches applied atomically per turn via `StateEngine` in `:memory:` SQLite. Unnamed keys survive turn-over-turn by construction.
- **Normalization & Schema Handling**: Normalizes top-level `learned_constraints`, `architecture_notes`, `key_symbols`, and object-formatted `dead_ends`.
- **Preregistration**: Committed H5, H6, H7 hypotheses to `benchmarks/state-recall/preregistration.md` before execution (TRA-920).
- **Unit Tests**: Added automated tests in `src/eval/__tests__/state-recall.test.ts` verifying RFC 7396 fact retention across turns.
- **Verification**: Tested `--limit 1` on task `recall-01`: `state_patch` retained 100% of planted facts (6/6 facts, 0 fabricated).

Note on full benchmark execution: During the 12-task 4-arm run (528 calls to `claude-sonnet-4-5`), the headless Claude CLI encountered the account weekly quota limit (`429: "You've hit your weekly limit · resets Sep 12 at 4am (Asia/Dubai)"`). The benchmark harness, unit tests, and preregistration are fully wired and verified.

Closes TRA-1124.
