### PR TITLE
docs(seo): internal link graph reinforcement, GSC 09-08 12:00 UTC crawl record, and /tools-index discovery integration (TRA-1207)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,7 @@ All state is centralized in `~/.trace/`, and what goes in it is set by
     api-server-b2c3d4e5.db
 ```
 
-Each project gets its own SQLite database, named `<project-basename>-<sha256-hash-of-path>.db`. The project registry tracks which projects are registered, their root paths, and last index time. Nothing is stored in the project directory itself.
+Each project gets its own SQLite database, named `<project-basename>-<sha256-hash-of-path>.db`. The project registry tracks which projects are registered, their root paths, and last index time. Nothing is stored in the project directory itself. For how background memory usage, cache limits, and daemon footprint are bounded across SQLite databases, see [daemon memory](daemon-memory.md).
 
 The **topology database** (`topology.db`) is shared across all projects. It stores:
 - **Subprojects** (= services) — bound to projects, auto-detected or manually added

--- a/docs/code-graph-mcp.md
+++ b/docs/code-graph-mcp.md
@@ -91,7 +91,7 @@ trace-mcp is a local-first code graph MCP server built around four architectural
 * **Polyglot tree-sitter parsing:** Parsers for {{ site.data.counts.languages }} programming languages compile into the binary, resolving symbols, classes, functions, and import chains without requiring language servers or build toolchains ([view language matrix](/language-matrix.html)).
 * **Framework-aware semantic edges:** Web applications do not live in isolated ASTs. trace-mcp resolves route-to-controller, controller-to-template, and model-to-table relationships across {{ site.data.counts.frameworks }} frameworks, including Laravel, Next.js, Django, Rails, Spring, and FastAPI ([supported frameworks](/supported-frameworks.html)).
 * **Zero-overhead local storage:** All graph nodes, edges, and FTS5 search indices live in an embedded SQLite database on your machine. No hosted services, no background daemons requiring cloud accounts, and no API keys.
-* **Controlled schema footprint:** An MCP server that advertises dozens of tools consumes thousands of tokens before the agent asks its first question. trace-mcp uses role presets to expose roughly 2K tokens of tool schemas on session start, while keeping extended tools accessible dynamically via `load_tools` ([tools reference](/tools-reference.html)).
+* **Controlled schema footprint:** An MCP server that advertises dozens of tools consumes thousands of tokens before the agent asks its first question. trace-mcp uses role presets to expose roughly 2K tokens of tool schemas on session start, while keeping extended tools accessible dynamically via `load_tools` ([tools reference](/tools-reference.html), [tool index](/tools-index.html)).
 
 ## The code graph MCP ecosystem
 
@@ -121,6 +121,6 @@ npx trace-mcp init
 
 The init command inspects your repository, detects your frameworks and languages, sets up client configurations for Claude Code, Cursor, or Windsurf, and indexes your codebase into a local `.trace/` database. See [what trace init installs](/what-trace-init-installs.html) for a complete breakdown of guard hooks, routing blocks, and client configurations written to your project.
 
-* Explore all available tools: [Tools Reference](/tools-reference.html)
+* Explore all available tools: [Tools Reference](/tools-reference.html) and the alphabetical [Tool Index](/tools-index.html)
 * Review configuration and preset options: [Configuration Guide](/configuration.html)
 * Inspect architecture and storage contracts: [Architecture Documentation](/architecture.html)

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,7 +1,7 @@
 ---
 title: "Contributing to trace-mcp — local setup, build, and test"
 description: "How to set up trace-mcp for local development: install, build, run the test suite, and the conventions to follow before opening a PR."
-updated: 2026-09-06
+updated: 2026-09-08
 ---
 
 # Development
@@ -35,7 +35,7 @@ updated: 2026-09-06
 
 Read [architecture](architecture.md) first — the two-pass pipeline, the plugin
 interface and the storage layout are what most of the code below is arranged
-around.
+around. To understand what the initialization command writes when run in consumer repositories, see [what trace init installs](what-trace-init-installs.md).
 
 ```bash
 git clone https://github.com/nikolai-vysotskyi/trace-mcp.git

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -44,7 +44,7 @@ trace-mcp is a local-first code graph MCP server built around four architectural
 * **Polyglot tree-sitter parsing:** Parsers for {{ site.data.counts.languages }} programming languages compile into the binary, resolving symbols, classes, functions, and import chains without requiring language servers or build toolchains ([view language matrix](/language-matrix.html)).
 * **Framework-aware semantic edges:** Web applications do not live in isolated ASTs. trace-mcp resolves route-to-controller, controller-to-template, and model-to-table relationships across {{ site.data.counts.frameworks }} frameworks, including Laravel, Next.js, Django, Rails, Spring, and FastAPI ([supported frameworks](/supported-frameworks.html)).
 * **Zero-overhead local storage:** All graph nodes, edges, and FTS5 search indices live in an embedded SQLite database on your machine. No hosted services, no background daemons requiring cloud accounts, and no API keys.
-* **Controlled schema footprint:** An MCP server that advertises dozens of tools consumes thousands of tokens before the agent asks its first question. trace-mcp uses role presets to expose roughly 2K tokens of tool schemas on session start, while keeping extended tools accessible dynamically via `load_tools` ([tools reference](/tools-reference.html)).
+* **Controlled schema footprint:** An MCP server that advertises dozens of tools consumes thousands of tokens before the agent asks its first question. trace-mcp uses role presets to expose roughly 2K tokens of tool schemas on session start, while keeping extended tools accessible dynamically via `load_tools` ([tools reference](/tools-reference.html), [tool index](/tools-index.html)).
 
 ## The code graph MCP ecosystem
 
@@ -74,7 +74,7 @@ npx trace-mcp init
 
 The init command inspects your repository, detects your frameworks and languages, sets up client configurations for Claude Code, Cursor, or Windsurf, and indexes your codebase into a local `.trace/` database. See [what trace init installs](/what-trace-init-installs.html) for a complete breakdown of guard hooks, routing blocks, and client configurations written to your project.
 
-* Explore all available tools: [Tools Reference](/tools-reference.html)
+* Explore all available tools: [Tools Reference](/tools-reference.html) and the alphabetical [Tool Index](/tools-index.html)
 * Review configuration and preset options: [Configuration Guide](/configuration.html)
 * Inspect architecture and storage contracts: [Architecture Documentation](/architecture.html)
 
@@ -91,7 +91,9 @@ This page groups the ones you reach for by hand. For how a persistent
 [code graph MCP server](/code-graph-mcp.html) powers these operations to cut
 agent token costs, see the category overview. For the complete list —
 every registered tool with its one-line description, generated from the
-registrations themselves — see the [tool index](tools-index.md).
+registrations themselves — see the [tool index](tools-index.md). For measured
+wire costs and baseline token comparisons across each tool, see the
+[tool response token cost](/perf/response-tokens/) benchmark.
 
 Tools are registered dynamically based on detected frameworks — you only see tools relevant to your project.
 
@@ -856,7 +858,9 @@ pick Base after a Standard or Max run and the guard, the lifecycle hooks and the
 above, and the `tweakcc` prompt files come out through `tweakcc` itself.
 
 Nothing here deletes a config key it did not write. An entry you configured
-yourself on the MCP server object survives a rename or a re-init.
+yourself on the MCP server object survives a rename or a re-init. For the
+complete reference of configuration settings, paths, and environment variables,
+see [configuration](configuration.md) and the [config index](config-index.md).
 
 ---
 
@@ -2661,7 +2665,7 @@ What to do about it:
 
 - Run `tools/list` against each server you have connected and count the tokens. Most people have never looked.
 - Disconnect servers you are not using in this project. A server connected "just in case" is a fixed tax.
-- Use a preset or allowlist where the server offers one. trace-mcp ships `minimal` (28 tools), `standard` (60 tools) and `full` ({{ site.data.counts.tools }} tools), plus `tools.include` / `tools.exclude` in config.
+- Use a preset or allowlist where the server offers one. trace-mcp ships `minimal` (28 tools), `standard` (60 tools) and `full` ({{ site.data.counts.tools }} tools), plus `tools.include` / `tools.exclude` in config (see the full [tool index](/tools-index.html)).
 - **Previously noted here as broken, now fixed:** presets used to take effect only when the daemon was bypassed (`TRACE_MCP_NO_DAEMON=1`) and were silently ignored on the default daemon-backed path. That bug is shipped and closed — the preset is honoured on both paths, and `TRACE_MCP_NO_DAEMON=1` is no longer needed as a workaround. Measured on the default path: `standard` serves ~18.8K tokens of `tools/list` plus ~1.75K of server instructions (~20.5K), against ~49.9K + ~2.1K for `full`.
 - **One caveat that is still live:** set these in the global `~/.trace/.config.json`. `tools.preset` is honoured from a project-local `.trace/.config.json` too, but `tools.description_verbosity` / `tools.instructions_verbosity` are not — set those globally until that is fixed.
 
@@ -2738,6 +2742,8 @@ No — clearing forces re-derivation, which usually costs more. Compact, or hand
 ## Next steps
 
 - [Tools reference](/tools-reference.html) — every trace-mcp tool, including the outline/symbol/impact ones above.
+- [Tool index](/tools-index.html) — alphabetical index of all {{ site.data.counts.tools }} tools with availability breakdown.
+- [System prompt routing via tweakcc](/tweakcc.html) — patch Claude Code's system prompts to enforce tool routing toward trace-mcp instead of native file reads.
 - [TOON savings](/toon-savings.html) — the full measurement method behind section 4.
 - [Configuration](/configuration.html) — presets and `tools.include` / `tools.exclude`.
 - [Get started](/#install) — no configuration required.
@@ -4164,7 +4170,7 @@ All state is centralized in `~/.trace/`, and what goes in it is set by
     api-server-b2c3d4e5.db
 ```
 
-Each project gets its own SQLite database, named `<project-basename>-<sha256-hash-of-path>.db`. The project registry tracks which projects are registered, their root paths, and last index time. Nothing is stored in the project directory itself.
+Each project gets its own SQLite database, named `<project-basename>-<sha256-hash-of-path>.db`. The project registry tracks which projects are registered, their root paths, and last index time. Nothing is stored in the project directory itself. For how background memory usage, cache limits, and daemon footprint are bounded across SQLite databases, see [daemon memory](daemon-memory.md).
 
 The **topology database** (`topology.db`) is shared across all projects. It stores:
 - **Subprojects** (= services) — bound to projects, auto-detected or manually added
@@ -6600,7 +6606,7 @@ Source: https://trace-mcp.com/development.html
 
 Read [architecture](architecture.md) first — the two-pass pipeline, the plugin
 interface and the storage layout are what most of the code below is arranged
-around.
+around. To understand what the initialization command writes when run in consumer repositories, see [what trace init installs](what-trace-init-installs.md).
 
 ```bash
 git clone https://github.com/nikolai-vysotskyi/trace-mcp.git

--- a/docs/reduce-claude-code-token-usage.md
+++ b/docs/reduce-claude-code-token-usage.md
@@ -1,7 +1,7 @@
 ---
 title: "How to Reduce Claude Code Token Usage — 7 measured tactics"
 description: "Seven ways to cut token usage in Claude Code, ordered by measured impact: stop full-file reads, trim your MCP tool surface, pick the output format."
-updated: 2026-09-06
+updated: 2026-09-08
 ---
 
 # How to reduce Claude Code token usage
@@ -112,7 +112,7 @@ What to do about it:
 
 - Run `tools/list` against each server you have connected and count the tokens. Most people have never looked.
 - Disconnect servers you are not using in this project. A server connected "just in case" is a fixed tax.
-- Use a preset or allowlist where the server offers one. trace-mcp ships `minimal` (28 tools), `standard` (60 tools) and `full` ({{ site.data.counts.tools }} tools), plus `tools.include` / `tools.exclude` in config.
+- Use a preset or allowlist where the server offers one. trace-mcp ships `minimal` (28 tools), `standard` (60 tools) and `full` ({{ site.data.counts.tools }} tools), plus `tools.include` / `tools.exclude` in config (see the full [tool index](/tools-index.html)).
 - **Previously noted here as broken, now fixed:** presets used to take effect only when the daemon was bypassed (`TRACE_MCP_NO_DAEMON=1`) and were silently ignored on the default daemon-backed path. That bug is shipped and closed — the preset is honoured on both paths, and `TRACE_MCP_NO_DAEMON=1` is no longer needed as a workaround. Measured on the default path: `standard` serves ~18.8K tokens of `tools/list` plus ~1.75K of server instructions (~20.5K), against ~49.9K + ~2.1K for `full`.
 - **One caveat that is still live:** set these in the global `~/.trace/.config.json`. `tools.preset` is honoured from a project-local `.trace/.config.json` too, but `tools.description_verbosity` / `tools.instructions_verbosity` are not — set those globally until that is fixed.
 
@@ -189,6 +189,8 @@ No — clearing forces re-derivation, which usually costs more. Compact, or hand
 ## Next steps
 
 - [Tools reference](/tools-reference.html) — every trace-mcp tool, including the outline/symbol/impact ones above.
+- [Tool index](/tools-index.html) — alphabetical index of all {{ site.data.counts.tools }} tools with availability breakdown.
+- [System prompt routing via tweakcc](/tweakcc.html) — patch Claude Code's system prompts to enforce tool routing toward trace-mcp instead of native file reads.
 - [TOON savings](/toon-savings.html) — the full measurement method behind section 4.
 - [Configuration](/configuration.html) — presets and `tools.include` / `tools.exclude`.
 - [Get started](/#install) — no configuration required.

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -26,7 +26,7 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/what-trace-init-installs.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -104,7 +104,7 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/reduce-claude-code-token-usage.html</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -194,7 +194,7 @@
   </url>
   <url>
     <loc>https://trace-mcp.com/development.html</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -37,7 +37,9 @@ This page groups the ones you reach for by hand. For how a persistent
 [code graph MCP server](/code-graph-mcp.html) powers these operations to cut
 agent token costs, see the category overview. For the complete list —
 every registered tool with its one-line description, generated from the
-registrations themselves — see the [tool index](tools-index.md).
+registrations themselves — see the [tool index](tools-index.md). For measured
+wire costs and baseline token comparisons across each tool, see the
+[tool response token cost](/perf/response-tokens/) benchmark.
 
 Tools are registered dynamically based on detected frameworks — you only see tools relevant to your project.
 

--- a/docs/what-trace-init-installs.md
+++ b/docs/what-trace-init-installs.md
@@ -1,7 +1,7 @@
 ---
 title: "What trace init installs — guard hooks, Read/Bash mirrors and client config"
 description: "What trace init writes to your machine and how to audit it: guard hooks, opt-in Read/Bash mirrors, the routing block, client config, tweakcc tiers."
-updated: 2026-09-07
+updated: 2026-09-08
 ---
 
 # What `trace init` installs
@@ -243,4 +243,6 @@ pick Base after a Standard or Max run and the guard, the lifecycle hooks and the
 above, and the `tweakcc` prompt files come out through `tweakcc` itself.
 
 Nothing here deletes a config key it did not write. An entry you configured
-yourself on the MCP server object survives a rename or a re-init.
+yourself on the MCP server object survives a rename or a re-init. For the
+complete reference of configuration settings, paths, and environment variables,
+see [configuration](configuration.md) and the [config index](config-index.md).

--- a/ops/index-coverage.md
+++ b/ops/index-coverage.md
@@ -559,4 +559,64 @@ Lab metrics for key landing pages (mobile):
 - **Homepage (`https://trace-mcp.com/`)**: Performance **98**, FCP 1.1s, LCP 1.9s, CLS 0, TBT 0ms.
 - **Category landing (`https://trace-mcp.com/code-graph-mcp.html`)**: Performance **99**, FCP 0.9s, LCP 1.1s, CLS 0, TBT 0ms.
 
+## Reading 2026-09-08 12:00 UTC (TRA-1207): 22nd page indexed (/tools-index.html), 3 URLs advance to Discovered, category target "codegraph mcp" enters SERP, internal link graph expansion
+
+Full Search Console API pass (URL Inspection across all 34 sitemap URLs, Search Analytics 28d, Sitemaps API), full internal link graph audit, and PageSpeed Insights mobile CWV audit on 2026-09-08 12:00 UTC.
+
+### 1. Google Indexation & Discovery Breakthroughs (CONFIRMED via GSC URL Inspection API)
+
+A full inspection of all 34 URLs in `sitemap.xml` verified continued crawl momentum:
+- **Total Indexed: 22 URLs** (up from 21):
+  - **`/tools-index.html` officially indexed**: Transitioned from "Discovered - currently not indexed" to **Submitted and indexed** (Googlebot crawl: `2026-09-08T03:57:26Z`).
+- **"Discovered - currently not indexed" tier expanded to 6 URLs**, with 3 pages advancing off "URL is unknown to Google":
+  - **`/code-graph-mcp.html`**: Advanced from unknown to **Discovered** (Googlebot credited referring source: `https://trace-mcp.com/analytics.html`).
+  - **`/vs/tokensave.html`**: Advanced from unknown to **Discovered** (Googlebot credited referring source: `https://trace-mcp.com/tools-index.html`).
+  - **`/vs/codegraphcontext.html`**: Advanced from unknown to **Discovered** (Googlebot credited referring source: `https://trace-mcp.com/analytics.html`).
+  - `/vs/repomix.html`: in **Discovered** (referring source: `/configuration.html`).
+  - `/reduce-claude-code-token-usage.html`: in **Discovered** (referring source: `/configuration.html`).
+  - `/daemon-memory.html`: in **Discovered** (referring source: `/pr-context-benchmark.html`).
+- **Current status across the 11 comparison pages (`/vs/`)**:
+  - Indexed (3): `/vs/codegraph.html`, `/vs/context-mode.html`, `/vs/codebase-memory-mcp.html`.
+  - Discovered (3): `/vs/repomix.html`, `/vs/codegraphcontext.html`, `/vs/tokensave.html`.
+  - Pending crawl (5): `/vs/serena.html`, `/vs/socraticode.html`, `/vs/jcodemunch.html`, `/vs/code-review-graph.html`, `/vs/repomix-vs-codegraph.html`.
+
+### 2. SERP Rankings: Target Keyword Emergence & Strong Spoke Conversion (CONFIRMED)
+
+GSC Search Analytics (28d) captured high-intent developments:
+- **Category keyword `codegraph mcp` entered Google SERP:** First impression recorded at **Position 7.0** landing directly on `/vs/codegraph.html` (previously 0 impressions on Sept 6, TRA-1024).
+- **Comparison spoke direct click:** `/vs/context-mode.html` recorded **1 click / 2 impressions (CTR 50.0%, pos 5.5)**.
+- **Category hub conversion:** `/comparisons.html` generated **5 clicks / 235 impressions (CTR 2.13%)**.
+- **Top rankings on competitor evaluation queries:**
+  - `serena alternatives`: **Position 1.0** (1 imp)
+  - `serena mcp vs codegraph`: **Position 1.0** (1 imp)
+  - `codegraph vs serena`: **Position 1.0** (1 click)
+  - `repomix vs codegraph`: **Position 2.0** (1 imp)
+  - `"codegraphcontext"`: **Position 1.5** (2 clicks)
+
+### 3. Internal Link Graph Optimization & Deficit Remediation
+
+A programmatic graph analysis of in-body internal links across all 34 documentation pages (`scratch/link_graph.py`) revealed isolated clusters and low-link pages. Remediated:
+1. **Newly indexed `tools-index.html` reinforced**:
+   - Linked from category landing `docs/code-graph-mcp.md` (0 -> 1 hub in-link).
+   - Linked from `docs/reduce-claude-code-token-usage.md` (tactic 3 & Next Steps).
+   - Total incoming in-body links increased: 1 -> **3 links**.
+2. **`tweakcc.md` bidirectional linking established**:
+   - `tweakcc.md` previously cited `reduce-claude-code-token-usage.md` as its token justification, but had no inbound link back from it. Added contextual routing link in `reduce-claude-code-token-usage.md`. Total in-links increased: 2 -> **3 links**.
+3. **`daemon-memory.md` (Discovered) connected from Architecture**:
+   - Linked from SQLite storage section in `docs/architecture.md`. Total in-links increased: 2 -> **3 links**.
+4. **`what-trace-init-installs.md` and `config-index.md` cross-linked**:
+   - Linked `config-index.md` from `what-trace-init-installs.md` configuration audit section.
+   - Linked `what-trace-init-installs.md` from `docs/development.md` setup section.
+5. **`tools-reference.md` linked to response token benchmark**:
+   - Contextual link to `/perf/response-tokens/` added in introduction.
+
+### 4. PageSpeed Insights & Mobile CWV Lab Validation
+
+Mobile Lighthouse audits executed via PageSpeed Insights API key confirm pristine performance:
+- **Homepage (`https://trace-mcp.com/`)**: Perf **98**, SEO **100**, A11y **100**, Best Practices **100** (FCP 1.1s, LCP 1.7s, CLS 0, TBT 0ms).
+- **`/code-graph-mcp.html`**: Perf **99**, SEO **100**, A11y **100**, Best Practices **100** (FCP 0.9s, LCP 1.1s, CLS 0, TBT 0ms).
+- **`/tools-index.html`**: Perf **100**, SEO **100**, A11y **100**, Best Practices **100** (FCP 0.9s, LCP 1.2s, CLS 0, TBT 0ms).
+- **`/comparisons.html`**: Perf **98**, SEO **100**, A11y **100**, Best Practices **100** (FCP 1.2s, LCP 1.4s, CLS 0, TBT 20ms).
+- **`/vs/context-mode.html`**: Perf **99**, SEO **100**, A11y **100**, Best Practices **100** (FCP 1.0s, LCP 1.2s, CLS 0, TBT 0ms).
+
 


### PR DESCRIPTION
## Summary

This PR delivers the findings and optimizations from the SEO pass on 2026-09-08 12:00 UTC (TRA-1207):

### 1. Google Search Console Indexation Breakthroughs (CONFIRMED via URL Inspection API)
* **Total indexed URLs reached 22** (up from 21). `/tools-index.html` was crawled and indexed by Googlebot on `2026-09-08T03:57:26Z`.
* **Discovered tier expanded to 6 URLs**, with 3 high-value pages advancing from unknown:
  - `/code-graph-mcp.html` (category landing page) advanced to **Discovered** (ref: `/analytics.html`).
  - `/vs/tokensave.html` advanced to **Discovered** (ref: `/tools-index.html`).
  - `/vs/codegraphcontext.html` advanced to **Discovered** (ref: `/analytics.html`).

### 2. Search Analytics & High-Intent Target SERP Emergence
* **Target category keyword `codegraph mcp` made its first SERP appearance** at **Position 7.0** (1 impression on `/vs/codegraph.html`).
* High-intent competitor SERP rankings hold #1.0–#2.0 positions, generating 5 clicks / 235 impressions on `/comparisons.html` and 1 direct click (CTR 50%) on `/vs/context-mode.html`.

### 3. Internal Link Graph Reinforcement
Programmatic audit of in-body links across all documentation pages eliminated link deficits for newly indexed and discovered hub pages:
* `docs/code-graph-mcp.md`: linked to `/tools-index.html` as the complete tool directory.
* `docs/reduce-claude-code-token-usage.md`: cross-linked to `/tools-index.html` (preset audit) and `/tweakcc.html` (closing the reciprocal linking gap with `tweakcc.md`).
* `docs/architecture.md`: linked to `daemon-memory.md` in SQLite storage section (reinforcing the Discovered page).
* `docs/what-trace-init-installs.md`: linked to `config-index.md` in configuration section.
* `docs/development.md`: linked to `what-trace-init-installs.md` in local setup section.
* `docs/tools-reference.md`: linked to `/perf/response-tokens/` benchmark.

### 4. Search Console Sitemap Resubmission
* `docs/sitemap.xml` (34 URLs) resubmitted via Search Console API `sitemaps().submit()` at `2026-09-08T12:25Z`.

### 5. Mobile CWV Validation
* PageSpeed Insights API checks across 5 core landing pages confirmed Performance scores 98–100, SEO 100, A11y 100, Best Practices 100 (FCP 0.9–1.2s, LCP 1.1–1.7s, CLS 0).

Closes TRA-1207.