### PR TITLE
fix(cli): sort recently changed files by mtime_ms DESC NULLS LAST (TRA-1069)

### DIFF
--- a/src/api/project-files-query.ts
+++ b/src/api/project-files-query.ts
@@ -1,0 +1,106 @@
+/**
+ * SQL builder for `GET /api/projects/files` (cli.ts). Pure and side-effect
+ * free so contract and integration tests can run the exact query the route
+ * uses against a real Store (TRA-1069: sorting by f.mtime_ms DESC NULLS LAST instead
+ * of f.indexed_at DESC).
+ */
+
+export const CODE_FILTER = `
+    AND f.path NOT LIKE '%.md'
+    AND f.path NOT LIKE '%.json'
+    AND f.path NOT LIKE '%.yaml'
+    AND f.path NOT LIKE '%.yml'
+    AND f.path NOT LIKE '%.toml'
+    AND f.path NOT LIKE '%.txt'
+    AND f.path NOT LIKE '%.css'
+    AND f.path NOT LIKE '%.html'
+    AND f.path NOT LIKE '%.svg'
+    AND f.path NOT LIKE '%.lock'
+    AND f.path NOT LIKE '%.env%'
+    AND f.path NOT LIKE '%package.json'
+    AND f.path NOT LIKE '%tsconfig%'
+`;
+
+export function buildProjectFilesQuery(
+  sortBy: string,
+  scope: string,
+  limit: number,
+): { sql: string; params: unknown[] } {
+  // Scope filter: match files by path prefix or glob-like pattern
+  let scopeFilter = '';
+  const scopeParams: unknown[] = [];
+  if (scope) {
+    if (scope.includes('*')) {
+      // Convert glob to LIKE: src/*.ts → src/%.ts
+      scopeFilter = `AND f.path LIKE ?`;
+      scopeParams.push(scope.replace(/\*/g, '%'));
+    } else if (scope.endsWith('/')) {
+      scopeFilter = `AND f.path LIKE ?`;
+      scopeParams.push(`%${scope}%`);
+    } else {
+      // Could be a directory prefix or exact file
+      scopeFilter = `AND (f.path LIKE ? OR f.path LIKE ?)`;
+      scopeParams.push(`%/${scope}%`, `%${scope}/%`);
+    }
+  }
+
+  let sql: string;
+  if (sortBy === 'isolated') {
+    sql = `
+      SELECT f.path,
+             COUNT(DISTINCT s.id) as symbols,
+             0 as edges
+      FROM files f
+      JOIN symbols s ON s.file_id = f.id
+      LEFT JOIN nodes n ON n.ref_id = s.id AND n.node_type = 'symbol'
+      LEFT JOIN edges e_out ON e_out.source_node_id = n.id
+      LEFT JOIN edges e_in ON e_in.target_node_id = n.id
+      WHERE e_out.id IS NULL AND e_in.id IS NULL
+      ${CODE_FILTER} ${scopeFilter}
+      GROUP BY f.id
+      HAVING symbols > 0
+      ORDER BY symbols DESC
+      LIMIT ?
+    `;
+  } else if (sortBy === 'edges') {
+    sql = `
+      SELECT f.path,
+             COUNT(DISTINCT s.id) as symbols,
+             COUNT(DISTINCT e.id) as edges
+      FROM files f
+      JOIN symbols s ON s.file_id = f.id
+      LEFT JOIN nodes n ON n.ref_id = s.id AND n.node_type = 'symbol'
+      LEFT JOIN edges e ON e.source_node_id = n.id OR e.target_node_id = n.id
+      WHERE 1=1 ${CODE_FILTER} ${scopeFilter}
+      GROUP BY f.id
+      ORDER BY edges DESC
+      LIMIT ?
+    `;
+  } else if (sortBy === 'recent') {
+    sql = `
+      SELECT f.path,
+             COUNT(DISTINCT s.id) as symbols,
+             0 as edges
+      FROM files f
+      LEFT JOIN symbols s ON s.file_id = f.id
+      WHERE 1=1 ${CODE_FILTER} ${scopeFilter}
+      GROUP BY f.id
+      ORDER BY f.mtime_ms DESC NULLS LAST
+      LIMIT ?
+    `;
+  } else {
+    sql = `
+      SELECT f.path,
+             COUNT(DISTINCT s.id) as symbols,
+             0 as edges
+      FROM files f
+      LEFT JOIN symbols s ON s.file_id = f.id
+      WHERE 1=1 ${CODE_FILTER} ${scopeFilter}
+      GROUP BY f.id
+      ORDER BY symbols DESC
+      LIMIT ?
+    `;
+  }
+
+  return { sql, params: [...scopeParams, limit] };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -151,6 +151,7 @@ import { handleDashboardRequest } from './api/dashboard-routes.js';
 import { handleJournalStatsRequest, type JournalStatsContext } from './api/journal-stats-routes.js';
 import { handleMemoryRequest } from './api/memory-routes.js';
 import { handleProjectStatsRequest } from './api/project-stats-routes.js';
+import { buildProjectFilesQuery } from './api/project-files-query.js';
 import { buildSymbolsSearchQuery } from './api/symbols-search-query.js';
 import { buildMemoryReport } from './daemon/memory-report.js';
 import { buildJournalEvent, buildJournalSnapshot } from './server/journal-broadcast.js';
@@ -2017,101 +2018,8 @@ program
         const managed = resolution.managed;
         try {
           const db = managed.store.db;
-          let sql: string;
-
-          // Scope filter: match files by path prefix or glob-like pattern
-          let SCOPE_FILTER = '';
-          const scopeParams: string[] = [];
-          if (scope) {
-            if (scope.includes('*')) {
-              // Convert glob to LIKE: src/*.ts → src/%.ts
-              SCOPE_FILTER = `AND f.path LIKE ?`;
-              scopeParams.push(scope.replace(/\*/g, '%'));
-            } else if (scope.endsWith('/')) {
-              SCOPE_FILTER = `AND f.path LIKE ?`;
-              scopeParams.push(`%${scope}%`);
-            } else {
-              // Could be a directory prefix or exact file
-              SCOPE_FILTER = `AND (f.path LIKE ? OR f.path LIKE ?)`;
-              scopeParams.push(`%/${scope}%`, `%${scope}/%`);
-            }
-          }
-
-          // Exclude non-code files from all queries
-          const CODE_FILTER = `
-              AND f.path NOT LIKE '%.md'
-              AND f.path NOT LIKE '%.json'
-              AND f.path NOT LIKE '%.yaml'
-              AND f.path NOT LIKE '%.yml'
-              AND f.path NOT LIKE '%.toml'
-              AND f.path NOT LIKE '%.txt'
-              AND f.path NOT LIKE '%.css'
-              AND f.path NOT LIKE '%.html'
-              AND f.path NOT LIKE '%.svg'
-              AND f.path NOT LIKE '%.lock'
-              AND f.path NOT LIKE '%.env%'
-              AND f.path NOT LIKE '%package.json'
-              AND f.path NOT LIKE '%tsconfig%'
-          `;
-
-          if (sortBy === 'isolated') {
-            sql = `
-              SELECT f.path,
-                     COUNT(DISTINCT s.id) as symbols,
-                     0 as edges
-              FROM files f
-              JOIN symbols s ON s.file_id = f.id
-              LEFT JOIN nodes n ON n.ref_id = s.id AND n.node_type = 'symbol'
-              LEFT JOIN edges e_out ON e_out.source_node_id = n.id
-              LEFT JOIN edges e_in ON e_in.target_node_id = n.id
-              WHERE e_out.id IS NULL AND e_in.id IS NULL
-              ${CODE_FILTER} ${SCOPE_FILTER}
-              GROUP BY f.id
-              HAVING symbols > 0
-              ORDER BY symbols DESC
-              LIMIT ?
-            `;
-          } else if (sortBy === 'edges') {
-            sql = `
-              SELECT f.path,
-                     COUNT(DISTINCT s.id) as symbols,
-                     COUNT(DISTINCT e.id) as edges
-              FROM files f
-              JOIN symbols s ON s.file_id = f.id
-              LEFT JOIN nodes n ON n.ref_id = s.id AND n.node_type = 'symbol'
-              LEFT JOIN edges e ON e.source_node_id = n.id OR e.target_node_id = n.id
-              WHERE 1=1 ${CODE_FILTER} ${SCOPE_FILTER}
-              GROUP BY f.id
-              ORDER BY edges DESC
-              LIMIT ?
-            `;
-          } else if (sortBy === 'recent') {
-            sql = `
-              SELECT f.path,
-                     COUNT(DISTINCT s.id) as symbols,
-                     0 as edges
-              FROM files f
-              LEFT JOIN symbols s ON s.file_id = f.id
-              WHERE 1=1 ${CODE_FILTER} ${SCOPE_FILTER}
-              GROUP BY f.id
-              ORDER BY f.indexed_at DESC
-              LIMIT ?
-            `;
-          } else {
-            sql = `
-              SELECT f.path,
-                     COUNT(DISTINCT s.id) as symbols,
-                     0 as edges
-              FROM files f
-              LEFT JOIN symbols s ON s.file_id = f.id
-              WHERE 1=1 ${CODE_FILTER} ${SCOPE_FILTER}
-              GROUP BY f.id
-              ORDER BY symbols DESC
-              LIMIT ?
-            `;
-          }
-
-          const files = db.prepare(sql).all(...scopeParams, limit) as {
+          const { sql, params } = buildProjectFilesQuery(sortBy, scope, limit);
+          const files = db.prepare(sql).all(...params) as {
             path: string;
             symbols: number;
             edges: number;

--- a/src/indexer/env-indexer.ts
+++ b/src/indexer/env-indexer.ts
@@ -80,6 +80,14 @@ export class EnvIndexer {
       const pathCheck = validatePath(relPath, this.rootPath);
       if (pathCheck.isErr()) continue;
 
+      let fileMtimeMs: number | null = null;
+      try {
+        const stat = fs.lstatSync(absPath);
+        fileMtimeMs = Math.floor(stat.mtimeMs);
+      } catch {
+        // stat failed — readFileSync below will handle ENOENT
+      }
+
       let content: string;
       try {
         content = fs.readFileSync(absPath, 'utf-8');
@@ -91,7 +99,12 @@ export class EnvIndexer {
       const hash = hashContent(Buffer.from(content));
       const existing = this.store.getFile(relPath);
 
-      if (!force && existing && existing.content_hash === hash) continue;
+      if (!force && existing && existing.content_hash === hash) {
+        if (fileMtimeMs != null && existing.mtime_ms !== fileMtimeMs) {
+          this.store.updateFileMtime(existing.id, fileMtimeMs);
+        }
+        continue;
+      }
 
       const entries = parseEnvFile(content);
 
@@ -99,9 +112,9 @@ export class EnvIndexer {
       if (existing) {
         fileId = existing.id;
         this.store.deleteEnvVarsByFile(fileId);
-        this.store.updateFileHash(fileId, hash, content.length);
+        this.store.updateFileHash(fileId, hash, content.length, fileMtimeMs);
       } else {
-        fileId = this.store.insertFile(relPath, 'env', hash, content.length);
+        fileId = this.store.insertFile(relPath, 'env', hash, content.length, null, fileMtimeMs);
         this.store.updateFileStatus(fileId, 'ok', 'config');
       }
 

--- a/tests/api/project-files-query.test.ts
+++ b/tests/api/project-files-query.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Contract and integration tests for GET /api/projects/files (TRA-1069):
+ * 1. buildProjectFilesQuery produces valid SQL for all sort modes ('recent', 'symbols', 'edges', 'isolated')
+ * 2. 'recent' sorts by f.mtime_ms DESC NULLS LAST, putting files with NULL mtime_ms (e.g. synthetic phantom files) last
+ * 3. End-to-end fixture test: indexing a project, touching a file, re-indexing, and verifying that the touched file is first in 'recent' mode
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildProjectFilesQuery } from '../../src/api/project-files-query.js';
+import type { TraceMcpConfig } from '../../src/config.js';
+import type { Store } from '../../src/db/store.js';
+import { IndexingPipeline } from '../../src/indexer/pipeline.js';
+import { TypeScriptLanguagePlugin } from '../../src/indexer/plugins/language/typescript/index.js';
+import { PluginRegistry } from '../../src/plugin-api/registry.js';
+import { initContentHasher } from '../../src/util/hash.js';
+import { createTestStore, createTmpDir, removeTmpDir } from '../test-utils.js';
+
+function seedFile(
+  store: Store,
+  filePath: string,
+  mtimeMs: number | null,
+  indexedAt: string = "datetime('now')",
+): number {
+  const info = store.db
+    .prepare(`INSERT INTO files (path, mtime_ms, indexed_at) VALUES (?, ?, ${indexedAt})`)
+    .run(filePath, mtimeMs);
+  return Number(info.lastInsertRowid);
+}
+
+function seedSymbol(store: Store, fileId: number, name: string) {
+  store.db
+    .prepare(
+      `INSERT INTO symbols (file_id, symbol_id, name, kind, byte_start, byte_end, line_start, line_end)
+       VALUES (?, ?, ?, 'function', 0, 0, 1, 1)`,
+    )
+    .run(fileId, `${fileId}::${name}`, name);
+}
+
+describe('buildProjectFilesQuery (contract)', () => {
+  it('recent mode sorts by mtime_ms DESC with NULLS LAST', () => {
+    const store = createTestStore();
+
+    // Seed files with different mtime_ms and indexed_at timestamps.
+    // Notice: old_touched has older indexed_at but NEWEST mtime_ms.
+    // synthetic file has NULL mtime_ms.
+    const f1 = seedFile(store, 'src/old_touched.ts', 1700000000000, "datetime('now', '-2 hours')");
+    seedSymbol(store, f1, 'fn1');
+
+    const f2 = seedFile(
+      store,
+      'src/recent_indexed_older_mtime.ts',
+      1600000000000,
+      "datetime('now')",
+    );
+    seedSymbol(store, f2, 'fn2');
+
+    const f3 = seedFile(store, 'src/middle.ts', 1650000000000, "datetime('now', '-1 hour')");
+    seedSymbol(store, f3, 'fn3');
+
+    const fNull = seedFile(
+      store,
+      '__external__/_root/pkg/node:fs.synthetic',
+      null,
+      "datetime('now')",
+    );
+    seedSymbol(store, fNull, 'fs');
+
+    const { sql, params } = buildProjectFilesQuery('recent', '', 10);
+    const rows = store.db.prepare(sql).all(...params) as Array<{
+      path: string;
+      symbols: number;
+      edges: number;
+    }>;
+
+    expect(rows.map((r) => r.path)).toEqual([
+      'src/old_touched.ts',
+      'src/middle.ts',
+      'src/recent_indexed_older_mtime.ts',
+      '__external__/_root/pkg/node:fs.synthetic',
+    ]);
+  });
+
+  it('excludes non-code files via CODE_FILTER', () => {
+    const store = createTestStore();
+    seedFile(store, 'README.md', 2000000000000);
+    seedFile(store, 'package.json', 2000000000000);
+    seedFile(store, 'tsconfig.json', 2000000000000);
+    seedFile(store, 'config.yml', 2000000000000);
+    seedFile(store, '.env.local', 2000000000000);
+    seedFile(store, 'src/valid.ts', 1000000000000);
+
+    const { sql, params } = buildProjectFilesQuery('recent', '', 10);
+    const rows = store.db.prepare(sql).all(...params) as Array<{ path: string }>;
+
+    expect(rows.map((r) => r.path)).toEqual(['src/valid.ts']);
+  });
+
+  it('supports directory, glob, and prefix scope filtering', () => {
+    const store = createTestStore();
+    seedFile(store, 'src/routes/api.ts', 1000);
+    seedFile(store, 'src/components/button.tsx', 2000);
+    seedFile(store, 'lib/util.ts', 3000);
+
+    // Directory scope
+    const dirQuery = buildProjectFilesQuery('recent', 'src/', 10);
+    const dirRows = store.db.prepare(dirQuery.sql).all(...dirQuery.params) as Array<{
+      path: string;
+    }>;
+    expect(dirRows.map((r) => r.path).sort()).toEqual([
+      'src/components/button.tsx',
+      'src/routes/api.ts',
+    ]);
+
+    // Glob scope
+    const globQuery = buildProjectFilesQuery('recent', '*.tsx', 10);
+    const globRows = store.db.prepare(globQuery.sql).all(...globQuery.params) as Array<{
+      path: string;
+    }>;
+    expect(globRows.map((r) => r.path)).toEqual(['src/components/button.tsx']);
+  });
+
+  it('handles symbols, edges, and isolated sort modes', () => {
+    const store = createTestStore();
+    const fA = seedFile(store, 'src/a.ts', 1000);
+    seedSymbol(store, fA, 'symA1');
+    seedSymbol(store, fA, 'symA2');
+
+    const fB = seedFile(store, 'src/b.ts', 1000);
+    seedSymbol(store, fB, 'symB1');
+
+    const symQuery = buildProjectFilesQuery('symbols', '', 10);
+    const symRows = store.db.prepare(symQuery.sql).all(...symQuery.params) as Array<{
+      path: string;
+      symbols: number;
+    }>;
+    expect(symRows[0].path).toBe('src/a.ts');
+    expect(symRows[0].symbols).toBe(2);
+    expect(symRows[1].path).toBe('src/b.ts');
+    expect(symRows[1].symbols).toBe(1);
+  });
+});
+
+describe('Recently Changed sidebar ordering with IndexingPipeline (TRA-1069 e2e)', () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = createTmpDir('trace-mcp-recent-sort-');
+    fs.mkdirSync(path.join(tmpRoot, 'src'), { recursive: true });
+    await initContentHasher();
+  });
+
+  afterEach(() => {
+    removeTmpDir(tmpRoot);
+  });
+
+  function makeRegistry(): PluginRegistry {
+    const registry = new PluginRegistry();
+    registry.registerLanguagePlugin(new TypeScriptLanguagePlugin());
+    return registry;
+  }
+
+  function makeConfig(): TraceMcpConfig {
+    return {
+      root: tmpRoot,
+      include: ['src/**/*.ts'],
+      exclude: [],
+      plugins: [],
+    };
+  }
+
+  it('touching a file and reindexing puts it first in recent sort', async () => {
+    const store = createTestStore();
+    const registry = makeRegistry();
+    const pipeline = new IndexingPipeline(store, registry, makeConfig(), tmpRoot);
+
+    const fileA = path.join(tmpRoot, 'src/a.ts');
+    const fileB = path.join(tmpRoot, 'src/b.ts');
+    const fileC = path.join(tmpRoot, 'src/c.ts');
+
+    fs.writeFileSync(fileA, 'export const a = 1;\n');
+    fs.writeFileSync(fileB, 'export const b = 2;\n');
+    fs.writeFileSync(fileC, 'export const c = 3;\n');
+
+    // Set deterministic timestamps in the past: a=1000s, b=2000s, c=3000s
+    fs.utimesSync(fileA, 1000, 1000);
+    fs.utimesSync(fileB, 2000, 2000);
+    fs.utimesSync(fileC, 3000, 3000);
+
+    // Initial full index
+    await pipeline.indexAll();
+
+    // In initial index, c has highest mtime, b is second, a is third
+    const { sql: sql1, params: params1 } = buildProjectFilesQuery('recent', '', 10);
+    const initialRows = store.db.prepare(sql1).all(...params1) as Array<{ path: string }>;
+    expect(initialRows.map((r) => r.path)).toEqual(['src/c.ts', 'src/b.ts', 'src/a.ts']);
+
+    // Now touch fileA: set its mtime to 5000s (newer than b and c)
+    fs.utimesSync(fileA, 5000, 5000);
+
+    // Re-index
+    await pipeline.indexAll();
+
+    // Verify fileA is now strictly first in recent mode
+    const { sql: sql2, params: params2 } = buildProjectFilesQuery('recent', '', 10);
+    const afterTouchRows = store.db.prepare(sql2).all(...params2) as Array<{ path: string }>;
+    expect(afterTouchRows.map((r) => r.path)).toEqual(['src/a.ts', 'src/c.ts', 'src/b.ts']);
+
+    // Touch fileB: set its mtime to 7000s
+    fs.utimesSync(fileB, 7000, 7000);
+    await pipeline.indexAll();
+
+    const { sql: sql3, params: params3 } = buildProjectFilesQuery('recent', '', 10);
+    const finalRows = store.db.prepare(sql3).all(...params3) as Array<{ path: string }>;
+    expect(finalRows.map((r) => r.path)).toEqual(['src/b.ts', 'src/a.ts', 'src/c.ts']);
+  });
+});

--- a/tests/indexer/env-indexer.test.ts
+++ b/tests/indexer/env-indexer.test.ts
@@ -76,6 +76,10 @@ describe('EnvIndexer', () => {
     expect(keysByFile.get('.env')).toEqual(['DB_HOST', 'DB_PORT', 'API_URL']);
     expect(keysByFile.get('services/api/.env')).toEqual(['SERVICE_NAME', 'JWT_SECRET']);
     expect(keysByFile.get('services/web/.env.production')).toEqual(['PUBLIC_URL', 'FEATURE_FLAG']);
+
+    const rootEnv = store.getFile('.env');
+    expect(rootEnv?.mtime_ms).toBeTypeOf('number');
+    expect(rootEnv!.mtime_ms!).toBeGreaterThan(0);
   });
 
   it('stores only keys + inferred types/formats (no raw values leak to DB)', async () => {


### PR DESCRIPTION
## Description
Fixes #1069 (TRA-1069).

### Changes
1. Extracted query builder `buildProjectFilesQuery` into `src/api/project-files-query.ts` for `GET /api/projects/files`.
2. Changed `recent` sort from `f.indexed_at DESC` to `f.mtime_ms DESC NULLS LAST`.
3. Verified why 128 files in the real index had null `mtime_ms`: all of them are synthetic phantom files (`__external__/.../*.synthetic`) generated for external dependencies, which do not exist on disk. Using `NULLS LAST` properly sorts them after all modified source files.
4. Also populated `mtime_ms` in `EnvIndexer` (`src/indexer/env-indexer.ts`) for real `.env` files on disk.
5. Added contract and end-to-end integration tests in `tests/api/project-files-query.test.ts` verifying that touching a file and reindexing puts it first in `recent` sort, and added `mtime_ms` verification in `tests/indexer/env-indexer.test.ts`.