### PR TITLE
test(launcher): force candidate home probing in hostile identity injection test (TRA-1206)

### DIFF
--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1937,8 +1937,9 @@ describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)'
     });
 
     it('never evaluates hostile command injection in USER or LOGNAME (TRA-1206)', () => {
-      const { home, traceHome, node, cli } = setupFakeHome();
-      writeConfig(traceHome, node, cli);
+      const { home, traceHome, node } = setupFakeHome();
+      const probedCli = plantNvmPackage(home);
+      writeConfig(traceHome, node, '/dead/cli.js');
 
       const canary = path.join(home, 'should-not-exist');
       const hostileUser = `user$(touch ${canary})`;
@@ -1956,6 +1957,7 @@ describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)'
       });
 
       expect(res.status).toBe(0);
+      expect(res.stdout).toContain(fs.realpathSync(probedCli));
       expect(fs.existsSync(canary)).toBe(false);
     });
 


### PR DESCRIPTION
Ensures `never evaluates hostile command injection in USER or LOGNAME (TRA-1206)` forces CLI probing through `candidate_homes()` by configuring a dead CLI path and planting an NVM package under fake HOME.

Addresses verification finding from Code Reviewer.

- Target test: `pnpm vitest run tests/init/launcher-integration.test.ts` (83/83 passed)
- `pnpm biome:ci` & `pnpm typecheck` clean.