### PR TITLE
fix(launcher,gc): sweep stale session artifacts in softGcSweep and support --preset variations in proxy fast path (TRA-1218)

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.6.13 (Windows)
+REM trace-mcp-launcher v0.6.14 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.6.13 (Windows)
+# trace-mcp-launcher v0.6.14 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.
@@ -297,12 +297,22 @@ function Test-DaemonPortOpen {
 }
 
 # True when argv is a plain `serve` invocation this shim understands well
-# enough to route to the thin proxy: no args, `serve`, or `serve --preset X`.
+# enough to route to the thin proxy: no args, `serve`, `serve --preset X`,
+# `--preset X`, or `--preset=X`.
 function Test-PlainServe {
     param([string[]]$CommandArgs)
     if (-not $CommandArgs -or $CommandArgs.Count -eq 0) { return $true }
-    if ($CommandArgs.Count -eq 1 -and $CommandArgs[0] -eq 'serve') { return $true }
-    if ($CommandArgs.Count -eq 3 -and $CommandArgs[0] -eq 'serve' -and $CommandArgs[1] -eq '--preset') { return $true }
+    if ($CommandArgs.Count -eq 1) {
+        if ($CommandArgs[0] -eq 'serve') { return $true }
+        if ($CommandArgs[0].StartsWith('--preset=') -and $CommandArgs[0].Length -gt 9) { return $true }
+        return $false
+    }
+    if ($CommandArgs.Count -eq 2) {
+        if ($CommandArgs[0] -eq 'serve' -and $CommandArgs[1].StartsWith('--preset=') -and $CommandArgs[1].Length -gt 9) { return $true }
+        if ($CommandArgs[0] -eq '--preset' -and -not [string]::IsNullOrEmpty($CommandArgs[1]) -and -not $CommandArgs[1].StartsWith('-')) { return $true }
+        return $false
+    }
+    if ($CommandArgs.Count -eq 3 -and $CommandArgs[0] -eq 'serve' -and $CommandArgs[1] -eq '--preset' -and -not [string]::IsNullOrEmpty($CommandArgs[2]) -and -not $CommandArgs[2].StartsWith('-')) { return $true }
     return $false
 }
 

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.6.13
+# trace-mcp-launcher v0.6.14
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -808,15 +808,36 @@ daemon_port_open() {
 }
 
 # True when argv is a plain `serve` invocation this shim understands well
-# enough to route to the thin proxy: no args, `serve`, or `serve --preset X`.
+# enough to route to the thin proxy: no args, `serve`, `serve --preset X`,
+# `--preset X`, or `--preset=X`.
 # Anything else (serve-http, doctor, add, unrecognised flags, ...) always
 # takes the full cli.js path — Commander stays the source of truth for
 # everything this heuristic does not explicitly recognise.
 is_plain_serve() {
   case $# in
     0) return 0 ;;
-    1) [ "$1" = "serve" ] ;;
-    3) [ "$1" = "serve" ] && [ "$2" = "--preset" ] ;;
+    1)
+      if [ "$1" = "serve" ]; then
+        return 0
+      fi
+      case "$1" in
+        --preset=*) [ "${1#--preset=}" != "" ] ;;
+        *) return 1 ;;
+      esac
+      ;;
+    2)
+      if [ "$1" = "serve" ]; then
+        case "$2" in
+          --preset=*) [ "${2#--preset=}" != "" ] ;;
+          *) return 1 ;;
+        esac
+      elif [ "$1" = "--preset" ]; then
+        [ -n "$2" ] && [ "${2#-}" = "$2" ]
+      else
+        return 1
+      fi
+      ;;
+    3) [ "$1" = "serve" ] && [ "$2" = "--preset" ] && [ -n "$3" ] && [ "${3#-}" = "$3" ] ;;
     *) return 1 ;;
   esac
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -162,6 +162,7 @@ import { scanCodeSmells } from './tools/quality/code-smells.js';
 import { TopologyStore } from './topology/topology-db.js';
 import { checkAndInstallUpdate, scheduleBackgroundUpdate } from './updater.js';
 import { atomicWriteJson, sweepOrphanTmpFilesUnderHome } from './utils/atomic-write.js';
+import { sweepSessionFiles } from './session/sweeper.js';
 import { sqliteUtcToIso } from './utils/sqlite-time.js';
 
 /**
@@ -331,6 +332,21 @@ function softGcSweep(): void {
     }
   } catch (err) {
     logger.warn({ err }, 'sweepOrphanTmpFiles soft-prune failed (non-fatal)');
+  }
+
+  // TRA-1218: sweep stale session snapshots, end logs, and orphaned resume
+  // summaries in SESSIONS_DIR.
+  try {
+    const sessionSummary = sweepSessionFiles();
+    if (sessionSummary.deleted.length > 0) {
+      const freedKb = Math.round(sessionSummary.freedBytes / 1024);
+      logger.info(
+        { deletedFiles: sessionSummary.deleted.length, freedKb },
+        `Pruned ${sessionSummary.deleted.length} stale session file(s) (${freedKb} KB freed)`,
+      );
+    }
+  } catch (err) {
+    logger.warn({ err }, 'sweepSessionFiles soft-prune failed (non-fatal)');
   }
 
   try {

--- a/src/cli/prune.ts
+++ b/src/cli/prune.ts
@@ -34,6 +34,7 @@ import { listProjects, pruneStaleProjects } from '../registry.js';
 import { INDEX_DIR } from '../shared/paths.js';
 import { TopologyStore } from '../topology/topology-db.js';
 import { DecisionStore } from '../memory/decision-store.js';
+import { sweepSessionFiles } from '../session/sweeper.js';
 
 /** Categories assigned to each DB candidate. */
 export type PruneCategory =
@@ -573,6 +574,9 @@ export const pruneCommand = new Command('prune')
       // Stale decisions / memory rows belonging to deleted project roots
       const decisionsSummary = scanOrPruneDecisions(apply);
 
+      // Stale session artifacts (snapshots >24h, end logs >7d, orphan summaries)
+      const sessionSummary = sweepSessionFiles({ dryRun: !apply });
+
       if (opts.json) {
         console.log(
           JSON.stringify(
@@ -593,6 +597,10 @@ export const pruneCommand = new Command('prune')
                 removedChunks: decisionsSummary.removedChunks,
                 removedClusters: decisionsSummary.removedClusters,
                 removedMemos: decisionsSummary.removedMemos,
+              },
+              sessions: {
+                deletedFiles: sessionSummary.deleted.length,
+                freedBytes: sessionSummary.freedBytes,
               },
             },
             null,
@@ -639,6 +647,20 @@ export const pruneCommand = new Command('prune')
           lines.push(`  ${shortPath(r)}`);
         }
         p.note(lines.join('\n'), 'Decision Memory');
+      }
+      if (sessionSummary.deleted.length > 0) {
+        const freedKb = Math.round(sessionSummary.freedBytes / 1024);
+        const heading = apply
+          ? `Removed ${sessionSummary.deleted.length} stale session file(s) (${freedKb} KB freed):`
+          : `${sessionSummary.deleted.length} stale session file(s) (${freedKb} KB) — would remove:`;
+        const lines = [heading];
+        for (const f of sessionSummary.deleted.slice(0, 10)) {
+          lines.push(`  ${f}`);
+        }
+        if (sessionSummary.deleted.length > 10) {
+          lines.push(`  ... and ${sessionSummary.deleted.length - 10} more`);
+        }
+        p.note(lines.join('\n'), 'Sessions');
       }
       if (!apply) {
         p.outro('Dry-run only — re-run with --apply to delete.');

--- a/src/global.ts
+++ b/src/global.ts
@@ -209,6 +209,9 @@ export function isEphemeralProjectRoot(root: string): boolean {
 /** Global project registry. */
 export const REGISTRY_PATH = path.join(TRACE_MCP_HOME, 'registry.json');
 
+/** Global sessions directory (snapshots, end logs, resume summaries). */
+export const SESSIONS_DIR = path.join(TRACE_MCP_HOME, 'sessions');
+
 /** Topology database (cross-service graph). */
 export const TOPOLOGY_DB_PATH = path.join(TRACE_MCP_HOME, 'topology.db');
 

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -117,4 +117,5 @@ export const MIRROR_HOOK_VERSION = '0.3.0';
 // and retry probe_cli across package swap windows.
 // 0.6.12 (TRA-1197): strip trailing CRs from launcher config, package roots and .npmrc
 // 0.6.13 (TRA-1206): candidate homes resolution under isolated HOME, Windows thin proxy daemon fast path
-export const LAUNCHER_VERSION = '0.6.13';
+// 0.6.14 (TRA-1218): support --preset variations in daemon-aware proxy routing
+export const LAUNCHER_VERSION = '0.6.14';

--- a/src/proxy-entry.ts
+++ b/src/proxy-entry.ts
@@ -25,6 +25,7 @@ import { DEFAULT_DAEMON_PORT } from './global.js';
 import { attachFileLogging, logger } from './logger.js';
 import { detectGitWorktree } from './project-root.js';
 import { resolveDbPath } from './registry.js';
+import { parsePresetArg } from './server/tool-filter.js';
 
 async function main(): Promise<void> {
   installProcessSafetyNet('serve');
@@ -32,8 +33,7 @@ async function main(): Promise<void> {
   // Mirrors the `serve` command's `--preset <name>` option (src/cli.ts) — the
   // only flag this fast path needs to understand. Anything else and the
   // launcher shim would not have picked this file in the first place.
-  const presetIdx = process.argv.indexOf('--preset');
-  const preset = presetIdx !== -1 ? process.argv[presetIdx + 1] : undefined;
+  const preset = parsePresetArg(process.argv);
   if (preset) process.env.TRACE_MCP_PRESET = preset;
 
   const projectRoot = process.cwd();

--- a/src/server/tool-filter.ts
+++ b/src/server/tool-filter.ts
@@ -53,6 +53,24 @@ export function resolvePresetName(config: TraceMcpConfig): string {
   return process.env.TRACE_MCP_PRESET ?? config.tools?.preset ?? DEFAULT_PRESET;
 }
 
+/**
+ * Extract preset name from command-line arguments if present.
+ * Supports both `--preset <name>` and `--preset=<name>`.
+ */
+export function parsePresetArg(argv: string[]): string | undefined {
+  const presetIdx = argv.indexOf('--preset');
+  if (presetIdx !== -1 && presetIdx + 1 < argv.length) {
+    const val = argv[presetIdx + 1];
+    return val && !val.startsWith('-') ? val : undefined;
+  }
+  const presetEq = argv.find((arg) => arg.startsWith('--preset='));
+  if (presetEq) {
+    const val = presetEq.slice('--preset='.length);
+    return val.length > 0 ? val : undefined;
+  }
+  return undefined;
+}
+
 /** The shipped default, and the surface an unresolvable preset name falls back to. */
 export const DEFAULT_PRESET = 'minimal';
 

--- a/src/session/resume.ts
+++ b/src/session/resume.ts
@@ -7,11 +7,15 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { ensureGlobalDirs, projectHash, TRACE_MCP_HOME } from '../global.js';
+import { ensureGlobalDirs, projectHash, SESSIONS_DIR, TRACE_MCP_HOME } from '../global.js';
 import { logger } from '../logger.js';
 import { atomicWriteJson } from '../utils/atomic-write.js';
 
-const SESSIONS_DIR = path.join(TRACE_MCP_HOME, 'sessions');
+export {
+  sweepSessionFiles,
+  type SessionSweepOptions,
+  type SessionSweepSummary,
+} from './sweeper.js';
 
 /** Max number of session summaries to keep per project */
 const MAX_SESSIONS = 20;

--- a/src/session/sweeper.ts
+++ b/src/session/sweeper.ts
@@ -1,0 +1,193 @@
+/**
+ * Session directory sweeper (TRA-1218).
+ *
+ * Reclaims disk space and inodes in `~/.trace-mcp/sessions/` (`SESSIONS_DIR`).
+ * Without this, every ephemeral task or project run leaks:
+ *  - `<hash>-snapshot.json` (transient context for PreCompact hook)
+ *  - `<hash>-end.log` (session-end exit marker)
+ *  - `<hash>.json` (rolling session summaries for `get_session_resume`)
+ * indefinitely, eventually accumulating thousands of orphaned files.
+ *
+ * Retention policy:
+ *  1. Snapshots: max age 24 hours (active session only; dead once session exits).
+ *  2. End logs: max age 7 days (or immediately if project root is confirmed gone).
+ *  3. Resumes:
+ *     - If project root is ephemeral (e.g. Multica workdir / Claude scratchpad)
+ *       and the directory no longer exists on disk: delete immediately.
+ *     - If project root is non-ephemeral but missing: delete after 7-day grace period.
+ *     - If all recorded sessions in the file are older than 30 days: delete.
+ *  4. Atomic-write tmp files (`.tmp.*`): delete if older than 1 hour.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { isEphemeralProjectRoot, SESSIONS_DIR } from '../global.js';
+import { logger } from '../logger.js';
+
+export interface SessionSweepOptions {
+  /** Directory where session files live (default: SESSIONS_DIR) */
+  sessionsDir?: string;
+  /** Max age in hours for *-snapshot.json files (default: 24) */
+  snapshotMaxAgeHours?: number;
+  /** Max age in hours for *-end.log files (default: 168 = 7 days) */
+  endLogMaxAgeHours?: number;
+  /** Max age in hours for session resume summary *.json files (default: 720 = 30 days) */
+  resumeMaxAgeHours?: number;
+  /** Grace period in days for non-ephemeral project roots that are missing (default: 7) */
+  missingRootGraceDays?: number;
+  /** If true, return candidates that would be deleted without actually unlinking them */
+  dryRun?: boolean;
+}
+
+export interface SessionSweepSummary {
+  deleted: string[];
+  freedBytes: number;
+}
+
+interface StoredSessionSummary {
+  session_id?: string;
+  project_root?: string;
+  started_at?: string;
+  ended_at?: string;
+}
+
+/**
+ * Sweep stale and orphaned files in the sessions directory.
+ */
+export function sweepSessionFiles(options?: SessionSweepOptions): SessionSweepSummary {
+  const dir = options?.sessionsDir ?? SESSIONS_DIR;
+  if (!fs.existsSync(dir)) {
+    return { deleted: [], freedBytes: 0 };
+  }
+
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch (err) {
+    logger.warn({ err, dir }, 'Failed to read sessions directory for sweep');
+    return { deleted: [], freedBytes: 0 };
+  }
+
+  const now = Date.now();
+  const snapshotMaxAgeMs = (options?.snapshotMaxAgeHours ?? 24) * 3600 * 1000;
+  const endLogMaxAgeMs = (options?.endLogMaxAgeHours ?? 168) * 3600 * 1000;
+  const resumeMaxAgeMs = (options?.resumeMaxAgeHours ?? 720) * 3600 * 1000;
+  const missingRootGraceMs = (options?.missingRootGraceDays ?? 7) * 24 * 3600 * 1000;
+  const dryRun = !!options?.dryRun;
+
+  const deadHashes = new Set<string>();
+  const candidatesToDelete = new Set<string>();
+
+  // Pass 1: analyze resume files (`<hash>.json`) to discover dead project roots
+  for (const filename of entries) {
+    if (
+      !filename.endsWith('.json') ||
+      filename.endsWith('-snapshot.json') ||
+      filename.includes('.tmp.')
+    ) {
+      continue;
+    }
+    const hash = filename.slice(0, -'.json'.length);
+    const fullPath = path.join(dir, filename);
+
+    let st: fs.Stats;
+    try {
+      st = fs.statSync(fullPath);
+    } catch {
+      continue;
+    }
+
+    let shouldDelete = false;
+    try {
+      const raw = fs.readFileSync(fullPath, 'utf-8');
+      const data = JSON.parse(raw);
+      if (!Array.isArray(data) || data.length === 0) {
+        shouldDelete = true;
+      } else {
+        const summaries = data as StoredSessionSummary[];
+        const root = summaries[0]?.project_root;
+
+        let latestSessionTime = 0;
+        for (const s of summaries) {
+          const t = Date.parse(s.ended_at || s.started_at || '') || 0;
+          if (t > latestSessionTime) latestSessionTime = t;
+        }
+
+        const fileAgeMs = now - st.mtimeMs;
+        const sessionAgeMs = latestSessionTime > 0 ? now - latestSessionTime : fileAgeMs;
+
+        if (!root || typeof root !== 'string') {
+          shouldDelete = true;
+        } else if (!fs.existsSync(root)) {
+          if (isEphemeralProjectRoot(root)) {
+            // Ephemeral roots never come back once deleted.
+            shouldDelete = true;
+            deadHashes.add(hash);
+          } else if (fileAgeMs > missingRootGraceMs && sessionAgeMs > missingRootGraceMs) {
+            // Missing non-ephemeral root past grace period.
+            shouldDelete = true;
+            deadHashes.add(hash);
+          }
+        } else if (fileAgeMs > resumeMaxAgeMs && sessionAgeMs > resumeMaxAgeMs) {
+          // Inactive past retention limit.
+          shouldDelete = true;
+        }
+      }
+    } catch {
+      // Unparseable / corrupted JSON.
+      shouldDelete = true;
+    }
+
+    if (shouldDelete) {
+      candidatesToDelete.add(filename);
+    }
+  }
+
+  // Pass 2: snapshots, end logs, and orphan tmp files
+  for (const filename of entries) {
+    if (candidatesToDelete.has(filename)) continue;
+
+    const fullPath = path.join(dir, filename);
+    let st: fs.Stats;
+    try {
+      st = fs.statSync(fullPath);
+    } catch {
+      continue;
+    }
+
+    if (filename.endsWith('-snapshot.json')) {
+      const hash = filename.slice(0, -'-snapshot.json'.length);
+      if (deadHashes.has(hash) || now - st.mtimeMs > snapshotMaxAgeMs) {
+        candidatesToDelete.add(filename);
+      }
+    } else if (filename.endsWith('-end.log')) {
+      const hash = filename.slice(0, -'-end.log'.length);
+      if (deadHashes.has(hash) || now - st.mtimeMs > endLogMaxAgeMs) {
+        candidatesToDelete.add(filename);
+      }
+    } else if (filename.includes('.tmp.')) {
+      if (now - st.mtimeMs > 3600 * 1000) {
+        candidatesToDelete.add(filename);
+      }
+    }
+  }
+
+  const deleted: string[] = [];
+  let freedBytes = 0;
+
+  for (const filename of candidatesToDelete) {
+    const fullPath = path.join(dir, filename);
+    try {
+      const st = fs.statSync(fullPath);
+      freedBytes += st.size;
+      if (!dryRun) {
+        fs.unlinkSync(fullPath);
+      }
+      deleted.push(filename);
+    } catch (err) {
+      logger.debug({ err, filename }, 'Failed to unlink session file during sweep');
+    }
+  }
+
+  return { deleted, freedBytes };
+}

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1609,6 +1609,30 @@ describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)'
       expect(out.stdout.trim()).toBe(`NODE_ARGS:${proxy} serve --preset core`);
     });
 
+    it('passes --preset variations through to the proxy (TRA-1218)', async () => {
+      const { home, traceHome, node, cli } = setupFakeHome();
+      writeConfig(traceHome, node, cli);
+      const proxy = plantProxy(cli);
+
+      const validCases: Array<{ args: string[]; expected: string }> = [
+        { args: ['--preset', 'core'], expected: `${proxy} --preset core` },
+        { args: ['serve', '--preset=core'], expected: `${proxy} serve --preset=core` },
+        { args: ['--preset=core'], expected: `${proxy} --preset=core` },
+        { args: [], expected: `${proxy}` },
+      ];
+
+      for (const { args, expected } of validCases) {
+        const out = await withListener((port) =>
+          runLauncherAsync(
+            { HOME: home, TRACE_MCP_HOME: traceHome, TRACE_MCP_DAEMON_PORT: String(port) },
+            args,
+          ),
+        );
+        expect(out.status).toBe(0);
+        expect(out.stdout.trim()).toBe(`NODE_ARGS:${expected}`);
+      }
+    });
+
     it('keeps cli.js for anything Commander owns, daemon or not', async () => {
       const { home, traceHome, node, cli } = setupFakeHome();
       writeConfig(traceHome, node, cli);
@@ -1616,7 +1640,15 @@ describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)'
 
       // serve-http, doctor and unrecognised serve flags all have to reach the
       // real CLI: the proxy only speaks plain stdio `serve`.
-      for (const args of [['serve-http'], ['doctor'], ['serve', '--http'], ['serve', '--preset']]) {
+      for (const args of [
+        ['serve-http'],
+        ['doctor'],
+        ['serve', '--http'],
+        ['serve', '--preset'],
+        ['--preset'],
+        ['serve', '--preset='],
+        ['--preset='],
+      ]) {
         const out = await withListener((port) =>
           runLauncherAsync(
             { HOME: home, TRACE_MCP_HOME: traceHome, TRACE_MCP_DAEMON_PORT: String(port) },

--- a/tests/proxy/parse-preset-arg.test.ts
+++ b/tests/proxy/parse-preset-arg.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { parsePresetArg } from '../../src/server/tool-filter.js';
+
+describe('parsePresetArg (TRA-1218)', () => {
+  it('parses --preset <name>', () => {
+    expect(parsePresetArg(['node', 'proxy.js', '--preset', 'core'])).toBe('core');
+    expect(parsePresetArg(['node', 'proxy.js', 'serve', '--preset', 'minimal'])).toBe('minimal');
+  });
+
+  it('parses --preset=<name>', () => {
+    expect(parsePresetArg(['node', 'proxy.js', '--preset=indexing'])).toBe('indexing');
+    expect(parsePresetArg(['node', 'proxy.js', 'serve', '--preset=review'])).toBe('review');
+  });
+
+  it('returns undefined when no preset flag is present', () => {
+    expect(parsePresetArg(['node', 'proxy.js'])).toBeUndefined();
+    expect(parsePresetArg(['node', 'proxy.js', 'serve'])).toBeUndefined();
+  });
+
+  it('returns undefined when preset argument is missing or malformed', () => {
+    expect(parsePresetArg(['node', 'proxy.js', '--preset'])).toBeUndefined();
+    expect(parsePresetArg(['node', 'proxy.js', '--preset='])).toBeUndefined();
+    expect(parsePresetArg(['node', 'proxy.js', '--preset', '--another-flag'])).toBeUndefined();
+  });
+});

--- a/tests/session/sweeper.test.ts
+++ b/tests/session/sweeper.test.ts
@@ -1,0 +1,209 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { sweepSessionFiles } from '../../src/session/sweeper.js';
+import { sweepSessionFiles as sweepFromResume } from '../../src/session/resume.js';
+
+describe('sweepSessionFiles (TRA-1218)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-sweep-test-'));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('re-exports cleanly from src/session/resume.ts', () => {
+    expect(typeof sweepFromResume).toBe('function');
+  });
+
+  it('returns empty result when directory does not exist or is empty', () => {
+    const nonExistent = path.join(tmpDir, 'does-not-exist');
+    expect(sweepSessionFiles({ sessionsDir: nonExistent })).toEqual({
+      deleted: [],
+      freedBytes: 0,
+    });
+
+    expect(sweepSessionFiles({ sessionsDir: tmpDir })).toEqual({
+      deleted: [],
+      freedBytes: 0,
+    });
+  });
+
+  it('sweeps snapshots older than 24 hours while keeping fresh ones', () => {
+    const oldSnap = path.join(tmpDir, 'old123456789-snapshot.json');
+    const freshSnap = path.join(tmpDir, 'fresh1234567-snapshot.json');
+
+    fs.writeFileSync(oldSnap, '{"content": "old"}');
+    fs.writeFileSync(freshSnap, '{"content": "fresh"}');
+
+    const twoDaysAgo = (Date.now() - 48 * 3600 * 1000) / 1000;
+    fs.utimesSync(oldSnap, twoDaysAgo, twoDaysAgo);
+
+    const res = sweepSessionFiles({ sessionsDir: tmpDir });
+    expect(res.deleted).toEqual(['old123456789-snapshot.json']);
+    expect(res.freedBytes).toBeGreaterThan(0);
+    expect(fs.existsSync(oldSnap)).toBe(false);
+    expect(fs.existsSync(freshSnap)).toBe(true);
+  });
+
+  it('sweeps end logs older than 7 days while keeping fresh ones', () => {
+    const oldLog = path.join(tmpDir, 'old123456789-end.log');
+    const freshLog = path.join(tmpDir, 'fresh1234567-end.log');
+
+    fs.writeFileSync(oldLog, '2026-08-01T00:00:00Z\tsession-1\n');
+    fs.writeFileSync(freshLog, '2026-09-08T00:00:00Z\tsession-2\n');
+
+    const tenDaysAgo = (Date.now() - 10 * 24 * 3600 * 1000) / 1000;
+    fs.utimesSync(oldLog, tenDaysAgo, tenDaysAgo);
+
+    const res = sweepSessionFiles({ sessionsDir: tmpDir });
+    expect(res.deleted).toEqual(['old123456789-end.log']);
+    expect(fs.existsSync(oldLog)).toBe(false);
+    expect(fs.existsSync(freshLog)).toBe(true);
+  });
+
+  it('sweeps orphaned atomic-write tmp files older than 1 hour', () => {
+    const oldTmp = path.join(tmpDir, '.somehash.tmp.1234.abcd');
+    const freshTmp = path.join(tmpDir, '.somehash.tmp.5678.ef01');
+
+    fs.writeFileSync(oldTmp, 'tmp data');
+    fs.writeFileSync(freshTmp, 'fresh tmp data');
+
+    const twoHoursAgo = (Date.now() - 2 * 3600 * 1000) / 1000;
+    fs.utimesSync(oldTmp, twoHoursAgo, twoHoursAgo);
+
+    const res = sweepSessionFiles({ sessionsDir: tmpDir });
+    expect(res.deleted).toEqual(['.somehash.tmp.1234.abcd']);
+    expect(fs.existsSync(oldTmp)).toBe(false);
+    expect(fs.existsSync(freshTmp)).toBe(true);
+  });
+
+  it('sweeps corrupt and empty session resume JSON files', () => {
+    const corruptFile = path.join(tmpDir, 'corrupt12345.json');
+    const emptyArrayFile = path.join(tmpDir, 'empty1234567.json');
+
+    fs.writeFileSync(corruptFile, 'not valid json {{{');
+    fs.writeFileSync(emptyArrayFile, '[]');
+
+    const res = sweepSessionFiles({ sessionsDir: tmpDir });
+    expect(res.deleted.sort()).toEqual(['corrupt12345.json', 'empty1234567.json']);
+    expect(fs.existsSync(corruptFile)).toBe(false);
+    expect(fs.existsSync(emptyArrayFile)).toBe(false);
+  });
+
+  it('immediately sweeps ephemeral project resumes and their associated artifacts when root is deleted', () => {
+    // Path matches Multica ephemeral workspace pattern
+    const deadEphemeralRoot =
+      '/Users/nikolai/multica_workspaces_desktop-api.multica.ai/tracemcp-2a3e85da063b/tra-999-123456789abc/workdir';
+    const hash = 'ephem1234567';
+
+    const resumeFile = path.join(tmpDir, `${hash}.json`);
+    const snapFile = path.join(tmpDir, `${hash}-snapshot.json`);
+    const endLogFile = path.join(tmpDir, `${hash}-end.log`);
+
+    const summary = [
+      {
+        session_id: 's-1',
+        project_root: deadEphemeralRoot,
+        started_at: new Date().toISOString(),
+        ended_at: new Date().toISOString(),
+      },
+    ];
+
+    fs.writeFileSync(resumeFile, JSON.stringify(summary));
+    fs.writeFileSync(snapFile, '{"snapshot": true}');
+    fs.writeFileSync(endLogFile, '2026-09-08T00:00:00Z\ts-1\n');
+
+    // Root does not exist; even though created just now, it is ephemeral so should be cleaned immediately
+    const res = sweepSessionFiles({ sessionsDir: tmpDir });
+    expect(res.deleted.sort()).toEqual(
+      [`${hash}-end.log`, `${hash}-snapshot.json`, `${hash}.json`].sort(),
+    );
+    expect(fs.existsSync(resumeFile)).toBe(false);
+    expect(fs.existsSync(snapFile)).toBe(false);
+    expect(fs.existsSync(endLogFile)).toBe(false);
+  });
+
+  it('keeps resume files for live projects', () => {
+    const liveRoot = fs.mkdtempSync(path.join(tmpDir, 'live-project-'));
+    const hash = 'live12345678';
+
+    const resumeFile = path.join(tmpDir, `${hash}.json`);
+    const snapFile = path.join(tmpDir, `${hash}-snapshot.json`);
+
+    const summary = [
+      {
+        session_id: 's-live',
+        project_root: liveRoot,
+        started_at: new Date().toISOString(),
+        ended_at: new Date().toISOString(),
+      },
+    ];
+
+    fs.writeFileSync(resumeFile, JSON.stringify(summary));
+    fs.writeFileSync(snapFile, '{"snapshot": true}');
+
+    const res = sweepSessionFiles({ sessionsDir: tmpDir });
+    expect(res.deleted).toEqual([]);
+    expect(fs.existsSync(resumeFile)).toBe(true);
+    expect(fs.existsSync(snapFile)).toBe(true);
+  });
+
+  it('respects missing root grace period for non-ephemeral project roots', () => {
+    const missingRoot = '/tmp/nonexistent-normal-project-xyz';
+    const hashYoung = 'young1234567';
+    const hashOld = 'oldroot12345';
+
+    const youngResume = path.join(tmpDir, `${hashYoung}.json`);
+    const oldResume = path.join(tmpDir, `${hashOld}.json`);
+
+    const youngSummary = [
+      {
+        session_id: 's-young',
+        project_root: missingRoot,
+        started_at: new Date(Date.now() - 2 * 24 * 3600 * 1000).toISOString(),
+        ended_at: new Date(Date.now() - 2 * 24 * 3600 * 1000).toISOString(),
+      },
+    ];
+
+    const oldSummary = [
+      {
+        session_id: 's-old',
+        project_root: missingRoot,
+        started_at: new Date(Date.now() - 14 * 24 * 3600 * 1000).toISOString(),
+        ended_at: new Date(Date.now() - 14 * 24 * 3600 * 1000).toISOString(),
+      },
+    ];
+
+    fs.writeFileSync(youngResume, JSON.stringify(youngSummary));
+    fs.writeFileSync(oldResume, JSON.stringify(oldSummary));
+
+    const fourteenDaysAgo = (Date.now() - 14 * 24 * 3600 * 1000) / 1000;
+    fs.utimesSync(oldResume, fourteenDaysAgo, fourteenDaysAgo);
+
+    const res = sweepSessionFiles({ sessionsDir: tmpDir, missingRootGraceDays: 7 });
+    expect(res.deleted).toEqual([`${hashOld}.json`]);
+    expect(fs.existsSync(youngResume)).toBe(true);
+    expect(fs.existsSync(oldResume)).toBe(false);
+  });
+
+  it('supports dry-run mode without unlinking files', () => {
+    const oldSnap = path.join(tmpDir, 'old123456789-snapshot.json');
+    fs.writeFileSync(oldSnap, '{"content": "old"}');
+    const twoDaysAgo = (Date.now() - 48 * 3600 * 1000) / 1000;
+    fs.utimesSync(oldSnap, twoDaysAgo, twoDaysAgo);
+
+    const res = sweepSessionFiles({ sessionsDir: tmpDir, dryRun: true });
+    expect(res.deleted).toEqual(['old123456789-snapshot.json']);
+    expect(res.freedBytes).toBeGreaterThan(0);
+    expect(fs.existsSync(oldSnap)).toBe(true); // preserved because dryRun is true
+  });
+});


### PR DESCRIPTION
## Summary
This PR addresses two MCP connection reliability and state hygiene issues uncovered during the TRA-1218 audit:

1. **`~/.trace-mcp/sessions/` directory leak (State hygiene & inode exhaustion)**:
   - Previously, every MCP session and ephemeral task run generated `<hash>-snapshot.json` (PreCompact hook context), `<hash>-end.log` (session exit marker), and `<hash>.json` (session resume summaries).
   - While `softGcSweep()` periodically cleaned up indexes, missing roots, implicit projects, config sections, and tmp files, it had **no sweeper for `SESSIONS_DIR`**. Over time, thousands of orphaned files accumulated on host machines (2,560 files / ~25 MB measured on this host alone).
   - Implemented `sweepSessionFiles` in `src/session/sweeper.ts` with sensible retention:
     - Snapshots older than 24h are deleted (active only during the session).
     - End logs older than 7d are deleted (or immediately if the project root is confirmed gone).
     - Session resumes are deleted immediately if the project root was ephemeral (`isEphemeralProjectRoot`) and deleted, or if missing for >7 days (grace period), or if inactive for >30 days.
     - Abandoned atomic `.tmp.*` files older than 1h are deleted.
   - Wired `sweepSessionFiles` into `softGcSweep()` in `src/cli.ts` (runs at server start and hourly in daemon) and into `trace-mcp prune` (with `--apply` and `--json` support).

2. **Launcher `is_plain_serve` missed valid client invocations**:
   - `serve` is registered as the default command in Commander (`isDefault: true`). Clients frequently invoke `trace-mcp --preset minimal` or `trace-mcp serve --preset=minimal` or `trace-mcp --preset=minimal`.
   - The launcher fast path shims (`hooks/trace-mcp-launcher.sh` and `hooks/trace-mcp-launcher.ps1`) only recognized 0 args, `["serve"]`, or `["serve", "--preset", "<name>"]`, completely missing `--preset <name>` (without `serve`), `serve --preset=<name>`, and `--preset=<name>`.
   - As a result, valid client sessions bypassed the thin proxy daemon fast path (`dist/proxy.js`) and paid the heavy 160MB V8 parse/compile floor loading `dist/cli.js`.
   - Updated `is_plain_serve` in bash and `Test-PlainServe` in PowerShell to recognize these valid variations while keeping Commander in charge of invalid flags.
   - Added `parsePresetArg` in `src/server/tool-filter.ts` to handle both `--preset <name>` and `--preset=<name>` in `src/proxy-entry.ts`.
   - Bumped `LAUNCHER_VERSION` to `0.6.14`.

## Test Evidence
- `tests/session/sweeper.test.ts`: 10/10 tests passed (snapshots aging, end logs aging, tmp files, corrupt JSON, ephemeral deletion, grace period, dryRun).
- `tests/proxy/parse-preset-arg.test.ts`: 4/4 tests passed.
- `tests/init/launcher-integration.test.ts`: passed (including new tests for `--preset` variations and CLI fallbacks).
- `tests/tools/session-resume.test.ts`: 5/5 tests passed.
- `tests/cli/prune.test.ts` & `tests/cli/prune-topology-decisions.test.ts`: 14/14 tests passed.
- `pnpm typecheck` & `pnpm biome:ci`: 0 errors.
- `pnpm run build`: built successfully.