### PR TITLE
feat(server): antigravity client profile with host tool retargeting and search suppression (TRA-1216)

### DIFF
--- a/src/server/__tests__/client-profile.test.ts
+++ b/src/server/__tests__/client-profile.test.ts
@@ -85,6 +85,9 @@ describe('client detection', () => {
     ['opencode', 'opencode'],
     ['OpenCode', 'opencode'],
     ['open-code', 'opencode'],
+    ['antigravity-client', 'antigravity'],
+    ['Antigravity', 'antigravity'],
+    ['antigravity', 'antigravity'],
   ])('resolves %s to the %s profile', (clientName, expected) => {
     expect(detectClientProfile(clientName)).toBe(expected);
   });
@@ -112,6 +115,7 @@ describe('resolved tool surface, per profile', () => {
     cursor: ['search_text'],
     vscode: ['search_text'],
     opencode: ['search_text'],
+    antigravity: ['search_text'],
     generic: [],
   };
 
@@ -176,6 +180,28 @@ describe('resolved tool surface, per profile', () => {
     }) as { result: { tools: Array<{ name: string }> } };
     expect(list.result.tools.map((t) => t.name)).toEqual(['search']);
   });
+
+  it('suppresses search_text and discover_hermes_sessions for antigravity', () => {
+    process.env.TRACE_MCP_CLIENT_PROFILE = 'antigravity';
+    const gate = new ClientProfileGate(cfg());
+    gate.observeFromClient({ method: 'initialize', params: {} });
+    const list = gate.applyToClient({
+      jsonrpc: '2.0',
+      id: 2,
+      result: {
+        tools: [
+          { name: 'search' },
+          { name: 'search_text' },
+          { name: 'discover_hermes_sessions' },
+          { name: 'get_symbol' },
+        ],
+      },
+    }) as { result: { tools: Array<{ name: string }> } };
+    expect(list.result.tools.map((t) => t.name)).toEqual(['search', 'get_symbol']);
+    expect(getClientProfile('antigravity').suppress).toEqual(
+      new Set(['search_text', 'discover_hermes_sessions']),
+    );
+  });
 });
 
 describe('overrides', () => {
@@ -229,6 +255,16 @@ describe('instructions retargeting', () => {
     expect(instructions).toContain('`grep`');
     expect(instructions).toContain('`glob`');
     expect(instructions).toContain('edit_file');
+    expect(instructions).not.toContain('host tool names vary');
+    expect(instructions).not.toContain('`content-match`');
+  });
+
+  it('retargets antigravity host tools', () => {
+    const { instructions } = runSession('antigravity-client');
+    expect(instructions).toContain('`view_file`');
+    expect(instructions).toContain('`grep_search`');
+    expect(instructions).toContain('`find_by_name`');
+    expect(instructions).toContain('replace_file_content/write_to_file');
     expect(instructions).not.toContain('host tool names vary');
     expect(instructions).not.toContain('`content-match`');
   });

--- a/src/server/client-profile.ts
+++ b/src/server/client-profile.ts
@@ -29,6 +29,7 @@ export const CLIENT_PROFILE_NAMES = [
   'cursor',
   'vscode',
   'opencode',
+  'antigravity',
   'generic',
 ] as const;
 export type ClientProfileName = (typeof CLIENT_PROFILE_NAMES)[number];
@@ -108,6 +109,18 @@ const PROFILES: Record<ClientProfileName, ClientProfile> = {
       edit: 'edit_file',
     },
   },
+  antigravity: {
+    name: 'antigravity',
+    suppress: HOST_COVERED,
+    hostTools: {
+      rubric:
+        "your host's own tools are `view_file`, `grep_search`, `find_by_name`, `replace_file_content`",
+      read: '`view_file`',
+      grep: '`grep_search`',
+      glob: '`find_by_name`',
+      edit: 'replace_file_content/write_to_file',
+    },
+  },
   // The fallback has to be a no-op, not a guess: a host we don't recognise may
   // have no file tools at all (Claude Desktop, a bare SDK client), and hiding
   // `search_text` there would take away its only content search.
@@ -126,6 +139,7 @@ const DETECTION: ReadonlyArray<[string, ClientProfileName]> = [
   ['copilot', 'vscode'],
   ['opencode', 'opencode'],
   ['open-code', 'opencode'],
+  ['antigravity', 'antigravity'],
 ];
 
 /**


### PR DESCRIPTION
## Summary
Adds dedicated client profile for Antigravity (Google agentic IDE/CLI) in `src/server/client-profile.ts`:
- Added `'antigravity'` to `CLIENT_PROFILE_NAMES`.
- Configured host-covered suppression (`search_text`, `discover_hermes_sessions`) since Antigravity ships native file inspection and search tools (`view_file`, `grep_search`, `find_by_name`).
- Retargets instructions rubric and tool pointers (`view_file`, `grep_search`, `find_by_name`, `replace_file_content/write_to_file`).
- Added detection rule mapping `antigravity` to `antigravity`.
- Comprehensive test coverage in `src/server/__tests__/client-profile.test.ts`.

Closes TRA-1216.
