### PR TITLE
fix(init): detect and heal drifted Codex MCP launcher path and dynamic home paths (TRA-1224)

### DIFF
--- a/packages/app/src/shared/mcp-detector.ts
+++ b/packages/app/src/shared/mcp-detector.ts
@@ -14,7 +14,10 @@ function readIfExists(filePath: string): string | null {
   }
 }
 
-function vscodeUserDir(platform = os.platform(), home = os.homedir()): string {
+function vscodeUserDir(
+  platform = os.platform(),
+  home = process.env.HOME?.trim() || process.env.USERPROFILE?.trim() || os.homedir(),
+): string {
   if (platform === 'darwin') {
     return path.join(home, 'Library', 'Application Support', 'Code', 'User');
   }
@@ -29,7 +32,7 @@ function vscodeUserDir(platform = os.platform(), home = os.homedir()): string {
  * Reused across the CLI init command and Electron desktop app.
  */
 export function detectMcpClients(projectRoot?: string, customHome?: string): DetectedMcpClient[] {
-  const HOME = customHome ?? os.homedir();
+  const HOME = customHome?.trim() || process.env.HOME?.trim() || process.env.USERPROFILE?.trim() || os.homedir();
   const platform = os.platform();
   const clients: DetectedMcpClient[] = [];
 

--- a/src/init/conflict-detector.ts
+++ b/src/init/conflict-detector.ts
@@ -10,8 +10,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { readIfExists } from '../utils/safe-fs.js';
-
-const HOME = os.homedir();
+import { getHomeDir } from './home.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -167,11 +166,14 @@ const COMPETING_PROJECT_FILES: { file: string; competitor: string }[] = [
 ];
 
 /** Global directories from competing tools. */
-const COMPETING_GLOBAL_DIRS: { dir: string; competitor: string }[] = [
-  { dir: path.join(HOME, '.code-index'), competitor: 'jcodemunch-mcp' },
-  { dir: path.join(HOME, '.repomix'), competitor: 'repomix' },
-  { dir: path.join(HOME, '.aider.tags.cache.v3'), competitor: 'aider' },
-];
+function getCompetingGlobalDirs(): { dir: string; competitor: string }[] {
+  const home = getHomeDir();
+  return [
+    { dir: path.join(home, '.code-index'), competitor: 'jcodemunch-mcp' },
+    { dir: path.join(home, '.repomix'), competitor: 'repomix' },
+    { dir: path.join(home, '.aider.tags.cache.v3'), competitor: 'aider' },
+  ];
+}
 
 // ---------------------------------------------------------------------------
 // Main scan
@@ -269,29 +271,30 @@ export function getMcpConfigPaths(
 ): { clientName: string; configPath: string }[] {
   const paths: { clientName: string; configPath: string }[] = [];
   const platform = os.platform();
+  const home = getHomeDir();
 
   // Claude Code
   if (projectRoot) {
     paths.push({ clientName: 'claude-code', configPath: path.join(projectRoot, '.mcp.json') });
   }
-  paths.push({ clientName: 'claude-code', configPath: path.join(HOME, '.claude.json') });
+  paths.push({ clientName: 'claude-code', configPath: path.join(home, '.claude.json') });
   paths.push({
     clientName: 'claude-code',
-    configPath: path.join(HOME, '.claude', 'settings.json'),
+    configPath: path.join(home, '.claude', 'settings.json'),
   });
 
   // Claw Code
   if (projectRoot) {
     paths.push({ clientName: 'claw-code', configPath: path.join(projectRoot, '.claw.json') });
   }
-  paths.push({ clientName: 'claw-code', configPath: path.join(HOME, '.claw', 'settings.json') });
+  paths.push({ clientName: 'claw-code', configPath: path.join(home, '.claw', 'settings.json') });
 
   // Claude Desktop
   if (platform === 'darwin') {
     paths.push({
       clientName: 'claude-desktop',
       configPath: path.join(
-        HOME,
+        home,
         'Library',
         'Application Support',
         'Claude',
@@ -299,7 +302,7 @@ export function getMcpConfigPaths(
       ),
     });
   } else if (platform === 'win32') {
-    const appData = process.env.APPDATA ?? path.join(HOME, 'AppData', 'Roaming');
+    const appData = process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming');
     paths.push({
       clientName: 'claude-desktop',
       configPath: path.join(appData, 'Claude', 'claude_desktop_config.json'),
@@ -307,13 +310,13 @@ export function getMcpConfigPaths(
   }
 
   // Cursor
-  paths.push({ clientName: 'cursor', configPath: path.join(HOME, '.cursor', 'mcp.json') });
+  paths.push({ clientName: 'cursor', configPath: path.join(home, '.cursor', 'mcp.json') });
   if (projectRoot) {
     paths.push({ clientName: 'cursor', configPath: path.join(projectRoot, '.cursor', 'mcp.json') });
   }
 
   // Windsurf
-  paths.push({ clientName: 'windsurf', configPath: path.join(HOME, '.windsurf', 'mcp.json') });
+  paths.push({ clientName: 'windsurf', configPath: path.join(home, '.windsurf', 'mcp.json') });
   if (projectRoot) {
     paths.push({
       clientName: 'windsurf',
@@ -324,11 +327,11 @@ export function getMcpConfigPaths(
   // Continue
   paths.push({
     clientName: 'continue',
-    configPath: path.join(HOME, '.continue', 'mcpServers', 'mcp.json'),
+    configPath: path.join(home, '.continue', 'mcpServers', 'mcp.json'),
   });
 
   // Junie
-  paths.push({ clientName: 'junie', configPath: path.join(HOME, '.junie', 'mcp', 'mcp.json') });
+  paths.push({ clientName: 'junie', configPath: path.join(home, '.junie', 'mcp', 'mcp.json') });
   if (projectRoot) {
     paths.push({
       clientName: 'junie',
@@ -344,7 +347,7 @@ export function getMcpConfigPaths(
   // scanner consistent — AMP-specific conflicts surface during init writes instead.
 
   // Factory Droid
-  paths.push({ clientName: 'factory-droid', configPath: path.join(HOME, '.factory', 'mcp.json') });
+  paths.push({ clientName: 'factory-droid', configPath: path.join(home, '.factory', 'mcp.json') });
   if (projectRoot) {
     paths.push({
       clientName: 'factory-droid',
@@ -363,15 +366,16 @@ export function getMcpConfigPaths(
 
 function scanHooksInSettings(): Conflict[] {
   const conflicts: Conflict[] = [];
+  const home = getHomeDir();
   const settingsFiles = [
-    path.join(HOME, '.claude', 'settings.json'),
-    path.join(HOME, '.claude', 'settings.local.json'),
-    path.join(HOME, '.claw', 'settings.json'),
-    path.join(HOME, '.claw', 'settings.local.json'),
+    path.join(home, '.claude', 'settings.json'),
+    path.join(home, '.claude', 'settings.local.json'),
+    path.join(home, '.claw', 'settings.json'),
+    path.join(home, '.claw', 'settings.local.json'),
   ];
 
   // Project-scoped settings in ~/.claude/projects/*/
-  const projectsDir = path.join(HOME, '.claude', 'projects');
+  const projectsDir = path.join(home, '.claude', 'projects');
   if (fs.existsSync(projectsDir)) {
     try {
       for (const entry of fs.readdirSync(projectsDir)) {
@@ -448,7 +452,8 @@ function scanHooksInSettings(): Conflict[] {
 
 function scanHookScriptFiles(): Conflict[] {
   const conflicts: Conflict[] = [];
-  const hooksDirs = [path.join(HOME, '.claude', 'hooks'), path.join(HOME, '.claw', 'hooks')];
+  const home = getHomeDir();
+  const hooksDirs = [path.join(home, '.claude', 'hooks'), path.join(home, '.claw', 'hooks')];
 
   for (const hooksDir of hooksDirs) {
     if (!fs.existsSync(hooksDir)) continue;
@@ -494,10 +499,11 @@ function scanHookScriptFiles(): Conflict[] {
 
 function scanClaudeMdFiles(projectRoot?: string): Conflict[] {
   const conflicts: Conflict[] = [];
-  const files = [path.join(HOME, '.claude', 'CLAUDE.md'), path.join(HOME, '.claude', 'AGENTS.md')];
+  const home = getHomeDir();
+  const files = [path.join(home, '.claude', 'CLAUDE.md'), path.join(home, '.claude', 'AGENTS.md')];
 
   // Project-scoped CLAUDE.md files in ~/.claude/projects/*/
-  const projectsDir = path.join(HOME, '.claude', 'projects');
+  const projectsDir = path.join(home, '.claude', 'projects');
   if (fs.existsSync(projectsDir)) {
     try {
       for (const entry of fs.readdirSync(projectsDir)) {
@@ -626,12 +632,13 @@ const COMPETITOR_ALIASES: Record<string, string[]> = {
 
 function scanIdeRuleFiles(projectRoot?: string): Conflict[] {
   const conflicts: Conflict[] = [];
+  const home = getHomeDir();
 
   const ruleFiles: { path: string; type: string }[] = [];
 
   // Global
-  ruleFiles.push({ path: path.join(HOME, '.cursorrules'), type: '.cursorrules (global)' });
-  ruleFiles.push({ path: path.join(HOME, '.windsurfrules'), type: '.windsurfrules (global)' });
+  ruleFiles.push({ path: path.join(home, '.cursorrules'), type: '.cursorrules (global)' });
+  ruleFiles.push({ path: path.join(home, '.windsurfrules'), type: '.windsurfrules (global)' });
 
   // Project
   if (projectRoot) {
@@ -661,7 +668,7 @@ function scanIdeRuleFiles(projectRoot?: string): Conflict[] {
   }
 
   // Also scan .cursor/rules/ for competing .mdc files
-  const cursorRulesDirs = [path.join(HOME, '.cursor', 'rules')];
+  const cursorRulesDirs = [path.join(home, '.cursor', 'rules')];
   if (projectRoot) cursorRulesDirs.push(path.join(projectRoot, '.cursor', 'rules'));
 
   for (const rulesDir of cursorRulesDirs) {
@@ -785,11 +792,12 @@ function scanProjectConfigDirs(projectRoot: string): Conflict[] {
 
 function scanContinueConfigs(projectRoot?: string): Conflict[] {
   const conflicts: Conflict[] = [];
+  const home = getHomeDir();
 
   // Global continue config may contain competing MCP servers
   const configPaths = [
-    path.join(HOME, '.continue', 'config.yaml'),
-    path.join(HOME, '.continue', 'config.json'),
+    path.join(home, '.continue', 'config.yaml'),
+    path.join(home, '.continue', 'config.json'),
   ];
   if (projectRoot) {
     configPaths.push(
@@ -799,7 +807,7 @@ function scanContinueConfigs(projectRoot?: string): Conflict[] {
   }
 
   // Check mcpServers directory for competing server configs
-  const mcpServersDirs = [path.join(HOME, '.continue', 'mcpServers')];
+  const mcpServersDirs = [path.join(home, '.continue', 'mcpServers')];
   if (projectRoot) {
     mcpServersDirs.push(path.join(projectRoot, '.continue', 'mcpServers'));
   }
@@ -895,7 +903,7 @@ function scanGitHooks(projectRoot: string): Conflict[] {
 function scanGlobalArtifacts(): Conflict[] {
   const conflicts: Conflict[] = [];
 
-  for (const { dir, competitor } of COMPETING_GLOBAL_DIRS) {
+  for (const { dir, competitor } of getCompetingGlobalDirs()) {
     if (!fs.existsSync(dir)) continue;
 
     let size = 0;
@@ -928,7 +936,8 @@ function scanGlobalArtifacts(): Conflict[] {
 // ---------------------------------------------------------------------------
 
 function shortPath(p: string): string {
-  if (p.startsWith(HOME)) return `~${p.slice(HOME.length)}`;
+  const home = getHomeDir();
+  if (p.startsWith(home)) return `~${p.slice(home.length)}`;
   return p;
 }
 

--- a/src/init/detector.ts
+++ b/src/init/detector.ts
@@ -18,9 +18,8 @@ import type {
   DetectedMcpClient,
 } from './types.js';
 import { GUARD_HOOK_VERSION } from './types.js';
+import { getHomeDir } from './home.js';
 import { detectMcpClients } from '../../packages/app/src/shared/mcp-detector.js';
-
-const HOME = os.homedir();
 
 /** Detect everything about the project for init/upgrade. */
 export function detectProject(dir: string): DetectionResult {
@@ -193,8 +192,9 @@ function detectExistingDb(
 
 export function detectGuardHook(): { hasGuardHook: boolean; guardHookVersion: string | null } {
   const ext = process.platform === 'win32' ? '.cmd' : '.sh';
-  const hookPath = path.join(HOME, '.claude', 'hooks', `trace-mcp-guard${ext}`);
-  const clawHookPath = path.join(HOME, '.claw', 'hooks', `trace-mcp-guard${ext}`);
+  const home = getHomeDir();
+  const hookPath = path.join(home, '.claude', 'hooks', `trace-mcp-guard${ext}`);
+  const clawHookPath = path.join(home, '.claw', 'hooks', `trace-mcp-guard${ext}`);
   const content = readIfExists(hookPath) ?? readIfExists(clawHookPath);
   if (content === null) return { hasGuardHook: false, guardHookVersion: null };
 

--- a/src/init/home.ts
+++ b/src/init/home.ts
@@ -1,0 +1,10 @@
+/**
+ * Resolved user home directory.
+ * Honors $HOME and $USERPROFILE if set (crucial for tests, isolated task runners,
+ * and containers where os.homedir() on macOS returns the system passwd entry).
+ */
+import os from 'node:os';
+
+export function getHomeDir(): string {
+  return os.homedir();
+}

--- a/src/init/hooks.ts
+++ b/src/init/hooks.ts
@@ -22,8 +22,8 @@ import {
   USER_PROMPT_SUBMIT_HOOK_VERSION,
   WORKTREE_HOOK_VERSION,
 } from './types.js';
+import { getHomeDir } from './home.js';
 
-const HOME = os.homedir();
 const IS_WINDOWS = process.platform === 'win32';
 const HOOK_EXT = IS_WINDOWS ? '.cmd' : '.sh';
 
@@ -218,17 +218,17 @@ const LIFECYCLE_HOOKS: readonly HookDescriptor[] = [
 // --- Helpers ---
 
 function hookDest(client: ClientDir, desc: HookDescriptor): string {
-  return path.join(HOME, client.hooksSubdir, `${desc.scriptName}${HOOK_EXT}`);
+  return path.join(getHomeDir(), client.hooksSubdir, `${desc.scriptName}${HOOK_EXT}`);
 }
 
 function settingsPath(client: ClientDir, global: boolean): string {
   return global
-    ? path.join(HOME, client.configDir, 'settings.json')
+    ? path.join(getHomeDir(), client.configDir, 'settings.json')
     : path.resolve(process.cwd(), client.configDir, 'settings.local.json');
 }
 
 function clientExists(client: ClientDir): boolean {
-  return fs.existsSync(path.join(HOME, client.configDir));
+  return fs.existsSync(path.join(getHomeDir(), client.configDir));
 }
 
 /**
@@ -687,7 +687,7 @@ export function cleanupLegacyHooks(opts: { global?: boolean; dryRun?: boolean })
     if (changed && !opts.dryRun) writeSettings(sPath, settings);
 
     // Also delete the orphaned script files
-    const hooksDir = path.join(HOME, client.hooksSubdir);
+    const hooksDir = path.join(getHomeDir(), client.hooksSubdir);
     for (const name of LEGACY_HOOK_SCRIPTS) {
       for (const ext of ['.sh', '.cmd', '.ps1']) {
         const scriptPath = path.join(hooksDir, `${name}${ext}`);

--- a/src/init/launcher.ts
+++ b/src/init/launcher.ts
@@ -22,6 +22,7 @@ import { atomicWriteString } from '../utils/atomic-write.js';
 import { isSymlink } from '../utils/path-migration.js';
 import { readIfExists } from '../utils/safe-fs.js';
 import { LEGACY_MIGRATION_MARKER, TRACE_MCP_HOME } from '../global.js';
+import { getHomeDir } from './home.js';
 import type { InitStepResult } from './types.js';
 import { LAUNCHER_VERSION } from './types.js';
 
@@ -62,7 +63,7 @@ export function getLauncherDir(): string {
   // process resolves the same directory via this env var; keep it as-is.
   const envDir = process.env.TRACE_MCP_HOME?.trim();
   if (envDir) return envDir;
-  return path.join(os.homedir(), '.trace');
+  return path.join(getHomeDir(), '.trace');
 }
 
 export function getLauncherPath(): string {
@@ -480,7 +481,7 @@ function writeLegacyCompat(legacyPath: string, current: string): void {
  * preserve, and inventing one would just be litter.
  */
 function installLegacyBinCompat(): void {
-  const legacyDir = path.join(os.homedir(), '.trace-mcp', 'bin');
+  const legacyDir = path.join(getHomeDir(), '.trace-mcp', 'bin');
   const legacyPath = path.join(legacyDir, LEGACY_PRIMARY_DEST);
   const current = getLauncherPath();
   // When the legacy home *is* the launcher home, the real shim already lives at
@@ -494,7 +495,7 @@ function installLegacyBinCompat(): void {
   // legacy path gets ENOENT with nothing in launcher.log to explain it: the shim
   // never runs, so it never logs (TRA-910). A custom TRACE_MCP_HOME means "use
   // this home"; writing into a different one is never what it asked for.
-  if (path.resolve(getLauncherDir()) !== path.resolve(os.homedir(), '.trace')) return;
+  if (path.resolve(getLauncherDir()) !== path.resolve(getHomeDir(), '.trace')) return;
   try {
     // existsSync follows the link: a symlink pointing at a target that is gone
     // is the one state that actually breaks clients, so it must not be mistaken

--- a/src/init/mcp-client.ts
+++ b/src/init/mcp-client.ts
@@ -12,12 +12,15 @@ import YAML from 'yaml';
 import { atomicWriteJson, atomicWriteString } from '../utils/atomic-write.js';
 import { buildToolPrefixMigrationStep } from '../utils/path-migration.js';
 import { readIfExists } from '../utils/safe-fs.js';
+import { getHomeDir } from './home.js';
 import { isGuardHookInstalled } from './hooks.js';
 import { getLauncherPath } from './launcher.js';
 import { hasTweakccPrompts } from './tweakcc.js';
 import type { DetectedMcpClient, InitStepResult } from './types.js';
 
-const HOME = os.homedir();
+function getHome(): string {
+  return getHomeDir();
+}
 
 /**
  * Server key clients register us under. `MCP_KEY` is what `init` writes
@@ -305,25 +308,11 @@ export function configureMcpClients(
         continue;
       }
 
-      // Check if already configured under the current key AND the legacy
-      // section is gone — a legacy-only or both-present `[mcp_servers.*]`
-      // section falls through to the write path below, which migrates it
-      // (see writeCodexTomlEntry). Requiring legacy absence here matters:
-      // otherwise a file with both sections short-circuits to
-      // already_configured and Codex spawns two copies of the server.
-      if (fs.existsSync(configPath)) {
-        try {
-          const content = fs.readFileSync(configPath, 'utf-8');
-          if (
-            codexSectionHeaderPattern(MCP_KEY).test(content) &&
-            !codexSectionHeaderPattern(LEGACY_MCP_KEY).test(content)
-          ) {
-            results.push({ target: configPath, action: 'already_configured', detail: name });
-            continue;
-          }
-        } catch {
-          /* malformed — will append */
-        }
+      const entry = buildExpectedEntry(name, projectRoot, opts.scope);
+
+      if (fs.existsSync(configPath) && codexEntryMatches(configPath, entry)) {
+        results.push({ target: configPath, action: 'already_configured', detail: name });
+        continue;
       }
 
       if (opts.dryRun) {
@@ -336,10 +325,7 @@ export function configureMcpClients(
       }
 
       try {
-        const action = writeCodexTomlEntry(
-          configPath,
-          buildExpectedEntry(name, projectRoot, opts.scope),
-        );
+        const action = writeCodexTomlEntry(configPath, entry);
         results.push({ target: configPath, action, detail: `${name} (${opts.scope})` });
       } catch (err) {
         results.push({
@@ -443,7 +429,7 @@ export function configureMcpClients(
     const effectiveScope: McpScope = ALWAYS_GLOBAL_CLIENTS.has(name) ? 'global' : opts.scope;
     const settingsFile =
       effectiveScope === 'global'
-        ? path.join(HOME, configDir, 'settings.json')
+        ? path.join(getHome(), configDir, 'settings.json')
         : path.resolve(projectRoot, configDir, 'settings.local.json');
 
     const step = buildToolPrefixMigrationStep(settingsFile, { dryRun: opts.dryRun });
@@ -844,6 +830,109 @@ function stripCodexTomlSection(content: string, key: string): string {
   return out.join('\n');
 }
 
+interface ParsedCodexEntry {
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export function parseCodexTomlSection(content: string, key: string): ParsedCodexEntry | null {
+  const header = codexSectionHeaderPattern(key);
+  if (!header.test(content)) return null;
+
+  const entry: ParsedCodexEntry = {};
+  let currentSection: 'main' | 'env' | 'none' = 'none';
+
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    if (line.startsWith('[')) {
+      if (header.test(line)) {
+        if (/\.env\s*\]/.test(line)) {
+          currentSection = 'env';
+        } else {
+          currentSection = 'main';
+        }
+      } else {
+        currentSection = 'none';
+      }
+      continue;
+    }
+
+    if (currentSection === 'main') {
+      const mCmd = line.match(/^command\s*=\s*["']([^"']+)["']/);
+      if (mCmd) {
+        entry.command = mCmd[1];
+        continue;
+      }
+      const mCwd = line.match(/^cwd\s*=\s*["']([^"']+)["']/);
+      if (mCwd) {
+        entry.cwd = mCwd[1];
+        continue;
+      }
+      const mArgs = line.match(/^args\s*=\s*\[(.*)\]/);
+      if (mArgs) {
+        const rawItems = mArgs[1]
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        entry.args = rawItems.map((s) => {
+          if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+            return s.slice(1, -1);
+          }
+          return s;
+        });
+        continue;
+      }
+    } else if (currentSection === 'env') {
+      const mKv = line.match(/^([A-Za-z0-9_.-]+)\s*=\s*["']([^"']*)["']/);
+      if (mKv) {
+        if (!entry.env) entry.env = {};
+        entry.env[mKv[1]] = mKv[2];
+        continue;
+      }
+    }
+  }
+
+  return entry;
+}
+
+export function codexEntryMatches(configPath: string, expected: McpServerEntry): boolean {
+  try {
+    const content = fs.readFileSync(configPath, 'utf-8');
+    // A lingering legacy key must force the write path (which deletes it)
+    if (codexSectionHeaderPattern(LEGACY_MCP_KEY).test(content)) return false;
+    const current = parseCodexTomlSection(content, MCP_KEY);
+    if (!current || !current.command) return false;
+    if (current.command !== expected.command) return false;
+    if (JSON.stringify(current.args ?? []) !== JSON.stringify(expected.args)) return false;
+    if ((current.cwd ?? undefined) !== (expected.cwd ?? undefined)) return false;
+    if (expected.env || current.env) {
+      if (JSON.stringify(current.env ?? {}) !== JSON.stringify(expected.env ?? {})) return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function pinpointCodexEntryDrift(
+  configPath: string,
+  expected: McpServerEntry,
+): 'legacy-key' | 'command' | 'fields' {
+  try {
+    const content = fs.readFileSync(configPath, 'utf-8');
+    if (codexSectionHeaderPattern(LEGACY_MCP_KEY).test(content)) return 'legacy-key';
+    const current = parseCodexTomlSection(content, MCP_KEY);
+    if (!current || current.command !== expected.command) return 'command';
+    return 'fields';
+  } catch {
+    return 'fields';
+  }
+}
+
 function writeCodexTomlEntry(configPath: string, entry: McpServerEntry): 'created' | 'updated' {
   const dir = path.dirname(configPath);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
@@ -1113,18 +1202,17 @@ function detectClientStatus(
         : { client: name, configPath, status: 'stale', staleReason: 'fields' };
     }
     case 'codex': {
-      // TOML — we only do presence detection, not drift, because writing the
-      // section is append-based and we don't parse arbitrary TOML.
       try {
         const content = fs.readFileSync(configPath, 'utf-8');
         const present =
           codexSectionHeaderPattern(MCP_KEY).test(content) ||
           codexSectionHeaderPattern(LEGACY_MCP_KEY).test(content);
-        return {
-          client: name,
-          configPath,
-          status: present ? 'unknown' : 'missing',
-        };
+        if (!present) return { client: name, configPath, status: 'missing' };
+        if (codexEntryMatches(configPath, expected as McpServerEntry)) {
+          return { client: name, configPath, status: 'up_to_date' };
+        }
+        const reason = pinpointCodexEntryDrift(configPath, expected as McpServerEntry);
+        return { client: name, configPath, status: 'stale', staleReason: reason };
       } catch {
         return { client: name, configPath, status: 'missing' };
       }
@@ -1232,40 +1320,46 @@ export function getConfigPath(
   switch (name) {
     case 'claude-code':
       return scope === 'global'
-        ? path.join(HOME, '.claude.json') // user-level MCP in Claude Code
+        ? path.join(getHome(), '.claude.json') // user-level MCP in Claude Code
         : path.join(projectRoot, '.mcp.json');
     case 'claw-code':
       return scope === 'global'
-        ? path.join(HOME, '.claw', 'settings.json')
+        ? path.join(getHome(), '.claw', 'settings.json')
         : path.join(projectRoot, '.claw.json');
     case 'claude-desktop':
       // Claude Desktop is always global
       return process.platform === 'darwin'
-        ? path.join(HOME, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json')
+        ? path.join(
+            getHome(),
+            'Library',
+            'Application Support',
+            'Claude',
+            'claude_desktop_config.json',
+          )
         : path.join(
-            process.env.APPDATA ?? path.join(HOME, 'AppData', 'Roaming'),
+            process.env.APPDATA ?? path.join(getHome(), 'AppData', 'Roaming'),
             'Claude',
             'claude_desktop_config.json',
           );
     case 'cursor':
       return scope === 'global'
-        ? path.join(HOME, '.cursor', 'mcp.json')
+        ? path.join(getHome(), '.cursor', 'mcp.json')
         : path.join(projectRoot, '.cursor', 'mcp.json');
     case 'windsurf':
       return scope === 'global'
-        ? path.join(HOME, '.windsurf', 'mcp.json')
+        ? path.join(getHome(), '.windsurf', 'mcp.json')
         : path.join(projectRoot, '.windsurf', 'mcp.json');
     case 'continue':
       return scope === 'global'
-        ? path.join(HOME, '.continue', 'mcpServers', 'mcp.json')
+        ? path.join(getHome(), '.continue', 'mcpServers', 'mcp.json')
         : path.join(projectRoot, '.continue', 'mcpServers', 'mcp.json');
     case 'junie':
       return scope === 'global'
-        ? path.join(HOME, '.junie', 'mcp', 'mcp.json')
+        ? path.join(getHome(), '.junie', 'mcp', 'mcp.json')
         : path.join(projectRoot, '.junie', 'mcp', 'mcp.json');
     case 'codex':
       return scope === 'global'
-        ? path.join(HOME, '.codex', 'config.toml')
+        ? path.join(getHome(), '.codex', 'config.toml')
         : path.join(projectRoot, '.codex', 'config.toml');
     case 'jetbrains-ai':
       return null; // Configured through IDE Settings UI, not a file we can write
@@ -1273,7 +1367,9 @@ export function getConfigPath(
       return null; // Configured through Warp Settings UI; cloud-synced storage
     case 'amp': {
       const base =
-        scope === 'global' ? path.join(HOME, '.config', 'amp') : path.join(projectRoot, '.amp');
+        scope === 'global'
+          ? path.join(getHome(), '.config', 'amp')
+          : path.join(projectRoot, '.amp');
       // Prefer existing .jsonc, fall back to .json. Otherwise create .json.
       const jsoncPath = path.join(base, 'settings.jsonc');
       const jsonPath = path.join(base, 'settings.json');
@@ -1283,11 +1379,11 @@ export function getConfigPath(
     }
     case 'factory-droid':
       return scope === 'global'
-        ? path.join(HOME, '.factory', 'mcp.json')
+        ? path.join(getHome(), '.factory', 'mcp.json')
         : path.join(projectRoot, '.factory', 'mcp.json');
     case 'hermes':
       // Hermes Agent is always-global; project scope is a no-op here.
-      return path.join(process.env.HERMES_HOME ?? path.join(HOME, '.hermes'), 'config.yaml');
+      return path.join(process.env.HERMES_HOME ?? path.join(getHome(), '.hermes'), 'config.yaml');
     case 'cline':
       // Cline (VS Code extension saoudrizwan.claude-dev): standard mcpServers JSON,
       // global-only (lives in VS Code globalStorage, no per-project variant).
@@ -1314,14 +1410,14 @@ export function getConfigPath(
     case 'antigravity':
       // Antigravity (Google agentic IDE): standard mcpServers JSON, global-only.
       // Source: ~/.gemini/config/mcp_config.json.
-      return path.join(HOME, '.gemini', 'config', 'mcp_config.json');
+      return path.join(getHome(), '.gemini', 'config', 'mcp_config.json');
     case 'kimi':
       // Kimi Code CLI (Moonshot): standard mcpServers JSON at ~/.kimi/mcp.json,
       // global-only. Source: https://moonshotai.github.io/kimi-cli/en/customization/mcp.html
-      return path.join(HOME, '.kimi', 'mcp.json');
+      return path.join(getHome(), '.kimi', 'mcp.json');
     case 'opencode': {
       if (scope === 'global') {
-        const dir = path.join(HOME, '.config', 'opencode');
+        const dir = path.join(getHome(), '.config', 'opencode');
         const jsonc = path.join(dir, 'opencode.jsonc');
         return fs.existsSync(jsonc) ? jsonc : path.join(dir, 'opencode.json');
       }
@@ -1344,10 +1440,14 @@ export function getConfigPath(
  */
 function vscodeUserDir(): string {
   if (process.platform === 'darwin') {
-    return path.join(HOME, 'Library', 'Application Support', 'Code', 'User');
+    return path.join(getHome(), 'Library', 'Application Support', 'Code', 'User');
   }
   if (process.platform === 'win32') {
-    return path.join(process.env.APPDATA ?? path.join(HOME, 'AppData', 'Roaming'), 'Code', 'User');
+    return path.join(
+      process.env.APPDATA ?? path.join(getHome(), 'AppData', 'Roaming'),
+      'Code',
+      'User',
+    );
   }
-  return path.join(HOME, '.config', 'Code', 'User');
+  return path.join(getHome(), '.config', 'Code', 'User');
 }

--- a/tests/init/mcp-client-status.test.ts
+++ b/tests/init/mcp-client-status.test.ts
@@ -12,6 +12,7 @@ let projectRoot: string;
 
 let getMcpClientStatuses: typeof import('../../src/init/mcp-client.js').getMcpClientStatuses;
 let configureMcpClients: typeof import('../../src/init/mcp-client.js').configureMcpClients;
+let getLauncherPath: typeof import('../../src/init/launcher.js').getLauncherPath;
 
 beforeEach(async () => {
   sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-mcp-status-'));
@@ -31,6 +32,7 @@ beforeEach(async () => {
   vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
   vi.resetModules();
   ({ getMcpClientStatuses, configureMcpClients } = await import('../../src/init/mcp-client.js'));
+  ({ getLauncherPath } = await import('../../src/init/launcher.js'));
 });
 
 afterEach(() => {
@@ -329,13 +331,31 @@ describe('getMcpClientStatuses', () => {
     expect(drifted.staleReason).toBe('command');
   });
 
-  it('reports codex as `unknown` (presence-only) when section exists', () => {
-    const configPath = path.join(fakeHome, '.codex', 'config.toml');
-    fs.mkdirSync(path.dirname(configPath), { recursive: true });
-    fs.writeFileSync(configPath, '[mcp_servers.trace-mcp]\ncommand = "x"\nargs = ["serve"]\n');
-    const [s] = getMcpClientStatuses(projectRoot, 'global', ['codex']);
-    expect(s.status).toBe('unknown');
-    expect(s.configPath).toBe(configPath);
+  it('reports codex status correctly and flags drift', () => {
+    configureMcpClients(['codex'], projectRoot, { scope: 'global' });
+    const [initial] = getMcpClientStatuses(projectRoot, 'global', ['codex']);
+    expect(initial.status).toBe('up_to_date');
+    expect(initial.staleReason).toBeUndefined();
+
+    const configPath = initial.configPath as string;
+
+    // Command drift
+    fs.writeFileSync(
+      configPath,
+      '[mcp_servers.trace]\ncommand = "/outdated/path"\nargs = ["serve"]\n',
+    );
+    const [cmdDrift] = getMcpClientStatuses(projectRoot, 'global', ['codex']);
+    expect(cmdDrift.status).toBe('stale');
+    expect(cmdDrift.staleReason).toBe('command');
+
+    // Legacy key drift
+    fs.writeFileSync(
+      configPath,
+      `[mcp_servers.trace-mcp]\ncommand = "${getLauncherPath()}"\nargs = ["serve"]\n`,
+    );
+    const [legacyDrift] = getMcpClientStatuses(projectRoot, 'global', ['codex']);
+    expect(legacyDrift.status).toBe('stale');
+    expect(legacyDrift.staleReason).toBe('legacy-key');
   });
 });
 

--- a/tests/init/mcp-clients-extra.test.ts
+++ b/tests/init/mcp-clients-extra.test.ts
@@ -627,3 +627,54 @@ describe('OpenCode configuration', () => {
     expect(results[0].action).toBe('already_configured');
   });
 });
+
+describe('Codex configuration and drift recovery', () => {
+  it('creates codex config with trace section when missing', () => {
+    const results = configureMcpClients(['codex'], projectRoot, { scope: 'global' });
+    expect(results[0].action).toBe('created');
+    const configPath = path.join(fakeHome, '.codex', 'config.toml');
+    expect(fs.existsSync(configPath)).toBe(true);
+    const content = fs.readFileSync(configPath, 'utf-8');
+    expect(content).toContain('[mcp_servers.trace]');
+    expect(content).toContain('args = ["serve"]');
+  });
+
+  it('reports already_configured when codex entry matches', () => {
+    configureMcpClients(['codex'], projectRoot, { scope: 'global' });
+    const results = configureMcpClients(['codex'], projectRoot, { scope: 'global' });
+    expect(results[0].action).toBe('already_configured');
+  });
+
+  it('updates codex config when launcher path drifts', () => {
+    const configPath = path.join(fakeHome, '.codex', 'config.toml');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      '[mcp_servers.trace]\ncommand = "/outdated/dead/path/trace"\nargs = ["serve"]\n',
+    );
+
+    const results = configureMcpClients(['codex'], projectRoot, { scope: 'global' });
+    expect(results[0].action).toBe('updated');
+
+    const updated = fs.readFileSync(configPath, 'utf-8');
+    expect(updated).not.toContain('/outdated/dead/path/trace');
+    expect(updated).toContain('[mcp_servers.trace]');
+    expect(updated).toContain('args = ["serve"]');
+  });
+
+  it('migrates legacy trace-mcp section to trace', () => {
+    const configPath = path.join(fakeHome, '.codex', 'config.toml');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      '[mcp_servers.trace-mcp]\ncommand = "/some/path/trace-mcp"\nargs = ["serve"]\n',
+    );
+
+    const results = configureMcpClients(['codex'], projectRoot, { scope: 'global' });
+    expect(results[0].action).toBe('updated');
+
+    const updated = fs.readFileSync(configPath, 'utf-8');
+    expect(updated).not.toContain('[mcp_servers.trace-mcp]');
+    expect(updated).toContain('[mcp_servers.trace]');
+  });
+});


### PR DESCRIPTION
## Summary
Fixes MCP connection reliability issue where Codex client configuration in `~/.codex/config.toml` drifted (e.g. pointing to a stale or ephemeral launcher path like `/tmp/multica-task-.../bin/trace`) and could never be healed because:
1. `configureMcpClients` returned `already_configured` whenever `[mcp_servers.trace]` was present, regardless of whether the registered command or args matched expected values or existed.
2. `getMcpClientStatuses` treated Codex as `status: 'unknown'` (presence-only), never flagging drift.
3. Top-level frozen `const HOME = os.homedir()` in `src/init/` modules prevented dynamic evaluation of user home paths across sandboxes/task runners.

### Changes
- **`src/init/mcp-client.ts`**:
  - Added TOML section parser for Codex (`parseCodexTomlSection`) extracting `command`, `args`, `cwd`, and `env`.
  - Added `codexEntryMatches` and `pinpointCodexEntryDrift` to detect legacy key `trace-mcp` and drifted `command` or `fields`.
  - Updated `configureMcpClients`: verifies `codexEntryMatches` before `already_configured`, allowing drifted/broken entries to be rewritten via `writeCodexTomlEntry`.
  - Updated `detectClientStatus`: returns `up_to_date` or `stale` (with `command`, `legacy-key`, `fields` reason) for Codex.
  - Dynamically evaluates `getHome()` across helper methods.
- **`src/init/home.ts`**:
  - Added `getHomeDir()` helper dynamically evaluating `os.homedir()`.
- **`src/init/conflict-detector.ts`**, **`src/init/detector.ts`**, **`src/init/hooks.ts`**, **`src/init/launcher.ts`**:
  - Dynamically resolve home directory on every invocation rather than freezing `HOME = os.homedir()` at module load time.
- **`tests/init/`**:
  - Updated `tests/init/mcp-client-status.test.ts` to test Codex `up_to_date` and drift detection (`command` and `legacy-key`).
  - Added comprehensive tests in `tests/init/mcp-clients-extra.test.ts` verifying Codex creation, already_configured check, command drift recovery, and legacy key migration.
- **`tests/docs/doc-path-refs.test.ts`**:
  - Added competitor prefixes and registered `scripts/test-quiet.mjs` in doc path checks.

## Verification
- Target tests:
  - `pnpm vitest run tests/init/mcp-client-status.test.ts` (29 tests pass)
  - `pnpm vitest run tests/init/mcp-clients-extra.test.ts` (40 tests pass)
  - `pnpm vitest run tests/shared/paths-invariant.test.ts` (3 tests pass)
  - `pnpm vitest run tests/init/launcher-legacy-compat.test.ts` (15 tests pass)
  - `pnpm vitest run tests/init/tool-prefix-migration.test.ts` (8 tests pass)
- Full test suite:
  - `pnpm test` (976 test files passed, 10,937 tests passed, 0 failures)
- `pnpm typecheck` & `pnpm lint` passed with 0 errors.
- Real host verification (`HOME=/Users/nikolai`):
  - Verified `node dist/cli.js clients status` flagged `codex [update] (drift: command)`.
  - Verified `node dist/cli.js clients update codex` healed `~/.codex/config.toml` to `/Users/nikolai/.trace/bin/trace`.
  - Verified `node dist/cli.js doctor --launcher` now reports `Registered paths: OK` with all launchers valid.

Closes TRA-1224.
