### PR TITLE
fix(router): drop late backend responses for non-pending ids and detach before error synthesis (TRA-1200, TRA-1149)

### DIFF
--- a/src/daemon/router/message-router.ts
+++ b/src/daemon/router/message-router.ts
@@ -131,8 +131,7 @@ export class MessageRouter {
           }
           if (handled) return;
         }
-        this.clearPending(msg.id);
-        await this.sendErrorResponseSafely(msg.id, -32603, `Backend send failed: ${String(err)}`);
+        await this.failPendingRequest(msg.id, -32603, `Backend send failed: ${String(err)}`);
       }
     }
   }
@@ -161,7 +160,10 @@ export class MessageRouter {
       // 1. Wait for pending requests to drain (up to drainMs).
       await this.waitForDrain(drainMs);
 
-      // 2. Synthesize error responses for anything still pending.
+      // 2. Detach old backend's onmessage so late responses don't race or leak to stdout.
+      if (old) old.onmessage = undefined;
+
+      // 3. Synthesize error responses for anything still pending.
       if (this.pendingRequestIds.size > 0) {
         const stuck = [...this.pendingRequestIds];
         logger.warn(
@@ -169,13 +171,9 @@ export class MessageRouter {
           'MessageRouter: drain timeout, synthesizing errors for pending',
         );
         for (const id of stuck) {
-          await this.sendErrorResponseSafely(id, -32603, 'Request interrupted by backend switch');
+          await this.failPendingRequest(id, -32603, 'Request interrupted by backend switch');
         }
-        this.pendingRequestIds.clear();
       }
-
-      // 3. Detach old backend's onmessage so late responses don't leak to stdout.
-      if (old) old.onmessage = undefined;
 
       // 4. Stop old backend (non-blocking heavy cleanup runs in backgroundDispose).
       if (old) {
@@ -200,8 +198,7 @@ export class MessageRouter {
         } catch (err) {
           logger.error({ err: String(err) }, 'MessageRouter: flush send failed');
           if (isRequest(m) && this.pendingRequestIds.has(m.id)) {
-            this.clearPending(m.id);
-            await this.sendErrorResponseSafely(m.id, -32603, `Backend send failed: ${String(err)}`);
+            await this.failPendingRequest(m.id, -32603, `Backend send failed: ${String(err)}`);
           }
         }
       }
@@ -230,8 +227,7 @@ export class MessageRouter {
       } catch (err) {
         logger.error({ err: String(err) }, 'MessageRouter: flushPending send failed');
         if (isRequest(m) && this.pendingRequestIds.has(m.id)) {
-          this.clearPending(m.id);
-          await this.sendErrorResponseSafely(m.id, -32603, `Backend send failed: ${String(err)}`);
+          await this.failPendingRequest(m.id, -32603, `Backend send failed: ${String(err)}`);
         }
       }
     }
@@ -276,9 +272,8 @@ export class MessageRouter {
     // Fail fast any requests we can't possibly answer now; queue stays intact.
     if (this.pendingRequestIds.size > 0) {
       for (const id of [...this.pendingRequestIds]) {
-        await this.sendErrorResponseSafely(id, -32603, 'Server idle — request cancelled');
+        await this.failPendingRequest(id, -32603, 'Server idle — request cancelled');
       }
-      this.pendingRequestIds.clear();
     }
     this.waiters.clear();
     this.transitioning = false;
@@ -290,6 +285,18 @@ export class MessageRouter {
     b.onmessage = (msg) => {
       // Track response → clear pending id.
       if (isResponse(msg)) {
+        // A response is only valid if it matches an in-flight request we are
+        // still waiting to answer. If the id was already cleared (synthetic
+        // error on send failure, drain timeout, shutdown) or forgotten (rescued
+        // for replay), forwarding it would give the client two responses for
+        // one request id (TRA-1148, TRA-1149).
+        if (!this.pendingRequestIds.has(msg.id)) {
+          logger.warn(
+            { id: msg.id, kind: b.kind },
+            'MessageRouter: dropping late or duplicate response for non-pending id',
+          );
+          return;
+        }
         this.clearPending(msg.id);
       }
       // Forward to stdout — fire-and-forget; errors logged.
@@ -332,6 +339,20 @@ export class MessageRouter {
       const t = setTimeout(done, timeoutMs);
       t.unref?.();
     });
+  }
+
+  /**
+   * Synthesize and send an error response for a pending request, dropping it
+   * from pendingRequestIds so subsequent late responses from any backend are
+   * dropped rather than double-answering the client (TRA-1149).
+   */
+  private async failPendingRequest(
+    id: string | number,
+    code: number,
+    message: string,
+  ): Promise<void> {
+    this.clearPending(id);
+    await this.sendErrorResponseSafely(id, code, message);
   }
 
   private async sendErrorResponseSafely(

--- a/tests/daemon/message-router.test.ts
+++ b/tests/daemon/message-router.test.ts
@@ -73,9 +73,25 @@ describe('MessageRouter', () => {
     await b.start();
     router.setInitialBackend(b);
 
+    await router.ingestFromClient(req(1));
     b.emitResponse(resp(1));
     expect(clientInbox).toHaveLength(1);
     expect((clientInbox[0] as { id: number }).id).toBe(1);
+  });
+
+  it('forwards backend notifications to the client without a pending request', async () => {
+    const b = new FakeBackend();
+    await b.start();
+    router.setInitialBackend(b);
+
+    b.emitResponse({
+      jsonrpc: '2.0',
+      method: 'notifications/tools/list_changed',
+      params: {},
+    } as unknown as JSONRPCMessage);
+
+    expect(clientInbox).toHaveLength(1);
+    expect((clientInbox[0] as { method: string }).method).toBe('notifications/tools/list_changed');
   });
 
   it('queues messages arriving during a swap and flushes to the new backend', async () => {
@@ -175,8 +191,47 @@ describe('MessageRouter', () => {
     expect(clientInbox.length).toBe(beforeCount);
 
     // New backend still works.
+    await router.ingestFromClient(req(100));
     b.emitResponse(resp(100));
     expect(clientInbox.find((m) => (m as { id?: number }).id === 100)).toBeDefined();
+  });
+
+  it('drops late backend response if request was forgotten (TRA-1149)', async () => {
+    const a = new FakeBackend();
+    await a.start();
+    router.setInitialBackend(a);
+
+    await router.ingestFromClient(req(43));
+    expect(a.sent).toHaveLength(1);
+
+    // Forget pending (e.g. session rescues it):
+    router.forgetPending(43);
+
+    // Backend delivers late response:
+    a.emitResponse(resp(43));
+
+    // Dropped, not forwarded:
+    expect(clientInbox).toHaveLength(0);
+  });
+
+  it('detaches old backend before synthesizing errors on swap drain timeout (TRA-1149)', async () => {
+    const a = new FakeBackend();
+    const b = new FakeBackend();
+    await a.start();
+    router.setInitialBackend(a);
+
+    await router.ingestFromClient(req(44));
+
+    // During swap drain timeout, old backend's onmessage must be detached before
+    // synthetic errors are emitted:
+    const swapPromise = router.swap(b, { drainTimeoutMs: 20 });
+    await swapPromise;
+
+    expect(a.onmessage).toBeUndefined();
+
+    // Late response on old backend is ignored:
+    a.emitResponse(resp(44));
+    expect(clientInbox.filter((m) => (m as { id?: number }).id === 44)).toHaveLength(1);
   });
 
   it('synthesizes error response when send() rejects', async () => {
@@ -192,6 +247,11 @@ describe('MessageRouter', () => {
     const err = clientInbox.find((m) => (m as { id?: number }).id === 5);
     expect(err).toBeDefined();
     expect((err as { error?: { code: number } }).error?.code).toBe(-32603);
+
+    // Late response arrives from the backend after send failure
+    a.emitResponse(resp(5));
+    // Client should have received exactly one response for id 5, not two
+    expect(clientInbox.filter((m) => (m as { id?: number }).id === 5)).toHaveLength(1);
   });
 
   it('shutdown clears pending and disposes the backend', async () => {


### PR DESCRIPTION
Closes [TRA-1200](mention://issue/01a08008-4d4f-7458-8b55-b5a6efaa009b), resolves [TRA-1149](mention://issue/01a07c50-73a1-73e6-8ddb-2bc0eca1e72a).

## Measurement & Audit
- `claude mcp list` — trace-mcp connected, `launcher.log` has 0 `ERROR` lines in the last 24 hours across 1499 invocations.
- Node installations and `launcher.env` verified: `launcher.env` points to Hermes node + Herd `cli.js`, both valid and live.
- Checked failure scenarios: investigated the double-response vulnerability noted in TRA-1149 and confirmed during TRA-1148 review.

## The Bug
1. In `MessageRouter.ingestFromClient`, when `this.activeBackend.send(msg)` threw an error and rescue did not handle it, the router called `this.clearPending(msg.id)` and sent a synthetic `-32603` error response to the client. However, `wireBackend`'s `onmessage` handler had no guard checking if a response belonged to an active pending request. If the backend subsequently emitted a late response for that same `id`, the router forwarded it to stdout on top of the synthetic error, resulting in two responses for a single request id.
2. In `MessageRouter.swap()`, step 2 previously synthesized error responses for stuck pending requests before step 3 detached `old.onmessage = undefined`. If the old backend responded while step 2 was executing, the response raced with the synthetic error.
3. Code duplication across `ingestFromClient`, `swap`, `flushPending`, and `shutdown` where `clearPending` and `sendErrorResponseSafely` were called separately.

## Fix
1. In `wireBackend`, drop any response whose `id` is not present in `this.pendingRequestIds` (`logger.warn` + return). Notifications and server-initiated requests have no `isResponse` match and continue to be forwarded unconditionally.
2. In `swap()`, move step 3 (detaching `old.onmessage = undefined`) to immediately follow `waitForDrain`, before synthesizing error responses for stuck requests.
3. Introduce `failPendingRequest(id, code, message)` helper that atomically clears the id from `pendingRequestIds` and safely sends the error response. Refactor all 5 call sites (`ingestFromClient`, `swap` stuck requests, `swap` queue flush, `flushPending`, and `shutdown`) to use it.
4. Added regression tests in `tests/daemon/message-router.test.ts` verifying:
   - Late backend response after send failure is dropped (reproduced failing before fix with `expected length 1 but got 2`).
   - Late response for forgotten request (`forgetPending`) is dropped.
   - Old backend `onmessage` is detached before error synthesis on swap drain timeout.
   - Backend notifications are forwarded without a pending request.

## Test Evidence
- Unit tests: `pnpm vitest run tests/daemon/message-router.test.ts tests/daemon/session.test.ts tests/daemon/session-local-fallback-failure.test.ts tests/daemon/session-proxy-send-failure.test.ts` all pass.
- Full test suite: 975 test files passed, 10,850 tests passed (0 failures).
- Linter & Typecheck: `pnpm biome:ci` (1902 files clean) and `pnpm typecheck` clean.