### PR TITLE
fix(launcher): prevent app runtime pairing with incompatible external npm CLI (TRA-1249)

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.6.14 (Windows)
+REM trace-mcp-launcher v0.6.15 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.6.14 (Windows)
+# trace-mcp-launcher v0.6.15 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.6.14
+# trace-mcp-launcher v0.6.15
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -307,7 +307,7 @@ node_major() {
 node_runtime_shim_ok() {
   local line target='' marked=0 i=0
   case "$1" in
-    */node-runtime) ;;
+    */node-runtime|node-runtime) ;;
     *) return 0 ;;
   esac
   [ -f "$1" ] && [ -r "$1" ] || return 1
@@ -496,10 +496,30 @@ cli_from_app_bundle() {
   is_usable_script "$cli" && normalise_path "$cli"
 }
 
-# True when $1 is the app's own binary, which only runs as Node with this set.
+# True when $1 is the app's own binary, or a node-runtime shim whose target
+# is inside an .app bundle.
 is_app_runtime() {
   case "$1" in
     *.app/Contents/MacOS/*) return 0 ;;
+    */node-runtime|node-runtime)
+      if [ -f "$1" ] && [ -r "$1" ]; then
+        local line target='' i=0
+        while [ "$i" -lt 8 ] && IFS= read -r line; do
+          i=$((i + 1))
+          line="${line%$'\r'}"
+          case "$line" in
+            'exec "'*'" "$@"')
+              target="${line#exec \"}"
+              target="${target%\" \"\$@\"}"
+              ;;
+          esac
+        done < "$1"
+        case "$target" in
+          *.app/Contents/MacOS/*) return 0 ;;
+        esac
+      fi
+      return 1
+      ;;
     *) return 1 ;;
   esac
 }
@@ -871,6 +891,19 @@ if [ "$USING_NODE_OVERRIDE" = 0 ] && [ -n "$NODE_PATH" ] && [ -x "$NODE_PATH" ];
   fi
 fi
 
+# An app runtime (Electron with Hardened Runtime / ABI 145) can only run the
+# server bundled inside the app. Exec-ing an external npm package fails with
+# ERR_DLOPEN_FAILED (macOS Team ID mismatch) and NODE_MODULE_VERSION mismatch.
+if [ "$USING_OVERRIDE" = 0 ] && is_app_runtime "$NODE_PATH" && [ -n "$CLI_PATH" ]; then
+  case "$CLI_PATH" in
+    *.app/Contents/Resources/server/dist/cli.js) ;;
+    *)
+      log "ERROR: app runtime node=$NODE_PATH cannot load external package cli=$CLI_PATH (Team ID / ABI mismatch) — reprobing"
+      CLI_PATH=""
+      ;;
+  esac
+fi
+
 # The version gate is also the liveness gate, and it runs on EVERY start.
 #
 # It used to be skipped whenever launcher.env carried a cached
@@ -924,22 +957,44 @@ if [ -z "$NODE_PATH" ] || [ ! -x "$NODE_PATH" ]; then
 fi
 
 if [ -z "$CLI_PATH" ] || ! is_usable_script "$CLI_PATH"; then
-  ROOTS=$(pkg_roots "$NODE_PATH")
-  CLI_PATH=$(probe_cli "$ROOTS") || {
-    # An update (npm install -g or self-update) may be swapping the package
-    # directory right this second. Wait briefly and retry before declaring
-    # a fatal error — MCP clients tolerate a 1-2s start delay but exit 127
-    # kills the session permanently.
-    retry=0
-    while [ "$retry" -lt 5 ]; do
-      sleep 0.3 2>/dev/null || sleep 1 2>/dev/null || true
-      retry=$((retry + 1))
-      CLI_PATH=$(probe_cli "$ROOTS") && break
-    done
-    [ -n "$CLI_PATH" ] || die "trace-mcp package not found in any known npm prefix — run: npm i -g trace-mcp && trace-mcp init"
-  }
-  log "probe: cli=$CLI_PATH"
-  HEALED=1
+  if is_app_runtime "$NODE_PATH"; then
+    CLI_PATH=$(cli_from_app_bundle) || CLI_PATH=""
+    if [ -n "$CLI_PATH" ]; then
+      log "probe: cli=$CLI_PATH"
+      HEALED=1
+    else
+      # An app runtime cannot run external npm packages (Team ID / ABI mismatch).
+      # If the app bundle has no cli.js, drop the app runtime and reprobe a real node.
+      log "app runtime node=$NODE_PATH has no bundled cli.js — reprobing for a real node"
+      NODE_PATH=""
+      if ! NODE_PATH=$(probe_node); then
+        if [ -n "$(node_candidates)" ]; then
+          die "no Node.js >= $NODE_MIN_MAJOR found — trace-mcp needs it; upgrade Node or set TRACE_MCP_NODE_OVERRIDE"
+        fi
+        die "node binary not found — install Node.js (brew install node / nvm / volta) or set TRACE_MCP_NODE_OVERRIDE"
+      fi
+      log "probe: node=$NODE_PATH"
+      HEALED=1
+    fi
+  fi
+  if [ -z "$CLI_PATH" ] || ! is_usable_script "$CLI_PATH"; then
+    ROOTS=$(pkg_roots "$NODE_PATH")
+    CLI_PATH=$(probe_cli "$ROOTS") || {
+      # An update (npm install -g or self-update) may be swapping the package
+      # directory right this second. Wait briefly and retry before declaring
+      # a fatal error — MCP clients tolerate a 1-2s start delay but exit 127
+      # kills the session permanently.
+      retry=0
+      while [ "$retry" -lt 5 ]; do
+        sleep 0.3 2>/dev/null || sleep 1 2>/dev/null || true
+        retry=$((retry + 1))
+        CLI_PATH=$(probe_cli "$ROOTS") && break
+      done
+      [ -n "$CLI_PATH" ] || die "trace-mcp package not found in any known npm prefix — run: npm i -g trace-mcp && trace-mcp init"
+    }
+    log "probe: cli=$CLI_PATH"
+    HEALED=1
+  fi
 fi
 
 # Overrides are a debugging escape hatch; never bake them into the config.

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -118,4 +118,5 @@ export const MIRROR_HOOK_VERSION = '0.3.0';
 // 0.6.12 (TRA-1197): strip trailing CRs from launcher config, package roots and .npmrc
 // 0.6.13 (TRA-1206): candidate homes resolution under isolated HOME, Windows thin proxy daemon fast path
 // 0.6.14 (TRA-1218): support --preset variations in daemon-aware proxy routing
-export const LAUNCHER_VERSION = '0.6.14';
+// 0.6.15 (TRA-1249): prevent app runtime pairing with incompatible external npm CLI (Team ID / ABI mismatch)
+export const LAUNCHER_VERSION = '0.6.15';

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -1459,6 +1459,54 @@ describe.skipIf(process.platform === 'win32')('app-only install (no npm prefix)'
     expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
   });
 
+  it('reprobes and uses bundled cli when launcher.env pairs app runtime with external npm cli (TRA-1249)', () => {
+    const { home, traceHome, cli: externalCli } = setupFakeHome();
+    const { app, cli: bundledCli } = plantAppBundle(home);
+    const shim = plantRuntimeShim(
+      path.join(traceHome, 'bin'),
+      path.join(app, 'Contents', 'MacOS', 'trace-mcp'),
+    );
+    writeAppLocation(traceHome, app);
+    writeConfig(traceHome, shim, externalCli);
+
+    const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe(`APP_NODE:1:${bundledCli} serve`);
+    const log = fs.readFileSync(path.join(traceHome, 'launcher.log'), 'utf-8');
+    expect(log).toMatch(/ERROR: app runtime node=.*cannot load external package cli=.*reprobing/);
+    const config = fs.readFileSync(path.join(traceHome, 'launcher.env'), 'utf-8');
+    expect(config).toContain(`TRACE_MCP_CLI="${bundledCli}"`);
+  });
+
+  it('resolves bundled cli directly when node is an app runtime, skipping npm prefixes (TRA-1249)', () => {
+    const { home, traceHome } = setupFakeHome();
+    const { app, cli: bundledCli } = plantAppBundle(home);
+    const shim = plantRuntimeShim(
+      path.join(traceHome, 'bin'),
+      path.join(app, 'Contents', 'MacOS', 'trace-mcp'),
+    );
+    writeAppLocation(traceHome, app);
+
+    const prefix = path.join(home, 'npm-prefix');
+    const prefixCli = path.join(prefix, 'lib', 'node_modules', 'trace-mcp', 'dist', 'cli.js');
+    fs.mkdirSync(path.dirname(prefixCli), { recursive: true });
+    fs.writeFileSync(prefixCli, '// external npm cli\n');
+    fs.writeFileSync(
+      path.join(traceHome, 'pkg-roots'),
+      `${path.join(prefix, 'lib', 'node_modules')}\n`,
+    );
+
+    writeConfig(traceHome, shim, '/nonexistent/cli.js');
+
+    const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe(`APP_NODE:1:${bundledCli} serve`);
+    const config = fs.readFileSync(path.join(traceHome, 'launcher.env'), 'utf-8');
+    expect(config).toContain(`TRACE_MCP_CLI="${bundledCli}"`);
+  });
+
   // Review of #1011: `read` reports failure on a final line with no trailing
   // newline, so a plain `while read` loop drops it. The writer happens to emit
   // `appPath` first today, which is key order, not a parser invariant — a


### PR DESCRIPTION
## Summary
Fixes an issue where the launcher shim could pair Desktop App's Electron binary (`node-runtime` / `*.app/Contents/MacOS/*`) with an external npm global package `dist/cli.js` (e.g. from Herd, Hermes, or global npm).

### Problem
- On macOS, Desktop App's Electron binary is code-signed with Hardened Runtime and Team ID.
- When `ELECTRON_RUN_AS_NODE=1` is set, loading external npm `.node` native addons (such as `oxc-resolver`) fails with:
  `ERR_DLOPEN_FAILED: mapping process and mapped file (non-platform) have different Team IDs` and `NODE_MODULE_VERSION` mismatch (145 vs 127).
- If `launcher.env` had `TRACE_MCP_NODE` pointing to the Desktop App, but `TRACE_MCP_CLI` was missing or stale, `probe_cli` prioritized scanning external `$ROOTS` before checking `cli_from_app_bundle`.
- `heal_config` then saved this broken pair into `launcher.env`, permanently locking MCP clients into failing silently with exit code 1.

### Solution
- Refined `is_app_runtime` in `hooks/trace-mcp-launcher.sh` to check for `.app/Contents/MacOS/*` executables or `node-runtime` shims whose target points to an `.app` bundle.
- Fast path: Rejects external `CLI_PATH` when `NODE_PATH` is an app runtime, logging ERROR to `launcher.log` and triggering a reprobe.
- Probe path: When `NODE_PATH` is an app runtime, directly resolves `CLI_PATH` from `cli_from_app_bundle`. If no bundled CLI is present, drops the app runtime and falls back to probing a real Node.js binary.
- Hardened `node_runtime_shim_ok` to match both `*/node-runtime` and bare `node-runtime`.
- Bumped launcher version to `0.6.15` in launcher files and `src/init/types.ts`.
- Added regression tests in `tests/init/launcher-integration.test.ts`.

### Verification
- Local unit & integration tests pass (all 86 integration tests + 62 launcher tests).
- Full quiet test suite passed: `978 files passed, 10979 tests passed`.
- `pnpm typecheck` and `pnpm biome check` pass.