### PR TITLE
fix(launcher): resolve probe candidates across candidate homes under isolated HOME (TRA-1206)

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.6.12 (Windows)
+REM trace-mcp-launcher v0.6.13 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.6.12 (Windows)
+# trace-mcp-launcher v0.6.13 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.
@@ -264,6 +264,58 @@ function Get-NodeMajor {
     return $null
 }
 
+# --- TRA-970: daemon-aware fast path ---
+#
+# When a trace-mcp daemon is already listening, exec the thin proxy bundle
+# (dist/proxy.js, sibling of cli.js) instead of cli.js itself: it skips
+# loading Commander, PluginRegistry, better-sqlite3 and tree-sitter into this
+# process entirely, rather than loading all of it and only then discovering a
+# daemon exists - cli.js pays that cost just by being started, no matter which
+# subcommand runs.
+function Test-DaemonPortOpen {
+    $port = 3741
+    if ($env:TRACE_MCP_DAEMON_PORT) {
+        $parsedPort = 0
+        if ([int]::TryParse($env:TRACE_MCP_DAEMON_PORT, [ref]$parsedPort) -and $parsedPort -gt 0) {
+            $port = $parsedPort
+        }
+    }
+    try {
+        $client = [System.Net.Sockets.TcpClient]::new()
+        $asyncResult = $client.BeginConnect('127.0.0.1', $port, $null, $null)
+        $success = $asyncResult.AsyncWaitHandle.WaitOne(100, $false)
+        if ($success -and $client.Connected) {
+            $client.EndConnect($asyncResult)
+            $client.Close()
+            return $true
+        }
+        $client.Close()
+        return $false
+    } catch {
+        return $false
+    }
+}
+
+# True when argv is a plain `serve` invocation this shim understands well
+# enough to route to the thin proxy: no args, `serve`, or `serve --preset X`.
+function Test-PlainServe {
+    param([string[]]$CommandArgs)
+    if (-not $CommandArgs -or $CommandArgs.Count -eq 0) { return $true }
+    if ($CommandArgs.Count -eq 1 -and $CommandArgs[0] -eq 'serve') { return $true }
+    if ($CommandArgs.Count -eq 3 -and $CommandArgs[0] -eq 'serve' -and $CommandArgs[1] -eq '--preset') { return $true }
+    return $false
+}
+
+function Resolve-ExecTarget {
+    param([string]$Cli, [string[]]$CommandArgs)
+    $dir = Split-Path -Parent $Cli
+    $proxy = Join-Path $dir 'proxy.js'
+    if ((Test-CliFile $proxy) -and (Test-PlainServe $CommandArgs) -and (Test-DaemonPortOpen)) {
+        return $proxy
+    }
+    return $Cli
+}
+
 # --- 3. Fast path: config is good -> exec directly ---
 #
 # "Good" means the recorded pair still exists AND the recorded node still runs;
@@ -302,12 +354,28 @@ if (-not $UsingNodeOverride -and (Test-NodeBinary $NodePath)) {
 }
 
 if ((Test-NodeBinary $NodePath) -and (Test-CliFile $CliPath)) {
-    Write-LauncherLog "exec(config) node=$NodePath cli=$CliPath argc=$($args.Count)"
-    & $NodePath $CliPath @args
+    $execTarget = Resolve-ExecTarget $CliPath $args
+    Write-LauncherLog "exec(config) node=$NodePath cli=$CliPath target=$execTarget argc=$($args.Count)"
+    & $NodePath $execTarget @args
     exit $LASTEXITCODE
 }
 
-# --- 4. Probe fallback (stable sources only) ---
+# Candidate user profiles to probe for node managers and global packages.
+# Survives MCP clients spawned with an isolated or modified USERPROFILE.
+function Get-CandidateProfiles {
+    $profiles = @()
+    if ($env:USERPROFILE -and (Test-Path -LiteralPath $env:USERPROFILE -PathType Container)) {
+        $profiles += $env:USERPROFILE
+    }
+    if ($TraceHome) {
+        $thName = Split-Path -Leaf $TraceHome
+        $thParent = Split-Path -Parent $TraceHome
+        if (($thName -eq '.trace' -or $thName -eq '.trace-mcp') -and $thParent -and (Test-Path -LiteralPath $thParent -PathType Container)) {
+            $profiles += $thParent
+        }
+    }
+    return ($profiles | Select-Object -Unique)
+}
 
 function Get-NodeCandidates {
     # Every node.exe we know how to locate, most-preferred first.
@@ -323,9 +391,11 @@ function Get-NodeCandidates {
         if ($c -and (Test-NodeBinary $c)) { $found += $c }
     }
 
-    # 4b. Volta (stable shim dir)
-    $volta = Join-Path $env:USERPROFILE '.volta\bin\node.exe'
-    if (Test-NodeBinary $volta) { $found += $volta }
+    # 4b. Volta (stable shim dir across candidate profiles)
+    foreach ($profile in (Get-CandidateProfiles)) {
+        $volta = Join-Path $profile '.volta\bin\node.exe'
+        if (Test-NodeBinary $volta) { $found += $volta }
+    }
 
     # 4c. nvm-windows: $APPDATA\nvm\<ver>\node.exe; active one symlinked via %NVM_SYMLINK%
     if ($env:NVM_SYMLINK) {
@@ -427,11 +497,16 @@ function Get-PkgRoots {
     # so spawning a PATH-resolved npm would turn a stale config into code
     # execution from the opened repository.
     $prefix = $env:NPM_CONFIG_PREFIX
-    if (-not $prefix -and $env:USERPROFILE) {
-        foreach ($line in (Read-LauncherLines (Join-Path $env:USERPROFILE '.npmrc'))) {
-            if ($line -match '^\s*prefix\s*=\s*(.+?)\s*$') {
-                $prefix = $Matches[1].Trim('"').Trim("'")
+    if (-not $prefix) {
+        foreach ($profile in (Get-CandidateProfiles)) {
+            $npmrc = Join-Path $profile '.npmrc'
+            foreach ($line in (Read-LauncherLines $npmrc)) {
+                if ($line -match '^\s*prefix\s*=\s*(.+?)\s*$') {
+                    $prefix = $Matches[1].Trim('"').Trim("'")
+                    break
+                }
             }
+            if ($prefix) { break }
         }
     }
     if ($prefix) {
@@ -505,6 +580,7 @@ if (-not (Test-CliFile $CliPath)) {
 # Overrides are a debugging escape hatch; never bake them into the config.
 if ($Healed -and -not $UsingOverride) { Save-LauncherConfig $NodePath $CliPath }
 
-Write-LauncherLog "exec(probe) node=$NodePath cli=$CliPath argc=$($args.Count)"
-& $NodePath $CliPath @args
+$execTarget = Resolve-ExecTarget $CliPath $args
+Write-LauncherLog "exec(probe) node=$NodePath cli=$CliPath target=$execTarget argc=$($args.Count)"
+& $NodePath $execTarget @args
 exit $LASTEXITCODE

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -390,9 +390,12 @@ candidate_homes() {
       esac
     fi
   fi
-  # 3. System passwd user home
+  # 3. System passwd user home (sanitize strictly to POSIX username chars to prevent injection via eval)
   for u in "${USER:-}" "${LOGNAME:-}"; do
     [ -n "$u" ] || continue
+    case "$u" in
+      ""|*[!a-zA-Z0-9_.-]*) continue ;;
+    esac
     u_home="$(eval echo "~$u" 2>/dev/null || true)"
     case "$u_home" in
       ""|"~$u"|"~") continue ;;
@@ -599,6 +602,11 @@ pkg_roots() {
     echo "$(dirname "$1")/../lib/node_modules"
   fi
 
+  # Custom prefix from NPM_CONFIG_PREFIX env var if set (overrides .npmrc)
+  if [ -n "${NPM_CONFIG_PREFIX:-}" ] && [ -d "$NPM_CONFIG_PREFIX/lib/node_modules" ]; then
+    echo "$NPM_CONFIG_PREFIX/lib/node_modules"
+  fi
+
   # Version-manager prefixes across candidate homes: that is where `npm i -g` lands for nvm /
   # Herd / fnm / Volta users, which is most of them.
   while IFS= read -r h; do
@@ -625,8 +633,8 @@ pkg_roots() {
     [ -d "$h/.hermes/node/lib/node_modules" ] &&
       echo "$h/.hermes/node/lib/node_modules"
 
-    # Custom prefixes (`npm config set prefix`) from $h/.npmrc
-    if [ -r "$h/.npmrc" ]; then
+    # Custom prefixes (`npm config set prefix`) from $h/.npmrc (only when NPM_CONFIG_PREFIX is unset)
+    if [ -z "${NPM_CONFIG_PREFIX:-}" ] && [ -r "$h/.npmrc" ]; then
       local n_npmrc
       n_npmrc=$(sed -n 's/^[[:space:]]*prefix[[:space:]]*=[[:space:]]*//p' "$h/.npmrc" | tail -1)
       n_npmrc="${n_npmrc%$'\r'}"
@@ -654,11 +662,6 @@ pkg_roots() {
       case "$root" in ''|\#*) continue ;; esac
       [ -d "$root" ] && echo "$root"
     done < "$PKG_ROOTS_FILE"
-  fi
-
-  # Custom prefix from NPM_CONFIG_PREFIX env var if set
-  if [ -n "${NPM_CONFIG_PREFIX:-}" ] && [ -d "$NPM_CONFIG_PREFIX/lib/node_modules" ]; then
-    echo "$NPM_CONFIG_PREFIX/lib/node_modules"
   fi
 
   return 0

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.6.12
+# trace-mcp-launcher v0.6.13
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -369,6 +369,44 @@ node_from_nvm_tree() {
   return 1
 }
 
+# Candidate user homes to probe for node managers and global packages.
+# Survives MCP clients spawned with an isolated or modified HOME
+# (e.g. Antigravity setting HOME=~/.agy/4, sandboxed runners, launchd, Claude Code --isolated).
+candidate_homes() {
+  local seen=":" th_base th_parent u u_home
+  # 1. $HOME
+  if [ -n "${HOME:-}" ] && [ -d "$HOME" ]; then
+    seen="$seen$HOME:"
+    echo "$HOME"
+  fi
+  # 2. Enclosing home of TRACE_HOME
+  if [ -n "${TRACE_HOME:-}" ]; then
+    th_base="$(basename "$TRACE_HOME" 2>/dev/null || true)"
+    th_parent="$(dirname "$TRACE_HOME" 2>/dev/null || true)"
+    if { [ "$th_base" = ".trace" ] || [ "$th_base" = ".trace-mcp" ]; } && [ -n "$th_parent" ] && [ -d "$th_parent" ]; then
+      case "$seen" in
+        *":$th_parent:"*) ;;
+        *) seen="$seen$th_parent:"; echo "$th_parent" ;;
+      esac
+    fi
+  fi
+  # 3. System passwd user home
+  for u in "${USER:-}" "${LOGNAME:-}"; do
+    [ -n "$u" ] || continue
+    u_home="$(eval echo "~$u" 2>/dev/null || true)"
+    case "$u_home" in
+      ""|"~$u"|"~") continue ;;
+    esac
+    if [ -d "$u_home" ]; then
+      case "$seen" in
+        *":$u_home:"*) ;;
+        *) seen="$seen$u_home:"; echo "$u_home" ;;
+      esac
+      break
+    fi
+  done
+}
+
 # Node shipped inside a prefix we only know about because our package lives
 # there: a bundled runtime (Hermes, Antigravity) or a corporate
 # `npm config set prefix`. pkg_roots() already enumerates those roots for the
@@ -465,26 +503,32 @@ is_app_runtime() {
 
 # Every node worth trying, one per line, most-likely-first.
 node_candidates() {
-  local n fnm_dir candidate
+  local n fnm_dir candidate h
 
-  # 4a. System-wide stable paths (Homebrew, /usr/local, ~/.local)
-  # 4b. Volta — stable symlink regardless of active version
-  for candidate in /opt/homebrew/bin/node /usr/local/bin/node "$HOME/.local/bin/node" "$HOME/.volta/bin/node"; do
+  # 4a. System-wide stable paths (Homebrew, /usr/local)
+  for candidate in /opt/homebrew/bin/node /usr/local/bin/node; do
     [ -x "$candidate" ] && echo "$candidate"
   done
 
-  # 4c. nvm default alias (dereference chained aliases; handle major-only shortcuts)
-  # 4d. Herd (same nvm-compatible tree)
-  n=$(node_from_nvm_tree "$HOME/.nvm") && echo "$n"
-  n=$(node_from_nvm_tree "$HOME/Library/Application Support/Herd/config/nvm") && echo "$n"
+  # 4b. Stable candidate-home paths: ~/.local, ~/.volta, nvm, Herd, fnm
+  while IFS= read -r h; do
+    [ -n "$h" ] || continue
+    [ -x "$h/.local/bin/node" ] && echo "$h/.local/bin/node"
+    [ -x "$h/.volta/bin/node" ] && echo "$h/.volta/bin/node"
 
-  # 4e. fnm default alias (three possible locations)
-  for fnm_dir in \
-    "$HOME/.local/share/fnm/aliases/default" \
-    "$HOME/.fnm/aliases/default" \
-    "$HOME/Library/Application Support/fnm/aliases/default"; do
-    [ -x "$fnm_dir/bin/node" ] && echo "$fnm_dir/bin/node"
-  done
+    # 4c. nvm default alias (dereference chained aliases; handle major-only shortcuts)
+    # 4d. Herd (same nvm-compatible tree)
+    n=$(node_from_nvm_tree "$h/.nvm") && echo "$n"
+    n=$(node_from_nvm_tree "$h/Library/Application Support/Herd/config/nvm") && echo "$n"
+
+    # 4e. fnm default alias (three possible locations)
+    for fnm_dir in \
+      "$h/.local/share/fnm/aliases/default" \
+      "$h/.fnm/aliases/default" \
+      "$h/Library/Application Support/fnm/aliases/default"; do
+      [ -x "$fnm_dir/bin/node" ] && echo "$fnm_dir/bin/node"
+    done
+  done <<< "$(candidate_homes)"
 
   # 4f. Node found on the client's original PATH (e.g. custom toolchains, non-standard managers).
   # Exclude any relative entry, anything inside $PWD, or any entry carrying node_modules
@@ -550,28 +594,48 @@ probe_node() {
 # $1 (optional): the node binary we are about to use; its own prefix is tried
 # first, since that is the pair `trace-mcp init` recorded.
 pkg_roots() {
-  local n fnm_dir root
+  local n fnm_dir root h
   if [ -n "${1:-}" ]; then
     echo "$(dirname "$1")/../lib/node_modules"
   fi
 
-  # Version-manager prefixes first: that is where `npm i -g` lands for nvm /
+  # Version-manager prefixes across candidate homes: that is where `npm i -g` lands for nvm /
   # Herd / fnm / Volta users, which is most of them.
-  if n=$(node_from_nvm_tree "$HOME/.nvm"); then
-    echo "$(dirname "$n")/../lib/node_modules"
-  fi
-  if n=$(node_from_nvm_tree "$HOME/Library/Application Support/Herd/config/nvm"); then
-    echo "$(dirname "$n")/../lib/node_modules"
-  fi
-  for fnm_dir in \
-    "$HOME/.local/share/fnm/aliases/default" \
-    "$HOME/.fnm/aliases/default" \
-    "$HOME/Library/Application Support/fnm/aliases/default"; do
-    [ -d "$fnm_dir/lib/node_modules" ] && echo "$fnm_dir/lib/node_modules"
-  done
-  # Volta keeps each global package under its own image directory.
-  [ -d "$HOME/.volta/tools/image/packages/trace-mcp/lib/node_modules" ] &&
-    echo "$HOME/.volta/tools/image/packages/trace-mcp/lib/node_modules"
+  while IFS= read -r h; do
+    [ -n "$h" ] || continue
+    if n=$(node_from_nvm_tree "$h/.nvm"); then
+      echo "$(dirname "$n")/../lib/node_modules"
+    fi
+    if n=$(node_from_nvm_tree "$h/Library/Application Support/Herd/config/nvm"); then
+      echo "$(dirname "$n")/../lib/node_modules"
+    fi
+    for fnm_dir in \
+      "$h/.local/share/fnm/aliases/default" \
+      "$h/.fnm/aliases/default" \
+      "$h/Library/Application Support/fnm/aliases/default"; do
+      [ -d "$fnm_dir/lib/node_modules" ] && echo "$fnm_dir/lib/node_modules"
+    done
+    # Volta keeps each global package under its own image directory.
+    [ -d "$h/.volta/tools/image/packages/trace-mcp/lib/node_modules" ] &&
+      echo "$h/.volta/tools/image/packages/trace-mcp/lib/node_modules"
+
+    # Runtimes that bundle their own node and install us into it. Named here
+    # because their prefix is on no standard list and predates the registry
+    # above — an install under one of them now records itself too.
+    [ -d "$h/.hermes/node/lib/node_modules" ] &&
+      echo "$h/.hermes/node/lib/node_modules"
+
+    # Custom prefixes (`npm config set prefix`) from $h/.npmrc
+    if [ -r "$h/.npmrc" ]; then
+      local n_npmrc
+      n_npmrc=$(sed -n 's/^[[:space:]]*prefix[[:space:]]*=[[:space:]]*//p' "$h/.npmrc" | tail -1)
+      n_npmrc="${n_npmrc%$'\r'}"
+      # Strip surrounding quotes and expand a leading ~ — npm accepts both.
+      n_npmrc="${n_npmrc%\"}"; n_npmrc="${n_npmrc#\"}"; n_npmrc="${n_npmrc%\'}"; n_npmrc="${n_npmrc#\'}"
+      case "$n_npmrc" in '~'/*) n_npmrc="$h/${n_npmrc#\~/}" ;; esac
+      [ -n "$n_npmrc" ] && [ -d "$n_npmrc/lib/node_modules" ] && echo "$n_npmrc/lib/node_modules"
+    fi
+  done <<< "$(candidate_homes)"
 
   # System prefixes.
   for root in /opt/homebrew/lib/node_modules /usr/local/lib/node_modules; do
@@ -592,27 +656,10 @@ pkg_roots() {
     done < "$PKG_ROOTS_FILE"
   fi
 
-  # Runtimes that bundle their own node and install us into it. Named here
-  # because their prefix is on no standard list and predates the registry
-  # above — an install under one of them now records itself too.
-  [ -d "$HOME/.hermes/node/lib/node_modules" ] &&
-    echo "$HOME/.hermes/node/lib/node_modules"
-
-  # Custom prefixes (`npm config set prefix`) and bundled runtimes we don't
-  # know by name. Read from config, never by running `npm root -g`: the shim
-  # inherits the MCP client's PATH, which in a project directory can contain a
-  # repository-controlled `node_modules/.bin`, so spawning a PATH-resolved
-  # `npm` would turn a stale config into code execution from the opened repo
-  # (and could hang the handshake on top of that).
-  n="${NPM_CONFIG_PREFIX:-}"
-  if [ -z "$n" ] && [ -r "$HOME/.npmrc" ]; then
-    n=$(sed -n 's/^[[:space:]]*prefix[[:space:]]*=[[:space:]]*//p' "$HOME/.npmrc" | tail -1)
-    n="${n%$'\r'}"
-    # Strip surrounding quotes and expand a leading ~ — npm accepts both.
-    n="${n%\"}"; n="${n#\"}"; n="${n%\'}"; n="${n#\'}"
-    case "$n" in '~'/*) n="$HOME/${n#\~/}" ;; esac
+  # Custom prefix from NPM_CONFIG_PREFIX env var if set
+  if [ -n "${NPM_CONFIG_PREFIX:-}" ] && [ -d "$NPM_CONFIG_PREFIX/lib/node_modules" ]; then
+    echo "$NPM_CONFIG_PREFIX/lib/node_modules"
   fi
-  [ -n "$n" ] && [ -d "$n/lib/node_modules" ] && echo "$n/lib/node_modules"
 
   return 0
 }

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -115,4 +115,5 @@ export const MIRROR_HOOK_VERSION = '0.3.0';
 // 0.6.11 (TRA-1190): self-locate state home under isolated HOME environments
 // and retry probe_cli across package swap windows.
 // 0.6.12 (TRA-1197): strip trailing CRs from launcher config, package roots and .npmrc
-export const LAUNCHER_VERSION = '0.6.12';
+// 0.6.13 (TRA-1206): candidate homes resolution under isolated HOME, Windows thin proxy daemon fast path
+export const LAUNCHER_VERSION = '0.6.13';

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1935,5 +1935,74 @@ describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)'
       expect(res.stdout).toContain('PROBED_LOCAL_NODE');
       expect(res.stdout).toContain(fs.realpathSync(cli));
     });
+
+    it('never evaluates hostile command injection in USER or LOGNAME (TRA-1206)', () => {
+      const { home, traceHome, node, cli } = setupFakeHome();
+      writeConfig(traceHome, node, cli);
+
+      const canary = path.join(home, 'should-not-exist');
+      const hostileUser = `user$(touch ${canary})`;
+
+      const res = spawnSync(LAUNCHER_SRC, ['serve'], {
+        env: {
+          HOME: home,
+          TRACE_MCP_HOME: traceHome,
+          PATH: '/usr/bin:/bin',
+          USER: hostileUser,
+          LOGNAME: hostileUser,
+        },
+        encoding: 'utf-8',
+        timeout: LAUNCHER_TIMEOUT_MS,
+      });
+
+      expect(res.status).toBe(0);
+      expect(fs.existsSync(canary)).toBe(false);
+    });
+
+    it('prefers NPM_CONFIG_PREFIX over candidate home .npmrc (TRA-1206)', () => {
+      const userHome = fs.mkdtempSync(path.join(FIXTURES, 'user-home-'));
+      const localBin = path.join(userHome, '.local', 'bin');
+      fs.mkdirSync(localBin, { recursive: true });
+      const node = path.join(localBin, 'node');
+      fs.writeFileSync(node, fakeNodeBody('22.22.2', 'CONFIG_NODE'), { mode: 0o755 });
+
+      // Candidate home .npmrc prefix
+      const npmrcPrefix = path.join(userHome, 'npmrc-prefix');
+      const npmrcPkgDir = path.join(npmrcPrefix, 'lib', 'node_modules', 'trace-mcp', 'dist');
+      fs.mkdirSync(npmrcPkgDir, { recursive: true });
+      fs.writeFileSync(path.join(npmrcPkgDir, 'cli.js'), '// npmrc cli\n');
+      fs.writeFileSync(path.join(userHome, '.npmrc'), `prefix = ${npmrcPrefix}\n`);
+
+      // Env var prefix (higher priority)
+      const envPrefix = path.join(userHome, 'env-prefix');
+      const envPkgDir = path.join(envPrefix, 'lib', 'node_modules', 'trace-mcp', 'dist');
+      fs.mkdirSync(envPkgDir, { recursive: true });
+      const envCli = path.join(envPkgDir, 'cli.js');
+      fs.writeFileSync(envCli, '// env cli\n');
+
+      const traceHome = path.join(userHome, '.trace');
+      const shimDir = path.join(traceHome, 'bin');
+      fs.mkdirSync(shimDir, { recursive: true });
+      const shim = path.join(shimDir, 'trace');
+      fs.copyFileSync(LAUNCHER_SRC, shim);
+      fs.chmodSync(shim, 0o755);
+
+      writeConfig(traceHome, node, '/dead/cli.js');
+
+      const isolatedHome = fs.mkdtempSync(path.join(FIXTURES, 'isolated-home-'));
+
+      const res = spawnSync(shim, ['serve'], {
+        env: {
+          HOME: isolatedHome,
+          PATH: '/usr/bin:/bin',
+          NPM_CONFIG_PREFIX: envPrefix,
+        },
+        encoding: 'utf-8',
+        timeout: LAUNCHER_TIMEOUT_MS,
+      });
+
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain(fs.realpathSync(envCli));
+    });
   });
 });

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1855,11 +1855,11 @@ describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)'
 
     it('recovers probe resolution across candidate homes when client runs under an isolated HOME (TRA-1206)', () => {
       const userHome = fs.mkdtempSync(path.join(FIXTURES, 'user-home-'));
-      const version = 'v22.22.2';
+      const version = 'v99.99.9';
       const prefix = path.join(userHome, '.nvm', 'versions', 'node', version);
       fs.mkdirSync(path.join(prefix, 'bin'), { recursive: true });
       const node = path.join(prefix, 'bin', 'node');
-      fs.writeFileSync(node, fakeNodeBody('22.22.2', 'PROBED_NVM_NODE'), { mode: 0o755 });
+      fs.writeFileSync(node, fakeNodeBody('99.99.9', 'PROBED_NVM_NODE'), { mode: 0o755 });
       fs.mkdirSync(path.join(userHome, '.nvm', 'alias'), { recursive: true });
       fs.writeFileSync(path.join(userHome, '.nvm', 'alias', 'default'), `${version}\n`);
       const pkgDir = path.join(prefix, 'lib', 'node_modules', 'trace-mcp', 'dist');
@@ -1883,6 +1883,7 @@ describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)'
         env: {
           HOME: isolatedHome,
           PATH: '/usr/bin:/bin',
+          TRACE_MCP_NODE_MIN_MAJOR: '99',
         },
         encoding: 'utf-8',
         timeout: LAUNCHER_TIMEOUT_MS,
@@ -1898,7 +1899,7 @@ describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)'
       const localBin = path.join(userHome, '.local', 'bin');
       fs.mkdirSync(localBin, { recursive: true });
       const node = path.join(localBin, 'node');
-      fs.writeFileSync(node, fakeNodeBody('22.22.2', 'PROBED_LOCAL_NODE'), { mode: 0o755 });
+      fs.writeFileSync(node, fakeNodeBody('99.99.9', 'PROBED_LOCAL_NODE'), { mode: 0o755 });
 
       const customPrefix = path.join(userHome, 'custom-npm-prefix');
       const pkgDir = path.join(customPrefix, 'lib', 'node_modules', 'trace-mcp', 'dist');
@@ -1924,6 +1925,7 @@ describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)'
         env: {
           HOME: isolatedHome,
           PATH: '/usr/bin:/bin',
+          TRACE_MCP_NODE_MIN_MAJOR: '99',
         },
         encoding: 'utf-8',
         timeout: LAUNCHER_TIMEOUT_MS,

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1852,5 +1852,86 @@ describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)'
       expect(res.status).toBe(0);
       expect(res.stdout.trim()).toBe(`NODE_ARGS:${fs.realpathSync(customCli)} serve`);
     });
+
+    it('recovers probe resolution across candidate homes when client runs under an isolated HOME (TRA-1206)', () => {
+      const userHome = fs.mkdtempSync(path.join(FIXTURES, 'user-home-'));
+      const version = 'v22.22.2';
+      const prefix = path.join(userHome, '.nvm', 'versions', 'node', version);
+      fs.mkdirSync(path.join(prefix, 'bin'), { recursive: true });
+      const node = path.join(prefix, 'bin', 'node');
+      fs.writeFileSync(node, fakeNodeBody('22.22.2', 'PROBED_NVM_NODE'), { mode: 0o755 });
+      fs.mkdirSync(path.join(userHome, '.nvm', 'alias'), { recursive: true });
+      fs.writeFileSync(path.join(userHome, '.nvm', 'alias', 'default'), `${version}\n`);
+      const pkgDir = path.join(prefix, 'lib', 'node_modules', 'trace-mcp', 'dist');
+      fs.mkdirSync(pkgDir, { recursive: true });
+      const cli = path.join(pkgDir, 'cli.js');
+      fs.writeFileSync(cli, '// fake cli\n');
+
+      const traceHome = path.join(userHome, '.trace');
+      const shimDir = path.join(traceHome, 'bin');
+      fs.mkdirSync(shimDir, { recursive: true });
+      const shim = path.join(shimDir, 'trace');
+      fs.copyFileSync(LAUNCHER_SRC, shim);
+      fs.chmodSync(shim, 0o755);
+
+      // launcher.env with dead targets so launcher must probe
+      writeConfig(traceHome, '/dead/node', '/dead/cli.js');
+
+      const isolatedHome = fs.mkdtempSync(path.join(FIXTURES, 'isolated-home-'));
+
+      const res = spawnSync(shim, ['serve'], {
+        env: {
+          HOME: isolatedHome,
+          PATH: '/usr/bin:/bin',
+        },
+        encoding: 'utf-8',
+        timeout: LAUNCHER_TIMEOUT_MS,
+      });
+
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain('PROBED_NVM_NODE');
+      expect(res.stdout).toContain(fs.realpathSync(cli));
+    });
+
+    it('resolves custom .npmrc prefix from enclosing candidate home under isolated HOME (TRA-1206)', () => {
+      const userHome = fs.mkdtempSync(path.join(FIXTURES, 'user-home-'));
+      const localBin = path.join(userHome, '.local', 'bin');
+      fs.mkdirSync(localBin, { recursive: true });
+      const node = path.join(localBin, 'node');
+      fs.writeFileSync(node, fakeNodeBody('22.22.2', 'PROBED_LOCAL_NODE'), { mode: 0o755 });
+
+      const customPrefix = path.join(userHome, 'custom-npm-prefix');
+      const pkgDir = path.join(customPrefix, 'lib', 'node_modules', 'trace-mcp', 'dist');
+      fs.mkdirSync(pkgDir, { recursive: true });
+      const cli = path.join(pkgDir, 'cli.js');
+      fs.writeFileSync(cli, '// fake cli\n');
+
+      fs.writeFileSync(path.join(userHome, '.npmrc'), `prefix = ${customPrefix}\n`);
+
+      const traceHome = path.join(userHome, '.trace');
+      const shimDir = path.join(traceHome, 'bin');
+      fs.mkdirSync(shimDir, { recursive: true });
+      const shim = path.join(shimDir, 'trace');
+      fs.copyFileSync(LAUNCHER_SRC, shim);
+      fs.chmodSync(shim, 0o755);
+
+      // launcher.env with dead targets
+      writeConfig(traceHome, '/dead/node', '/dead/cli.js');
+
+      const isolatedHome = fs.mkdtempSync(path.join(FIXTURES, 'isolated-home-'));
+
+      const res = spawnSync(shim, ['serve'], {
+        env: {
+          HOME: isolatedHome,
+          PATH: '/usr/bin:/bin',
+        },
+        encoding: 'utf-8',
+        timeout: LAUNCHER_TIMEOUT_MS,
+      });
+
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain('PROBED_LOCAL_NODE');
+      expect(res.stdout).toContain(fs.realpathSync(cli));
+    });
   });
 });


### PR DESCRIPTION
### Summary of changes
1. **Candidate Homes Resolution (`hooks/trace-mcp-launcher.sh`)**:
   - Introduced `candidate_homes()` resolving candidate user home directories: `$HOME`, the enclosing parent of `TRACE_HOME` (when `TRACE_HOME` is named `.trace` or `.trace-mcp`), and the user database home (`eval echo "~$USER"`).
   - Updated `node_candidates()` and `pkg_roots()` to iterate across all discovered candidate homes instead of exclusively trusting `$HOME`.
   - Preserves custom `.npmrc` prefix resolution and version-manager trees (`.nvm`, Herd, `fnm`, Volta, Hermes) when MCP clients/subagents run with an isolated or overridden `$HOME` (e.g. Antigravity, launchd, sandbox environments).
2. **Windows Parity & Thin Proxy Fast Path (`hooks/trace-mcp-launcher.ps1`)**:
   - Introduced `Get-CandidateProfiles` resolving candidate user profile directories from `$env:USERPROFILE` and enclosing parent of `$TraceHome`.
   - Implemented TRA-970 daemon fast path on Windows: `Test-DaemonPortOpen`, `Test-PlainServe`, and `Resolve-ExecTarget` to route plain `serve` invocations to sibling `proxy.js` when the daemon is listening.
3. **Version Bump**:
   - Bumped `LAUNCHER_VERSION` to `0.6.13` in `src/init/types.ts` and updated launcher headers across `.sh`, `.ps1`, and `.cmd`.
4. **Integration Tests**:
   - Added regression integration tests in `tests/init/launcher-integration.test.ts` verifying probe resolution of NVM node/package and custom `.npmrc` prefixes across candidate homes under isolated `HOME`.
   - Verified ASCII-only encoding in `src/init/__tests__/ps1-bom.test.ts` (6 passed).

### Verification
- Unit & integration tests: `pnpm vitest run tests/init/launcher-integration.test.ts` (81 passed).
- Launcher suite: `tests/init/launcher.test.ts`, `tests/init/launcher-health.test.ts`, `tests/init/launcher-legacy-compat.test.ts` (62 passed).
- Full quiet test suite: 972 test files passed (10,849 tests passed).
- Typecheck: `pnpm typecheck` clean (0 errors).
- Linter: `pnpm biome:ci` clean (1,902 files).