### PR TITLE
fix(launcher): multi-version node resolution and client drift healing (TRA-1266)

### DIFF
--- a/hooks/trace-mcp-launcher.cmd
+++ b/hooks/trace-mcp-launcher.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM trace-mcp-launcher v0.6.15 (Windows)
+REM trace-mcp-launcher v0.6.16 (Windows)
 REM Tiny .cmd shim that invokes the PowerShell launcher. MCP clients spawn
 REM this .cmd because they rely on %PATHEXT% resolution which prefers .cmd.
 REM -WindowStyle Hidden keeps the cmd->powershell hop windowless: windowsHide

--- a/hooks/trace-mcp-launcher.ps1
+++ b/hooks/trace-mcp-launcher.ps1
@@ -1,4 +1,4 @@
-# trace-mcp-launcher v0.6.15 (Windows)
+# trace-mcp-launcher v0.6.16 (Windows)
 # Stable shim backend: resolves node + cli.js at runtime from launcher.env,
 # with a probe fallback for nvm-windows/nvs/Volta/system installs.
 # Managed by trace-mcp - do not edit by hand. Re-run `trace-mcp init` to refresh.
@@ -192,6 +192,19 @@ function Test-RuntimeShim {
     return (Test-Path -LiteralPath $target -PathType Leaf)
 }
 
+function Test-AppRuntime {
+    param([string]$Path)
+    if (-not $Path) { return $false }
+    if ($Path -like '*\Contents\MacOS\*' -or $Path -like '*\trace-mcp.app\*') { return $true }
+    if ([System.IO.Path]::GetFileName($Path) -eq 'node-runtime.cmd') {
+        try {
+            $head = Get-Content -LiteralPath $Path -TotalCount 8 -ErrorAction Stop
+            if ($head | Where-Object { $_ -match '^rem Managed by the trace-mcp app' }) { return $true }
+        } catch { return $false }
+    }
+    return $false
+}
+
 # `Length -gt 0`, not merely "the file is there" (TRA-1132). Test-NodeBinary
 # above closed "exists but does not run" for node; this is the same class on
 # the other half of the pair. A zero-byte dist/cli.js - what a disk-full write,
@@ -339,6 +352,16 @@ if (-not $UsingNodeOverride -and (Test-NodeBinary $NodePath) -and -not (Test-Run
     $NodePath = ''
 }
 
+# An app runtime (Electron with Hardened Runtime / ABI 145) can only run the
+# server bundled inside the app. Exec-ing an external npm package fails with
+# ABI mismatch.
+if (-not $UsingOverride -and (Test-AppRuntime $NodePath) -and $CliPath) {
+    if ($CliPath -notmatch '[\\/]trace-mcp\.app[\\/]' -and $CliPath -notmatch '[\\/]Contents[\\/]Resources[\\/]server[\\/]dist[\\/]cli\.js') {
+        Write-LauncherLog "ERROR: app runtime node=$NodePath cannot load external package cli=$CliPath (ABI mismatch) - reprobing"
+        $CliPath = ''
+    }
+}
+
 # The version gate is also the liveness gate, and it runs on EVERY start.
 #
 # It used to be skipped whenever the config carried a cached
@@ -366,6 +389,7 @@ if (-not $UsingNodeOverride -and (Test-NodeBinary $NodePath)) {
 if ((Test-NodeBinary $NodePath) -and (Test-CliFile $CliPath)) {
     $execTarget = Resolve-ExecTarget $CliPath $args
     Write-LauncherLog "exec(config) node=$NodePath cli=$CliPath target=$execTarget argc=$($args.Count)"
+    if (Test-AppRuntime $NodePath) { $env:ELECTRON_RUN_AS_NODE = '1' }
     & $NodePath $execTarget @args
     exit $LASTEXITCODE
 }
@@ -414,12 +438,14 @@ function Get-NodeCandidates {
     }
     $nvmRoot = Join-Path $env:APPDATA 'nvm'
     if (Test-Path -LiteralPath $nvmRoot -PathType Container) {
-        $latest = Get-ChildItem -LiteralPath $nvmRoot -Directory -ErrorAction SilentlyContinue |
-                  Where-Object { $_.Name -match '^v?\d+\.\d+\.\d+$' } |
-                  Sort-Object -Property Name -Descending |
-                  Select-Object -First 1
-        if ($latest) {
-            $candidate = Join-Path $latest.FullName 'node.exe'
+        $versions = Get-ChildItem -LiteralPath $nvmRoot -Directory -ErrorAction SilentlyContinue |
+                    Where-Object { $_.Name -match '^v?\d+\.\d+\.\d+$' } |
+                    Sort-Object -Property {
+                        $clean = $_.Name.TrimStart('v')
+                        try { [version]$clean } catch { [version]'0.0.0' }
+                    } -Descending
+        foreach ($v in $versions) {
+            $candidate = Join-Path $v.FullName 'node.exe'
             if (Test-NodeBinary $candidate) { $found += $candidate }
         }
     }
@@ -500,6 +526,19 @@ function Get-PkgRoots {
     # Volta keeps each global package under its own image directory.
     if ($env:LOCALAPPDATA) {
         $roots += (Join-Path $env:LOCALAPPDATA 'Volta\tools\image\packages\trace-mcp\lib\node_modules')
+    }
+    # pnpm global roots
+    foreach ($base in @($env:LOCALAPPDATA, $env:APPDATA)) {
+        if (-not $base) { continue }
+        $pnpmGlobal = Join-Path $base 'pnpm\global'
+        if (Test-Path -LiteralPath $pnpmGlobal -PathType Container) {
+            Get-ChildItem -LiteralPath $pnpmGlobal -Directory -ErrorAction SilentlyContinue | ForEach-Object {
+                $m = Join-Path $_.FullName 'node_modules'
+                if (Test-Path -LiteralPath $m -PathType Container) { $roots += $m }
+            }
+        }
+        $pnpmRoot = Join-Path $base 'pnpm\node_modules'
+        if (Test-Path -LiteralPath $pnpmRoot -PathType Container) { $roots += $pnpmRoot }
     }
     # Custom prefixes (`npm config set prefix`). Read from config files, never
     # by spawning npm: the shim inherits the MCP client's PATH, which in
@@ -592,5 +631,6 @@ if ($Healed -and -not $UsingOverride) { Save-LauncherConfig $NodePath $CliPath }
 
 $execTarget = Resolve-ExecTarget $CliPath $args
 Write-LauncherLog "exec(probe) node=$NodePath cli=$CliPath target=$execTarget argc=$($args.Count)"
+if (Test-AppRuntime $NodePath) { $env:ELECTRON_RUN_AS_NODE = '1' }
 & $NodePath $execTarget @args
 exit $LASTEXITCODE

--- a/hooks/trace-mcp-launcher.sh
+++ b/hooks/trace-mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trace-mcp-launcher v0.6.15
+# trace-mcp-launcher v0.6.16
 # Stable shim: MCP clients invoke this path forever; it resolves node + cli.js
 # at runtime from a config file written by `trace-mcp init`, with a probe
 # fallback for when the config is stale (e.g. Node was reinstalled, or the
@@ -369,6 +369,45 @@ node_from_nvm_tree() {
   return 1
 }
 
+# Resolve all candidate nodes from an nvm-layout tree ($1 = root).
+# Emits the default alias first, then all installed versions sorted newest-first.
+# This prevents an older default alias (e.g. Node 18) or missing default alias from
+# masking newer supported Node versions installed in the same tree (TRA-1266).
+nodes_from_nvm_tree() {
+  local root="$1" n='' v list
+  [ -d "$root/versions/node" ] || return 0
+  if n=$(node_from_nvm_tree "$root"); then
+    echo "$n"
+  fi
+  list=$(ls -d "$root"/versions/node/* 2>/dev/null | sort -V -r) || return 0
+  while IFS= read -r v; do
+    [ -n "$v" ] || continue
+    [ -x "$v/bin/node" ] || continue
+    [ -n "$n" ] && [ "$v/bin/node" = "$n" ] && continue
+    echo "$v/bin/node"
+  done <<< "$list"
+}
+
+# Resolve all global node_modules roots from an nvm-layout tree ($1 = root).
+# Emits the default alias root first, then all installed versions sorted newest-first.
+# This finds trace-mcp installed under another Node version even when the active alias
+# points to a sibling version (TRA-1266).
+pkg_roots_from_nvm_tree() {
+  local root="$1" n='' v n_root='' list
+  [ -d "$root/versions/node" ] || return 0
+  if n=$(node_from_nvm_tree "$root"); then
+    n_root="$(dirname "$n")/../lib/node_modules"
+    [ -d "$n_root" ] && echo "$n_root"
+  fi
+  list=$(ls -d "$root"/versions/node/* 2>/dev/null | sort -V -r) || return 0
+  while IFS= read -r v; do
+    [ -n "$v" ] || continue
+    [ -d "$v/lib/node_modules" ] || continue
+    [ -n "$n_root" ] && [ "$v/lib/node_modules" = "$n_root" ] && continue
+    echo "$v/lib/node_modules"
+  done <<< "$list"
+}
+
 # Candidate user homes to probe for node managers and global packages.
 # Survives MCP clients spawned with an isolated or modified HOME
 # (e.g. Antigravity setting HOME=~/.agy/4, sandboxed runners, launchd, Claude Code --isolated).
@@ -539,10 +578,10 @@ node_candidates() {
     [ -x "$h/.local/bin/node" ] && echo "$h/.local/bin/node"
     [ -x "$h/.volta/bin/node" ] && echo "$h/.volta/bin/node"
 
-    # 4c. nvm default alias (dereference chained aliases; handle major-only shortcuts)
+    # 4c. nvm default alias + all installed versions (sorted newest-first)
     # 4d. Herd (same nvm-compatible tree)
-    n=$(node_from_nvm_tree "$h/.nvm") && echo "$n"
-    n=$(node_from_nvm_tree "$h/Library/Application Support/Herd/config/nvm") && echo "$n"
+    nodes_from_nvm_tree "$h/.nvm"
+    nodes_from_nvm_tree "$h/Library/Application Support/Herd/config/nvm"
 
     # 4e. fnm default alias (three possible locations)
     for fnm_dir in \
@@ -631,12 +670,8 @@ pkg_roots() {
   # Herd / fnm / Volta users, which is most of them.
   while IFS= read -r h; do
     [ -n "$h" ] || continue
-    if n=$(node_from_nvm_tree "$h/.nvm"); then
-      echo "$(dirname "$n")/../lib/node_modules"
-    fi
-    if n=$(node_from_nvm_tree "$h/Library/Application Support/Herd/config/nvm"); then
-      echo "$(dirname "$n")/../lib/node_modules"
-    fi
+    pkg_roots_from_nvm_tree "$h/.nvm"
+    pkg_roots_from_nvm_tree "$h/Library/Application Support/Herd/config/nvm"
     for fnm_dir in \
       "$h/.local/share/fnm/aliases/default" \
       "$h/.fnm/aliases/default" \
@@ -646,6 +681,19 @@ pkg_roots() {
     # Volta keeps each global package under its own image directory.
     [ -d "$h/.volta/tools/image/packages/trace-mcp/lib/node_modules" ] &&
       echo "$h/.volta/tools/image/packages/trace-mcp/lib/node_modules"
+
+    # pnpm global roots
+    for pnpm_dir in \
+      "$h/Library/pnpm/global"/*/node_modules \
+      "$h/Library/pnpm/node_modules" \
+      "$h/.local/share/pnpm/global"/*/node_modules \
+      "$h/.local/share/pnpm/node_modules"; do
+      [ -d "$pnpm_dir" ] && echo "$pnpm_dir"
+    done
+
+    # bun and yarn global roots
+    [ -d "$h/.bun/install/global/node_modules" ] && echo "$h/.bun/install/global/node_modules"
+    [ -d "$h/.config/yarn/global/node_modules" ] && echo "$h/.config/yarn/global/node_modules"
 
     # Runtimes that bundle their own node and install us into it. Named here
     # because their prefix is on no standard list and predates the registry

--- a/src/init/launcher.ts
+++ b/src/init/launcher.ts
@@ -241,6 +241,7 @@ export type LauncherPathStatus =
   | 'not_executable'
   | 'broken_interpreter'
   | 'broken_delegate'
+  | 'unmanaged_binary'
   | 'foreign'
   | 'unchecked';
 
@@ -305,6 +306,13 @@ export function checkLauncherFile(file: string): LauncherPathCheck {
     }
   }
   if (!isOwnedShim(target)) {
+    if (isDirectTraceMcpBinary(file, target)) {
+      return {
+        path: file,
+        status: 'unmanaged_binary',
+        detail: 'direct trace-mcp binary (bypasses launcher shim) — run: trace clients update',
+      };
+    }
     return { path: file, status: 'foreign', detail: 'not a trace-mcp launcher — left alone' };
   }
   // Mode bits are not the last gate: the kernel still has to find the shim's
@@ -408,6 +416,37 @@ export function isOwnedShim(file: string): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Detect whether a file or its symlink target is a direct npm binary or cli.js of trace-mcp,
+ * rather than the canonical launcher shim. Direct binaries bypass launcher.env and daemon proxy,
+ * and break when the host Node environment changes (TRA-1266).
+ */
+export function isDirectTraceMcpBinary(file: string, target: string): boolean {
+  if (/[/\\]trace-mcp[/\\]dist[/\\]cli\.[cm]?js$/.test(target)) return true;
+  const base = path.basename(file).toLowerCase();
+  if (
+    base === 'trace' ||
+    base === 'trace-mcp' ||
+    base === 'trace.cmd' ||
+    base === 'trace-mcp.cmd' ||
+    base === 'trace.ps1' ||
+    base === 'trace-mcp.ps1'
+  ) {
+    if (/[/\\]dist[/\\]cli\.[cm]?js$/.test(target)) {
+      const parentPkg = path.resolve(path.dirname(target), '..', 'package.json');
+      try {
+        if (fs.existsSync(parentPkg)) {
+          const pkg = JSON.parse(fs.readFileSync(parentPkg, 'utf-8'));
+          if (pkg.name === 'trace-mcp') return true;
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  return false;
 }
 
 /**

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -119,4 +119,5 @@ export const MIRROR_HOOK_VERSION = '0.3.0';
 // 0.6.13 (TRA-1206): candidate homes resolution under isolated HOME, Windows thin proxy daemon fast path
 // 0.6.14 (TRA-1218): support --preset variations in daemon-aware proxy routing
 // 0.6.15 (TRA-1249): prevent app runtime pairing with incompatible external npm CLI (Team ID / ABI mismatch)
-export const LAUNCHER_VERSION = '0.6.15';
+// 0.6.16 (TRA-1266): multi-version node resolution across nvm/Herd trees, pnpm global roots, and unmanaged binary drift detection
+export const LAUNCHER_VERSION = '0.6.16';

--- a/tests/init/launcher-health.test.ts
+++ b/tests/init/launcher-health.test.ts
@@ -82,6 +82,21 @@ describe.skipIf(process.platform === 'win32')('checkLauncherFile', () => {
     expect(isBroken(check.status)).toBe(false);
   });
 
+  it('detects a direct trace-mcp npm binary or cli.js as unmanaged_binary and broken', () => {
+    const pkgDir = path.join(dir, 'node_modules', 'trace-mcp', 'dist');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    const cli = path.join(pkgDir, 'cli.js');
+    fs.writeFileSync(cli, '#!/usr/bin/env node\nconsole.log("direct cli");\n', { mode: 0o755 });
+    const symlink = path.join(dir, 'bin', 'trace-mcp');
+    fs.mkdirSync(path.dirname(symlink), { recursive: true });
+    fs.symlinkSync(cli, symlink);
+
+    const check = checkLauncherFile(symlink);
+    expect(check.status).toBe('unmanaged_binary');
+    expect(isBroken(check.status)).toBe(true);
+    expect(check.detail).toContain('bypasses launcher shim');
+  });
+
   it('does not guess at a PATH-resolved command name', () => {
     expect(checkLauncherFile('npx').status).toBe('unchecked');
   });

--- a/tests/init/launcher-integration.test.ts
+++ b/tests/init/launcher-integration.test.ts
@@ -530,6 +530,31 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
         );
       });
 
+      it('finds supported node and package in sibling nvm version when default alias is older node (TRA-1266)', () => {
+        const { home, traceHome } = setupFakeHome();
+        // Default alias points to older Node 18.0.0 (too old)
+        const oldPrefix = path.join(home, '.nvm', 'versions', 'node', 'v18.0.0');
+        fs.mkdirSync(path.join(oldPrefix, 'bin'), { recursive: true });
+        fs.writeFileSync(path.join(oldPrefix, 'bin', 'node'), fakeNodeBody('18.0.0'), {
+          mode: 0o755,
+        });
+        fs.mkdirSync(path.join(home, '.nvm', 'alias'), { recursive: true });
+        fs.writeFileSync(path.join(home, '.nvm', 'alias', 'default'), 'v18.0.0\n');
+
+        // Sibling version v99.0.0 is installed with node + trace-mcp package
+        const good = plantNvm(home, '99.0.0');
+
+        const { status, stdout } = runLauncher(
+          { HOME: home, TRACE_MCP_HOME: traceHome, ...ABOVE_ANY_REAL },
+          ['serve'],
+        );
+
+        expect(status).toBe(0);
+        expect(stdout.trim()).toBe(`NODE_ARGS:${good.cli} serve`);
+        const cfg = fs.readFileSync(path.join(traceHome, 'launcher.env'), 'utf-8');
+        expect(cfg).toContain(`TRACE_MCP_NODE="${good.node}"`);
+      });
+
       it('re-probes when launcher.env already pins an unsupported node', () => {
         const { home, traceHome, cli } = setupFakeHome();
         const old = path.join(home, 'old-node');
@@ -838,6 +863,54 @@ describe.skipIf(process.platform === 'win32')('launcher shim integration', () =>
       fs.writeFileSync(path.join(pkgDir, 'cli.js'), '// custom prefix cli\n');
       const cli = fs.realpathSync(path.join(pkgDir, 'cli.js'));
       fs.writeFileSync(path.join(home, '.npmrc'), `prefix=${prefix}\n`);
+      writeConfig(traceHome, node, path.join(home, 'gone', 'cli.js'));
+
+      const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+    });
+
+    it('finds package installed in pnpm global root across candidate homes (TRA-1266)', () => {
+      const { home, traceHome, node } = setupFakeHome();
+      const pnpmDir = path.join(
+        home,
+        'Library',
+        'pnpm',
+        'global',
+        '5',
+        'node_modules',
+        'trace-mcp',
+        'dist',
+      );
+      fs.mkdirSync(pnpmDir, { recursive: true });
+      fs.writeFileSync(path.join(pnpmDir, 'cli.js'), '// pnpm global cli\n');
+      const cli = fs.realpathSync(path.join(pnpmDir, 'cli.js'));
+      writeConfig(traceHome, node, path.join(home, 'gone', 'cli.js'));
+
+      const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe(`NODE_ARGS:${cli} serve`);
+    });
+
+    it('finds package in sibling nvm version when default alias lacks package (TRA-1266)', () => {
+      const { home, traceHome, node } = setupFakeHome();
+      // default alias points to v24.0.0 which has node but no trace-mcp
+      const defPrefix = path.join(home, '.nvm', 'versions', 'node', 'v24.0.0');
+      fs.mkdirSync(path.join(defPrefix, 'bin'), { recursive: true });
+      fs.writeFileSync(path.join(defPrefix, 'bin', 'node'), fakeNodeBody('24.0.0'), {
+        mode: 0o755,
+      });
+      fs.mkdirSync(path.join(home, '.nvm', 'alias'), { recursive: true });
+      fs.writeFileSync(path.join(home, '.nvm', 'alias', 'default'), 'v24.0.0\n');
+
+      // sibling version v22.22.2 has trace-mcp installed
+      const sibPrefix = path.join(home, '.nvm', 'versions', 'node', 'v22.22.2');
+      const pkgDir = path.join(sibPrefix, 'lib', 'node_modules', 'trace-mcp', 'dist');
+      fs.mkdirSync(pkgDir, { recursive: true });
+      fs.writeFileSync(path.join(pkgDir, 'cli.js'), '// sibling nvm cli\n');
+      const cli = fs.realpathSync(path.join(pkgDir, 'cli.js'));
       writeConfig(traceHome, node, path.join(home, 'gone', 'cli.js'));
 
       const { status, stdout } = runLauncher({ HOME: home, TRACE_MCP_HOME: traceHome }, ['serve']);


### PR DESCRIPTION
## Summary

Addresses MCP connection failures and client drift caused by multi-version Node setups (nvm, Herd) and direct unmanaged binary references (TRA-1266).

### 1. Multi-Version Node & Package Resolution
- **nvm & Herd tree traversal**: When probing `~/.nvm` or Herd's nvm-compatible tree (`~/Library/Application Support/Herd/config/nvm`), `nodes_from_nvm_tree` and `pkg_roots_from_nvm_tree` now enumerate all installed versions sorted newest-first (`sort -V -r`) instead of only querying the default alias. An older or missing default alias (e.g. Node 18) no longer masks newer supported Node versions installed in the same tree.
- **Windows nvm traversal**: In `trace-mcp-launcher.ps1`, `Get-NodeCandidates` now enumerates all versions under `$APPDATA\nvm` sorted descending by semver, and `Get-PkgRoots` searches pnpm global roots under `%LOCALAPPDATA%\pnpm\global` and `%APPDATA%\pnpm\global`. Also ensures `ELECTRON_RUN_AS_NODE = '1'` when delegating to app runtime node.
- **Global package discovery**: Added discovery across pnpm global roots (`~/Library/pnpm/global/*/node_modules`, `~/.local/share/pnpm/global/*/node_modules`), bun (`~/.bun/install/global/node_modules`), and yarn (`~/.config/yarn/global/node_modules`).

### 2. Client Drift & Unmanaged Binary Healing
- **`unmanaged_binary` classification**: Added `isDirectTraceMcpBinary(file, target)` to `src/init/launcher.ts`. If an MCP client config directly references an unmanaged npm binary (`.../bin/trace-mcp`) or raw `cli.js` (e.g. Claude Desktop pointing directly to a Herd Node version binary), `checkLauncherFile` now returns `{ status: 'unmanaged_binary', detail: 'direct trace-mcp binary (bypasses launcher shim) — run: trace clients update' }` instead of treating it as `'foreign'`.
- **Health integration**: `isBroken('unmanaged_binary')` evaluates to true, enabling `doctor --launcher` and `trace clients doctor` to detect configuration drift and recommend `trace clients update`.

### 3. Version Bump
- Bumped `LAUNCHER_VERSION` to `0.6.16` across `src/init/types.ts`, `hooks/trace-mcp-launcher.sh`, `hooks/trace-mcp-launcher.ps1`, and `hooks/trace-mcp-launcher.cmd`.

### Verification Evidence
- `tests/init/launcher-health.test.ts`: Added unit test verifying unmanaged direct trace-mcp binaries are classified as broken `unmanaged_binary`. 27/27 tests passed.
- `tests/init/launcher-integration.test.ts`: Added tests for sibling nvm node resolution when default alias is older, pnpm global root discovery, and sibling nvm package discovery. All 89 tests passed.
- All init tests: 18 test files passed (361 tests passed, 10 skipped).
- Static checks: `tsc --noEmit` clean, `biome format` clean.
- Real machine verification: `HOME=/Users/nikolai node ./dist/cli.js doctor --launcher` correctly identifies drifted Claude Desktop config as `[unmanaged_binary]`.