### PR TITLE
feat(client): opencode client profile, auto-config in init, and neutral tool routing in AGENTS.md (TRA-1204)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,27 +1,28 @@
 <!-- trace:start -->
 ## trace Tool Routing
 
-IMPORTANT: For ANY code exploration task, ALWAYS use trace tools first. NEVER use Read/Grep/Glob/Bash(ls,find) for navigating source code.
+IMPORTANT: For ANY code exploration task, ALWAYS use trace tools first. NEVER use host file-reading, grep, glob, or shell (ls, find) tools for navigating source code.
 
 | Task | trace tool | Instead of |
 |------|------------|------------|
-| Find a function/class/method | `search` | Grep |
-| Understand a file before editing | `get_outline` | Read (full file) |
-| Read one symbol's source | `get_symbol` | Read (full file) |
+| Find a function/class/method | `search` | text grep |
+| Understand a file before editing | `get_outline` | full-file read |
+| Read one symbol's source | `get_symbol` | full-file read |
 | What breaks if I change X | `get_change_impact` | guessing |
-| All usages of a symbol | `find_usages` | Grep |
-| All implementations of an interface | `get_implementations` | ls/find on directories |
-| All classes implementing X | `search` with `implements` filter | Grep |
+| All usages of a symbol | `find_usages` | text grep |
+| All implementations of an interface | `get_implementations` | directory search (ls/find) |
+| All classes implementing X | `search` with `implements` filter | text grep |
 | Project health / coverage gaps | `self_audit` | manual inspection |
-| Dead code / dead exports | `get_dead_code` (`mode: "exports_only"`) | Grep for unused |
+| Dead code / dead exports | `get_dead_code` (`mode: "exports_only"`) | text grep for unused |
 | Context for a task | `get_feature_context` | reading 15 files |
-| Tests for a symbol | `get_tests_for` | Glob + Grep |
+| Tests for a symbol | `get_tests_for` | glob + grep |
 | Untested symbols (deep) | `get_untested_symbols` (deferred — load via `load_tools`) | manual audit |
 | HTTP request flow | `get_request_flow` (framework-gated) | reading route files |
 | DB model relationships | `get_model_context` (framework-gated) | reading model + migrations |
 | Component tree | `get_component_tree` (framework-gated) | reading component files |
 | Circular dependencies | `get_circular_imports` | manual tracing |
+| Task spanning many turns | `trace_state_init` once, then `trace_state_patch` / `trace_state_add_dead_end` per step, `trace_state_get` to re-read (deferred — `load_tools({preset:"state"})`) | re-reading the whole transcript every turn |
 
-Use Read/Grep/Glob ONLY for non-code files (.md, .json, .yaml, config) or before Edit.
+Use host file-reading and grep tools ONLY for non-code files (.md, .json, .yaml, config) or before edit.
 Start sessions with `get_project_map` (summary_only=true).
 <!-- trace:end -->

--- a/packages/app/src/shared/mcp-detector-types.ts
+++ b/packages/app/src/shared/mcp-detector-types.ts
@@ -15,7 +15,8 @@ export type DetectedMcpClientName =
   | 'cline'
   | 'kilocode'
   | 'antigravity'
-  | 'kimi';
+  | 'kimi'
+  | 'opencode';
 
 export interface DetectedMcpClient {
   name: DetectedMcpClientName;
@@ -41,4 +42,5 @@ export const MCP_CLIENT_DISPLAY_NAMES: Record<DetectedMcpClientName, string> = {
   kilocode: 'KiloCode',
   antigravity: 'Antigravity',
   kimi: 'Kimi Code CLI',
+  opencode: 'OpenCode',
 };

--- a/packages/app/src/shared/mcp-detector.ts
+++ b/packages/app/src/shared/mcp-detector.ts
@@ -264,5 +264,39 @@ export function detectMcpClients(projectRoot?: string, customHome?: string): Det
   // Kimi Code CLI
   checkConfig('kimi', path.join(HOME, '.kimi', 'mcp.json'));
 
+  // OpenCode: JSON/JSONC with `mcp` key at ~/.config/opencode/opencode.json[c] (user)
+  // or opencode.json[c] (project).
+  {
+    const checkOpenCode = (configPath: string) => {
+      try {
+        const content = readIfExists(configPath);
+        if (content === null) return;
+        const parsed = parseJsonc(content) as Record<string, unknown> | null;
+        const servers = parsed?.mcp as Record<string, unknown> | undefined;
+        const hasTraceMcp = !!(servers?.['trace'] ?? servers?.['trace-mcp']);
+        clients.push({ name: 'opencode', configPath, hasTraceMcp });
+      } catch {
+        clients.push({ name: 'opencode', configPath, hasTraceMcp: false });
+      }
+    };
+    const openCodeUserBase = path.join(HOME, '.config', 'opencode');
+    for (const file of ['opencode.jsonc', 'opencode.json']) {
+      const p = path.join(openCodeUserBase, file);
+      if (fs.existsSync(p)) {
+        checkOpenCode(p);
+        break;
+      }
+    }
+    if (projectRoot && !clients.some((c) => c.name === 'opencode')) {
+      for (const file of ['opencode.jsonc', 'opencode.json']) {
+        const p = path.join(projectRoot, file);
+        if (fs.existsSync(p)) {
+          checkOpenCode(p);
+          break;
+        }
+      }
+    }
+  }
+
   return clients;
 }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -71,7 +71,7 @@ export const initCommand = new Command('init')
   .option('--skip-app', 'Do not install or update the menu bar app')
   .option(
     '--mcp-client <name>',
-    'Force MCP client: claude-code | claw-code | claude-desktop | cursor | windsurf | continue | junie | codex | hermes | amp | warp | factory-droid | cline | kilocode | antigravity | kimi',
+    'Force MCP client: claude-code | claw-code | claude-desktop | cursor | windsurf | continue | junie | codex | hermes | amp | warp | factory-droid | cline | kilocode | antigravity | kimi | opencode',
   )
   .option('--scope <scope>', 'MCP config target: project | global', 'global')
   .option('--force', 'Overwrite existing configuration')
@@ -179,6 +179,7 @@ export const initCommand = new Command('init')
             'kilocode',
             'antigravity',
             'kimi',
+            'opencode',
           ];
           const detectedNames = new Set(mcpClients.map((c) => c.name));
 
@@ -715,10 +716,16 @@ function executeSteps(
   }
 
   // 4b. AGENTS.md (project-scope) for clients that read it from the project root.
-  // Hermes, AMP, Warp Agents, and Factory Droid all consume AGENTS.md as their
+  // Hermes, AMP, Warp Agents, Factory Droid, and OpenCode all consume AGENTS.md as their
   // primary instruction surface. Cursor/Windsurf have their own per-tool rule
   // formats (covered above), so they don't trigger AGENTS.md generation.
-  const agentsMdClients: DetectedMcpClient['name'][] = ['hermes', 'amp', 'warp', 'factory-droid'];
+  const agentsMdClients: DetectedMcpClient['name'][] = [
+    'hermes',
+    'amp',
+    'warp',
+    'factory-droid',
+    'opencode',
+  ];
   if (opts.selectedClients.some((c) => agentsMdClients.includes(c))) {
     const agentsResult = updateAgentsMd(process.cwd(), { dryRun: opts.dryRun });
     steps.push(agentsResult);
@@ -965,6 +972,7 @@ function formatClientName(name: string): string {
     kilocode: 'Kilo Code',
     antigravity: 'Antigravity',
     kimi: 'Kimi Code CLI',
+    opencode: 'OpenCode',
   };
   return names[name] ?? name;
 }

--- a/src/init/agents-md.ts
+++ b/src/init/agents-md.ts
@@ -9,7 +9,7 @@
  * insists; the default `scope: 'project'` writes next to the current project.
  */
 import path from 'node:path';
-import { upsertTraceMcpBlock } from './md-block.js';
+import { AGENTS_ROUTING_BLOCK, upsertTraceMcpBlock } from './md-block.js';
 import type { InitStepResult } from './types.js';
 
 export function updateAgentsMd(
@@ -21,5 +21,5 @@ export function updateAgentsMd(
   // to make the API symmetrical with `updateClaudeMd` for future flexibility.
   void _scope;
   const filePath = path.join(projectRoot, 'AGENTS.md');
-  return upsertTraceMcpBlock(filePath, { dryRun: opts.dryRun });
+  return upsertTraceMcpBlock(filePath, { dryRun: opts.dryRun, block: AGENTS_ROUTING_BLOCK });
 }

--- a/src/init/launcher-health.ts
+++ b/src/init/launcher-health.ts
@@ -92,7 +92,12 @@ function commandsFromYaml(raw: string): string[] {
 function commandsFromJson(raw: string): string[] {
   const parsed = parseJsonc(raw) as Record<string, unknown> | null;
   if (!parsed || typeof parsed !== 'object') return [];
-  const buckets: unknown[] = [parsed.mcpServers, parsed.servers, parsed['amp.mcpServers']];
+  const buckets: unknown[] = [
+    parsed.mcpServers,
+    parsed.servers,
+    parsed['amp.mcpServers'],
+    parsed.mcp,
+  ];
   const projects = parsed.projects as Record<string, { mcpServers?: unknown }> | undefined;
   if (projects && typeof projects === 'object') {
     for (const proj of Object.values(projects)) buckets.push(proj?.mcpServers);
@@ -108,6 +113,9 @@ function collectCommands(buckets: unknown[]): string[] {
     for (const key of [MCP_KEY, LEGACY_MCP_KEY]) {
       const cmd = servers[key]?.command;
       if (typeof cmd === 'string' && cmd.trim()) out.push(cmd.trim());
+      else if (Array.isArray(cmd) && typeof cmd[0] === 'string' && cmd[0].trim()) {
+        out.push(cmd[0].trim());
+      }
     }
   }
   return out;

--- a/src/init/mcp-client.ts
+++ b/src/init/mcp-client.ts
@@ -226,6 +226,40 @@ export function configureMcpClients(
       continue;
     }
 
+    // OpenCode: JSON format with `mcp` key and `command: string[]`
+    if (name === 'opencode') {
+      const configPath = getConfigPath(name, projectRoot, opts.scope);
+      if (!configPath) {
+        results.push({ target: name, action: 'skipped', detail: 'Unknown client' });
+        continue;
+      }
+      const entry = buildExpectedOpenCodeEntry();
+
+      if (fs.existsSync(configPath) && opencodeEntryMatches(configPath, entry)) {
+        results.push({ target: configPath, action: 'already_configured', detail: name });
+        continue;
+      }
+      if (opts.dryRun) {
+        results.push({
+          target: configPath,
+          action: 'skipped',
+          detail: `Would configure ${name} (${opts.scope})`,
+        });
+        continue;
+      }
+      try {
+        const action = writeOpenCodeJsonEntry(configPath, entry);
+        results.push({ target: configPath, action, detail: `${name} (${opts.scope})` });
+      } catch (err) {
+        results.push({
+          target: configPath,
+          action: 'skipped',
+          detail: `Error: ${(err as Error).message}`,
+        });
+      }
+      continue;
+    }
+
     // Hermes Agent: YAML format, always global, key `mcp_servers.trace-mcp`.
     if (name === 'hermes') {
       const configPath = getConfigPath(name, projectRoot, opts.scope);
@@ -684,6 +718,96 @@ function writeFactoryJsonEntry(
 }
 
 // ---------------------------------------------------------------------------
+// OpenCode JSON writer (top-level `mcp` key, `type: "local"`, `command: string[]`)
+// ---------------------------------------------------------------------------
+
+export interface OpenCodeMcpServerEntry {
+  type: 'local';
+  command: string[];
+  enabled: boolean;
+  cwd?: string;
+  environment?: Record<string, string>;
+}
+
+function buildExpectedOpenCodeEntry(): OpenCodeMcpServerEntry {
+  return {
+    type: 'local',
+    command: [getLauncherPath(), 'serve'],
+    enabled: true,
+  };
+}
+
+function opencodeEntryMatches(configPath: string, expected: OpenCodeMcpServerEntry): boolean {
+  try {
+    const raw = fs.readFileSync(configPath, 'utf-8');
+    const content = parseJsonc(raw) as Record<string, unknown> | null;
+    const mcp = content?.mcp as Record<string, unknown> | undefined;
+    // A lingering legacy key must force the write path (which deletes it)
+    if (mcp && typeof mcp === 'object' && LEGACY_MCP_KEY in mcp) return false;
+    const current = mcp?.[MCP_KEY] as Record<string, unknown> | undefined;
+    if (!current || typeof current !== 'object') return false;
+    if (current.type !== expected.type) return false;
+    if (JSON.stringify(current.command ?? []) !== JSON.stringify(expected.command)) return false;
+    if ((current.enabled ?? true) !== expected.enabled) return false;
+    if ((current.cwd ?? undefined) !== (expected.cwd ?? undefined)) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function writeOpenCodeJsonEntry(
+  configPath: string,
+  entry: OpenCodeMcpServerEntry,
+): 'created' | 'updated' {
+  const dir = path.dirname(configPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  let config: Record<string, unknown> = {};
+  let isNew = true;
+  const raw = readIfExists(configPath);
+  if (raw !== null) {
+    try {
+      config = parseJsonc(raw) as Record<string, unknown>;
+      isNew = false;
+    } catch {
+      /* malformed — overwrite */
+    }
+  }
+
+  if (!config.mcp || typeof config.mcp !== 'object') {
+    config.mcp = {};
+  }
+  const mcp = config.mcp as Record<string, unknown>;
+  delete mcp[LEGACY_MCP_KEY];
+  mcp[MCP_KEY] = entry;
+
+  atomicWriteJson(configPath, config);
+  return isNew ? 'created' : 'updated';
+}
+
+function pinpointOpenCodeEntryDrift(configPath: string, expected: OpenCodeMcpServerEntry): string {
+  try {
+    const raw = fs.readFileSync(configPath, 'utf-8');
+    const content = parseJsonc(raw) as Record<string, unknown> | null;
+    const mcp = content?.mcp as Record<string, unknown> | undefined;
+    const current = mcp?.[MCP_KEY] as Record<string, unknown> | undefined;
+    if (!current || typeof current !== 'object') {
+      return mcp?.[LEGACY_MCP_KEY] ? 'legacy-key' : 'entry-missing';
+    }
+    if (mcp && typeof mcp === 'object' && LEGACY_MCP_KEY in mcp) return 'legacy-key';
+    if (current.type !== expected.type) return 'type';
+    if (JSON.stringify(current.command ?? []) !== JSON.stringify(expected.command))
+      return 'command';
+    if ((current.enabled ?? true) !== expected.enabled) return 'enabled';
+    if ((current.cwd ?? undefined) !== (expected.cwd ?? undefined)) return 'cwd';
+    return 'fields';
+  } catch {
+    return 'parse-error';
+  }
+}
+
+// ---------------------------------------------------------------------------
 // TOML writer (Codex)
 // ---------------------------------------------------------------------------
 
@@ -867,6 +991,7 @@ export const ALL_MCP_CLIENT_NAMES: ReadonlyArray<DetectedMcpClient['name']> = [
   'kilocode',
   'antigravity',
   'kimi',
+  'opencode',
 ];
 
 /**
@@ -1003,6 +1128,25 @@ function detectClientStatus(
       } catch {
         return { client: name, configPath, status: 'missing' };
       }
+    }
+    case 'opencode': {
+      const expected = buildExpectedOpenCodeEntry();
+      const present = (() => {
+        try {
+          const raw = fs.readFileSync(configPath, 'utf-8');
+          const content = parseJsonc(raw) as Record<string, unknown> | null;
+          const mcp = content?.mcp as Record<string, unknown> | undefined;
+          return Boolean(mcp?.[MCP_KEY] ?? mcp?.[LEGACY_MCP_KEY]);
+        } catch {
+          return false;
+        }
+      })();
+      if (!present) return { client: name, configPath, status: 'missing' };
+      if (opencodeEntryMatches(configPath, expected)) {
+        return { client: name, configPath, status: 'up_to_date' };
+      }
+      const reason = pinpointOpenCodeEntryDrift(configPath, expected);
+      return { client: name, configPath, status: 'stale', staleReason: reason };
     }
     default: {
       // claude-code, claw-code, claude-desktop, cursor, windsurf, continue, junie,
@@ -1175,6 +1319,15 @@ export function getConfigPath(
       // Kimi Code CLI (Moonshot): standard mcpServers JSON at ~/.kimi/mcp.json,
       // global-only. Source: https://moonshotai.github.io/kimi-cli/en/customization/mcp.html
       return path.join(HOME, '.kimi', 'mcp.json');
+    case 'opencode': {
+      if (scope === 'global') {
+        const dir = path.join(HOME, '.config', 'opencode');
+        const jsonc = path.join(dir, 'opencode.jsonc');
+        return fs.existsSync(jsonc) ? jsonc : path.join(dir, 'opencode.json');
+      }
+      const projJsonc = path.join(projectRoot, 'opencode.jsonc');
+      return fs.existsSync(projJsonc) ? projJsonc : path.join(projectRoot, 'opencode.json');
+    }
     default:
       return null;
   }

--- a/src/init/md-block.ts
+++ b/src/init/md-block.ts
@@ -71,11 +71,48 @@ ${END_MARKER}`;
 /** Backwards-compatible alias for legacy imports. */
 export const TRACE_MCP_ROUTING_BLOCK = TRACE_ROUTING_BLOCK;
 
+/**
+ * Neutral routing block for AGENTS.md.
+ * Unlike CLAUDE.md, which targets Claude Code and names its native tools
+ * (Read, Grep, Glob, Edit), AGENTS.md targets cross-client agents (Hermes,
+ * OpenCode, Codex, Factory Droid, AMP) and uses neutral tool descriptions.
+ */
+export const AGENTS_ROUTING_BLOCK = `${START_MARKER}
+## trace Tool Routing
+
+IMPORTANT: For ANY code exploration task, ALWAYS use trace tools first. NEVER use host file-reading, grep, glob, or shell (ls, find) tools for navigating source code.
+
+| Task | trace tool | Instead of |
+|------|------------|------------|
+| Find a function/class/method | \`search\` | text grep |
+| Understand a file before editing | \`get_outline\` | full-file read |
+| Read one symbol's source | \`get_symbol\` | full-file read |
+| What breaks if I change X | \`get_change_impact\` | guessing |
+| All usages of a symbol | \`find_usages\` | text grep |
+| All implementations of an interface | \`get_implementations\` | directory search (ls/find) |
+| All classes implementing X | \`search\` with \`implements\` filter | text grep |
+| Project health / coverage gaps | \`self_audit\` | manual inspection |
+| Dead code / dead exports | \`get_dead_code\` (\`mode: "exports_only"\`) | text grep for unused |
+| Context for a task | \`get_feature_context\` | reading 15 files |
+| Tests for a symbol | \`get_tests_for\` | glob + grep |
+| Untested symbols (deep) | \`get_untested_symbols\` (deferred — load via \`load_tools\`) | manual audit |
+| HTTP request flow | \`get_request_flow\` (framework-gated) | reading route files |
+| DB model relationships | \`get_model_context\` (framework-gated) | reading model + migrations |
+| Component tree | \`get_component_tree\` (framework-gated) | reading component files |
+| Circular dependencies | \`get_circular_imports\` | manual tracing |
+| Task spanning many turns | \`trace_state_init\` once, then \`trace_state_patch\` / \`trace_state_add_dead_end\` per step, \`trace_state_get\` to re-read (deferred — \`load_tools({preset:"state"})\`) | re-reading the whole transcript every turn |
+
+Use host file-reading and grep tools ONLY for non-code files (.md, .json, .yaml, config) or before edit.
+Start sessions with \`get_project_map\` (summary_only=true).
+${END_MARKER}`;
+
 /** Upsert the trace routing block into `filePath`. Idempotent. */
 export function upsertTraceMcpBlock(
   filePath: string,
-  opts: { dryRun?: boolean } = {},
+  opts: { dryRun?: boolean; block?: string } = {},
 ): InitStepResult {
+  const isAgentsMd = basename(filePath) === 'AGENTS.md';
+  const block = opts.block ?? (isAgentsMd ? AGENTS_ROUTING_BLOCK : TRACE_ROUTING_BLOCK);
   const existing = readIfExists(filePath);
 
   const hasAnyMarker =
@@ -93,7 +130,7 @@ export function upsertTraceMcpBlock(
   }
 
   if (existing === null) {
-    fs.writeFileSync(filePath, `${TRACE_ROUTING_BLOCK}\n`);
+    fs.writeFileSync(filePath, `${block}\n`);
     return { target: filePath, action: 'created' };
   }
 
@@ -108,7 +145,7 @@ export function upsertTraceMcpBlock(
   );
 
   if (markerRe.test(content)) {
-    content = content.replace(markerRe, TRACE_ROUTING_BLOCK);
+    content = content.replace(markerRe, block);
     content = cleanupWhitespace(content);
     if (content === originalContent) {
       return { target: filePath, action: 'already_configured' };
@@ -124,7 +161,7 @@ export function upsertTraceMcpBlock(
 
   content = cleanupWhitespace(content);
   const separator = content.endsWith('\n') ? '\n' : '\n\n';
-  fs.writeFileSync(filePath, `${content + separator + TRACE_ROUTING_BLOCK}\n`);
+  fs.writeFileSync(filePath, `${content + separator + block}\n`);
   const cleaned = originalContent !== content;
   return {
     target: filePath,

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -52,7 +52,8 @@ export interface DetectedMcpClient {
     | 'cline'
     | 'kilocode'
     | 'antigravity'
-    | 'kimi';
+    | 'kimi'
+    | 'opencode';
   configPath: string;
   hasTraceMcp: boolean;
 }

--- a/src/server/__tests__/client-profile.test.ts
+++ b/src/server/__tests__/client-profile.test.ts
@@ -82,6 +82,9 @@ describe('client detection', () => {
     ['Cursor', 'cursor'],
     ['Visual Studio Code', 'vscode'],
     ['vscode-copilot', 'vscode'],
+    ['opencode', 'opencode'],
+    ['OpenCode', 'opencode'],
+    ['open-code', 'opencode'],
   ])('resolves %s to the %s profile', (clientName, expected) => {
     expect(detectClientProfile(clientName)).toBe(expected);
   });
@@ -108,6 +111,7 @@ describe('resolved tool surface, per profile', () => {
     codex: ['search_text'],
     cursor: ['search_text'],
     vscode: ['search_text'],
+    opencode: ['search_text'],
     generic: [],
   };
 
@@ -217,6 +221,16 @@ describe('instructions retargeting', () => {
     const cursor = retargetInstructions(minimal, getClientProfile('cursor'));
     expect(cursor).toContain('`grep_search`');
     expect(cursor).not.toContain('`content-match`');
+  });
+
+  it('retargets opencode host tools', () => {
+    const { instructions } = runSession('opencode');
+    expect(instructions).toContain('`read_file`');
+    expect(instructions).toContain('`grep`');
+    expect(instructions).toContain('`glob`');
+    expect(instructions).toContain('edit_file');
+    expect(instructions).not.toContain('host tool names vary');
+    expect(instructions).not.toContain('`content-match`');
   });
 
   it('leaves an empty instructions block alone', () => {

--- a/src/server/client-profile.ts
+++ b/src/server/client-profile.ts
@@ -28,6 +28,7 @@ export const CLIENT_PROFILE_NAMES = [
   'codex',
   'cursor',
   'vscode',
+  'opencode',
   'generic',
 ] as const;
 export type ClientProfileName = (typeof CLIENT_PROFILE_NAMES)[number];
@@ -96,6 +97,17 @@ const PROFILES: Record<ClientProfileName, ClientProfile> = {
       edit: 'editFile',
     },
   },
+  opencode: {
+    name: 'opencode',
+    suppress: HOST_COVERED,
+    hostTools: {
+      rubric: "your host's own tools are `read_file`, `grep`, `glob`, `edit_file`",
+      read: '`read_file`',
+      grep: '`grep`',
+      glob: '`glob`',
+      edit: 'edit_file',
+    },
+  },
   // The fallback has to be a no-op, not a guess: a host we don't recognise may
   // have no file tools at all (Claude Desktop, a bare SDK client), and hiding
   // `search_text` there would take away its only content search.
@@ -112,6 +124,8 @@ const DETECTION: ReadonlyArray<[string, ClientProfileName]> = [
   ['visual-studio-code', 'vscode'],
   ['vscode', 'vscode'],
   ['copilot', 'vscode'],
+  ['opencode', 'opencode'],
+  ['open-code', 'opencode'],
 ];
 
 /**

--- a/tests/init/claude-md.test.ts
+++ b/tests/init/claude-md.test.ts
@@ -20,6 +20,7 @@ function throwEnoent(): never {
 }
 
 let updateClaudeMd: typeof import('../../src/init/claude-md.js').updateClaudeMd;
+let updateAgentsMd: typeof import('../../src/init/agents-md.js').updateAgentsMd;
 
 beforeEach(async () => {
   vi.resetModules();
@@ -31,6 +32,8 @@ beforeEach(async () => {
 
   const mod = await import('../../src/init/claude-md.js');
   updateClaudeMd = mod.updateClaudeMd;
+  const agentsMod = await import('../../src/init/agents-md.js');
+  updateAgentsMd = agentsMod.updateAgentsMd;
 });
 
 afterEach(() => {
@@ -198,5 +201,52 @@ describe('updateClaudeMd', () => {
 
     const result = updateClaudeMd('/project', {});
     expect(result.action).toBe('already_configured');
+  });
+});
+
+describe('updateAgentsMd', () => {
+  it('creates AGENTS.md with neutral host-tool instructions', () => {
+    const result = updateAgentsMd('/project', {});
+    expect(result.action).toBe('created');
+    expect(result.target).toBe(path.join('/project', 'AGENTS.md'));
+    expect(mockFs.writeFileSync).toHaveBeenCalledOnce();
+
+    const content = String(mockFs.writeFileSync.mock.calls[0][1]);
+    expect(content).toContain(START_MARKER);
+    expect(content).toContain(END_MARKER);
+    expect(content).toContain('trace Tool Routing');
+
+    // Neutral host tool descriptions for cross-client agents (TRA-1204)
+    expect(content).toContain(
+      'NEVER use host file-reading, grep, glob, or shell (ls, find) tools for navigating source code.',
+    );
+    expect(content).toContain(
+      'Use host file-reading and grep tools ONLY for non-code files (.md, .json, .yaml, config) or before edit.',
+    );
+    expect(content).toContain('full-file read');
+    expect(content).toContain('text grep');
+
+    // Does NOT contain Claude-specific capitalized tool names
+    expect(content).not.toContain('NEVER use Read/Grep/Glob/Bash(ls,find)');
+    expect(content).not.toContain('Use Read/Grep/Glob ONLY');
+    expect(content).not.toContain('Read (full file)');
+  });
+
+  it('preserves Claude-specific tool names in CLAUDE.md while AGENTS.md stays neutral', () => {
+    updateClaudeMd('/project', {});
+    const claudeContent = String(mockFs.writeFileSync.mock.calls[0][1]);
+    expect(claudeContent).toContain('NEVER use Read/Grep/Glob/Bash(ls,find)');
+    expect(claudeContent).toContain('Read (full file)');
+
+    vi.resetAllMocks();
+    mockFs.writeFileSync.mockImplementation(() => {});
+    mockFs.readFileSync.mockImplementation(throwEnoent);
+
+    updateAgentsMd('/project', {});
+    const agentsContent = String(mockFs.writeFileSync.mock.calls[0][1]);
+    expect(agentsContent).toContain(
+      'NEVER use host file-reading, grep, glob, or shell (ls, find) tools',
+    );
+    expect(agentsContent).not.toContain('NEVER use Read/Grep/Glob/Bash(ls,find)');
   });
 });

--- a/tests/init/mcp-client-status.test.ts
+++ b/tests/init/mcp-client-status.test.ts
@@ -279,6 +279,7 @@ describe('getMcpClientStatuses', () => {
       'kilocode',
       'antigravity',
       'kimi',
+      'opencode',
     ]) {
       expect(names.has(expected as never)).toBe(true);
     }
@@ -309,6 +310,21 @@ describe('getMcpClientStatuses', () => {
     c.mcpServers['trace'].command = '/old/launcher/path';
     fs.writeFileSync(configPath, JSON.stringify(c, null, 2));
     const [drifted] = getMcpClientStatuses(projectRoot, 'global', ['cline']);
+    expect(drifted.status).toBe('stale');
+    expect(drifted.staleReason).toBe('command');
+  });
+
+  it('flags opencode `stale` reason="command" when the launcher command drifts', () => {
+    configureMcpClients(['opencode'], projectRoot, { scope: 'global' });
+    const [s] = getMcpClientStatuses(projectRoot, 'global', ['opencode']);
+    expect(s.status).toBe('up_to_date');
+
+    const configPath = s.configPath as string;
+    const c = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    c.mcp.trace.command = ['/old/launcher', 'serve'];
+    fs.writeFileSync(configPath, JSON.stringify(c, null, 2));
+
+    const [drifted] = getMcpClientStatuses(projectRoot, 'global', ['opencode']);
     expect(drifted.status).toBe('stale');
     expect(drifted.staleReason).toBe('command');
   });

--- a/tests/init/mcp-clients-extra.test.ts
+++ b/tests/init/mcp-clients-extra.test.ts
@@ -497,3 +497,133 @@ describe('Warp configuration', () => {
     expect(warp?.detail).toContain('File-based MCP servers');
   });
 });
+
+describe('OpenCode detection', () => {
+  it('parses ~/.config/opencode/opencode.json and detects trace-mcp', () => {
+    const dir = path.join(fakeHome, '.config', 'opencode');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'opencode.json'),
+      JSON.stringify({
+        mcp: {
+          'trace-mcp': {
+            type: 'local',
+            command: ['trace-mcp', 'serve'],
+            enabled: true,
+          },
+        },
+      }),
+    );
+    const clients = detectMcpClients(projectRoot);
+    const opencode = clients.find((c) => c.name === 'opencode');
+    expect(opencode).toBeDefined();
+    expect(opencode?.hasTraceMcp).toBe(true);
+  });
+
+  it('parses opencode.jsonc with comments and detects trace', () => {
+    const dir = path.join(fakeHome, '.config', 'opencode');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'opencode.jsonc'),
+      [
+        '// OpenCode user settings',
+        '{',
+        '  /* MCP servers */',
+        '  "mcp": {',
+        '    "trace": {',
+        '      "type": "local",',
+        '      "command": ["/path/to/trace-mcp", "serve"],',
+        '      "enabled": true',
+        '    }',
+        '  }',
+        '}',
+      ].join('\n'),
+    );
+    const clients = detectMcpClients(projectRoot);
+    const opencode = clients.find((c) => c.name === 'opencode');
+    expect(opencode).toBeDefined();
+    expect(opencode?.hasTraceMcp).toBe(true);
+    expect(opencode?.configPath).toMatch(/opencode\.jsonc$/);
+  });
+
+  it('falls back to project-level opencode.json when user-level is absent', () => {
+    fs.writeFileSync(
+      path.join(projectRoot, 'opencode.json'),
+      JSON.stringify({
+        mcp: {
+          trace: {
+            type: 'local',
+            command: ['trace-mcp', 'serve'],
+            enabled: true,
+          },
+        },
+      }),
+    );
+    const clients = detectMcpClients(projectRoot);
+    const opencode = clients.find((c) => c.name === 'opencode');
+    expect(opencode?.hasTraceMcp).toBe(true);
+    expect(opencode?.configPath.startsWith(projectRoot)).toBe(true);
+  });
+});
+
+describe('OpenCode configuration', () => {
+  it('creates global opencode.json with local MCP entry', () => {
+    const results = configureMcpClients(['opencode'], projectRoot, { scope: 'global' });
+    expect(results[0].action).toBe('created');
+
+    const configPath = path.join(fakeHome, '.config', 'opencode', 'opencode.json');
+    expect(fs.existsSync(configPath)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcp).toBeDefined();
+    expect(content.mcp.trace).toEqual({
+      type: 'local',
+      command: [expect.stringContaining('trace-mcp'), 'serve'],
+      enabled: true,
+    });
+  });
+
+  it('creates project-level opencode.json when scope is project', () => {
+    const results = configureMcpClients(['opencode'], projectRoot, { scope: 'project' });
+    expect(results[0].action).toBe('created');
+
+    const configPath = path.join(projectRoot, 'opencode.json');
+    expect(fs.existsSync(configPath)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcp.trace.type).toBe('local');
+    expect(content.mcp.trace.enabled).toBe(true);
+    expect(content.mcp.trace.command[1]).toBe('serve');
+  });
+
+  it('migrates legacy trace-mcp key to trace in place', () => {
+    const dir = path.join(fakeHome, '.config', 'opencode');
+    fs.mkdirSync(dir, { recursive: true });
+    const configPath = path.join(dir, 'opencode.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcp: {
+          'trace-mcp': {
+            type: 'local',
+            command: ['trace-mcp', 'serve'],
+            enabled: true,
+          },
+        },
+      }),
+    );
+
+    const results = configureMcpClients(['opencode'], projectRoot, { scope: 'global' });
+    expect(results[0].action).toBe('updated');
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcp['trace-mcp']).toBeUndefined();
+    expect(content.mcp.trace).toBeDefined();
+    expect(content.mcp.trace.type).toBe('local');
+    expect(content.mcp.trace.enabled).toBe(true);
+  });
+
+  it('reports already_configured when entry matches', () => {
+    configureMcpClients(['opencode'], projectRoot, { scope: 'global' });
+    const results = configureMcpClients(['opencode'], projectRoot, { scope: 'global' });
+    expect(results[0].action).toBe('already_configured');
+  });
+});

--- a/tests/init/state-routing.test.ts
+++ b/tests/init/state-routing.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { installCursorRules } from '../../src/init/ide-rules.js';
-import { TRACE_ROUTING_BLOCK } from '../../src/init/md-block.js';
+import { AGENTS_ROUTING_BLOCK, TRACE_ROUTING_BLOCK } from '../../src/init/md-block.js';
 
 /**
  * The state tools (TRA-596) are deferred behind `load_tools`, so the generated
@@ -29,6 +29,7 @@ describe('SKILL.state routing', () => {
 
   it('names the state tools in the CLAUDE.md / AGENTS.md block', () => {
     mustRoute(TRACE_ROUTING_BLOCK);
+    mustRoute(AGENTS_ROUTING_BLOCK);
   });
 
   it('names the state tools in the Cursor/Windsurf rules', () => {


### PR DESCRIPTION
Closes TRA-1204

### Context & Motivation
Telemetry from `adoption.yml` indicates that non-Claude Code clients now make up 45% of identified installs, including OpenCode (e.g. real user config from Windows in TRA-1087). Previously:
1. OpenCode had no tailored client profile in `src/server/client-profile.ts` and fell through to `generic`, failing to suppress `search_text` and `discover_hermes_sessions` and showing generic instruction rubrics.
2. OpenCode was missing from `trace-mcp init` / `mcp-client.ts`, forcing manual user configuration and path errors.
3. `AGENTS.md` was hardcoded to Claude Code tool names (`Read`/`Grep`/`Glob`/`Edit`), confusing agents in OpenCode, Codex CLI, Cursor, and Hermes.

### Changes
1. **OpenCode profile in `src/server/client-profile.ts`**:
   - Added `'opencode'` to `CLIENT_PROFILE_NAMES` and detection table (`['opencode', 'opencode']`, `['open-code', 'opencode']`).
   - Added profile with `suppress: HOST_COVERED` (`search_text`, `discover_hermes_sessions`) and `hostTools` mapping: `read_file`, `grep`, `glob`, `edit_file`.
2. **OpenCode auto-config in `src/init/mcp-client.ts`**:
   - Added `'opencode'` to `ALL_MCP_CLIENT_NAMES` and `DetectedMcpClient['name']`.
   - Global config at `~/.config/opencode/opencode.json` (or `.jsonc`) and project-scoped `opencode.json` (or `.jsonc`).
   - Config format: `"mcp": { "trace": { "type": "local", "command": ["<launcher>", "serve"], "enabled": true } }`.
   - Automatic migration of legacy `trace-mcp` key in `mcp`.
   - Updated `launcher-health.ts` to detect `parsed.mcp` and array-based `command`.
   - Updated `packages/app/src/shared/mcp-detector.ts` and `mcp-detector-types.ts` for desktop detection.
   - Updated CLI `init.ts` `--mcp-client` options, selection list, and `agentsMdClients`.
3. **Neutral tool routing in `AGENTS.md` (`src/init/md-block.ts`, `src/init/agents-md.ts`)**:
   - Exported `AGENTS_ROUTING_BLOCK` using neutral host tool names (`full-file read`, `text grep`, `directory search (ls/find)`, `glob + grep`), replacing Claude-specific capitalized `Read`/`Grep`/`Glob`/`Edit`.
   - `upsertTraceMcpBlock` automatically uses `AGENTS_ROUTING_BLOCK` for `AGENTS.md` and `TRACE_ROUTING_BLOCK` for `CLAUDE.md`.
   - Synchronized root `AGENTS.md`.

### Verification
- `pnpm run typecheck` passed (0 errors).
- `pnpm run biome:ci` passed (0 errors).
- `pnpm run build` passed.
- Targeted tests passed:
  - `src/server/__tests__/client-profile.test.ts` (36 passed)
  - `tests/init/mcp-clients-extra.test.ts` (36 passed)
  - `tests/init/mcp-client-status.test.ts` (29 passed)
  - `tests/init/claude-md.test.ts` (14 passed)
  - `tests/init/state-routing.test.ts` (2 passed)
  - `tests/init/launcher-health.test.ts` (26 passed)
  - `tests/docs/readme-claims.test.ts` (76 passed)
- Full test suite passed (10,862 passed).